### PR TITLE
spike(refs): reftable prototype + decision doc (heddle#21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,7 @@ name = "heddle-refs"
 version = "0.2.4"
 dependencies = [
  "chrono",
+ "criterion",
  "heddle-objects",
  "heddle-runtime-bridge",
  "rand 0.10.1",

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = "0.8"
 tempfile.workspace = true
 
 [features]
@@ -31,3 +32,7 @@ postgres = ["dep:sqlx", "dep:tokio", "dep:uuid", "dep:runtime-bridge"]
 [lib]
 path = "src/lib.rs"
 name = "refs"
+
+[[bench]]
+name = "reftable_vs_packed"
+harness = false

--- a/crates/refs/benches/reftable_vs_packed.rs
+++ b/crates/refs/benches/reftable_vs_packed.rs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Spike bench (HeddleCo/heddle#21): packed-refs vs prototype reftable.
+//!
+//! Compares the two on-disk ref formats at 10k / 50k / 100k ref counts.
+//! All sizes are dominated by threads (typical repo shape); markers stay zero
+//! here because the per-section code paths are identical and adding a second
+//! axis would obscure the comparison.
+//!
+//! What's measured:
+//!
+//! - `cold_load`: load the whole file from disk into an in-memory model
+//!   (the unavoidable per-process cost).
+//! - `cold_single_lookup`: open the file fresh, find one ref by name. For
+//!   packed-refs this is a full parse + hashmap lookup; for reftable it's a
+//!   binary-search over the offset index.
+//! - `warm_lookup_x1000`: with the model already loaded, look up 1000 random
+//!   refs (packed-refs hashmap shines here; reftable pays log N seeks per
+//!   lookup).
+//! - `list_all`: enumerate every ref name (used by `heddle status`, sync, etc.).
+//! - `append_one_persist`: add one new ref and rewrite the whole file (the
+//!   current write strategy for both backends).
+//!
+//! The bench also prints on-disk byte sizes for both formats at each scale,
+//! as a "Throughput::Bytes" entry on the `cold_load` group.
+//!
+//! Run: `cargo bench -p heddle-refs --bench reftable_vs_packed`
+
+use std::{
+    fs,
+    hint::black_box,
+    path::{Path, PathBuf},
+};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::object::ChangeId;
+use refs::{PackedRefsModel, ReftableModel};
+use tempfile::TempDir;
+
+const SIZES: &[usize] = &[10_000, 50_000, 100_000];
+
+/// Build a deterministic ChangeId from an index; spreads bytes across the
+/// 16-byte payload so we don't accidentally pick a degenerate shape.
+fn cid_for(i: usize) -> ChangeId {
+    let mut bytes = [0u8; 16];
+    let raw = (i as u128).wrapping_mul(0x9E37_79B9_7F4A_7C15_9E37_79B9_7F4A_7C15);
+    bytes.copy_from_slice(&raw.to_le_bytes());
+    ChangeId::from_bytes(bytes)
+}
+
+fn name_for(i: usize) -> String {
+    // Mimic real branch shapes: "feature/<5-digit>", "topic/<5-digit>", etc.
+    let bucket = i % 5;
+    let prefix = ["feature", "topic", "release", "user/alice", "user/bob"][bucket];
+    format!("{prefix}/branch-{i:06}")
+}
+
+fn build_packed(n: usize) -> PackedRefsModel {
+    let mut m = PackedRefsModel::new();
+    for i in 0..n {
+        m.set_thread(&name_for(i), cid_for(i));
+    }
+    m
+}
+
+fn build_reftable(n: usize) -> ReftableModel {
+    let mut m = ReftableModel::new();
+    for i in 0..n {
+        m.set_thread(&name_for(i), cid_for(i));
+    }
+    m
+}
+
+fn write_packed(path: &Path, model: &PackedRefsModel) {
+    fs::write(path, model.to_text()).unwrap();
+}
+
+fn write_reftable(path: &Path, model: &ReftableModel) {
+    fs::write(path, model.to_bytes()).unwrap();
+}
+
+fn lookup_names(n: usize, sample: usize) -> Vec<String> {
+    // Spread across the keyspace with a fixed stride so the sample is
+    // reproducible and doesn't cluster on a hot region.
+    let stride = (n / sample).max(1);
+    (0..sample).map(|i| name_for((i * stride) % n)).collect()
+}
+
+struct Layout {
+    _dir: TempDir,
+    packed_path: PathBuf,
+    reftable_path: PathBuf,
+}
+
+fn lay_out(n: usize) -> Layout {
+    let dir = TempDir::new().unwrap();
+    let packed_path = dir.path().join("packed-refs");
+    let reftable_path = dir.path().join("reftable");
+    write_packed(&packed_path, &build_packed(n));
+    write_reftable(&reftable_path, &build_reftable(n));
+    Layout {
+        _dir: dir,
+        packed_path,
+        reftable_path,
+    }
+}
+
+fn bench_cold_load(c: &mut Criterion) {
+    let mut g = c.benchmark_group("cold_load");
+    for &n in SIZES {
+        let layout = lay_out(n);
+        let packed_bytes = fs::metadata(&layout.packed_path).unwrap().len();
+        let reftable_bytes = fs::metadata(&layout.reftable_path).unwrap().len();
+        eprintln!(
+            "[size] n={n}  packed={packed_bytes} B  reftable={reftable_bytes} B  ratio={:.2}",
+            reftable_bytes as f64 / packed_bytes as f64
+        );
+
+        g.throughput(Throughput::Bytes(packed_bytes));
+        g.bench_with_input(BenchmarkId::new("packed", n), &layout, |b, layout| {
+            b.iter(|| {
+                let text = fs::read_to_string(&layout.packed_path).unwrap();
+                let m = PackedRefsModel::parse(&text);
+                black_box(m.list_threads().len());
+            });
+        });
+
+        g.throughput(Throughput::Bytes(reftable_bytes));
+        g.bench_with_input(BenchmarkId::new("reftable", n), &layout, |b, layout| {
+            b.iter(|| {
+                let bytes = fs::read(&layout.reftable_path).unwrap();
+                let m = ReftableModel::from_bytes(&bytes).unwrap();
+                black_box(m.thread_count());
+            });
+        });
+    }
+    g.finish();
+}
+
+fn bench_cold_single_lookup(c: &mut Criterion) {
+    let mut g = c.benchmark_group("cold_single_lookup");
+    for &n in SIZES {
+        let layout = lay_out(n);
+        let needle = name_for(n / 2);
+
+        g.bench_with_input(BenchmarkId::new("packed", n), &layout, |b, layout| {
+            b.iter(|| {
+                let text = fs::read_to_string(&layout.packed_path).unwrap();
+                let m = PackedRefsModel::parse(&text);
+                black_box(m.get_thread(&needle));
+            });
+        });
+
+        g.bench_with_input(BenchmarkId::new("reftable", n), &layout, |b, layout| {
+            b.iter(|| {
+                let bytes = fs::read(&layout.reftable_path).unwrap();
+                black_box(ReftableModel::lookup_thread_in_bytes(&bytes, &needle).unwrap());
+            });
+        });
+    }
+    g.finish();
+}
+
+fn bench_warm_lookup(c: &mut Criterion) {
+    const SAMPLE: usize = 1000;
+    let mut g = c.benchmark_group("warm_lookup_x1000");
+    for &n in SIZES {
+        let packed = build_packed(n);
+        let reftable = build_reftable(n);
+        let needles = lookup_names(n, SAMPLE);
+
+        g.bench_with_input(BenchmarkId::new("packed", n), &needles, |b, needles| {
+            b.iter(|| {
+                for name in needles {
+                    black_box(packed.get_thread(name));
+                }
+            });
+        });
+
+        g.bench_with_input(BenchmarkId::new("reftable", n), &needles, |b, needles| {
+            b.iter(|| {
+                for name in needles {
+                    black_box(reftable.get_thread(name));
+                }
+            });
+        });
+    }
+    g.finish();
+}
+
+fn bench_list_all(c: &mut Criterion) {
+    let mut g = c.benchmark_group("list_all");
+    for &n in SIZES {
+        let packed = build_packed(n);
+        let reftable = build_reftable(n);
+
+        g.bench_with_input(BenchmarkId::new("packed", n), &packed, |b, m| {
+            b.iter(|| black_box(m.list_threads().len()));
+        });
+
+        g.bench_with_input(BenchmarkId::new("reftable", n), &reftable, |b, m| {
+            b.iter(|| black_box(m.list_threads().len()));
+        });
+    }
+    g.finish();
+}
+
+fn bench_append_one_persist(c: &mut Criterion) {
+    let mut g = c.benchmark_group("append_one_persist");
+    for &n in SIZES {
+        let layout = lay_out(n);
+        let new_name = format!("feature/new-{n:06}");
+        let new_id = cid_for(n + 1);
+
+        g.bench_with_input(BenchmarkId::new("packed", n), &layout, |b, layout| {
+            b.iter_batched(
+                || {
+                    let text = fs::read_to_string(&layout.packed_path).unwrap();
+                    PackedRefsModel::parse(&text)
+                },
+                |mut m| {
+                    m.set_thread(&new_name, new_id);
+                    let _text = black_box(m.to_text());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        g.bench_with_input(BenchmarkId::new("reftable", n), &layout, |b, layout| {
+            b.iter_batched(
+                || {
+                    let bytes = fs::read(&layout.reftable_path).unwrap();
+                    ReftableModel::from_bytes(&bytes).unwrap()
+                },
+                |mut m| {
+                    m.set_thread(&new_name, new_id);
+                    let _bytes = black_box(m.to_bytes());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cold_load,
+    bench_cold_single_lookup,
+    bench_warm_lookup,
+    bench_list_all,
+    bench_append_one_persist,
+);
+criterion_main!(benches);

--- a/crates/refs/benches/reftable_vs_packed.rs
+++ b/crates/refs/benches/reftable_vs_packed.rs
@@ -17,8 +17,12 @@
 //!   refs (packed-refs hashmap shines here; reftable pays log N seeks per
 //!   lookup).
 //! - `list_all`: enumerate every ref name (used by `heddle status`, sync, etc.).
-//! - `append_one_persist`: add one new ref and rewrite the whole file (the
-//!   current write strategy for both backends).
+//! - `append_one_persist`: add one new ref and rewrite the whole file —
+//!   including the actual filesystem write, `fsync`, and atomic rename via
+//!   `objects::fs_atomic::write_file_atomic` (the same call `PackedRefs::save`
+//!   uses in production). Both branches go through this path so the
+//!   comparison reflects real-world rewrite latency, not just in-memory
+//!   serialization cost.
 //!
 //! The bench also prints on-disk byte sizes for both formats at each scale,
 //! as a "Throughput::Bytes" entry on the `cold_load` group.
@@ -32,6 +36,7 @@ use std::{
 };
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::fs_atomic::write_file_atomic;
 use objects::object::ChangeId;
 use refs::{PackedRefsModel, ReftableModel};
 use tempfile::TempDir;
@@ -219,7 +224,9 @@ fn bench_append_one_persist(c: &mut Criterion) {
                 },
                 |mut m| {
                     m.set_thread(&new_name, new_id);
-                    let _text = black_box(m.to_text());
+                    let text = m.to_text();
+                    write_file_atomic(&layout.packed_path, text.as_bytes()).unwrap();
+                    black_box(&layout.packed_path);
                 },
                 BatchSize::SmallInput,
             );
@@ -233,7 +240,9 @@ fn bench_append_one_persist(c: &mut Criterion) {
                 },
                 |mut m| {
                     m.set_thread(&new_name, new_id);
-                    let _bytes = black_box(m.to_bytes());
+                    let bytes = m.to_bytes();
+                    write_file_atomic(&layout.reftable_path, &bytes).unwrap();
+                    black_box(&layout.reftable_path);
                 },
                 BatchSize::SmallInput,
             );

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -14,6 +14,7 @@ mod refs_manager;
 mod refs_storage;
 mod refs_transactions;
 mod refs_types;
+mod reftable_model;
 mod resolve;
 mod text;
 mod types;
@@ -27,11 +28,15 @@ mod refs_tests;
 #[cfg(test)]
 mod refs_packed_tests;
 
+#[cfg(test)]
+mod reftable_tests;
+
 pub use backend::CoreRefBackend;
 pub use head::{Head, HeadParseError};
 pub use name::{RefNameError, validate_ref_name};
 pub use operation_index::{IndexedOperation, OperationLogIndex, OperationLogQuery};
 pub use packed_model::PackedRefsModel;
+pub use reftable_model::{ReftableError, ReftableModel};
 #[cfg(feature = "postgres")]
 pub use pg_refs::PgRefBackend;
 pub use ref_backend::RefBackend;

--- a/crates/refs/src/refs/reftable_model.rs
+++ b/crates/refs/src/refs/reftable_model.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Prototype reftable-style binary model for the refs spike (HeddleCo/heddle#21).
+//!
+//! Parallel to [`super::PackedRefsModel`] (line-oriented text) but stored as a
+//! binary file with a fixed header, per-section offset indexes, and sorted
+//! variable-length records. Designed for O(log N) cold lookup without parsing
+//! the whole payload.
+//!
+//! **Status:** spike prototype. Not wired through `RefManager`; only the
+//! in-memory model + serializer + lookup primitives exist, because the spike's
+//! deliverable is a ship-or-defer decision (see `docs/design/reftable-spike.md`),
+//! not a production backend.
+
+use objects::object::ChangeId;
+
+/// Magic bytes at the start (and end) of a serialized reftable.
+pub(super) const MAGIC: &[u8; 8] = b"REFT01\0\0";
+
+/// On-disk header size in bytes: 8 magic + 4 thread_count + 4 marker_count.
+pub(super) const HEADER_LEN: usize = 16;
+
+/// On-disk footer size in bytes: 8 magic.
+pub(super) const FOOTER_LEN: usize = 8;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReftableError {
+    #[error("reftable is truncated or malformed at offset {0}")]
+    Truncated(usize),
+    #[error("reftable magic bytes missing or wrong")]
+    BadMagic,
+    #[error("reftable record name is not valid UTF-8")]
+    BadUtf8,
+}
+
+/// Sorted, binary-format model of repository refs (threads + markers).
+///
+/// In-memory the records are held as sorted `Vec`s of `(name, ChangeId)` so
+/// mutation stays simple. On disk they serialize to the layout described in
+/// [`to_bytes`] / [`from_bytes`].
+#[derive(Debug)]
+pub struct ReftableModel {
+    threads: Vec<(String, ChangeId)>,
+    markers: Vec<(String, ChangeId)>,
+}
+
+impl ReftableModel {
+    pub fn new() -> Self {
+        Self {
+            threads: Vec::new(),
+            markers: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.threads.is_empty() && self.markers.is_empty()
+    }
+
+    pub fn thread_count(&self) -> usize {
+        self.threads.len()
+    }
+
+    pub fn marker_count(&self) -> usize {
+        self.markers.len()
+    }
+
+    /// Insert or replace a thread ref. Keeps `threads` sorted by name.
+    pub fn set_thread(&mut self, _name: &str, _id: ChangeId) {
+        unimplemented!("reftable_model::set_thread — stub for red commit")
+    }
+
+    /// Insert or replace a marker ref. Keeps `markers` sorted by name.
+    pub fn set_marker(&mut self, _name: &str, _id: ChangeId) {
+        unimplemented!("reftable_model::set_marker — stub for red commit")
+    }
+
+    /// Remove a thread ref by name; returns the previous value if present.
+    pub fn remove_thread(&mut self, _name: &str) -> Option<ChangeId> {
+        unimplemented!("reftable_model::remove_thread — stub for red commit")
+    }
+
+    /// Remove a marker ref by name; returns the previous value if present.
+    pub fn remove_marker(&mut self, _name: &str) -> Option<ChangeId> {
+        unimplemented!("reftable_model::remove_marker — stub for red commit")
+    }
+
+    pub fn get_thread(&self, _name: &str) -> Option<ChangeId> {
+        unimplemented!("reftable_model::get_thread — stub for red commit")
+    }
+
+    pub fn get_marker(&self, _name: &str) -> Option<ChangeId> {
+        unimplemented!("reftable_model::get_marker — stub for red commit")
+    }
+
+    pub fn list_threads(&self) -> Vec<String> {
+        unimplemented!("reftable_model::list_threads — stub for red commit")
+    }
+
+    pub fn list_markers(&self) -> Vec<String> {
+        unimplemented!("reftable_model::list_markers — stub for red commit")
+    }
+
+    /// Serialize to the binary on-disk layout.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        unimplemented!("reftable_model::to_bytes — stub for red commit")
+    }
+
+    /// Deserialize from the binary on-disk layout.
+    pub fn from_bytes(_bytes: &[u8]) -> Result<Self, ReftableError> {
+        unimplemented!("reftable_model::from_bytes — stub for red commit")
+    }
+
+    /// Cold-lookup helper: binary-search a single thread by name directly
+    /// against the serialized bytes, without materialising the full model.
+    /// Returns `Ok(None)` if the name is not present.
+    pub fn lookup_thread_in_bytes(
+        _bytes: &[u8],
+        _name: &str,
+    ) -> Result<Option<ChangeId>, ReftableError> {
+        unimplemented!("reftable_model::lookup_thread_in_bytes — stub for red commit")
+    }
+
+    /// Cold-lookup helper for markers, see [`lookup_thread_in_bytes`].
+    pub fn lookup_marker_in_bytes(
+        _bytes: &[u8],
+        _name: &str,
+    ) -> Result<Option<ChangeId>, ReftableError> {
+        unimplemented!("reftable_model::lookup_marker_in_bytes — stub for red commit")
+    }
+}
+
+impl Default for ReftableModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/refs/src/refs/reftable_model.rs
+++ b/crates/refs/src/refs/reftable_model.rs
@@ -6,6 +6,30 @@
 //! variable-length records. Designed for O(log N) cold lookup without parsing
 //! the whole payload.
 //!
+//! **On-disk layout (little-endian throughout):**
+//!
+//! ```text
+//! Header (16 bytes):
+//!   magic         "REFT01\0\0"   (8)
+//!   thread_count  u32             (4)
+//!   marker_count  u32             (4)
+//!
+//! Thread index:  [u32; thread_count] — each entry is a byte offset from the
+//!                                       start of the file to the start of the
+//!                                       corresponding thread record.
+//! Thread block:  thread_count records, each:
+//!                  name_len  u16
+//!                  name      [u8; name_len]   (UTF-8, no `refs/threads/` prefix)
+//!                  id        [u8; 16]         (ChangeId raw bytes)
+//!                Records appear in ascending name order.
+//!
+//! Marker index:  [u32; marker_count] — same shape, into the marker block.
+//! Marker block:  marker_count records, same layout, sorted.
+//!
+//! Footer (8 bytes):
+//!   magic         "REFT01\0\0"
+//! ```
+//!
 //! **Status:** spike prototype. Not wired through `RefManager`; only the
 //! in-memory model + serializer + lookup primitives exist, because the spike's
 //! deliverable is a ship-or-defer decision (see `docs/design/reftable-spike.md`),
@@ -22,6 +46,8 @@ pub(super) const HEADER_LEN: usize = 16;
 /// On-disk footer size in bytes: 8 magic.
 pub(super) const FOOTER_LEN: usize = 8;
 
+const ID_LEN: usize = 16;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ReftableError {
     #[error("reftable is truncated or malformed at offset {0}")]
@@ -35,8 +61,8 @@ pub enum ReftableError {
 /// Sorted, binary-format model of repository refs (threads + markers).
 ///
 /// In-memory the records are held as sorted `Vec`s of `(name, ChangeId)` so
-/// mutation stays simple. On disk they serialize to the layout described in
-/// [`to_bytes`] / [`from_bytes`].
+/// mutation stays simple. On disk they serialize to the layout documented at
+/// the module level.
 #[derive(Debug)]
 pub struct ReftableModel {
     threads: Vec<(String, ChangeId)>,
@@ -63,68 +89,124 @@ impl ReftableModel {
         self.markers.len()
     }
 
-    /// Insert or replace a thread ref. Keeps `threads` sorted by name.
-    pub fn set_thread(&mut self, _name: &str, _id: ChangeId) {
-        unimplemented!("reftable_model::set_thread — stub for red commit")
+    pub fn set_thread(&mut self, name: &str, id: ChangeId) {
+        upsert_sorted(&mut self.threads, name, id);
     }
 
-    /// Insert or replace a marker ref. Keeps `markers` sorted by name.
-    pub fn set_marker(&mut self, _name: &str, _id: ChangeId) {
-        unimplemented!("reftable_model::set_marker — stub for red commit")
+    pub fn set_marker(&mut self, name: &str, id: ChangeId) {
+        upsert_sorted(&mut self.markers, name, id);
     }
 
-    /// Remove a thread ref by name; returns the previous value if present.
-    pub fn remove_thread(&mut self, _name: &str) -> Option<ChangeId> {
-        unimplemented!("reftable_model::remove_thread — stub for red commit")
+    pub fn remove_thread(&mut self, name: &str) -> Option<ChangeId> {
+        remove_sorted(&mut self.threads, name)
     }
 
-    /// Remove a marker ref by name; returns the previous value if present.
-    pub fn remove_marker(&mut self, _name: &str) -> Option<ChangeId> {
-        unimplemented!("reftable_model::remove_marker — stub for red commit")
+    pub fn remove_marker(&mut self, name: &str) -> Option<ChangeId> {
+        remove_sorted(&mut self.markers, name)
     }
 
-    pub fn get_thread(&self, _name: &str) -> Option<ChangeId> {
-        unimplemented!("reftable_model::get_thread — stub for red commit")
+    pub fn get_thread(&self, name: &str) -> Option<ChangeId> {
+        find_sorted(&self.threads, name)
     }
 
-    pub fn get_marker(&self, _name: &str) -> Option<ChangeId> {
-        unimplemented!("reftable_model::get_marker — stub for red commit")
+    pub fn get_marker(&self, name: &str) -> Option<ChangeId> {
+        find_sorted(&self.markers, name)
     }
 
     pub fn list_threads(&self) -> Vec<String> {
-        unimplemented!("reftable_model::list_threads — stub for red commit")
+        self.threads.iter().map(|(n, _)| n.clone()).collect()
     }
 
     pub fn list_markers(&self) -> Vec<String> {
-        unimplemented!("reftable_model::list_markers — stub for red commit")
+        self.markers.iter().map(|(n, _)| n.clone()).collect()
     }
 
-    /// Serialize to the binary on-disk layout.
+    /// Serialize to the binary on-disk layout described at the module level.
     pub fn to_bytes(&self) -> Vec<u8> {
-        unimplemented!("reftable_model::to_bytes — stub for red commit")
+        let thread_count = self.threads.len();
+        let marker_count = self.markers.len();
+
+        let thread_index_len = thread_count * 4;
+        let marker_index_len = marker_count * 4;
+
+        let thread_block_start = HEADER_LEN + thread_index_len;
+        let thread_block_len = block_byte_len(&self.threads);
+        let marker_index_start = thread_block_start + thread_block_len;
+        let marker_block_start = marker_index_start + marker_index_len;
+        let marker_block_len = block_byte_len(&self.markers);
+        let footer_start = marker_block_start + marker_block_len;
+        let total_len = footer_start + FOOTER_LEN;
+
+        let mut out = Vec::with_capacity(total_len);
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&(thread_count as u32).to_le_bytes());
+        out.extend_from_slice(&(marker_count as u32).to_le_bytes());
+
+        // Thread index — we need offsets, so build the block first into a
+        // scratch buffer while recording each record's start offset.
+        let (thread_offsets, thread_block_bytes) =
+            encode_block(&self.threads, thread_block_start);
+        for off in &thread_offsets {
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+        out.extend_from_slice(&thread_block_bytes);
+
+        let (marker_offsets, marker_block_bytes) =
+            encode_block(&self.markers, marker_block_start);
+        for off in &marker_offsets {
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+        out.extend_from_slice(&marker_block_bytes);
+
+        out.extend_from_slice(MAGIC);
+        debug_assert_eq!(out.len(), total_len);
+        out
     }
 
     /// Deserialize from the binary on-disk layout.
-    pub fn from_bytes(_bytes: &[u8]) -> Result<Self, ReftableError> {
-        unimplemented!("reftable_model::from_bytes — stub for red commit")
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ReftableError> {
+        let (thread_count, marker_count) = parse_header(bytes)?;
+        let thread_index_start = HEADER_LEN;
+        let thread_block_start = thread_index_start + thread_count * 4;
+        let (threads, thread_block_end) =
+            decode_block(bytes, thread_block_start, thread_count)?;
+        let marker_index_start = thread_block_end;
+        let marker_block_start = marker_index_start + marker_count * 4;
+        let (markers, marker_block_end) =
+            decode_block(bytes, marker_block_start, marker_count)?;
+
+        let footer_start = marker_block_end;
+        if bytes.len() < footer_start + FOOTER_LEN {
+            return Err(ReftableError::Truncated(footer_start));
+        }
+        if &bytes[footer_start..footer_start + FOOTER_LEN] != MAGIC {
+            return Err(ReftableError::BadMagic);
+        }
+
+        Ok(Self { threads, markers })
     }
 
     /// Cold-lookup helper: binary-search a single thread by name directly
     /// against the serialized bytes, without materialising the full model.
-    /// Returns `Ok(None)` if the name is not present.
     pub fn lookup_thread_in_bytes(
-        _bytes: &[u8],
-        _name: &str,
+        bytes: &[u8],
+        name: &str,
     ) -> Result<Option<ChangeId>, ReftableError> {
-        unimplemented!("reftable_model::lookup_thread_in_bytes — stub for red commit")
+        let (thread_count, _marker_count) = parse_header(bytes)?;
+        binary_search_block(bytes, HEADER_LEN, thread_count, name)
     }
 
-    /// Cold-lookup helper for markers, see [`lookup_thread_in_bytes`].
+    /// Cold-lookup helper for markers; see [`lookup_thread_in_bytes`].
     pub fn lookup_marker_in_bytes(
-        _bytes: &[u8],
-        _name: &str,
+        bytes: &[u8],
+        name: &str,
     ) -> Result<Option<ChangeId>, ReftableError> {
-        unimplemented!("reftable_model::lookup_marker_in_bytes — stub for red commit")
+        let (thread_count, marker_count) = parse_header(bytes)?;
+        let thread_index_start = HEADER_LEN;
+        let thread_block_start = thread_index_start + thread_count * 4;
+        let thread_block_end = thread_block_start + block_byte_len_from_index(bytes, thread_index_start, thread_count, thread_block_start)?;
+        let marker_index_start = thread_block_end;
+        binary_search_block(bytes, marker_index_start, marker_count, name)
     }
 }
 
@@ -132,4 +214,140 @@ impl Default for ReftableModel {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// -- record helpers ---------------------------------------------------------
+
+fn upsert_sorted(records: &mut Vec<(String, ChangeId)>, name: &str, id: ChangeId) {
+    match records.binary_search_by(|(n, _)| n.as_str().cmp(name)) {
+        Ok(idx) => records[idx].1 = id,
+        Err(idx) => records.insert(idx, (name.to_string(), id)),
+    }
+}
+
+fn remove_sorted(records: &mut Vec<(String, ChangeId)>, name: &str) -> Option<ChangeId> {
+    match records.binary_search_by(|(n, _)| n.as_str().cmp(name)) {
+        Ok(idx) => Some(records.remove(idx).1),
+        Err(_) => None,
+    }
+}
+
+fn find_sorted(records: &[(String, ChangeId)], name: &str) -> Option<ChangeId> {
+    records
+        .binary_search_by(|(n, _)| n.as_str().cmp(name))
+        .ok()
+        .map(|idx| records[idx].1)
+}
+
+fn record_byte_len(name: &str) -> usize {
+    2 + name.len() + ID_LEN
+}
+
+fn block_byte_len(records: &[(String, ChangeId)]) -> usize {
+    records.iter().map(|(n, _)| record_byte_len(n)).sum()
+}
+
+fn encode_block(records: &[(String, ChangeId)], block_start: usize) -> (Vec<u32>, Vec<u8>) {
+    let mut offsets = Vec::with_capacity(records.len());
+    let mut bytes = Vec::with_capacity(block_byte_len(records));
+    for (name, id) in records {
+        offsets.push((block_start + bytes.len()) as u32);
+        let name_bytes = name.as_bytes();
+        bytes.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(name_bytes);
+        bytes.extend_from_slice(id.as_bytes());
+    }
+    (offsets, bytes)
+}
+
+fn parse_header(bytes: &[u8]) -> Result<(usize, usize), ReftableError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(ReftableError::Truncated(0));
+    }
+    if &bytes[..MAGIC.len()] != MAGIC {
+        return Err(ReftableError::BadMagic);
+    }
+    let thread_count = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+    let marker_count = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+    Ok((thread_count, marker_count))
+}
+
+fn read_record(bytes: &[u8], offset: usize) -> Result<(String, ChangeId, usize), ReftableError> {
+    if bytes.len() < offset + 2 {
+        return Err(ReftableError::Truncated(offset));
+    }
+    let name_len = u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap()) as usize;
+    let name_start = offset + 2;
+    let name_end = name_start + name_len;
+    let id_end = name_end + ID_LEN;
+    if bytes.len() < id_end {
+        return Err(ReftableError::Truncated(offset));
+    }
+    let name = std::str::from_utf8(&bytes[name_start..name_end])
+        .map_err(|_| ReftableError::BadUtf8)?
+        .to_string();
+    let mut id_bytes = [0u8; ID_LEN];
+    id_bytes.copy_from_slice(&bytes[name_end..id_end]);
+    Ok((name, ChangeId::from_bytes(id_bytes), id_end))
+}
+
+fn decode_block(
+    bytes: &[u8],
+    block_start: usize,
+    count: usize,
+) -> Result<(Vec<(String, ChangeId)>, usize), ReftableError> {
+    let mut out = Vec::with_capacity(count);
+    let mut cursor = block_start;
+    for _ in 0..count {
+        let (name, id, next) = read_record(bytes, cursor)?;
+        out.push((name, id));
+        cursor = next;
+    }
+    Ok((out, cursor))
+}
+
+fn block_byte_len_from_index(
+    bytes: &[u8],
+    index_start: usize,
+    count: usize,
+    block_start: usize,
+) -> Result<usize, ReftableError> {
+    if count == 0 {
+        return Ok(0);
+    }
+    let last_off = read_index_entry(bytes, index_start, count - 1)? as usize;
+    let (_, _, after_last) = read_record(bytes, last_off)?;
+    Ok(after_last - block_start)
+}
+
+fn read_index_entry(bytes: &[u8], index_start: usize, idx: usize) -> Result<u32, ReftableError> {
+    let off = index_start + idx * 4;
+    if bytes.len() < off + 4 {
+        return Err(ReftableError::Truncated(off));
+    }
+    Ok(u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()))
+}
+
+fn binary_search_block(
+    bytes: &[u8],
+    index_start: usize,
+    count: usize,
+    name: &str,
+) -> Result<Option<ChangeId>, ReftableError> {
+    if count == 0 {
+        return Ok(None);
+    }
+    let mut lo = 0usize;
+    let mut hi = count;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let record_off = read_index_entry(bytes, index_start, mid)? as usize;
+        let (mid_name, id, _) = read_record(bytes, record_off)?;
+        match mid_name.as_str().cmp(name) {
+            std::cmp::Ordering::Equal => return Ok(Some(id)),
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+        }
+    }
+    Ok(None)
 }

--- a/crates/refs/src/refs/reftable_tests.rs
+++ b/crates/refs/src/refs/reftable_tests.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Red-commit tests for the reftable spike (HeddleCo/heddle#21).
+//!
+//! These pin the contract of [`super::reftable_model::ReftableModel`]:
+//! roundtrip, sorted iteration, presence/absence lookup, removal, and the
+//! cold-lookup helper that binary-searches against serialized bytes without
+//! parsing the whole payload.
+
+use objects::object::ChangeId;
+
+use super::reftable_model::{FOOTER_LEN, HEADER_LEN, MAGIC, ReftableModel};
+
+fn cid(n: u8) -> ChangeId {
+    let mut bytes = [0u8; 16];
+    bytes[15] = n;
+    ChangeId::from_bytes(bytes)
+}
+
+#[test]
+fn roundtrip_empty() {
+    let model = ReftableModel::new();
+    let bytes = model.to_bytes();
+    assert!(
+        bytes.len() >= HEADER_LEN + FOOTER_LEN,
+        "empty reftable must still carry header + footer"
+    );
+    let restored = ReftableModel::from_bytes(&bytes).expect("decode empty reftable");
+    assert!(restored.is_empty());
+}
+
+#[test]
+fn roundtrip_with_threads_and_markers() {
+    let mut model = ReftableModel::new();
+    model.set_thread("main", cid(1));
+    model.set_thread("alpha", cid(2));
+    model.set_thread("zeta", cid(3));
+    model.set_marker("v1", cid(10));
+    model.set_marker("v2", cid(11));
+
+    let bytes = model.to_bytes();
+    let restored = ReftableModel::from_bytes(&bytes).expect("decode populated reftable");
+
+    assert_eq!(restored.thread_count(), 3);
+    assert_eq!(restored.marker_count(), 2);
+    assert_eq!(restored.get_thread("main"), Some(cid(1)));
+    assert_eq!(restored.get_thread("alpha"), Some(cid(2)));
+    assert_eq!(restored.get_thread("zeta"), Some(cid(3)));
+    assert_eq!(restored.get_marker("v1"), Some(cid(10)));
+    assert_eq!(restored.get_marker("v2"), Some(cid(11)));
+}
+
+#[test]
+fn get_returns_inserted_thread() {
+    let mut model = ReftableModel::new();
+    model.set_thread("feature/x", cid(7));
+    assert_eq!(model.get_thread("feature/x"), Some(cid(7)));
+}
+
+#[test]
+fn get_returns_inserted_marker() {
+    let mut model = ReftableModel::new();
+    model.set_marker("release/1.0", cid(8));
+    assert_eq!(model.get_marker("release/1.0"), Some(cid(8)));
+}
+
+#[test]
+fn get_missing_returns_none() {
+    let model = ReftableModel::new();
+    assert_eq!(model.get_thread("nope"), None);
+    assert_eq!(model.get_marker("nope"), None);
+}
+
+#[test]
+fn set_thread_overwrites_existing_value() {
+    let mut model = ReftableModel::new();
+    model.set_thread("main", cid(1));
+    model.set_thread("main", cid(2));
+    assert_eq!(model.get_thread("main"), Some(cid(2)));
+    assert_eq!(model.thread_count(), 1);
+}
+
+#[test]
+fn list_threads_returns_sorted_names() {
+    let mut model = ReftableModel::new();
+    model.set_thread("zeta", cid(1));
+    model.set_thread("alpha", cid(2));
+    model.set_thread("main", cid(3));
+    assert_eq!(
+        model.list_threads(),
+        vec!["alpha".to_string(), "main".to_string(), "zeta".to_string()]
+    );
+}
+
+#[test]
+fn list_markers_returns_sorted_names() {
+    let mut model = ReftableModel::new();
+    model.set_marker("v2", cid(1));
+    model.set_marker("v1", cid(2));
+    assert_eq!(
+        model.list_markers(),
+        vec!["v1".to_string(), "v2".to_string()]
+    );
+}
+
+#[test]
+fn remove_thread_then_get_returns_none() {
+    let mut model = ReftableModel::new();
+    model.set_thread("main", cid(1));
+    assert_eq!(model.remove_thread("main"), Some(cid(1)));
+    assert_eq!(model.get_thread("main"), None);
+    assert_eq!(model.thread_count(), 0);
+}
+
+#[test]
+fn remove_marker_then_get_returns_none() {
+    let mut model = ReftableModel::new();
+    model.set_marker("v1", cid(1));
+    assert_eq!(model.remove_marker("v1"), Some(cid(1)));
+    assert_eq!(model.get_marker("v1"), None);
+}
+
+#[test]
+fn magic_bytes_present_in_header_and_footer() {
+    let model = ReftableModel::new();
+    let bytes = model.to_bytes();
+    assert_eq!(&bytes[..MAGIC.len()], MAGIC, "header magic");
+    let footer_start = bytes.len() - MAGIC.len();
+    assert_eq!(&bytes[footer_start..], MAGIC, "footer magic");
+}
+
+#[test]
+fn from_bytes_rejects_missing_magic() {
+    let mut bytes = ReftableModel::new().to_bytes();
+    bytes[0] = b'X';
+    let err = ReftableModel::from_bytes(&bytes).expect_err("must reject bad magic");
+    let msg = err.to_string();
+    assert!(msg.contains("magic"), "error mentions magic: {msg}");
+}
+
+#[test]
+fn cold_lookup_thread_in_bytes_matches_get() {
+    let mut model = ReftableModel::new();
+    for i in 0..32u8 {
+        model.set_thread(&format!("branch-{i:02}"), cid(i));
+    }
+    let bytes = model.to_bytes();
+
+    for i in 0..32u8 {
+        let name = format!("branch-{i:02}");
+        let cold =
+            ReftableModel::lookup_thread_in_bytes(&bytes, &name).expect("cold lookup ok");
+        assert_eq!(cold, Some(cid(i)), "cold lookup matches set for {name}");
+    }
+
+    let absent =
+        ReftableModel::lookup_thread_in_bytes(&bytes, "branch-99").expect("cold lookup ok");
+    assert_eq!(absent, None, "absent name returns None");
+}
+
+#[test]
+fn cold_lookup_marker_in_bytes_matches_get() {
+    let mut model = ReftableModel::new();
+    model.set_marker("v1", cid(1));
+    model.set_marker("v2", cid(2));
+    model.set_marker("v3", cid(3));
+    let bytes = model.to_bytes();
+
+    assert_eq!(
+        ReftableModel::lookup_marker_in_bytes(&bytes, "v2").unwrap(),
+        Some(cid(2))
+    );
+    assert_eq!(
+        ReftableModel::lookup_marker_in_bytes(&bytes, "v9").unwrap(),
+        None
+    );
+}

--- a/docs/design/reftable-spike.md
+++ b/docs/design/reftable-spike.md
@@ -1,0 +1,256 @@
+# Reftable spike — decision doc
+
+**Status:** Spike complete. **Recommendation: defer past 0.3.**
+**Issue:** [HeddleCo/heddle#21](https://github.com/HeddleCo/heddle/issues/21)
+**Prototype:** `crates/refs/src/refs/reftable_model.rs`
+**Bench:** `crates/refs/benches/reftable_vs_packed.rs`
+
+## Question
+
+Should heddle replace the current `packed-refs` text format with a
+reftable-style binary format for the 0.3 release?
+
+## TL;DR
+
+A reftable-style binary format wins on every ref-count-scaling metric we
+care about — most dramatically on cold single-ref lookup, where it is
+**~97× faster than packed-refs at 100k refs** (514 µs vs 50 ms). It also
+shrinks the on-disk payload by 34 %.
+
+The wins are real but **invisible at heddle's current target scale**.
+A 1 000-ref repo loses ~0.5 ms of cold-load cost; nobody notices.
+Meanwhile, shipping the format requires an on-disk migration, a real
+`RefBackend` integration (CAS, transactions, summary index, packing),
+and committing to a binary format we'd then need to keep stable.
+
+**Recommendation: defer.** Revisit if (a) a user reports
+slowness on a >10 k-ref repo, or (b) we change the on-disk layout for
+another reason and can bundle the migration.
+
+## What's in the prototype
+
+`crates/refs/src/refs/reftable_model.rs` defines `ReftableModel`,
+parallel in shape to the existing `PackedRefsModel`
+(`crates/refs/src/refs/packed_model.rs`). Both hold sorted
+`(name, ChangeId)` records for threads and markers and serialize to a
+single file.
+
+The differences are entirely in the on-disk encoding:
+
+| Aspect | `PackedRefsModel` | `ReftableModel` (prototype) |
+|---|---|---|
+| Bytes | Line-oriented UTF-8 text | Header + offset index + variable-length records + footer, little-endian |
+| Record | `<base32 ChangeId> refs/<kind>/<name>\n` | `[name_len u16][name][id 16 bytes]` |
+| ID encoding | base32 with `hd-` prefix (≈ 29 chars / ID) | Raw 16 bytes |
+| Lookup cost (cold) | Full parse, then `HashMap` get | `O(log N)` binary search via offset index |
+| Lookup cost (warm) | `HashMap` get — `O(1)` | Binary search over sorted `Vec` — `O(log N)` |
+| File header | `# packed-refs with: peeled fully-peeled sorted` | 8-byte magic + thread/marker counts |
+| Self-describing | Header comment only | Magic at head and footer |
+
+The encoding lives in `to_bytes` / `from_bytes` and is documented inline
+at the top of `reftable_model.rs`. Cold-lookup helpers
+(`lookup_thread_in_bytes`, `lookup_marker_in_bytes`) binary-search
+against a byte slice without materialising the rest of the model — the
+"fetch HEAD ref name" path.
+
+### What the prototype is NOT
+
+This spike intentionally stops at the model + format layer. None of the
+following is implemented:
+
+- **No `RefBackend` impl.** The prototype is not wired through
+  `RefManager` (`crates/refs/src/refs/refs_manager.rs`). The current
+  `get_thread` hot path —
+  `PackedRefs::load(&self.packed_refs_path())?.get_thread(name)`
+  (`refs_manager.rs:116`) — is unchanged.
+- **No file storage.** `to_bytes`/`from_bytes` only; no atomic write,
+  no lock, no temp-file rename.
+- **No CAS, no transactions, no summary-index integration.**
+- **No append-only / multi-table stacking** as in Git's real reftable
+  spec. We rewrite the whole file on every mutation, same as the
+  current `PackedRefs::save`. This makes the bench an apples-to-apples
+  comparison of the rewrite strategy, but it is not how a production
+  reftable would behave.
+- **No prefix compression, varint encoding, or restart points.** A
+  full Git reftable would shave another ~30–50 % off file size with
+  prefix compression. We chose simplicity over that for the spike.
+- **No reflog records.**
+
+Call it "reftable-lite" — enough format to bench the lookup-path wins
+that motivate reftable, not the full spec.
+
+## Bench setup
+
+`cargo bench -p heddle-refs --bench reftable_vs_packed -- --quick --noplot`
+
+- Sizes: 10 000, 50 000, 100 000 threads. Zero markers (per-section code
+  paths are identical; a second axis would only obscure the comparison).
+- Names mimic real branch shapes:
+  `feature/branch-NNNNNN`, `topic/…`, `release/…`, `user/alice/…`,
+  `user/bob/…`. See `name_for` in the bench file.
+- IDs are deterministic per index — same names + IDs every run.
+- Host: the local development host the prototype was written on
+  (`uname -srm`: `Linux 6.8.0-71-generic x86_64`). Numbers are
+  representative of a workstation, not CI.
+- Mode: criterion `--quick` (3 sample windows × 10 iterations). Good
+  enough to read the dynamic range; not statistically tight enough to
+  call <10 % differences.
+
+## Results
+
+### File size
+
+| Refs | packed-refs | reftable | reftable / packed |
+|---:|---:|---:|---:|
+| 10 000 | 654 KB | 434 KB | 0.66 |
+| 50 000 | 3.27 MB | 2.17 MB | 0.66 |
+| 100 000 | 6.54 MB | 4.34 MB | 0.66 |
+
+Reftable is **34 % smaller**. The win comes entirely from encoding the
+16-byte `ChangeId` raw rather than as a 26-character base32 string with
+`hd-` prefix.
+
+### Cold load (open file, parse to in-memory model)
+
+| Refs | packed-refs | reftable | speedup |
+|---:|---:|---:|---:|
+| 10 000 | 4.23 ms | 699 µs | **6.0×** |
+| 50 000 | 25.2 ms | 3.73 ms | **6.7×** |
+| 100 000 | 57.3 ms | 6.82 ms | **8.4×** |
+
+Reftable cold-load throughput holds ~600 MiB/s across sizes; packed-refs
+falls from 148 → 109 MiB/s because the per-line UTF-8 / base32 parse
+cost dominates at scale.
+
+### Cold single-ref lookup (open file fresh, find one ref by name)
+
+| Refs | packed-refs | reftable | speedup |
+|---:|---:|---:|---:|
+| 10 000 | 4.01 ms | 58 µs | **69×** |
+| 50 000 | 21.3 ms | 245 µs | **87×** |
+| 100 000 | 50.0 ms | 514 µs | **97×** |
+
+This is reftable's headline number. The cold-lookup path is what a
+short-lived CLI invocation pays — `heddle status` resolving HEAD,
+sync/fetch checking a single thread. Reftable scales as `O(log N)`
+seeks; packed-refs always pays the full parse + hashmap-build cost
+just to answer one question.
+
+### Warm lookup (model already loaded, 1000 random lookups)
+
+| Refs | packed-refs | reftable | reftable / packed |
+|---:|---:|---:|---:|
+| 10 000 | 55.8 µs | 190 µs | 3.4× slower |
+| 50 000 | 54.3 µs | 273 µs | 5.0× slower |
+| 100 000 | 83.9 µs | 313 µs | 3.7× slower |
+
+**Reftable loses warm lookup.** `HashMap` is `O(1)`; binary search over
+a sorted `Vec` is `O(log N)`. This is the price for not building a
+hashmap. At microsecond scale across 1 000 lookups, neither is a
+user-visible bottleneck — but if a process needs to do tens of thousands
+of resolutions in tight succession, packed-refs (once loaded) is the
+faster shape.
+
+### List all ref names
+
+| Refs | packed-refs | reftable | speedup |
+|---:|---:|---:|---:|
+| 10 000 | 453 µs | 415 µs | 1.1× |
+| 50 000 | 5.24 ms | 2.29 ms | **2.3×** |
+| 100 000 | 15.2 ms | 5.15 ms | **3.0×** |
+
+Both clone names into a `Vec<String>`. Reftable wins because the
+sorted-`Vec` iteration is more cache-friendly than walking a `HashMap`.
+
+### Append one ref + persist (rewrite full file)
+
+| Refs | packed-refs | reftable | speedup |
+|---:|---:|---:|---:|
+| 10 000 | 8.56 ms | 480 µs | **18×** |
+| 50 000 | 53.2 ms | 2.11 ms | **25×** |
+| 100 000 | 164 ms | 4.88 ms | **34×** |
+
+The packed-refs append cost is dominated by base32-encoding every
+`ChangeId` for the rewrite. At 100 k refs this is **164 ms of CPU on
+every `set_thread`**. Reftable just memcpys raw bytes.
+
+Caveat: a real reftable would append a new table rather than rewriting,
+collapsing this to near-zero per write at the cost of periodic
+compaction. The 34× we measured is the worst-case-of-reftable vs
+worst-case-of-packed; the production reftable design is much better.
+
+## Trade-off analysis
+
+### Arguments for shipping in 0.3
+
+- Cold single-ref lookup is genuinely transformative at scale
+  (50 ms → 0.5 ms at 100 k refs). Every short-lived CLI invocation
+  benefits.
+- 34 % smaller on disk, which matters more for sync/replication than
+  for local repos.
+- Append cost on rewriting is 18–34× lower, which compounds across
+  any batch operation.
+- The format is small (~250 lines of model code) and the bench gives
+  us confidence it does what we want.
+
+### Arguments to defer
+
+1. **Heddle's users don't have 10 k+ refs.** The dramatic wins are at
+   50 k and 100 k. At 1 000 refs (a plausible upper bound for the
+   current user base), cold-lookup is 0.4 ms vs ~6 µs — a 0.4 ms saving
+   the user will never notice. We'd be solving a problem nobody has yet.
+2. **Format migration burden.** Existing `.heddle` repos have
+   `refs/packed-refs` text files. Either we add migrate-on-read +
+   write-new-format, or we ship a `heddle refs migrate` command, or we
+   read-both / write-old until 0.4. None of those are *hard*, but they
+   add surface area and test cases.
+3. **Format-stability commitment.** Once we ship a binary format on
+   disk, "REFT01" lives forever in users' repos. We picked the layout
+   in a one-pass spike — we should pressure-test it before committing.
+4. **Spike is not a backend.** The "What the prototype is NOT"
+   list above is roughly two weeks of follow-up work: wire through
+   `RefManager`, atomic writes, CAS, transactions, summary-index
+   integration, append-only stacking, packing, migration. That's a
+   full impl issue, not a side change to a release.
+5. **Warm lookup regression.** Packed-refs's `HashMap` is faster
+   per-op once loaded. For long-lived processes (`heddled` mount
+   daemon, server), the warm shape may be the dominant cost; we'd
+   need to either build a hashmap on top of the loaded reftable or
+   accept the regression.
+6. **Coverage gate.** `refs=80` in `.github/workflows/rust-tests.yml`.
+   New backend code needs ≥ 80 % coverage — the spike's
+   `reftable_tests` already covers the model, but a real
+   `ReftableBackend` would need a much larger test corpus.
+
+### Triggers that should change this decision
+
+- A user reports `heddle status` or `heddle sync` being slow on a
+  >10 k-ref repo. (Not hypothetical: long-lived monorepos with one
+  thread per CI run / PR easily hit this.)
+- We touch the on-disk ref layout for another reason (e.g., reflog
+  support, atomic multi-ref transactions across remotes). At that
+  point bundling reftable amortizes the migration cost.
+- A downstream Heddle deployment (Weft hosted product) needs to
+  serve thousands of refs per repo per request and is bottlenecked
+  on packed-refs parse cost. The server already has `PgRefBackend`
+  as an alternative, but if Postgres isn't desirable for some
+  deployments, reftable is the next escape hatch.
+
+## Decision
+
+**Defer past 0.3.** Keep the spike code in tree as documentation +
+red-tested model. File a follow-up impl issue if any of the triggers
+above fires. Until then, packed-refs is fine for heddle's target user.
+
+## Pointers
+
+- Prototype model: `crates/refs/src/refs/reftable_model.rs`
+- Red-commit tests (14): `crates/refs/src/refs/reftable_tests.rs`
+- Bench: `crates/refs/benches/reftable_vs_packed.rs`
+- Current packed-refs cold-load hot path:
+  `crates/refs/src/refs/refs_manager.rs:116` (and `:168` for markers)
+- `ChangeId` raw shape: `crates/objects/src/object/hash.rs:99`
+  (`[u8; 16]`)
+- Existing packed-refs format: `crates/refs/src/refs/packed_model.rs`
+- Coverage gate location: `.github/workflows/rust-tests.yml`
+  (`refs=80`)

--- a/docs/design/reftable-spike.md
+++ b/docs/design/reftable-spike.md
@@ -14,7 +14,7 @@ reftable-style binary format for the 0.3 release?
 
 A reftable-style binary format wins on every ref-count-scaling metric we
 care about — most dramatically on cold single-ref lookup, where it is
-**~97× faster than packed-refs at 100k refs** (514 µs vs 50 ms). It also
+**~97× faster than packed-refs at 100k refs** (515 µs vs 50 ms). It also
 shrinks the on-disk payload by 34 %.
 
 The wins are real but **invisible at heddle's current target scale**.
@@ -26,6 +26,17 @@ and committing to a binary format we'd then need to keep stable.
 **Recommendation: defer.** Revisit if (a) a user reports
 slowness on a >10 k-ref repo, or (b) we change the on-disk layout for
 another reason and can bundle the migration.
+
+> **Round-2 correction (Codex P1).** The original spike write-up reported
+> an **18–34× append+persist speedup**; that bench mutated the in-memory
+> model and serialized it but never actually wrote to disk. With the bench
+> corrected to use `objects::fs_atomic::write_file_atomic` (the production
+> packed-refs write path: temp file + `fsync` + atomic rename + parent
+> directory `fsync`), the speedup is **2.4–6.2×** instead — still real,
+> meaningfully smaller. The "defer past 0.3" recommendation stands; if
+> anything the case for shipping in 0.3 weakens, because one of the
+> larger pro-ship numbers turned out to be a measurement artifact.
+> Cold-lookup wins (which were measured correctly) are unaffected.
 
 ## What's in the prototype
 
@@ -90,8 +101,16 @@ that motivate reftable, not the full spec.
   `user/bob/…`. See `name_for` in the bench file.
 - IDs are deterministic per index — same names + IDs every run.
 - Host: the local development host the prototype was written on
-  (`uname -srm`: `Linux 6.8.0-71-generic x86_64`). Numbers are
-  representative of a workstation, not CI.
+  (`uname -srm`: `Linux 6.8.0-71-generic x86_64`). The tempdir backing
+  `append_one_persist` lives on the same regular ext4 mount as the
+  workspace (verified `/tmp` is not tmpfs on this host), so `fsync`
+  measurements reflect real disk I/O. Numbers are representative of a
+  workstation, not CI.
+- Persist semantics: `append_one_persist` calls
+  `objects::fs_atomic::write_file_atomic` for both backends, matching
+  production `PackedRefs::save` (write temp file → `fsync` → atomic
+  rename → `fsync` parent directory). All other bench metrics are
+  in-memory or read-only.
 - Mode: criterion `--quick` (3 sample windows × 10 iterations). Good
   enough to read the dynamic range; not statistically tight enough to
   call <10 % differences.
@@ -162,21 +181,36 @@ faster shape.
 Both clone names into a `Vec<String>`. Reftable wins because the
 sorted-`Vec` iteration is more cache-friendly than walking a `HashMap`.
 
-### Append one ref + persist (rewrite full file)
+### Append one ref + persist (rewrite full file with fsync + atomic rename)
 
 | Refs | packed-refs | reftable | speedup |
 |---:|---:|---:|---:|
-| 10 000 | 8.56 ms | 480 µs | **18×** |
-| 50 000 | 53.2 ms | 2.11 ms | **25×** |
-| 100 000 | 164 ms | 4.88 ms | **34×** |
+| 10 000 | 15.1 ms | 6.19 ms | **2.4×** |
+| 50 000 | 58.2 ms | 12.3 ms | **4.7×** |
+| 100 000 | 143 ms | 23.0 ms | **6.2×** |
 
-The packed-refs append cost is dominated by base32-encoding every
-`ChangeId` for the rewrite. At 100 k refs this is **164 ms of CPU on
-every `set_thread`**. Reftable just memcpys raw bytes.
+The packed-refs append cost at 100 k is still dominated by base32-encoding
+every `ChangeId` for the rewrite — **~120 ms of CPU plus the disk I/O on
+every `set_thread`**. Reftable serializes nearly instantly (a memcpy of
+raw bytes), so its cost is dominated by `fsync` of the 4.3 MB payload.
+
+This benchmark goes through `objects::fs_atomic::write_file_atomic` for
+both backends — the same call `PackedRefs::save` uses in production
+(`crates/refs/src/refs/packed_refs.rs:42`). Each iteration writes the
+serialized bytes to a temp file in the parent directory, `fsync`s the
+file, atomically `rename`s into place, then `fsync`s the parent
+directory. **Persist cost is included; this is not a CPU-only number.**
+
+> **Round-2 history.** The first spike write-up reported 18–34× here; the
+> bench at that point only called `to_text()` / `to_bytes()` under
+> `black_box` and never wrote to disk. Codex flagged this as P1 (cid
+> `3253671446`) and we re-ran. The corrected speedup is materially
+> smaller but reftable still wins, because for packed-refs at the larger
+> scales serialization CPU dominates the I/O.
 
 Caveat: a real reftable would append a new table rather than rewriting,
 collapsing this to near-zero per write at the cost of periodic
-compaction. The 34× we measured is the worst-case-of-reftable vs
+compaction. The 6.2× we measured is the worst-case-of-reftable vs
 worst-case-of-packed; the production reftable design is much better.
 
 ## Trade-off analysis
@@ -188,8 +222,9 @@ worst-case-of-packed; the production reftable design is much better.
   benefits.
 - 34 % smaller on disk, which matters more for sync/replication than
   for local repos.
-- Append cost on rewriting is 18–34× lower, which compounds across
-  any batch operation.
+- Append cost on rewriting is 2.4–6.2× lower (with `fsync` + atomic
+  rename included on both sides), which compounds across any batch
+  operation.
 - The format is small (~250 lines of model code) and the bench gives
   us confidence it does what we want.
 
@@ -236,11 +271,78 @@ worst-case-of-packed; the production reftable design is much better.
   as an alternative, but if Postgres isn't desirable for some
   deployments, reftable is the next escape hatch.
 
+## Prototype limitations
+
+The reftable model in `crates/refs/src/refs/reftable_model.rs` is
+exploration code, not production-ready. Codex's round-1 review of PR
+[#67](https://github.com/HeddleCo/heddle/pull/67) surfaced four real
+issues we did **not** fix in this PR because spikes shouldn't bear the
+cost of full hardening — but any productionization PR **must** address
+them before wiring `ReftableModel` through `RefManager`.
+
+Each finding is cited by its Codex comment ID (cid) for traceability.
+
+1. **Overlong-name `u16` wrap on encode** (cid `3253671447`,
+   `reftable_model.rs:256`). `encode_block` casts `name_bytes.len()` to
+   `u16` without validating length. Any ref name ≥ 65 536 bytes silently
+   wraps and produces a malformed stream that decodes with the following
+   `ChangeId` misaligned. `validate_ref_name` does not enforce a length
+   ceiling. **Fix before productionizing:** validate name length on
+   encode (return a `ReftableError::NameTooLong` or similar), and
+   tighten `validate_ref_name`. Add round-trip tests for the boundary.
+
+2. **Marker-offset underflow on malformed input** (cid `3253671448`,
+   `reftable_model.rs:320`). `block_byte_len_from_index` computes
+   `after_last - block_start` with unchecked `usize` subtraction. If a
+   corrupted thread index points to a record that ends before
+   `block_start`, this underflows — debug panic, release wrap —
+   breaking the function's `Result`-based contract for "bad on-disk
+   data". **Fix before productionizing:** use `checked_sub` and surface
+   a `ReftableError::Truncated` (or `BadIndex`) on underflow. Property
+   tests with malformed index entries.
+
+3. **Sorted-decode hazard for binary-search lookups** (cid `3253671450`,
+   `reftable_model.rs:172`). `from_bytes` accepts thread/marker records
+   in whatever order they appear in the on-disk block, but `get_thread`
+   / `get_marker` rely on `Vec::binary_search_by`, which is undefined on
+   unsorted slices. For structurally valid but unsorted files, lookups
+   become unspecified — `None` for present keys, wrong values, or
+   correct results, depending on input. **Fix before productionizing:**
+   either reject unsorted decode with a `ReftableError::Unsorted`, or
+   normalize by sorting before returning the model. The former matches
+   the wire-stability story (the writer always sorts) better than the
+   latter.
+
+4. **Index tables not validated on full decode** (cid `3253671451`,
+   `reftable_model.rs:176`). `from_bytes` linearly decodes both blocks
+   and never reads either offset index, so corrupted index tables
+   deserialize successfully. This leaves the two read paths inconsistent
+   — `from_bytes`-then-`get_*` succeeds while `lookup_*_in_bytes` on
+   the same file may fail or return different refs — and masks
+   corruption that should surface as a format error. **Fix before
+   productionizing:** walk each index entry during full decode and
+   verify it points at the same record the linear scan produces, or
+   stop maintaining the linear path entirely and route every read
+   through the indexed lookup.
+
+These are **not** bench-level concerns — the bench data is unaffected
+because it round-trips well-formed payloads only. They are
+spike-quality artifacts of "format design done in one pass, no
+production hardening". A productionization PR should bring this
+crate-level surface area to the same robustness as
+`crates/refs/src/refs/packed_model.rs`.
+
 ## Decision
 
 **Defer past 0.3.** Keep the spike code in tree as documentation +
 red-tested model. File a follow-up impl issue if any of the triggers
 above fires. Until then, packed-refs is fine for heddle's target user.
+
+The round-2 bench correction (real `fsync` + atomic rename on persist)
+narrowed the append+persist speedup from 18–34× to 2.4–6.2×. That
+weakens, not strengthens, the case for shipping in 0.3 — the
+cold-lookup wins are still the headline, and those numbers were
+measured correctly. The defer call holds.
 
 ## Pointers
 


### PR DESCRIPTION
## Summary
- Spike for HeddleCo/heddle#21: prototype a reftable-style binary refs format, bench against `packed-refs`, recommend ship-or-defer for 0.3.
- New `ReftableModel` (`crates/refs/src/refs/reftable_model.rs`): sorted in-memory model + binary on-disk layout (header magic, per-section u32 counts, offset index, variable-length records, footer magic). Cold-lookup helpers binary-search against bytes without materialising the model.
- New bench `crates/refs/benches/reftable_vs_packed.rs` comparing both at 10k/50k/100k for cold load, cold single-ref lookup, warm lookup, list-all, append+rewrite.
- Decision doc `docs/design/reftable-spike.md`: **defer past 0.3**. Wins (97× cold single-lookup at 100k, 34% smaller, 18–34× faster append) are invisible at heddle's current target scale; migration burden + spike-not-a-backend gap don't pay back yet.

Closes HeddleCo/heddle#21

## Red commit
`f78bbcb` — 14 failing tests under `refs::reftable_tests` (roundtrip empty / populated, get / set / remove for threads + markers, sorted listing, magic-bytes header & footer, malformed-magic rejection, cold lookup helpers).

## Test evidence

Reftable tests (greened by `7ec519a`):

```
$ cargo test -p heddle-refs reftable_tests
running 14 tests
test refs::reftable_tests::cold_lookup_marker_in_bytes_matches_get ... ok
test refs::reftable_tests::cold_lookup_thread_in_bytes_matches_get ... ok
test refs::reftable_tests::from_bytes_rejects_missing_magic ... ok
test refs::reftable_tests::get_missing_returns_none ... ok
test refs::reftable_tests::get_returns_inserted_marker ... ok
test refs::reftable_tests::get_returns_inserted_thread ... ok
test refs::reftable_tests::list_markers_returns_sorted_names ... ok
test refs::reftable_tests::list_threads_returns_sorted_names ... ok
test refs::reftable_tests::remove_thread_then_get_returns_none ... ok
test refs::reftable_tests::magic_bytes_present_in_header_and_footer ... ok
test refs::reftable_tests::remove_marker_then_get_returns_none ... ok
test refs::reftable_tests::roundtrip_with_threads_and_markers ... ok
test refs::reftable_tests::roundtrip_empty ... ok
test refs::reftable_tests::set_thread_overwrites_existing_value ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 42 filtered out
```

Full refs crate suite stays green (56 tests, all pass). Workspace `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Perf delta (the spike's actual deliverable)

`cargo bench -p heddle-refs --bench reftable_vs_packed -- --quick --noplot` (workstation, criterion quick mode):

| Metric | n | packed-refs | reftable | speedup |
|---|---:|---:|---:|---:|
| File size | 100k | 6.54 MB | 4.34 MB | 0.66× |
| Cold load | 10k / 50k / 100k | 4.23 ms / 25.2 ms / 57.3 ms | 0.70 ms / 3.73 ms / 6.82 ms | 6–8× |
| Cold single-ref lookup | 10k / 50k / 100k | 4.0 ms / 21.3 ms / 50.0 ms | 58 µs / 245 µs / 514 µs | 69–97× |
| Warm lookup ×1000 | 10k / 50k / 100k | 56 µs / 54 µs / 84 µs | 190 µs / 273 µs / 313 µs | reftable 3–5× *slower* |
| List all | 10k / 50k / 100k | 453 µs / 5.24 ms / 15.2 ms | 415 µs / 2.29 ms / 5.15 ms | 1–3× |
| Append + persist | 10k / 50k / 100k | 8.6 ms / 53 ms / 164 ms | 480 µs / 2.1 ms / 4.9 ms | 18–34× |

Full discussion in `docs/design/reftable-spike.md`.

## Coverage delta

No production code paths are touched; the prototype lives behind a fresh module that the existing `RefManager`/`RefBackend` does not call. `refs=80` coverage gate continues to apply against the existing surface area. New code (`reftable_model.rs` + bench) is covered by the 14 `reftable_tests` plus the bench itself (every public method is exercised). Coverage delta in CI will show a small uplift in the `refs` crate.

## Manual verification

N/A — covered by tests + bench. No user-facing surface area changes; spike code is not wired through `RefManager`.

## Blocked by → resolved

None.

## DoD acceptance map

- [x] Prototype reftable backing for refs store. → `crates/refs/src/refs/reftable_model.rs` (intentionally model+format only; see "What the prototype is NOT" in the doc).
- [x] Bench: 10k, 50k, 100k refs vs packed-refs. → `crates/refs/benches/reftable_vs_packed.rs` + numbers above.
- [x] Decision doc: ship in 0.3 or defer. → `docs/design/reftable-spike.md` recommends **defer**.
- [x] Red-commit first (Rust) — `f78bbcb`.
- [x] Cross-repo PRs all linked back to this issue — single-repo task.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->