### PR TITLE
feat(init): default .heddleignore + common-noise hints (heddle#80)

### DIFF
--- a/crates/cli/src/cli/commands/heddleignore_defaults.rs
+++ b/crates/cli/src/cli/commands/heddleignore_defaults.rs
@@ -33,7 +33,12 @@ pub const DEFAULT_HEDDLEIGNORE: &str = "\
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
+# Custom-folder icon metadata: the on-disk basename is literally
+# `Icon\r` (four chars + a trailing carriage return). Plain `Icon`
+# would only catch a normal file named `Icon` (false positive on
+# real assets like an `Icon` source file) and miss the actual
+# metadata. The single-char glob `?` matches the `\r` byte.
+Icon?
 ._*
 
 # Xcode / iOS dev artifacts
@@ -174,11 +179,22 @@ pub fn noise_hint_for(path: &Path) -> Option<NoiseHint> {
                 suggested_pattern: ".DS_Store",
             });
         }
-        ".AppleDouble" | ".LSOverride" | "Icon" => {
+        ".AppleDouble" | ".LSOverride" => {
             return Some(NoiseHint {
                 category: NoiseCategory::MacOsFinder,
                 label: "macOS Finder metadata",
                 suggested_pattern: name_to_static(name),
+            });
+        }
+        // macOS custom-folder icon: the real on-disk name is
+        // `Icon\r`. Suggest the `Icon?` glob (matches the trailing
+        // `\r`) rather than a literal control-char line that's
+        // awkward to copy-paste.
+        "Icon\r" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::MacOsFinder,
+                label: "macOS Finder metadata",
+                suggested_pattern: "Icon?",
             });
         }
         "Thumbs.db" => {
@@ -290,7 +306,6 @@ fn name_to_static(name: &str) -> &'static str {
     match name {
         ".AppleDouble" => ".AppleDouble",
         ".LSOverride" => ".LSOverride",
-        "Icon" => "Icon",
         _ => "",
     }
 }
@@ -398,9 +413,50 @@ mod tests {
         assert!(noise_hint_for(&PathBuf::from("src/main.rs")).is_none());
         assert!(noise_hint_for(&PathBuf::from("docs/README.md")).is_none());
         assert!(noise_hint_for(&PathBuf::from("Cargo.toml")).is_none());
-        // `Icon-512.png` shares a prefix with the macOS `Icon`
+        // `Icon-512.png` shares a prefix with the macOS `Icon\r`
         // metadata sentinel but is a real app asset; exact-basename
         // match prevents the false positive.
         assert!(noise_hint_for(&PathBuf::from("assets/Icon-512.png")).is_none());
+        // A plain file literally named `Icon` (e.g. a Rust source
+        // module someone created) is NOT the macOS metadata file
+        // and must not be flagged. The metadata's real basename
+        // ends in `\r`; see `macos_icon_metadata_hint`.
+        assert!(noise_hint_for(&PathBuf::from("src/Icon")).is_none());
+    }
+
+    #[test]
+    fn macos_icon_metadata_hint() {
+        // The real on-disk filename ends in a carriage return —
+        // that's what `Finder` writes for a custom folder icon.
+        // The plain `Icon` arm used to (incorrectly) match a bare
+        // `Icon` file *and* miss this one. Now `Icon\r` matches
+        // and the suggestion is the `Icon?` glob.
+        let hint = noise_hint_for(&PathBuf::from("Icon\r")).unwrap();
+        assert_eq!(hint.category, NoiseCategory::MacOsFinder);
+        assert_eq!(hint.suggested_pattern, "Icon?");
+    }
+
+    #[test]
+    fn icon_glob_in_template_matches_real_metadata_filename() {
+        // Belt-and-braces: confirm the `Icon?` line in the bundled
+        // template actually suppresses the `Icon\r` basename when
+        // fed through the gitignore matcher, and that a plain
+        // `Icon` source file is NOT suppressed.
+        use objects::worktree::worktree_ignore::should_ignore;
+        let patterns = vec!["Icon?".to_string()];
+        assert!(should_ignore(&PathBuf::from("Icon\r"), &patterns));
+        assert!(should_ignore(
+            &PathBuf::from("subdir/Icon\r"),
+            &patterns
+        ));
+        // `Icon?` is a single-char glob, so a bare `Icon` (only
+        // 4 chars) is NOT matched — the prior `Icon` literal would
+        // have suppressed it as a false positive. The narrower
+        // pattern is the win.
+        assert!(!should_ignore(&PathBuf::from("Icon"), &patterns));
+        assert!(!should_ignore(
+            &PathBuf::from("Icon-512.png"),
+            &patterns
+        ));
     }
 }

--- a/crates/cli/src/cli/commands/heddleignore_defaults.rs
+++ b/crates/cli/src/cli/commands/heddleignore_defaults.rs
@@ -61,9 +61,11 @@ desktop.ini
 # OS / shell temporary debris
 *.tmp
 
-# Shell-redirect typos (`> -r foo` lands a literal file named `-r`)
-/-r
-/-rv
+# Shell-redirect typos (`> -r foo` lands a literal file named `-r`).
+# Unanchored so a typo created from a subdirectory (`src/-r`) is also
+# suppressed — leading `/` would only catch the repo-root variant.
+-r
+-rv
 
 # Local tool state — uncomment if your team uses these and the
 # state files leak in. Left commented by default so teams that DO
@@ -197,7 +199,7 @@ pub fn noise_hint_for(path: &Path) -> Option<NoiseHint> {
             return Some(NoiseHint {
                 category: NoiseCategory::ShellTypo,
                 label: "shell-redirect typo artifact",
-                suggested_pattern: if name == "-r" { "/-r" } else { "/-rv" },
+                suggested_pattern: if name == "-r" { "-r" } else { "-rv" },
             });
         }
         _ => {}
