### PR TITLE
chore(.github): add sub-issue/spike issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,85 @@
+name: Spike
+description: A time-boxed investigation whose deliverable is a decision document, not shipped code.
+title: "Spike: [question to resolve]"
+labels: ["p1", "spike"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the answer to "should we build it this way?" is unknown and worth a few hours / days to find out before committing to an implementation issue.
+
+        After filing: set `DoD Type = Spike`, `Size = S` or `M` (spikes that need `L` are usually two spikes), and `Priority` per how much it blocks downstream work. Spikes typically block one or more sub-issues — list those under `Blocked by → unblocks` so the orchestrator can re-route once the decision lands.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is the open question? Why can't we just decide it now? What downstream work is waiting on the answer?
+      placeholder: 2–4 sentences. Name the constraint that makes this a real question (perf budget, bundle size, security model, API surface, etc.).
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: A spike is "done" when the decision is committed. List the artifacts that must exist.
+      value: |
+        - [ ] Decision doc in `<repo>/docs/<EPIC>_<TOPIC>_DECISION.md` covering: problem statement, options considered, measured evidence, recommendation.
+        - [ ] PR description includes the headline numbers (KB / ms / lines / whatever the constraint is).
+        - [ ] Each downstream issue listed under "Unblocks" has its `Blocked by` line removed once this lands.
+        - [ ] Decision reviewed and signed off by a maintainer.
+    validations:
+      required: true
+  - type: textarea
+    id: options
+    attributes:
+      label: Options to evaluate
+      description: Concrete options the spike will compare. Naming them up-front prevents scope creep mid-spike.
+      value: |
+        - Option A —
+        - Option B —
+        - Option C (do nothing / defer) —
+    validations:
+      required: true
+  - type: textarea
+    id: time-box
+    attributes:
+      label: Time box
+      description: How long until we either have an answer or escalate? Spikes that exceed their budget should post a BUDGET comment, not silently expand.
+      placeholder: "Examples: 1 day, half-day, 4h."
+    validations:
+      required: true
+  - type: textarea
+    id: file-scope
+    attributes:
+      label: File scope
+      description: Paths the spike expects to touch (often just a new doc file plus a throwaway POC dir).
+      value: |
+        - `<repo>/docs/<EPIC>_<TOPIC>_DECISION.md`
+        - `<repo>/spikes/<topic>/` (throwaway POC, may be deleted on merge)
+  - type: textarea
+    id: unblocks
+    attributes:
+      label: Unblocks
+      description: Sub-issues that are waiting on this decision. List them so the orchestrator can re-evaluate `Blocked by` once the spike closes.
+      placeholder: |
+        - HeddleCo/tapestry#42
+        - HeddleCo/weft#19
+  - type: textarea
+    id: blocked-by
+    attributes:
+      label: Blocked by
+      description: Issues that must close before this spike can start. Often empty for spikes.
+      placeholder: |
+        - HeddleCo/heddle#5
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Spike DoD — the deliverable is the decision, not code.
+      value: |
+        - [ ] **Spike output**: decision doc committed under the right `docs/` tree.
+        - [ ] PR description includes the measured evidence that drove the recommendation.
+        - [ ] All sub-issues listed in "Unblocks" have their `Blocked by` reference cleared once this lands.
+        - [ ] Reviewed by a maintainer.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/sub-issue.yml
@@ -1,0 +1,59 @@
+name: Sub-issue
+description: A scoped piece of work that rolls up to an epic on the HeddleCo kanban board.
+title: "[short imperative title — no leading verb noise]"
+labels: ["p1"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for normal sub-issues that an agent (human or AI) can pick up and ship in one PR.
+
+        Before filing: skim [BOARD.md](https://github.com/HeddleCo/.github/blob/main/profile/BOARD.md) for field conventions. After filing: set the project fields on the issue card (Epic, Scope, DoD Type, Size, Priority).
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this matters, how we got here, and what the agent picking this up cold needs to know to start. 2–6 sentences.
+      placeholder: One paragraph. Link the parent epic (`Part of #N`) and any prior issues/PRs that informed this.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checkboxes that define done. Each one must be verifiable from the diff or a CI artifact. Avoid prose; prefer bullets that read as "thing exists / behaviour holds".
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: file-scope
+    attributes:
+      label: File scope
+      description: Paths the agent expects to touch. Used by the orchestrator to detect parallel-work collisions. If unsure, infer from the parent epic's `## Critical files` and update later.
+      value: |
+        - `path/to/file_or_dir/`
+        - `another/path.rs`
+  - type: textarea
+    id: blocked-by
+    attributes:
+      label: Blocked by
+      description: Issues that must close before this one can move from Backlog to Ready. Cross-repo refs allowed (`HeddleCo/weft#42`).
+      placeholder: |
+        - HeddleCo/heddle#19
+        - HeddleCo/weft#42
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Standard DoD shell — leave as-is unless the issue genuinely doesn't need a particular line. Which lines apply depends on the project board's `DoD Type` field.
+      value: |
+        - [ ] **Red-commit first** (Rust): failing tests pushed before implementation; link the red SHA in the PR.
+        - [ ] **Playwright e2e + verification checklist** (UI): viewports, auth states, before/after screenshots in PR.
+        - [ ] PR description includes test command output + coverage delta + perf delta where relevant.
+        - [ ] Cross-repo PRs all linked back to this issue.
+        - [ ] Acceptance criteria above all checked.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,78 @@
+<!--
+  HeddleCo PR template — fill in every section below; the inline guidance
+  comments are safe to leave in place. The DoD CI gate (.github/workflows/
+  dod-check.yml) parses this body and will fail the check if a required
+  section is missing for your file scope:
+
+    - All PRs:                  a Closes / Fixes / Resolves / Part of /
+                                Tracked by / Refs line.
+    - Touches non-doc code:     a Test evidence section with a fenced code block.
+    - Touches .rs files:        a Red commit section with a SHA.
+    - Touches UI code only:     a Manual verification section.
+
+  Pure-docs (.md/.txt) and pure-CI (.github/) PRs are exempt from the
+  test-evidence requirement. See the kanban contract for the full DoD shape:
+  https://github.com/HeddleCo/.github/blob/main/profile/BOARD.md
+-->
+
+## Summary
+
+<!-- 2–4 bullets. What changed and why. Reviewer-facing, not commit-history-facing. -->
+
+-
+-
+
+## Closes
+
+<!--
+  REQUIRED. Pick one form:
+    Closes HeddleCo/<repo>#<n>     — this PR's merge should close the issue.
+    Part of HeddleCo/<repo>#<n>    — cross-repo work; the issue stays open until siblings land.
+    Refs HeddleCo/<repo>#<n>       — referenced for context only.
+
+  Use Closes only on the *last* PR in a multi-PR change. Use Part of on every
+  cross-repo PR otherwise.
+-->
+
+Closes HeddleCo/<repo>#<n>
+
+<!--
+  Required when the PR touches .rs files. Replace <sha> with the SHA of the
+  commit that pushed failing tests *before* implementation, per TDD-Rust DoD.
+  Skip the section (or write `N/A — not a Rust PR`) for non-Rust PRs.
+-->
+
+## Red commit
+`<sha>`
+
+<!--
+  Required unless the entire diff is .md/.txt or under .github/. Paste actual
+  command output (cargo test, bun test, playwright report, etc.) inside the
+  fenced block. Show the tests from the red commit now passing.
+-->
+
+## Test evidence
+```
+<paste test output here>
+```
+
+## Manual verification
+
+<!--
+  Required for UI PRs (TS/TSX/Svelte/JS). For Rust-only or pure-server PRs,
+  write: N/A — covered by tests.
+
+  UI PRs should list:
+    - Viewports tested (375×812, 768×1024, 1280×800, etc.)
+    - Auth states tested (signed-out, signed-in, admin)
+    - Before/after screenshot URLs (Playwright `--screenshot=on` or manual)
+-->
+
+## Blocked by → resolved
+
+<!--
+  If merging this PR resolves another issue's `## Blocked by` reference,
+  list those issues so the orchestrator can re-evaluate them. Otherwise None.
+-->
+
+None


### PR DESCRIPTION
## Summary
- Adds three GitHub templates to heddle's `.github/` so new sub-issues, spikes, and PRs land in a shape the orchestrator and the DoD CI gate expect.
- `ISSUE_TEMPLATE/sub-issue.yml` mirrors the auto-generated sub-issue body shape (Context, Acceptance criteria, File scope, Blocked by, DoD).
- `ISSUE_TEMPLATE/spike.yml` is a separate spike form whose deliverable is a decision doc (Options, Time box, Unblocks).
- `PULL_REQUEST_TEMPLATE.md` enforces the DoD shape: required Closes/Part of ref, fenced Test evidence block, Red commit SHA section (Rust), Manual verification section (UI). Validated against the regexes in the prepped `dod-check.yml` workflow.
- Sibling PRs: HeddleCo/weft#118 (templates), HeddleCo/tapestry#40 (templates), HeddleCo/.github#1 (BOARD.md contract).

## Closes
Part of HeddleCo/heddle#30

## Red commit
N/A — not a Rust PR.

## Test evidence
```
N/A — pure docs / template files; validated by:

  1. Issue templates: parsed as YAML with `ruby -ryaml`:
     OK: sub-issue.yml (6 fields)
     OK: spike.yml (9 fields)

  2. PR template: simulated the DoD CI workflow's regexes
     (.github/workflows/dod-check.yml — see /tmp/heddleco-board/) against
     a filled-in PR body:

       Closing/tracking ref: True
       Test evidence:        True
       Red commit:           True
       Manual verification:  True
```

## Manual verification
N/A — covered by the validation in Test evidence. The issue templates' GitHub-rendered behaviour (form fields, default labels, picker on the New Issue page) cannot be verified pre-merge; if the YAML is malformed GitHub silently hides the template from the picker — the schema validation above is the strongest pre-merge signal available.

## Blocked by → resolved
None