### PR TITLE
deps: drop vestigial rustls-pemfile from client + cli-shared (#41)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -75,7 +75,6 @@ jobs:
           cargo audit \
             --deny warnings \
             --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2025-0134 \
             --ignore RUSTSEC-2026-0098 \
             --ignore RUSTSEC-2026-0099 \
             --ignore RUSTSEC-2026-0104

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,6 @@ dependencies = [
  "heddle-proto",
  "heddle-repo",
  "rustls 0.23.40",
- "rustls-pemfile",
  "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
@@ -2800,7 +2799,6 @@ dependencies = [
  "reqwest 0.13.3",
  "rmp-serde",
  "rustls 0.23.40",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5277,15 +5275,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -16,7 +16,6 @@ objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
 rustls.workspace = true
-rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,7 +29,6 @@ prost-types.workspace = true
 reqwest.workspace = true
 rmp-serde.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,6 @@ ignore = [
     { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101: wildcard SAN constraint bypass. Transitive via aws-sdk-s3 → smithy-http-client → old rustls 0.21. Heddle doesn't validate certificates with wildcard name constraints on attacker-supplied trust anchors; mitigation is the aws-sdk-s3 bump tracked as a follow-up." },
     { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101: URI name constraint accepted. Same transitive chain as RUSTSEC-2026-0099; same mitigation path." },
     { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101: reachable panic parsing malformed CRL. Heddle does not consume attacker-supplied CRLs over the aws-sdk-s3 path (S3 endpoint TLS uses a small fixed root set); same mitigation path." },
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile 2.2: unmaintained notice (not a vulnerability). Declared by heddle-client and heddle-cli-shared via Cargo.toml but not actually imported by any .rs file in those crates — likely vestigial. Recommended follow-up: remove the dep, which would eliminate this advisory entirely. Out of scope for the gate-landing PR." },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `heddle-client` and `heddle-cli-shared` each declared `rustls-pemfile.workspace = true` in `Cargo.toml`, but neither crate actually imports the crate from any `.rs` file. The dep was vestigial — surfaced as a recommended follow-up in PR #40 while landing the supply-chain gate.
- Removing the two declarations also lets us drop `RUSTSEC-2025-0134` (the rustls-pemfile 2.2 *unmaintained* notice) from both `deny.toml` `[advisories].ignore` and the `cargo audit --ignore` arg list in `.github/workflows/audit.yml`.
- Lockfile updated to drop the orphaned `[[package]] rustls-pemfile` entry and the two consumer references. `cargo update --workspace` removed only `rustls-pemfile v2.2.0` — no other crate touched.

## Closes
HeddleCo/heddle#41

## Red commit
N/A — this is a dependency/config-only change. Per `HeddleCo/AGENTS.md` § "What you must do → 1." the red-commit step is **Rust only**; there is no Rust source code in this PR. Same justification as PR #40 (the gate-landing PR this follow-up was carved out of).

## Test evidence

### 1. Grep evidence — no `.rs` file in either crate references `rustls_pemfile`

```
$ grep -rn 'rustls_pemfile' crates/client/src/ crates/cli-shared/src/
(no matches)

$ grep -rn 'rustls[-_]pemfile' crates/client/ crates/cli-shared/  # pre-change
crates/client/Cargo.toml:32:rustls-pemfile.workspace = true
crates/cli-shared/Cargo.toml:19:rustls-pemfile.workspace = true
```

Snake-case `rustls_pemfile` is the only form Rust source can spell (the crate's hyphenated `Cargo.toml` name `rustls-pemfile` is normalized to `rustls_pemfile` at the language level). Both spellings searched, both clean across `crates/client/` and `crates/cli-shared/` except the two `Cargo.toml` lines this PR deletes.

### 2. Cargo.lock regenerated cleanly

```
$ cargo update --workspace
    Updating crates.io index
     Locking 0 packages to latest compatible versions
    Removing rustls-pemfile v2.2.0
note: pass `--verbose` to see 28 unchanged dependencies behind latest
```

Only `rustls-pemfile v2.2.0` removed. Lockfile diff is an 11-line deletion: 2 references in `heddle-client` / `heddle-cli-shared` dep arrays + the 8-line `[[package]] rustls-pemfile` block.

### 3. Local cargo gates (run in this worktree on HEAD)

| Command | Result | Time |
|---|---|---|
| `cargo build --locked --workspace --tests` | ✅ Finished `dev` profile | 2m 40s |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | ✅ exit 0 | 1m 39s |
| `cargo test --locked --workspace` | ✅ **1972 passed, 0 failed** (unit + integration + doctests) | — |
| `cargo deny check` | ✅ `advisories ok, bans ok, licenses ok, sources ok` (exit 0) | — |
| `cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104` | ✅ exit 0 | — |

For comparison, `cargo audit` *without* any ignores reports 4 advisories (RUSTSEC-2023-0071 on rsa, plus the three rustls-webpki 0.101 advisories on the aws-sdk-s3 chain). **RUSTSEC-2025-0134 (rustls-pemfile) no longer appears in the audit output** — that's the AC.

cargo-deny prints three `advisory-not-detected` warnings for the rustls-webpki 0.101 advisories (a cargo-deny ↔ cargo-audit matcher difference). These warnings are pre-existing on `main` (unchanged by this PR) and the gate still exits ok.

### 4. CI on this PR ✅ (all green on HEAD ca3ca8a)

| Job | Result | Run |
|---|---|---|
| `cargo-deny` (check all) | ✅ pass (29s) | https://github.com/HeddleCo/heddle/actions/runs/25933623748/job/76233363330 |
| `cargo-audit` (--deny warnings) | ✅ pass (18s) | https://github.com/HeddleCo/heddle/actions/runs/25933623748/job/76233363286 |
| `Check & test` (build + clippy + test, all `--locked`) | ✅ pass (4m43s) | https://github.com/HeddleCo/heddle/actions/runs/25933623912/job/76233363958 |
| `Coverage` (cargo llvm-cov) | ✅ pass (5m59s) | https://github.com/HeddleCo/heddle/actions/runs/25933623912/job/76233363948 |

## Manual verification
N/A — covered by tests + supply-chain gates above. No user-visible behavior change; pure dep-removal.

## Blocked by → resolved
None.

## Notes for the orchestrator
- **Workspace-root `Cargo.toml` still declares `rustls-pemfile = "2"`** under `[workspace.dependencies]` (line 77). With both consumers gone, that entry is now orphaned but harmless: `[workspace.dependencies]` only materializes a crate when a workspace member opts in via `.workspace = true`, and `cargo update` confirmed nothing else does (`rustls-pemfile v2.2.0` was the *only* package removed). I left the workspace-root line in place to stay inside the issue's declared file scope (`crates/client/Cargo.toml`, `crates/cli-shared/Cargo.toml`, `deny.toml`, `.github/workflows/audit.yml`). Suggested 1-line follow-up issue: `chore: drop orphan rustls-pemfile from [workspace.dependencies]`.
- **Tooling setup**: this worktree was the first Rust task to land on the host since the orchestrator was set up. `cargo` was not installed system-wide, so I ran the standard `rustup-init` (`stable`, `minimal` profile) into `~/.cargo` to produce the local evidence above. Reversible / user-local; doesn't affect the shared target dir convention. Future Rust agents on this host now find `cargo` automatically once they source `~/.cargo/env` (already wired through any login shell via `.profile`/`.bashrc`). Flagging in case the orchestrator wants to add a step to `scripts/init.sh`.