@@ -310,7 +312,14 @@ mod tests {
         assert!(tpl.contains("*~"));
         assert!(tpl.contains("Thumbs.db"));
         assert!(tpl.contains("*.tmp"));
-        assert!(tpl.contains("/-r"));
+        // Unanchored so the typo is suppressed wherever it lands —
+        // `/-r` would only catch the repo-root variant.
+        assert!(tpl.contains("\n-r\n"));
+        assert!(tpl.contains("\n-rv\n"));
+        // Old root-anchored shape must not reappear as an actual
+        // pattern line — the comment may legitimately reference it.
+        assert!(!tpl.contains("\n/-r\n"));
+        assert!(!tpl.contains("\n/-rv\n"));
     }
 
     #[test]
@@ -358,7 +367,21 @@ mod tests {
     fn shell_redirect_typo() {
         let hint = noise_hint_for(&PathBuf::from("-r")).unwrap();
         assert_eq!(hint.category, NoiseCategory::ShellTypo);
-        assert_eq!(hint.suggested_pattern, "/-r");
+        // Unanchored — leading `/` would limit suppression to the
+        // repo root, but the same typo can land anywhere.
+        assert_eq!(hint.suggested_pattern, "-r");
+    }
+
+    #[test]
+    fn shell_redirect_typo_pattern_matches_subdir() {
+        // Belt-and-braces: confirm the suggested pattern actually
+        // suppresses the typo when it lands in a nested directory,
+        // which the old root-anchored `/-r` would have missed.
+        use objects::worktree::worktree_ignore::should_ignore;
+        let patterns = vec!["-r".to_string(), "-rv".to_string()];
+        assert!(should_ignore(&PathBuf::from("-r"), &patterns));
+        assert!(should_ignore(&PathBuf::from("src/-r"), &patterns));
+        assert!(should_ignore(&PathBuf::from("a/b/-rv"), &patterns));
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/heddleignore_defaults.rs
+++ b/crates/cli/src/cli/commands/heddleignore_defaults.rs
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Default `.heddleignore` template + common-noise classifier.
+//!
+//! The template is installed by `heddle init` on a fresh repo (no
+//! `.heddleignore` present) so day-one users don't have to discover
+//! the file's existence before macOS Finder writes `.DS_Store` or
+//! Xcode drops `xcuserdata/` next to their source. Patterns are kept
+//! conservative: only paths the entire team is overwhelmingly likely
+//! to want suppressed. Anything project-specific (build outputs,
+//! per-IDE preferences, `.env*`) is left to the user.
+//!
+//! The same per-category pattern list also backs [`noise_hint_for`],
+//! which other commands (merge refusal, capture preflight) use to
+//! turn a stray untracked path into a one-line suggestion.
+
+use std::path::Path;
+
+/// Default `.heddleignore` written by `heddle init` when no file is
+/// present. Mirrors the per-category patterns enumerated in this
+/// module so the two stay in sync — editing either side here also
+/// edits the user-facing template.
+pub const DEFAULT_HEDDLEIGNORE: &str = "\
+# Default .heddleignore — installed by `heddle init`.
+#
+# Syntax matches `.gitignore` (globs, negation with `!`, leading `/`
+# for root-anchored, trailing `/` for directory-only). See
+# `docs/heddleignore.md` for the full divergence from `.gitignore` —
+# in particular, heddle does NOT read `.gitignore` itself, so any
+# patterns you want suppressed during `heddle capture` must live
+# here.
+
+# macOS Finder / Spotlight noise
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+
+# Xcode / iOS dev artifacts
+xcuserdata/
+*.xcuserstate
+*.xcscmblueprint
+*.xccheckout
+
+# JetBrains / VS Code / Fleet IDE caches
+.idea/
+.vscode/
+.fleet/
+*.iml
+
+# Editor backups and swap files
+*~
+.~lock.*
+*.swp
+*.swo
+
+# Windows shell metadata
+Thumbs.db
+desktop.ini
+
+# OS / shell temporary debris
+*.tmp
+
+# Shell-redirect typos (`> -r foo` lands a literal file named `-r`)
+/-r
+/-rv
+
+# Local tool state — uncomment if your team uses these and the
+# state files leak in. Left commented by default so teams that DO
+# version their tool prompts (e.g. `.claude/CLAUDE.md`) aren't
+# surprised by silent suppression.
+# .claude/
+";
+
+/// Category of common-noise match. Used to produce both a
+/// human-readable label and a suggested `.heddleignore` line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoiseCategory {
+    MacOsFinder,
+    Xcode,
+    IdeCache,
+    EditorBackup,
+    WindowsMetadata,
+    TempFile,
+    ShellTypo,
+}
+
+/// A suggestion to suppress one stray path. Carries enough context
+/// for the caller (merge refusal, capture preflight) to render the
+/// hint inline next to the offending path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoiseHint {
+    pub category: NoiseCategory,
+    /// One-line human label naming the noise category. Stable
+    /// strings so tests can pin on them.
+    pub label: &'static str,
+    /// `.heddleignore` line we'd suggest adding. Either the exact
+    /// basename (`Thumbs.db`) or the glob that covers the family
+    /// (`*.swp`).
+    pub suggested_pattern: &'static str,
+}
+
+impl NoiseHint {
+    /// Pre-formatted bracket hint suitable for inline rendering:
+    /// `[HINT: looks like macOS noise — add `.DS_Store` to .heddleignore?]`
+    pub fn render_inline(&self) -> String {
+        format!(
+            "[HINT: looks like {} — add `{}` to .heddleignore?]",
+            self.label, self.suggested_pattern
+        )
+    }
+}
+
+/// Classify `path` against the same families that the default
+/// template covers. Returns `None` for paths that don't match any
+/// noise category — those are presumed to be real user content the
+/// caller should NOT auto-hint about.
+///
+/// Matching is on the path's basename (`.DS_Store`, `foo.swp`) and,
+/// for directory-shaped noise like `xcuserdata/`, on any path
+/// component. We deliberately don't probe the filesystem here so
+/// the helper is safe to call from preflight code that may be
+/// running before a tree exists on disk.
+pub fn noise_hint_for(path: &Path) -> Option<NoiseHint> {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let components: Vec<&str> = path
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+
+    // Directory-shaped patterns: any component matches.
+    for comp in &components {
+        match *comp {
+            "xcuserdata" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::Xcode,
+                    label: "Xcode user state",
+                    suggested_pattern: "xcuserdata/",
+                });
+            }
+            ".idea" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::IdeCache,
+                    label: "JetBrains IDE cache",
+                    suggested_pattern: ".idea/",
+                });
+            }
+            ".vscode" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::IdeCache,
+                    label: "VS Code workspace cache",
+                    suggested_pattern: ".vscode/",
+                });
+            }
+            ".fleet" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::IdeCache,
+                    label: "Fleet IDE cache",
+                    suggested_pattern: ".fleet/",
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Exact-basename matches.
+    match name {
+        ".DS_Store" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::MacOsFinder,
+                label: "macOS Finder metadata",
+                suggested_pattern: ".DS_Store",
+            });
+        }
+        ".AppleDouble" | ".LSOverride" | "Icon" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::MacOsFinder,
+                label: "macOS Finder metadata",
+                suggested_pattern: name_to_static(name),
+            });
+        }
+        "Thumbs.db" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::WindowsMetadata,
+                label: "Windows thumbnail cache",
+                suggested_pattern: "Thumbs.db",
+            });
+        }
+        "desktop.ini" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::WindowsMetadata,
+                label: "Windows folder metadata",
+                suggested_pattern: "desktop.ini",
+            });
+        }
+        "-r" | "-rv" => {
+            return Some(NoiseHint {
+                category: NoiseCategory::ShellTypo,
+                label: "shell-redirect typo artifact",
+                suggested_pattern: if name == "-r" { "/-r" } else { "/-rv" },
+            });
+        }
+        _ => {}
+    }
+
+    // AppleDouble dot-underscore companions: `._foo`.
+    if name.starts_with("._") && name.len() > 2 {
+        return Some(NoiseHint {
+            category: NoiseCategory::MacOsFinder,
+            label: "macOS AppleDouble companion",
+            suggested_pattern: "._*",
+        });
+    }
+
+    // Extension-driven families.
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        match ext {
+            "xcuserstate" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::Xcode,
+                    label: "Xcode user state",
+                    suggested_pattern: "*.xcuserstate",
+                });
+            }
+            "xcscmblueprint" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::Xcode,
+                    label: "Xcode SCM blueprint",
+                    suggested_pattern: "*.xcscmblueprint",
+                });
+            }
+            "xccheckout" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::Xcode,
+                    label: "Xcode workspace checkout",
+                    suggested_pattern: "*.xccheckout",
+                });
+            }
+            "iml" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::IdeCache,
+                    label: "JetBrains module file",
+                    suggested_pattern: "*.iml",
+                });
+            }
+            "swp" | "swo" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::EditorBackup,
+                    label: "Vim swap file",
+                    suggested_pattern: if ext == "swp" { "*.swp" } else { "*.swo" },
+                });
+            }
+            "tmp" => {
+                return Some(NoiseHint {
+                    category: NoiseCategory::TempFile,
+                    label: "temporary file",
+                    suggested_pattern: "*.tmp",
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Editor backup tildes (`foo.txt~`) and LibreOffice `.~lock.*`.
+    if name.ends_with('~') {
+        return Some(NoiseHint {
+            category: NoiseCategory::EditorBackup,
+            label: "Emacs/Vim backup file",
+            suggested_pattern: "*~",
+        });
+    }
+    if name.starts_with(".~lock.") {
+        return Some(NoiseHint {
+            category: NoiseCategory::EditorBackup,
+            label: "LibreOffice lock file",
+            suggested_pattern: ".~lock.*",
+        });
+    }
+
+    None
+}
+
+/// Map a tiny set of literal-name noise paths to their canonical
+/// `.heddleignore` line. `noise_hint_for` carries `&'static str`
+/// pattern strings so the suggestion is cheap to copy out — this
+/// helper exists so the match arm doesn't have to repeat the literal.
+fn name_to_static(name: &str) -> &'static str {
+    match name {
+        ".AppleDouble" => ".AppleDouble",
+        ".LSOverride" => ".LSOverride",
+        "Icon" => "Icon",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn template_covers_each_category() {
+        // Spot-check that every NoiseCategory has at least one
+        // literal in the template — keeps the two from drifting.
+        let tpl = DEFAULT_HEDDLEIGNORE;
+        assert!(tpl.contains(".DS_Store"));
+        assert!(tpl.contains("xcuserdata/"));
+        assert!(tpl.contains(".idea/"));
+        assert!(tpl.contains("*~"));
+        assert!(tpl.contains("Thumbs.db"));
+        assert!(tpl.contains("*.tmp"));
+        assert!(tpl.contains("/-r"));
+    }
+
+    #[test]
+    fn ds_store_hint() {
+        let hint = noise_hint_for(&PathBuf::from(".DS_Store")).unwrap();
+        assert_eq!(hint.category, NoiseCategory::MacOsFinder);
+        assert_eq!(hint.suggested_pattern, ".DS_Store");
+        assert!(hint.render_inline().contains(".DS_Store"));
+    }
+
+    #[test]
+    fn ds_store_in_subdir() {
+        // Common shape: `src/.DS_Store`. Basename match suffices.
+        let hint = noise_hint_for(&PathBuf::from("src/.DS_Store")).unwrap();
+        assert_eq!(hint.category, NoiseCategory::MacOsFinder);
+    }
+
+    #[test]
+    fn xcuserdata_directory_match() {
+        // The match should fire on a child path under xcuserdata/,
+        // not just the bare directory entry — the walker can hand
+        // us either shape.
+        let hint = noise_hint_for(&PathBuf::from(
+            "App.xcodeproj/xcuserdata/user.xcuserdatad/UserInterfaceState.xcuserstate",
+        ))
+        .unwrap();
+        assert_eq!(hint.category, NoiseCategory::Xcode);
+        assert_eq!(hint.suggested_pattern, "xcuserdata/");
+    }
+
+    #[test]
+    fn apple_double_dot_underscore() {
+        let hint = noise_hint_for(&PathBuf::from("._main.rs")).unwrap();
+        assert_eq!(hint.suggested_pattern, "._*");
+    }
+
+    #[test]
+    fn vim_swap() {
+        let hint = noise_hint_for(&PathBuf::from(".main.rs.swp")).unwrap();
+        assert_eq!(hint.category, NoiseCategory::EditorBackup);
+        assert_eq!(hint.suggested_pattern, "*.swp");
+    }
+
+    #[test]
+    fn shell_redirect_typo() {
+        let hint = noise_hint_for(&PathBuf::from("-r")).unwrap();
+        assert_eq!(hint.category, NoiseCategory::ShellTypo);
+        assert_eq!(hint.suggested_pattern, "/-r");
+    }
+
+    #[test]
+    fn libreoffice_lock() {
+        let hint = noise_hint_for(&PathBuf::from(".~lock.report.odt#")).unwrap();
+        assert_eq!(hint.suggested_pattern, ".~lock.*");
+    }
+
+    #[test]
+    fn real_source_returns_none() {
+        // The whole point: real user files must NOT trip the hint
+        // detector. A false positive here would suppress real
+        // content during merge or capture.
+        assert!(noise_hint_for(&PathBuf::from("src/main.rs")).is_none());
+        assert!(noise_hint_for(&PathBuf::from("docs/README.md")).is_none());
+        assert!(noise_hint_for(&PathBuf::from("Cargo.toml")).is_none());
+        // `Icon-512.png` shares a prefix with the macOS `Icon`
+        // metadata sentinel but is a real app asset; exact-basename
+        // match prevents the false positive.
+        assert!(noise_hint_for(&PathBuf::from("assets/Icon-512.png")).is_none());
+    }
+}

--- a/crates/cli/src/cli/commands/heddleignore_defaults.rs
+++ b/crates/cli/src/cli/commands/heddleignore_defaults.rs
@@ -33,13 +33,13 @@ pub const DEFAULT_HEDDLEIGNORE: &str = "\
 .DS_Store
 .AppleDouble
 .LSOverride
-# Custom-folder icon metadata: the on-disk basename is literally
-# `Icon\r` (four chars + a trailing carriage return). Plain `Icon`
-# would only catch a normal file named `Icon` (false positive on
-# real assets like an `Icon` source file) and miss the actual
-# metadata. The single-char glob `?` matches the `\r` byte.
-Icon?
 ._*
+# Note: macOS custom-folder icon metadata (`Icon\r` — four chars +
+# a trailing carriage return) is intentionally NOT suppressed by
+# default. The only safely-typable glob (`Icon?`) is too broad and
+# would also hide legitimate basenames like `Icons` or `Icon1`,
+# including directories. If your team needs this, see
+# `docs/heddleignore.md` for a project-specific recipe.
 
 # Xcode / iOS dev artifacts
 xcuserdata/
@@ -186,17 +186,12 @@ pub fn noise_hint_for(path: &Path) -> Option<NoiseHint> {
                 suggested_pattern: name_to_static(name),
             });
         }
