### PR TITLE
release: v0.2.3 — cross-replica redaction propagation + .heddleignore globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,80 @@ recorded here. Hosted-product work (Postgres, Biscuit, the web app,
 GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 `HeddleCo/tapestry` repos.
 
+## 0.2.3 - 2026-05-14
+
+### Added
+
+- **Cross-replica redaction wire propagation** (#12). A signed
+  `Redaction` declared on one replica now propagates via the existing
+  object-transfer machinery and the receiver replays it: verifies the
+  signature, checks the signer against the trust list, persists the
+  sidecar, and replays any `purged_at` byte-removal locally.
+  - New `proto::ObjectType::Redaction` variant; `enumerate_state_closure`
+    emits a Redaction entry for every blob in the closure that has a
+    sidecar.
+  - New `ObjectStore` trait methods for sidecar access:
+    `has_redactions_for_blob`, `get_redactions_bytes_for_blob`,
+    `put_redactions_bytes_for_blob`, `list_blobs_with_redactions`.
+    Default impls return empty; `FsStore` and `InMemoryStore` implement.
+  - New `Repository::accept_wire_redactions`: decodes the incoming
+    `RedactionsBlob`, refuses unsigned records, rejects signatures from
+    untrusted keys, rejects tampered records, then merges via
+    content-addressed idempotency. Records with `purged_at: Some(_)`
+    drive a local `purge_blob`.
+  - New `WireRejection` enum: `Unsigned` | `Tampered` |
+    `UntrustedKey { algorithm, public_key }`. Trust gate is fail-closed:
+    an empty trust list rejects every signed redaction.
+  - New `[redact] trusted_keys` repo config section. Operators manage
+    via the new CLI subcommands:
+    - `heddle redact trust add --from-pem <path>` (or
+      `--algorithm <a> --public-key <hex>`)
+    - `heddle redact trust list`
+    - `heddle redact trust remove <hex>`
+  - `LocalSync` ferries redaction sidecars during local→local copies.
+    Propagation runs unconditionally on every state walk, so the
+    redact-after-peer-fetched flow re-syncs correctly even when no new
+    objects are copied.
+  - `heddle fetch <remote>` no longer short-circuits when the state is
+    already present locally; the redaction sweep needs the walk to run.
+- **Ignore-hint on `redact`/`purge` output** (#12). After a
+  redact/purge, the working-tree file is unchanged — the next
+  `heddle capture` would re-snapshot the leaked bytes. The CLI now
+  emits a hint pointing at `.heddleignore` if the path isn't already
+  covered by heddle's effective ignore set (`.heddleignore` + repo
+  config `worktree.ignore`). Coverage check uses gitignore-spec globs.
+- **`.heddleignore` upgraded to full gitignore-spec** (#12). `*` and
+  `**` globs, character classes (`[abc]`), `!` negation rules, leading
+  `/` for root-anchored matches, trailing `/` for directory-only.
+  Both matchers (`objects::worktree::should_ignore` and the compiled
+  `WorktreeIgnoreMatcher`) delegate to `ignore::gitignore`. Legacy
+  patterns behave identically; the three root-admin special-cases
+  (`.heddle`, `.heddleignore`, `.git`) stay root-anchored.
+
+### Changed
+
+- `WorktreeIgnoreMatcher::fingerprint` hashes raw pattern strings in
+  declaration order (was: sorted). Gitignore semantics are
+  order-sensitive — `*.log` then `!keep.log` is not the same as the
+  reverse. Cache keys reflect that now.
+- `proto::native_pack::build_native_pack` skips `Redaction` entries;
+  sidecars live structurally outside `.heddle/objects/` so GC can't
+  reach them and they don't enter the content-addressed pack.
+- `proto::object_transfer::store_received_object` refuses
+  `ObjectType::Redaction` so callers route via
+  `Repository::accept_wire_redactions` (forcing signature verification).
+
+### Security
+
+- Closed a spoof vector in cross-replica redaction propagation:
+  before this release, `verify_wire_redaction` accepted any
+  mathematically-valid signature because it verified using the public
+  key embedded in the redaction itself. An attacker could mint a
+  redaction, sign with their own key, and pass. The new trust gate
+  ties acceptance to an operator-configured `[redact] trusted_keys`
+  list. Fail-closed default rejects every signed redaction until the
+  operator explicitly trusts a key via `heddle redact trust add`.
+
 ## 0.2.2 - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-stream",
  "chrono",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "protoc-bin-vendored",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "fs2",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-proto"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -7222,7 +7222,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli-shared"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "CLI-side utilities shared between Heddle's OSS cli crate and the closed heddle-client crate: user config, remote target resolution, client config."

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-client"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle hosted-backend client: auth, support, presence, the gRPC client wrappers, and the global credential store."

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-crypto"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-daemon"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle local-mode gRPC daemon and service implementations"

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-devtools"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "Developer tooling for the Heddle workspace"

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-ingest"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "Import git history (commits, refs, reflogs) into a native Heddle repository with agent attribution and reasoning annotations."

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-mount"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-objects"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-oplog"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-proto"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-refs"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-repo"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-review"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-semantic"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-state-review"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weft-client-shim"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 description = "Trait surface for client extensions to the Heddle CLI. OSS default is a noop impl; closed builds replace it via [patch.crates-io]."


### PR DESCRIPTION
## Summary

Bumps all 18 OSS crates from `0.2.2` → `0.2.3` to ship the work from [#12](https://github.com/HeddleCo/heddle/pull/12): cross-replica redaction wire propagation, the operator-facing trust-gate CLI, the redact/purge ignore-hint, and the `.heddleignore` gitignore-spec upgrade.

## Changes

- 18× `crates/*/Cargo.toml`: `version = "0.2.2"` → `version = "0.2.3"`
- `Cargo.lock`: regenerated
- `CHANGELOG.md`: new `## 0.2.3` section grouped by Added / Changed / Security, covering every public-API surface from #12

Inter-crate dependencies use `version = "0.2"` (matches `>=0.2.0, <0.3.0`) so no dep-version edits needed.

## Surface compatibility note

`proto::ObjectType` grows a new `Redaction` variant. Downstream crates that exhaustively `match` on `ObjectType` will need to add the arm. The change is shipped at a `0.2.x` patch bump per project policy of additive-but-possibly-breaking patches in the pre-1.0 series.

## After merge

Publishing sequence (topological from `release-plz.toml`, plus heddle-client which slots in after heddle-repo since that's what it depends on):

```bash
for c in heddle-objects heddle-refs heddle-oplog heddle-crypto \
         heddle-proto heddle-semantic heddle-repo heddle-grpc \
         heddle-client heddle-ingest heddle-mount heddle-daemon \
         heddle-cli-shared heddle-devtools heddle-review \
         heddle-state-review weft-client-shim heddle-cli; do
  cargo publish -p "$c"
  sleep 5
done
```

Then tag:

```bash
git tag -a v0.2.3 -m "v0.2.3 — cross-replica redaction propagation + .heddleignore globs"
git push origin v0.2.3
```

I'll handle both steps once you merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)