### PR TITLE
docs(redact): mark original brief as shipped historical

### DIFF
--- a/.agents/redaction-primitive.md
+++ b/.agents/redaction-primitive.md
@@ -1,5 +1,27 @@
 # Build prompt — Redaction primitive
 
+> **Status:** historical — shipped in 0.2.3 (#12) and 0.2.4 (#14). This
+> file is the original build brief, kept for context. Sections marked
+> "for now" / "Single-repo only" / "verify" reflect the pre-implementation
+> plan and are *not* current. The shipped behaviour:
+>
+> - Cross-replica propagation works via `proto::ObjectType::Redaction`
+>   and the gRPC `RedactionTransfer` channel. Both `LocalSync` (peer-to-peer
+>   file sync) and `HostedGrpcClient` (network sync) route incoming
+>   redactions through `Repository::accept_wire_redactions`.
+> - The wire path is fail-closed: unsigned, tampered, and
+>   untrusted-key redactions are refused. Operators populate
+>   `[redact] trusted_keys` per repo via `heddle redact trust add`.
+> - `purge` propagates as a `Redaction` with `purged_at: Some(_)` and
+>   replays via the same `accept_wire_redactions` chokepoint on each
+>   replica. Bytes are dropped locally on the receiver, matching
+>   `Repository::purge_blob` semantics. Packfile repack after wire-purge
+>   remains an operator follow-up (`blob_remains_in_pack` flag).
+>
+> Current docs: `CHANGELOG.md` (0.2.3, 0.2.4 entries), the
+> `commands_redact.rs` module doc, and `Repository::accept_wire_redactions`
+> in `crates/repo/src/repository_redaction.rs`.
+
 > Self-contained brief for the agent implementing `heddle redact` + `heddle purge`. Don't dispatch sub-agents for the implementation itself — touch the crates directly. Dispatch reviewers only at the end if you want a second opinion before commit.
 
 ## Goal


### PR DESCRIPTION
## Summary

`.agents/redaction-primitive.md` is the pre-implementation build brief for the redaction primitive. A few of its sections are now stale — most notably line 83 (a `verify` hand-wave about sync handlers) and line 121 (`Single-repo only for now`) — because the cross-replica wire propagation work shipped in 0.2.3 ([#12](https://github.com/HeddleCo/heddle/pull/12)) and the gRPC `RedactionTransfer` channel shipped in 0.2.4 ([#14](https://github.com/HeddleCo/heddle/pull/14)).

Rather than rewrite the brief in place (which would erase useful historical context), this PR adds a status banner at the top noting it's historical and pointing readers at the canonical surfaces for current behaviour:

- `CHANGELOG.md` — 0.2.3 + 0.2.4 entries describe the shipped wire contract.
- `commands_redact.rs` module doc — current CLI behaviour.
- `Repository::accept_wire_redactions` in `crates/repo/src/repository_redaction.rs` — receiver chokepoint.

Banner also captures one operator follow-up that wasn't part of the propagation scope: packfile repack after wire-purge (`blob_remains_in_pack` flag) is still an operator action; `purge_blob` only drops loose objects.

## Test plan

- [x] Documentation-only change.
- [x] `cargo build --workspace` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->