### PR TITLE
chore: update absolute paths after weft dir move

### DIFF
--- a/crates/ingest/src/reasoning_pipeline.rs
+++ b/crates/ingest/src/reasoning_pipeline.rs
@@ -1164,7 +1164,7 @@ mod tests {
     fn normalize_target_path_strips_slashless_absolute_same_repo_path() {
         let root = Path::new("/Users/lukethorne/.codex/worktrees/60c1/heddle");
         let got = normalize_target_path(
-            "Users/lukethorne/dev/heddle/crates/repo/src/worktree_index_storage.rs",
+            "Users/lukethorne/dev/HeddleCo/weft/crates/repo/src/worktree_index_storage.rs",
             root,
         );
         assert_eq!(got, "crates/repo/src/worktree_index_storage.rs");
@@ -1174,7 +1174,7 @@ mod tests {
     fn normalize_target_path_strips_absolute_other_checkout_of_same_repo() {
         let root = Path::new("/Users/lukethorne/.codex/worktrees/60c1/heddle");
         let got = normalize_target_path(
-            "/Users/lukethorne/dev/heddle/crates/repo/src/status_untracked_scan.rs",
+            "/Users/lukethorne/dev/HeddleCo/weft/crates/repo/src/status_untracked_scan.rs",
             root,
         );
         assert_eq!(got, "crates/repo/src/status_untracked_scan.rs");
@@ -1268,7 +1268,7 @@ mod tests {
         // absolute inputs. We don't short-circuit the agent-worktree
         // helper for absolute paths because that would leave a stray
         // `heddle/` prefix on the output.
-        let root = Path::new("/Users/lukethorne/dev/heddle");
+        let root = Path::new("/Users/lukethorne/dev/HeddleCo/weft");
         let got = normalize_target_path(
             "/Users/lukethorne/.codex/worktrees/89d4/heddle/src/auth.rs",
             root,

--- a/crates/ingest/tests/extract_real_reasoning.rs
+++ b/crates/ingest/tests/extract_real_reasoning.rs
@@ -3,7 +3,7 @@
 //! for the Heddle repo and print the top candidates. Ignored by default.
 //!
 //! ```text
-//! HEDDLE_MATCHER_SMOKE_REPO=/Users/lukethorne/dev/heddle \
+//! HEDDLE_MATCHER_SMOKE_REPO=/Users/lukethorne/dev/HeddleCo/weft \
 //!   cargo test -p ingest --test extract_real_reasoning -- --ignored --nocapture
 //! ```
 //!

--- a/crates/ingest/tests/match_real_sessions.rs
+++ b/crates/ingest/tests/match_real_sessions.rs
@@ -5,7 +5,7 @@
 //! Run manually from the repo root:
 //!
 //! ```text
-//! HEDDLE_MATCHER_SMOKE_REPO=/Users/lukethorne/dev/heddle \
+//! HEDDLE_MATCHER_SMOKE_REPO=/Users/lukethorne/dev/HeddleCo/weft \
 //!   cargo test -p ingest --test match_real_sessions -- --ignored --nocapture
 //! ```
 //!


### PR DESCRIPTION
## Summary

The closed weft checkout moved from `~/dev/heddle` to `~/dev/HeddleCo/weft` after the OSS split (HeddleCo/weft#78). This updates the 5 lines across 3 files in `crates/ingest` that named the old absolute path.

Files touched:
- `crates/ingest/tests/match_real_sessions.rs` (doc-comment env-var example)
- `crates/ingest/tests/extract_real_reasoning.rs` (same)
- `crates/ingest/src/reasoning_pipeline.rs` (3 test-input strings in `mod tests`)

No behavior change — the path-normalization tests assert on pure string manipulation, and the smoke tests use the env var only as a documentation hint.

Intentionally left alone: `crates/ingest/src/transcript/locator.rs` and the `/Users/x/...` / `/Users/foo/...` placeholders in `reasoning_pipeline.rs` — those are generic-username documentation for slug encoding, not stale absolute paths.

The two trailing-newline additions in the test files are a file-hygiene fix the formatter applied while editing.

## Test plan

- [ ] `cargo check --tests -p ingest` succeeds
- [ ] Path-normalization unit tests still pass (no behavior change expected)