### PR TITLE
ci: route card-sync through blacksmith runners

### DIFF
--- a/.github/workflows/project-card-sync.yml
+++ b/.github/workflows/project-card-sync.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   add-issue-to-project:
     if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Add issue to project
         uses: actions/add-to-project@v1.0.2
@@ -72,7 +72,7 @@ jobs:
     if: |
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
     steps:


### PR DESCRIPTION
Switch the project-card-sync workflow from `ubuntu-latest` (GitHub-hosted) to `blacksmith-2vcpu-ubuntu-2404` to bypass the GitHub Actions billing block.

Workflow logic is unchanged — only `runs-on` differs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->