-        // macOS custom-folder icon: the real on-disk name is
-        // `Icon\r`. Suggest the `Icon?` glob (matches the trailing
-        // `\r`) rather than a literal control-char line that's
-        // awkward to copy-paste.
-        "Icon\r" => {
-            return Some(NoiseHint {
-                category: NoiseCategory::MacOsFinder,
-                label: "macOS Finder metadata",
-                suggested_pattern: "Icon?",
-            });
-        }
+        // macOS custom-folder icon metadata (`Icon\r`) is deliberately
+        // not hinted: the only safely-typable suggestion is `Icon?`,
+        // which would also suppress legitimate basenames like `Icons`
+        // or `Icon1`. Leaving the path un-hinted lets the user choose
+        // a project-specific recipe rather than nudging them toward a
+        // broad pattern. See `docs/heddleignore.md`.
         "Thumbs.db" => {
             return Some(NoiseHint {
                 category: NoiseCategory::WindowsMetadata,
@@ -425,38 +420,36 @@ mod tests {
     }
 
     #[test]
-    fn macos_icon_metadata_hint() {
-        // The real on-disk filename ends in a carriage return —
-        // that's what `Finder` writes for a custom folder icon.
-        // The plain `Icon` arm used to (incorrectly) match a bare
-        // `Icon` file *and* miss this one. Now `Icon\r` matches
-        // and the suggestion is the `Icon?` glob.
-        let hint = noise_hint_for(&PathBuf::from("Icon\r")).unwrap();
-        assert_eq!(hint.category, NoiseCategory::MacOsFinder);
-        assert_eq!(hint.suggested_pattern, "Icon?");
+    fn macos_icon_metadata_returns_no_hint() {
+        // Regression: an earlier revision hinted `Icon?` for the
+        // `Icon\r` macOS metadata basename. The `Icon?` glob is too
+        // broad — it also matches `Icons`, `Icon1`, etc. — so we no
+        // longer nudge users toward it. The path is left un-hinted
+        // and the user can pick a project-specific recipe.
+        assert!(noise_hint_for(&PathBuf::from("Icon\r")).is_none());
     }
 
     #[test]
-    fn icon_glob_in_template_matches_real_metadata_filename() {
-        // Belt-and-braces: confirm the `Icon?` line in the bundled
-        // template actually suppresses the `Icon\r` basename when
-        // fed through the gitignore matcher, and that a plain
-        // `Icon` source file is NOT suppressed.
+    fn icon_glob_not_in_default_template() {
+        // Regression: the default template must not re-introduce
+        // `Icon?` (or a bare `Icon` line). Both are too broad and
+        // would silently hide legitimate basenames like `Icons` or
+        // an `Icon` source file from `status` / `capture`.
+        let tpl = DEFAULT_HEDDLEIGNORE;
+        assert!(!tpl.contains("\nIcon?\n"));
+        assert!(!tpl.contains("\nIcon\n"));
+        // And confirm the matcher would NOT suppress an `Icons`
+        // directory or an `Icon` source file given the current
+        // template — i.e. no other pattern accidentally covers them.
         use objects::worktree::worktree_ignore::should_ignore;
-        let patterns = vec!["Icon?".to_string()];
-        assert!(should_ignore(&PathBuf::from("Icon\r"), &patterns));
-        assert!(should_ignore(
-            &PathBuf::from("subdir/Icon\r"),
-            &patterns
-        ));
-        // `Icon?` is a single-char glob, so a bare `Icon` (only
-        // 4 chars) is NOT matched — the prior `Icon` literal would
-        // have suppressed it as a false positive. The narrower
-        // pattern is the win.
-        assert!(!should_ignore(&PathBuf::from("Icon"), &patterns));
-        assert!(!should_ignore(
-            &PathBuf::from("Icon-512.png"),
-            &patterns
-        ));
+        let patterns: Vec<String> = tpl
+            .lines()
+            .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
+            .map(|l| l.to_string())
+            .collect();
+        assert!(!should_ignore(&PathBuf::from("Icons"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("Icons/foo.png"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("src/Icon"), &patterns));
+        assert!(!should_ignore(&PathBuf::from("Icon1"), &patterns));
     }
 }

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Initialize command.
 
-use std::path::PathBuf;
+use std::{fs::OpenOptions, io::Write, path::PathBuf};
 
 use anyhow::Result;
 use repo::Repository;
@@ -105,12 +105,28 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 /// cases (permission denied with the file *not* present, etc.).
 pub(crate) fn maybe_install_default_heddleignore(root: &std::path::Path) -> Result<bool> {
     let path = root.join(".heddleignore");
-    if path.exists() {
-        return Ok(false);
+    // Atomic create-or-fail: the prior `path.exists()` + `fs::write`
+    // shape was a TOCTOU window where a concurrent `heddle init` (or
+    // a user dropping their own `.heddleignore` between the two
+    // syscalls) could see "absent" and then have its file silently
+    // overwritten. `O_CREAT | O_EXCL` collapses the check and the
+    // write into one kernel-enforced step.
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut f) => {
+            f.write_all(super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE.as_bytes())
+                .map_err(|e| anyhow::anyhow!("failed to write default .heddleignore: {}", e))?;
+            Ok(true)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(anyhow::anyhow!(
+            "failed to create default .heddleignore: {}",
+            e
+        )),
     }
-    std::fs::write(&path, super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE)
-        .map_err(|e| anyhow::anyhow!("failed to write default .heddleignore: {}", e))?;
-    Ok(true)
 }
 
 fn render_init(output: &InitOutput, json: bool) -> Result<()> {
@@ -120,4 +136,35 @@ fn render_init(output: &InitOutput, json: bool) -> Result<()> {
         println!("{}", output.message);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_writes_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let wrote = maybe_install_default_heddleignore(dir.path()).unwrap();
+        assert!(wrote);
+        let body = std::fs::read_to_string(dir.path().join(".heddleignore")).unwrap();
+        assert_eq!(body, super::super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE);
+    }
+
+    #[test]
+    fn install_preserves_existing_via_create_new() {
+        // The atomic `O_CREAT | O_EXCL` path must NOT overwrite a
+        // curated `.heddleignore`. Pre-create one with custom content,
+        // then confirm `maybe_install_default_heddleignore` returns
+        // `false` and leaves the body untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".heddleignore");
+        let curated = "# curated\nsecrets/\n";
+        std::fs::write(&path, curated).unwrap();
+
+        let wrote = maybe_install_default_heddleignore(dir.path()).unwrap();
+        assert!(!wrote);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, curated);
+    }
 }

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -43,6 +43,15 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 
     debug!(heddle_dir = %repo.heddle_dir().display(), "Repository initialized");
 
+    // Install the default `.heddleignore` if the repo doesn't ship
+    // one yet. Auto-install (no prompt) is the explicit UX call: the
+    // friction we're paying is `heddle merge` refusals on day-one
+    // `.DS_Store` / `xcuserdata/` noise, and a prompt would just
+    // delay that suppression to whenever the user noticed. The file
+    // is plain text the user can edit or delete afterwards, so the
+    // blast radius of "wrong choice" is small.
+    let installed_heddleignore = maybe_install_default_heddleignore(repo.root())?;
+
     if args.principal_name.is_some() || args.principal_email.is_some() {
         let name = args
             .principal_name
@@ -61,22 +70,47 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 
     super::maybe_prompt_init_install(cli, &repo, &args)?;
 
+    let mut message = if has_git {
+        format!(
+            "Initialized Heddle sidecar in {} for Git-overlay workflows",
+            repo.heddle_dir().display()
+        )
+    } else {
+        format!(
+            "Initialized Heddle repository in {}",
+            repo.heddle_dir().display()
+        )
+    };
+    if installed_heddleignore {
+        message.push_str("\nWrote default .heddleignore (edit to customize)");
+    }
+
     let output = InitOutput {
         path: repo.heddle_dir().to_path_buf(),
-        message: if has_git {
-            format!(
-                "Initialized Heddle sidecar in {} for Git-overlay workflows",
-                repo.heddle_dir().display()
-            )
-        } else {
-            format!(
-                "Initialized Heddle repository in {}",
-                repo.heddle_dir().display()
-            )
-        },
+        message,
     };
 
     render_init(&output, should_output_json(cli, Some(repo.config())))
+}
+
+/// Write the bundled default `.heddleignore` into the worktree root
+/// if (and only if) no `.heddleignore` already exists there. Returns
+/// whether a write actually happened so the caller can surface a
+/// single-line notice to the user.
+///
+/// Failure to write is non-fatal: a freshly-initialized repo without
+/// the default template is still a valid Heddle repo, and a noisy
+/// failure here would block init for paths the user can recreate by
+/// hand. We propagate I/O errors only for the genuinely unexpected
+/// cases (permission denied with the file *not* present, etc.).
+pub(crate) fn maybe_install_default_heddleignore(root: &std::path::Path) -> Result<bool> {
+    let path = root.join(".heddleignore");
+    if path.exists() {
+        return Ok(false);
+    }
+    std::fs::write(&path, super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE)
+        .map_err(|e| anyhow::anyhow!("failed to write default .heddleignore: {}", e))?;
+    Ok(true)
 }
 
 fn render_init(output: &InitOutput, json: bool) -> Result<()> {

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -117,8 +117,23 @@ pub(crate) fn maybe_install_default_heddleignore(root: &std::path::Path) -> Resu
         .open(&path)
     {
         Ok(mut f) => {
-            f.write_all(super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE.as_bytes())
-                .map_err(|e| anyhow::anyhow!("failed to write default .heddleignore: {}", e))?;
+            // If `write_all` fails after `create_new` already
+            // landed an empty file (ENOSPC, EIO, ...), a naïve
+            // bail-out would leave the zero-byte file on disk —
+            // and a retried `heddle init` would then hit the
+            // `AlreadyExists` arm and silently report success
+            // without ever installing the template. Remove the
+            // partial file so the retry path can recreate it.
+            if let Err(e) =
+                f.write_all(super::heddleignore_defaults::DEFAULT_HEDDLEIGNORE.as_bytes())
+            {
+                drop(f);
+                let _ = std::fs::remove_file(&path);
+                return Err(anyhow::anyhow!(
+                    "failed to write default .heddleignore: {}",
+                    e
+                ));
+            }
             Ok(true)
         }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),

--- a/crates/cli/src/cli/commands/merge/git_commit.rs
+++ b/crates/cli/src/cli/commands/merge/git_commit.rs
@@ -119,7 +119,22 @@ pub(super) fn validate_git_state(
     if !unrelated.is_empty() {
         // Cap the rendered list — the user gets the count and a few
         // examples; the full set lives in the workspace anyway.
-        let preview: Vec<String> = unrelated.iter().take(5).cloned().collect();
+        // Per-path: if the path looks like common noise (`.DS_Store`,
+        // `xcuserdata/...`, editor swap files), append an inline
+        // `.heddleignore` hint so the user can fix the root cause in
+        // one edit instead of guessing the right glob.
+        let preview: Vec<String> = unrelated
+            .iter()
+            .take(5)
+            .map(|path| {
+                match super::super::heddleignore_defaults::noise_hint_for(std::path::Path::new(
+                    path,
+                )) {
+                    Some(hint) => format!("{path} {}", hint.render_inline()),
+                    None => path.clone(),
+                }
+            })
+            .collect();
         let suffix = if unrelated.len() > preview.len() {
             format!(" (+{} more)", unrelated.len() - preview.len())
         } else {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -31,6 +31,7 @@ mod fsck_checks;
 mod gc;
 mod goto;
 mod harness_bridge;
+pub(crate) mod heddleignore_defaults;
 mod history_target;
 mod hook;
 mod index;
@@ -167,12 +168,12 @@ pub use semantic_cmd::cmd_semantic;
 pub use session::{
     cmd_session_end, cmd_session_list, cmd_session_segment, cmd_session_show, cmd_session_start,
 };
+pub use shell::cmd_shell;
 pub use show::cmd_show;
 pub use snapshot::{SnapshotAgentOverrides, cmd_snapshot};
 pub use stash::cmd_stash;
 pub use status::cmd_status;
 pub use store_cmd::cmd_store;
-pub use shell::cmd_shell;
 pub use thread::{cmd_start, cmd_thread_show};
 pub use thread_cmd::cmd_thread;
 pub use thread_shaping::{

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -727,16 +727,22 @@ fn redact_apply_json(temp: &TempDir, state: &str) -> Value {
 
 #[test]
 fn redact_apply_emits_ignore_hint_when_neither_file_covers_path() {
-    // Fresh repo, no `.heddleignore` and no `.gitignore`. The hint
-    // must surface and point at `.heddleignore` (heddle-native
-    // preference for fresh repos) with `already_exists: false`.
+    // Fresh repo: `heddle init` ships a default `.heddleignore` now
+    // (heddle#80), but the default template doesn't cover the leaked
+    // `config/secrets.toml` path. The hint must still surface,
+    // pointing at `.heddleignore` with `already_exists: true` (so
+    // the message renders as "add ... to .heddleignore", not
+    // "create ...").
     let (temp, state) = setup_repo_with_secret();
     let apply = redact_apply_json(&temp, &state);
     let hint = apply
         .get("ignore_hint")
         .expect("ignore_hint should be present when path is uncovered");
     assert_eq!(hint["ignore_file"].as_str().unwrap(), ".heddleignore");
-    assert!(!hint["already_exists"].as_bool().unwrap());
+    assert!(
+        hint["already_exists"].as_bool().unwrap(),
+        "init now installs a default .heddleignore"
+    );
     assert_eq!(
         hint["suggested_pattern"].as_str().unwrap(),
         "config/secrets.toml"
@@ -794,8 +800,8 @@ fn redact_apply_emits_hint_when_only_gitignore_covers_the_path() {
         ".gitignore is not consulted by heddle capture; hint must target .heddleignore"
     );
     assert!(
-        !hint["already_exists"].as_bool().unwrap(),
-        "should report .heddleignore as not-yet-present"
+        hint["already_exists"].as_bool().unwrap(),
+        "init installs a default .heddleignore (heddle#80)"
     );
 }
 
@@ -863,7 +869,10 @@ fn purge_apply_also_emits_ignore_hint() {
         .get("ignore_hint")
         .expect("purge output must include ignore_hint");
     assert_eq!(hint["ignore_file"].as_str().unwrap(), ".heddleignore");
-    assert!(!hint["already_exists"].as_bool().unwrap());
+    assert!(
+        hint["already_exists"].as_bool().unwrap(),
+        "init installs a default .heddleignore (heddle#80)"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/core_functionality/file_operations.rs
+++ b/crates/cli/tests/core_functionality/file_operations.rs
@@ -148,3 +148,74 @@ fn test_nested_tracked_heddle_paths_are_not_ignored_by_status_or_snapshot() {
         std::fs::read_to_string(temp.path().join("examples/calculator/.heddle/HEAD")).unwrap();
     assert_eq!(restored, "hd-examplehead-v1\n");
 }
+
+#[test]
+fn init_writes_default_heddleignore() {
+    // Red-commit for heddle#80: fresh `heddle init` must install the
+    // bundled `.heddleignore` so day-one users don't have to discover
+    // the file's existence before macOS noise lands.
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    let path = temp.path().join(".heddleignore");
+    assert!(
+        path.is_file(),
+        ".heddleignore must be installed by `heddle init`"
+    );
+    let contents = std::fs::read_to_string(&path).unwrap();
+    // Spot-check a few representative patterns from each family —
+    // template-completeness is unit-tested in the module itself.
+    assert!(contents.contains(".DS_Store"));
+    assert!(contents.contains("xcuserdata/"));
+    assert!(contents.contains("*.swp"));
+}
+
+#[test]
+fn init_preserves_existing_heddleignore() {
+    // If the operator already curated a `.heddleignore`, init must
+    // NOT clobber it. The default template is a starter, not a
+    // mandate.
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join(".heddleignore");
+    std::fs::write(&path, "# my custom rules\n*.private\n").unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert!(after.contains("*.private"));
+    assert!(
+        !after.contains(".DS_Store"),
+        "existing .heddleignore must not be overwritten"
+    );
+}
+
+#[test]
+fn default_heddleignore_suppresses_common_macos_noise() {
+    // Red-commit: after `heddle init`, dropping `.DS_Store` and an
+    // `xcuserdata/` tree into the worktree must NOT show them as
+    // untracked. This is the day-one friction the issue cites.
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("real.txt"), "content").unwrap();
+    std::fs::write(temp.path().join(".DS_Store"), b"\x00\x00\x00").unwrap();
+    let xcuserdata = temp.path().join("App.xcodeproj/xcuserdata/u.xcuserdatad");
+    std::fs::create_dir_all(&xcuserdata).unwrap();
+    std::fs::write(xcuserdata.join("UserInterfaceState.xcuserstate"), b"x").unwrap();
+
+    let status = heddle_must_succeed(&["--json", "status"], temp.path());
+    let status_json: Value = serde_json::from_str(&status).unwrap();
+    let untracked = status_json["changes"]["added"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let untracked_paths: Vec<&str> = untracked.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        !untracked_paths.iter().any(|p| p.contains(".DS_Store")),
+        ".DS_Store must be suppressed by the default .heddleignore; saw: {untracked_paths:?}"
+    );
+    assert!(
+        !untracked_paths.iter().any(|p| p.contains("xcuserdata")),
+        "xcuserdata/ must be suppressed by the default .heddleignore; saw: {untracked_paths:?}"
+    );
+    assert!(
+        untracked_paths.iter().any(|p| p.contains("real.txt")),
+        "real.txt must still surface as untracked; saw: {untracked_paths:?}"
+    );
+}

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -79,17 +79,14 @@ like `Icons`, `Icon1`, or an `Icons/` directory full of real
 assets, which would silently hide project content from `status` and
 `capture`.
 
-If your team uses macOS custom folder icons heavily and the
-metadata files become noise, add the literal-`\r` form as a
-project-specific pattern. Most editors won't insert a bare `\r`
-cleanly; the reliable recipe is to append it from a shell:
-
-```
-printf 'Icon\r\n' >> .heddleignore
-```
-
-Verify with `xxd .heddleignore | tail` that the line ends `49 63
-6f 6e 0d 0a` (`Icon\r\n`) rather than `49 63 6f 6e 0a`.
+**Note:** heddle's `.heddleignore` parser normalizes whitespace
+including trailing `\r`, so the `Icon\r` filename cannot be
+expressed as a `.heddleignore` pattern — any line written as
+`Icon\r` is read back as plain `Icon` and would suppress
+legitimate files or directories named `Icon`. If these metadata
+files are noise in your workflow, suppress them at the macOS
+level instead: delete the custom folder icon, or set Finder's
+"Hide" attribute on the file.
 
 ## Local-tool state (`.claude/`, etc.)
 

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -13,8 +13,8 @@ overwhelmingly-common cross-platform noise — macOS Finder metadata
 `.vscode/`, `.fleet/`, `*.iml`), Vim/Emacs swap and backup files
 (`*.swp`, `*.swo`, `*~`), Windows shell metadata (`Thumbs.db`,
 `desktop.ini`), LibreOffice locks (`.~lock.*`), and the two
-shell-redirect typo artifacts that periodically show up (`/-r`,
-`/-rv`).
+shell-redirect typo artifacts that periodically show up (`-r`,
+`-rv` — unanchored, so a `src/-r` typo is suppressed too).
 
 The template is intentionally conservative: only patterns the entire
 team is overwhelmingly likely to want suppressed. Project-specific

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -1,0 +1,85 @@
+# `.heddleignore`
+
+`.heddleignore` is heddle's per-repo file for telling `heddle capture`,
+`heddle status`, and `heddle merge` which paths to ignore. It lives at
+the worktree root, next to your code.
+
+## Default template
+
+`heddle init` writes a starter `.heddleignore` covering the
+overwhelmingly-common cross-platform noise — macOS Finder metadata
+(`.DS_Store`, `._*`), Xcode user state (`xcuserdata/`,
+`*.xcuserstate`), JetBrains / VS Code / Fleet caches (`.idea/`,
+`.vscode/`, `.fleet/`, `*.iml`), Vim/Emacs swap and backup files
+(`*.swp`, `*.swo`, `*~`), Windows shell metadata (`Thumbs.db`,
+`desktop.ini`), LibreOffice locks (`.~lock.*`), and the two
+shell-redirect typo artifacts that periodically show up (`/-r`,
+`/-rv`).
+
+The template is intentionally conservative: only patterns the entire
+team is overwhelmingly likely to want suppressed. Project-specific
+patterns (build outputs, generated bindings, `.env*`, lockfiles) are
+yours to add — the file is plain text.
+
+## Syntax
+
+The matcher is `gitignore`-compatible: glob patterns (`*.log`,
+`config/*.toml`), `**` for recursive directory globs, leading `/`
+for root-anchored, trailing `/` for directory-only, and `!` for
+negation. Order is significant — a later rule can re-include a path
+a previous rule ignored. The same rules apply as in `.gitignore`.
+
+## Relationship to `.gitignore`
+
+**Heddle does not read `.gitignore`.** `.heddleignore` and
+`.gitignore` are independent files. If you keep both Git and Heddle
+in the same repository (the git-overlay workflow), patterns that
+should suppress both walks must appear in both files. We considered
+auto-reading `.gitignore`, but kept them separate because:
+
+- Heddle is a different VCS with its own capture semantics —
+  `heddle capture` snapshots the worktree directly, so what you
+  want suppressed during capture may not match what Git ignores
+  during `git add`.
+- Some teams want one file checked into Git and the other left
+  uncommitted as a local override.
+- A surprising auto-merge of `.gitignore` rules would make heddle's
+  behavior depend on a file it does not otherwise own.
+
+If your team's `.gitignore` and `.heddleignore` should track the
+same content, symlink one to the other locally — heddle reads
+`.heddleignore` directly off disk every walk, so a symlink is
+transparent.
+
+## Common-noise hints
+
+When `heddle merge` refuses because of untracked paths the workflow
+didn't expect, paths that look like common noise are annotated
+inline with a `.heddleignore` suggestion:
+
+```
+heddle: 3 unrelated uncommitted git change(s) outside the merge:
+  .DS_Store [HINT: looks like macOS Finder metadata — add `.DS_Store` to .heddleignore?]
+  src/.foo.rs.swp [HINT: looks like Vim swap file — add `*.swp` to .heddleignore?]
+  src/main.rs
+```
+
+Real source files (no matching noise category) are listed without a
+hint — heddle never suggests suppressing a path it doesn't recognize
+as noise.
+
+## Local-tool state (`.claude/`, etc.)
+
+The default template leaves `.claude/` commented out. Some teams
+version their tool prompts (`.claude/CLAUDE.md`, agent definitions);
+others don't. If your `.claude/` directory only carries local state
+(`scheduled_tasks.lock`, ephemeral chat history), uncomment the line
+in the default template or add the specific paths.
+
+## Editing
+
+`.heddleignore` is read fresh on every walk — no daemon restart, no
+re-init. Add, remove, or reorder rules as needed. The bundled
+default template is shipped in
+`crates/cli/src/cli/commands/heddleignore_defaults.rs` if you want
+to copy patterns back in after editing.

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -68,6 +68,29 @@ Real source files (no matching noise category) are listed without a
 hint — heddle never suggests suppressing a path it doesn't recognize
 as noise.
 
+## macOS `Icon` metadata
+
+macOS Finder stores custom-folder icon metadata in a file whose
+basename is literally `Icon` followed by a carriage return (`Icon\r`
+— four chars + the `\r` byte). The default template does **not**
+suppress this. The only glob that targets it without an awkward
+literal control-char (`Icon?`) also matches legitimate basenames
+like `Icons`, `Icon1`, or an `Icons/` directory full of real
+assets, which would silently hide project content from `status` and
+`capture`.
+
+If your team uses macOS custom folder icons heavily and the
+metadata files become noise, add the literal-`\r` form as a
+project-specific pattern. Most editors won't insert a bare `\r`
+cleanly; the reliable recipe is to append it from a shell:
+
+```
+printf 'Icon\r\n' >> .heddleignore
+```
+
+Verify with `xxd .heddleignore | tail` that the line ends `49 63
+6f 6e 0d 0a` (`Icon\r\n`) rather than `49 63 6f 6e 0a`.
+
 ## Local-tool state (`.claude/`, etc.)
 
 The default template leaves `.claude/` commented out. Some teams


### PR DESCRIPTION
## Summary

- `heddle init` now writes a default `.heddleignore` covering common cross-platform noise (`.DS_Store`, `xcuserdata/`, IDE caches, Vim/Emacs backups, Windows metadata, LibreOffice locks, shell-redirect typo artifacts). Existing `.heddleignore` files are preserved untouched.
- Adds a shared noise classifier (`heddleignore_defaults::noise_hint_for`) that the `heddle merge --git-commit` blocker output now uses to annotate noise-looking unrelated paths with the `.heddleignore` line that would suppress them. Real source files get no hint.
- Doc at `docs/heddleignore.md` covers syntax and the deliberate divergence from `.gitignore` (heddle does not auto-read `.gitignore`).

Closes HeddleCo/heddle#80

## UX call

Auto-install rather than prompt. The friction we're paying is `.DS_Store` / `xcuserdata/` noise on day-one captures and merge refusals — a prompt would just delay suppression to whenever the user noticed. The file is plain text the user can edit or delete; blast radius of "wrong choice" is small. Surfaces a one-line `Wrote default .heddleignore (edit to customize)` notice after init.

## Test plan

- [x] `cargo test -p heddle-cli --lib heddleignore_defaults` — 9 unit tests pass (template/category coverage, basename/extension/directory matching, real-source negative)
- [x] `cargo test -p heddle-cli --test core_functionality heddleignore` — 3 integration tests pass:
  - `init_writes_default_heddleignore` (red-commit AC #1)
  - `init_preserves_existing_heddleignore`
  - `default_heddleignore_suppresses_common_macos_noise` (red-commit AC for `.DS_Store` + `xcuserdata/`)
- [x] `cargo test -p heddle-cli --test cli_integration redact_purge` — 22 pass (3 existing tests updated to reflect that init now installs `.heddleignore`)
- [x] `cargo test -p heddle-cli --test cli_integration` — 284 pass, 0 fail
- [x] `cargo test -p heddle-cli --test core_functionality --test state_management --test comprehensive --test production_features` — all green (240+ tests)
- [x] `cargo clippy -p heddle-cli --no-deps -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->