### PR TITLE
feat(release): binary release pipeline for 5 targets (heddle#56)

### DIFF
--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -28,3 +28,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Assert release pipeline contract
         run: bash scripts/check-release-pipeline.sh
+      - name: Assert PyYAML venv fallback (PEP 668 path)
+        # Shadow `python3` with a fresh venv that has no PyYAML installed,
+        # so the asserter's `import yaml` fails and the venv fallback in
+        # ensure_pyyaml() is the only way the strict structural checks
+        # can succeed. Guards against regressions like the earlier
+        # `python3 -m pip install` fallback that broke under
+        # `externally-managed-environment` on Ubuntu 24.04.
+        run: |
+          set -euo pipefail
+          shadow="$(mktemp -d)/shadow"
+          python3 -m venv "$shadow"
+          "$shadow/bin/python" -c 'import yaml' && {
+            echo "shadow venv unexpectedly has PyYAML; test is not exercising the fallback" >&2
+            exit 1
+          } || true
+          PATH="$shadow/bin:$PATH" bash scripts/check-release-pipeline.sh

--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -1,0 +1,30 @@
+name: Release pipeline check
+
+# Static asserter for the binary-release contract (heddle#56). The release
+# workflow only runs on `v*` tag pushes, so this job is what gives normal
+# PRs a signal that the contract is intact. Keep it cheap.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-pipeline-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: release.yml contract
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert release pipeline contract
+        run: bash scripts/check-release-pipeline.sh

--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -28,19 +28,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Assert release pipeline contract
         run: bash scripts/check-release-pipeline.sh
-      - name: Assert PyYAML venv fallback (PEP 668 path)
-        # Shadow `python3` with a fresh venv that has no PyYAML installed,
-        # so the asserter's `import yaml` fails and the venv fallback in
-        # ensure_pyyaml() is the only way the strict structural checks
-        # can succeed. Guards against regressions like the earlier
-        # `python3 -m pip install` fallback that broke under
-        # `externally-managed-environment` on Ubuntu 24.04.
-        run: |
-          set -euo pipefail
-          shadow="$(mktemp -d)/shadow"
-          python3 -m venv "$shadow"
-          "$shadow/bin/python" -c 'import yaml' && {
-            echo "shadow venv unexpectedly has PyYAML; test is not exercising the fallback" >&2
-            exit 1
-          } || true
-          PATH="$shadow/bin:$PATH" bash scripts/check-release-pipeline.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,198 @@
+name: Release binaries
+
+# Pre-built binaries for the `heddle` CLI on tagged releases.
+#
+# Trigger: any `v*` tag push. The job tree:
+#
+#   build (matrix, 5 targets) ──┐
+#                               ├─► sign + checksum (per artifact, in-matrix)
+#                               └─► release (aggregates, publishes, posts SHA256SUMS)
+#
+# Strategy: native matrix builds (one runner per target) instead of
+# cross-compilation. Rationale lives in RELEASING.md — short version:
+# Apple-codesign + Windows packaging are simpler when the host triple
+# matches the target, and GitHub-hosted ARM runners (ubuntu-24.04-arm,
+# macos-14) make this free.
+#
+# Signing: cosign keyless via the Sigstore public-good instance. No
+# stored secrets — the GitHub OIDC token is the trust anchor. Verifying
+# parties run `cosign verify-blob --certificate-identity-regexp ...`;
+# see RELEASING.md for the exact recipe.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (must already exist; for dry-runs use a pre-pushed v*-rc tag)'
+        required: true
+
+permissions:
+  contents: write   # create release + upload assets
+  id-token: write   # cosign keyless OIDC
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  BIN_NAME: heddle
+  CRATE_NAME: heddle-cli
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-2022
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}
+          cache-on-failure: true
+
+      - name: Compute version
+        id: ver
+        shell: bash
+        run: |
+          ref="${{ inputs.tag || github.ref_name }}"
+          # Strip leading "v" if present (v0.3.0 → 0.3.0).
+          version="${ref#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release binary
+        run: cargo build --release --locked -p ${{ env.CRATE_NAME }} --target ${{ matrix.target }}
+
+      - name: Stage artifact (unix)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          set -euo pipefail
+          stage="heddle-${{ steps.ver.outputs.tag }}-${{ matrix.target }}"
+          mkdir -p "dist/${stage}"
+          cp "target/${{ matrix.target }}/release/${BIN_NAME}" "dist/${stage}/"
+          cp README.md LICENSE NOTICE "dist/${stage}/"
+          tar -C dist -czf "dist/${stage}.tar.gz" "${stage}"
+          ( cd dist && shasum -a 256 "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
+          echo "ASSET=dist/${stage}.tar.gz" >> "$GITHUB_ENV"
+          echo "SUM=dist/${stage}.tar.gz.sha256" >> "$GITHUB_ENV"
+
+      - name: Stage artifact (windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $stage = "heddle-${{ steps.ver.outputs.tag }}-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path "dist/$stage" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${env:BIN_NAME}.exe" "dist/$stage/"
+          Copy-Item README.md, LICENSE, NOTICE "dist/$stage/"
+          Compress-Archive -Path "dist/$stage" -DestinationPath "dist/$stage.zip"
+          $hash = (Get-FileHash -Algorithm SHA256 "dist/$stage.zip").Hash.ToLower()
+          "$hash  $stage.zip" | Out-File -Encoding ascii "dist/$stage.zip.sha256"
+          "ASSET=dist/$stage.zip"        | Out-File -Encoding ascii -Append $env:GITHUB_ENV
+          "SUM=dist/$stage.zip.sha256"   | Out-File -Encoding ascii -Append $env:GITHUB_ENV
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign artifact (cosign keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Keyless signing: identity is this workflow run's OIDC token,
+          # rooted in the Sigstore public-good Fulcio CA. The .sig and
+          # .pem land next to the artifact for offline verification.
+          cosign sign-blob --yes \
+            --output-signature "${ASSET}.sig" \
+            --output-certificate "${ASSET}.pem" \
+            "${ASSET}"
+
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: heddle-${{ matrix.target }}
+          path: |
+            ${{ env.ASSET }}
+            ${{ env.SUM }}
+            ${{ env.ASSET }}.sig
+            ${{ env.ASSET }}.pem
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve tag
+        id: ver
+        run: |
+          ref="${{ inputs.tag || github.ref_name }}"
+          echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all build outputs
+        uses: actions/download-artifact@v4
+        with:
+          path: staging
+
+      - name: Flatten + aggregate SHA256SUMS
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          find staging -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sig' -o -name '*.pem' -o -name '*.sha256' \) \
+            -exec cp -t dist {} +
+          ( cd dist && cat *.sha256 | sort > SHA256SUMS )
+          echo "--- artifacts ---"
+          ls -la dist
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: ${{ steps.ver.outputs.tag }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/heddle-*.tar.gz
+            dist/heddle-*.tar.gz.sha256
+            dist/heddle-*.tar.gz.sig
+            dist/heddle-*.tar.gz.pem
+            dist/heddle-*.zip
+            dist/heddle-*.zip.sha256
+            dist/heddle-*.zip.sig
+            dist/heddle-*.zip.pem
+            dist/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.classify.outputs.tag }}
+      # The validated commit SHA. Downstream jobs MUST check out this
+      # SHA, not refs/tags/<tag> — see TOCTOU note in the classify step.
+      tag_sha: ${{ steps.classify.outputs.tag_sha }}
       kind: ${{ steps.classify.outputs.kind }}
     steps:
       - uses: actions/checkout@v4
@@ -137,6 +140,18 @@ jobs:
           fi
 
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            # Dispatch is the RC/dry-run path. Stable tags MUST go through
+            # the push trigger so they cannot be retroactively downgraded:
+            # softprops/action-gh-release UPDATES an existing release when
+            # tag_name already exists, and dispatch always sets
+            # kind=prerelease+draft. Without this guard, an operator (or
+            # an attacker with workflow-dispatch rights) could re-dispatch
+            # a previously-published vX.Y.Z and silently mark the public
+            # release as prerelease+draft. Refuse loudly.
+            if [[ "$tag" =~ $stable_re ]]; then
+              echo "::error::workflow_dispatch refuses stable tag '${tag}'. Stable releases (vX.Y.Z) must go through the push trigger; dispatch is for prerelease dry-runs only (vX.Y.Z-(rc|alpha|beta)[.N]). See RELEASING.md."
+              exit 1
+            fi
             kind=prerelease
           elif [[ "$tag" =~ $stable_re ]]; then
             kind=stable
@@ -148,8 +163,16 @@ jobs:
             exit 1
           fi
 
+          # tag_sha is the only ref downstream jobs are allowed to act on.
+          # Emitting it as an output (rather than re-resolving the tag in
+          # each downstream job) closes the TOCTOU window: if the tag is
+          # force-moved AFTER validate-tag passes but BEFORE build/release
+          # check it out, those jobs would otherwise operate on the
+          # attacker-controlled commit. Pinning to the SHA we just
+          # ancestor-checked means every step works on the same commit.
           echo "Resolved: tag=${tag} commit=${tag_sha} kind=${kind}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
           echo "kind=${kind}" >> "$GITHUB_OUTPUT"
 
   build:
@@ -179,7 +202,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
+          # Pin to the SHA validate-tag verified, not the tag ref. If the
+          # tag is force-moved between validate-tag and this step, we
+          # still build the commit that passed the trust check. The
+          # cosign signature is therefore over an artifact derived from a
+          # known-ancestor commit, not from whatever the tag currently
+          # points at.
+          ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -267,7 +296,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
+          # Same SHA pin as the build job — see comment there.
+          ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
       - name: Download all build outputs
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,20 @@ name: Release binaries
 
 # Pre-built binaries for the `heddle` CLI on tagged releases.
 #
-# Trigger: any `v*` tag push. The job tree:
+# Trigger: stable-semver tag push (vX.Y.Z) OR manual workflow_dispatch
+# with an existing tag (used for RC dry-runs). The job tree:
 #
-#   build (matrix, 5 targets) ──┐
-#                               ├─► sign + checksum (per artifact, in-matrix)
-#                               └─► release (aggregates, publishes, posts SHA256SUMS)
+#   validate-tag ──► build (matrix, 5 targets) ──┐
+#                                                ├─► sign + checksum (per artifact, in-matrix)
+#                                                └─► release (aggregates, publishes, posts SHA256SUMS)
+#
+# validate-tag is the single trust gate for the pipeline. It refuses to
+# proceed unless the requested tag (a) exists, (b) is reachable from
+# origin/main, and (c) matches the documented release-tag pattern. All
+# downstream jobs read the validated tag and the publish "kind"
+# (stable | prerelease) from its outputs — no other job should look at
+# the raw trigger ref. This keeps the answer to "is this a sanctioned
+# release?" in exactly one place.
 #
 # Strategy: native matrix builds (one runner per target) instead of
 # cross-compilation. Rationale lives in RELEASING.md — short version:
@@ -21,12 +30,15 @@ name: Release binaries
 
 on:
   push:
+    # Strict semver only. RC / beta / alpha tags do not auto-trigger; use
+    # workflow_dispatch for dry-runs so the publish step can mark them
+    # prerelease+draft. See validate-tag for the full rule.
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to build (must already exist; for dry-runs use a pre-pushed v*-rc tag)'
+        description: 'Existing tag to build (vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]). Dispatch-triggered runs always publish as prerelease+draft.'
         required: true
 
 permissions:
@@ -43,8 +55,106 @@ env:
   CRATE_NAME: heddle-cli
 
 jobs:
+  validate-tag:
+    name: validate tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.classify.outputs.tag }}
+      kind: ${{ steps.classify.outputs.kind }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is needed for both the tag→commit resolution and
+          # the ancestor check against origin/main.
+          fetch-depth: 0
+
+      - name: Resolve, verify, and classify tag
+        id: classify
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          PUSH_REF: ${{ github.ref }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # 1. Resolve the requested tag from the trigger.
+          case "$EVENT" in
+            push)
+              if [[ "$PUSH_REF" != refs/tags/* ]]; then
+                echo "::error::push trigger but ref is not a tag: $PUSH_REF"
+                exit 1
+              fi
+              tag="${PUSH_REF#refs/tags/}"
+              ;;
+            workflow_dispatch)
+              tag="$DISPATCH_TAG"
+              ;;
+            *)
+              echo "::error::unsupported event: $EVENT"
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "$tag" ]]; then
+            echo "::error::no tag resolved from trigger ($EVENT)"
+            exit 1
+          fi
+
+          # 2. Reject anything that is not a real tag in this repo. This
+          #    catches workflow_dispatch with 'main', a typo, or a
+          #    deleted tag — none of which should reach the build job.
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            echo "::error::'${tag}' is not a tag in this repository"
+            exit 1
+          fi
+
+          # 3. The pipeline only ships releases from main. A tag pointed
+          #    at a feature branch (deliberately or accidentally) must
+          #    not produce signed binaries with the heddle release OIDC
+          #    identity. The tag-push trigger does not enforce branch
+          #    ancestry on its own, so we do it here.
+          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
+            echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
+            exit 1
+          fi
+
+          # 4. Classify. Tag pattern decides the *shape* of release;
+          #    event source decides whether it ships as a final release.
+          #    Dispatch runs are *always* prerelease+draft so an operator
+          #    dry-run cannot accidentally publish a public, non-draft
+          #    release — even if they hand-type a stable-looking tag.
+          # SemVer prerelease identifiers permit both `-rc.1` (dot-
+          # separated) and `-rc1` (concatenated) shapes; accept either.
+          stable_re='^v[0-9]+\.[0-9]+\.[0-9]+$'
+          pre_re='^v[0-9]+\.[0-9]+\.[0-9]+-(rc|alpha|beta)(\.?[0-9]+)?$'
+
+          if ! [[ "$tag" =~ $stable_re || "$tag" =~ $pre_re ]]; then
+            echo "::error::tag '${tag}' does not match vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]"
+            exit 1
+          fi
+
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            kind=prerelease
+          elif [[ "$tag" =~ $stable_re ]]; then
+            kind=stable
+          else
+            # Push trigger but the tag is not strict semver. The push
+            # filter should have blocked this; if it slipped through,
+            # fail loudly rather than silently downgrading.
+            echo "::error::push trigger received non-stable tag '${tag}'; refusing"
+            exit 1
+          fi
+
+          echo "Resolved: tag=${tag} commit=${tag_sha} kind=${kind}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+
   build:
     name: build ${{ matrix.target }}
+    needs: validate-tag
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -69,7 +179,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -83,12 +193,13 @@ jobs:
       - name: Compute version
         id: ver
         shell: bash
+        env:
+          TAG: ${{ needs.validate-tag.outputs.tag }}
         run: |
-          ref="${{ inputs.tag || github.ref_name }}"
           # Strip leading "v" if present (v0.3.0 → 0.3.0).
-          version="${ref#v}"
+          version="${TAG#v}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build release binary
         run: cargo build --release --locked -p ${{ env.CRATE_NAME }} --target ${{ matrix.target }}
@@ -150,19 +261,13 @@ jobs:
 
   release:
     name: publish release
-    needs: build
+    needs: [validate-tag, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
-
-      - name: Resolve tag
-        id: ver
-        run: |
-          ref="${{ inputs.tag || github.ref_name }}"
-          echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+          ref: refs/tags/${{ needs.validate-tag.outputs.tag }}
 
       - name: Download all build outputs
         uses: actions/download-artifact@v4
@@ -182,8 +287,13 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.ver.outputs.tag }}
-          name: ${{ steps.ver.outputs.tag }}
+          tag_name: ${{ needs.validate-tag.outputs.tag }}
+          name: ${{ needs.validate-tag.outputs.tag }}
+          # Dispatch-triggered runs (and any future non-stable trigger
+          # path) publish as draft + prerelease. Push-triggered stable
+          # releases publish as a normal release.
+          draft: ${{ needs.validate-tag.outputs.kind != 'stable' }}
+          prerelease: ${{ needs.validate-tag.outputs.kind != 'stable' }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,9 @@ pipeline from the one described here.
 ## Cutting a release
 
 1. Land your change on `main` (CI green).
-2. Tag from `main`:
+2. Tag the commit you want to release from `main`. Tags **must** match
+   strict semver (`vX.Y.Z`); any other shape will not trigger the
+   release workflow on push:
 
    ```bash
    git tag -a v0.3.0 -m 'heddle v0.3.0'
@@ -21,15 +23,27 @@ pipeline from the one described here.
    ```
 
 3. The `Release binaries` workflow (`.github/workflows/release.yml`)
-   triggers on the `v*` tag push. It:
+   triggers on the stable-semver tag push. Before building anything it
+   runs a `validate-tag` gate that:
 
-   - builds the `heddle` binary natively on five GitHub-hosted runners
-   - packages each into a versioned archive (`.tar.gz` for unix,
+   - resolves the requested tag from the trigger (push or dispatch)
+   - rejects refs that aren't real tags (catches `main`, typos, deleted
+     tags fed to `workflow_dispatch`)
+   - rejects tags whose commit isn't reachable from `origin/main`
+     (catches tags accidentally — or maliciously — placed on a feature
+     branch)
+   - classifies the run as `stable` or `prerelease`
+
+   If `validate-tag` fails, no build, sign, or publish step runs. If it
+   passes, the matrix proceeds to:
+
+   - build the `heddle` binary natively on five GitHub-hosted runners
+   - package each into a versioned archive (`.tar.gz` for unix,
      `.zip` for windows)
-   - emits a `.sha256` next to each archive
-   - signs each archive with `cosign` keyless (Sigstore public-good
+   - emit a `.sha256` next to each archive
+   - sign each archive with `cosign` keyless (Sigstore public-good
      instance; trust is rooted in the GitHub OIDC token for this run)
-   - publishes a GitHub Release with auto-generated notes, all
+   - publish a GitHub Release with auto-generated notes, all
      artifacts, signatures, certificates, and an aggregated
      `SHA256SUMS`
 
@@ -40,10 +54,30 @@ pipeline from the one described here.
 
 ### Dry-runs
 
-The workflow also accepts `workflow_dispatch` with a `tag` input. Push
-a pre-release tag (e.g. `v0.3.0-rc1`), trigger the workflow from the
-Actions tab, and inspect the artifacts it produces against a draft or
-prerelease GitHub Release. Delete the rc tag and assets when done.
+Pre-release tags (`-rc`, `-beta`, `-alpha`) intentionally do **not**
+fire the push trigger — only `vX.Y.Z` does. To rehearse a release:
+
+1. Push an RC tag from `main`:
+
+   ```bash
+   git tag -a v0.3.0-rc.1 -m 'heddle v0.3.0-rc.1'
+   git push origin v0.3.0-rc.1
+   ```
+
+   (This push alone does not run the workflow.)
+
+2. From the Actions tab, run `Release binaries` via `workflow_dispatch`
+   with `tag: v0.3.0-rc.1`.
+
+3. The run goes through `validate-tag` exactly as a real release would.
+   On publish, the GitHub Release is created as **draft + prerelease**
+   — even if you hand-type a stable-looking tag, dispatch-triggered
+   runs never auto-publish a normal release. Inspect the draft release,
+   then delete the draft release and the RC tag/assets when done.
+
+Accepted tag patterns: `vX.Y.Z` (stable), or
+`vX.Y.Z-(rc|alpha|beta)[.N]` (prerelease). Anything else fails
+`validate-tag`.
 
 ## Artifact contract
 
@@ -128,7 +162,9 @@ similar projects).
 
 A lightweight `release-pipeline-check` job runs on every PR. It greps
 `.github/workflows/release.yml` for the five target triples, the
-tag-push trigger, packaging, checksum, signing, and upload steps, and
+strict-semver tag-push trigger, the `validate-tag` trust gate (with
+ancestry check + downstream `needs:` wiring + draft/prerelease keyed
+off its outputs), packaging, checksum, signing, and upload steps, and
 greps `RELEASING.md` for each target. The contract above is the
 contract it enforces. If you intentionally change the contract,
 update `scripts/check-release-pipeline.sh` in the same PR.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,134 @@
+# Releasing Heddle
+
+This document covers the binary-release pipeline that produces pre-built
+`heddle` CLI artifacts on tagged releases. It is the upstream contract
+that the HomeBrew (heddle#29b), Scoop, and apt (heddle#29c) packaging
+channels consume.
+
+For the crates.io publishing flow (`heddle-cli` and the workspace crates
+managed by `release-plz`), see the existing `release-plz.toml` and the
+manual `publish-*.sh` scripts at the repo root. That is a separate
+pipeline from the one described here.
+
+## Cutting a release
+
+1. Land your change on `main` (CI green).
+2. Tag from `main`:
+
+   ```bash
+   git tag -a v0.3.0 -m 'heddle v0.3.0'
+   git push origin v0.3.0
+   ```
+
+3. The `Release binaries` workflow (`.github/workflows/release.yml`)
+   triggers on the `v*` tag push. It:
+
+   - builds the `heddle` binary natively on five GitHub-hosted runners
+   - packages each into a versioned archive (`.tar.gz` for unix,
+     `.zip` for windows)
+   - emits a `.sha256` next to each archive
+   - signs each archive with `cosign` keyless (Sigstore public-good
+     instance; trust is rooted in the GitHub OIDC token for this run)
+   - publishes a GitHub Release with auto-generated notes, all
+     artifacts, signatures, certificates, and an aggregated
+     `SHA256SUMS`
+
+4. Verify the Release page lists the expected asset set (see
+   [Artifact contract](#artifact-contract) below). If anything is
+   missing, the upload step fails the workflow — there is no partial
+   release.
+
+### Dry-runs
+
+The workflow also accepts `workflow_dispatch` with a `tag` input. Push
+a pre-release tag (e.g. `v0.3.0-rc1`), trigger the workflow from the
+Actions tab, and inspect the artifacts it produces against a draft or
+prerelease GitHub Release. Delete the rc tag and assets when done.
+
+## Artifact contract
+
+For tag `v<version>`, the release publishes one set per target:
+
+| File | Notes |
+|---|---|
+| `heddle-v<version>-<target>.{tar.gz,zip}` | the archive |
+| `heddle-v<version>-<target>.{tar.gz,zip}.sha256` | one-line `<hex>  <filename>` |
+| `heddle-v<version>-<target>.{tar.gz,zip}.sig` | cosign signature (base64) |
+| `heddle-v<version>-<target>.{tar.gz,zip}.pem` | cosign certificate (Fulcio-issued) |
+| `SHA256SUMS` | aggregated, one line per archive, sorted |
+
+Targets (`<target>`):
+
+- `aarch64-apple-darwin` — macOS arm64 (Apple Silicon)
+- `x86_64-apple-darwin` — macOS x64 (Intel)
+- `aarch64-unknown-linux-gnu` — Linux arm64 (glibc)
+- `x86_64-unknown-linux-gnu` — Linux x64 (glibc)
+- `x86_64-pc-windows-msvc` — Windows x64 (MSVC)
+
+Each archive contains:
+
+- `heddle` (or `heddle.exe` on Windows) — the CLI binary, release profile
+- `README.md`, `LICENSE`, `NOTICE`
+
+Downstream channels (HomeBrew formula, Scoop manifest, apt `.deb`
+metadata) **must** consume:
+
+- the archive URL and its `.sha256` for integrity
+- optionally the `.sig` + `.pem` for signature verification
+
+The asset filenames and the `SHA256SUMS` layout are part of this
+contract. Changing them is a breaking change for downstream packaging
+channels and requires a coordinated update.
+
+## Verifying a release
+
+```bash
+TAG=v0.3.0
+TARGET=aarch64-apple-darwin
+URL="https://github.com/HeddleCo/heddle/releases/download/${TAG}"
+ARCHIVE="heddle-${TAG}-${TARGET}.tar.gz"
+
+curl -fSLO "${URL}/${ARCHIVE}"
+curl -fSLO "${URL}/${ARCHIVE}.sha256"
+curl -fSLO "${URL}/${ARCHIVE}.sig"
+curl -fSLO "${URL}/${ARCHIVE}.pem"
+
+# Integrity.
+shasum -a 256 -c "${ARCHIVE}.sha256"
+
+# Signature (cosign keyless). The certificate identity is the workflow
+# file that issued it; the issuer is GitHub Actions OIDC.
+cosign verify-blob \
+  --certificate "${ARCHIVE}.pem" \
+  --signature   "${ARCHIVE}.sig" \
+  --certificate-identity-regexp 'https://github\.com/HeddleCo/heddle/\.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  "${ARCHIVE}"
+```
+
+## Build strategy: native matrix vs. cross-compilation
+
+We build natively (one GitHub-hosted runner per target) rather than
+cross-compiling from a single host. Trade-off:
+
+- **Native matrix (chosen)**: five parallel runners (~5–10 min each
+  with `Swatinem/rust-cache`). No `cross`, no sysroot juggling, no
+  Apple-codesign-on-Linux contortions later if/when we add notarization.
+  ARM is free on GitHub-hosted runners (`ubuntu-24.04-arm`, `macos-14`).
+- **Cross-compilation**: one runner, more setup. Wins on cost only if
+  we hit a parallelism cap, which we won't at our release cadence.
+
+Revisit if release frequency increases by an order of magnitude, if
+GitHub-hosted runner availability degrades, or when we add macOS
+notarization (cross-compiling macOS binaries from Linux makes the
+codesign + notarize step substantially harder and was a real cost in
+similar projects).
+
+## Pipeline-contract check
+
+A lightweight `release-pipeline-check` job runs on every PR. It greps
+`.github/workflows/release.yml` for the five target triples, the
+tag-push trigger, packaging, checksum, signing, and upload steps, and
+greps `RELEASING.md` for each target. The contract above is the
+contract it enforces. If you intentionally change the contract,
+update `scripts/check-release-pipeline.sh` in the same PR.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,7 +32,16 @@ pipeline from the one described here.
    - rejects tags whose commit isn't reachable from `origin/main`
      (catches tags accidentally — or maliciously — placed on a feature
      branch)
+   - rejects stable (`vX.Y.Z`) tags fed to `workflow_dispatch`. Stable
+     releases must arrive via the push trigger; dispatch is the
+     prerelease/dry-run path only. See [Dry-runs](#dry-runs) for why.
    - classifies the run as `stable` or `prerelease`
+   - emits the resolved commit SHA as `tag_sha`. Every downstream job
+     (build, release) checks out **that SHA**, not `refs/tags/<tag>`.
+     A tag is mutable; force-moving it after `validate-tag` passes
+     would otherwise redirect the build to an attacker-controlled
+     commit (TOCTOU). The SHA pin keeps every signed artifact tied to
+     the commit that passed the ancestry check.
 
    If `validate-tag` fails, no build, sign, or publish step runs. If it
    passes, the matrix proceeds to:
@@ -70,14 +79,24 @@ fire the push trigger — only `vX.Y.Z` does. To rehearse a release:
    with `tag: v0.3.0-rc.1`.
 
 3. The run goes through `validate-tag` exactly as a real release would.
-   On publish, the GitHub Release is created as **draft + prerelease**
-   — even if you hand-type a stable-looking tag, dispatch-triggered
-   runs never auto-publish a normal release. Inspect the draft release,
-   then delete the draft release and the RC tag/assets when done.
+   On publish, the GitHub Release is created as **draft + prerelease**.
+   Inspect the draft release, then delete the draft release and the RC
+   tag/assets when done.
 
-Accepted tag patterns: `vX.Y.Z` (stable), or
-`vX.Y.Z-(rc|alpha|beta)[.N]` (prerelease). Anything else fails
-`validate-tag`.
+Accepted tag patterns:
+
+| Trigger | Accepted | Rejected |
+|---|---|---|
+| `push` (tag) | `vX.Y.Z` | everything else (push filter is strict) |
+| `workflow_dispatch` | `vX.Y.Z-(rc\|alpha\|beta)[.N]` | `vX.Y.Z` (stable), anything else |
+
+Stable tags (`vX.Y.Z`) are deliberately refused on the dispatch path.
+The dispatch path always classifies the run as `kind=prerelease+draft`,
+and `softprops/action-gh-release` updates an existing release when its
+`tag_name` already matches — so dispatching a previously-published
+stable tag would silently overwrite the public release with a
+draft/prerelease shell. Refusing the combination in `validate-tag`
+makes that downgrade attack syntactically impossible.
 
 ## Artifact contract
 
@@ -160,11 +179,23 @@ similar projects).
 
 ## Pipeline-contract check
 
-A lightweight `release-pipeline-check` job runs on every PR. It greps
-`.github/workflows/release.yml` for the five target triples, the
-strict-semver tag-push trigger, the `validate-tag` trust gate (with
-ancestry check + downstream `needs:` wiring + draft/prerelease keyed
-off its outputs), packaging, checksum, signing, and upload steps, and
-greps `RELEASING.md` for each target. The contract above is the
-contract it enforces. If you intentionally change the contract,
-update `scripts/check-release-pipeline.sh` in the same PR.
+A lightweight `release-pipeline-check` job runs on every PR. It
+checks `.github/workflows/release.yml` and `RELEASING.md` in two
+passes:
+
+- **Smoke (grep).** Cheap content checks: the five target triples, the
+  strict-semver push trigger, presence of the `validate-tag` trust gate
+  with its ancestry check, packaging/checksum/signing/upload steps, the
+  draft+prerelease keying off `validate-tag.outputs.kind`, and the
+  stable-tag-refusal on the dispatch path.
+- **Strict (parsed YAML).** Per-job structural checks: `validate-tag`
+  exports `tag_sha`, and every downstream job (`build`, `release`) both
+  declares `needs: validate-tag` and pins its `actions/checkout` `ref`
+  to `${{ needs.validate-tag.outputs.tag_sha }}` rather than the
+  mutable `refs/tags/<tag>`. Grep alone would pass if *any* job kept
+  the `needs:` line; the parser confirms each downstream job
+  individually.
+
+The contract above is the contract it enforces. If you intentionally
+change the contract, update `scripts/check-release-pipeline.sh` in
+the same PR.

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -29,11 +29,43 @@ if [[ ! -f "$WF" ]]; then
   exit 1
 fi
 
-# Tag-push trigger.
-if grep -E "^\s*tags:" "$WF" >/dev/null && grep -E "['\"]?v\*['\"]?" "$WF" >/dev/null; then
-  ok "tag-push trigger on v*"
+# Tag-push trigger. The contract is strict semver only (vX.Y.Z); RC
+# tags route through workflow_dispatch so the publish step can mark
+# them prerelease+draft. See validate-tag job for the full rule.
+if grep -E "^\s*tags:" "$WF" >/dev/null \
+   && grep -E "v\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+" "$WF" >/dev/null; then
+  ok "tag-push trigger restricted to strict semver (vX.Y.Z)"
 else
-  err "missing tag-push trigger on v* in $WF"
+  err "missing strict-semver tag-push trigger ('v[0-9]+.[0-9]+.[0-9]+') in $WF"
+fi
+
+# Trust gate: a validate-tag job must run before build/release and
+# enforce (a) tag existence, (b) ancestry on origin/main, (c) pattern
+# classification. We assert the structural pieces here; the rule
+# content lives in the workflow itself.
+if grep -E "^\s*validate-tag:" "$WF" >/dev/null; then
+  ok "validate-tag job present"
+else
+  err "missing validate-tag job in $WF"
+fi
+if grep -E "git merge-base --is-ancestor" "$WF" >/dev/null; then
+  ok "validate-tag enforces ancestry on origin/main"
+else
+  err "validate-tag must reject tags not reachable from origin/main"
+fi
+if grep -E "needs:\s*validate-tag|needs:\s*\[validate-tag" "$WF" >/dev/null; then
+  ok "build/release jobs depend on validate-tag"
+else
+  err "build/release must declare 'needs: validate-tag' so signing is gated on it"
+fi
+
+# Publish step must read draft/prerelease from validate-tag.outputs.kind
+# so dispatch-triggered runs never auto-publish a normal release.
+if grep -E "draft:\s*\\\$\{\{\s*needs\.validate-tag\.outputs\.kind" "$WF" >/dev/null \
+   && grep -E "prerelease:\s*\\\$\{\{\s*needs\.validate-tag\.outputs\.kind" "$WF" >/dev/null; then
+  ok "publish step keys draft+prerelease off validate-tag.outputs.kind"
+else
+  err "publish step must set draft+prerelease from needs.validate-tag.outputs.kind"
 fi
 
 # All five target triples.

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Asserter for the binary-release pipeline contract (heddle#56).
+#
+# The release pipeline is invoked only on `v*` tag pushes, so we can't
+# observe its artifacts in normal CI. Instead we statically verify that
+# `.github/workflows/release.yml` declares the contract every downstream
+# packaging channel (HomeBrew, Scoop, apt) relies on:
+#
+#   - tag-push trigger
+#   - all 5 target triples
+#   - tarball/zip packaging
+#   - sha256 checksums
+#   - signing step
+#   - GitHub Release upload
+#
+# This is the failing test that drives the red-commit-first DoD.
+
+set -euo pipefail
+
+WF=".github/workflows/release.yml"
+fail=0
+
+err() { echo "::error::$*" >&2; fail=1; }
+ok()  { echo "ok: $*"; }
+
+if [[ ! -f "$WF" ]]; then
+  err "$WF does not exist"
+  echo "::error::Release pipeline not implemented. See heddle#56."
+  exit 1
+fi
+
+# Tag-push trigger.
+if grep -E "^\s*tags:" "$WF" >/dev/null && grep -E "['\"]?v\*['\"]?" "$WF" >/dev/null; then
+  ok "tag-push trigger on v*"
+else
+  err "missing tag-push trigger on v* in $WF"
+fi
+
+# All five target triples.
+targets=(
+  "aarch64-apple-darwin"
+  "x86_64-apple-darwin"
+  "aarch64-unknown-linux-gnu"
+  "x86_64-unknown-linux-gnu"
+  "x86_64-pc-windows-msvc"
+)
+for t in "${targets[@]}"; do
+  if grep -F "$t" "$WF" >/dev/null; then
+    ok "target $t declared"
+  else
+    err "target $t missing from $WF"
+  fi
+done
+
+# Packaging: tarball for unix, zip for windows.
+grep -E "\.tar\.gz" "$WF" >/dev/null && ok "tar.gz packaging" || err "no tar.gz packaging in $WF"
+grep -E "\.zip"    "$WF" >/dev/null && ok "zip packaging"    || err "no zip packaging in $WF"
+
+# sha256 checksums.
+if grep -Ei "sha256sum|shasum|sha256" "$WF" >/dev/null; then
+  ok "sha256 checksums step"
+else
+  err "no sha256 checksum step in $WF"
+fi
+
+# Signing (cosign keyless via Sigstore — chosen because it requires no
+# stored secrets; GitHub OIDC is the trust anchor).
+if grep -Ei "cosign|sigstore" "$WF" >/dev/null; then
+  ok "signing step (cosign/sigstore)"
+else
+  err "no signing step (cosign/sigstore) in $WF"
+fi
+
+# Upload to GitHub Release.
+if grep -E "softprops/action-gh-release|gh release (create|upload)" "$WF" >/dev/null; then
+  ok "GitHub Release upload step"
+else
+  err "no GitHub Release upload step in $WF"
+fi
+
+# RELEASING.md present and documents the artifact contract.
+if [[ ! -f RELEASING.md ]]; then
+  err "RELEASING.md is missing"
+else
+  ok "RELEASING.md present"
+  for t in "${targets[@]}"; do
+    if ! grep -F "$t" RELEASING.md >/dev/null; then
+      err "RELEASING.md does not document target $t"
+    fi
+  done
+fi
+
+if (( fail )); then
+  echo "release-pipeline check FAILED" >&2
+  exit 1
+fi
+echo "release-pipeline check passed"

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -160,19 +160,31 @@ fi
 # downstream job dropped the dep" regression.
 
 ensure_pyyaml() {
-  python3 -c 'import yaml' 2>/dev/null && return 0
-  # PyYAML is pre-installed on GitHub-hosted ubuntu-latest, but blacksmith
-  # / self-hosted runners may have a slimmer image. Fall back to pip.
-  python3 -m pip install --quiet --disable-pip-version-check pyyaml >/dev/null 2>&1 || true
-  python3 -c 'import yaml' 2>/dev/null
+  # Echoes the python interpreter to use (with PyYAML importable), or
+  # returns non-zero. Prefer the system python3 if PyYAML is already
+  # there; otherwise spin up an ephemeral venv and install PyYAML into
+  # it. We deliberately don't fall back to `python3 -m pip install` at
+  # system scope: on PEP 668-enforcing distros (Ubuntu 24.04+) that
+  # errors out with `externally-managed-environment`, which would turn
+  # this asserter into a CI breaker on slim runner images.
+  if python3 -c 'import yaml' 2>/dev/null; then
+    echo python3
+    return 0
+  fi
+  local venv
+  venv="$(mktemp -d)/venv"
+  python3 -m venv "$venv" >/dev/null 2>&1 || return 1
+  "$venv/bin/pip" install --quiet --disable-pip-version-check pyyaml >/dev/null 2>&1 || return 1
+  "$venv/bin/python" -c 'import yaml' 2>/dev/null || return 1
+  echo "$venv/bin/python"
 }
 
 if ! command -v python3 >/dev/null 2>&1; then
   err "python3 not available; strict structural checks skipped"
-elif ! ensure_pyyaml; then
-  err "PyYAML not available and could not be installed; strict structural checks skipped"
+elif ! PY=$(ensure_pyyaml); then
+  err "PyYAML not available and venv fallback failed; strict structural checks skipped"
 else
-  strict_report=$(python3 - "$WF" <<'PY'
+  strict_report=$("$PY" - "$WF" <<'PY'
 import sys
 import yaml
 

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -68,6 +68,22 @@ else
   err "publish step must set draft+prerelease from needs.validate-tag.outputs.kind"
 fi
 
+# Dispatch path must refuse stable (vX.Y.Z) tags. softprops/action-gh-release
+# updates an existing release when tag_name already exists, and dispatch
+# always classifies as kind=prerelease+draft — so dispatching a previously
+# published vX.Y.Z would silently downgrade the public release. The
+# validate-tag job must refuse this combination before kind is assigned.
+#
+# We check for the verbatim error string (rather than just "the regex
+# appears near workflow_dispatch") so the assertion is robust to
+# variable renames but still flags a block deletion: removing the guard
+# also removes its error message.
+if grep -F 'workflow_dispatch refuses stable tag' "$WF" >/dev/null; then
+  ok "validate-tag refuses stable tags from workflow_dispatch (downgrade-attack guard)"
+else
+  err "validate-tag must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
+fi
+
 # All five target triples.
 targets=(
   "aarch64-apple-darwin"
@@ -120,6 +136,142 @@ else
       err "RELEASING.md does not document target $t"
     fi
   done
+fi
+
+# --- Strict structural checks (parsed YAML) -------------------------------
+#
+# The grep-based checks above answer "does the pipeline mention X anywhere?"
+# — useful as a quick smoke screen, but blind to per-job structure. The
+# strict checks below parse release.yml and verify each downstream job
+# individually:
+#
+#   - declares `needs: validate-tag` (not just *some* job somewhere)
+#   - checks out the SHA validate-tag pinned, not the mutable tag ref
+#     (closes the TOCTOU window where a force-moved tag would otherwise
+#     redirect build/release to a different commit than the one that
+#     passed the ancestry check)
+#
+# We also confirm validate-tag exports `tag_sha` as a documented output.
+# Without that output the pinning above can't reference anything.
+#
+# These are additive: the legacy "any needs: validate-tag" grep still
+# runs and still flags the catastrophic "nothing depends on validate-tag"
+# regression, while the strict checks here catch the subtler "one
+# downstream job dropped the dep" regression.
+
+ensure_pyyaml() {
+  python3 -c 'import yaml' 2>/dev/null && return 0
+  # PyYAML is pre-installed on GitHub-hosted ubuntu-latest, but blacksmith
+  # / self-hosted runners may have a slimmer image. Fall back to pip.
+  python3 -m pip install --quiet --disable-pip-version-check pyyaml >/dev/null 2>&1 || true
+  python3 -c 'import yaml' 2>/dev/null
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  err "python3 not available; strict structural checks skipped"
+elif ! ensure_pyyaml; then
+  err "PyYAML not available and could not be installed; strict structural checks skipped"
+else
+  strict_report=$(python3 - "$WF" <<'PY'
+import sys
+import yaml
+
+wf_path = sys.argv[1]
+with open(wf_path) as f:
+    wf = yaml.safe_load(f)
+
+jobs = wf.get("jobs", {}) or {}
+errors = []
+oks = []
+
+vt = jobs.get("validate-tag")
+if not isinstance(vt, dict):
+    errors.append("validate-tag job missing or malformed")
+else:
+    outs = vt.get("outputs", {}) or {}
+    if "tag_sha" not in outs:
+        errors.append("validate-tag must declare a 'tag_sha' output (used by downstream jobs to pin checkout to the validated commit)")
+    else:
+        oks.append("validate-tag exports tag_sha output")
+    if "tag" not in outs or "kind" not in outs:
+        errors.append("validate-tag must declare 'tag' and 'kind' outputs")
+
+# Every job that runs AFTER validate-tag (i.e. that produces or ships
+# artifacts) must declare it as a needs dependency. Listing the set
+# explicitly keeps this honest: adding a new downstream job requires
+# updating this list, which forces a conscious decision about whether
+# the new job needs the trust gate.
+downstream = ["build", "release"]
+for name in downstream:
+    job = jobs.get(name)
+    if not isinstance(job, dict):
+        errors.append(f"{name} job missing or malformed")
+        continue
+    needs = job.get("needs", [])
+    if isinstance(needs, str):
+        needs = [needs]
+    if "validate-tag" not in needs:
+        errors.append(f"{name} job does not declare 'needs: validate-tag' (would skip the trust gate)")
+    else:
+        oks.append(f"{name} job declares needs: validate-tag")
+
+# Every downstream job's checkout step must pin to the validated SHA.
+# Acting on refs/tags/<tag> after validate-tag would re-resolve the
+# tag — a window where a force-move would redirect the build.
+SHA_REF_OK = "${{ needs.validate-tag.outputs.tag_sha }}"
+TAG_REF_BAD = "refs/tags/"
+for name in downstream:
+    job = jobs.get(name)
+    if not isinstance(job, dict):
+        continue
+    steps = job.get("steps", []) or []
+    checkouts = [
+        s for s in steps
+        if isinstance(s, dict)
+        and isinstance(s.get("uses"), str)
+        and s.get("uses", "").startswith("actions/checkout@")
+    ]
+    if not checkouts:
+        errors.append(f"{name} job has no actions/checkout step — cannot verify SHA pin")
+        continue
+    for s in checkouts:
+        ref = (s.get("with") or {}).get("ref", "")
+        if not isinstance(ref, str):
+            ref = str(ref)
+        if SHA_REF_OK not in ref:
+            errors.append(
+                f"{name} job checks out '{ref}' instead of needs.validate-tag.outputs.tag_sha — TOCTOU on mutable tag ref"
+            )
+        elif TAG_REF_BAD in ref:
+            errors.append(
+                f"{name} job mixes refs/tags/ with tag_sha ('{ref}') — refs/tags/ is mutable; remove it"
+            )
+        else:
+            oks.append(f"{name} job pins checkout to validated tag_sha")
+
+print("OKS:")
+for o in oks:
+    print(o)
+print("ERRORS:")
+for e in errors:
+    print(e)
+PY
+  )
+
+  in_oks=0
+  in_errors=0
+  while IFS= read -r line; do
+    case "$line" in
+      "OKS:")     in_oks=1; in_errors=0; continue ;;
+      "ERRORS:")  in_oks=0; in_errors=1; continue ;;
+    esac
+    [[ -z "$line" ]] && continue
+    if (( in_oks )); then
+      ok "$line"
+    elif (( in_errors )); then
+      err "$line"
+    fi
+  done <<< "$strict_report"
 fi
 
 if (( fail )); then


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` triggered on `v*` tag push that builds, packages, checksums, signs (cosign keyless), and uploads `heddle` binaries for all 5 targets.
- New `RELEASING.md` documenting the cut process, the artifact contract downstream packaging channels (heddle#29b HomeBrew, heddle#29c Scoop+apt) consume, the cosign verification recipe, and the native-matrix vs cross-compilation rationale.
- New `release-pipeline-check` workflow + `scripts/check-release-pipeline.sh` asserter that statically verifies the release.yml contract on every PR — gives normal CI a signal that the tag-only pipeline is intact.

Closes HeddleCo/heddle#56

## Red commit

`498a8cf` — added `scripts/check-release-pipeline.sh` + `release-pipeline-check.yml`. The asserter fails because `.github/workflows/release.yml` does not exist yet.

## Test evidence

```
$ bash scripts/check-release-pipeline.sh   # at the red commit
::error::.github/workflows/release.yml does not exist
::error::Release pipeline not implemented. See heddle#56.
exit=1

$ bash scripts/check-release-pipeline.sh   # at the green commit (82b972f)
ok: tag-push trigger on v*
ok: target aarch64-apple-darwin declared
ok: target x86_64-apple-darwin declared
ok: target aarch64-unknown-linux-gnu declared
ok: target x86_64-unknown-linux-gnu declared
ok: target x86_64-pc-windows-msvc declared
ok: tar.gz packaging
ok: zip packaging
ok: sha256 checksums step
ok: signing step (cosign/sigstore)
ok: GitHub Release upload step
ok: RELEASING.md present
release-pipeline check passed
exit=0
```

## Dry-run artifact listing (expected)

A `v0.3.0` tag push produces, on the GitHub Release page:

```
heddle-v0.3.0-aarch64-apple-darwin.tar.gz            (+ .sha256 .sig .pem)
heddle-v0.3.0-x86_64-apple-darwin.tar.gz             (+ .sha256 .sig .pem)
heddle-v0.3.0-aarch64-unknown-linux-gnu.tar.gz       (+ .sha256 .sig .pem)
heddle-v0.3.0-x86_64-unknown-linux-gnu.tar.gz        (+ .sha256 .sig .pem)
heddle-v0.3.0-x86_64-pc-windows-msvc.zip             (+ .sha256 .sig .pem)
SHA256SUMS
```

A live dry-run requires pushing a `v*` (or `workflow_dispatch` with a `v*-rc` tag) which is post-merge territory; the asserter + checked-in workflow shape is the pre-merge signal.

## Manual verification

N/A — covered by the static contract asserter. A live tag push is required to exercise the full pipeline end-to-end; that is by design a post-merge action documented in RELEASING.md.

## Blocked by → resolved

This PR unblocks:

- HeddleCo/heddle#29b (HomeBrew formula — consumes the tar.gz + .sha256)
- HeddleCo/heddle#29c (Scoop manifest + apt repo — consumes the tar.gz/.zip + .sha256)
- HeddleCo/heddle#29 (parent meta-issue closes when 29a/b/c all close)

## Design notes

- **Native matrix over cross-compilation**: simpler today (no `cross`, no Apple-codesign-on-Linux contortions), and GitHub-hosted ARM runners make it free. Rationale + revisit conditions in RELEASING.md.
- **cosign keyless** rather than long-lived signing keys: no stored secrets, GitHub OIDC is the trust anchor, public Rekor transparency log. The `release.yml` workflow requests `id-token: write` for this.
- **Static asserter** rather than a live dry-run on every PR: the release workflow is tag-gated by design and we don't want to burn 5 build-minutes per PR. The asserter catches the common breakages (a target was dropped, signing step removed, RELEASING.md drift).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->