### PR TITLE
release: v0.2.4 — RedactionTransfer gRPC channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ recorded here. Hosted-product work (Postgres, Biscuit, the web app,
 GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 `HeddleCo/tapestry` repos.
 
+## 0.2.4 - 2026-05-14
+
+### Added
+
+- **`RedactionTransfer` gRPC message + oneof variants**
+  (`crates/grpc/proto/heddle/v1/service.proto`). Out-of-pack
+  transport for redaction sidecars on hosted-gRPC push and pull.
+  - New `message RedactionTransfer { string blob_hash; bytes redactions_blob; }`.
+  - Added as variant 5 to `PushMessage.body` oneof and variant 6 to
+    `PullMessage.body` oneof.
+  - Sender emits one per blob hash with an active redaction in the
+    state closure; receiver routes through
+    `Repository::accept_wire_redactions` for signature + trust-list
+    verification.
+
+Sidecars live structurally outside `.heddle/objects/` (so GC can't
+reach them) and therefore can't ride the native-pack object
+channel. This release closes the follow-up flagged in 0.2.3's
+"hosted-gRPC redaction transport" note. Server-side biscuit
+capability gating + the actual handler wiring lives downstream of
+heddle (in `weft-server`), so this release is purely the wire-format
+addition.
+
 ## 0.2.3 - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-stream",
  "chrono",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "protoc-bin-vendored",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-proto"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -7222,7 +7222,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli-shared"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "CLI-side utilities shared between Heddle's OSS cli crate and the closed heddle-client crate: user config, remote target resolution, client config."

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-client"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle hosted-backend client: auth, support, presence, the gRPC client wrappers, and the global credential store."

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -6,8 +6,9 @@ use std::{
 use grpc::heddle::v1::{
     GetBlobRequest, ListRefsRequest, ObjectAvailabilityStatus, ObjectDescriptor, PackChunk,
     PackStreamKind, PartialFetchStatus, PullMessage, PullRequest, PushMessage, PushRequest,
-    ThreadConfidenceSummary, ThreadIntegrationPolicy, ThreadMetadata, ThreadVerificationSummary,
-    TransportMode, UpdateRefRequest, WantObjects, pull_message, push_message,
+    RedactionTransfer, ThreadConfidenceSummary, ThreadIntegrationPolicy, ThreadMetadata,
+    ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects, pull_message,
+    push_message,
 };
 use objects::{
     object::{ChangeId, ContentHash},
@@ -239,8 +240,17 @@ impl HostedGrpcClient {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if !wanted_infos.is_empty() {
-            let bundle = proto::build_native_pack(repo.store(), &wanted_infos)?;
+        // Split want_objects: blob/tree/state/action → native pack;
+        // redactions → out-of-pack `RedactionTransfer` channel (the
+        // sidecar lives outside `.heddle/objects/` so GC can't reach
+        // it and it can't ride the pack — `build_native_pack` already
+        // skips Redaction entries on the sender side).
+        let (wanted_redactions, wanted_packable): (Vec<_>, Vec<_>) = wanted_infos
+            .into_iter()
+            .partition(|info| info.obj_type == proto::ObjectType::Redaction);
+
+        if !wanted_packable.is_empty() {
+            let bundle = proto::build_native_pack(repo.store(), &wanted_packable)?;
             for message in encode_native_pack_messages(
                 &bundle,
                 &transfer_id,
@@ -252,6 +262,42 @@ impl HostedGrpcClient {
                     ProtocolError::InvalidState("push stream closed unexpectedly".to_string())
                 })?;
             }
+        }
+
+        for info in wanted_redactions {
+            let proto::ObjectId::Hash(blob) = info.id else {
+                return Err(ProtocolError::InvalidState(
+                    "wanted Redaction must be keyed by ObjectId::Hash(content_hash)".to_string(),
+                ));
+            };
+            // Sender-side: load the byte-identical sidecar payload
+            // that `Repository::put_redaction` wrote to disk. The
+            // receiver verifies the signature + trust list and then
+            // persists these bytes verbatim.
+            let bytes = repo
+                .store()
+                .get_redactions_bytes_for_blob(&blob)
+                .map_err(|err| {
+                    ProtocolError::InvalidState(format!(
+                        "load redactions sidecar for {}: {err}",
+                        blob.to_hex()
+                    ))
+                })?
+                .ok_or_else(|| {
+                    ProtocolError::InvalidState(format!(
+                        "server wants redaction for blob {} but sender has no sidecar",
+                        blob.to_hex()
+                    ))
+                })?;
+            let message = PushMessage {
+                body: Some(push_message::Body::Redaction(RedactionTransfer {
+                    blob_hash: blob.to_hex(),
+                    redactions_blob: bytes,
+                })),
+            };
+            tx.send(message).await.map_err(|_| {
+                ProtocolError::InvalidState("push stream closed unexpectedly".to_string())
+            })?;
         }
         drop(tx);
 
@@ -675,6 +721,32 @@ impl HostedGrpcClient {
                     profile.pack_decode += decode_elapsed;
                     profile.pack_decode_apply += decode_elapsed;
                     profile.decode += decode_elapsed;
+                }
+                Some(pull_message::Body::Redaction(transfer)) => {
+                    // Out-of-pack channel: receive a redaction sidecar
+                    // and route through `Repository::accept_wire_redactions`
+                    // for signature + trust-list verification. The
+                    // server emitted these only for blobs in our want
+                    // set that carry an active redaction.
+                    profile.bytes_received = profile
+                        .bytes_received
+                        .saturating_add(transfer.redactions_blob.len());
+                    profile.object_mix.record(ObjectType::Redaction);
+                    let blob = ContentHash::from_hex(&transfer.blob_hash).map_err(|err| {
+                        ProtocolError::InvalidState(format!(
+                            "RedactionTransfer.blob_hash is not a valid content hash: {err}"
+                        ))
+                    })?;
+                    let decode_start = Instant::now();
+                    repo.accept_wire_redactions(blob, &transfer.redactions_blob)
+                        .map_err(|err| {
+                            ProtocolError::InvalidState(format!(
+                                "accept_wire_redactions for blob {}: {err}",
+                                transfer.blob_hash
+                            ))
+                        })?;
+                    let decode_elapsed = decode_start.elapsed();
+                    profile.store_receive_object += decode_elapsed;
                 }
                 Some(pull_message::Body::Complete(complete)) => {
                     profile.receive_and_apply = receive_start.elapsed();

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-crypto"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-daemon"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "Heddle local-mode gRPC daemon and service implementations"

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-devtools"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "Developer tooling for the Heddle workspace"

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -313,12 +313,32 @@ message PushComplete {
   TransferCheckpoint transfer = 4;
 }
 
+// Out-of-pack transport for redaction sidecars. Sidecars live
+// structurally outside `.heddle/objects/` (so GC can't reach them)
+// and therefore can't ride the native-pack object channel. The
+// sender emits one `RedactionTransfer` per blob hash with an active
+// redaction in the state closure; the receiver routes through
+// `Repository::accept_wire_redactions` for signature + trust-list
+// verification.
+//
+// `blob_hash` is the hex-encoded ContentHash of the *redacted blob*
+// (the redactions store is keyed by that hash, not by the
+// redaction-record content hash).
+// `redactions_blob` is the rmp-encoded `RedactionsBlob` byte payload
+// — byte-identical to what `Repository::put_redaction` wrote on the
+// sender's disk.
+message RedactionTransfer {
+  string blob_hash = 1;
+  bytes redactions_blob = 2;
+}
+
 message PushMessage {
   oneof body {
     PushRequest request = 1;
     PushReady ready = 2;
     PackChunk pack = 3;
     PushComplete complete = 4;
+    RedactionTransfer redaction = 5;
   }
 }
 
@@ -368,6 +388,7 @@ message PullMessage {
     WantObjects want = 3;
     PackChunk pack = 4;
     PullComplete complete = 5;
+    RedactionTransfer redaction = 6;
   }
 }
 

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-ingest"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "Import git history (commits, refs, reflogs) into a native Heddle repository with agent attribution and reasoning annotations."

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-mount"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-objects"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-oplog"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-proto"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-refs"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-repo"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-review"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-semantic"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-state-review"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weft-client-shim"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 description = "Trait surface for client extensions to the Heddle CLI. OSS default is a noop impl; closed builds replace it via [patch.crates-io]."


### PR DESCRIPTION
## Summary

Wire-format addition for the hosted-gRPC redaction transport flagged in [v0.2.3](https://github.com/HeddleCo/heddle/releases/tag/v0.2.3) as a follow-up. Sidecars can't ride the native-pack object channel (they live structurally outside \`.heddle/objects/\` so GC can't reach them), so the gRPC schema grows a dedicated message variant.

## Changes

- \`crates/grpc/proto/heddle/v1/service.proto\`:
  - New \`message RedactionTransfer { string blob_hash; bytes redactions_blob; }\`.
  - Added as variant 5 to \`PushMessage.body\` oneof and variant 6 to \`PullMessage.body\` oneof.
- 18× \`crates/*/Cargo.toml\`: \`0.2.3\` → \`0.2.4\`.
- \`CHANGELOG.md\`: new \`## 0.2.4\` section.

Sender emits one \`RedactionTransfer\` per blob hash with an active redaction in the state closure; receiver routes through \`Repository::accept_wire_redactions\` for signature + trust-list verification.

Server-side biscuit capability gating (\`can_redact\` / \`can_purge\`) and the actual stream-handler wiring lives downstream of heddle in \`weft-server\` — companion PR at [HeddleCo/weft#82](https://github.com/HeddleCo/weft/pull/82).

## After merge

```bash
for c in heddle-objects heddle-refs heddle-oplog heddle-crypto \\
         heddle-proto heddle-semantic heddle-repo heddle-grpc \\
         heddle-client heddle-ingest heddle-mount heddle-daemon \\
         heddle-cli-shared heddle-devtools heddle-review \\
         heddle-state-review weft-client-shim heddle-cli; do
  cargo publish -p \"\$c\"
  sleep 8
done
git tag -a v0.2.4 -m \"v0.2.4 — RedactionTransfer gRPC channel\"
git push origin v0.2.4
```

I'll handle both steps once you merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)