### PR TITLE
fix(deps): bump internal heddle-grpc consumers to ^0.3 + asserter check (heddle#76)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2", features = ["memory-backend"] }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.2" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 heddle-client = { path = "../client", version = "0.2", optional = true }
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -48,7 +48,7 @@ walkdir.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.2" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 fs2.workspace = true
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.2" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }

--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -427,6 +427,36 @@ def parse_ver_full(s):
     return (out[0], out[1], out[2], pre)
 
 
+def _cmp_prerelease(a, b):
+    """Compare two prerelease identifier strings per semver §11. Returns
+    -1/0/1. Empty string means "no prerelease" and sorts ABOVE any
+    prerelease (1.0.0 > 1.0.0-anything). Within prereleases: dot-separated
+    identifiers compared left-to-right; numeric identifiers compare
+    numerically, alphanumerics lexicographically, numerics rank below
+    alphanumerics, a shorter prefix loses to a longer one with the same
+    prefix (alpha < alpha.1)."""
+    if a == b:
+        return 0
+    if a == "":
+        return 1
+    if b == "":
+        return -1
+    ap, bp = a.split("."), b.split(".")
+    for x, y in zip(ap, bp):
+        xn, yn = x.isdigit(), y.isdigit()
+        if xn and yn:
+            xi, yi = int(x), int(y)
+            if xi != yi:
+                return -1 if xi < yi else 1
+        elif xn != yn:
+            return -1 if xn else 1
+        elif x != y:
+            return -1 if x < y else 1
+    if len(ap) != len(bp):
+        return -1 if len(ap) < len(bp) else 1
+    return 0
+
+
 def satisfies(req, ver):
     """Cargo caret semantics. Returns True / False, or None to signal an
     unsupported comparator shape (the caller treats None as a hard error).
@@ -443,10 +473,23 @@ def satisfies(req, ver):
     and must widen to <1.0.0, where the previous all-zero collapse to
     exact-patch was wrong (Codex r1 finding).
 
-    Prerelease rule: a source version carrying a prerelease tag (e.g.
-    0.3.0-alpha.1) MUST NOT satisfy a non-prerelease requirement; cargo
-    only admits prereleases when the requirement explicitly asks for one
-    (we model that as an exact `=X.Y.Z-pre` match).
+    Prerelease rules (cargo opts in only when the requirement asks for one):
+      - source has prerelease, req does not → reject.
+      - req has prerelease → restrict matches to the same (major,minor,patch)
+        tuple (cargo's documented behavior), and within that tuple require
+        source prerelease >= req prerelease using semver ordering. Catches
+        both "0.3.0-alpha.0 satisfying 0.3.0-alpha.1" (Codex r2 P2 finding)
+        and "1.0.1 leaking through a 1.0.0-alpha requirement" (Codex r2 P2).
+      - exact `=X.Y.Z-pre` still routes through the exact branch.
+
+    Exact `=` comparator:
+      - Build metadata (`+...`) is ignored on both sides — semver §10 says
+        build metadata MUST NOT factor into precedence (Codex r2 P3).
+      - Partial exact requirements widen to ranges per cargo:
+        `=4`   → >=4.0.0, <5.0.0-0
+        `=4.2` → >=4.2.0, <4.3.0-0
+        `=4.2.3` (or with prerelease tag) stays an exact normalized match.
+        (Codex r2 P3 finding.)
 
     Wildcards (`*` anywhere in the requirement) are rejected outright —
     `1.2.*` is a valid cargo comparator but the workspace convention is
@@ -460,10 +503,28 @@ def satisfies(req, ver):
     if "*" in req:
         return None
 
-    # Exact `=` comparator: full-string equality including prerelease.
-    # This is the ONLY way a prerelease source version can satisfy.
     if req.startswith("="):
-        return req[1:].strip() == ver.strip()
+        body = req[1:].strip()
+        body_no_meta = body.partition("+")[0]
+        has_pre = "-" in body_no_meta
+        base = body_no_meta.split("-", 1)[0]
+        base_parts_given = len([p for p in base.split(".") if p != ""])
+        # Partial `=` requirements are ranges (no prerelease in this form).
+        if not has_pre and base_parts_given < 3:
+            rmaj, rmin, rpat, _ = parse_ver_full(body)
+            vmaj, vmin, vpat, vpre = parse_ver_full(ver)
+            if vpre:
+                return False
+            if base_parts_given == 1:
+                return (vmaj, vmin, vpat) >= (rmaj, 0, 0) and vmaj == rmaj
+            # base_parts_given == 2
+            return (
+                (vmaj, vmin, vpat) >= (rmaj, rmin, 0)
+                and (vmaj, vmin) == (rmaj, rmin)
+            )
+        # Full exact (`=X.Y.Z` or `=X.Y.Z-pre`): ignore build metadata on
+        # BOTH sides per semver §10.
+        return body_no_meta == ver.strip().partition("+")[0]
 
     # Other comparators / multi-clause requirements: surface, don't guess.
     if req[:1] in (">", "<", "~") or "," in req:
@@ -479,15 +540,19 @@ def satisfies(req, ver):
     rmaj, rmin, rpat, rpre = parse_ver_full(req)
     vmaj, vmin, vpat, vpre = parse_ver_full(ver)
 
+    # Req has a prerelease tag: cargo restricts matches to the same
+    # (major,minor,patch) tuple AND requires source prerelease >= req
+    # prerelease (release counts as > any prerelease on the same tuple).
+    if rpre:
+        if (vmaj, vmin, vpat) != (rmaj, rmin, rpat):
+            return False
+        return _cmp_prerelease(vpre, rpre) >= 0
+
     # Prerelease in source but not in requirement → not satisfied.
-    # (Exact `=req-pre` matches were already handled above.)
-    if vpre and not rpre:
+    if vpre:
         return False
 
-    # Lower bound: source >= requirement (numeric tuple compare; pre-release
-    # ordering against same numeric is not material here — cargo treats a
-    # prerelease as "less than" the same release, but the prior branch
-    # already filtered the asymmetric case).
+    # Lower bound: source >= requirement (no prerelease on either side here).
     if (vmaj, vmin, vpat) < (rmaj, rmin, rpat):
         return False
 
@@ -543,6 +608,48 @@ _selftest(
     [
         (satisfies("1.2.*", "1.2.5"), None),
         (satisfies("*", "1.0.0"),     None),
+    ],
+)
+_selftest(
+    "caret prerelease lower-bound ordering (alpha.0 fails alpha.1; release sat. prerelease)",
+    [
+        (satisfies("0.3.0-alpha.1", "0.3.0-alpha.0"), False),
+        (satisfies("0.3.0-alpha.1", "0.3.0-alpha.1"), True),
+        (satisfies("0.3.0-alpha.1", "0.3.0-alpha.2"), True),
+        (satisfies("0.3.0-alpha.1", "0.3.0-beta"),    True),
+        (satisfies("0.3.0-alpha.1", "0.3.0"),         True),
+    ],
+)
+_selftest(
+    "prerelease requirements pin to same (M,m,p) tuple (cargo's documented rule)",
+    [
+        (satisfies("1.0.0-alpha", "1.0.0-alpha"),   True),
+        (satisfies("1.0.0-alpha", "1.0.0-alpha.1"), True),
+        (satisfies("1.0.0-alpha", "1.0.0"),         True),
+        (satisfies("1.0.0-alpha", "1.0.1-alpha"),   False),
+        (satisfies("1.0.0-alpha", "1.0.1"),         False),
+    ],
+)
+_selftest(
+    "exact `=` ignores build metadata on both sides (semver §10)",
+    [
+        (satisfies("=0.3.0-alpha.1", "0.3.0-alpha.1+build.5"), True),
+        (satisfies("=0.3.0+meta",    "0.3.0+other"),           True),
+        (satisfies("=0.3.0",         "0.3.0+build"),           True),
+        (satisfies("=0.3.0",         "0.3.1"),                 False),
+    ],
+)
+_selftest(
+    "partial `=` requirements widen to ranges (=4 → <5.0.0-0; =4.2 → <4.3.0-0)",
+    [
+        (satisfies("=4",   "4.0.0"),     True),
+        (satisfies("=4",   "4.999.999"), True),
+        (satisfies("=4",   "5.0.0"),     False),
+        (satisfies("=4",   "3.9.9"),     False),
+        (satisfies("=4.2", "4.2.0"),     True),
+        (satisfies("=4.2", "4.2.99"),    True),
+        (satisfies("=4.2", "4.3.0"),     False),
+        (satisfies("=4.2", "4.1.9"),     False),
     ],
 )
 

--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -356,15 +356,32 @@ fi
 # is publishable). That way a brand-new publishable crate added to the
 # workspace gets caught by this asserter without anyone remembering to
 # update the check.
+# TOML parser detection: tomllib lands in stdlib at Python 3.11. On 3.10
+# and earlier we fall back to the third-party `tomli` (the same code,
+# pre-stdlib). If neither is importable we emit a genuine `skip:` line
+# and do NOT set fail — "I couldn't run this check" is not the same as
+# "this check failed" (Codex r1 finding).
+toml_module=""
+if command -v python3 >/dev/null 2>&1; then
+  if python3 -c 'import tomllib' 2>/dev/null; then
+    toml_module="tomllib"
+  elif python3 -c 'import tomli' 2>/dev/null; then
+    toml_module="tomli"
+  fi
+fi
+
 if ! command -v python3 >/dev/null 2>&1; then
-  err "python3 not available; consumer-version check skipped"
-elif ! python3 -c 'import tomllib' 2>/dev/null; then
-  err "python3 tomllib unavailable (needs 3.11+); consumer-version check skipped"
+  echo "skip: python3 unavailable; consumer-version check skipped"
+elif [[ -z "$toml_module" ]]; then
+  echo "skip: tomllib (Python 3.11+) and tomli both unavailable; consumer-version check skipped"
 else
-  consumer_report=$(python3 - <<'PY'
+  ok "toml parser available ($toml_module)"
+  consumer_report=$(TOML_MODULE="$toml_module" python3 - <<'PY'
 import glob
+import importlib
+import os
 import re
-import tomllib
+tomllib = importlib.import_module(os.environ["TOML_MODULE"])
 
 crates = []
 for cm in sorted(glob.glob("crates/*/Cargo.toml")):
@@ -391,40 +408,143 @@ for cm, toml in crates:
         publishable.add(name)
 
 
-def parse_ver(s):
-    s = re.split(r"[-+]", s, maxsplit=1)[0]
-    parts = (s.split(".") + ["0", "0", "0"])[:3]
+def parse_ver_full(s):
+    """Returns (major, minor, patch, prerelease) where prerelease is the
+    raw pre-release identifier (everything after the first `-`, with build
+    metadata stripped) or "" if absent."""
+    s = s.strip()
+    base, dash, rest = s.partition("-")
+    # Strip +build metadata from whichever side it appears.
+    base = base.partition("+")[0]
+    pre = rest.partition("+")[0] if dash else ""
+    parts = (base.split(".") + ["0", "0", "0"])[:3]
     out = []
     for p in parts:
         try:
             out.append(int(p))
         except ValueError:
             out.append(0)
-    return tuple(out)
+    return (out[0], out[1], out[2], pre)
 
 
 def satisfies(req, ver):
-    # Cargo's default operator is caret. `cargo metadata` normalizes
-    # "0.2" → "^0.2", but Cargo.toml may carry the bare form, so we
-    # treat unprefixed as caret too. We deliberately don't try to
-    # parse `>=`, `~`, or comma-joined comparators — the workspace
-    # convention is caret, and a foreign comparator should be loudly
-    # surfaced rather than silently passed.
+    """Cargo caret semantics. Returns True / False, or None to signal an
+    unsupported comparator shape (the caller treats None as a hard error).
+
+    Cargo's caret rules (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html):
+      ^1.2.3 → >=1.2.3, <2.0.0   (uppermost nonzero major)
+      ^0.2.3 → >=0.2.3, <0.3.0   (uppermost nonzero minor when major == 0)
+      ^0.0.3 → >=0.0.3, <0.0.4   (uppermost nonzero patch when major+minor == 0)
+      ^0.0   → >=0.0.0, <0.1.0
+      ^0     → >=0.0.0, <1.0.0
+    Bare requirements (no leading operator) follow caret by default; the
+    width is determined by how many components the requirement specifies,
+    not the parsed integer tuple — `"0"` is a 1-component all-zero req
+    and must widen to <1.0.0, where the previous all-zero collapse to
+    exact-patch was wrong (Codex r1 finding).
+
+    Prerelease rule: a source version carrying a prerelease tag (e.g.
+    0.3.0-alpha.1) MUST NOT satisfy a non-prerelease requirement; cargo
+    only admits prereleases when the requirement explicitly asks for one
+    (we model that as an exact `=X.Y.Z-pre` match).
+
+    Wildcards (`*` anywhere in the requirement) are rejected outright —
+    `1.2.*` is a valid cargo comparator but the workspace convention is
+    caret, and the previous loose guard let `1.2.*` fall through to
+    numeric parsing where `*` coerced to 0 and the check effectively
+    became major-only (Codex r1 finding).
+    """
     req = req.strip()
+
+    # Wildcards anywhere are rejected (not just leading). Catches "1.2.*".
+    if "*" in req:
+        return None
+
+    # Exact `=` comparator: full-string equality including prerelease.
+    # This is the ONLY way a prerelease source version can satisfy.
+    if req.startswith("="):
+        return req[1:].strip() == ver.strip()
+
+    # Other comparators / multi-clause requirements: surface, don't guess.
+    if req[:1] in (">", "<", "~") or "," in req:
+        return None
+
     if req.startswith("^"):
         req = req[1:]
-    elif req[:1] in ("=", ">", "<", "~", "*") or "," in req:
-        # Unsupported comparator shape. Flag conservatively.
-        return None
-    r = parse_ver(req)
-    v = parse_ver(ver)
-    if v < r:
+
+    # How many components did the requirement actually specify?
+    # ("0" vs "0.0" vs "0.0.0" differ in caret width when all zero.)
+    req_parts_given = len([p for p in req.split(".") if p != ""])
+
+    rmaj, rmin, rpat, rpre = parse_ver_full(req)
+    vmaj, vmin, vpat, vpre = parse_ver_full(ver)
+
+    # Prerelease in source but not in requirement → not satisfied.
+    # (Exact `=req-pre` matches were already handled above.)
+    if vpre and not rpre:
         return False
-    if r[0] > 0:
-        return v[0] == r[0]
-    if r[1] > 0:
-        return v[0] == 0 and v[1] == r[1]
-    return v[0] == 0 and v[1] == 0 and v[2] == r[2]
+
+    # Lower bound: source >= requirement (numeric tuple compare; pre-release
+    # ordering against same numeric is not material here — cargo treats a
+    # prerelease as "less than" the same release, but the prior branch
+    # already filtered the asymmetric case).
+    if (vmaj, vmin, vpat) < (rmaj, rmin, rpat):
+        return False
+
+    # Upper bound: caret widens at the leftmost-nonzero component.
+    if rmaj > 0:
+        return vmaj == rmaj
+    if rmin > 0:
+        return vmaj == 0 and vmin == rmin
+    if rpat > 0:
+        return vmaj == 0 and vmin == 0 and vpat == rpat
+
+    # All-zero requirement: width depends on how many components were given.
+    if req_parts_given <= 1:
+        # "0" → <1.0.0
+        return vmaj == 0
+    if req_parts_given == 2:
+        # "0.0" → <0.1.0
+        return vmaj == 0 and vmin == 0
+    # "0.0.0" → <0.0.1 (exact)
+    return (vmaj, vmin, vpat) == (0, 0, 0)
+
+
+# --- Self-test the caret-semver parser ------------------------------------
+# One assertion bundle per Codex r1 P2 finding. Each bundle that passes
+# emits a single `ok:` line; failures become `err:` so a future edit
+# that reintroduces one of the four bugs fails the asserter immediately.
+def _selftest(label, cases):
+    for got, want in cases:
+        if got != want:
+            errors.append(f"satisfies() self-test failed: {label} (got {got!r}, want {want!r})")
+            return
+    oks.append(f"satisfies() self-test: {label}")
+
+_selftest(
+    "caret semantics for bare 0 and 0.0 (cargo default widens to <1.0.0 / <0.1.0)",
+    [
+        (satisfies("0", "0.5.2"),    True),
+        (satisfies("0", "1.0.0"),    False),
+        (satisfies("0.0", "0.0.7"),  True),
+        (satisfies("0.0", "0.1.0"),  False),
+    ],
+)
+_selftest(
+    "prerelease versions excluded from non-prerelease requirements (= opts in)",
+    [
+        (satisfies("0.3", "0.3.0-alpha.1"),            False),
+        (satisfies("=0.3.0-alpha.1", "0.3.0-alpha.1"), True),
+        (satisfies("=0.3.0-alpha.1", "0.3.0"),         False),
+    ],
+)
+_selftest(
+    "wildcard requirements rejected (1.2.* surfaces as unsupported)",
+    [
+        (satisfies("1.2.*", "1.2.5"), None),
+        (satisfies("*", "1.0.0"),     None),
+    ],
+)
 
 
 DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")

--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -335,6 +335,173 @@ PY
   done <<< "$strict_report"
 fi
 
+# --- Internal-consumer / publishable-version compat ----------------------
+#
+# Why this check exists: heddle#63 r2 bumped the heddle-grpc source crate
+# to 0.3.0 but left three internal workspace consumers (cli, daemon,
+# client) pinned at `version = "0.2"`. Local `cargo build` was happy
+# (path deps override version reqs in-workspace), but the push-to-main
+# publish workflow tried `cargo publish` — which strips path deps and
+# resolves consumers against crates.io — and failed loud with
+# "candidate versions found which didn't match: 0.3.0".
+#
+# The structural rule: every internal workspace consumer of a
+# publishable crate must declare a version requirement that the
+# publishable crate's CURRENT version satisfies. If it doesn't, the
+# next push-to-main publish will fail.
+#
+# Trust-aspect: we DON'T trust the PUBLISHABLE_CRATES env var from the
+# workflow as the source of truth here. We re-derive the publishable
+# set from each Cargo.toml's [package].publish field (default-publish
+# is publishable). That way a brand-new publishable crate added to the
+# workspace gets caught by this asserter without anyone remembering to
+# update the check.
+if ! command -v python3 >/dev/null 2>&1; then
+  err "python3 not available; consumer-version check skipped"
+elif ! python3 -c 'import tomllib' 2>/dev/null; then
+  err "python3 tomllib unavailable (needs 3.11+); consumer-version check skipped"
+else
+  consumer_report=$(python3 - <<'PY'
+import glob
+import re
+import tomllib
+
+crates = []
+for cm in sorted(glob.glob("crates/*/Cargo.toml")):
+    with open(cm, "rb") as f:
+        crates.append((cm, tomllib.load(f)))
+
+errors = []
+oks = []
+
+by_name = {}      # crate name → current version string
+publishable = set()
+for cm, toml in crates:
+    pkg = toml.get("package", {})
+    name = pkg.get("name")
+    version = pkg.get("version")
+    if not name or not isinstance(version, str):
+        continue
+    by_name[name] = version
+    # `publish` unset defaults to true (publishable). A non-empty list
+    # restricts the registries but is still publishable. `false` /
+    # empty list / explicit False means not publishable.
+    pub = pkg.get("publish")
+    if pub is None or pub is True or (isinstance(pub, list) and len(pub) > 0):
+        publishable.add(name)
+
+
+def parse_ver(s):
+    s = re.split(r"[-+]", s, maxsplit=1)[0]
+    parts = (s.split(".") + ["0", "0", "0"])[:3]
+    out = []
+    for p in parts:
+        try:
+            out.append(int(p))
+        except ValueError:
+            out.append(0)
+    return tuple(out)
+
+
+def satisfies(req, ver):
+    # Cargo's default operator is caret. `cargo metadata` normalizes
+    # "0.2" → "^0.2", but Cargo.toml may carry the bare form, so we
+    # treat unprefixed as caret too. We deliberately don't try to
+    # parse `>=`, `~`, or comma-joined comparators — the workspace
+    # convention is caret, and a foreign comparator should be loudly
+    # surfaced rather than silently passed.
+    req = req.strip()
+    if req.startswith("^"):
+        req = req[1:]
+    elif req[:1] in ("=", ">", "<", "~", "*") or "," in req:
+        # Unsupported comparator shape. Flag conservatively.
+        return None
+    r = parse_ver(req)
+    v = parse_ver(ver)
+    if v < r:
+        return False
+    if r[0] > 0:
+        return v[0] == r[0]
+    if r[1] > 0:
+        return v[0] == 0 and v[1] == r[1]
+    return v[0] == 0 and v[1] == 0 and v[2] == r[2]
+
+
+DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+checked = 0
+for cm, toml in crates:
+    consumer_name = toml.get("package", {}).get("name", cm)
+    tables = []
+    for k in DEP_TABLES:
+        if isinstance(toml.get(k), dict):
+            tables.append(toml[k])
+    for _tk, tv in (toml.get("target", {}) or {}).items():
+        if not isinstance(tv, dict):
+            continue
+        for k in DEP_TABLES:
+            if isinstance(tv.get(k), dict):
+                tables.append(tv[k])
+
+    for deps in tables:
+        for dep_key, dep_val in deps.items():
+            if not isinstance(dep_val, dict):
+                continue
+            pkg_name = dep_val.get("package") or dep_key
+            if pkg_name not in publishable:
+                continue
+            req = dep_val.get("version")
+            if not isinstance(req, str):
+                continue
+            src_ver = by_name.get(pkg_name)
+            if src_ver is None:
+                continue
+            checked += 1
+            result = satisfies(req, src_ver)
+            if result is None:
+                errors.append(
+                    f"{consumer_name} declares {pkg_name} = \"{req}\" "
+                    f"(unsupported comparator shape; workspace convention is caret)"
+                )
+            elif not result:
+                errors.append(
+                    f"{consumer_name} requires {pkg_name} = \"{req}\", "
+                    f"but {pkg_name} current version is {src_ver} (incompatible)"
+                )
+
+if not by_name:
+    errors.append("could not parse any crates/*/Cargo.toml")
+elif not errors:
+    oks.append(
+        f"internal workspace consumers satisfy publishable crate versions "
+        f"({checked} req/version pairs, {len(publishable)} publishable crates)"
+    )
+
+print("OKS:")
+for o in oks:
+    print(o)
+print("ERRORS:")
+for e in errors:
+    print(e)
+PY
+)
+
+  in_oks=0
+  in_errors=0
+  while IFS= read -r line; do
+    case "$line" in
+      "OKS:")     in_oks=1; in_errors=0; continue ;;
+      "ERRORS:")  in_oks=0; in_errors=1; continue ;;
+    esac
+    [[ -z "$line" ]] && continue
+    if (( in_oks )); then
+      ok "$line"
+    elif (( in_errors )); then
+      err "$line"
+    fi
+  done <<< "$consumer_report"
+fi
+
 if (( fail )); then
   echo "publish-pipeline check FAILED" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Bump `heddle-grpc` version requirement from `"0.2"` → `"0.3"` in the three internal workspace consumers (`crates/cli`, `crates/daemon`, `crates/client`). Unblocks the auto-publish workflow (heddle#72), which has been failing on every push-to-main since heddle#63 r2 because `cargo publish` strips path deps and the published heddle-grpc 0.3.0 has no compatible candidate at `^0.2`.
- Extend `scripts/check-publish-pipeline.sh` with a new structural check: for every workspace crate that is publishable (re-derived from `[package].publish`, not the workflow's `PUBLISHABLE_CRATES` env var), walk every internal consumer and assert the version requirement is satisfied by the source crate's current version under cargo's caret semantics. Would have caught this exact bug at PR review time.

## Asserter behavior

- New check is the 20th `ok:` line (19 → 20). All 19 prior checks unchanged.
- Trust-aspect: re-derives the publishable set from each `[package].publish` field, so a future publishable crate is automatically covered without editing the asserter.
- Caret-only: workspace convention is caret reqs (cargo's default). Any non-caret comparator that slips in is loudly surfaced rather than silently passed.
- Output on regression:
  `heddle-cli requires heddle-grpc = "0.2", but heddle-grpc current version is 0.3.0 (incompatible)`

## Test plan

- [x] `cargo build --workspace` is clean after the version bumps.
- [x] `cargo metadata --no-deps | jq '.packages[].dependencies[] | select(.name == "heddle-grpc") | .req'` shows only `^0.3` (no `^0.2` residue).
- [x] `bash scripts/check-publish-pipeline.sh` passes with 20 `ok:` lines.
- [x] Mutation test: revert `crates/cli/Cargo.toml` to `version = "0.2"`, re-run the asserter, observe `::error::heddle-cli requires heddle-grpc = "0.2", but heddle-grpc current version is 0.3.0 (incompatible)` and exit 1.
- [ ] Once merged: `gh run list --workflow=publish-crates.yml --limit 1` shows a green run; heddle-grpc 0.3.0 lands on crates.io, unblocking weft#139 and tapestry#57.

Closes HeddleCo/heddle#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->