### PR TITLE
ci: add cargo-audit + cargo-deny supply-chain gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,77 @@
+name: Supply-chain audit
+
+# Blocking gate for the Rust supply chain.
+#
+# - cargo-deny enforces the policy in deny.toml (licenses, banned crates,
+#   advisories, registry/git sources).
+# - cargo-audit cross-checks the RustSec advisory DB. cargo-deny already
+#   reads the same DB; running cargo-audit too gives us a second tool's
+#   take and surfaces yanked-crate warnings explicitly.
+#
+# The weekly cron catches advisories filed against unchanged dependencies
+# (a new CVE against a crate we already ship will trip the gate on Monday
+# even if no one has pushed code).
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/audit.yml'
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly: Mondays 05:17 UTC. Offset minute avoids the top-of-the-hour
+    # GitHub-Actions scheduling stampede.
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          # `check all` runs advisories + bans + licenses + sources in one pass.
+          command: check all
+
+  cargo-audit:
+    name: cargo-audit
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo-audit
+        # --deny warnings escalates yanked / unmaintained / notice advisories
+        # to errors. The --ignore list below MUST mirror deny.toml's
+        # [advisories].ignore — cargo-audit doesn't read deny.toml. If you add
+        # an ignore there, add it here too (and update CONTRIBUTING's Security
+        # section so the rationale stays discoverable).
+        run: |
+          cargo audit \
+            --deny warnings \
+            --ignore RUSTSEC-2023-0071

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -74,4 +74,8 @@ jobs:
         run: |
           cargo audit \
             --deny warnings \
-            --ignore RUSTSEC-2023-0071
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,68 @@ From [docs/PRINCIPLES.md](docs/PRINCIPLES.md):
 If a proposed change makes any of those weaker — even slightly — the
 change is wrong. Argue from the principles, not around them.
 
+## Security
+
+Heddle gates every PR (and runs a weekly cron) through a supply-chain
+audit. The gate is enforced by
+[`.github/workflows/audit.yml`](.github/workflows/audit.yml) and lives
+across two tools:
+
+- **cargo-deny** — reads [`deny.toml`](deny.toml). Enforces the license
+  allow-list, the banned-crates list (e.g. `openssl` / `openssl-sys` /
+  `native-tls` — Heddle standardizes on rustls), the registry/git source
+  allow-list, and the RustSec advisory database.
+- **cargo-audit** — second-opinion advisory scan against the same
+  RustSec DB, run with `--deny warnings` so yanked / unmaintained /
+  notice advisories also fail the build.
+
+### Running the gate locally
+
+```bash
+cargo install --locked cargo-deny  # once
+cargo install --locked cargo-audit # once
+
+cargo deny check                   # full policy run
+cargo audit --deny warnings        # advisory check
+```
+
+Both should be green before you push. CI runs them on every push to
+`main`, every PR that touches `Cargo.toml` / `Cargo.lock` / `deny.toml`
+/ `audit.yml`, and on a weekly schedule (Mondays 05:17 UTC) so a fresh
+advisory against an unchanged dependency surfaces without anyone
+having to push code.
+
+### Ignoring an advisory
+
+If a RustSec advisory cannot be fixed by a version bump (upstream
+hasn't released; advisory doesn't apply to our usage; etc.), add an
+entry to **both** of:
+
+1. `deny.toml` — `[advisories].ignore` with `{ id, reason }`. The
+   `reason` must explain *why* it's safe to ignore in Heddle's context,
+   not just acknowledge the advisory exists.
+2. `.github/workflows/audit.yml` — `cargo audit --ignore <ID>` in the
+   `cargo-audit` step. cargo-audit doesn't read `deny.toml`, so the
+   two lists must be kept in sync by hand.
+
+When upstream ships a fix, remove the entry from both places in the
+same PR that bumps the dependency.
+
+### Adding a license to the allow-list
+
+Adding a license is a policy decision. Discuss in the PR before
+extending `[licenses].allow` in `deny.toml`. Copyleft licenses
+(GPL-*, AGPL-*, LGPL-*) are not on the allow-list by design and
+should not be added without sign-off — Heddle ships under Apache-2.0
+and we don't want copyleft obligations leaking into binaries.
+
+### Lifting a crate ban
+
+Same shape as license additions: discuss first. The banned list in
+`[bans].deny` reflects intentional architectural choices (rustls only,
+no OpenSSL coupling), not arbitrary preferences. If you have a real
+need, the PR should explain why the alternative isn't viable.
+
 ## Getting unstuck
 
 - Quick how-to questions: open a GitHub Discussion.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,131 @@
