### PR TITLE
feat(cli): add `clone --filter <spec>` (synonym for `--lazy`) (#48)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1281,3 +1281,38 @@ pub struct WatchArgs {
 // file. A second copy was left here by the rebase (the workstreams
 // commit added them twice when the cherry-pick had lost the
 // originals and we re-added them mid-rebase). Removed.
+
+#[cfg(test)]
+mod clone_filter_tests {
+    use clap::Parser;
+
+    use crate::cli::{Cli, Commands, CloneArgs};
+
+    fn parse_clone(extra: &[&str]) -> Result<CloneArgs, clap::Error> {
+        let mut argv: Vec<&str> = vec!["heddle", "clone", "remote", "local"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(argv)?;
+        match cli.command {
+            Commands::Clone(args) => Ok(args),
+            _ => panic!("expected Commands::Clone"),
+        }
+    }
+
+    #[test]
+    fn parses_clone_filter_blob_none() {
+        let args = parse_clone(&["--filter", "blob:none"]).expect("parse --filter blob:none");
+        assert_eq!(args.filter.as_deref(), Some("blob:none"));
+        assert!(!args.lazy);
+    }
+
+    #[test]
+    fn rejects_unknown_filter_spec() {
+        let err = parse_clone(&["--filter", "tree:0"])
+            .expect_err("unknown --filter spec should fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tree:0") && msg.contains("blob:none"),
+            "error should name the bad spec and the supported one: {msg}"
+        );
+    }
+}

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1011,6 +1011,22 @@ pub struct CloneArgs {
     /// Leave blob content absent by design and hydrate it explicitly later.
     #[arg(long)]
     pub lazy: bool,
+
+    /// Partial-clone filter spec. Currently only `blob:none` is supported,
+    /// which is a synonym for `--lazy` (skip blob content; hydrate on demand
+    /// later). Other git-style filters such as `tree:0` or `blob:limit=…`
+    /// are rejected.
+    #[arg(long, value_name = "SPEC", value_parser = parse_clone_filter_spec)]
+    pub filter: Option<String>,
+}
+
+fn parse_clone_filter_spec(s: &str) -> Result<String, String> {
+    match s {
+        "blob:none" => Ok(s.to_string()),
+        other => Err(format!(
+            "unsupported --filter spec `{other}`; only `blob:none` is supported today"
+        )),
+    }
 }
 
 /// Arguments for the `session start` command.

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -29,6 +29,7 @@ struct CloneOptions {
     thread: Option<String>,
     depth: Option<u32>,
     lazy: bool,
+    filter: Option<String>,
 }
 
 pub async fn cmd_clone(
@@ -38,12 +39,14 @@ pub async fn cmd_clone(
     thread: Option<String>,
     depth: Option<u32>,
     lazy: bool,
+    filter: Option<String>,
 ) -> Result<()> {
     let local_path = Path::new(&local);
     let options = CloneOptions {
         thread,
         depth: depth.filter(|depth| *depth > 0),
         lazy,
+        filter,
     };
 
     if local_path.exists() {
@@ -122,6 +125,12 @@ fn finish_git_overlay_clone(
     options: &CloneOptions,
     remote_label: String,
 ) -> Result<()> {
+    if let Some(filter) = options.filter.as_deref() {
+        return Err(anyhow!(
+            "--filter {} is not available for Git-overlay clones yet; run a full clone",
+            filter
+        ));
+    }
     if options.lazy {
         return Err(anyhow!(
             "lazy clone is not available for Git-overlay clones yet; run a full clone"
@@ -227,8 +236,15 @@ async fn clone_local(
         thread,
         depth,
         lazy,
+        filter,
     } = options;
     let depth = *depth;
+    if let Some(filter) = filter.as_deref() {
+        return Err(anyhow!(
+            "--filter {} is only supported for hosted/network remotes",
+            filter
+        ));
+    }
     if *lazy {
         return Err(anyhow!(
             "lazy clone is only supported for hosted/network remotes"
@@ -319,9 +335,12 @@ async fn clone_network(
         thread,
         depth,
         lazy,
+        filter,
     } = options;
     let depth = *depth;
-    let lazy = *lazy;
+    // `--filter blob:none` is a synonym for `--lazy` on hosted/network
+    // remotes; both produce a clone whose blob content is hydrated on demand.
+    let lazy = *lazy || filter.is_some();
 
     // Create the local directory
     fs::create_dir_all(local_path)?;

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -102,6 +102,7 @@ fn clone_git_overlay_url(
     local_path: &Path,
     options: &CloneOptions,
 ) -> Result<()> {
+    reject_unsupported_for_git_overlay(options)?;
     fs::create_dir_all(local_path)?;
     clone_url_to_bare(url, &local_path.join(".git")).map_err(anyhow::Error::msg)?;
     finish_git_overlay_clone(cli, local_path, options, url.to_string())
@@ -113,18 +114,20 @@ fn clone_git_overlay_path(
     local_path: &Path,
     options: &CloneOptions,
 ) -> Result<()> {
+    reject_unsupported_for_git_overlay(options)?;
     fs::create_dir_all(local_path)?;
     gix::init(local_path).map_err(anyhow::Error::msg)?;
     copy_local_repo_to_bare(remote_path, &local_path.join(".git")).map_err(anyhow::Error::msg)?;
     finish_git_overlay_clone(cli, local_path, options, remote_path.display().to_string())
 }
 
-fn finish_git_overlay_clone(
-    cli: &Cli,
-    local_path: &Path,
-    options: &CloneOptions,
-    remote_label: String,
-) -> Result<()> {
+/// Reject options the Git-overlay path doesn't support yet, BEFORE any
+/// filesystem or network work runs. Without this, the user pays the
+/// full clone cost (potentially seconds-to-minutes) and is left with a
+/// partially-initialized destination directory before seeing the error.
+/// Tracked separately for `--filter`, `--lazy`, and `--depth` so each
+/// rejection message stays scannable.
+fn reject_unsupported_for_git_overlay(options: &CloneOptions) -> Result<()> {
     if let Some(filter) = options.filter.as_deref() {
         return Err(anyhow!(
             "--filter {} is not available for Git-overlay clones yet; run a full clone",
@@ -141,7 +144,15 @@ fn finish_git_overlay_clone(
             "shallow Git-overlay clone is not available yet; run a full clone"
         ));
     }
+    Ok(())
+}
 
+fn finish_git_overlay_clone(
+    cli: &Cli,
+    local_path: &Path,
+    options: &CloneOptions,
+    remote_label: String,
+) -> Result<()> {
     write_git_overlay_origin(local_path, &remote_label)?;
     let repo = Repository::init(local_path)?;
     let mut bridge = GitBridge::new(&repo);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -757,6 +757,7 @@ async fn main() -> Result<()> {
             thread,
             depth,
             lazy,
+            filter,
         }) => {
             resolve_operation_id(&cli)?;
             cmd_clone(
@@ -766,6 +767,7 @@ async fn main() -> Result<()> {
                 thread.clone(),
                 *depth,
                 *lazy,
+                filter.clone(),
             )
             .await
         }

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -124,6 +124,30 @@ fn test_cli_clone_local_lazy_is_rejected() {
 }
 
 #[test]
+fn test_cli_clone_git_overlay_filter_is_rejected() {
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin.git");
+    let work = temp.path().join("work");
+    gix::init_bare(&origin).expect("init bare git origin");
+
+    let err = heddle(
+        &[
+            "clone",
+            origin.to_str().expect("origin path utf8"),
+            work.to_str().expect("work path utf8"),
+            "--filter",
+            "blob:none",
+        ],
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("--filter") && err.contains("Git-overlay"),
+        "Git-overlay clone with --filter should fail with a tailored message: {err}"
+    );
+}
+
+#[test]
 fn test_cli_pull_local_lazy_is_rejected() {
     let source = TempDir::new().unwrap();
     let target = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- Add `--filter <SPEC>` to `heddle clone`. Initial supported value: `blob:none`; other specs reject at clap parse time.
- UX decision: `--filter blob:none` is a **synonym** for `--lazy` — both yield `PullMaterialization::Lazy` on hosted/network clones. Neither flag deprecated; `--filter` is the git-compatible spelling, `--lazy` is the heddle-native shorthand.
- Distinct rejection messages on the Git-overlay path and on local `file://` clones, mirroring the existing `--lazy` rejections (#20b will land actual Git-overlay filter support).

## Closes
HeddleCo/heddle#48

## Red commit
`66f34bd`

## Test evidence
```
$ cargo test -p heddle-cli --lib clone_filter_tests
running 2 tests
test cli::cli_args::commands_args::clone_filter_tests::rejects_unknown_filter_spec ... ok
test cli::cli_args::commands_args::clone_filter_tests::parses_clone_filter_blob_none ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 268 filtered out; finished in 0.01s

$ cargo test -p heddle-cli --test cli_integration test_cli_clone_git_overlay_filter_is_rejected
running 1 test
test remotes::test_cli_clone_git_overlay_filter_is_rejected ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 293 filtered out; finished in 0.03s
```

Adjacent suites still green (no regressions in existing clone/lazy behavior):
```
$ cargo test -p heddle-cli --test cli_integration remotes::
test result: ok. 11 passed; 0 failed; 0 ignored

$ cargo test -p heddle-cli --test production_features shallow_clone
test result: ok. 3 passed; 0 failed; 0 ignored
```

## Manual verification
N/A — covered by tests.

## Blocked by → resolved
Unblocks HeddleCo/heddle#20b (Git-overlay shallow + filter) and #20c (lazy on-read hydration), which both depend on this flag landing first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->