### PR TITLE
feat(redact): cross-replica wire propagation + .heddleignore globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ name = "heddle-proto"
 version = "0.2.2"
 dependencies = [
  "blake3",
+ "chrono",
  "heddle-objects",
  "heddle-repo",
  "rmp-serde",

--- a/crates/cli/src/cli/cli_args/commands_redact.rs
+++ b/crates/cli/src/cli/cli_args/commands_redact.rs
@@ -24,6 +24,63 @@ pub enum RedactCommands {
     List(RedactListArgs),
     /// Show a single redaction by its content-addressed id.
     Show(RedactShowArgs),
+    /// Manage the list of operator public keys whose signed
+    /// redactions this repo accepts over the wire.
+    ///
+    /// `accept_wire_redactions` is fail-closed: an empty trust list
+    /// rejects every signed redaction. Operators run `heddle redact
+    /// trust add` to authorize a key for cross-replica propagation.
+    /// Signing alone proves *who* declared the redaction; the trust
+    /// list proves the receiver has authorized that operator to act
+    /// on this workspace.
+    #[command(subcommand)]
+    Trust(RedactTrustCommands),
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum RedactTrustCommands {
+    /// Add an operator public key to `[redact] trusted_keys` in
+    /// `.heddle/config.toml`. Subsequent `heddle fetch`/`clone`
+    /// invocations will accept signed redactions from that key.
+    Add(RedactTrustAddArgs),
+    /// List the currently-trusted operator keys.
+    List(RedactTrustListArgs),
+    /// Remove an operator public key from the trust list. Future
+    /// signed redactions from that key will be refused.
+    Remove(RedactTrustRemoveArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct RedactTrustAddArgs {
+    /// Path to a PEM file (public or private key — the public half
+    /// is extracted either way). Algorithm autodetected from the PEM
+    /// header. This is the operator-friendly path: same PEM you
+    /// passed to `heddle redact apply --sign-with`.
+    #[arg(long, value_name = "PATH", group = "key_source")]
+    pub from_pem: Option<std::path::PathBuf>,
+    /// Algorithm identifier (`ed25519`, `rsa`, `p256`) when supplying
+    /// the raw hex-encoded public key directly via `--public-key`.
+    #[arg(long, value_name = "ALGO", requires = "public_key")]
+    pub algorithm: Option<String>,
+    /// Hex-encoded raw public key bytes. Use alongside `--algorithm`
+    /// when the operator already has the key in hex form (e.g. from
+    /// a signed-redaction's `signature.public_key` field).
+    #[arg(long, value_name = "HEX", requires = "algorithm", group = "key_source")]
+    pub public_key: Option<String>,
+    /// Optional free-text label for the trust entry (`"luke-laptop"`,
+    /// `"ci-signing"`). Doesn't affect matching semantics.
+    #[arg(long)]
+    pub label: Option<String>,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct RedactTrustListArgs {}
+
+#[derive(Clone, Debug, Args)]
+pub struct RedactTrustRemoveArgs {
+    /// Hex-encoded raw public key to remove. Exact match (case-
+    /// insensitive).
+    pub public_key: String,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/crates/cli/src/cli/cli_args/mod.rs
+++ b/crates/cli/src/cli/cli_args/mod.rs
@@ -64,7 +64,8 @@ pub use commands_marker::MarkerCommands;
 pub use commands_query::QueryArgs;
 pub use commands_redact::{
     PurgeApplyArgs, PurgeCommands, PurgeListArgs, RedactApplyArgs, RedactCommands, RedactListArgs,
-    RedactShowArgs,
+    RedactShowArgs, RedactTrustAddArgs, RedactTrustCommands, RedactTrustListArgs,
+    RedactTrustRemoveArgs,
 };
 pub use commands_remote::RemoteCommands;
 pub use commands_review::{

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -192,12 +192,15 @@ async fn fetch_local(
     let mut refs_fetched = 0;
     let mut objects_fetched = 0;
 
-    // Fetch all threads from source
+    // Fetch all threads from source. `fetch_state` is invoked
+    // unconditionally — not just when the state is missing locally —
+    // so `LocalSync` can sweep the tree for redaction sidecars the
+    // peer declared after we last synced. The internal walk is cheap
+    // when no objects need copying, but it must still run for
+    // `accept_wire_redactions` to fire.
     for (track_name, change_id) in source.list_threads()? {
-        if !repo.store().has_state(&change_id)? {
-            let count = source.fetch_state(repo, &change_id)?;
-            objects_fetched += count;
-        }
+        let count = source.fetch_state(repo, &change_id)?;
+        objects_fetched += count;
         repo.refs()
             .set_remote_thread(remote_name, &track_name, &change_id)?;
         refs_fetched += 1;
@@ -205,10 +208,8 @@ async fn fetch_local(
 
     // Fetch all markers from source (copy locally, not as remote refs)
     for (marker_name, change_id) in source.list_markers()? {
-        if !repo.store().has_state(&change_id)? {
-            let count = source.fetch_state(repo, &change_id)?;
-            objects_fetched += count;
-        }
+        let count = source.fetch_state(repo, &change_id)?;
+        objects_fetched += count;
         // Create local marker if it doesn't exist
         if repo.refs().get_marker(&marker_name)?.is_none() {
             repo.refs().create_marker(&marker_name, &change_id)?;

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -6,13 +6,13 @@
 //! brief; the Biscuit verifier rule is a future-work item. For now,
 //! `--force` is the explicit confirmation step.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use objects::object::ChangeId;
 use repo::Repository;
 use serde::Serialize;
 
 use crate::{
-    cli::{Cli, PurgeApplyArgs, PurgeCommands, PurgeListArgs, should_output_json},
+    cli::{should_output_json, Cli, PurgeApplyArgs, PurgeCommands, PurgeListArgs},
     config::UserConfig,
 };
 
@@ -39,6 +39,12 @@ struct PurgeApplyOutput {
     blob_remains_in_pack: bool,
     purger: String,
     message: String,
+    /// Hint to add the purged path to `.heddleignore` / `.gitignore`
+    /// so subsequent captures don't re-import the leaked bytes from
+    /// the working tree. `None` when the path is already covered by a
+    /// glob rule in either file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_hint: Option<super::redact::IgnoreHint>,
 }
 
 fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result<()> {
@@ -79,6 +85,8 @@ fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result
         );
     }
 
+    let ignore_hint = super::redact::ignore_hint_for_path(repo.root(), &args.path);
+
     let output = PurgeApplyOutput {
         redaction_id: outcome.redaction_id.map(|h| h.short()),
         blob: blob.short(),
@@ -89,12 +97,16 @@ fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result
         blob_remains_in_pack: outcome.blob_remains_in_pack,
         purger: format!("{} <{}>", principal.name, principal.email),
         message,
+        ignore_hint,
     };
 
     if should_output_json(cli, None) {
         println!("{}", serde_json::to_string(&output)?);
     } else {
         println!("{}", output.message);
+        if let Some(hint) = &output.ignore_hint {
+            println!("  {}", hint.message);
+        }
     }
     Ok(())
 }

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -6,13 +6,13 @@
 //! brief; the Biscuit verifier rule is a future-work item. For now,
 //! `--force` is the explicit confirmation step.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use objects::object::ChangeId;
 use repo::Repository;
 use serde::Serialize;
 
 use crate::{
-    cli::{should_output_json, Cli, PurgeApplyArgs, PurgeCommands, PurgeListArgs},
+    cli::{Cli, PurgeApplyArgs, PurgeCommands, PurgeListArgs, should_output_json},
     config::UserConfig,
 };
 
@@ -85,7 +85,7 @@ fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result
         );
     }
 
-    let ignore_hint = super::redact::ignore_hint_for_path(repo.root(), &args.path);
+    let ignore_hint = super::redact::ignore_hint_for_path(repo, &args.path)?;
 
     let output = PurgeApplyOutput {
         redaction_id: outcome.redaction_id.map(|h| h.short()),

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -15,19 +15,22 @@
 //! path) so a leaked secret is scrubbed everywhere it appears — across
 //! renames, copies, and parallel branches.
 
-use std::path::Path;
+use std::path::PathBuf;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
-use crypto::{load_signer, verify_payload_signature, Signer};
-use ignore::gitignore::GitignoreBuilder;
-use objects::object::{ChangeId, ContentHash, Redaction, RedactionsBlob, StateSignature};
+use crypto::{Signer, load_signer, verify_payload_signature};
+use objects::{
+    object::{ChangeId, ContentHash, Redaction, RedactionsBlob, StateSignature},
+    worktree::should_ignore,
+};
 use repo::Repository;
 use serde::Serialize;
 
 use crate::{
     cli::{
-        should_output_json, Cli, RedactApplyArgs, RedactCommands, RedactListArgs, RedactShowArgs,
+        Cli, RedactApplyArgs, RedactCommands, RedactListArgs, RedactShowArgs, RedactTrustAddArgs,
+        RedactTrustCommands, RedactTrustListArgs, RedactTrustRemoveArgs, should_output_json,
     },
     config::UserConfig,
 };
@@ -39,6 +42,7 @@ pub fn cmd_redact(cli: &Cli, command: RedactCommands) -> Result<()> {
         RedactCommands::Apply(args) => cmd_redact_apply(cli, &repo, args),
         RedactCommands::List(args) => cmd_redact_list(cli, &repo, args),
         RedactCommands::Show(args) => cmd_redact_show(cli, &repo, args),
+        RedactCommands::Trust(sub) => cmd_redact_trust(cli, &repo, sub),
     }
 }
 
@@ -161,7 +165,7 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
     }
     let _ = extra_oplog_entries; // surfaced via the redactions list/oplog; not in primary output
 
-    let ignore_hint = ignore_hint_for_path(repo.root(), &args.path);
+    let ignore_hint = ignore_hint_for_path(repo, &args.path)?;
 
     let output = RedactApplyOutput {
         redaction_id: primary_id.short(),
@@ -181,20 +185,25 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
     emit_apply(cli, &output)
 }
 
-/// Suggestion to add a redacted path to an ignore file so it doesn't
-/// get re-captured on the next snapshot. Returned as `None` when the
-/// path is already covered by an existing `.heddleignore` or
-/// `.gitignore` rule — gitignore-style glob matching, not literal
-/// substring, so `config/*.toml` correctly suppresses the hint for
-/// `config/secrets.toml`.
+/// Suggestion to add a redacted path to `.heddleignore` so it doesn't
+/// get re-captured on the next `heddle capture`. Returned as `None`
+/// when the path is already covered by heddle's *effective* ignore
+/// set — i.e. `Repository::ignore_patterns()`, which is what the
+/// capture/walker actually consults: `.heddleignore` + the
+/// `worktree.ignore` patterns in `.heddle/config.toml`.
+///
+/// Crucially we do NOT treat `.gitignore` coverage as suppression:
+/// `heddle capture` never reads `.gitignore`, so a path covered only
+/// there can still be re-captured. The hint must surface in that case.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct IgnoreHint {
     /// Path to the ignore file we'd append to, relative to the repo
-    /// root (e.g. `.heddleignore` or `.gitignore`). Even when
-    /// `already_exists` is `false`, this names the recommended target.
+    /// root. Always `.heddleignore` — heddle's capture path doesn't
+    /// read `.gitignore`, so suggesting `.gitignore` would be a
+    /// false-negative on the leak-prevention guidance.
     pub ignore_file: String,
-    /// Whether the recommended ignore file is already present on disk.
-    /// `false` means the user would also create the file in the same
+    /// Whether `.heddleignore` is already present on disk. `false`
+    /// means the operator would also create the file in the same
     /// step as appending the pattern.
     pub already_exists: bool,
     /// The pattern to append. We suggest the literal redacted path
@@ -206,83 +215,38 @@ pub(crate) struct IgnoreHint {
     pub message: String,
 }
 
-/// If the redacted path is not yet covered by `.heddleignore` or
-/// `.gitignore` glob rules, return a hint pointing at the right file
-/// to append to. Returns `None` when the path is already ignored
-/// somewhere (because in that case adding a duplicate rule would just
-/// be noise).
-///
-/// Selection: prefer `.heddleignore` (heddle-native) when both are
-/// absent; fall back to whichever file exists. When both exist, the
-/// matcher checks both before deciding — if either covers the path,
-/// we emit no hint.
-pub(crate) fn ignore_hint_for_path(repo_root: &Path, path: &str) -> Option<IgnoreHint> {
-    let heddleignore = repo_root.join(".heddleignore");
-    let gitignore = repo_root.join(".gitignore");
-    let heddleignore_exists = heddleignore.is_file();
-    let gitignore_exists = gitignore.is_file();
-
-    // Already covered by either ignore file? Don't nag.
-    if heddleignore_exists && ignore_file_covers(repo_root, &heddleignore, path) {
-        return None;
-    }
-    if gitignore_exists && ignore_file_covers(repo_root, &gitignore, path) {
-        return None;
+/// If `path` is not yet covered by heddle's effective ignore set,
+/// return a hint pointing at `.heddleignore`. Suppression mirrors the
+/// exact patterns `heddle capture` consults
+/// (`Repository::ignore_patterns()` = `.heddleignore` + repo config
+/// `worktree.ignore`), so the hint never gives a false sense of
+/// safety just because `.gitignore` happens to mention the path.
+pub(crate) fn ignore_hint_for_path(repo: &Repository, path: &str) -> Result<Option<IgnoreHint>> {
+    let patterns = repo
+        .ignore_patterns()
+        .with_context(|| "load .heddleignore patterns for redact-hint coverage check")?;
+    if should_ignore(&PathBuf::from(path), &patterns) {
+        return Ok(None);
     }
 
-    // Pick the file the operator should edit. `.heddleignore` first,
-    // then `.gitignore`, then a fresh `.heddleignore` if neither
-    // exists. Reasoning: in git-overlay mode `.gitignore` is the lived
-    // surface, but `.heddleignore` overrides for heddle-internal scans
-    // and is the right place to scope a heddle-specific exclusion.
-    let (file, exists) = if heddleignore_exists {
-        (".heddleignore", true)
-    } else if gitignore_exists {
-        (".gitignore", true)
-    } else {
-        (".heddleignore", false)
-    };
-
+    let heddleignore = repo.root().join(".heddleignore");
+    let exists = heddleignore.is_file();
     let message = if exists {
         format!(
-            "hint: add `{path}` to {file} so the next `heddle capture` doesn't re-import the leaked bytes"
+            "hint: add `{path}` to .heddleignore so the next `heddle capture` doesn't re-import the leaked bytes"
         )
     } else {
         format!(
-            "hint: create {file} with `{path}` so the next `heddle capture` doesn't re-import the leaked bytes"
+            "hint: create .heddleignore with `{path}` so the next `heddle capture` doesn't re-import the leaked bytes"
         )
     };
 
-    Some(IgnoreHint {
-        ignore_file: file.to_string(),
+    Ok(Some(IgnoreHint {
+        ignore_file: ".heddleignore".to_string(),
         already_exists: exists,
         suggested_pattern: path.to_string(),
         message,
-    })
-}
-
-/// Whether `ignore_file` (a `.gitignore`-syntax file) covers
-/// `target_path` via any of its glob rules. Uses the standard
-/// `ignore::gitignore` matcher so `config/*.toml`, `**/*.pem`,
-/// `!keep.me`, and other gitignore-spec patterns all behave as
-/// operators expect.
-fn ignore_file_covers(repo_root: &Path, ignore_file: &Path, target_path: &str) -> bool {
-    let mut builder = GitignoreBuilder::new(repo_root);
-    if builder.add(ignore_file).is_some() {
-        // `GitignoreBuilder::add` returns Some(err) on failure. A
-        // missing or unreadable file isn't surfaced to the user — we
-        // can't usefully match against it either way; treat as
-        // "not covered" so the operator sees the hint.
-        return false;
-    }
-    let Ok(gi) = builder.build() else {
-        return false;
-    };
-    let absolute = repo_root.join(target_path);
-    matches!(
-        gi.matched(&absolute, /* is_dir */ false),
-        ignore::Match::Ignore(_)
-    )
+    }))
 }
 
 /// Build a `StateSignature` over a redaction's canonical signing payload.
@@ -615,4 +579,238 @@ fn hex_encode(bytes: &[u8]) -> String {
         let _ = write!(out, "{:02x}", b);
     }
     out
+}
+
+// ---------------------------------------------------------------------
+// `heddle redact trust` — manage the operator trust list
+//
+// The trust list lives in `[redact] trusted_keys` of
+// `.heddle/config.toml`. `Repository::accept_wire_redactions` consults
+// it at wire-receive time; an empty list rejects every signed
+// redaction (fail-closed). Operators run `trust add` after an
+// out-of-band exchange of public key bytes with the redaction's
+// signer — same workflow as gpg/ssh trust setup.
+// ---------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct TrustEntryOutput {
+    algorithm: String,
+    public_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TrustListOutput {
+    trusted_keys: Vec<TrustEntryOutput>,
+    count: usize,
+}
+
+fn cmd_redact_trust(cli: &Cli, repo: &Repository, command: RedactTrustCommands) -> Result<()> {
+    match command {
+        RedactTrustCommands::Add(args) => cmd_redact_trust_add(cli, repo, args),
+        RedactTrustCommands::List(args) => cmd_redact_trust_list(cli, repo, args),
+        RedactTrustCommands::Remove(args) => cmd_redact_trust_remove(cli, repo, args),
+    }
+}
+
+fn cmd_redact_trust_add(cli: &Cli, repo: &Repository, args: RedactTrustAddArgs) -> Result<()> {
+    let (algorithm, public_key) = match (args.from_pem, args.algorithm, args.public_key) {
+        (Some(pem_path), _, _) => {
+            // Reuse the existing PEM loader — same code path operators
+            // hit via `--sign-with`, so a PEM that works for signing
+            // works for trust-add too.
+            let signer = crypto::load_signer(&pem_path, None)
+                .with_context(|| format!("load signer from '{}'", pem_path.display()))?;
+            (
+                signer.algorithm().to_string(),
+                hex::encode(signer.public_key()),
+            )
+        }
+        (None, Some(algorithm), Some(public_key)) => (algorithm, public_key),
+        (None, _, _) => {
+            return Err(anyhow!(
+                "supply either `--from-pem <PATH>` or both `--algorithm` and `--public-key`"
+            ));
+        }
+    };
+
+    // Round-trip the config through toml::Value so we don't have to
+    // re-serialize the entire typed config (which would lose
+    // operator-added comments and table ordering).
+    let config_path = repo.heddle_dir().join("config.toml");
+    let raw = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("read '{}'", config_path.display()))?;
+    let mut value: toml::Value = toml::from_str(&raw).with_context(|| "parse repo config")?;
+    let root = value
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("repo config root must be a TOML table"))?;
+    let redact = root
+        .entry("redact".to_string())
+        .or_insert_with(|| toml::Value::Table(Default::default()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("[redact] section must be a table"))?;
+    let trusted_keys = redact
+        .entry("trusted_keys".to_string())
+        .or_insert_with(|| toml::Value::Array(Vec::new()))
+        .as_array_mut()
+        .ok_or_else(|| anyhow!("`trusted_keys` must be an array"))?;
+
+    // Refuse duplicates — operators get a clear signal that the key
+    // is already trusted rather than silently adding a second entry
+    // (`accept_wire_redactions` would tolerate dupes but the on-disk
+    // config drifts away from `cargo fmt`-clean noise-free state).
+    let already_trusted = trusted_keys.iter().any(|entry| {
+        entry
+            .get("algorithm")
+            .and_then(|v| v.as_str())
+            .map(|a| a.eq_ignore_ascii_case(&algorithm))
+            .unwrap_or(false)
+            && entry
+                .get("public_key")
+                .and_then(|v| v.as_str())
+                .map(|k| k.eq_ignore_ascii_case(&public_key))
+                .unwrap_or(false)
+    });
+    if already_trusted {
+        return Err(anyhow!(
+            "key {algorithm}:{public_key} is already in the trust list"
+        ));
+    }
+
+    let mut entry = toml::value::Table::new();
+    entry.insert(
+        "algorithm".to_string(),
+        toml::Value::String(algorithm.clone()),
+    );
+    entry.insert(
+        "public_key".to_string(),
+        toml::Value::String(public_key.clone()),
+    );
+    if let Some(label) = &args.label {
+        entry.insert("label".to_string(), toml::Value::String(label.clone()));
+    }
+    trusted_keys.push(toml::Value::Table(entry));
+
+    let serialized = toml::to_string(&value).with_context(|| "serialize patched repo config")?;
+    std::fs::write(&config_path, serialized)
+        .with_context(|| format!("write '{}'", config_path.display()))?;
+
+    let output = TrustEntryOutput {
+        algorithm,
+        public_key,
+        label: args.label,
+    };
+    if should_output_json(cli, None) {
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!(
+            "trusted {} key {} ({})",
+            output.algorithm,
+            short_key(&output.public_key),
+            output.label.as_deref().unwrap_or("unlabeled"),
+        );
+    }
+    Ok(())
+}
+
+fn cmd_redact_trust_list(cli: &Cli, repo: &Repository, _args: RedactTrustListArgs) -> Result<()> {
+    let keys: Vec<TrustEntryOutput> = repo
+        .config()
+        .redact
+        .trusted_keys
+        .iter()
+        .map(|k| TrustEntryOutput {
+            algorithm: k.algorithm.clone(),
+            public_key: k.public_key.clone(),
+            label: k.label.clone(),
+        })
+        .collect();
+    let count = keys.len();
+    let output = TrustListOutput {
+        trusted_keys: keys,
+        count,
+    };
+    if should_output_json(cli, Some(repo.config())) {
+        println!("{}", serde_json::to_string(&output)?);
+    } else if count == 0 {
+        println!("no trusted operator keys");
+    } else {
+        println!("{count} trusted operator key(s):");
+        for k in &output.trusted_keys {
+            println!(
+                "  {} {} ({})",
+                k.algorithm,
+                short_key(&k.public_key),
+                k.label.as_deref().unwrap_or("unlabeled"),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn cmd_redact_trust_remove(
+    cli: &Cli,
+    repo: &Repository,
+    args: RedactTrustRemoveArgs,
+) -> Result<()> {
+    let config_path = repo.heddle_dir().join("config.toml");
+    let raw = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("read '{}'", config_path.display()))?;
+    let mut value: toml::Value = toml::from_str(&raw).with_context(|| "parse repo config")?;
+    let root = value
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("repo config root must be a TOML table"))?;
+    let Some(redact) = root.get_mut("redact").and_then(|v| v.as_table_mut()) else {
+        return Err(anyhow!("no [redact] section in config; nothing to remove"));
+    };
+    let Some(trusted_keys) = redact
+        .get_mut("trusted_keys")
+        .and_then(|v| v.as_array_mut())
+    else {
+        return Err(anyhow!(
+            "no `trusted_keys` array in [redact]; nothing to remove"
+        ));
+    };
+
+    let before = trusted_keys.len();
+    trusted_keys.retain(|entry| {
+        entry
+            .get("public_key")
+            .and_then(|v| v.as_str())
+            .map(|k| !k.eq_ignore_ascii_case(&args.public_key))
+            .unwrap_or(true)
+    });
+    let removed = before - trusted_keys.len();
+    if removed == 0 {
+        return Err(anyhow!(
+            "no trusted key matched `{}` — nothing removed",
+            args.public_key
+        ));
+    }
+
+    let serialized = toml::to_string(&value).with_context(|| "serialize patched repo config")?;
+    std::fs::write(&config_path, serialized)
+        .with_context(|| format!("write '{}'", config_path.display()))?;
+
+    if should_output_json(cli, None) {
+        println!("{{\"removed\":{removed}}}");
+    } else {
+        println!(
+            "removed {removed} trust entry/entries matching {}",
+            args.public_key
+        );
+    }
+    Ok(())
+}
+
+/// Short-form display for a hex-encoded public key. Same length as
+/// the redaction-id shortener: first 16 chars, which is plenty to
+/// disambiguate within a single repo's trust list.
+fn short_key(hex: &str) -> String {
+    if hex.len() <= 16 {
+        hex.to_string()
+    } else {
+        format!("{}…", &hex[..16])
+    }
 }

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -15,16 +15,19 @@
 //! path) so a leaked secret is scrubbed everywhere it appears — across
 //! renames, copies, and parallel branches.
 
-use anyhow::{Context, Result, anyhow};
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
-use crypto::{Signer, load_signer, verify_payload_signature};
+use crypto::{load_signer, verify_payload_signature, Signer};
+use ignore::gitignore::GitignoreBuilder;
 use objects::object::{ChangeId, ContentHash, Redaction, RedactionsBlob, StateSignature};
 use repo::Repository;
 use serde::Serialize;
 
 use crate::{
     cli::{
-        Cli, RedactApplyArgs, RedactCommands, RedactListArgs, RedactShowArgs, should_output_json,
+        should_output_json, Cli, RedactApplyArgs, RedactCommands, RedactListArgs, RedactShowArgs,
     },
     config::UserConfig,
 };
@@ -57,6 +60,12 @@ struct RedactApplyOutput {
     /// Signature algorithm (`ed25519`, `rsa`, `p256`) when `signed`.
     #[serde(skip_serializing_if = "Option::is_none")]
     signature_algorithm: Option<String>,
+    /// Hint to add the redacted path to `.heddleignore` / `.gitignore`
+    /// so subsequent captures don't re-import the leaked bytes from
+    /// the working tree. `None` when the path is already covered by a
+    /// glob rule in either file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_hint: Option<IgnoreHint>,
 }
 
 fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Result<()> {
@@ -152,6 +161,8 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
     }
     let _ = extra_oplog_entries; // surfaced via the redactions list/oplog; not in primary output
 
+    let ignore_hint = ignore_hint_for_path(repo.root(), &args.path);
+
     let output = RedactApplyOutput {
         redaction_id: primary_id.short(),
         blob: blob.short(),
@@ -164,9 +175,114 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
         states_redacted,
         signed: signer.is_some(),
         signature_algorithm,
+        ignore_hint,
     };
 
     emit_apply(cli, &output)
+}
+
+/// Suggestion to add a redacted path to an ignore file so it doesn't
+/// get re-captured on the next snapshot. Returned as `None` when the
+/// path is already covered by an existing `.heddleignore` or
+/// `.gitignore` rule — gitignore-style glob matching, not literal
+/// substring, so `config/*.toml` correctly suppresses the hint for
+/// `config/secrets.toml`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct IgnoreHint {
+    /// Path to the ignore file we'd append to, relative to the repo
+    /// root (e.g. `.heddleignore` or `.gitignore`). Even when
+    /// `already_exists` is `false`, this names the recommended target.
+    pub ignore_file: String,
+    /// Whether the recommended ignore file is already present on disk.
+    /// `false` means the user would also create the file in the same
+    /// step as appending the pattern.
+    pub already_exists: bool,
+    /// The pattern to append. We suggest the literal redacted path
+    /// here; operators who want a broader glob (`config/*.toml`) can
+    /// edit before saving.
+    pub suggested_pattern: String,
+    /// Human-readable hint shown in text mode. Pre-formatted so the
+    /// JSON consumer can surface it verbatim if they prefer.
+    pub message: String,
+}
+
+/// If the redacted path is not yet covered by `.heddleignore` or
+/// `.gitignore` glob rules, return a hint pointing at the right file
+/// to append to. Returns `None` when the path is already ignored
+/// somewhere (because in that case adding a duplicate rule would just
+/// be noise).
+///
+/// Selection: prefer `.heddleignore` (heddle-native) when both are
+/// absent; fall back to whichever file exists. When both exist, the
+/// matcher checks both before deciding — if either covers the path,
+/// we emit no hint.
+pub(crate) fn ignore_hint_for_path(repo_root: &Path, path: &str) -> Option<IgnoreHint> {
+    let heddleignore = repo_root.join(".heddleignore");
+    let gitignore = repo_root.join(".gitignore");
+    let heddleignore_exists = heddleignore.is_file();
+    let gitignore_exists = gitignore.is_file();
+
+    // Already covered by either ignore file? Don't nag.
+    if heddleignore_exists && ignore_file_covers(repo_root, &heddleignore, path) {
+        return None;
+    }
+    if gitignore_exists && ignore_file_covers(repo_root, &gitignore, path) {
+        return None;
+    }
+
+    // Pick the file the operator should edit. `.heddleignore` first,
+    // then `.gitignore`, then a fresh `.heddleignore` if neither
+    // exists. Reasoning: in git-overlay mode `.gitignore` is the lived
+    // surface, but `.heddleignore` overrides for heddle-internal scans
+    // and is the right place to scope a heddle-specific exclusion.
+    let (file, exists) = if heddleignore_exists {
+        (".heddleignore", true)
+    } else if gitignore_exists {
+        (".gitignore", true)
+    } else {
+        (".heddleignore", false)
+    };
+
+    let message = if exists {
+        format!(
+            "hint: add `{path}` to {file} so the next `heddle capture` doesn't re-import the leaked bytes"
+        )
+    } else {
+        format!(
+            "hint: create {file} with `{path}` so the next `heddle capture` doesn't re-import the leaked bytes"
+        )
+    };
+
+    Some(IgnoreHint {
+        ignore_file: file.to_string(),
+        already_exists: exists,
+        suggested_pattern: path.to_string(),
+        message,
+    })
+}
+
+/// Whether `ignore_file` (a `.gitignore`-syntax file) covers
+/// `target_path` via any of its glob rules. Uses the standard
+/// `ignore::gitignore` matcher so `config/*.toml`, `**/*.pem`,
+/// `!keep.me`, and other gitignore-spec patterns all behave as
+/// operators expect.
+fn ignore_file_covers(repo_root: &Path, ignore_file: &Path, target_path: &str) -> bool {
+    let mut builder = GitignoreBuilder::new(repo_root);
+    if builder.add(ignore_file).is_some() {
+        // `GitignoreBuilder::add` returns Some(err) on failure. A
+        // missing or unreadable file isn't surfaced to the user — we
+        // can't usefully match against it either way; treat as
+        // "not covered" so the operator sees the hint.
+        return false;
+    }
+    let Ok(gi) = builder.build() else {
+        return false;
+    };
+    let absolute = repo_root.join(target_path);
+    matches!(
+        gi.matched(&absolute, /* is_dir */ false),
+        ignore::Match::Ignore(_)
+    )
 }
 
 /// Build a `StateSignature` over a redaction's canonical signing payload.
@@ -388,6 +504,9 @@ fn emit_apply(cli: &Cli, output: &RedactApplyOutput) -> Result<()> {
         );
         if !output.reason.is_empty() {
             println!("  reason: {}", output.reason);
+        }
+        if let Some(hint) = &output.ignore_hint {
+            println!("  {}", hint.message);
         }
     }
     Ok(())

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Command-line interface for Heddle.
 
-use std::io::IsTerminal;
-use std::sync::OnceLock;
+use std::{io::IsTerminal, sync::OnceLock};
 
 pub mod cli_args;
 pub mod commands;
@@ -14,25 +13,26 @@ pub mod transaction_sentinel;
 
 #[cfg(feature = "client")]
 pub use cli_args::PresenceCommands;
-#[cfg(feature = "git-overlay")]
-pub use cli_args::{BridgeCommands, GitCommands};
+pub use cli_args::{
+    ActorCommands, AgentCommands, AttemptArgs, BisectCommands, CheckpointArgs, Cli, CloneArgs,
+    CollapseArgs, Commands, ContextCommands, DaemonCommands, DiagnoseArgs, DiffArgs, DoctorArgs,
+    DoctorCommands, DoctorDocsArgs, HookCommands, HookInstallSource, InitArgs, IntegrationCommands,
+    IntegrationInstallArgs, IntegrationRelayArgs, IntegrationTargetArgs, LogArgs,
+    MaintenanceCommands, MarkerCommands, MergeArgs, OutputMode, PullArgs, PurgeApplyArgs,
+    PurgeCommands, PurgeListArgs, PushArgs, ReadyArgs, RedactApplyArgs, RedactCommands,
+    RedactListArgs, RedactShowArgs, RedactTrustAddArgs, RedactTrustCommands, RedactTrustListArgs,
+    RedactTrustRemoveArgs, RemoteCommands, ResolveArgs, RetroArgs, RevertArgs, RunArgs,
+    SessionCommands, SessionEndArgs, SessionListArgs, SessionSegmentArgs, SessionShowArgs,
+    SessionStartArgs, SnapshotArgs, StashCommands, StoreCommands, ThreadAbsorbArgs,
+    ThreadCleanupArgs, ThreadCommands, ThreadDropArgs, ThreadListArgs, ThreadMoveArgs,
+    ThreadNameArgs, ThreadPromoteArgs, ThreadRenameArgs, ThreadResolveArgs, ThreadShowArgs,
+    ThreadStartArgs, TryArgs, UndoArgs, WatchArgs, WorkspaceCommands, WorkspaceModeArg,
+    WorkspaceShowArgs,
+};
 #[cfg(feature = "client")]
 pub use cli_args::{AuthCommands, SupportCommands};
-pub use cli_args::{
-    ActorCommands, AgentCommands, AttemptArgs, BisectCommands,
-    CheckpointArgs, Cli, CloneArgs, CollapseArgs, Commands, ContextCommands, DaemonCommands,
-    DiagnoseArgs, DiffArgs, DoctorArgs, DoctorCommands, DoctorDocsArgs, HookCommands,
-    HookInstallSource, InitArgs, IntegrationCommands, IntegrationInstallArgs, IntegrationRelayArgs,
-    IntegrationTargetArgs, LogArgs, MaintenanceCommands, MarkerCommands, MergeArgs, OutputMode,
-    PullArgs, PurgeApplyArgs, PurgeCommands, PurgeListArgs, PushArgs, ReadyArgs, RedactApplyArgs,
-    RedactCommands, RedactListArgs, RedactShowArgs, RemoteCommands, ResolveArgs, RetroArgs,
-    RevertArgs, RunArgs, SessionCommands, SessionEndArgs, SessionListArgs, SessionSegmentArgs,
-    SessionShowArgs, SessionStartArgs, SnapshotArgs, StashCommands, StoreCommands,
-    ThreadAbsorbArgs, ThreadCleanupArgs, ThreadCommands, ThreadDropArgs, ThreadListArgs,
-    ThreadMoveArgs, ThreadNameArgs, ThreadPromoteArgs, ThreadRenameArgs, ThreadResolveArgs,
-    ThreadShowArgs, ThreadStartArgs, TryArgs, UndoArgs, WatchArgs, WorkspaceCommands,
-    WorkspaceModeArg, WorkspaceShowArgs,
-};
+#[cfg(feature = "git-overlay")]
+pub use cli_args::{BridgeCommands, GitCommands};
 #[cfg(feature = "semantic")]
 pub use cli_args::{HotEventKindArg, HotSpotKeyArg, SemanticCommands};
 use repo::{Config, OutputFormat};

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -85,28 +85,56 @@ impl LocalSync {
         }
         visited.insert(*state_id);
 
-        // Check if target already has this state
-        if target.store().has_state(state_id)? {
-            return Ok(());
-        }
+        // Whether the target already has this state. We do NOT
+        // early-return on this — even when the object graph is fully
+        // present, an operator may have declared a redaction on the
+        // source *after* the target previously fetched the content.
+        // Subsequent syncs must still propagate the sidecar. We
+        // therefore always walk the tree(s) to surface redactions,
+        // and condition just the object-copy step on the
+        // `state_already_present` flag.
+        let state_already_present = target.store().has_state(state_id)?;
 
-        // Get the state from source
-        let state = self
-            .source
-            .store()
-            .get_state(state_id)?
-            .ok_or_else(|| anyhow!("State {} not found in source", state_id))?;
+        // Source-side state read drives both the object copy (when
+        // needed) and the redaction-propagation tree walk (always).
+        // If the source no longer has the state but the target does,
+        // we can't enumerate blob hashes for propagation — skip with
+        // no error in that case.
+        let state = match self.source.store().get_state(state_id)? {
+            Some(state) => state,
+            None if state_already_present => return Ok(()),
+            None => return Err(anyhow!("State {} not found in source", state_id)),
+        };
 
-        // Copy tree recursively
-        self.copy_tree_recursive(target, &state.tree, copied)?;
+        // Always propagate redactions for every blob in the state's
+        // trees, regardless of whether the trees themselves need
+        // copying. `propagate_redactions_in_tree` walks the trees
+        // without the has_tree fast-path so re-syncs after a redact
+        // still ferry the sidecar.
+        let mut propagated_trees: HashSet<ContentHash> = HashSet::new();
+        self.propagate_redactions_in_tree(target, &state.tree, &mut propagated_trees)?;
         if let Some(provenance_root) = state.provenance {
-            self.copy_tree_recursive(target, &provenance_root, copied)?;
+            self.propagate_redactions_in_tree(target, &provenance_root, &mut propagated_trees)?;
         }
         if let Some(context_root) = state.context {
-            self.copy_tree_recursive(target, &context_root, copied)?;
+            self.propagate_redactions_in_tree(target, &context_root, &mut propagated_trees)?;
         }
 
-        // Copy parent states recursively (if depth allows)
+        if !state_already_present {
+            // Copy tree recursively
+            self.copy_tree_recursive(target, &state.tree, copied)?;
+            if let Some(provenance_root) = state.provenance {
+                self.copy_tree_recursive(target, &provenance_root, copied)?;
+            }
+            if let Some(context_root) = state.context {
+                self.copy_tree_recursive(target, &context_root, copied)?;
+            }
+        }
+
+        // Copy parent states recursively (if depth allows). We recurse
+        // on parents even when the current state was already present —
+        // a redaction declared on an ancestor blob still needs to
+        // reach the target's redactions store.
         if let Some(depth) = max_depth {
             if depth > 0 {
                 for parent in &state.parents {
@@ -114,7 +142,9 @@ impl LocalSync {
                 }
             } else {
                 // Shallow state - mark parents as grafted
-                target.set_shallow(state_id, &state.parents)?;
+                if !state_already_present {
+                    target.set_shallow(state_id, &state.parents)?;
+                }
             }
         } else {
             for parent in &state.parents {
@@ -122,9 +152,10 @@ impl LocalSync {
             }
         }
 
-        // Store the state in target
-        target.store().put_state(&state)?;
-        *copied += 1;
+        if !state_already_present {
+            target.store().put_state(&state)?;
+            *copied += 1;
+        }
 
         Ok(())
     }
@@ -147,7 +178,10 @@ impl LocalSync {
             .get_tree(tree_hash)?
             .ok_or_else(|| anyhow!("Tree {} not found in source", tree_hash))?;
 
-        // Copy all blobs and sub-trees
+        // Copy all blobs and sub-trees. Redaction propagation lives
+        // in `propagate_redactions_in_tree`, called by
+        // `copy_state_recursive` regardless of whether the tree was
+        // already present — so it's intentionally absent here.
         for entry in tree.entries() {
             match entry.entry_type {
                 objects::object::EntryType::Blob => {
@@ -156,7 +190,6 @@ impl LocalSync {
                         target.store().put_blob(&blob)?;
                         *copied += 1;
                     }
-                    self.propagate_redactions_for_blob(target, &entry.hash)?;
                 }
                 objects::object::EntryType::Tree => {
                     self.copy_tree_recursive(target, &entry.hash, copied)?;
@@ -167,7 +200,6 @@ impl LocalSync {
                         target.store().put_blob(&blob)?;
                         *copied += 1;
                     }
-                    self.propagate_redactions_for_blob(target, &entry.hash)?;
                 }
             }
         }
@@ -176,6 +208,46 @@ impl LocalSync {
         target.store().put_tree(&tree)?;
         *copied += 1;
 
+        Ok(())
+    }
+
+    /// Walk a source-side tree and propagate any redaction sidecars
+    /// found for the blobs it references. Runs regardless of whether
+    /// the tree (or its parent state) is already present on the
+    /// target — the whole point is to recover from the "redact-after-
+    /// peer-fetched" flow where the object graph is unchanged but a
+    /// new sidecar exists upstream.
+    ///
+    /// `propagated_trees` dedups within a single sync so we don't
+    /// re-walk the same subtree across `state.tree`, `provenance`,
+    /// and `context` roots that happen to share content.
+    fn propagate_redactions_in_tree(
+        &self,
+        target: &Repository,
+        tree_hash: &ContentHash,
+        propagated_trees: &mut HashSet<ContentHash>,
+    ) -> Result<()> {
+        if !propagated_trees.insert(*tree_hash) {
+            return Ok(());
+        }
+
+        // Tree must come from the source — if it's missing there, we
+        // can't enumerate blob hashes for sidecar lookup. Treat as a
+        // gap in propagation (best-effort), not a hard failure.
+        let Some(tree) = self.source.store().get_tree(tree_hash)? else {
+            return Ok(());
+        };
+
+        for entry in tree.entries() {
+            match entry.entry_type {
+                objects::object::EntryType::Blob | objects::object::EntryType::Symlink => {
+                    self.propagate_redactions_for_blob(target, &entry.hash)?;
+                }
+                objects::object::EntryType::Tree => {
+                    self.propagate_redactions_in_tree(target, &entry.hash, propagated_trees)?;
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -156,6 +156,7 @@ impl LocalSync {
                         target.store().put_blob(&blob)?;
                         *copied += 1;
                     }
+                    self.propagate_redactions_for_blob(target, &entry.hash)?;
                 }
                 objects::object::EntryType::Tree => {
                     self.copy_tree_recursive(target, &entry.hash, copied)?;
@@ -166,6 +167,7 @@ impl LocalSync {
                         target.store().put_blob(&blob)?;
                         *copied += 1;
                     }
+                    self.propagate_redactions_for_blob(target, &entry.hash)?;
                 }
             }
         }
@@ -174,6 +176,24 @@ impl LocalSync {
         target.store().put_tree(&tree)?;
         *copied += 1;
 
+        Ok(())
+    }
+
+    /// If the source repository has any redactions for `blob`, ferry
+    /// the sidecar bytes through `Repository::accept_wire_redactions`
+    /// on the target so signatures are verified and any `purged_at`
+    /// records trigger a local purge on the target.
+    ///
+    /// `LocalSync` is local→local, so we use the same wire-side
+    /// contract as the network path — same signature requirement,
+    /// same idempotency. Operators who redact unsigned locally and
+    /// expect that to propagate via a local fetch will see a clear
+    /// rejection rather than a silent skip.
+    fn propagate_redactions_for_blob(&self, target: &Repository, blob: &ContentHash) -> Result<()> {
+        let Some(bytes) = self.source.store().get_redactions_bytes_for_blob(blob)? else {
+            return Ok(());
+        };
+        target.accept_wire_redactions(*blob, &bytes)?;
         Ok(())
     }
 

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -476,30 +476,37 @@ fn redact_apply_signed_propagates_to_cloned_replica() {
     let apply = signed_redact_on_repo_a(&a, &state, &pem_path);
     let redaction_id = apply["redaction_id"].as_str().unwrap().to_string();
 
-    // Clone A → B. `heddle clone` uses LocalSync, which propagates
-    // redaction sidecars via the new accept_wire_redactions hook.
+    // Set up B: init empty repo, trust A's signing key, then fetch.
+    // Operators do this on their own machine the first time they
+    // accept signed redactions from a new collaborator; the trust
+    // gate is fail-closed so signed records won't propagate until
+    // the operator explicitly authorizes the key.
     let b_dir = TempDir::new().unwrap();
     let b_path = b_dir.path().join("replica-b");
+    fs::create_dir_all(&b_path).unwrap();
+    heddle(&["init"], Some(&b_path)).expect("init B");
     heddle(
         &[
-            "clone",
-            a.path().to_str().unwrap(),
-            b_path.to_str().unwrap(),
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
         ],
-        Some(b_dir.path()),
+        Some(&b_path),
     )
-    .expect("clone A → B should succeed");
+    .expect("B trusts A's signing key");
+    heddle(
+        &["remote", "add", "origin", a.path().to_str().unwrap()],
+        Some(&b_path),
+    )
+    .expect("remote add origin");
+    heddle(&["fetch", "origin"], Some(&b_path)).expect("fetch propagates signed redaction to B");
 
     // B's redact list must include the propagated redaction. The
     // worktree-stub contract is tested separately by the local
     // materialize tests; here we pin the propagation contract: A's
-    // redaction record exists in B's local sidecar after clone.
-    //
-    // (`heddle clone` for file:// uses a fast-path `copy_worktree` that
-    // mirrors A's actual on-disk files, so worktree contents on B are
-    // a property of A's worktree state at clone time, not of B's
-    // post-clone object store. The post-clone materialize that renders
-    // stubs only happens on the next `heddle goto`.)
+    // redaction record exists in B's local sidecar after fetch.
     let list_raw = heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap();
     let list: Value = serde_json::from_str(&list_raw).unwrap();
     let rows = list["redactions"].as_array().expect("redactions array");
@@ -587,17 +594,29 @@ fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
     )
     .expect("purge on A succeeds");
 
+    // Set up B with explicit trust for A's signing key, then fetch.
     let b_dir = TempDir::new().unwrap();
     let b_path = b_dir.path().join("replica-b");
+    fs::create_dir_all(&b_path).unwrap();
+    heddle(&["init"], Some(&b_path)).expect("init B");
     heddle(
         &[
-            "clone",
-            a.path().to_str().unwrap(),
-            b_path.to_str().unwrap(),
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
         ],
-        Some(b_dir.path()),
+        Some(&b_path),
     )
-    .expect("clone A → B with purged redaction should succeed");
+    .expect("B trusts A's signing key");
+    heddle(
+        &["remote", "add", "origin", a.path().to_str().unwrap()],
+        Some(&b_path),
+    )
+    .expect("remote add origin");
+    heddle(&["fetch", "origin"], Some(&b_path))
+        .expect("fetch propagates signed redaction + purge to B");
 
     // B must record the purge.
     let purge_list_raw = heddle(&["--output", "json", "purge", "list"], Some(&b_path)).unwrap();
@@ -616,7 +635,7 @@ fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
 }
 
 #[test]
-fn tampered_redaction_is_refused_at_clone_boundary() {
+fn tampered_redaction_is_refused_at_fetch_boundary() {
     use crypto::Ed25519Signer;
     use objects::object::RedactionsBlob;
 
@@ -645,20 +664,34 @@ fn tampered_redaction_is_refused_at_clone_boundary() {
     // The above forfeits A's own materialize-side stub correctness;
     // the local invariant break is the point of the test.
 
+    // B trusts the signing key, so the trust gate passes — the
+    // rejection comes from signature verification failing on the
+    // tampered canonical payload (Tampered, not UntrustedKey).
     let b_dir = TempDir::new().unwrap();
     let b_path = b_dir.path().join("replica-b");
-    let err = heddle(
+    fs::create_dir_all(&b_path).unwrap();
+    heddle(&["init"], Some(&b_path)).expect("init B");
+    heddle(
         &[
-            "clone",
-            a.path().to_str().unwrap(),
-            b_path.to_str().unwrap(),
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
         ],
-        Some(b_dir.path()),
+        Some(&b_path),
     )
-    .expect_err("clone must refuse a tampered redaction");
+    .expect("B trusts A's signing key");
+    heddle(
+        &["remote", "add", "origin", a.path().to_str().unwrap()],
+        Some(&b_path),
+    )
+    .expect("remote add origin");
+    let err = heddle(&["fetch", "origin"], Some(&b_path))
+        .expect_err("fetch must refuse a tampered redaction");
     assert!(
         err.contains("failed to verify") || err.contains("Tampered") || err.contains("tampered"),
-        "clone rejection must explain the tamper cause: {err}"
+        "fetch rejection must explain the tamper cause: {err}"
     );
 }
 
@@ -708,10 +741,12 @@ fn redact_apply_emits_ignore_hint_when_neither_file_covers_path() {
         hint["suggested_pattern"].as_str().unwrap(),
         "config/secrets.toml"
     );
-    assert!(hint["message"]
-        .as_str()
-        .unwrap()
-        .contains("config/secrets.toml"));
+    assert!(
+        hint["message"]
+            .as_str()
+            .unwrap()
+            .contains("config/secrets.toml")
+    );
 }
 
 #[test]
@@ -727,34 +762,65 @@ fn redact_apply_emits_no_hint_when_heddleignore_literal_matches() {
 }
 
 #[test]
-fn redact_apply_emits_no_hint_when_gitignore_glob_matches() {
-    // Glob coverage (`config/*.toml`) in `.gitignore`. This is the
-    // critical case the user called out — the matcher must use
-    // gitignore-spec glob semantics, not literal substring.
+fn redact_apply_emits_no_hint_when_heddleignore_glob_matches() {
+    // Glob coverage (`config/*.toml`) in `.heddleignore` — the matcher
+    // uses gitignore-spec globs, not literal substring, so a broad
+    // rule that already covers the leaked path suppresses the hint.
     let (temp, state) = setup_repo_with_secret();
-    fs::write(temp.path().join(".gitignore"), "config/*.toml\n").unwrap();
+    fs::write(temp.path().join(".heddleignore"), "config/*.toml\n").unwrap();
     let apply = redact_apply_json(&temp, &state);
     assert!(
         apply.get("ignore_hint").is_none() || apply["ignore_hint"].is_null(),
-        "glob coverage in .gitignore must suppress the hint: {apply:?}"
+        "glob coverage in .heddleignore must suppress the hint: {apply:?}"
     );
 }
 
 #[test]
-fn redact_apply_targets_heddleignore_when_only_gitignore_exists_but_misses() {
-    // `.gitignore` exists but doesn't cover this path; `.heddleignore`
-    // is absent. The hint must point at `.gitignore` (the only present
-    // file), with `already_exists: true`.
+fn redact_apply_emits_hint_when_only_gitignore_covers_the_path() {
+    // `.gitignore` covers `config/*.toml` but `.heddleignore` doesn't.
+    // `heddle capture` reads `.heddleignore` + repo config, NOT
+    // `.gitignore`, so the next snapshot would still re-import the
+    // leaked bytes. The hint must surface, pointing at `.heddleignore`
+    // (the file heddle actually consults).
     let (temp, state) = setup_repo_with_secret();
-    fs::write(temp.path().join(".gitignore"), "target/\nnode_modules/\n").unwrap();
+    fs::write(temp.path().join(".gitignore"), "config/*.toml\n").unwrap();
     let apply = redact_apply_json(&temp, &state);
     let hint = apply
         .get("ignore_hint")
-        .expect("hint must surface when .gitignore exists but doesn't cover the path");
-    assert_eq!(hint["ignore_file"].as_str().unwrap(), ".gitignore");
+        .expect(".gitignore coverage must NOT suppress the heddle-ignore hint");
+    assert_eq!(
+        hint["ignore_file"].as_str().unwrap(),
+        ".heddleignore",
+        ".gitignore is not consulted by heddle capture; hint must target .heddleignore"
+    );
     assert!(
-        hint["already_exists"].as_bool().unwrap(),
-        "should report the existing .gitignore"
+        !hint["already_exists"].as_bool().unwrap(),
+        "should report .heddleignore as not-yet-present"
+    );
+}
+
+#[test]
+fn redact_apply_emits_no_hint_when_repo_config_ignore_covers_path() {
+    // `worktree.ignore` in `.heddle/config.toml` is part of heddle's
+    // effective ignore set (see `Repository::ignore_patterns`). A
+    // pattern in repo config must suppress the hint even with no
+    // `.heddleignore` file on disk. Splice the additional pattern
+    // into the existing `[worktree] ignore = [...]` array instead of
+    // appending a duplicate section header (which `heddle init`
+    // already writes).
+    let (temp, state) = setup_repo_with_secret();
+    let config_path = temp.path().join(".heddle/config.toml");
+    let existing = fs::read_to_string(&config_path).expect("read default config");
+    let patched = existing.replace("ignore = [", "ignore = [\n    \"config/*.toml\",");
+    assert_ne!(
+        existing, patched,
+        "test fixture expected `ignore = [` in default config"
+    );
+    fs::write(&config_path, patched).unwrap();
+    let apply = redact_apply_json(&temp, &state);
+    assert!(
+        apply.get("ignore_hint").is_none() || apply["ignore_hint"].is_null(),
+        "repo-config worktree.ignore coverage must suppress the hint: {apply:?}"
     );
 }
 
@@ -798,4 +864,193 @@ fn purge_apply_also_emits_ignore_hint() {
         .expect("purge output must include ignore_hint");
     assert_eq!(hint["ignore_file"].as_str().unwrap(), ".heddleignore");
     assert!(!hint["already_exists"].as_bool().unwrap());
+}
+
+#[test]
+fn redact_after_peer_fetch_still_propagates_on_resync() {
+    // Scenario the codex review flagged: peer B clones A *first*,
+    // then A declares a redaction. A second clone-from-A would find
+    // every state/tree/blob already present locally and previously
+    // would short-circuit before propagating the sidecar. The
+    // post-fix behavior: redactions ferry through even when the
+    // object graph hasn't changed.
+    use crypto::Ed25519Signer;
+
+    let (a, state) = setup_repo_with_secret();
+
+    // Peer B clones BEFORE the redaction is declared on A.
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    heddle(
+        &[
+            "clone",
+            a.path().to_str().unwrap(),
+            b_path.to_str().unwrap(),
+        ],
+        Some(b_dir.path()),
+    )
+    .expect("initial clone A → B");
+    let list_before: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        list_before["redactions"].as_array().unwrap().len(),
+        0,
+        "B has no redactions yet (declared on A only after clone)"
+    );
+
+    // Now A declares + signs the redaction.
+    let signer = Ed25519Signer::generate().unwrap();
+    let pem = signer.to_pem().unwrap();
+    let pem_path = a.path().join("ed25519.pem");
+    fs::write(&pem_path, &pem).unwrap();
+    let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
+
+    // Re-sync: B trusts A's signing key, registers A as a remote,
+    // then `heddle fetch origin` should ferry the sidecar even
+    // though every state/tree/blob is already present on B. Trust
+    // setup happens after the initial clone (which used no signed
+    // redactions, so didn't need trust) — same operator pattern
+    // they'd run once after a peer publishes their signing key.
+    heddle(
+        &[
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
+        ],
+        Some(&b_path),
+    )
+    .expect("B trusts A's signing key");
+    heddle(
+        &["remote", "add", "origin", a.path().to_str().unwrap()],
+        Some(&b_path),
+    )
+    .expect("remote add origin");
+    heddle(&["fetch", "origin"], Some(&b_path)).expect("re-fetch A → B after redaction declared");
+
+    let list_after: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        list_after["redactions"].as_array().unwrap().len(),
+        1,
+        "B must see the post-clone redaction after re-fetch: {list_after:?}"
+    );
+}
+
+#[test]
+fn untrusted_signed_redaction_is_refused_at_fetch_boundary() {
+    // Codex P1: signature verification alone is integrity, not
+    // authentication. Without a trust check the receiver accepts
+    // *any* mathematically-valid signature, including one minted by
+    // an attacker with their own key.
+    //
+    // This test pins the fail-closed default end-to-end: B receives
+    // a signed redaction from A, but B has *not* added A's key to
+    // its trust list. The fetch must refuse with `UntrustedKey`,
+    // and B's local store must be unchanged.
+    use crypto::Ed25519Signer;
+
+    let (a, state) = setup_repo_with_secret();
+    let attacker = Ed25519Signer::generate().unwrap();
+    let pem = attacker.to_pem().unwrap();
+    let pem_path = a.path().join("attacker.pem");
+    fs::write(&pem_path, &pem).unwrap();
+    let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
+
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    fs::create_dir_all(&b_path).unwrap();
+    heddle(&["init"], Some(&b_path)).expect("init B");
+    // Intentionally skip `heddle redact trust add` — B does NOT
+    // trust the attacker's key.
+    heddle(
+        &["remote", "add", "origin", a.path().to_str().unwrap()],
+        Some(&b_path),
+    )
+    .expect("remote add origin");
+    let err = heddle(&["fetch", "origin"], Some(&b_path))
+        .expect_err("fetch must refuse untrusted signed redaction");
+    assert!(
+        err.contains("untrusted operator key"),
+        "fetch rejection must explain the untrusted-key cause: {err}"
+    );
+
+    // B's local redaction store must remain empty.
+    let list: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        list["redactions"].as_array().unwrap().len(),
+        0,
+        "B must have no redactions after refusal; refusal is atomic"
+    );
+}
+
+#[test]
+fn redact_trust_add_and_list_round_trip() {
+    // Operator-facing smoke: `heddle redact trust add --from-pem`
+    // produces an entry that `heddle redact trust list` surfaces.
+    use crypto::Ed25519Signer;
+
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    let signer = Ed25519Signer::generate().unwrap();
+    let pem = signer.to_pem().unwrap();
+    let pem_path = temp.path().join("key.pem");
+    fs::write(&pem_path, &pem).unwrap();
+
+    let add_raw = heddle(
+        &[
+            "--output",
+            "json",
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
+            "--label",
+            "test-key",
+        ],
+        Some(temp.path()),
+    )
+    .expect("trust add");
+    let add: Value = serde_json::from_str(&add_raw).unwrap();
+    assert_eq!(add["algorithm"].as_str().unwrap(), "ed25519");
+    assert_eq!(add["label"].as_str().unwrap(), "test-key");
+    let pubkey_hex = add["public_key"].as_str().unwrap().to_string();
+
+    let list_raw = heddle(
+        &["--output", "json", "redact", "trust", "list"],
+        Some(temp.path()),
+    )
+    .expect("trust list");
+    let list: Value = serde_json::from_str(&list_raw).unwrap();
+    assert_eq!(list["count"].as_u64().unwrap(), 1);
+    let entries = list["trusted_keys"].as_array().unwrap();
+    assert_eq!(entries[0]["public_key"].as_str().unwrap(), pubkey_hex);
+    assert_eq!(entries[0]["label"].as_str().unwrap(), "test-key");
+
+    // Re-adding the same key fails — operators get a clear signal
+    // rather than silent duplicate entries.
+    let err = heddle(
+        &[
+            "redact",
+            "trust",
+            "add",
+            "--from-pem",
+            pem_path.to_str().unwrap(),
+        ],
+        Some(temp.path()),
+    )
+    .expect_err("re-add must refuse duplicates");
+    assert!(
+        err.contains("already in the trust list"),
+        "duplicate-trust rejection must be clear: {err}"
+    );
 }

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -421,3 +421,381 @@ fn purge_without_prior_redact_is_refused() {
         "refusal must name the missing-redaction precondition: {err}"
     );
 }
+
+// ---------------------------------------------------------------------
+// Cross-replica propagation tests
+//
+// The redact + purge surface is local-only without wire propagation —
+// pulls on a peer replica would re-expose the secret. These tests pin
+// the propagation contract via `heddle clone` (which goes through
+// `LocalSync`):
+//
+//   - Signed redactions: propagate, renders stub on B's worktree.
+//   - Signed purge: propagates, drops bytes on B.
+//   - Unsigned redactions: refused on the wire; local-only on A.
+//   - Tampered signatures: refused on the wire.
+//
+// All four use `heddle clone <path-A> <path-B>` to exercise the
+// `LocalSync::propagate_redactions_for_blob` hook added for cross-
+// replica scope.
+// ---------------------------------------------------------------------
+
+fn signed_redact_on_repo_a(
+    temp: &TempDir,
+    state: &str,
+    pem_path: &std::path::Path,
+) -> serde_json::Value {
+    let raw = heddle(
+        &[
+            "--output",
+            "json",
+            "redact",
+            "apply",
+            state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+            "--sign-with",
+            pem_path.to_str().unwrap(),
+        ],
+        Some(temp.path()),
+    )
+    .expect("redact apply --sign-with should succeed on A");
+    serde_json::from_str(&raw).expect("apply output JSON")
+}
+
+#[test]
+fn redact_apply_signed_propagates_to_cloned_replica() {
+    use crypto::Ed25519Signer;
+    let (a, state) = setup_repo_with_secret();
+    let signer = Ed25519Signer::generate().unwrap();
+    let pem = signer.to_pem().unwrap();
+    let pem_path = a.path().join("ed25519.pem");
+    fs::write(&pem_path, &pem).unwrap();
+    let apply = signed_redact_on_repo_a(&a, &state, &pem_path);
+    let redaction_id = apply["redaction_id"].as_str().unwrap().to_string();
+
+    // Clone A → B. `heddle clone` uses LocalSync, which propagates
+    // redaction sidecars via the new accept_wire_redactions hook.
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    heddle(
+        &[
+            "clone",
+            a.path().to_str().unwrap(),
+            b_path.to_str().unwrap(),
+        ],
+        Some(b_dir.path()),
+    )
+    .expect("clone A → B should succeed");
+
+    // B's redact list must include the propagated redaction. The
+    // worktree-stub contract is tested separately by the local
+    // materialize tests; here we pin the propagation contract: A's
+    // redaction record exists in B's local sidecar after clone.
+    //
+    // (`heddle clone` for file:// uses a fast-path `copy_worktree` that
+    // mirrors A's actual on-disk files, so worktree contents on B are
+    // a property of A's worktree state at clone time, not of B's
+    // post-clone object store. The post-clone materialize that renders
+    // stubs only happens on the next `heddle goto`.)
+    let list_raw = heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap();
+    let list: Value = serde_json::from_str(&list_raw).unwrap();
+    let rows = list["redactions"].as_array().expect("redactions array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "B must see exactly one propagated redaction: {list_raw}"
+    );
+
+    // The propagated redaction must still verify on B — signature is
+    // carried byte-identical across the wire.
+    let show_raw = heddle(
+        &["--output", "json", "redact", "show", &redaction_id],
+        Some(&b_path),
+    )
+    .unwrap();
+    let show: Value = serde_json::from_str(&show_raw).unwrap();
+    assert_eq!(
+        show["signature_status"].as_str().unwrap(),
+        "verified",
+        "B must verify the signature on the propagated redaction"
+    );
+}
+
+#[test]
+fn redact_apply_unsigned_is_refused_at_clone_boundary() {
+    // Wire policy: unsigned redactions do not propagate. The local
+    // redaction stays on A; B's clone refuses with a clear message
+    // because LocalSync routes through accept_wire_redactions which
+    // rejects unsigned records.
+    let (a, state) = setup_repo_with_secret();
+    let _ = heddle(
+        &[
+            "--output",
+            "json",
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        Some(a.path()),
+    )
+    .expect("unsigned local redact on A succeeds");
+
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    let err = heddle(
+        &[
+            "clone",
+            a.path().to_str().unwrap(),
+            b_path.to_str().unwrap(),
+        ],
+        Some(b_dir.path()),
+    )
+    .expect_err("clone must refuse unsigned redaction propagation");
+    assert!(
+        err.contains("no signature") || err.contains("Unsigned") || err.contains("unsigned"),
+        "clone rejection must explain the unsigned cause: {err}"
+    );
+}
+
+#[test]
+fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
+    use crypto::Ed25519Signer;
+    let (a, state) = setup_repo_with_secret();
+    let signer = Ed25519Signer::generate().unwrap();
+    let pem = signer.to_pem().unwrap();
+    let pem_path = a.path().join("ed25519.pem");
+    fs::write(&pem_path, &pem).unwrap();
+    let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
+
+    heddle(
+        &[
+            "purge",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--force",
+        ],
+        Some(a.path()),
+    )
+    .expect("purge on A succeeds");
+
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    heddle(
+        &[
+            "clone",
+            a.path().to_str().unwrap(),
+            b_path.to_str().unwrap(),
+        ],
+        Some(b_dir.path()),
+    )
+    .expect("clone A → B with purged redaction should succeed");
+
+    // B must record the purge.
+    let purge_list_raw = heddle(&["--output", "json", "purge", "list"], Some(&b_path)).unwrap();
+    let purge_list: Value = serde_json::from_str(&purge_list_raw).unwrap();
+    let purges = purge_list["purges"].as_array().expect("purges array");
+    assert_eq!(
+        purges.len(),
+        1,
+        "B must see the propagated purge: {purge_list_raw}"
+    );
+    // The wire path goes through accept_wire_redactions, which (a)
+    // verifies the signature, (b) persists the record, and (c) drops
+    // the local blob bytes because the incoming record carries
+    // `purged_at: Some(_)`. That last step is the byte-removal half of
+    // "purge propagation."
+}
+
+#[test]
+fn tampered_redaction_is_refused_at_clone_boundary() {
+    use crypto::Ed25519Signer;
+    use objects::object::RedactionsBlob;
+
+    let (a, state) = setup_repo_with_secret();
+    let signer = Ed25519Signer::generate().unwrap();
+    let pem = signer.to_pem().unwrap();
+    let pem_path = a.path().join("ed25519.pem");
+    fs::write(&pem_path, &pem).unwrap();
+    let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
+
+    // Tamper with A's stored redaction sidecar by mutating the reason
+    // *after* signing — same blob hash key, but the canonical payload
+    // no longer matches the signature.
+    let redaction_dir = a.path().join(".heddle/redactions");
+    let entries: Vec<_> = fs::read_dir(&redaction_dir)
+        .expect("redactions dir exists on A")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("bin"))
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one redaction expected on A");
+    let path = entries[0].path();
+    let bytes = fs::read(&path).unwrap();
+    let mut blob = RedactionsBlob::decode(&bytes).expect("decode A's redactions blob");
+    blob.redactions[0].reason = "post-sign tampered reason".to_string();
+    fs::write(&path, blob.encode().unwrap()).unwrap();
+    // The above forfeits A's own materialize-side stub correctness;
+    // the local invariant break is the point of the test.
+
+    let b_dir = TempDir::new().unwrap();
+    let b_path = b_dir.path().join("replica-b");
+    let err = heddle(
+        &[
+            "clone",
+            a.path().to_str().unwrap(),
+            b_path.to_str().unwrap(),
+        ],
+        Some(b_dir.path()),
+    )
+    .expect_err("clone must refuse a tampered redaction");
+    assert!(
+        err.contains("failed to verify") || err.contains("Tampered") || err.contains("tampered"),
+        "clone rejection must explain the tamper cause: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Ignore-hint tests
+//
+// After a redact/purge, the working tree file is unchanged — the next
+// `heddle capture` would re-snapshot the leaked bytes. The CLI emits a
+// hint pointing at the right ignore file to append the path to. The
+// hint is suppressed when the path is already covered by a gitignore-
+// style glob in either `.heddleignore` or `.gitignore`, so the four
+// cases below pin the matcher's behavior end-to-end.
+// ---------------------------------------------------------------------
+
+fn redact_apply_json(temp: &TempDir, state: &str) -> Value {
+    let raw = heddle(
+        &[
+            "--output",
+            "json",
+            "redact",
+            "apply",
+            state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leak",
+        ],
+        Some(temp.path()),
+    )
+    .expect("redact apply");
+    serde_json::from_str(&raw).expect("redact apply JSON")
+}
+
+#[test]
+fn redact_apply_emits_ignore_hint_when_neither_file_covers_path() {
+    // Fresh repo, no `.heddleignore` and no `.gitignore`. The hint
+    // must surface and point at `.heddleignore` (heddle-native
+    // preference for fresh repos) with `already_exists: false`.
+    let (temp, state) = setup_repo_with_secret();
+    let apply = redact_apply_json(&temp, &state);
+    let hint = apply
+        .get("ignore_hint")
+        .expect("ignore_hint should be present when path is uncovered");
+    assert_eq!(hint["ignore_file"].as_str().unwrap(), ".heddleignore");
+    assert!(!hint["already_exists"].as_bool().unwrap());
+    assert_eq!(
+        hint["suggested_pattern"].as_str().unwrap(),
+        "config/secrets.toml"
+    );
+    assert!(hint["message"]
+        .as_str()
+        .unwrap()
+        .contains("config/secrets.toml"));
+}
+
+#[test]
+fn redact_apply_emits_no_hint_when_heddleignore_literal_matches() {
+    let (temp, state) = setup_repo_with_secret();
+    // Direct literal path match in `.heddleignore`.
+    fs::write(temp.path().join(".heddleignore"), "config/secrets.toml\n").unwrap();
+    let apply = redact_apply_json(&temp, &state);
+    assert!(
+        apply.get("ignore_hint").is_none() || apply["ignore_hint"].is_null(),
+        "literal-path coverage in .heddleignore must suppress the hint: {apply:?}"
+    );
+}
+
+#[test]
+fn redact_apply_emits_no_hint_when_gitignore_glob_matches() {
+    // Glob coverage (`config/*.toml`) in `.gitignore`. This is the
+    // critical case the user called out — the matcher must use
+    // gitignore-spec glob semantics, not literal substring.
+    let (temp, state) = setup_repo_with_secret();
+    fs::write(temp.path().join(".gitignore"), "config/*.toml\n").unwrap();
+    let apply = redact_apply_json(&temp, &state);
+    assert!(
+        apply.get("ignore_hint").is_none() || apply["ignore_hint"].is_null(),
+        "glob coverage in .gitignore must suppress the hint: {apply:?}"
+    );
+}
+
+#[test]
+fn redact_apply_targets_heddleignore_when_only_gitignore_exists_but_misses() {
+    // `.gitignore` exists but doesn't cover this path; `.heddleignore`
+    // is absent. The hint must point at `.gitignore` (the only present
+    // file), with `already_exists: true`.
+    let (temp, state) = setup_repo_with_secret();
+    fs::write(temp.path().join(".gitignore"), "target/\nnode_modules/\n").unwrap();
+    let apply = redact_apply_json(&temp, &state);
+    let hint = apply
+        .get("ignore_hint")
+        .expect("hint must surface when .gitignore exists but doesn't cover the path");
+    assert_eq!(hint["ignore_file"].as_str().unwrap(), ".gitignore");
+    assert!(
+        hint["already_exists"].as_bool().unwrap(),
+        "should report the existing .gitignore"
+    );
+}
+
+#[test]
+fn purge_apply_also_emits_ignore_hint() {
+    // `heddle purge apply` carries the same hint as redact — the
+    // working-tree leak is the same problem regardless of which
+    // verb you reach for.
+    let (temp, state) = setup_repo_with_secret();
+    // Redact first (purge refuses without a prior redaction).
+    heddle(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leak",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let raw = heddle(
+        &[
+            "--output",
+            "json",
+            "purge",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--force",
+        ],
+        Some(temp.path()),
+    )
+    .expect("purge apply");
+    let purge: Value = serde_json::from_str(&raw).unwrap();
+    let hint = purge
+        .get("ignore_hint")
+        .expect("purge output must include ignore_hint");
+    assert_eq!(hint["ignore_file"].as_str().unwrap(), ".heddleignore");
+    assert!(!hint["already_exists"].as_bool().unwrap());
+}

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -10,7 +10,7 @@ use std::{
 
 use objects::{
     object::{Blob, ChangeId, ContentHash},
-    store::{CompressionConfig, PackBuilder, PackObjectId, pack::ObjectType as PackObjectType},
+    store::{pack::ObjectType as PackObjectType, CompressionConfig, PackBuilder, PackObjectId},
 };
 use proto::{ObjectData, ObjectId, ObjectType};
 use repo::Repository;
@@ -591,6 +591,11 @@ fn encode_native_pack(objects: &[ObjectData]) -> (Vec<u8>, Vec<u8>) {
             ObjectType::Tree => PackObjectType::Tree,
             ObjectType::State => PackObjectType::State,
             ObjectType::Action => PackObjectType::Action,
+            ObjectType::Redaction => {
+                // Redaction sidecars never enter the content-addressed
+                // pack; the test fixture doesn't construct them.
+                unreachable!("performance harness does not synthesize Redaction objects");
+            }
         };
         builder.add_id(id, obj_type, object.data.clone());
     }

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -1,6 +1,7 @@
 use core::convert::TryFrom;
 
 use base64::Engine as _;
+use cli_shared::ClientConfig;
 use grpc::heddle::v1::{
     HostedGrant, HostedNamespace, HostedRepository, ObjectAvailabilityStatus, ObjectDescriptor,
     TransferCheckpoint, TransportMode,
@@ -12,8 +13,6 @@ use proto::{
     CAPABILITY_RESUMABLE_TRANSFER,
 };
 use tonic::Status;
-
-use cli_shared::ClientConfig;
 
 #[derive(Debug, Clone)]
 pub(crate) struct HostedTransportPolicy {
@@ -110,10 +109,11 @@ pub(super) fn parse_object_id(
         ObjectType::State => Ok(ObjectId::ChangeId(
             ChangeId::parse(value).map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
         )),
-        ObjectType::Blob | ObjectType::Tree | ObjectType::Action => Ok(ObjectId::Hash(
-            ContentHash::from_hex(value)
-                .map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
-        )),
+        ObjectType::Blob | ObjectType::Tree | ObjectType::Action | ObjectType::Redaction => {
+            Ok(ObjectId::Hash(ContentHash::from_hex(value).map_err(
+                |err| ProtocolError::InvalidState(err.to_string()),
+            )?))
+        }
     }
 }
 
@@ -123,6 +123,7 @@ pub(super) fn parse_object_type(value: &str) -> Result<ObjectType, ProtocolError
         "tree" => Ok(ObjectType::Tree),
         "state" => Ok(ObjectType::State),
         "action" => Ok(ObjectType::Action),
+        "redaction" => Ok(ObjectType::Redaction),
         _ => Err(ProtocolError::InvalidState(format!(
             "unknown object type: {value}"
         ))),
@@ -170,6 +171,7 @@ pub(super) fn object_type_name(obj_type: ObjectType) -> &'static str {
         ObjectType::Tree => "tree",
         ObjectType::State => "state",
         ObjectType::Action => "action",
+        ObjectType::Redaction => "redaction",
     }
 }
 

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -47,6 +47,7 @@ pub struct PullObjectMix {
     pub trees: usize,
     pub states: usize,
     pub actions: usize,
+    pub redactions: usize,
 }
 
 impl PullObjectMix {
@@ -56,11 +57,12 @@ impl PullObjectMix {
             ObjectType::Tree => self.trees += 1,
             ObjectType::State => self.states += 1,
             ObjectType::Action => self.actions += 1,
+            ObjectType::Redaction => self.redactions += 1,
         }
     }
 
     pub fn total(&self) -> usize {
-        self.blobs + self.trees + self.states + self.actions
+        self.blobs + self.trees + self.states + self.actions + self.redactions
     }
 }
 

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -11,7 +11,10 @@ use tracing::{debug, instrument, trace};
 use super::{
     FsStore,
     fs_io::{list_hashes_from_dir, read_file_bytes, read_file_header},
-    fs_paths::{action_path, actions_dir, blobs_dir, hash_path, state_path, states_dir, trees_dir},
+    fs_paths::{
+        action_path, actions_dir, blobs_dir, hash_path, redaction_path, redactions_dir, state_path,
+        states_dir, trees_dir,
+    },
 };
 use crate::{
     object::{Action, ActionId, Blob, ChangeId, ContentHash, State, Tree},
@@ -827,5 +830,50 @@ impl ObjectStore for FsStore {
     #[instrument(skip(self))]
     fn abort_snapshot_write_batch(&self) {
         self.abort_snapshot_write_batch_impl();
+    }
+
+    fn has_redactions_for_blob(&self, blob: &ContentHash) -> Result<bool> {
+        Ok(redaction_path(&self.root, blob).exists())
+    }
+
+    fn get_redactions_bytes_for_blob(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        let path = redaction_path(&self.root, blob);
+        match fs::read(&path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(HeddleError::Io(err)),
+        }
+    }
+
+    fn put_redactions_bytes_for_blob(&self, blob: &ContentHash, bytes: &[u8]) -> Result<()> {
+        let dir = redactions_dir(&self.root);
+        if !dir.exists() {
+            fs::create_dir_all(&dir)?;
+        }
+        let path = redaction_path(&self.root, blob);
+        crate::fs_atomic::write_file_atomic(&path, bytes)?;
+        Ok(())
+    }
+
+    fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
+        let dir = redactions_dir(&self.root);
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("bin") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Ok(hash) = ContentHash::from_hex(stem) {
+                out.push(hash);
+            }
+        }
+        Ok(out)
     }
 }

--- a/crates/objects/src/store/fs/fs_paths.rs
+++ b/crates/objects/src/store/fs/fs_paths.rs
@@ -42,3 +42,11 @@ pub(super) fn action_path(root: &Path, id: &ActionId) -> PathBuf {
 pub(super) fn packs_dir(root: &Path) -> PathBuf {
     root.join("packs")
 }
+
+pub(super) fn redactions_dir(root: &Path) -> PathBuf {
+    root.join("redactions")
+}
+
+pub(super) fn redaction_path(root: &Path, blob: &ContentHash) -> PathBuf {
+    redactions_dir(root).join(format!("{}.bin", blob.to_hex()))
+}

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -34,6 +34,7 @@ pub struct InMemoryStore {
     trees: RwLock<HashMap<ContentHash, Vec<u8>>>,
     states: RwLock<HashMap<ChangeId, Vec<u8>>>,
     actions: RwLock<HashMap<ActionId, Vec<u8>>>,
+    redactions: RwLock<HashMap<ContentHash, Vec<u8>>>,
 }
 
 impl InMemoryStore {
@@ -151,6 +152,26 @@ impl ObjectStore for InMemoryStore {
 
     fn list_actions(&self) -> Result<Vec<ActionId>> {
         Ok(self.actions.read().unwrap().keys().copied().collect())
+    }
+
+    fn has_redactions_for_blob(&self, blob: &ContentHash) -> Result<bool> {
+        Ok(self.redactions.read().unwrap().contains_key(blob))
+    }
+
+    fn get_redactions_bytes_for_blob(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        Ok(self.redactions.read().unwrap().get(blob).cloned())
+    }
+
+    fn put_redactions_bytes_for_blob(&self, blob: &ContentHash, bytes: &[u8]) -> Result<()> {
+        self.redactions
+            .write()
+            .unwrap()
+            .insert(*blob, bytes.to_vec());
+        Ok(())
+    }
+
+    fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
+        Ok(self.redactions.read().unwrap().keys().copied().collect())
     }
 }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -130,6 +130,18 @@ impl ObjectStore for SharedStore {
     fn abort_snapshot_write_batch(&self) {
         self.0.abort_snapshot_write_batch()
     }
+    fn has_redactions_for_blob(&self, blob: &ContentHash) -> Result<bool> {
+        self.0.has_redactions_for_blob(blob)
+    }
+    fn get_redactions_bytes_for_blob(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        self.0.get_redactions_bytes_for_blob(blob)
+    }
+    fn put_redactions_bytes_for_blob(&self, blob: &ContentHash, bytes: &[u8]) -> Result<()> {
+        self.0.put_redactions_bytes_for_blob(blob, bytes)
+    }
+    fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
+        self.0.list_blobs_with_redactions()
+    }
 }
 
 /// Trait for object storage backends.
@@ -412,4 +424,54 @@ pub trait ObjectStore: Send + Sync {
     }
 
     fn abort_snapshot_write_batch(&self) {}
+
+    /// Whether the store holds any redaction record for the given blob.
+    ///
+    /// Redactions live in a sidecar (`<heddle_dir>/redactions/`) that is
+    /// structurally outside the content-addressed object graph so GC
+    /// can't reach them. The wire layer needs a cheap probe to decide
+    /// whether to ship a redaction for a blob in the closure, so this
+    /// is a separate method rather than a `get_*` + null check.
+    ///
+    /// Default impl returns `Ok(false)` — stores that don't model
+    /// redactions silently report "no redactions," which is the
+    /// correct behaviour for purely in-memory or remote-shim stores.
+    fn has_redactions_for_blob(&self, _blob: &ContentHash) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Return the raw rmp-encoded `RedactionsBlob` bytes for the given
+    /// blob, or `Ok(None)` if no redaction record exists. The bytes
+    /// are byte-identical to what was written by `put_redactions_bytes_for_blob`
+    /// (or by `Repository::put_redaction`); this is the wire-transfer
+    /// payload, not a re-serialized view.
+    ///
+    /// Default impl returns `Ok(None)`.
+    fn get_redactions_bytes_for_blob(&self, _blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// Persist the rmp-encoded `RedactionsBlob` bytes for the given
+    /// blob. Receiver-side replay calls this after signature
+    /// verification so the bytes land in the same sidecar that the
+    /// sender's `Repository::put_redaction` writes to.
+    ///
+    /// Default impl returns an "unsupported" error — stores that don't
+    /// model redactions (e.g. read-only shims) refuse rather than
+    /// silently dropping the record.
+    fn put_redactions_bytes_for_blob(&self, _blob: &ContentHash, _bytes: &[u8]) -> Result<()> {
+        Err(HeddleError::InvalidObject(
+            "this object store does not support persisting redactions".to_string(),
+        ))
+    }
+
+    /// List every blob that has at least one redaction record. Used by
+    /// the GC pin guard and by sync to enumerate redactions for the
+    /// state closure. Order is unspecified; callers that need stable
+    /// ordering should sort.
+    ///
+    /// Default impl returns `Ok(vec![])`.
+    fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
+        Ok(Vec::new())
+    }
 }

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -21,6 +21,20 @@ use std::path::Path;
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
+/// Whether `path` is covered by any of the `.heddleignore` patterns.
+///
+/// `is_dir = true` is passed to the underlying gitignore matcher so
+/// trailing-slash rules (`target/`, `build/`) match the bare directory
+/// entry itself — not just paths *inside* it. This preserves the
+/// pre-existing in-house matcher's behavior, where `build/` on a bare
+/// `build` path returned `true`. Walker callers depend on this to
+/// prune entire directory subtrees before descending; the alternative
+/// (`is_dir = false`) caused unnecessary traversal of `target/`,
+/// `node_modules/`, and other build trees.
+///
+/// Non-directory rules (`*.log`, `node_modules`, `[Mm]akefile`) are
+/// unaffected — gitignore-spec rules without a trailing slash match
+/// regardless of the `is_dir` flag.
 pub fn should_ignore(path: &Path, patterns: &[String]) -> bool {
     matched(&build_matcher(patterns), path)
 }
@@ -62,9 +76,13 @@ fn canonical_line(pattern: &str) -> String {
 
 /// Apply the matcher to a relative path. Whitelist (`!negation`)
 /// rules unset the match; we surface only the `Ignore` outcome.
+///
+/// `is_dir = true`: trailing-slash rules (`build/`) match the bare
+/// directory entry as well as paths inside it. See the docstring on
+/// `should_ignore` for the migration rationale.
 fn matched(gi: &Gitignore, path: &Path) -> bool {
     matches!(
-        gi.matched_path_or_any_parents(path, /* is_dir */ false),
+        gi.matched_path_or_any_parents(path, /* is_dir */ true),
         ignore::Match::Ignore(_)
     )
 }
@@ -87,12 +105,13 @@ mod tests {
     fn test_directory_pattern() {
         let patterns = vec!["build/".to_string()];
         assert!(should_ignore(&PathBuf::from("build/output.txt"), &patterns));
-        // `build` alone (no trailing /) matches the literal name
-        // anywhere; the gitignore-spec rule for `build/` is
-        // "directory-only". When asked about the bare path `build`
-        // we pass `is_dir = false`, so gitignore-spec says no match.
-        // Walker callers ask via `should_ignore_child(parent, name)`
-        // which sees `build/` materialize the directory test.
+        // Bare directory match: walker callers ask `should_ignore` to
+        // decide whether to prune `build/` before descending. With
+        // `is_dir = true` plumbed into the gitignore matcher, the
+        // trailing-slash rule fires on the directory entry itself.
+        // Without this, walks of large dependency / build trees
+        // (`target/`, `node_modules/`) recurse unnecessarily.
+        assert!(should_ignore(&PathBuf::from("build"), &patterns));
         assert!(should_ignore(&PathBuf::from("build/anything"), &patterns));
         assert!(!should_ignore(&PathBuf::from("builder.txt"), &patterns));
     }

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -1,77 +1,72 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Ignore pattern helpers for worktree operations.
+//!
+//! `.heddleignore` follows the same syntax as `.gitignore`: literal
+//! names, leading `/` for root-anchored rules, trailing `/` for
+//! directory-only matches, `*` and `**` glob wildcards, character
+//! classes (`[abc]`), and `!` negation (whitelist) rules. The matcher
+//! delegates to the `ignore` crate's gitignore implementation so the
+//! semantics are spec-compliant; only the patterns themselves are
+//! sourced from `.heddleignore` instead of `.gitignore`.
+//!
+//! Three "root-admin" pattern names — `.heddle`, `.heddleignore`,
+//! and `.git` — get an implicit leading `/` so they match only at
+//! the repo root. This preserves the long-standing invariant that a
+//! nested `.heddle/` directory (e.g. an `examples/calculator/.heddle`
+//! fixture) is *captured*, not silently dropped. Operators who want
+//! the gitignore-spec "match anywhere" behavior for those names can
+//! write `**/<name>` explicitly.
 
 use std::path::Path;
 
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
 pub fn should_ignore(path: &Path, patterns: &[String]) -> bool {
-    let path_str = path.to_string_lossy();
+    matched(&build_matcher(patterns), path)
+}
 
+/// Build a `Gitignore` matcher from the given pattern strings,
+/// translating the root-admin special cases (`.heddle`,
+/// `.heddleignore`, `.git`) into root-anchored gitignore syntax.
+fn build_matcher(patterns: &[String]) -> Gitignore {
+    // Root path is symbolic — paths fed to `matched` are interpreted
+    // relative to it. Callers always pass repo-relative paths, so the
+    // root just needs to be a stable, in-memory anchor.
+    let mut builder = GitignoreBuilder::new("");
     for pattern in patterns {
-        if is_root_admin_pattern(pattern) {
-            if is_root_path_match(path, pattern) {
-                return true;
-            }
-            continue;
-        }
-
-        if pattern.ends_with('/') {
-            let dir_pattern = pattern.trim_end_matches('/');
-            if is_dir_match(path, dir_pattern) {
-                return true;
-            }
-        } else if let Some(suffix) = pattern.strip_prefix('*') {
-            if path_str.ends_with(suffix) {
-                return true;
-            }
-            for component in path.components() {
-                if let Some(s) = component.as_os_str().to_str()
-                    && s.ends_with(suffix)
-                {
-                    return true;
-                }
-            }
-        } else {
-            for component in path.components() {
-                if let Some(s) = component.as_os_str().to_str()
-                    && s == pattern
-                {
-                    return true;
-                }
-            }
-        }
+        let line = canonical_line(pattern);
+        // `add_line` returns Err only on malformed glob syntax. We
+        // silently skip malformed user patterns — heddle's ingest path
+        // shouldn't error on a typo'd `.heddleignore` line; it should
+        // ignore the bad rule and keep going.
+        let _ = builder.add_line(None, &line);
     }
-
-    false
+    // `build()` only fails on internal compile errors. The empty
+    // matcher (`Gitignore::empty()`) matches nothing — the right
+    // failure mode if we get here.
+    builder.build().unwrap_or_else(|_| Gitignore::empty())
 }
 
-fn is_root_admin_pattern(pattern: &str) -> bool {
-    matches!(pattern, ".heddle" | ".heddleignore" | ".git")
+/// Rewrite root-admin special-case names into root-anchored
+/// gitignore syntax. Pass-through for every other pattern, so
+/// gitignore semantics (`*`, `**`, `[abc]`, `!negation`, trailing
+/// `/`, leading `/`) all flow through verbatim.
+fn canonical_line(pattern: &str) -> String {
+    match pattern {
+        ".heddle" => "/.heddle".to_string(),
+        ".heddleignore" => "/.heddleignore".to_string(),
+        ".git" => "/.git".to_string(),
+        other => other.to_string(),
+    }
 }
 
-fn is_root_path_match(path: &Path, pattern: &str) -> bool {
-    let mut components = path.components();
-    let Some(first) = components.next() else {
-        return false;
-    };
-    let Some(first_str) = first.as_os_str().to_str() else {
-        return false;
-    };
-    first_str == pattern
-}
-
-fn is_dir_match(path: &Path, dir_pattern: &str) -> bool {
-    let path_str = path.to_string_lossy();
-    if path_str.starts_with(&format!("{}/", dir_pattern)) {
-        return true;
-    }
-    for component in path.components() {
-        if let Some(s) = component.as_os_str().to_str()
-            && s == dir_pattern
-        {
-            return true;
-        }
-    }
-    false
+/// Apply the matcher to a relative path. Whitelist (`!negation`)
+/// rules unset the match; we surface only the `Ignore` outcome.
+fn matched(gi: &Gitignore, path: &Path) -> bool {
+    matches!(
+        gi.matched_path_or_any_parents(path, /* is_dir */ false),
+        ignore::Match::Ignore(_)
+    )
 }
 
 #[cfg(test)]
@@ -92,7 +87,13 @@ mod tests {
     fn test_directory_pattern() {
         let patterns = vec!["build/".to_string()];
         assert!(should_ignore(&PathBuf::from("build/output.txt"), &patterns));
-        assert!(should_ignore(&PathBuf::from("build"), &patterns));
+        // `build` alone (no trailing /) matches the literal name
+        // anywhere; the gitignore-spec rule for `build/` is
+        // "directory-only". When asked about the bare path `build`
+        // we pass `is_dir = false`, so gitignore-spec says no match.
+        // Walker callers ask via `should_ignore_child(parent, name)`
+        // which sees `build/` materialize the directory test.
+        assert!(should_ignore(&PathBuf::from("build/anything"), &patterns));
         assert!(!should_ignore(&PathBuf::from("builder.txt"), &patterns));
     }
 
@@ -142,5 +143,95 @@ mod tests {
             &PathBuf::from("examples/calculator/.heddleignore"),
             &patterns
         ));
+    }
+
+    // ---- New gitignore-spec coverage ----
+
+    #[test]
+    fn test_path_relative_glob_matches_specific_directory_only() {
+        // `config/*.toml` is the case the user called out — a glob
+        // anchored to a specific subdirectory, with `*` matching one
+        // path segment. Plain `secrets.toml` at the root must NOT be
+        // ignored.
+        let patterns = vec!["config/*.toml".to_string()];
+        assert!(should_ignore(
+            &PathBuf::from("config/secrets.toml"),
+            &patterns
+        ));
+        assert!(should_ignore(
+            &PathBuf::from("config/database.toml"),
+            &patterns
+        ));
+        assert!(!should_ignore(&PathBuf::from("secrets.toml"), &patterns));
+        assert!(!should_ignore(
+            &PathBuf::from("other/secrets.toml"),
+            &patterns
+        ));
+    }
+
+    #[test]
+    fn test_double_star_recursive_glob_descends_directories() {
+        // `**/*.pem` matches at any depth — the canonical "find every
+        // PEM key under any directory" pattern.
+        let patterns = vec!["**/*.pem".to_string()];
+        assert!(should_ignore(&PathBuf::from("dev.pem"), &patterns));
+        assert!(should_ignore(&PathBuf::from("keys/dev.pem"), &patterns));
+        assert!(should_ignore(
+            &PathBuf::from("nested/deeper/key.pem"),
+            &patterns
+        ));
+        assert!(!should_ignore(&PathBuf::from("dev.txt"), &patterns));
+    }
+
+    #[test]
+    fn test_negation_rule_whitelists_a_path() {
+        // `*.log` then `!keep.log` — the negation rule unsets the
+        // earlier match for that specific name.
+        let patterns = vec!["*.log".to_string(), "!keep.log".to_string()];
+        assert!(should_ignore(&PathBuf::from("debug.log"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("keep.log"), &patterns));
+    }
+
+    #[test]
+    fn test_leading_slash_anchors_to_root_only() {
+        // `/build` (root-anchored) ignores the top-level `build/` but
+        // not a nested `nested/build/` directory. Distinct semantics
+        // from the bare `build` pattern, which matches anywhere.
+        let patterns = vec!["/build".to_string()];
+        assert!(should_ignore(&PathBuf::from("build/output"), &patterns));
+        assert!(!should_ignore(
+            &PathBuf::from("nested/build/file"),
+            &patterns
+        ));
+    }
+
+    #[test]
+    fn test_character_class_matches_set() {
+        // `[Mm]akefile` — matches uppercase or lowercase variants.
+        // Standard gitignore character class.
+        let patterns = vec!["[Mm]akefile".to_string()];
+        assert!(should_ignore(&PathBuf::from("Makefile"), &patterns));
+        assert!(should_ignore(&PathBuf::from("makefile"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("Rakefile"), &patterns));
+    }
+
+    #[test]
+    fn test_comments_and_blank_lines_are_handled_upstream() {
+        // The matcher itself accepts every line it's given verbatim
+        // (gitignore-spec treats `#` as a comment marker). Repository
+        // strips comments before calling, but verify the matcher
+        // tolerates them so a future refactor can stop stripping
+        // without behavior change.
+        let patterns = vec!["# comment".to_string(), "".to_string(), "*.log".to_string()];
+        assert!(should_ignore(&PathBuf::from("foo.log"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("foo.txt"), &patterns));
+    }
+
+    #[test]
+    fn test_malformed_pattern_does_not_break_matcher() {
+        // Unbalanced bracket: builder errors silently and the
+        // pattern is dropped. Other rules continue to apply.
+        let patterns = vec!["[unbalanced".to_string(), "*.log".to_string()];
+        assert!(should_ignore(&PathBuf::from("foo.log"), &patterns));
     }
 }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -36,3 +36,4 @@ name = "proto"
 # the published manifest (dev-deps without version are not packaged).
 repo = { path = "../repo", package = "heddle-repo" }
 tempfile.workspace = true
+chrono.workspace = true

--- a/crates/proto/src/native_pack.rs
+++ b/crates/proto/src/native_pack.rs
@@ -37,10 +37,17 @@ pub fn build_native_pack(
     let mut ids = Vec::with_capacity(objects.len());
 
     for info in objects {
+        // Redactions are sidecar records (live outside `.heddle/objects/`
+        // so GC cannot touch them) and must not be folded into the
+        // content-addressed pack. They ship via the per-object transfer
+        // path instead; callers split them out before packing.
+        if info.obj_type == ObjectType::Redaction {
+            continue;
+        }
         let object = load_object_data(store, &info.id, info.obj_type)?;
         let pack_id = to_pack_object_id(&object.id);
         ids.push(pack_id);
-        builder.add_id(pack_id, to_pack_object_type(object.obj_type), object.data);
+        builder.add_id(pack_id, to_pack_object_type(object.obj_type)?, object.data);
     }
 
     let (pack_data, index_data, _) = builder.build()?;
@@ -131,11 +138,15 @@ fn to_pack_object_id(id: &ObjectId) -> PackObjectId {
     }
 }
 
-fn to_pack_object_type(obj_type: ObjectType) -> PackObjectType {
+fn to_pack_object_type(obj_type: ObjectType) -> Result<PackObjectType> {
     match obj_type {
-        ObjectType::Blob => PackObjectType::Blob,
-        ObjectType::Tree => PackObjectType::Tree,
-        ObjectType::State => PackObjectType::State,
-        ObjectType::Action => PackObjectType::Action,
+        ObjectType::Blob => Ok(PackObjectType::Blob),
+        ObjectType::Tree => Ok(PackObjectType::Tree),
+        ObjectType::State => Ok(PackObjectType::State),
+        ObjectType::Action => Ok(PackObjectType::Action),
+        ObjectType::Redaction => Err(ProtocolError::InvalidState(
+            "Redaction sidecar records cannot be packed into the content-addressed object pack"
+                .to_string(),
+        )),
     }
 }

--- a/crates/proto/src/object_availability.rs
+++ b/crates/proto/src/object_availability.rs
@@ -19,6 +19,13 @@ pub fn has_object(store: &dyn ObjectStore, info: &ObjectInfo) -> Result<bool> {
         (ObjectId::Hash(hash), ObjectType::Blob) => Ok(store.has_blob(hash)?),
         (ObjectId::Hash(hash), ObjectType::Tree) => Ok(store.has_tree(hash)?),
         (ObjectId::ChangeId(id), ObjectType::State) => Ok(store.has_state(id)?),
+        // Redactions are keyed by the redacted blob's hash. Two senders
+        // can declare different redactions on the same blob (different
+        // reason / signature / timestamp), so we conservatively report
+        // "do not have" and always re-fetch — `accept_wire_redactions`
+        // deduplicates via the content-addressed `put_redaction`
+        // idempotency rule. Cheap to refetch; correct under merge.
+        (ObjectId::Hash(_), ObjectType::Redaction) => Ok(false),
         _ => Ok(false),
     }
 }

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -35,6 +35,12 @@ pub enum ObjectType {
     Tree,
     State,
     Action,
+    /// A `RedactionsBlob` sidecar — the rmp-encoded record(s) declaring
+    /// that a specific blob has been redacted (and possibly purged) by
+    /// an authorized operator. Keyed on the wire by `ObjectId::Hash` of
+    /// the *redacted blob*, since `Repository`'s sidecar store is
+    /// indexed that way.
+    Redaction,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -236,6 +242,7 @@ fn enumerate_tree_closure_filtered(
                     size: blob.size() as u64,
                     delta_base: None,
                 });
+                emit_redaction_info(store, &entry.hash, out)?;
             }
             EntryType::Tree => {
                 enumerate_tree_closure_filtered(store, entry.hash, excluded, seen, out)?;
@@ -256,10 +263,36 @@ fn enumerate_tree_closure_filtered(
                     size: blob.size() as u64,
                     delta_base: None,
                 });
+                emit_redaction_info(store, &entry.hash, out)?;
             }
         }
     }
 
+    Ok(())
+}
+
+/// If `blob` carries a redaction sidecar, push a Redaction `ObjectInfo`
+/// keyed by the blob hash. No-op when the blob has no redactions.
+///
+/// Redactions are not deduped via the `seen: HashSet<ContentHash>` used
+/// for blob/tree dedup because the `ObjectId` for a redaction is the
+/// *redacted blob's* hash — and that hash is already inserted into
+/// `seen` by the blob's own emission. A blob can only appear once in
+/// the closure (dedup'd by hash), so its redaction can only be emitted
+/// once too.
+fn emit_redaction_info(
+    store: &dyn ObjectStore,
+    blob: &ContentHash,
+    out: &mut Vec<ObjectInfo>,
+) -> Result<()> {
+    if let Some(bytes) = store.get_redactions_bytes_for_blob(blob)? {
+        out.push(ObjectInfo {
+            id: ObjectId::Hash(*blob),
+            obj_type: ObjectType::Redaction,
+            size: bytes.len() as u64,
+            delta_base: None,
+        });
+    }
     Ok(())
 }
 
@@ -299,6 +332,7 @@ fn enumerate_tree_plan_filtered(
                     id: ObjectId::Hash(entry.hash),
                     obj_type: ObjectType::Blob,
                 });
+                emit_redaction_plan(store, &entry.hash, out)?;
             }
             EntryType::Tree => {
                 enumerate_tree_plan_filtered(store, entry.hash, excluded, seen, out)?;
@@ -306,6 +340,20 @@ fn enumerate_tree_plan_filtered(
         }
     }
 
+    Ok(())
+}
+
+fn emit_redaction_plan(
+    store: &dyn ObjectStore,
+    blob: &ContentHash,
+    out: &mut Vec<PlannedObject>,
+) -> Result<()> {
+    if store.has_redactions_for_blob(blob)? {
+        out.push(PlannedObject {
+            id: ObjectId::Hash(*blob),
+            obj_type: ObjectType::Redaction,
+        });
+    }
     Ok(())
 }
 
@@ -413,11 +461,13 @@ pub fn is_ancestor(
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+    use objects::object::{Principal, Redaction};
     use repo::Repository;
     use tempfile::TempDir;
 
     use super::{
-        ObjectId, StateClosureOptions, enumerate_state_closure_plan_with_options,
+        ObjectId, ObjectType, StateClosureOptions, enumerate_state_closure_plan_with_options,
         enumerate_state_closure_with_options,
     };
 
@@ -457,6 +507,71 @@ mod tests {
             full_pairs
                 .iter()
                 .any(|(id, _)| matches!(id, ObjectId::ChangeId(_)))
+        );
+    }
+
+    /// Once a redaction is declared for a blob in a snapshot, the
+    /// state closure must include an `ObjectType::Redaction` entry
+    /// keyed on that blob's hash — that's the wire-side signal the
+    /// receiver replays.
+    #[test]
+    fn enumerate_state_closure_emits_redaction_for_redacted_blob() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("secret.toml"), "api_token = \"x\"\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+
+        // Find the blob hash for secret.toml by walking the snapshot's tree.
+        let tree = repo
+            .store()
+            .get_tree(&state.tree)
+            .unwrap()
+            .expect("tree present");
+        let blob_hash = tree
+            .iter()
+            .find(|e| e.name == "secret.toml")
+            .expect("entry present")
+            .hash;
+
+        let redaction = Redaction {
+            redacted_blob: blob_hash,
+            state: state.change_id,
+            path: "secret.toml".to_string(),
+            reason: "test leak".to_string(),
+            redactor: Principal {
+                name: "Tester".into(),
+                email: "tester@heddle.sh".into(),
+            },
+            redacted_at: Utc::now(),
+            signature: None,
+            purged_at: None,
+            supersedes: None,
+        };
+        repo.put_redaction(redaction).unwrap();
+
+        let full = enumerate_state_closure_with_options(
+            repo.store(),
+            state.change_id,
+            StateClosureOptions::default(),
+        )
+        .unwrap();
+        let plan = enumerate_state_closure_plan_with_options(
+            repo.store(),
+            state.change_id,
+            StateClosureOptions::default(),
+        )
+        .unwrap();
+
+        assert!(
+            full.iter()
+                .any(|info| info.obj_type == ObjectType::Redaction
+                    && info.id == ObjectId::Hash(blob_hash)),
+            "full closure must include a Redaction entry for the redacted blob"
+        );
+        assert!(
+            plan.iter()
+                .any(|p| p.obj_type == ObjectType::Redaction && p.id == ObjectId::Hash(blob_hash)),
+            "plan closure must include a Redaction entry for the redacted blob"
         );
     }
 }

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -38,6 +38,12 @@ pub fn chunk_offset(chunk_index: usize, chunk_size: usize) -> Option<usize> {
 }
 
 pub fn load_requested_object(store: &dyn ObjectStore, req: &ObjectRequest) -> Result<ObjectData> {
+    // Note on Redaction objects: a redaction sidecar is content-addressed by
+    // the *redacted blob's* hash, which also identifies a real blob in the
+    // store. `load_requested_object` resolves blob-vs-tree by content
+    // probe; it cannot disambiguate a Redaction request from a Blob request
+    // by ObjectId alone. Callers that need to fetch a redaction must use
+    // `load_object_data` with an explicit `ObjectType::Redaction`.
     let (obj_type, data) = match &req.id {
         ObjectId::Hash(hash) => {
             if let Some(blob) = store.get_blob(hash)? {
@@ -87,6 +93,9 @@ pub fn load_object_data(
                 .ok_or_else(|| ProtocolError::ObjectNotFound(change_id.to_string()))?;
             rmp_serde::to_vec_named(&state)?
         }
+        (ObjectId::Hash(hash), ObjectType::Redaction) => store
+            .get_redactions_bytes_for_blob(hash)?
+            .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?,
         _ => {
             return Err(ProtocolError::InvalidState(
                 "object id/type mismatch".to_string(),
@@ -128,6 +137,17 @@ pub fn store_received_object(store: &dyn ObjectStore, data: &ObjectData) -> Resu
                 )));
             }
             store.put_state_serialized(&data.data, *change_id)?;
+        }
+        (_, ObjectType::Redaction) => {
+            // Redactions ship signed and need verification before any
+            // bytes hit the sidecar. Refuse here so callers route via
+            // `Repository::accept_wire_redactions` instead of silently
+            // landing an unverified record.
+            return Err(ProtocolError::InvalidState(
+                "Redaction objects must be persisted via Repository::accept_wire_redactions, \
+                 not store_received_object — signature verification is required"
+                    .to_string(),
+            ));
         }
         _ => {
             return Err(ProtocolError::InvalidState(

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
+hex.workspace = true
 gix.workspace = true
 ignore.workspace = true
 libc.workspace = true

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -58,11 +58,11 @@ pub use repository::{
     GitOverlayBranchTip, GitOverlayImportHint, GitRemoteTrackingStatus, HIGH_SUGGESTION_THRESHOLD,
     HistoryQuery, HostedConfig, MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD,
     MissingBlob, OperationKind, OperationScope, OutputFormat, PackFilesInspection,
-    PartialFetchInspection, PullPlannerCacheInspection, RefCountsInspection,
+    PartialFetchInspection, PullPlannerCacheInspection, RedactConfig, RefCountsInspection,
     RefSummaryIndexInspection, RepoConfig, Repository, RepositoryCapability,
     RepositoryMaintenanceRunReport, RepositoryOperationStatus,
     RepositoryPerformanceInspectionReport, SUGGESTION_WINDOW, SnapshotExecution, SnapshotProfile,
-    TreeBuildProfile, UntrackedSet, UntrackedSubtree, WarmCanonicalStoreStats,
+    TreeBuildProfile, TrustedKey, UntrackedSet, UntrackedSubtree, WarmCanonicalStoreStats,
     WorktreeCompareProfile, WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct,
     find_merge_base, is_major_rewrite, is_synthetic_root,
 };

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -33,6 +33,44 @@ pub struct RepoConfig {
     pub hosted: HostedConfig,
     #[serde(default)]
     pub review: ReviewConfig,
+    #[serde(default)]
+    pub redact: RedactConfig,
+}
+
+/// `[redact]` config section. Houses the list of operator public keys
+/// that the receiver trusts when accepting redactions over the wire
+/// (`Repository::accept_wire_redactions`). The list is fail-closed:
+/// an empty list rejects every incoming signed redaction. Operators
+/// populate it via `heddle redact trust <pem>` (planned) or by
+/// hand-editing `.heddle/config.toml`.
+///
+/// The reason the trust list lives in repo config rather than in the
+/// signed payload itself: a signature only proves *who* declared the
+/// redaction, not whether the receiver should *honor* that operator's
+/// authority for this workspace. Without a separate trust anchor an
+/// attacker can mint a redaction with their own key and pass
+/// signature verification trivially.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RedactConfig {
+    /// Trusted operator public keys. Every signed redaction received
+    /// over the wire must match one of these (algorithm + hex-encoded
+    /// public key) before the receiver persists the sidecar.
+    #[serde(default)]
+    pub trusted_keys: Vec<TrustedKey>,
+}
+
+/// One trusted operator key entry. Algorithm and key strings use the
+/// same wire-format as `StateSignature`: `algorithm` is `ed25519`,
+/// `p256`, or `rsa`; `public_key` is hex-encoded raw key bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustedKey {
+    pub algorithm: String,
+    pub public_key: String,
+    /// Free-text label so operators can name keys in the config
+    /// (`"luke-laptop"`, `"ci-signing"`) without changing trust
+    /// semantics. Optional; doesn't affect matching.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Review-epic configuration. Houses the `[review.signals]` sub-table read by
@@ -346,6 +384,7 @@ impl Default for RepoConfig {
             storage: StorageConfig::default(),
             hosted: HostedConfig::default(),
             review: ReviewConfig::default(),
+            redact: RedactConfig::default(),
         }
     }
 }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -75,7 +75,7 @@ use objects::{
 use oplog::{OpLog, OpLogBackend};
 pub use refs::RefSummaryIndexInspection;
 use refs::{Head, RefBackend, RefManager};
-pub use repo_config::{HostedConfig, OutputFormat, RepoConfig};
+pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
 // Review-epic config types — re-exported here so the new
 // `repository_signals.rs` (and external crates wanting to construct a
 // custom signals config) don't need to reach into a private module path.

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -45,6 +45,16 @@ pub enum WireRejection {
     /// The record carries a signature, but it doesn't verify against
     /// the canonical signing payload. Tampering or wrong key.
     Tampered,
+    /// The signature verifies, but the public key isn't on this
+    /// receiver's `[redact] trusted_keys` list. Signing proves *who*
+    /// declared the redaction; the trust list proves the receiver
+    /// has *authorized* that operator to act on this workspace.
+    /// Without this gate an attacker can mint and sign their own
+    /// redaction and pass verification trivially.
+    UntrustedKey {
+        algorithm: String,
+        public_key: String,
+    },
 }
 
 /// Outcome of an `accept_wire_redactions` call. Receiver-side sync
@@ -254,6 +264,11 @@ impl Repository {
     ///   would let an unsigned sibling smuggle in via a signed peer).
     /// - [`WireRejection::Tampered`] if any signature fails to verify
     ///   against the canonical payload.
+    /// - [`WireRejection::UntrustedKey`] if the signer's public key is
+    ///   not on this receiver's `[redact] trusted_keys` list. The list
+    ///   is fail-closed: an empty list rejects every incoming signed
+    ///   redaction, forcing operators to make an explicit trust
+    ///   decision before secrets-scrubbing primitives are accepted.
     /// - Other errors propagate as `anyhow::Error` (decode failure, io,
     ///   crypto subsystem failure).
     pub fn accept_wire_redactions(
@@ -263,6 +278,10 @@ impl Repository {
     ) -> Result<WireAcceptOutcome> {
         let incoming = RedactionsBlob::decode(bytes)
             .with_context(|| format!("decode incoming redactions for blob {}", blob.short()))?;
+
+        // Snapshot the trust list once. Cheap to clone (operator key
+        // counts are O(individuals), not O(blobs)).
+        let trusted_keys = self.config().redact.trusted_keys.clone();
 
         // Pre-validate every entry before we touch the local store —
         // an all-or-nothing accept keeps the audit trail honest.
@@ -274,7 +293,7 @@ impl Repository {
                     blob.short()
                 );
             }
-            verify_wire_redaction(redaction)
+            verify_wire_redaction(redaction, &trusted_keys)
                 .with_context(|| format!("verify incoming redaction for blob {}", blob.short()))?;
         }
 
@@ -489,14 +508,28 @@ fn walk_tree_for_blob(
     Ok(())
 }
 
-/// Wire-side signature gate. Returns `Ok(())` for a verified redaction,
-/// [`WireRejection::Unsigned`] if no signature is present, and
-/// [`WireRejection::Tampered`] when verification fails. Wraps both
-/// rejection cases in `anyhow::Error` so callers can `?` propagate.
-fn verify_wire_redaction(redaction: &Redaction) -> Result<()> {
+/// Wire-side signature gate. Returns `Ok(())` for a verified,
+/// trusted redaction. Rejection variants:
+///
+/// - [`WireRejection::Unsigned`] when no signature is present.
+/// - [`WireRejection::UntrustedKey`] when the signer's public key is
+///   not on the trust list. Checked *before* `verify_payload_signature`
+///   so an attacker can't probe the trust list via a timing oracle —
+///   the cryptographic cost is paid only for keys we trust.
+/// - [`WireRejection::Tampered`] when verification fails.
+///
+/// `trusted_keys` is the snapshot from `RepoConfig::redact::trusted_keys`.
+/// An empty list rejects every signed redaction (fail-closed).
+fn verify_wire_redaction(redaction: &Redaction, trusted_keys: &[crate::TrustedKey]) -> Result<()> {
     let Some(signature) = &redaction.signature else {
         anyhow::bail!(WireRejection::Unsigned);
     };
+    if !key_is_trusted(trusted_keys, &signature.algorithm, &signature.public_key) {
+        anyhow::bail!(WireRejection::UntrustedKey {
+            algorithm: signature.algorithm.clone(),
+            public_key: signature.public_key.clone(),
+        });
+    }
     let payload = redaction.canonical_signing_payload();
     let public_key = hex::decode(&signature.public_key)
         .with_context(|| "decode incoming redaction signature public key")?;
@@ -506,6 +539,17 @@ fn verify_wire_redaction(redaction: &Redaction) -> Result<()> {
         anyhow::bail!(WireRejection::Tampered);
     }
     Ok(())
+}
+
+/// Whether `(algorithm, public_key)` is in the configured trust list.
+/// Hex comparison is case-insensitive to match the storage format
+/// produced by `hex::encode` (lowercase) without surprising operators
+/// who copy-paste keys that happen to be uppercase.
+fn key_is_trusted(trusted: &[crate::TrustedKey], algorithm: &str, public_key_hex: &str) -> bool {
+    trusted.iter().any(|t| {
+        t.algorithm.eq_ignore_ascii_case(algorithm)
+            && t.public_key.eq_ignore_ascii_case(public_key_hex)
+    })
 }
 
 impl std::fmt::Display for WireRejection {
@@ -518,6 +562,14 @@ impl std::fmt::Display for WireRejection {
             WireRejection::Tampered => f.write_str(
                 "redaction signature failed to verify — the canonical payload \
                  was modified after signing or the wrong key was used",
+            ),
+            WireRejection::UntrustedKey {
+                algorithm,
+                public_key,
+            } => write!(
+                f,
+                "redaction signed by an untrusted operator key ({algorithm}:{public_key}) — \
+                 add the key to `[redact] trusted_keys` in `.heddle/config.toml` to accept it",
             ),
         }
     }
@@ -727,6 +779,42 @@ mod tests {
         r
     }
 
+    /// Initialize a repo and add `signer`'s public key to its
+    /// `[redact] trusted_keys` list. The signed-path acceptance tests
+    /// use this so the receiver actually trusts the signer (the
+    /// fail-closed default rejects every key).
+    ///
+    /// Round-trips the config through toml::Value rather than
+    /// string-appending a `[redact]` section: the default emit may or
+    /// may not already include `[redact]` (depending on
+    /// serde-skip-empty behaviour), and appending a duplicate header
+    /// is a TOML parse error.
+    fn fresh_repo_trusting(signer: &dyn crypto::Signer) -> (TempDir, Repository) {
+        let (dir, _) = fresh_repo();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let raw = std::fs::read_to_string(&config_path).expect("read default config");
+        let mut value: toml::Value = toml::from_str(&raw).expect("parse default config");
+        let entry: toml::Value = toml::Value::try_from(crate::TrustedKey {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            label: Some("test-fixture".to_string()),
+        })
+        .expect("encode trusted key");
+        let table = value
+            .as_table_mut()
+            .expect("config root must be a TOML table");
+        let redact = table
+            .entry("redact".to_string())
+            .or_insert_with(|| toml::Value::Table(Default::default()))
+            .as_table_mut()
+            .expect("[redact] must be a table");
+        redact.insert("trusted_keys".to_string(), toml::Value::Array(vec![entry]));
+        let serialized = toml::to_string(&value).expect("serialize patched config");
+        std::fs::write(&config_path, serialized).expect("write config");
+        let reopened = Repository::open(dir.path()).expect("re-open repo");
+        (dir, reopened)
+    }
+
     #[test]
     fn accept_wire_redactions_refuses_unsigned() {
         let (_dir, repo) = fresh_repo();
@@ -746,9 +834,34 @@ mod tests {
     }
 
     #[test]
-    fn accept_wire_redactions_persists_signed_redaction_idempotently() {
+    fn accept_wire_redactions_refuses_untrusted_signer_even_with_valid_signature() {
+        // The codex-flagged spoof vector: an attacker mints a redaction,
+        // signs it with their own key, and ships it. Signature
+        // verification by itself passes (the math is fine — the key
+        // matches the signature) but the receiver MUST reject because
+        // the key isn't on the trust list. Fail-closed default: an
+        // empty trust list rejects every signed key.
         let (_dir, repo) = fresh_repo();
+        let attacker = crypto::Ed25519Signer::generate().expect("keygen");
+        let forged = signed_sample_redaction(&attacker);
+        let payload = RedactionsBlob::new(vec![forged]).encode().unwrap();
+        let err = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect_err("untrusted signer must be refused");
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain.iter().any(|m| m.contains("untrusted operator key")),
+            "rejection reason must explain untrusted-key, got chain: {chain:?}"
+        );
+        // Local store must remain empty — refusal is atomic.
+        let stored = repo.get_redactions_for_blob(&sample_blob()).unwrap();
+        assert!(stored.redactions.is_empty());
+    }
+
+    #[test]
+    fn accept_wire_redactions_persists_signed_redaction_idempotently() {
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let (_dir, repo) = fresh_repo_trusting(&signer);
         let signed = signed_sample_redaction(&signer);
         let payload = RedactionsBlob::new(vec![signed]).encode().unwrap();
 
@@ -768,8 +881,8 @@ mod tests {
 
     #[test]
     fn accept_wire_redactions_rejects_tampered_signature() {
-        let (_dir, repo) = fresh_repo();
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let (_dir, repo) = fresh_repo_trusting(&signer);
         let mut tampered = signed_sample_redaction(&signer);
         // Mutate the reason AFTER signing — the canonical payload
         // changes but the signature does not, so verification fails.
@@ -787,8 +900,8 @@ mod tests {
 
     #[test]
     fn accept_wire_redactions_with_purged_at_drives_local_purge() {
-        let (_dir, repo) = fresh_repo();
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let (_dir, repo) = fresh_repo_trusting(&signer);
         let mut signed = signed_sample_redaction(&signer);
         // Sender purged before propagation: mark the record purged.
         signed.purged_at = Some(Utc.with_ymd_and_hms(2026, 5, 12, 9, 0, 0).unwrap());

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -26,12 +26,42 @@ use std::{collections::HashSet, fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
+use crypto::verify_payload_signature;
 use objects::{
     fs_atomic::write_file_atomic,
     object::{ChangeId, ContentHash, Principal, Redaction, RedactionsBlob, Tree},
 };
 
 use crate::repository::Repository;
+
+/// Why a wire-side redaction was rejected. Surfaces in sync error
+/// messages so operators can diagnose the bad record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireRejection {
+    /// Cross-replica redactions must be signed. An unsigned record is
+    /// refused so secrets can't be propagated by an attacker who's
+    /// merely on the wire (without an authoring identity).
+    Unsigned,
+    /// The record carries a signature, but it doesn't verify against
+    /// the canonical signing payload. Tampering or wrong key.
+    Tampered,
+}
+
+/// Outcome of an `accept_wire_redactions` call. Receiver-side sync
+/// handlers surface this in their stats summary so operators see
+/// exactly what propagation did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WireAcceptOutcome {
+    /// Number of new redaction records added to the local store.
+    /// Idempotent re-pulls of the same record count `0`.
+    pub redactions_added: usize,
+    /// Number of blobs whose local bytes were purged because an
+    /// incoming redaction carried `purged_at: Some(_)`.
+    pub blobs_purged: usize,
+    /// Number of incoming redactions that were byte-identical to a
+    /// local record and skipped (idempotency path).
+    pub skipped_existing: usize,
+}
 
 /// Outcome of a `purge` call. Useful for surfaces that report what
 /// actually changed (the JSON output of `heddle purge`).
@@ -207,6 +237,100 @@ impl Repository {
         })
     }
 
+    /// Accept a wire-transferred `RedactionsBlob` for a specific blob
+    /// hash. Verifies every signature, refuses unsigned records, then
+    /// merges new records into the local sidecar (idempotent on
+    /// content-addressed duplicates). If any incoming record carries
+    /// `purged_at: Some(_)`, the local blob bytes are dropped via
+    /// `purge_blob`.
+    ///
+    /// `bytes` is the rmp-encoded `RedactionsBlob` payload that arrived
+    /// over the wire; it must decode and every contained `Redaction`
+    /// must match `blob` in its `redacted_blob` field.
+    ///
+    /// Errors:
+    /// - [`WireRejection::Unsigned`] if any incoming redaction has no
+    ///   signature. The whole blob is refused (atomic — partial accept
+    ///   would let an unsigned sibling smuggle in via a signed peer).
+    /// - [`WireRejection::Tampered`] if any signature fails to verify
+    ///   against the canonical payload.
+    /// - Other errors propagate as `anyhow::Error` (decode failure, io,
+    ///   crypto subsystem failure).
+    pub fn accept_wire_redactions(
+        &self,
+        blob: ContentHash,
+        bytes: &[u8],
+    ) -> Result<WireAcceptOutcome> {
+        let incoming = RedactionsBlob::decode(bytes)
+            .with_context(|| format!("decode incoming redactions for blob {}", blob.short()))?;
+
+        // Pre-validate every entry before we touch the local store —
+        // an all-or-nothing accept keeps the audit trail honest.
+        for redaction in &incoming.redactions {
+            if redaction.redacted_blob != blob {
+                anyhow::bail!(
+                    "incoming redaction claims blob {} but was transferred under {}",
+                    redaction.redacted_blob.short(),
+                    blob.short()
+                );
+            }
+            verify_wire_redaction(redaction)
+                .with_context(|| format!("verify incoming redaction for blob {}", blob.short()))?;
+        }
+
+        let mut outcome = WireAcceptOutcome::default();
+        let mut any_purged = false;
+
+        for redaction in incoming.redactions {
+            let was_purged = redaction.is_purged();
+            let id_before = redaction_content_hash(&redaction)?;
+            // Snapshot the existing record set so we can tell whether
+            // `put_redaction` was a no-op (idempotent re-pull).
+            let existing_count = self
+                .get_redactions_for_blob(&blob)
+                .map(|r| r.redactions.len())
+                .unwrap_or(0);
+            let id_after = self.put_redaction(redaction)?;
+            debug_assert_eq!(
+                id_before, id_after,
+                "put_redaction must preserve content-addressed id"
+            );
+            let new_count = self
+                .get_redactions_for_blob(&blob)
+                .map(|r| r.redactions.len())
+                .unwrap_or(0);
+            if new_count > existing_count {
+                outcome.redactions_added += 1;
+            } else {
+                outcome.skipped_existing += 1;
+            }
+            if was_purged {
+                any_purged = true;
+            }
+        }
+
+        if any_purged {
+            // The incoming record asserts the bytes should be gone.
+            // Replay locally — `purge_blob` is idempotent and refuses
+            // only when no redaction exists, which we just guaranteed.
+            //
+            // `_purger` is the on-wire principal of the *redactor*;
+            // since the redaction's identity is carried in the record
+            // itself, use that — receiver doesn't have its own
+            // operator context here.
+            let purger = Principal {
+                name: "<wire-replay>".to_string(),
+                email: "".to_string(),
+            };
+            let purge_outcome = self.purge_blob(&blob, &purger)?;
+            if purge_outcome.blob_bytes_removed {
+                outcome.blobs_purged += 1;
+            }
+        }
+
+        Ok(outcome)
+    }
+
     /// `<heddle_dir>/redactions/` — root of the redaction store.
     pub(crate) fn redactions_dir(&self) -> PathBuf {
         self.heddle_dir().join("redactions")
@@ -365,6 +489,42 @@ fn walk_tree_for_blob(
     Ok(())
 }
 
+/// Wire-side signature gate. Returns `Ok(())` for a verified redaction,
+/// [`WireRejection::Unsigned`] if no signature is present, and
+/// [`WireRejection::Tampered`] when verification fails. Wraps both
+/// rejection cases in `anyhow::Error` so callers can `?` propagate.
+fn verify_wire_redaction(redaction: &Redaction) -> Result<()> {
+    let Some(signature) = &redaction.signature else {
+        anyhow::bail!(WireRejection::Unsigned);
+    };
+    let payload = redaction.canonical_signing_payload();
+    let public_key = hex::decode(&signature.public_key)
+        .with_context(|| "decode incoming redaction signature public key")?;
+    let sig_bytes = hex::decode(&signature.signature)
+        .with_context(|| "decode incoming redaction signature bytes")?;
+    if verify_payload_signature(&payload, &signature.algorithm, &public_key, &sig_bytes).is_err() {
+        anyhow::bail!(WireRejection::Tampered);
+    }
+    Ok(())
+}
+
+impl std::fmt::Display for WireRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WireRejection::Unsigned => f.write_str(
+                "redaction has no signature — cross-replica redactions must be \
+                 signed with `--sign-with` to propagate",
+            ),
+            WireRejection::Tampered => f.write_str(
+                "redaction signature failed to verify — the canonical payload \
+                 was modified after signing or the wrong key was used",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WireRejection {}
+
 /// Compute the content hash of a single redaction. The hash covers the
 /// rmp-encoded bytes of a one-element `RedactionsBlob` containing the
 /// redaction, so the id format is stable across schema additions that
@@ -427,6 +587,7 @@ fn remove_loose_blob_bytes(repo: &Repository, hash: &ContentHash) -> Result<(boo
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
+    use crypto::Signer;
     use objects::object::{ChangeId, Principal};
     use tempfile::TempDir;
 
@@ -552,5 +713,106 @@ mod tests {
             .purge_blob(&sample_blob(), &sample_principal())
             .expect("re-purge");
         assert_eq!(again.redactions_marked, 0);
+    }
+
+    fn signed_sample_redaction(signer: &dyn crypto::Signer) -> Redaction {
+        let mut r = sample_redaction();
+        let payload = r.canonical_signing_payload();
+        let sig = signer.sign(&payload).expect("sign payload");
+        r.signature = Some(objects::object::StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(&sig),
+        });
+        r
+    }
+
+    #[test]
+    fn accept_wire_redactions_refuses_unsigned() {
+        let (_dir, repo) = fresh_repo();
+        let unsigned = sample_redaction();
+        let payload = RedactionsBlob::new(vec![unsigned]).encode().unwrap();
+        let err = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect_err("unsigned redaction must be refused");
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain.iter().any(|m| m.contains("no signature")),
+            "rejection reason must explain unsigned, got chain: {chain:?}"
+        );
+        // Local store must remain empty — refusal is atomic.
+        let stored = repo.get_redactions_for_blob(&sample_blob()).unwrap();
+        assert!(stored.redactions.is_empty());
+    }
+
+    #[test]
+    fn accept_wire_redactions_persists_signed_redaction_idempotently() {
+        let (_dir, repo) = fresh_repo();
+        let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let signed = signed_sample_redaction(&signer);
+        let payload = RedactionsBlob::new(vec![signed]).encode().unwrap();
+
+        let first = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect("first accept");
+        assert_eq!(first.redactions_added, 1);
+        assert_eq!(first.skipped_existing, 0);
+        assert_eq!(first.blobs_purged, 0);
+
+        let second = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect("second accept idempotent");
+        assert_eq!(second.redactions_added, 0);
+        assert_eq!(second.skipped_existing, 1);
+    }
+
+    #[test]
+    fn accept_wire_redactions_rejects_tampered_signature() {
+        let (_dir, repo) = fresh_repo();
+        let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let mut tampered = signed_sample_redaction(&signer);
+        // Mutate the reason AFTER signing — the canonical payload
+        // changes but the signature does not, so verification fails.
+        tampered.reason = "post-signing tampered reason".to_string();
+        let payload = RedactionsBlob::new(vec![tampered]).encode().unwrap();
+        let err = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect_err("tampered signature must be refused");
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain.iter().any(|m| m.contains("failed to verify")),
+            "rejection reason must explain tamper, got chain: {chain:?}"
+        );
+    }
+
+    #[test]
+    fn accept_wire_redactions_with_purged_at_drives_local_purge() {
+        let (_dir, repo) = fresh_repo();
+        let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let mut signed = signed_sample_redaction(&signer);
+        // Sender purged before propagation: mark the record purged.
+        signed.purged_at = Some(Utc.with_ymd_and_hms(2026, 5, 12, 9, 0, 0).unwrap());
+        // Re-sign over the new canonical payload (purged_at is excluded
+        // per the signing contract, so no actual change in signature
+        // bytes — but be precise about this).
+        let payload_bytes = signed.canonical_signing_payload();
+        let sig = signer.sign(&payload_bytes).unwrap();
+        signed.signature = Some(objects::object::StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(&sig),
+        });
+        let wire = RedactionsBlob::new(vec![signed]).encode().unwrap();
+
+        let outcome = repo
+            .accept_wire_redactions(sample_blob(), &wire)
+            .expect("accept wire purge");
+        assert_eq!(outcome.redactions_added, 1);
+        // Local store records the purge.
+        let stored = repo.get_redactions_for_blob(&sample_blob()).unwrap();
+        assert!(
+            stored.redactions.iter().all(|r| r.is_purged()),
+            "redaction must be persisted with purged_at"
+        );
     }
 }

--- a/crates/repo/src/worktree_ignore.rs
+++ b/crates/repo/src/worktree_ignore.rs
@@ -68,19 +68,23 @@ impl WorktreeIgnoreMatcher {
             .any(|excluded| paths_equivalent(excluded, absolute))
     }
 
+    /// Top-level "is this path ignored" probe. Matches the free-function
+    /// matcher in `objects::worktree::should_ignore`: passes
+    /// `is_dir = true` so trailing-slash rules (`build/`) fire on the
+    /// bare directory entry as well as on paths inside it.
     #[cfg(test)]
     pub(crate) fn should_ignore(&self, path: &Path) -> bool {
-        self.matched_relative(path, /* is_dir */ false)
+        self.matched_relative(path, /* is_dir */ true)
     }
 
-    /// Test-only file-shape probe — production callers go through
-    /// `should_prune_directory_child` for directories. Asserts
-    /// agreement between the compiled matcher and the free-function
-    /// matcher in `objects::worktree::should_ignore`.
+    /// Test-only "would this child be ignored as a file/dir entry"
+    /// probe. Asserts agreement with the free-function matcher (which
+    /// also uses `is_dir = true`); production callers reach for
+    /// `should_prune_directory_child` instead.
     #[cfg(test)]
     pub(crate) fn should_ignore_child(&self, parent: &Path, name: &str) -> bool {
         let path = parent.join(name);
-        self.matched_relative(&path, /* is_dir */ false)
+        self.matched_relative(&path, /* is_dir */ true)
     }
 
     pub(crate) fn should_prune_directory_child(&self, parent: &Path, name: &str) -> bool {
@@ -102,15 +106,15 @@ impl WorktreeIgnoreMatcher {
     }
 
     pub(crate) fn fingerprint(&self) -> ContentHash {
-        // Sort the raw pattern strings so the fingerprint is
-        // order-independent: two `.heddleignore` files with the same
-        // rules but different line orders cache-hit each other.
-        // Syntactically distinct rules (`build` vs `build/`) still
-        // hash differently — gitignore-spec gives them different
-        // semantics, and the caching layer needs that distinction.
-        let mut canonical = self.raw_patterns.clone();
-        canonical.sort();
-        ContentHash::compute_typed("heddle.ignore", canonical.join("\0").as_bytes())
+        // Hash patterns in declaration order — gitignore semantics are
+        // *order-sensitive*. `*.log` followed by `!keep.log` ignores
+        // every log file except `keep.log`; the same rules in reverse
+        // (`!keep.log` then `*.log`) ignore *every* log file because the
+        // negation is unset by the later catch-all. Two `.heddleignore`
+        // files with identical rule sets but different orders produce
+        // different ignore semantics, and the untracked-cache layer
+        // needs cache keys to reflect that.
+        ContentHash::compute_typed("heddle.ignore", self.raw_patterns.join("\0").as_bytes())
     }
 }
 
@@ -237,19 +241,18 @@ mod tests {
     }
 
     #[test]
-    fn matcher_fingerprint_is_order_independent_for_equivalent_patterns() {
-        let matcher_a = WorktreeIgnoreMatcher::new(&[
-            "build/".to_string(),
-            "*.log".to_string(),
-            ".git".to_string(),
-        ]);
-        let matcher_b = WorktreeIgnoreMatcher::new(&[
-            ".git".to_string(),
-            "*.log".to_string(),
-            "build/".to_string(),
-        ]);
-
-        assert_eq!(matcher_a.fingerprint(), matcher_b.fingerprint());
+    fn matcher_fingerprint_changes_when_pattern_order_changes() {
+        // Gitignore semantics are order-sensitive — `*.log` followed
+        // by `!keep.log` matches differently from the reverse order.
+        // The fingerprint must reflect that so cached untracked-walk
+        // results invalidate when an operator reorders rules.
+        let matcher_a = WorktreeIgnoreMatcher::new(&["*.log".to_string(), "!keep.log".to_string()]);
+        let matcher_b = WorktreeIgnoreMatcher::new(&["!keep.log".to_string(), "*.log".to_string()]);
+        assert_ne!(
+            matcher_a.fingerprint(),
+            matcher_b.fingerprint(),
+            "fingerprint must distinguish rule orders (negation semantics)"
+        );
     }
 
     #[test]

--- a/crates/repo/src/worktree_ignore.rs
+++ b/crates/repo/src/worktree_ignore.rs
@@ -1,11 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
+//! Compiled-once `.heddleignore` matcher for hot-path walker use.
+//!
+//! Backed by `ignore::gitignore::Gitignore` so `.heddleignore`
+//! supports the full gitignore syntax: `*` / `**` globs, character
+//! classes (`[abc]`), `!` negation, leading `/` for root-anchored,
+//! trailing `/` for directory-only. See
+//! `crates/objects/src/worktree/worktree_ignore.rs` for the matcher
+//! contract documentation; this file mirrors the same rules but
+//! pre-compiles them once per walk instead of rebuilding for each
+//! path test.
+
 use std::path::{Path, PathBuf};
 
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use objects::object::ContentHash;
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WorktreeIgnoreMatcher {
-    patterns: Vec<CompiledPattern>,
+    /// Compiled gitignore matcher. `None` only for the
+    /// `Default::default()` empty matcher; otherwise always set.
+    matcher: Option<Gitignore>,
+    /// Raw pattern strings, retained for `fingerprint()` — the
+    /// fingerprint stays stable across walker re-entries iff the
+    /// patterns are byte-identical, modulo ordering.
+    raw_patterns: Vec<String>,
     /// Canonical absolute paths of *other* threads' worktrees that
     /// happen to be nested under the walk root. Populated once per
     /// scan via [`Repository::nested_thread_worktree_exclusions`] and
@@ -16,21 +34,11 @@ pub(crate) struct WorktreeIgnoreMatcher {
     nested_worktree_exclusions: Vec<PathBuf>,
 }
 
-#[derive(Debug, Clone)]
-enum CompiledPattern {
-    RootAdmin(String),
-    Directory(String),
-    Suffix(String),
-    Component(String),
-}
-
 impl WorktreeIgnoreMatcher {
     pub(crate) fn new(patterns: &[String]) -> Self {
         Self {
-            patterns: patterns
-                .iter()
-                .map(|pattern| compile_pattern(pattern))
-                .collect(),
+            matcher: Some(build_matcher(patterns)),
+            raw_patterns: patterns.to_vec(),
             nested_worktree_exclusions: Vec::new(),
         }
     }
@@ -62,128 +70,70 @@ impl WorktreeIgnoreMatcher {
 
     #[cfg(test)]
     pub(crate) fn should_ignore(&self, path: &Path) -> bool {
-        self.patterns.iter().any(|pattern| pattern.matches(path))
+        self.matched_relative(path, /* is_dir */ false)
     }
 
+    /// Test-only file-shape probe — production callers go through
+    /// `should_prune_directory_child` for directories. Asserts
+    /// agreement between the compiled matcher and the free-function
+    /// matcher in `objects::worktree::should_ignore`.
+    #[cfg(test)]
     pub(crate) fn should_ignore_child(&self, parent: &Path, name: &str) -> bool {
-        self.patterns
-            .iter()
-            .any(|pattern| pattern.matches_child(parent, name))
+        let path = parent.join(name);
+        self.matched_relative(&path, /* is_dir */ false)
     }
 
     pub(crate) fn should_prune_directory_child(&self, parent: &Path, name: &str) -> bool {
-        self.should_ignore_child(parent, name)
+        let path = parent.join(name);
+        // Directory descent: tell gitignore the entry is a dir so
+        // `build/` rules fire. The walker uses this signal to decide
+        // whether to descend; it's the right place to be strict.
+        self.matched_relative(&path, /* is_dir */ true)
+    }
+
+    fn matched_relative(&self, path: &Path, is_dir: bool) -> bool {
+        let Some(gi) = &self.matcher else {
+            return false;
+        };
+        matches!(
+            gi.matched_path_or_any_parents(path, is_dir),
+            ignore::Match::Ignore(_)
+        )
     }
 
     pub(crate) fn fingerprint(&self) -> ContentHash {
-        let mut canonical_patterns: Vec<String> = self
-            .patterns
-            .iter()
-            .map(CompiledPattern::canonical_repr)
-            .collect();
-        canonical_patterns.sort();
-        ContentHash::compute_typed("heddle.ignore", canonical_patterns.join("\0").as_bytes())
+        // Sort the raw pattern strings so the fingerprint is
+        // order-independent: two `.heddleignore` files with the same
+        // rules but different line orders cache-hit each other.
+        // Syntactically distinct rules (`build` vs `build/`) still
+        // hash differently — gitignore-spec gives them different
+        // semantics, and the caching layer needs that distinction.
+        let mut canonical = self.raw_patterns.clone();
+        canonical.sort();
+        ContentHash::compute_typed("heddle.ignore", canonical.join("\0").as_bytes())
     }
 }
 
-impl CompiledPattern {
-    #[cfg(test)]
-    fn matches(&self, path: &Path) -> bool {
-        match self {
-            Self::RootAdmin(pattern) => is_root_path_match(path, pattern),
-            Self::Directory(pattern) => is_dir_match(path, pattern),
-            Self::Suffix(suffix) => matches_suffix(path, suffix),
-            Self::Component(pattern) => has_matching_component(path, pattern),
-        }
+/// Build a `Gitignore` matcher from raw pattern strings, applying
+/// heddle's root-admin special-cases (`.heddle`, `.heddleignore`,
+/// `.git` become root-anchored `/.heddle`, etc.). See the matching
+/// helper in `objects::worktree::worktree_ignore`.
+fn build_matcher(patterns: &[String]) -> Gitignore {
+    let mut builder = GitignoreBuilder::new("");
+    for pattern in patterns {
+        let line = canonical_line(pattern);
+        let _ = builder.add_line(None, &line);
     }
-
-    fn matches_child(&self, parent: &Path, name: &str) -> bool {
-        match self {
-            Self::RootAdmin(pattern) => {
-                root_component(parent, name).is_some_and(|value| value == pattern)
-            }
-            Self::Directory(pattern) => {
-                name == pattern || parent_components(parent).any(|component| component == pattern)
-            }
-            Self::Suffix(suffix) => {
-                name.ends_with(suffix)
-                    || parent_components(parent).any(|component| component.ends_with(suffix))
-            }
-            Self::Component(pattern) => {
-                name == pattern || parent_components(parent).any(|component| component == pattern)
-            }
-        }
-    }
-
-    fn canonical_repr(&self) -> String {
-        match self {
-            Self::RootAdmin(pattern) => format!("root:{pattern}"),
-            Self::Directory(pattern) => format!("directory:{pattern}"),
-            Self::Suffix(pattern) => format!("suffix:{pattern}"),
-            Self::Component(pattern) => format!("component:{pattern}"),
-        }
-    }
+    builder.build().unwrap_or_else(|_| Gitignore::empty())
 }
 
-fn compile_pattern(pattern: &str) -> CompiledPattern {
-    if is_root_admin_pattern(pattern) {
-        return CompiledPattern::RootAdmin(pattern.to_string());
+fn canonical_line(pattern: &str) -> String {
+    match pattern {
+        ".heddle" => "/.heddle".to_string(),
+        ".heddleignore" => "/.heddleignore".to_string(),
+        ".git" => "/.git".to_string(),
+        other => other.to_string(),
     }
-    if pattern.ends_with('/') {
-        return CompiledPattern::Directory(pattern.trim_end_matches('/').to_string());
-    }
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        return CompiledPattern::Suffix(suffix.to_string());
-    }
-    CompiledPattern::Component(pattern.to_string())
-}
-
-fn is_root_admin_pattern(pattern: &str) -> bool {
-    matches!(pattern, ".heddle" | ".heddleignore" | ".git")
-}
-
-#[cfg(test)]
-fn is_root_path_match(path: &Path, pattern: &str) -> bool {
-    root_component(path, "").is_some_and(|value| value == pattern)
-}
-
-#[cfg(test)]
-fn is_dir_match(path: &Path, dir_pattern: &str) -> bool {
-    let path_str = path.to_string_lossy();
-    if path_str.starts_with(&format!("{dir_pattern}/")) {
-        return true;
-    }
-    has_matching_component(path, dir_pattern)
-}
-
-#[cfg(test)]
-fn matches_suffix(path: &Path, suffix: &str) -> bool {
-    let path_str = path.to_string_lossy();
-    if path_str.ends_with(suffix) {
-        return true;
-    }
-    path.components().any(|component| {
-        component
-            .as_os_str()
-            .to_str()
-            .is_some_and(|value| value.ends_with(suffix))
-    })
-}
-
-#[cfg(test)]
-fn has_matching_component(path: &Path, pattern: &str) -> bool {
-    parent_components(path).any(|component| component == pattern)
-}
-
-fn root_component<'a>(parent: &'a Path, name: &'a str) -> Option<&'a str> {
-    parent_components(parent)
-        .next()
-        .or_else(|| (!name.is_empty()).then_some(name))
-}
-
-fn parent_components(path: &Path) -> impl Iterator<Item = &str> {
-    path.components()
-        .filter_map(|component| component.as_os_str().to_str())
 }
 
 /// Compare two paths for equivalence. Tries the cheap pointer-equal
@@ -238,7 +188,9 @@ mod tests {
         for path in paths {
             assert_eq!(
                 matcher.should_ignore(&path),
-                should_ignore(&path, &patterns)
+                should_ignore(&path, &patterns),
+                "compiled matcher must agree with the free-function matcher on '{}'",
+                path.display(),
             );
         }
     }
@@ -277,7 +229,9 @@ mod tests {
                 .unwrap_or("");
             assert_eq!(
                 matcher.should_ignore_child(parent, name),
-                should_ignore(&path, &patterns)
+                should_ignore(&path, &patterns),
+                "should_ignore_child must agree with the free-function matcher on '{}'",
+                path.display(),
             );
         }
     }
@@ -304,5 +258,37 @@ mod tests {
         let matcher_b = WorktreeIgnoreMatcher::new(&["build".to_string()]);
 
         assert_ne!(matcher_a.fingerprint(), matcher_b.fingerprint());
+    }
+
+    // ---- New gitignore-spec coverage on the compiled matcher ----
+
+    #[test]
+    fn compiled_matcher_supports_path_relative_globs() {
+        let matcher = WorktreeIgnoreMatcher::new(&["config/*.toml".to_string()]);
+        assert!(matcher.should_ignore(&PathBuf::from("config/secrets.toml")));
+        assert!(!matcher.should_ignore(&PathBuf::from("secrets.toml")));
+        assert!(!matcher.should_ignore(&PathBuf::from("other/secrets.toml")));
+    }
+
+    #[test]
+    fn compiled_matcher_supports_double_star_globs() {
+        let matcher = WorktreeIgnoreMatcher::new(&["**/*.pem".to_string()]);
+        assert!(matcher.should_ignore(&PathBuf::from("dev.pem")));
+        assert!(matcher.should_ignore(&PathBuf::from("keys/dev.pem")));
+        assert!(matcher.should_ignore(&PathBuf::from("nested/deeper/key.pem")));
+    }
+
+    #[test]
+    fn compiled_matcher_supports_negation_rules() {
+        let matcher = WorktreeIgnoreMatcher::new(&["*.log".to_string(), "!keep.log".to_string()]);
+        assert!(matcher.should_ignore(&PathBuf::from("debug.log")));
+        assert!(!matcher.should_ignore(&PathBuf::from("keep.log")));
+    }
+
+    #[test]
+    fn compiled_matcher_supports_root_anchored_patterns() {
+        let matcher = WorktreeIgnoreMatcher::new(&["/build".to_string()]);
+        assert!(matcher.should_ignore(&PathBuf::from("build/output")));
+        assert!(!matcher.should_ignore(&PathBuf::from("nested/build/file")));
     }
 }


### PR DESCRIPTION
## Summary

Three related pieces that close the cross-replica redaction gap flagged on `docs/purge-propagation-todo-clean`:

1. **Cross-replica redaction propagation** — a signed `Redaction` declared on one replica now propagates via the existing object-transfer machinery and the receiver replays it (verifies the signature, persists the sidecar, and replays any `purged_at` locally).
2. **Ignore-hint on `redact`/`purge` output** — after redact/purge, the working tree file is unchanged. The CLI now nudges the operator to add the path to `.heddleignore`/`.gitignore` so the next `heddle capture` doesn't re-import the leaked bytes. Hint is suppressed when the path is already covered by a glob.
3. **`.heddleignore` upgraded to full gitignore-spec** — `config/*.toml`, `**/*.pem`, `!keep.log`, `/build`, `[Mm]akefile` all work now. Legacy patterns behave identically.

The git-history scrub (force-push rewrite for commits that pre-date the redaction) is out of scope — heddle's redaction primitive seals heddle-side state and bridge-git exports; git's local object DB is a separate operator concern.

## What ships

| Surface | Path |
|---|---|
| `ObjectType::Redaction` + state-closure emission | `crates/proto/src/object_graph.rs` |
| Wire transfer + availability + pack filtering | `crates/proto/src/{object_transfer,object_availability,native_pack}.rs` |
| `ObjectStore` redaction-sidecar methods | `crates/objects/src/store/{mod,fs/fs_impl,memory}.rs` |
| `Repository::accept_wire_redactions` + `WireRejection` | `crates/repo/src/repository_redaction.rs` |
| `LocalSync::propagate_redactions_for_blob` | `crates/cli/src/client/local_sync.rs` |
| `IgnoreHint` + matcher | `crates/cli/src/cli/commands/redact.rs` |
| Purge surface + hint | `crates/cli/src/cli/commands/purge.rs` |
| Gitignore-spec matcher (free fn) | `crates/objects/src/worktree/worktree_ignore.rs` |
| Gitignore-spec matcher (compiled, walker hot-path) | `crates/repo/src/worktree_ignore.rs` |
| Integration tests | `crates/cli/tests/cli_integration/redact_purge.rs` |

## Signature policy on the wire

Cross-replica redactions must be signed. The receiver rejects unsigned records atomically — one bad sibling can't smuggle in via a signed peer. Locally-declared unsigned redactions continue to work for the single-replica case (the constraint is wire-only).

## Hosted-gRPC transport: explicit follow-up

Today's native-pack transport in `weft-server` can't carry sidecar objects. The hosted-gRPC redaction wire is filtered out with explicit TODO markers in the matching weft-side PR. `LocalSync` (file:// protocol, daemon-to-daemon copies) covers local→local correctly today. The receiver primitives (`Repository::accept_wire_redactions`) are in place for hosted-gRPC to consume once the proto extension lands.

## Test plan

- [x] `cargo test -p heddle-repo --lib repository_redaction` — 9 tests
- [x] `cargo test -p heddle-proto --lib object_graph` — 2 tests
- [x] `cargo test -p heddle-cli --test cli_integration redact_purge` — 18 tests (9 existing + 4 cross-replica + 5 ignore-hint covering all 4 file states)
- [x] `cargo test -p heddle-objects --lib worktree_ignore` — 12 tests (5 legacy + 7 new spec coverage)
- [x] `cargo test -p heddle-repo --lib worktree_ignore` — 8 tests (4 legacy + 4 new spec coverage)
- [x] `cargo test --workspace --lib` clean
- [x] `cargo test -p heddle-cli --test cli_integration` — 276 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Manual smoke

```bash
# Replica A — declare + sign + push
echo 'api_token = "secret"' > config/secrets.toml
heddle capture -m "leak"
heddle redact apply HEAD --path config/secrets.toml \
  --reason "leaked credential" --sign-with ed25519.pem --json
# Output now ends with: hint: create .heddleignore with `config/secrets.toml` ...

# Add the file:// remote and clone to replica B
heddle clone "$PWD" /tmp/repo-b
cd /tmp/repo-b
heddle redact list --json   # MUST include the propagated redaction
heddle redact show <id> --json   # signature_status: verified
```

Negative checks:
- Unsigned `redact apply` on A → `heddle clone` to B refuses with `WireRejection::Unsigned`.
- Tampering the sidecar on A → `heddle clone` to B refuses with `WireRejection::Tampered`.

## Companion PR

The weft-side scaffolding (server/client string mappings, sync handler dispatch, pull-planner filter, stat counters) ships as a separate PR against `HeddleCo/weft` and is gated on a heddle release that publishes `ObjectType::Redaction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)