+# cargo-deny configuration — Heddle supply-chain gate.
+#
+# Enforced by .github/workflows/audit.yml on push + PR + weekly cron.
+# Run locally with: cargo deny check
+#
+# Schema reference: https://embarkstudios.github.io/cargo-deny/
+
+# ---------------------------------------------------------------------------
+# Target scope
+# ---------------------------------------------------------------------------
+# Heddle ships for Linux, macOS, and Windows on x86_64 + aarch64. Scoping the
+# graph to these triples cuts noise from platform-specific deps we never link
+# (e.g. wasm shims, redox, openbsd-only crates).
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = false
+
+[output]
+feature-depth = 1
+
+# ---------------------------------------------------------------------------
+# Advisories — RustSec database
+# ---------------------------------------------------------------------------
+[advisories]
+version = 2
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Any advisory not explicitly ignored below is a hard fail. Yanked crates
+# warn rather than fail so a yank during CI flight doesn't break unrelated PRs;
+# the weekly cron will still surface them.
+yanked = "warn"
+ignore = [
+    # rsa 0.9.x: Marvin timing sidechannel on RSA decryption. Upstream-tracked
+    # (https://github.com/RustCrypto/RSA/issues/19); no fixed release in the
+    # 0.9 line yet. Heddle's use is signature verification on hosted control-
+    # plane tokens, not RSA decryption with attacker-chosen ciphertexts, so the
+    # Marvin attack precondition is not present on our paths. Revisit when
+    # rsa 0.10 (with constant-time decryption) ships.
+    { id = "RUSTSEC-2023-0071", reason = "rsa 0.9 Marvin timing sidechannel; precondition (attacker-chosen ciphertext decryption) not present in Heddle's signature-verification use; tracked upstream" },
+]
+
+# ---------------------------------------------------------------------------
+# Licenses — permissive allow-list with explicit exceptions
+# ---------------------------------------------------------------------------
+[licenses]
+version = 2
+# SPDX expressions. Every license in a dependency's expression must appear
+# here (AND-joined expressions require all components). Adding a license is a
+# policy decision — discuss in the PR before extending this list.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "CC0-1.0",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    # MPL-2.0 is file-level copyleft; safe to consume as a dependency without
+    # modification. Used by webpki-roots and a handful of other ecosystem
+    # crates. If we ever vendor or fork an MPL crate, revisit.
+    "MPL-2.0",
+    # OpenSSL license: required by ring and aws-lc-sys, which are upstream
+    # of rustls. Both crates carry permissive-OR-OpenSSL composite licenses;
+    # the OpenSSL component is OSI-approved and BSD-style with an advertising
+    # clause we satisfy via README attribution.
+    "OpenSSL",
+]
+confidence-threshold = 0.8
+# Per-crate exceptions go here if a single dependency needs a license that
+# we do NOT want to bless wholesale. Empty for now; the allow-list above
+# covers everything we've encountered.
+exceptions = []
+
+# Note: ring (>= 0.17) and aws-lc-sys (>= 0.30) now ship SPDX expressions in
+# their Cargo.toml manifests, so cargo-deny reads the license expression
+# directly and no [[licenses.clarify]] entry is required. If we ever pin an
+# older ring (0.16.x) we will need to add a clarify block with a verified
+# LICENSE file hash.
+
+# ---------------------------------------------------------------------------
+# Bans — crates we refuse to depend on
+# ---------------------------------------------------------------------------
+[bans]
+# Multiple versions of the same crate bloat the supply-chain surface but are
+# common in large workspaces (transitive disagreement on semver). Warn so the
+# growth is visible; do not block on it.
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+deny = [
+    # Heddle standardizes on rustls (see workspace Cargo.toml: reqwest,
+    # gix, tonic, tokio-rustls all pin the rustls flavor explicitly).
+    # Pulling in OpenSSL would re-introduce system-OpenSSL coupling, widen
+    # the CVE-relevant surface, and break our reproducible-build story on
+    # platforms without a system libssl. If you have a justified need,
+    # discuss in #infra before lifting the ban.
+    { crate = "openssl", reason = "rustls is the project standard; OpenSSL would widen supply-chain surface and break the rustls-only invariant" },
+    { crate = "openssl-sys", reason = "see openssl ban — sys crate is the actual native-link offender" },
+    { crate = "native-tls", reason = "wraps OpenSSL/SChannel/SecureTransport; rustls is the project standard" },
+    { crate = "openssl-probe", reason = "only useful alongside openssl; banning it keeps OpenSSL adjacency out of the graph" },
+]
+
+# Crates that legitimately appear multiple times in the graph today. Each
+# entry is a known-and-accepted duplication; revisit when the upstream
+# ecosystem converges.
+skip = []
+skip-tree = []
+
+# ---------------------------------------------------------------------------
+# Sources — registries and git remotes
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Git deps must be explicitly listed. Empty list means "crates.io only" — if
+# you add a `git = "..."` dependency, add the remote here with a comment
+# explaining why crates.io isn't sufficient.
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -111,6 +111,11 @@ exceptions = []
 # growth is visible; do not block on it.
 multiple-versions = "warn"
 wildcards = "deny"
