### PR TITLE
fix(repo): route S3 store init through builder bridge (#61)

### DIFF
--- a/crates/objects/src/store/s3/s3_store.rs
+++ b/crates/objects/src/store/s3/s3_store.rs
@@ -228,6 +228,31 @@ impl S3StoreBuilder {
         self
     }
 
+    /// Build the S3 store synchronously.
+    ///
+    /// Equivalent to [`Self::build`] but callable from a sync context — even
+    /// from inside a caller's Tokio runtime, where `Handle::block_on(self.build())`
+    /// would panic with "Cannot start a runtime from within a runtime".
+    ///
+    /// Routes the async `build()` future through a short-lived
+    /// [`RuntimeBridge`] worker thread (its own private current-thread
+    /// runtime), so the caller's runtime is never re-entered. The bridge
+    /// is dropped on return; the resulting [`S3Store`] carries its own
+    /// lazy `OnceLock<RuntimeBridge>` for subsequent sync `ObjectStore`
+    /// calls, so no worker thread lingers beyond the build phase.
+    ///
+    /// `Repository::open` uses this entry point to construct an S3-backed
+    /// store from sync code that may itself be running on a Tokio
+    /// runtime (`#[tokio::main]`, `#[tokio::test]`, a daemon worker).
+    pub fn build_blocking(self) -> crate::store::Result<S3Store> {
+        let bridge = RuntimeBridge::new().map_err(|err| {
+            crate::store::StoreError::Config(format!(
+                "S3 store: spawn worker thread for builder: {err}"
+            ))
+        })?;
+        bridge.block_on(self.build())
+    }
+
     /// Build the S3 store.
     pub async fn build(self) -> crate::store::Result<S3Store> {
         let bucket = self.bucket.ok_or_else(|| {

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -377,14 +377,17 @@ impl Repository {
             builder = builder.force_path_style(true);
         }
 
-        // S3StoreBuilder::build is async; block on it.
-        let rt = tokio::runtime::Handle::try_current().or_else(|_| {
-            tokio::runtime::Runtime::new()
-                .map(|rt| rt.handle().clone())
-                .map_err(|e| HeddleError::Config(format!("failed to create tokio runtime: {e}")))
-        })?;
-        let store = rt
-            .block_on(builder.build())
+        // `S3StoreBuilder::build` is async. The previous design here was
+        // `Handle::try_current().or_else(Runtime::new()).block_on(builder.build())`
+        // — that nested `block_on` panicked with "Cannot start a runtime
+        // from within a runtime" whenever `Repository::open` was called
+        // from inside a Tokio runtime (`#[tokio::main]`, `#[tokio::test]`,
+        // a daemon worker). `build_blocking` routes the async `build()`
+        // through a short-lived worker-thread runtime, so the caller's
+        // runtime is never re-entered — mirrors the heddle#60 fix for the
+        // `ObjectStore` impl on `S3Store`.
+        let store = builder
+            .build_blocking()
             .map_err(|e| HeddleError::Config(format!("S3 store initialization failed: {e}")))?;
         Ok(Box::new(store))
     }

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1351,3 +1351,90 @@ mod blob_hydrator_callback {
         }
     }
 }
+
+/// Issue #61: `Repository::open` must be callable from inside a Tokio
+/// runtime (`#[tokio::main]`, `#[tokio::test]`, a daemon worker) when
+/// the repo is configured with an `[storage.s3]` backend, without
+/// panicking on a nested `block_on`.
+///
+/// Pre-fix, `Repository::build_s3_store` did
+/// `Handle::try_current().or_else(Runtime::new()).block_on(builder.build())`:
+/// inside a Tokio runtime, `try_current()` succeeded and the subsequent
+/// `block_on` panicked with "Cannot start a runtime from within a
+/// runtime". This test reproduces that path — with the bug, the call
+/// panics; with the fix it returns an `Err(HeddleError::Config)` from
+/// the deliberately-unreachable bucket endpoint.
+///
+/// Mirrors `objects::store::s3::s3_tests::s3_store_methods_do_not_panic_in_tokio_context`
+/// (issue #60 regression for the `ObjectStore` impl on `S3Store`).
+#[cfg(feature = "s3")]
+mod s3_init_nested_runtime {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use crate::{HeddleError, Repository};
+
+    /// Append an `[storage.s3]` section to a fresh repo's
+    /// `.heddle/config.toml`, pointing at a port nothing is listening on
+    /// so the S3 builder's `head_bucket()` ping fails with a connect
+    /// error — but only *after* clearing the nested-runtime panic path.
+    fn write_s3_config(heddle_dir: &std::path::Path, endpoint: &str) {
+        let cfg_path = heddle_dir.join("config.toml");
+        let mut text = fs::read_to_string(&cfg_path).expect("read default config.toml");
+        text.push_str(&format!(
+            "\n\
+             [storage.s3]\n\
+             bucket = \"issue-61-test\"\n\
+             region = \"us-east-1\"\n\
+             endpoint_url = \"{endpoint}\"\n\
+             access_key_id = \"test\"\n\
+             secret_access_key = \"test\"\n\
+             force_path_style = true\n",
+        ));
+        fs::write(&cfg_path, text).expect("write config.toml with s3 section");
+    }
+
+    /// The load-bearing assertion: `Repository::open` returns an error
+    /// (does not panic) when invoked inside a multi-thread Tokio runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_with_s3_backend_does_not_panic_in_tokio_context() {
+        let tmp = TempDir::new().expect("tempdir");
+        Repository::init_default(tmp.path()).expect("init_default");
+        write_s3_config(&tmp.path().join(".heddle"), "http://127.0.0.1:1");
+
+        let result = Repository::open(tmp.path());
+        match result {
+            Ok(_) => panic!(
+                "expected S3 init to fail against unreachable endpoint; \
+                 got Ok — was the bug actually exercised?"
+            ),
+            Err(HeddleError::Config(msg)) => {
+                assert!(
+                    msg.contains("S3 store initialization failed"),
+                    "expected S3 init error, got: {msg}",
+                );
+            }
+            Err(other) => panic!("expected Config error, got: {other:?}"),
+        }
+    }
+
+    /// Same fix, exercised on a single-thread runtime. The
+    /// nested-`block_on` panic the original code triggered did not
+    /// depend on flavor — the bridge fix must hold on both.
+    #[tokio::test(flavor = "current_thread")]
+    async fn open_with_s3_backend_does_not_panic_current_thread() {
+        let tmp = TempDir::new().expect("tempdir");
+        Repository::init_default(tmp.path()).expect("init_default");
+        write_s3_config(&tmp.path().join(".heddle"), "http://127.0.0.1:1");
+
+        match Repository::open(tmp.path()) {
+            Ok(_) => panic!("expected S3 init to fail against unreachable endpoint"),
+            Err(HeddleError::Config(msg)) => assert!(
+                msg.contains("S3 store initialization failed"),
+                "expected S3 init error, got: {msg}",
+            ),
+            Err(other) => panic!("expected Config error, got: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `Repository::open` previously panicked with "Cannot start a runtime from within a runtime" whenever it was called from inside a Tokio runtime against a config that selected the S3 storage backend — daemons, `#[tokio::main]`, `#[tokio::test]`, anything wrapping `Repository::open` in async. The path through `build_s3_store` did `Handle::try_current().or_else(Runtime::new()).block_on(builder.build())`, the same nested-`block_on` shape heddle#60 just fixed for the `ObjectStore` impl on `S3Store`.
- Adds `S3StoreBuilder::build_blocking()` — a synchronous entry point that reuses the existing `RuntimeBridge` (worker thread + private current-thread Tokio runtime, defined in `s3_store.rs`) as a one-shot to drive the async `build()` future. The caller's runtime is never re-entered.
- `Repository::build_s3_store` now calls `builder.build_blocking()?`; the manual `Handle::try_current` / `Runtime::new` construction is gone. The resulting `S3Store` still owns its own lazy `OnceLock<RuntimeBridge>` for subsequent sync `ObjectStore` calls, so no worker thread lingers beyond the build phase.

### Design choice (option 3 of the brief)

The brief offered three approaches. I picked **option 3** — surface a sync API on the builder — over option 1 (promote `RuntimeBridge` to a shared module) and option 2 (duplicate the bridge in `repo`):

- The builder runs *once* per `Repository::open`; a persistent worker thread is overkill for one-shot construction. The bridge is dropped immediately after `build()` resolves.
- The post-construction `S3Store` already owns its own bridge for sync `ObjectStore` calls — that's the persistent bridge users actually need. Adding a second one at the repo layer would be redundant.
- Keeping `RuntimeBridge` private to `objects::store::s3::s3_store` avoids leaking the Send/JoinHandle/`mpsc::Sender` triple as a public surface across the workspace before there's a forcing function for it. heddle#62 (pg_oplog / pg_refs) bridges *per-call* async work rather than one-shot construction; it doesn't share enough shape to motivate a unified primitive. If a third call site appears later with the same one-shot-construction shape, that's the right moment to promote.

Closes HeddleCo/heddle#61

## Red commit

`fc298cd` — two `#[tokio::test]` reproductions (multi-thread + current-thread) that drive `Repository::open` against an S3 config with an unreachable endpoint. Pre-fix, both panic on the nested `block_on` before reaching the network step:

```
thread '…open_with_s3_backend_does_not_panic_current_thread' panicked at crates/repo/src/repository.rs:387:14:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`)
attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```

## Test evidence

The two new reproductions, post-fix:

```
$ cargo test -p heddle-repo --features s3 --lib s3_init_nested_runtime
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.45s

running 2 tests
test repository::repository_tests::s3_init_nested_runtime::open_with_s3_backend_does_not_panic_in_tokio_context ... ok
test repository::repository_tests::s3_init_nested_runtime::open_with_s3_backend_does_not_panic_current_thread ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 1.98s
```

Full `heddle-repo --features s3` and `heddle-objects --features s3` suites — including the heddle#60 regression tests for the `ObjectStore` impl on `S3Store`:

```
$ cargo test -p heddle-repo --features s3 --lib
test result: ok. 249 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.94s

$ cargo test -p heddle-objects --features s3
test result: ok. 302 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 33.90s
  (includes s3_store_methods_do_not_panic_in_tokio_context,
           s3_store_multi_method_sequence_no_panic,
           test_s3_store_compliance,
           and the cross-object-swap rejection tests — all still green)
```

CI-mirroring workspace runs, all green:

```
$ cargo build --workspace --tests       → ok
$ cargo clippy --workspace --all-targets -- -D warnings   → ok
$ cargo test --workspace                → 1900+ tests pass, 0 fail
$ cargo check -p heddle-cli --no-default-features --features git-overlay,semantic,zstd   → ok
$ cargo check -p heddle-cli --no-default-features --features native,semantic,zstd        → ok
```

## Manual verification

N/A — covered by tests. The nested-`block_on` panic is deterministic and reproduced by the two `#[tokio::test]` cases in the red commit; no environment-dependent setup is required.

## Rule-7 cross-check

1. **`Handle::try_current` / `Handle::current` / `Runtime::new` / `block_on` sweep in `crates/repo`** — the only call site was the one being fixed at `repository.rs:381`. Other sites in the workspace are out of scope:
   - `crates/oplog/src/oplog/pg_oplog.rs:41` and `crates/refs/src/refs/pg_refs.rs:36` use `block_in_place(|| Handle::current().block_on(...))` — covered by heddle#62.
   - `crates/client/src/grpc_hosted/hydration.rs` already owns its own bridge worker thread + private runtime (heddle#50 precedent); no nested-runtime risk.
2. **Public-surface audit on `RuntimeBridge`** — kept `pub(super)` (unchanged). `build_blocking` is a thin `pub fn` on the builder; it doesn't expose any thread-handle or channel types and doesn't surface any `unsafe`. The bridge's existing safety notes in `s3_store.rs` remain accurate.
3. **heddle#60 regression tests** — the `S3Store::*` sync `ObjectStore` surface tests (`s3_store_methods_do_not_panic_in_tokio_context`, `s3_store_multi_method_sequence_no_panic`, `test_s3_store_compliance`) all pass against the new builder API; no behavior change there.

## Blocked by → resolved

None — heddle#61 had no open `## Blocked by`. heddle#62 (pg_oplog / pg_refs) is independent and should stay independent; this PR does not change its design space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->