### PR TITLE
fix(merge): anchor conflict markers at column 0 (heddle#78)

### DIFF
--- a/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
+++ b/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
@@ -399,9 +399,24 @@ fn format_conflict_content(
 ) -> Vec<u8> {
     let our_text = String::from_utf8_lossy(our_content);
     let their_text = String::from_utf8_lossy(their_content);
+    // Conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) MUST start at
+    // column 0 — git diff/mergetool, IDE conflict resolvers, and the
+    // hunk-level merge engine all parse line-anchored. If a side's
+    // content lacks a trailing newline, inject one so the following
+    // marker doesn't get glued onto the last content line.
+    let our_sep = if our_text.is_empty() || our_text.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    let their_sep = if their_text.is_empty() || their_text.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
     format!(
-        "<<<<<<< {}\n{}=======\n{}>>>>>>> {}\n",
-        labels.current, our_text, their_text, labels.incoming
+        "<<<<<<< {}\n{}{}=======\n{}{}>>>>>>> {}\n",
+        labels.current, our_text, our_sep, their_text, their_sep, labels.incoming
     )
     .into_bytes()
 }

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -1708,3 +1708,113 @@ fn test_merge_git_commit_without_git_overlay_blocks_with_clear_error() {
         "blockers must flag the missing git repo: {parsed}"
     );
 }
