### PR TITLE
release: v0.2.1 — oplog PII fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ recorded here. Hosted-product work (Postgres, Biscuit, the web app,
 GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 `HeddleCo/tapestry` repos.
 
+## 0.2.1 - 2026-05-14
+
+### Fixed
+- `oplog`: `Repository::op_scope` no longer canonicalizes HEAD to its
+  absolute filesystem path. Every recorded op was embedding the user's
+  home directory and username (`/Users/<name>/.../.heddle/HEAD`) into
+  the oplog. The fix records a blake3 digest of the canonical pointer
+  path (`wt-<16-hex>`) — stable per checkout, unique across worktrees
+  that share an oplog backend, opaque on disk.
+
 ## 0.2.0 - 2026-05-13
 
 First public release on crates.io. The CLI and its workspace ship as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,7 +2597,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-stream",
  "chrono",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "protoc-bin-vendored",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "prost",
  "prost-types",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-proto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "heddle-objects",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -6966,7 +6966,7 @@ checksum = "ca7016c477ef99218bcbe30ba8f8ad8bdfd11d9207a985d4441ee590d60e1d65"
 
 [[package]]
 name = "weft-client-shim"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli-shared"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description = "CLI-side utilities shared between Heddle's OSS cli crate and the closed hosted-client crate: user config, remote target resolution, client config."

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-crypto"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-daemon"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle local-mode gRPC daemon and service implementations"

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-devtools"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description = "Developer tooling for the Heddle workspace"

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-ingest"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description = "Import git history (commits, refs, reflogs) into a native Heddle repository with agent attribution and reasoning annotations."

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-mount"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-objects"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-oplog"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-proto"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-refs"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-repo"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-review"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-semantic"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-state-review"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weft-client-shim"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 description = "Trait surface for hosted-client extensions to the Heddle CLI. OSS default is a noop impl; closed builds replace it via [patch.crates-io]."


### PR DESCRIPTION
## Summary

Bumps all 17 OSS crates from \`0.2.0\` to \`0.2.1\` to ship the fix from #7 (\`op_scope\` no longer embeds absolute paths in the oplog).

## Changes

- 17× \`crates/*/Cargo.toml\`: \`version = \"0.2.0\"\` → \`version = \"0.2.1\"\`
- \`Cargo.lock\`: regenerated via \`cargo check --workspace\`
- \`CHANGELOG.md\`: new \`## 0.2.1\` section

Inter-crate dependencies use the \`version = \"0.2\"\` range (equivalent to \`^0.2.0\`, matching \`>=0.2.0, <0.3.0\`) so no dependency-version edits are needed — the new patch is in-range.

## Publish

After this merges, the publish sequence (in topological order from \`release-plz.toml\`) is:

\`\`\`bash
for c in heddle-objects heddle-refs heddle-oplog heddle-crypto \\
         heddle-proto heddle-semantic heddle-repo heddle-grpc \\
         heddle-ingest heddle-mount heddle-daemon heddle-cli-shared \\
         heddle-devtools heddle-review heddle-state-review \\
         weft-client-shim heddle-cli; do
  cargo publish -p "$c"
  sleep 5  # crates.io indexing lag
done
\`\`\`

Or just run \`release-plz update && release-plz release\` if you install release-plz locally.

Then tag the merge commit:

\`\`\`bash
git tag -a v0.2.1 -m "v0.2.1 — oplog PII fix"
git push origin v0.2.1
\`\`\`