+# Intra-workspace path deps (e.g. `{ path = "../foo", package = "heddle-foo" }`)
+# resolve to a wildcard version requirement and would otherwise trip the
+# `wildcards = "deny"` gate. Allow them — they're not the supply-chain risk
+# we're guarding against; crates.io wildcard requirements are.
+allow-wildcard-paths = true
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
@@ -125,7 +130,10 @@ deny = [
     { crate = "openssl", reason = "rustls is the project standard; OpenSSL would widen supply-chain surface and break the rustls-only invariant" },
     { crate = "openssl-sys", reason = "see openssl ban — sys crate is the actual native-link offender" },
     { crate = "native-tls", reason = "wraps OpenSSL/SChannel/SecureTransport; rustls is the project standard" },
-    { crate = "openssl-probe", reason = "only useful alongside openssl; banning it keeps OpenSSL adjacency out of the graph" },
+    # Note: openssl-probe is intentionally NOT banned. It's a small helper
+    # for locating the system CA-bundle path (env vars + file probes) and
+    # does not link libssl. rustls-native-certs depends on it on Linux,
+    # which is reached transitively via aws-sdk-s3 → smithy-http-client.
 ]
 
 # Crates that legitimately appear multiple times in the graph today. Each

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ targets = [
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
 ]
-all-features = false
 
 [output]
 feature-depth = 1
@@ -42,6 +41,18 @@ ignore = [
     # Marvin attack precondition is not present on our paths. Revisit when
     # rsa 0.10 (with constant-time decryption) ships.
     { id = "RUSTSEC-2023-0071", reason = "rsa 0.9 Marvin timing sidechannel; precondition (attacker-chosen ciphertext decryption) not present in Heddle's signature-verification use; tracked upstream" },
+
+    # The next four advisories all stem from a single transitive dep chain:
+    #   aws-sdk-s3 → aws-smithy-runtime → aws-smithy-http-client → hyper-rustls 0.24 → rustls 0.21 → rustls-webpki 0.101 / rustls-pemfile 2
+    # Heddle's *direct* deps pin rustls 0.23 (see workspace Cargo.toml) but
+    # aws-smithy-http-client 1.1.x is on the old rustls 0.21 line. Fixing it
+    # requires bumping aws-sdk-s3 to a version whose smithy stack uses
+    # rustls 0.23 — out of scope for this gate-landing PR. Tracked as a
+    # follow-up; remove these ignores in the same PR that bumps aws-sdk-s3.
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101: wildcard SAN constraint bypass. Transitive via aws-sdk-s3 → smithy-http-client → old rustls 0.21. Heddle doesn't validate certificates with wildcard name constraints on attacker-supplied trust anchors; mitigation is the aws-sdk-s3 bump tracked as a follow-up." },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101: URI name constraint accepted. Same transitive chain as RUSTSEC-2026-0099; same mitigation path." },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101: reachable panic parsing malformed CRL. Heddle does not consume attacker-supplied CRLs over the aws-sdk-s3 path (S3 endpoint TLS uses a small fixed root set); same mitigation path." },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile 2.2: unmaintained notice (not a vulnerability). Declared by heddle-client and heddle-cli-shared via Cargo.toml but not actually imported by any .rs file in those crates — likely vestigial. Recommended follow-up: remove the dep, which would eliminate this advisory entirely. Out of scope for the gate-landing PR." },
 ]
 
 # ---------------------------------------------------------------------------
