### PR TITLE
release: v0.2.2 — heddle-client moves into the OSS workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ recorded here. Hosted-product work (Postgres, Biscuit, the web app,
 GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 `HeddleCo/tapestry` repos.
 
+## 0.2.2 - 2026-05-14
+
+### Added
+- New `heddle-client` crate — the hosted-backend command implementations
+  (`auth`, `support`, `presence`), the gRPC client wrappers, and the
+  global credential store. Moved out of the closed `weft` workspace and
+  into OSS heddle so the workspace builds standalone with
+  `--all-features` and third-party hosted clients can extend via the
+  public gRPC protocol surface rather than a closed crate.
+
+### Changed
+- `heddle-cli`: optional dep `weft-client = "0.0"` → `heddle-client`.
+  The feature gating that dep renamed `weft-client` → `client`.
+- `heddle-cli-shared`: `UserConfig::weft_client_config` →
+  `UserConfig::heddle_client_config`.
+
+### Note
+- The `weft-client` placeholder crate on crates.io (v0.0.0) is now
+  unreferenced. Safe to yank.
+
 ## 0.2.1 - 2026-05-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "chrono",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "protoc-bin-vendored",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "blake3",
  "heddle-objects",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli-shared"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "CLI-side utilities shared between Heddle's OSS cli crate and the closed heddle-client crate: user config, remote target resolution, client config."

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-client"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle hosted-backend client: auth, support, presence, the gRPC client wrappers, and the global credential store."

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-crypto"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-daemon"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle local-mode gRPC daemon and service implementations"

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-devtools"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "Developer tooling for the Heddle workspace"

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-ingest"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "Import git history (commits, refs, reflogs) into a native Heddle repository with agent attribution and reasoning annotations."

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-mount"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-objects"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-oplog"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-proto"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-refs"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-repo"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-review"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-semantic"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-state-review"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weft-client-shim"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 description = "Trait surface for client extensions to the Heddle CLI. OSS default is a noop impl; closed builds replace it via [patch.crates-io]."


### PR DESCRIPTION
## Summary

Bumps all 18 OSS crates (now including the new \`heddle-client\`) from \`0.2.1\` → \`0.2.2\` to ship the refactor from #10.

## Changes

- 18× \`crates/*/Cargo.toml\`: \`version = "0.2.1"\` → \`version = "0.2.2"\`
- \`Cargo.lock\`: regenerated
- \`CHANGELOG.md\`: new \`## 0.2.2\` section documenting heddle-client addition, dep+feature rename in cli, and the cli-shared method rename

Inter-crate dependencies use \`version = "0.2"\` (matches \`>=0.2.0, <0.3.0\`) so no dependency-version edits needed.

## After merge

Publishing sequence (topological from \`release-plz.toml\`, plus heddle-client which slots in after heddle-repo since that's what it depends on):

\`\`\`bash
for c in heddle-objects heddle-refs heddle-oplog heddle-crypto \
         heddle-proto heddle-semantic heddle-repo heddle-grpc \
         heddle-client heddle-ingest heddle-mount heddle-daemon \
         heddle-cli-shared heddle-devtools heddle-review \
         heddle-state-review weft-client-shim heddle-cli; do
  cargo publish -p "$c"
  sleep 5
done
\`\`\`

Then tag:

\`\`\`bash
git tag -a v0.2.2 -m "v0.2.2 — heddle-client into OSS workspace"
git push origin v0.2.2
\`\`\`

I'll handle both steps once you merge this.