### PR TITLE
ci/docs: mirror weft's 3 audit-gate fixes (#43)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,14 +13,14 @@ name: Supply-chain audit
 # even if no one has pushed code).
 
 on:
+  # Run on every PR (no paths filter). If we limited to Cargo*/deny.toml
+  # changes and this workflow is set as a Required check, GitHub leaves the
+  # required-but-skipped run pending forever for PRs that don't touch those
+  # files, blocking merge. Always-run keeps the gate workable as a Required
+  # check; the work itself is fast enough that it doesn't matter.
   pull_request:
     branches:
       - main
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - 'deny.toml'
-      - '.github/workflows/audit.yml'
   push:
     branches:
       - main
@@ -50,6 +50,11 @@ jobs:
         with:
           # `check all` runs advisories + bans + licenses + sources in one pass.
           command: check all
+          # Pin a modern toolchain explicitly. The action's default falls
+          # back to Rust 1.71, but this workspace is `edition = "2024"`
+          # (workspace Cargo.toml), which requires Rust 1.85+. Without
+          # this, cargo-deny errors out before policy checks run.
+          rust-version: stable
 
   cargo-audit:
     name: cargo-audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,20 +161,28 @@ cargo install --locked cargo-deny  # once
 cargo install --locked cargo-audit # once
 
 cargo deny check                   # full policy run
-cargo audit --deny warnings        # advisory check
+
+# advisory check — flags MUST mirror .github/workflows/audit.yml so a green
+# local run means a green CI run. If you add/remove an --ignore here, also
+# update the workflow (cargo-audit doesn't read deny.toml's ignore list).
+cargo audit \
+  --deny warnings \
+  --ignore RUSTSEC-2023-0071 \
+  --ignore RUSTSEC-2026-0098 \
+  --ignore RUSTSEC-2026-0099 \
+  --ignore RUSTSEC-2026-0104
 ```
 
-Both should be green before you push. CI runs them on every push to
-`main`, every PR that touches `Cargo.toml` / `Cargo.lock` / `deny.toml`
-/ `audit.yml`, and on a weekly schedule (Mondays 05:17 UTC) so a fresh
-advisory against an unchanged dependency surfaces without anyone
-having to push code.
+Both should be green before you push. CI runs them on every PR (no
+paths filter — see `audit.yml` for why), every push to `main`, and on a
+weekly schedule (Mondays 05:17 UTC) so a fresh advisory against an
+unchanged dependency surfaces without anyone having to push code.
 
 ### Ignoring an advisory
 
 If a RustSec advisory cannot be fixed by a version bump (upstream
 hasn't released; advisory doesn't apply to our usage; etc.), add an
-entry to **both** of:
+entry to **all three** of:
 
 1. `deny.toml` — `[advisories].ignore` with `{ id, reason }`. The
    `reason` must explain *why* it's safe to ignore in Heddle's context,
@@ -182,9 +190,11 @@ entry to **both** of:
 2. `.github/workflows/audit.yml` — `cargo audit --ignore <ID>` in the
    `cargo-audit` step. cargo-audit doesn't read `deny.toml`, so the
    two lists must be kept in sync by hand.
+3. The local-run command in this file (above) — so contributors running
+   `cargo audit` locally see the same advisories pass that CI does.
 
-When upstream ships a fix, remove the entry from both places in the
-same PR that bumps the dependency.
+When upstream ships a fix, remove the entry from all three places in
+the same PR that bumps the dependency.
 
 ### Adding a license to the allow-list
 


### PR DESCRIPTION
## Summary

- Remove `pull_request.paths` filter from `audit.yml` so the gate works as a Required check (filtered-out runs would otherwise sit pending forever and block merge).
- Pin `rust-version: stable` on `EmbarkStudios/cargo-deny-action@v2` — workspace is `edition = "2024"` (Cargo.toml:26), needs Rust 1.85+; action defaults to 1.71.
- Mirror the four `--ignore RUSTSEC-…` flags from `audit.yml` into CONTRIBUTING.md's documented local cargo-audit command (previous command failed on every run).
- Add CONTRIBUTING.md as a third sync point alongside `deny.toml` and `audit.yml` in the "Ignoring an advisory" checklist.

## Closes

HeddleCo/heddle#43

## Red commit

N/A — DoD Type ≠ TDD-Rust (ci/docs only; no behavior change in compiled crates).

## Test evidence

Documented local command from CONTRIBUTING.md, run inside this worktree:

```
$ cargo audit \
    --deny warnings \
    --ignore RUSTSEC-2023-0071 \
    --ignore RUSTSEC-2026-0098 \
    --ignore RUSTSEC-2026-0099 \
    --ignore RUSTSEC-2026-0104
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1090 security advisories (from /home/heddleco/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (701 crate dependencies)
$ echo $?
0
```

YAML sanity check on the workflow:

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit.yml'))" && echo OK
OK
```

## Manual verification

N/A — covered by the cargo-audit run above plus CI's own re-run of the gate on this PR.

## Blocked by → resolved

None.

## Reference

Mirrors `HeddleCo/weft@1885abdf` (PR HeddleCo/weft#125). heddle ignores four advisories vs weft's six; the rest of the diff shape is identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->