@@ -73,6 +84,11 @@ allow = [
     # the OpenSSL component is OSI-approved and BSD-style with an advertising
     # clause we satisfy via README attribution.
     "OpenSSL",
+    # CDLA-Permissive-2.0: data license (Community Data License Agreement —
+    # Permissive), used by webpki-roots to ship Mozilla's CA root certificate
+    # bundle. It's a permissive license tailored for datasets; including the
+    # cert bundle in our distribution is the intended use. Allow.
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 # Per-crate exceptions go here if a single dependency needs a license that


### PR DESCRIPTION
## Summary
- New blocking CI gate (`.github/workflows/audit.yml`) that runs `cargo-deny check all` + `cargo audit --deny warnings` on push, PRs touching Cargo or policy files, and a weekly Monday 05:17 UTC cron.
- `deny.toml` codifies the supply-chain policy: license allow-list, RustSec advisory enforcement (with five explicitly-documented ignores — see below), banned crates that preserve the project's rustls-only invariant, and an explicit registry/git source allow-list.
- `CONTRIBUTING.md` gains a Security section that documents how to run the gate locally, how to add an advisory ignore (the two-file sync requirement between `deny.toml` and `audit.yml`), and the policy for extending licenses or lifting crate bans.

## Closes
HeddleCo/heddle#32

## Red commit
N/A — this is a CI/config-only change. Per `HeddleCo/AGENTS.md` § "What you must do → 1." the red-commit step is **Rust only**; there is no Rust source code in this PR.

## Test evidence

Both gate jobs are green on this PR's HEAD ([commit e525c88](https://github.com/HeddleCo/heddle/pull/40/commits/e525c88)):

| Job | Result | Run |
|---|---|---|
| `cargo-deny` (check all) | ✅ pass (22s) | https://github.com/HeddleCo/heddle/actions/runs/25928627090/job/76216514920 |
| `cargo-audit` (--deny warnings) | ✅ pass (18s) | https://github.com/HeddleCo/heddle/actions/runs/25928627090/job/76216514882 |
| `Check & test` (rust-tests.yml) | ✅ pass (4m23s) | https://github.com/HeddleCo/heddle/actions/runs/25928627076/job/76216666768 |

Iteration history shows the gate is actually catching things rather than rubber-stamping:

1. **First run (cceb231)** — surfaced (a) webpki-roots' `CDLA-Permissive-2.0` license (data-license for Mozilla's CA bundle) missing from my initial allow-list, and (b) 4 advisories against the old rustls 0.21 / rustls-pemfile 2.2 chain that aws-sdk-s3 transitively pins.
2. **Second run (5faa736)** — surfaced (a) `wildcards = "deny"` tripping on intra-workspace path deps without explicit versions, and (b) `openssl-probe` ban being over-eager (the crate is a CA-bundle path locator, not an OpenSSL link).
3. **Third run (e525c88)** — green.

Advisories ignored, all upstream-tracked and out of scope to fix in this PR:

| ID | Crate | Why we ignore |
|---|---|---|
| RUSTSEC-2023-0071 | rsa 0.9.x | Marvin timing sidechannel on RSA decryption; precondition (attacker-chosen ciphertext) absent in Heddle's signature-verification use. Tracked upstream; no 0.9.x fix. |
| RUSTSEC-2026-0098 | rustls-webpki 0.101 | URI name constraint bypass. Reached only via `aws-sdk-s3 → smithy-http-client → rustls 0.21`; mitigation is the aws-sdk-s3 bump. |
| RUSTSEC-2026-0099 | rustls-webpki 0.101 | Wildcard SAN constraint bypass. Same chain. |
| RUSTSEC-2026-0104 | rustls-webpki 0.101 | Reachable panic in CRL parsing. Same chain. |
| RUSTSEC-2025-0134 | rustls-pemfile 2.2 | Unmaintained notice (not a vuln). Vestigial Cargo.toml entry in heddle-client/cli-shared with no `.rs` imports — recommended follow-up: remove the dep. |

## Manual verification
- ✅ The audit gate jobs are green on this PR.
- ✅ The full `Check & test` job is green (no Rust regressions from any of these config-only changes).
- ⚠️ The `Coverage` job is failing on the **Codecov upload** step (HTTP 404 "Repository not found" from the Codecov SaaS — see https://github.com/HeddleCo/heddle/actions/runs/25928627076/job/76216666739). The coverage report itself generates fine; only the third-party upload fails. This is **pre-existing infra** unrelated to this PR's diff (this PR doesn't touch the coverage workflow, `lcov.info`, or any Rust source). Recent main has the same `Upload coverage to Codecov` step — orchestrator should treat this as out of scope for this issue or check whether the CODECOV_TOKEN / repo registration needs refresh.

## Blocked by → resolved
None.

## Notes for the orchestrator
- The acceptance criterion **"Mirror the workflow in weft (parallel sub-issue in weft if needed)"** is **not** addressed in this PR. Per `HeddleCo/CLAUDE.md` § "Things that should make you stop and ask the user", spike-style sub-issue creation needs orchestrator sign-off. Recommend filing `HeddleCo/weft#<new>`: `ci: mirror cargo-audit + cargo-deny gate from heddle#32`, porting this same `audit.yml` + `deny.toml` shape (the deny policy will differ in license-allow specifics — weft has a different dep set).
- Bonus follow-up that fell out of this work: heddle-client and heddle-cli-shared declare `rustls-pemfile.workspace = true` in `Cargo.toml` but no `.rs` file in either crate imports it. Removing the dep would eliminate RUSTSEC-2025-0134 from the ignore list entirely.