+
+// ----- Conflict-marker column-0 well-formedness (heddle#78) ---------
+//
+// Conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) must each start at
+// column 0. The pre-fix `format_conflict_content` concatenated the
+// "our" / "their" bodies directly against the separator marker, so a
+// side whose content lacked a trailing newline produced output like
+// `pub type Config = RepoConfig;=======` — invalid to git diff, IDEs,
+// and the upcoming hunk-level merge engine.
+
+/// Iterate the marker lines on a conflicted file and assert each one
+/// is anchored at column 0 (i.e. appears as its own line).
+fn assert_markers_at_column_zero(content: &str, ctx: &str) {
+    for marker in ["<<<<<<<", "=======", ">>>>>>>"] {
+        let appears = content.contains(marker);
+        assert!(
+            appears,
+            "expected marker `{marker}` in conflict output ({ctx}): {content}"
+        );
+        // Every occurrence must be at start-of-line. Walk lines and
+        // confirm at least one starts with the marker; also confirm no
+        // line contains the marker anywhere but at column 0.
+        let mut found_at_col_0 = false;
+        for line in content.split('\n') {
+            if line.starts_with(marker) {
+                found_at_col_0 = true;
+            } else if line.contains(marker) {
+                panic!(
+                    "marker `{marker}` is not at column 0 in line ({ctx}): {line:?}\nfull: {content}"
+                );
+            }
+        }
+        assert!(
+            found_at_col_0,
+            "marker `{marker}` never appears at column 0 ({ctx}): {content}"
+        );
+    }
+}
+
+/// Red-commit for heddle#78: when a side's content lacks a trailing
+/// newline, the `=======` separator used to be appended directly after
+/// the last content line. Reproduces the exact `pub type Config = ...`
+/// shape from the heddle#54 trip report.
+#[test]
+fn test_merge_conflict_markers_anchored_at_column_zero_no_trailing_newline() {
+    let temp = TempDir::new().unwrap();
+    let file = temp.path().join("config.rs");
+
+    heddle(&["init"], Some(temp.path())).unwrap();
+    fs::write(&file, "pub type Config = BaseConfig;").unwrap();
+    heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+    heddle(&["thread", "create", "feature"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+    // No trailing newline on the feature side — the exact shape from
+    // the trip report.
+    fs::write(&file, "pub type Config = RepoConfig;").unwrap();
+    heddle(&["capture", "-m", "Feature edit"], Some(temp.path())).unwrap();
+
+    heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+    // No trailing newline on the main side either.
+    fs::write(&file, "pub type Config = MainConfig;").unwrap();
+    heddle(&["capture", "-m", "Main edit"], Some(temp.path())).unwrap();
+
+    heddle(&["merge", "feature"], Some(temp.path())).unwrap();
+    let content = fs::read_to_string(&file).unwrap();
+    assert_markers_at_column_zero(&content, "no-trailing-newline both sides");
+
+    // Belt-and-braces: the specific trip-report shape (content glued to
+    // the separator) must not reappear.
+    assert!(
+        !content.contains("RepoConfig;=======") && !content.contains("MainConfig;======="),
+        "content must not be glued to the `=======` separator: {content}"
+    );
+}
+
+/// Red-commit: a marker-validator sweep across multiple fixture
+/// shapes — one side missing newline, the other side missing newline,
+/// both missing, both ending in newline. All four must produce
+/// well-formed markers.
+#[test]
+fn test_merge_conflict_markers_well_formed_across_newline_shapes() {
+    let cases: &[(&str, &str, &str)] = &[
+        ("ours-only-newline", "ours\n", "theirs"),
+        ("theirs-only-newline", "ours", "theirs\n"),
+        ("neither-newline", "ours", "theirs"),
+        ("both-newline", "ours\n", "theirs\n"),
+    ];
+    for (label, ours, theirs) in cases {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("f.txt");
+
+        heddle(&["init"], Some(temp.path())).unwrap();
+        fs::write(&file, "base\n").unwrap();
+        heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "create", "feature"], Some(temp.path())).unwrap();
+        heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+        fs::write(&file, theirs).unwrap();
+        heddle(&["capture", "-m", "feature edit"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+        fs::write(&file, ours).unwrap();
+        heddle(&["capture", "-m", "main edit"], Some(temp.path())).unwrap();
+
+        heddle(&["merge", "feature"], Some(temp.path())).unwrap();
+        let content = fs::read_to_string(&file).unwrap();
+        assert_markers_at_column_zero(&content, label);
+    }
+}


### PR DESCRIPTION
## Summary

Heddle's merge output emitted markers like `pub type Config = RepoConfig;=======` on a single line when a side's content lacked a trailing newline (trip report in heddle#54). Git diff/mergetool, IDE conflict resolvers, and the upcoming hunk-level merge engine (heddle#79) all require `<<<<<<<`, `=======`, `>>>>>>>` at column 0.

Fix is in `format_conflict_content` (`crates/cli/src/cli/commands/merge/merge_algo/executor.rs`): inject a `\n` before each separator/closing marker when the preceding side doesn't already end in one. Output is now byte-equivalent to `git merge-file -p` modulo label strings.

## Red-commit evidence

Two new tests in `crates/cli/tests/state_management/merge.rs`:

1. `test_merge_conflict_markers_anchored_at_column_zero_no_trailing_newline` — mirrors the exact `pub type Config = ...` shape from heddle#54.
2. `test_merge_conflict_markers_well_formed_across_newline_shapes` — sweeps four newline shapes (ours-only, theirs-only, neither, both).

Confirmed both fail without the fix:

```
thread '...' panicked: marker `=======` is not at column 0 in line: "pub type Config = MainConfig;======="
```

Both pass with the fix. Full `state_management` suite: 60/60 passing.

External tooling verification:

```
$ git diff --check config.rs
config.rs:1: leftover conflict marker
config.rs:3: leftover conflict marker
config.rs:5: leftover conflict marker
```

`git diff --check` now recognizes all three marker lines (it ignored the malformed glued shape pre-fix).

## Rule-7 (other emitter sites)

Workspace-wide grep for `<<<<<<<` / `=======` / `>>>>>>>` literals in non-test code: only `crates/objects/src/object/structured_conflict.rs` line 5 (doc comment, not an emitter) and `executor.rs:403` (the site we fixed). Single emitter; the upcoming heddle#79 hunk merger should funnel through the same helper so both whole-file and hunk-level merges share the well-formedness guarantee.

## Test plan

- [x] `cargo test -p heddle-cli --test state_management` — 60/60
- [x] Red-commit confirmed (tests fail without the fix)
- [x] `git diff --check` accepts heddle-produced conflicts
- [x] Output byte-equivalent to `git merge-file -p` modulo labels

Closes HeddleCo/heddle#78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->