### PR TITLE
fix(mount): make Linux FUSE actually work end-to-end (heddle#74)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -65,6 +65,73 @@ jobs:
       - name: sccache stats
         run: sccache --show-stats
 
+  # Linux FUSE mount smoke. Pinned to a GitHub-hosted `ubuntu-latest`
+  # runner so we get `/dev/fuse`, `fusermount3`, and the system-wide
+  # FUSE policy without having to special-case the Blacksmith image.
+  # The blacksmith ARM runner above doesn't ship `fuse3 libfuse3-dev`
+  # by default, and asking it to install them post-boot adds image
+  # drift we'd rather not chase.
+  #
+  # This job is the load-bearing check that Linux teammates can mount
+  # a heddle thread, read it, write through the mount, and unmount
+  # cleanly — i.e. the "use heddle over git in repo development"
+  # daily-use path. If it breaks, the daily-use story breaks.
+  #
+  # The `fuse_mount.rs` integration tests are `#[ignore]` so they
+  # don't run by default (a `cargo test -p heddle-mount` from a
+  # contributor's laptop doesn't need FUSE installed). This job opts
+  # in explicitly with `-- --ignored`.
+  fuse-smoke:
+    name: FUSE mount smoke (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: fuse-smoke-${{ runner.os }}
+          cache-on-failure: true
+
+      # `fuse3` ships `fusermount3`, the SUID helper the FUSE shell
+      # uses to publish the mount to the kernel; `libfuse3-dev` is
+      # what `fuser`'s build links against.
+      - name: Install FUSE
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fuse3 libfuse3-dev
+          fusermount3 --version
+          ls -l /dev/fuse
+
+      # Single-threaded so a kernel-side hang on one mount can't
+      # cascade into the others' tempdir lifetimes. `--nocapture` so
+      # the CI log shows the FUSE write/release path if a test
+      # regresses.
+      - name: FUSE integration tests
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          cargo test --locked -p heddle-mount --features fuse --test fuse_mount \
+            -- --ignored --test-threads=1 --nocapture
+
+      # Panic-recovery unit tests live alongside the FUSE shell; run
+      # them on the same job so a regression in the `guard_call`
+      # contract trips a single, well-scoped CI failure.
+      - name: FUSE panic-recovery unit tests
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          cargo test --locked -p heddle-mount --features fuse --lib fuse::
+
+      - name: sccache stats
+        run: sccache --show-stats
+
   # Coverage requires an instrumented build that can't share `target/`
   # with the regular profile, so it stays as its own job.
   coverage:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,6 +2936,7 @@ dependencies = [
  "heddle-repo",
  "libc",
  "lru",
+ "memmap2",
  "nfsserve",
  "proptest",
  "tempfile",

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -58,6 +58,11 @@ windows = { version = "0.58", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
+# Used by the Linux mount integration tests to exercise the
+# `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
+# `fuse_mount_serves_mmap_readers` regression test that locks in
+# `FUSE_DIRECT_IO_ALLOW_MMAP` opt-in (kernel 5.16+).
+memmap2.workspace = true
 oplog = { path = "../oplog", package = "heddle-oplog" }
 proptest.workspace = true
 tempfile.workspace = true

--- a/crates/mount/README.md
+++ b/crates/mount/README.md
@@ -36,6 +36,111 @@ cargo build -p mount --features fuse
 cargo build -p mount --features fskit
 ```
 
+## Linux runtime requirements (FUSE)
+
+The FUSE shell is the daily-use path on Linux. To mount, the host
+needs:
+
+1. **`/dev/fuse` available and readable by the mount-owner.** Most
+   distros ship this enabled in the kernel; containers may need
+   `--device=/dev/fuse --cap-add SYS_ADMIN`.
+
+2. **`fusermount3` on `PATH`.** This is the SUID helper that
+   actually publishes the mount to the kernel. Debian/Ubuntu ships
+   it in `fuse3`; RHEL/Fedora in `fuse-libs` + `fuse3`. Install with:
+
+   ```bash
+   sudo apt-get install fuse3 libfuse3-dev     # Debian/Ubuntu
+   sudo dnf install fuse3 fuse3-devel          # Fedora/RHEL
+   ```
+
+3. **No special `/etc/fuse.conf` configuration is required for the
+   default mount.** The shell uses `Owner`-scoped ACL (the kernel
+   gates access to the mountpoint at the user level), so
+   `user_allow_other` is not needed. If you want to allow other
+   local users (or root) to read into the mount — uncommon for
+   heddle's single-user workflow — that's where `user_allow_other`
+   in `/etc/fuse.conf` comes in, paired with explicit
+   `MountOption::AllowOther` / `AllowRoot` in
+   [`crate::fuse::default_config`]. The default shell does *not*
+   enable `AutoUnmount` for this reason: fuser 0.17 rejects
+   `AutoUnmount` without `AllowOther`/`AllowRoot`, and we'd rather
+   require an explicit unmount path than depend on host-level
+   policy.
+
+4. **The `fuse` cargo feature**, propagated through
+   `heddle-cli`'s `mount` feature.
+
+### Cleaning up a stale FUSE mount
+
+The clean-shutdown path is a `BackgroundSession::drop` (the CLI's
+`MountHandle::unmount`). If the daemon is `kill -9`'d or the
+session is leaked, the mount lingers — userspace sees the
+content-addressed view, but no daemon is answering. To clear:
+
+```bash
+fusermount3 -u <mountpoint>
+```
+
+If `fusermount3 -u` fails with `Device or resource busy`, kill any
+process with a working directory or open file descriptor under the
+mountpoint (`lsof <mountpoint>`), then retry. As a last resort,
+`umount -l <mountpoint>` does a lazy detach — the kernel hides the
+mount from new accesses while waiting for outstanding handles to
+close.
+
+### Errno mapping
+
+The shell translates a `MountError` into a kernel-replied errno via
+[`crate::error::MountError::to_errno`]. Today's mapping:
+
+| `MountError` variant | errno     | Surfaced as |
+|----------------------|-----------|-------------|
+| `NotFound`           | `ENOENT`  | "No such file or directory" |
+| `UnknownThread`      | `ENOENT`  | (a thread name we can't resolve looks like a path miss to userspace) |
+| `Stale`              | `ESTALE`  | "Stale file handle" — usually the inode was invalidated mid-flight |
+| `NotADirectory`      | `ENOTDIR` | "Not a directory" |
+| `ReadOnly`           | `EROFS`   | "Read-only file system" |
+| `Store(NotFound)`    | `ENOENT`  | underlying object missing |
+| `Store(Io)`          | passthrough | the wrapped `std::io::Error`'s `raw_os_error()` if present, else `EIO` |
+| `Store(_)`           | `EIO`     | "Input/output error" — generic catch-all for unmapped object-store errors |
+
+Any panic deep in a `PlatformShell` call surfaces to userspace as
+`EIO` (the FUSE shell wraps each callback in `guard_call`; see
+[`crate::fuse`] module docs). Without that guard, a single panic in
+a worker thread would either wedge the mount (kernel waits for
+replies that never come) or — post Rust 1.81 — abort the daemon
+process across an `extern "C"` boundary inside `fuser`. The
+`fuse::tests::guard_call_translates_panic_to_eio` test pins the
+contract.
+
+### Platform feature parity
+
+The Linux FUSE shell, macOS FSKit shell, and Windows ProjFS shell
+all share the same [`PlatformShell`] core, so the set of
+**heddle-visible** operations is identical across platforms:
+`lookup`, `read`, `write`, `enumerate`, `attrs`, `flush`, `release`,
+`invalidate`. What differs is the **kernel-side capabilities** each
+backend exposes to userspace:
+
+| Capability             | FUSE (Linux)         | FSKit (macOS)        | ProjFS (Windows)     |
+|------------------------|----------------------|----------------------|----------------------|
+| Per-write callbacks    | yes                  | yes                  | no (close-time only) |
+| Extended attributes    | not wired            | not wired            | n/a                  |
+| `mkdir` / `create`     | not wired (ENOSYS)   | not wired            | not wired            |
+| `setattr(size)` (O_TRUNC) | not wired (ENOSYS)   | not wired            | n/a                  |
+| Symlink readback       | works (read-only)    | works (read-only)    | works (read-only)    |
+| ACLs / chmod through mount | not honored      | not honored          | n/a                  |
+| Auto-unmount on daemon death | off by default | n/a                  | n/a                  |
+| Panic-recovery in callbacks | yes (`guard_call`) | yes (`guarded_c_int`) | yes (`guarded_hresult`) |
+
+"Not wired" means heddle's adapter doesn't override the framework's
+default — typically `ENOSYS`. Wiring an op is a matter of
+implementing the relevant trait method *and* adding a
+[`PlatformShell`] hook for it; the existing seven ops are sufficient
+for the daily "mount → read → edit-existing-file → capture" loop
+that drives the 2-day milestone.
+
 ## macOS install requirements (FSKit)
 
 The FSKit shell needs:
@@ -89,7 +194,11 @@ is set, so a generic CI runner won't fail on it accidentally.
 ## Status
 
 - Linux FUSE shell: production. Used by the heddle CLI when
-  `--features mount` is enabled.
+  `--features mount` is enabled. Production hardening (panic
+  recovery in every callback, write-through-mount round-trip,
+  concurrent-read smoke, clean unmount on drop) is locked in by
+  the `fuse-smoke` CI matrix entry; see
+  `.github/workflows/rust-tests.yml` and `tests/fuse_mount.rs`.
 - macOS FSKit shell: scaffolded. The C ABI between the Swift
   adapter and the Rust trampolines is wired end-to-end; the
   `PlatformShell` dispatch is exercised by the unit test. The

--- a/crates/mount/README.md
+++ b/crates/mount/README.md
@@ -71,6 +71,20 @@ needs:
 4. **The `fuse` cargo feature**, propagated through
    `heddle-cli`'s `mount` feature.
 
+5. **Linux 5.16+ for shared `mmap` on mounted files.** The shell
+   hands back `FOPEN_DIRECT_IO` on every `open` so kernel page-cache
+   reads don't shadow hot-tier writes (see
+   [`crate::fuse::FuseShell::open`]). Under default kernel semantics
+   that disables `mmap(MAP_SHARED, ...)` on every fd — calls return
+   `ENODEV`. The shell opts out of that restriction by requesting
+   the `FUSE_DIRECT_IO_ALLOW_MMAP` capability in `init`; the kernel
+   bit was added in 5.16. On older kernels the cap is silently
+   dropped and shared mmap fails with `ENODEV` — rust-analyzer,
+   cargo (when reading dep-info files via `mmap`), IDEs, and
+   `grep --mmap` will misbehave on heddle-mounted trees. The mount
+   itself still works; only the mmap path is affected. Upgrade the
+   kernel or use clients that fall back to `read(2)`.
+
 ### Cleaning up a stale FUSE mount
 
 The clean-shutdown path is a `BackgroundSession::drop` (the CLI's
@@ -130,6 +144,7 @@ backend exposes to userspace:
 | `mkdir` / `create`     | not wired (ENOSYS)   | not wired            | not wired            |
 | `setattr(size)` (O_TRUNC) | not wired (ENOSYS)   | not wired            | n/a                  |
 | Symlink readback       | works (read-only)    | works (read-only)    | works (read-only)    |
+| Shared `mmap` on mounted files | yes (kernel 5.16+; falls back to ENODEV on older kernels) | yes (UBC-backed) | yes (projected files are physical on the volume) |
 | ACLs / chmod through mount | not honored      | not honored          | n/a                  |
 | Auto-unmount on daemon death | off by default | n/a                  | n/a                  |
 | Panic-recovery in callbacks | yes (`guard_call`) | yes (`guarded_c_int`) | yes (`guarded_hresult`) |

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -59,8 +59,8 @@ use std::{
     ffi::{OsStr, OsString},
     path::{Component, Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
         Arc, Mutex, RwLock, Weak,
+        atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
     },
     thread::JoinHandle,
     time::{Duration, Instant, SystemTime},
@@ -609,8 +609,7 @@ fn prewarm_run(weak: Weak<MountInner>, cancel: Arc<AtomicBool>) -> PrewarmStats 
     let mut hashes: Vec<ContentHash> = Vec::new();
     let root_tree = inner.state.read().expect("mount state lock").tree;
     let mut queue: VecDeque<ContentHash> = VecDeque::from([root_tree]);
-    let mut seen_trees: std::collections::HashSet<ContentHash> =
-        std::collections::HashSet::new();
+    let mut seen_trees: std::collections::HashSet<ContentHash> = std::collections::HashSet::new();
     while let Some(tree_hash) = queue.pop_front() {
         if cancel.load(Ordering::Relaxed) {
             return stats;
@@ -1205,7 +1204,6 @@ impl ContentAddressedMount {
         }
         out.into_iter().collect()
     }
-
 }
 
 /// Copy `[offset, offset+buf.len())` from `src` into `buf`, returning
@@ -1222,6 +1220,24 @@ fn copy_into(src: &[u8], offset: u64, buf: &mut [u8]) -> usize {
     let take = std::cmp::min(buf.len(), src.len() - offset);
     buf[..take].copy_from_slice(&src[offset..offset + take]);
     take
+}
+
+/// Pending-tier overlay for a captured-tree path. Consumed by `read`
+/// to decide whether to serve the captured blob (`None` returned by
+/// the lookup) or the pending overlay's bytes.
+enum Overlay {
+    /// In-flight hot buffer keyed at a sibling NodeId for the same
+    /// path — typically a coalesced write through a different inode
+    /// number than the captured `File` record.
+    Hot(Vec<u8>),
+    /// Promoted warm-tier blob. Same path now points at this blob in
+    /// the pending tier; the captured `File` record's blob is
+    /// effectively stale until capture folds the warm tier in.
+    Warm(ContentHash),
+    /// Tombstoned through the mount. The kernel will get a stale
+    /// inode reply; subsequent dentry refresh resolves the entry as
+    /// gone.
+    Gone,
 }
 
 /// What `pending_lookup` found at a given path.
@@ -1501,7 +1517,49 @@ impl PlatformShell for ContentAddressedMount {
                     ))),
                 }
             }
-            NodeRecord::File { blob, .. } | NodeRecord::Symlink { blob } => {
+            NodeRecord::File { blob, path, .. } => {
+                // A captured-tree file whose path now has a pending
+                // overlay (hot buffer on a sibling NodeId, warm-tier
+                // promotion, or tombstone) must serve the overlay,
+                // not the captured blob. Without this, a FUSE
+                // `write → flush → read` round-trip through the
+                // *same* kernel-cached NodeId silently returns the
+                // pre-write bytes (the kernel reuses its dentry for
+                // the duration of the entry TTL and never re-issues
+                // `lookup`, so the inode record is never refreshed
+                // from `File` to `PendingFile`).
+                //
+                // Priority: hot @ another NodeId → warm → tombstone
+                // (ENOENT-shaped Stale) → captured blob.
+                let overlay = {
+                    let pending = self.inner.pending.lock().expect("pending lock");
+                    if pending.tombstones.contains(path) {
+                        Some(Overlay::Gone)
+                    } else if let Some(other_id) = pending.hot_by_path.get(path).copied()
+                        && let Some(hot) = pending.hot.get(&other_id)
+                    {
+                        Some(Overlay::Hot(hot.bytes.clone()))
+                    } else {
+                        pending.warm.get(path).map(|warm| Overlay::Warm(warm.blob))
+                    }
+                };
+                match overlay {
+                    Some(Overlay::Gone) => Err(MountError::Stale(format!(
+                        "file {} was unlinked through the mount",
+                        path.display()
+                    ))),
+                    Some(Overlay::Hot(bytes)) => Ok(copy_into(&bytes, offset, buf)),
+                    Some(Overlay::Warm(blob)) => {
+                        let bytes = self.load_blob_bytes(&blob)?;
+                        Ok(copy_into(&bytes, offset, buf))
+                    }
+                    None => {
+                        let bytes = self.load_blob_bytes(blob)?;
+                        Ok(copy_into(&bytes, offset, buf))
+                    }
+                }
+            }
+            NodeRecord::Symlink { blob } => {
                 let bytes = self.load_blob_bytes(blob)?;
                 Ok(copy_into(&bytes, offset, buf))
             }
@@ -1763,17 +1821,44 @@ impl PlatformShell for ContentAddressedMount {
                 // pending tier. Size = direct-child count.
                 (self.pending_children_at(path).len() as u64, 2)
             }
-            NodeRecord::File { blob, .. } | NodeRecord::Symlink { blob } => {
-                // Hot buffer overrides the captured size if the agent
-                // is currently editing this file via this NodeId.
-                let pending = self.inner.pending.lock().expect("pending lock");
-                if let Some(buf) = pending.hot.get(&node.0) {
-                    (buf.bytes.len() as u64, 1)
-                } else {
-                    drop(pending);
-                    (self.blob_size(blob)?, 1)
+            NodeRecord::File { blob, path, .. } => {
+                // Same overlay priority as `read`: hot @ this NodeId
+                // → hot @ another NodeId for the same path → warm-tier
+                // promotion → tombstone (stale) → captured blob.
+                // Keeping `attrs` and `read` symmetric is mandatory:
+                // `read` consults the warm tier for captured files
+                // (so `WORLD` shadows `world`), and a stale `attrs`
+                // that still reports the captured size would clip the
+                // returned bytes in the kernel's read buffer.
+                let overlay_size = {
+                    let pending = self.inner.pending.lock().expect("pending lock");
+                    if let Some(buf) = pending.hot.get(&node.0) {
+                        Some(Some(buf.bytes.len() as u64))
+                    } else if pending.tombstones.contains(path) {
+                        // Tombstoned via the mount: treat as
+                        // not-yet-collected. The path is gone but the
+                        // inode is still registered.
+                        Some(None)
+                    } else if let Some(other_id) = pending.hot_by_path.get(path).copied()
+                        && let Some(hot) = pending.hot.get(&other_id)
+                    {
+                        Some(Some(hot.bytes.len() as u64))
+                    } else {
+                        pending.warm.get(path).map(|warm| Some(warm.size))
+                    }
+                };
+                match overlay_size {
+                    Some(Some(size)) => (size, 1),
+                    Some(None) => {
+                        return Err(MountError::Stale(format!(
+                            "file {} was unlinked through the mount",
+                            path.display()
+                        )));
+                    }
+                    None => (self.blob_size(blob)?, 1),
                 }
             }
+            NodeRecord::Symlink { blob } => (self.blob_size(blob)?, 1),
             NodeRecord::PendingFile { path, .. } => {
                 let hit = self
                     .pending_lookup(path)

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -7,18 +7,46 @@
 //! are buffered in the core's hot tier, promoted to CAS on `flush`
 //! /`release`, and folded into a real heddle state by
 //! [`ContentAddressedMount::capture`].
+//!
+//! ## Panic safety
+//!
+//! Every callback body runs inside [`std::panic::catch_unwind`] via
+//! the [`guarded`] helpers below. A panic deep in the
+//! [`PlatformShell`] dispatch (poisoned mutex, integer overflow,
+//! `unwrap()` on a freshly-evicted cache entry) translates to a
+//! single `reply.error(EIO)` for the offending operation instead of
+//! one of two production-hostile outcomes:
+//!
+//!  1. **Lost worker thread.** `fuser` spawns one worker per session
+//!     (or a small pool for multi-threaded mode) and dispatches
+//!     callbacks on it. A panic that escapes the callback unwinds
+//!     out of the worker, terminating it. The kernel side keeps
+//!     waiting for replies that will never come — userspace
+//!     processes accessing the mount block until `fusermount -u` or
+//!     a `SIGKILL` of the FUSE driver. The remaining mounts hosted
+//!     by `heddled` keep serving, but this one wedges.
+//!  2. **Process abort (Rust ≥1.81).** `fuser`'s reply path goes
+//!     through `extern "C"` shims internally. A panic that unwinds
+//!     across that boundary aborts the process — taking every
+//!     mount, daemon worker, and unsaved hot-tier buffer with it.
+//!
+//! The FSKit shell hits the same risk and uses the same fix
+//! ([`crate::fskit::guarded_c_int`]). Keeping the two adapters
+//! symmetric means a panic in shared core code can't take down one
+//! platform while sparing the other.
 
 use std::{
     ffi::OsStr,
+    panic::AssertUnwindSafe,
     path::Path,
     sync::Arc,
     time::{Duration, UNIX_EPOCH},
 };
 
 use fuser::{
-    BackgroundSession, Config, Errno, FileAttr, FileHandle, FileType, Filesystem, Generation,
-    INodeNo, LockOwner, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEmpty,
-    ReplyEntry, ReplyWrite, Request, Session, WriteFlags,
+    BackgroundSession, Config, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
+    Generation, INodeNo, LockOwner, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory,
+    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request, Session, WriteFlags,
 };
 use tracing::warn;
 
@@ -83,13 +111,51 @@ fn default_config() -> Config {
     // `Config` is `#[non_exhaustive]` so we mutate a `Default` value
     // instead of constructing fields directly — that keeps us
     // forward-compatible with future Config additions.
+    //
+    // We deliberately do *not* set `AutoUnmount`: fuser 0.17 rejects
+    // `AutoUnmount` unless the session ACL is `AllowOther` or
+    // `AllowRoot`, which in turn requires `user_allow_other` in
+    // `/etc/fuse.conf` on most distros. That's a host-side gate we
+    // can't assume — and for heddle's single-user-mount model
+    // `Owner`-scoped ACLs are correct anyway. Clean unmount on
+    // `BackgroundSession::drop` is the real safety net (see
+    // [`crate::fuse::FuseShell::mount_background`]); for the
+    // `kill -9 heddled` case operators run `fusermount3 -u
+    // <mountpoint>` to clear the stale mount.
+    //
+    // See `crates/mount/README.md` for the full operational note.
+    //
+    // We also deliberately do *not* set `DefaultPermissions`. That
+    // option tells the kernel to enforce the unix-mode bits we hand
+    // back in `getattr` against the caller's uid/gid. Heddle mounts
+    // are single-user (the default `Owner` ACL already gates the
+    // mountpoint at the kernel boundary — only the mount-owner and
+    // root can `open(2)` anything underneath), so a second layer of
+    // mode-based checks adds nothing and *blocks* writes: the
+    // mount's captured-tree files report `mode 0644 uid 0 gid 0`,
+    // and a non-root mount-owner would fail the kernel's permission
+    // check with `EACCES`. Letting the FUSE-side
+    // [`PlatformShell::write`] decide what's permitted matches the
+    // FSKit / ProjFS shells and the daily-use shape we want.
     let mut config = Config::default();
-    config.mount_options = vec![
-        MountOption::FSName("heddle-mount".into()),
-        MountOption::AutoUnmount,
-        MountOption::DefaultPermissions,
-    ];
+    config.mount_options = vec![MountOption::FSName("heddle-mount".into())];
     config
+}
+
+/// The uid/gid the shell reports for every node it serves. Resolved
+/// once per process: heddle mounts are single-user and the mount
+/// owner is by definition the process owner. Reporting the caller's
+/// actual uid keeps `ls -l` from showing `0 0` for every file
+/// (cosmetic, but the kind of cosmetic that has tripped operators
+/// expecting "owned by me" semantics).
+fn process_uid() -> u32 {
+    // SAFETY: `getuid` is async-signal-safe and has no preconditions.
+    unsafe { libc::getuid() }
+}
+
+fn process_gid() -> u32 {
+    // SAFETY: `getgid` is async-signal-safe and has no preconditions.
+    unsafe { libc::getgid() }
 }
 
 fn file_type_for_kind(kind: NodeKind) -> FileType {
@@ -115,8 +181,8 @@ fn file_attr_from(attrs: Attrs) -> FileAttr {
         // just the permission bits in `perm`.
         perm: (attrs.unix_mode & 0o7777) as u16,
         nlink: attrs.nlink,
-        uid: 0,
-        gid: 0,
+        uid: process_uid(),
+        gid: process_gid(),
         rdev: 0,
         blksize: 4096,
         flags: 0,
@@ -135,8 +201,8 @@ fn entry_attr_from(entry: &Entry, mtime: std::time::SystemTime) -> FileAttr {
         kind: file_type_for_kind(entry.kind),
         perm: (entry.unix_mode & 0o7777) as u16,
         nlink: 1,
-        uid: 0,
-        gid: 0,
+        uid: process_uid(),
+        gid: process_gid(),
         rdev: 0,
         blksize: 4096,
         flags: 0,
@@ -151,26 +217,96 @@ fn errno_from_mount_error(err: crate::error::MountError) -> Errno {
     Errno::from_i32(err.to_errno())
 }
 
+/// Run `f` and translate the outcome into either the trait result or
+/// a kernel-replied errno. Catches panics so a buggy inner call can't
+/// kill the FUSE worker (which would wedge every userspace process
+/// holding the mount) or — worse, post Rust 1.81 — abort the whole
+/// daemon process across an `extern "C"` frame inside `fuser`.
+///
+/// `AssertUnwindSafe` is sound here: the closure borrows only the
+/// `Arc<ContentAddressedMount>` (whose interior is `Mutex` / `RwLock`-
+/// guarded and tolerates poisoning at construction sites), and any
+/// outparams it would write live behind the `Reply*` types — which
+/// we deliberately do not touch on the error path, leaving them to
+/// the single `reply.error(...)` below.
+fn guard_call<T>(label: &'static str, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    match std::panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let msg = panic_payload_str(&payload);
+            tracing::error!(callback = label, %msg, "FUSE callback panicked; returning EIO");
+            Err(crate::error::MountError::Store(
+                objects::error::HeddleError::Io(std::io::Error::other(format!(
+                    "panic in FUSE {label}: {msg}"
+                ))),
+            ))
+        }
+    }
+}
+
+fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
 impl Filesystem for FuseShell {
+    fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        // Open every file in `direct_io` mode so the kernel never
+        // serves bytes from its page cache. The content-addressed
+        // mount maintains its own blob cache ([`BlobCachePool`]),
+        // which already deduplicates repeated reads against the
+        // captured tree — so the kernel-side page cache wins us
+        // nothing, and *costs* correctness on the write-then-read
+        // path:
+        //
+        // Without `direct_io`, after a captured file is opened-for-
+        // write, mutated, closed (→ `flush` promotes the hot tier
+        // into the warm tier), and reopened, the kernel happily
+        // serves the *pre-write* bytes from its page cache. The
+        // dentry/inode caching at our 1-second TTL doesn't help —
+        // the page cache is keyed off the kernel-side inode, and
+        // the kernel has no way to know we replaced the blob behind
+        // it. `direct_io` short-circuits the page cache entirely;
+        // every kernel `read(2)` becomes a FUSE `read` callback,
+        // which we serve from the hot-tier-then-warm-tier-then-
+        // captured-blob priority chain.
+        //
+        // FH=0 mirrors the fuser default (we don't track per-handle
+        // state — open files identify by inode in [`PlatformShell`]).
+        reply.opened(FileHandle(0), FopenFlags::FOPEN_DIRECT_IO);
+    }
+
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
-        match self.inner.lookup(NodeId(parent.0), name) {
-            Ok(Some(entry)) => {
-                // Ask the core for canonical attrs (it already loaded
-                // the blob in `lookup`, so this is a hash-table hit).
-                let mtime = match self.inner.attrs(entry.node) {
-                    Ok(a) => a.mtime,
-                    Err(_) => UNIX_EPOCH,
-                };
-                let attr = entry_attr_from(&entry, mtime);
-                reply.entry(&TTL, &attr, GENERATION);
+        let result = guard_call("lookup", || {
+            let entry = self.inner.lookup(NodeId(parent.0), name)?;
+            match entry {
+                None => Ok(None),
+                Some(entry) => {
+                    // Ask the core for canonical attrs (it already loaded
+                    // the blob in `lookup`, so this is a hash-table hit).
+                    let mtime = self
+                        .inner
+                        .attrs(entry.node)
+                        .map(|a| a.mtime)
+                        .unwrap_or(UNIX_EPOCH);
+                    Ok(Some(entry_attr_from(&entry, mtime)))
+                }
             }
+        });
+        match result {
+            Ok(Some(attr)) => reply.entry(&TTL, &attr, GENERATION),
             Ok(None) => reply.error(Errno::ENOENT),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
 
     fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
-        match self.inner.attrs(NodeId(ino.0)) {
+        match guard_call("getattr", || self.inner.attrs(NodeId(ino.0))) {
             Ok(attrs) => reply.attr(&TTL, &file_attr_from(attrs)),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
@@ -187,9 +323,14 @@ impl Filesystem for FuseShell {
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
-        let mut buf = vec![0u8; size as usize];
-        match self.inner.read(NodeId(ino.0), offset, &mut buf) {
-            Ok(n) => reply.data(&buf[..n]),
+        let result = guard_call("read", || {
+            let mut buf = vec![0u8; size as usize];
+            let n = self.inner.read(NodeId(ino.0), offset, &mut buf)?;
+            buf.truncate(n);
+            Ok(buf)
+        });
+        match result {
+            Ok(buf) => reply.data(&buf),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
@@ -202,25 +343,33 @@ impl Filesystem for FuseShell {
         offset: u64,
         mut reply: ReplyDirectory,
     ) {
-        let entries = match self.inner.enumerate(NodeId(ino.0)) {
-            Ok(e) => e,
+        // Precompute the full vec inside the panic guard. The `reply.add`
+        // loop below is infallible and can't panic — leaving it outside
+        // the guard means a torn buffer state on partial-fill never
+        // matters.
+        let prepared = guard_call("readdir", || {
+            let entries = self.inner.enumerate(NodeId(ino.0))?;
+            let mut all: Vec<(u64, FileType, std::ffi::OsString)> =
+                Vec::with_capacity(entries.len() + 2);
+            all.push((ino.0, FileType::Directory, ".".into()));
+            all.push((ino.0, FileType::Directory, "..".into()));
+            for entry in entries {
+                all.push((entry.node.0, file_type_for_kind(entry.kind), entry.name));
+            }
+            Ok(all)
+        });
+        let all = match prepared {
+            Ok(v) => v,
             Err(err) => {
                 reply.error(errno_from_mount_error(err));
                 return;
             }
         };
 
-        // FUSE expects `.` and `..` first, then the actual entries.
-        // The `offset` is opaque-but-monotonic; we just use index+1
-        // as the next-offset cookie, which is the standard recipe.
-        let mut all: Vec<(u64, FileType, std::ffi::OsString)> =
-            Vec::with_capacity(entries.len() + 2);
-        all.push((ino.0, FileType::Directory, ".".into()));
-        all.push((ino.0, FileType::Directory, "..".into()));
-        for entry in entries {
-            all.push((entry.node.0, file_type_for_kind(entry.kind), entry.name));
-        }
-
+        // FUSE expects `.` and `..` first (already prepended), then the
+        // actual entries. `offset` is opaque-but-monotonic; we use
+        // `index+1` as the next-offset cookie, which is the standard
+        // recipe.
         for (i, (child_ino, kind, name)) in all.into_iter().enumerate().skip(offset as usize) {
             let next_offset = (i + 1) as u64;
             if reply.add(INodeNo(child_ino), next_offset, kind, &name) {
@@ -244,7 +393,7 @@ impl Filesystem for FuseShell {
         _lock_owner: Option<LockOwner>,
         reply: ReplyWrite,
     ) {
-        match self.inner.write(NodeId(ino.0), offset, data) {
+        match guard_call("write", || self.inner.write(NodeId(ino.0), offset, data)) {
             Ok(n) => reply.written(n as u32),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
@@ -260,7 +409,7 @@ impl Filesystem for FuseShell {
     ) {
         // Flush fires on `close(2)` from userspace. This is the
         // natural place to promote the hot buffer to CAS.
-        match self.inner.flush(NodeId(ino.0)) {
+        match guard_call("flush", || self.inner.flush(NodeId(ino.0))) {
             Ok(()) => reply.ok(),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
@@ -279,7 +428,7 @@ impl Filesystem for FuseShell {
         // Belt-and-braces: a process that exits without an explicit
         // close still gets a release on the inode. Promote any
         // surviving buffer.
-        match self.inner.release(NodeId(ino.0)) {
+        match guard_call("release", || self.inner.release(NodeId(ino.0))) {
             Ok(()) => reply.ok(),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
@@ -292,5 +441,62 @@ impl Filesystem for FuseShell {
             thread = %self.inner.thread(),
             "fuse mount destroyed"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::mocks::PanicShell;
+
+    /// A panic in `guard_call`'s closure must translate to an `Err`
+    /// with a usable errno, not unwind out of the callback. The FUSE
+    /// dispatcher relies on this so a poisoned mutex deep in the core
+    /// can't either (a) kill the fuser worker thread (wedging every
+    /// userspace process holding the mount) or (b) abort the daemon
+    /// process via Rust ≥1.81's "no unwind across extern C" rule —
+    /// `fuser` has extern C shims internally on the reply path.
+    ///
+    /// We exercise `guard_call` directly rather than driving the full
+    /// `Filesystem::lookup` path because constructing a fuser
+    /// `ReplyEntry` requires a private channel handle. The translation
+    /// is the part that needs locking down; the trait dispatch is
+    /// straight-line code around it.
+    #[test]
+    fn guard_call_translates_panic_to_eio() {
+        let result: Result<()> = guard_call("test", || {
+            // Panic from the same shape of bug a real shell could
+            // raise — a poisoned mutex unwrap inside core dispatch.
+            panic!("simulated mutex poison");
+        });
+        let err = result.expect_err("expected guard_call to return Err on panic");
+        assert_eq!(
+            err.to_errno(),
+            libc::EIO,
+            "panic must translate to EIO, got errno {} ({err})",
+            err.to_errno()
+        );
+    }
+
+    /// And the happy path: a successful inner call passes through
+    /// unchanged.
+    #[test]
+    fn guard_call_passes_through_ok() {
+        let result: Result<i32> = guard_call("test", || Ok(42));
+        assert_eq!(result.expect("ok"), 42);
+    }
+
+    /// A `PlatformShell` that panics on every operation must surface
+    /// as `Err(MountError)` with errno `EIO` when driven through
+    /// `guard_call`. This is the FUSE-side analogue of the FSKit
+    /// `trampoline_lookup_recovers_eio_on_panic` test and locks in
+    /// cross-platform parity: a future change to either shell that
+    /// breaks panic recovery must trip one of these two tests.
+    #[test]
+    fn panic_shell_dispatch_yields_eio() {
+        let shell = Arc::new(PanicShell) as Arc<dyn PlatformShell + Send + Sync>;
+        let result: Result<usize> = guard_call("read", || shell.read(NodeId(1), 0, &mut [0u8; 4]));
+        let err = result.expect_err("expected PanicShell to panic");
+        assert_eq!(err.to_errno(), libc::EIO);
     }
 }

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -45,10 +45,11 @@ use std::{
 
 use fuser::{
     BackgroundSession, Config, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
-    Generation, INodeNo, LockOwner, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory,
-    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request, Session, WriteFlags,
+    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, MountOption, OpenFlags, ReplyAttr,
+    ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request, Session,
+    WriteFlags,
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     core::ContentAddressedMount,
@@ -255,6 +256,32 @@ fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
 }
 
 impl Filesystem for FuseShell {
+    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> std::io::Result<()> {
+        // Opt into `FUSE_DIRECT_IO_ALLOW_MMAP`. We hand back
+        // `FOPEN_DIRECT_IO` from `open` (see the comment there), and
+        // under default kernel semantics that disables shared `mmap`
+        // on every fd — calls to `mmap(MAP_SHARED, ...)` return
+        // `ENODEV`. The kernel cap added in 5.16 keeps direct-IO
+        // bypass for `read(2)`/`write(2)` but re-enables shared mmap,
+        // which is the daily-use path for rust-analyzer, cargo, IDEs,
+        // and `grep --mmap` on heddle-mounted trees.
+        //
+        // `add_capabilities` errors when the kernel is < 5.16 (the
+        // bit wasn't defined). That's not fatal — older kernels just
+        // get the pre-cap behaviour (no shared mmap), which is the
+        // same shape r1 of this fix shipped with. Log it once at
+        // mount time so operators on old kernels can correlate
+        // `ENODEV` from a mapping syscall with the missing cap.
+        if let Err(unsupported) = config.add_capabilities(InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP) {
+            debug!(
+                ?unsupported,
+                "kernel does not support FUSE_DIRECT_IO_ALLOW_MMAP (requires 5.16+); \
+                 shared mmap on mounted files will fail with ENODEV"
+            );
+        }
+        Ok(())
+    }
+
     fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         // Open every file in `direct_io` mode so the kernel never
         // serves bytes from its page cache. The content-addressed
@@ -275,6 +302,15 @@ impl Filesystem for FuseShell {
         // every kernel `read(2)` becomes a FUSE `read` callback,
         // which we serve from the hot-tier-then-warm-tier-then-
         // captured-blob priority chain.
+        //
+        // The kernel's default rule for direct-IO files is "no shared
+        // mmap" (the page cache is the mapping substrate; bypass it
+        // and `mmap(MAP_SHARED, ...)` returns `ENODEV`). We opt out
+        // of that rule by requesting `FUSE_DIRECT_IO_ALLOW_MMAP` in
+        // [`Self::init`] — on Linux 5.16+ the kernel keeps the
+        // direct-IO bypass for `read`/`write` but lets shared mmap
+        // through, which is the daily-use path for rust-analyzer,
+        // cargo, IDEs, and `grep --mmap` on heddle-mounted trees.
         //
         // FH=0 mirrors the fuser default (we don't track per-handle
         // state — open files identify by inode in [`PlatformShell`]).

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -11,8 +11,8 @@ use std::{
     ffi::OsStr,
     fs,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -31,13 +31,15 @@ use crate::{
 };
 
 /// Shared test mocks. Lives under `tests::mocks` so the per-platform
-/// adapter unit tests (FSKit on macOS, ProjFS on Windows) can reuse
-/// the same in-memory shell without duplicating it inline.
+/// adapter unit tests (FUSE on Linux, FSKit on macOS, ProjFS on
+/// Windows) can reuse the same in-memory shell without duplicating
+/// it inline.
 ///
 /// Gated on the features that actually consume the mocks so OSS-only
-/// Linux builds (no `fskit` / `projfs`) don't trip clippy's
+/// builds (no `fuse` / `fskit` / `projfs`) don't trip clippy's
 /// `-D warnings` on dead test code.
 #[cfg(any(
+    all(target_os = "linux", feature = "fuse"),
     all(target_os = "macos", feature = "fskit"),
     all(target_os = "windows", feature = "projfs"),
 ))]
@@ -45,15 +47,15 @@ pub(crate) mod mocks {
     use std::{
         ffi::OsStr,
         sync::{
-            atomic::{AtomicUsize, Ordering},
             Arc,
+            atomic::{AtomicUsize, Ordering},
         },
         time::UNIX_EPOCH,
     };
 
     use crate::{
         error::{MountError, Result},
-        shell::{Attrs, Entry, NodeId, NodeKind, PlatformShell, DIR_UNIX_MODE},
+        shell::{Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell},
     };
 
     /// Trivial in-memory shell that lets adapter unit tests validate
@@ -63,10 +65,17 @@ pub(crate) mod mocks {
     /// Increments `drops` exactly once when the shell is finally
     /// dropped, so a test that boxes the shell into a C ABI handle can
     /// assert the box was reclaimed.
+    ///
+    /// `dead_code` is silenced because this is only consumed by the
+    /// FSKit / ProjFS unit tests — the FUSE shell tests use
+    /// [`PanicShell`] but never [`CountingShell`], and clippy's
+    /// `-D warnings` would otherwise fail the Linux+fuse build.
+    #[allow(dead_code)]
     pub struct CountingShell {
         pub drops: Arc<AtomicUsize>,
     }
 
+    #[allow(dead_code)]
     impl CountingShell {
         pub fn new() -> (Self, Arc<AtomicUsize>) {
             let drops = Arc::new(AtomicUsize::new(0));
@@ -650,6 +659,49 @@ fn flush_promotes_buffer_to_warm_tier() {
     let warm = mount.warm_keys();
     assert_eq!(warm.len(), 1);
     assert_eq!(warm[0], std::path::PathBuf::from("out.txt"));
+}
+
+#[test]
+fn captured_file_read_after_flush_through_same_node_id_serves_overlay() {
+    // Regression: the FUSE shell reuses the NodeId the kernel cached
+    // for a captured-tree file across the open → write → close →
+    // reopen → read cycle (FUSE's dentry TTL keeps the dentry alive
+    // for the cache window, so the kernel never re-issues `lookup`).
+    // The core's `read` must therefore consult the pending overlay
+    // for a `NodeRecord::File`'s path before falling back to the
+    // captured blob — otherwise post-flush reads through the same
+    // NodeId silently return the *pre*-write bytes and "write through
+    // the mount" looks broken from userspace.
+    //
+    // The companion `lookup_after_write_serves_new_content` test
+    // doesn't trip this because it re-resolves via `lookup_path`
+    // after the flush, which refreshes the inode record. Real FUSE
+    // dispatchers don't do that re-resolution — the kernel does.
+    let (_temp, mount) = open_mount();
+    let node = mount.lookup_path("hello.txt").unwrap();
+
+    // Sanity: pre-write content from the captured tree.
+    let mut buf = vec![0u8; 64];
+    let n = mount.read(node, 0, &mut buf).unwrap();
+    assert_eq!(&buf[..n], b"world");
+
+    // Write through the *captured* file's NodeId, flush to warm.
+    mount.write(node, 0, b"WORLD").unwrap();
+    mount.flush(node).unwrap();
+
+    // Re-read via the same NodeId — no fresh `lookup_path` call.
+    let mut buf = vec![0u8; 64];
+    let n = mount.read(node, 0, &mut buf).unwrap();
+    assert_eq!(
+        &buf[..n],
+        b"WORLD",
+        "captured-file read after flush must serve warm tier, not captured blob"
+    );
+    let attrs = mount.attrs(node).unwrap();
+    assert_eq!(
+        attrs.size, 5,
+        "captured-file attrs after flush must reflect warm-tier size"
+    );
 }
 
 #[test]

--- a/crates/mount/tests/fuse_mount.rs
+++ b/crates/mount/tests/fuse_mount.rs
@@ -1,50 +1,226 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Linux end-to-end mount test.
+//! Linux end-to-end mount tests.
 //!
-//! Marked `#[ignore]` so CI doesn't auto-run it: FUSE needs a working
-//! `fuse` kernel module + the `fusermount3` binary on PATH, and that
-//! isn't a fair assumption for a generic CI runner. To run:
+//! Marked `#[ignore]` so the default `cargo test` invocation doesn't
+//! auto-run them: FUSE needs a working `fuse` kernel module + the
+//! `fusermount3` binary on PATH, and that isn't a fair assumption for
+//! a generic CI runner. CI opts in explicitly via the `fuse-smoke`
+//! matrix entry in `.github/workflows/rust-tests.yml`, which installs
+//! `fuse3 libfuse3-dev` first and then runs:
 //!
 //! ```bash
-//! cargo test -p mount --features fuse --test fuse_mount -- --ignored
+//! cargo test -p heddle-mount --features fuse --test fuse_mount -- --ignored
 //! ```
+//!
+//! Local invocation matches CI. If a test wedges, `fusermount3 -u
+//! <mountpoint>` from outside (or rebooting the runner) clears the
+//! kernel side; the per-test `TempDir` will be reaped by the OS even
+//! if the mount lingered.
+//!
+//! ## What each test locks in
+//!
+//! * [`fuse_mount_serves_blob_content`] — the load-bearing daily-use
+//!   smoke. Snapshot a file → mount → read via `std::fs::read_to_string`
+//!   → assert exact content → drop session.
+//! * [`fuse_mount_round_trips_writes_to_existing_file`] — write path.
+//!   Captures a file, mounts, opens-for-write, writes new bytes,
+//!   closes, re-reads through the mount, asserts the hot/warm tier
+//!   served the new content (not the captured original).
+//! * [`fuse_mount_serves_concurrent_readers`] — N threads reading the
+//!   same file repeatedly. Locks in that the FUSE worker dispatching
+//!   to `ContentAddressedMount` is safe under realistic read
+//!   parallelism (a build of any non-trivial project will issue tens
+//!   of these per second).
+//! * [`fuse_mount_unmounts_cleanly_on_session_drop`] — drop semantics.
+//!   After the session is dropped the mountpoint must no longer
+//!   serve the captured file; reading should fail with `NotFound` and
+//!   the directory listing must be empty (the underlying tempdir).
+//!
+//! Each test reuses [`build_fixture`] to construct a deterministic
+//! repo and gives the kernel a bounded poll window before asserting
+//! visibility — `mount_background` returns once the session is
+//! spawned, but the FS isn't visible until the kernel finishes
+//! attaching it (usually <100 ms).
 
 #![cfg(all(target_os = "linux", feature = "fuse"))]
 
 use std::{
     fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+    thread,
     time::{Duration, Instant},
 };
 
-use mount::{ContentAddressedMount, FuseShell};
+use mount::{BackgroundSession, ContentAddressedMount, FuseShell};
 use repo::Repository;
 use tempfile::TempDir;
 
-#[test]
-#[ignore = "requires FUSE on host; opt-in via --ignored"]
-fn fuse_mount_serves_blob_content() {
-    let repo_dir = TempDir::new().unwrap();
-    let repo = Repository::init_default(repo_dir.path()).unwrap();
-    fs::write(repo_dir.path().join("hello.txt"), b"world").unwrap();
-    repo.snapshot(Some("fixture".into()), None).unwrap();
+/// Build a tiny repo with one captured file (`hello.txt` containing
+/// `"world"`) and return the temp dir + an open `Repository` handle.
+/// Both shipped because the temp dir's `Drop` cleans up the on-disk
+/// repo and we don't want it to fire before the test ends.
+fn build_fixture() -> (TempDir, Repository) {
+    let repo_dir = TempDir::new().expect("tempdir for repo");
+    let repo = Repository::init_default(repo_dir.path()).expect("init_default");
+    fs::write(repo_dir.path().join("hello.txt"), b"world").expect("write hello.txt");
+    repo.snapshot(Some("fixture".into()), None)
+        .expect("snapshot fixture");
+    (repo_dir, repo)
+}
 
-    let mount = ContentAddressedMount::new(repo, "main").unwrap();
-    let mountpoint = TempDir::new().unwrap();
+/// Mount the fixture via FUSE and return the session + an empty
+/// tempdir for the mountpoint. Polls for the kernel to attach the
+/// FS so callers can read immediately on return.
+fn mount_fixture(repo: Repository) -> (BackgroundSession, TempDir) {
+    let mount = ContentAddressedMount::new(repo, "main").expect("open mount");
+    let mountpoint = TempDir::new().expect("tempdir for mountpoint");
     let session = FuseShell::new(mount)
         .mount_background(mountpoint.path())
         .expect("mount session");
 
     // Wait briefly for the FUSE worker to be ready. `mount_background`
     // returns once the session is spawned, but the kernel may take a
-    // moment to publish the FS. A short bounded poll is plenty.
+    // moment to publish the FS.
     let target = mountpoint.path().join("hello.txt");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while !target.exists() && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    wait_for(&target, true, Duration::from_secs(5));
+    (session, mountpoint)
+}
 
+/// Poll up to `deadline` for `target` to exist (`expect_present=true`)
+/// or to no longer exist (`expect_present=false`).
+fn wait_for(target: &Path, expect_present: bool, dur: Duration) {
+    let deadline = Instant::now() + dur;
+    while target.exists() != expect_present && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_serves_blob_content() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+
+    let target = mountpoint.path().join("hello.txt");
     let read = fs::read_to_string(&target).expect("read mounted file");
     assert_eq!(read, "world");
 
     drop(session); // triggers unmount
+}
+
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_round_trips_writes_to_existing_file() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+
+    let target = mountpoint.path().join("hello.txt");
+
+    // Sanity: captured content is visible.
+    assert_eq!(fs::read_to_string(&target).expect("read captured"), "world");
+
+    // Open-for-write *without* `truncate(true)` so we don't depend on
+    // a `setattr(size=0)` callback the FUSE shell doesn't implement
+    // yet (the kernel issues setattr-with-size for `O_TRUNC` and the
+    // default fuser impl is `ENOSYS`). New content is the same
+    // length as the original so no truncation is needed for the
+    // read-back to be unambiguous.
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .open(&target)
+            .expect("open for write");
+        f.write_all(b"WORLD").expect("write through mount");
+        // Drop closes the file → kernel issues `flush` then `release`,
+        // which the shell promotes through the hot/warm tier.
+    }
+
+    // Re-read through the mount. The pending tier (hot buffer or
+    // promoted warm blob) must shadow the captured state's blob.
+    let after = fs::read_to_string(&target).expect("read after write");
+    assert_eq!(
+        after, "WORLD",
+        "expected write-through-mount to be visible on re-read"
+    );
+
+    drop(session);
+}
+
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_serves_concurrent_readers() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+
+    let target = Arc::new(mountpoint.path().join("hello.txt"));
+
+    // Four threads × twenty reads each = 80 round-trips through the
+    // FUSE worker. This is enough to surface obvious lock-ordering
+    // or aliasing bugs in the shell's read dispatch; it's deliberately
+    // small enough to stay fast in CI.
+    const THREADS: usize = 4;
+    const READS_PER_THREAD: usize = 20;
+
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let target = Arc::clone(&target);
+            thread::spawn(move || {
+                for _ in 0..READS_PER_THREAD {
+                    let read = fs::read_to_string(&*target).expect("concurrent read");
+                    assert_eq!(read, "world");
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("reader thread panicked");
+    }
+
+    drop(session);
+}
+
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_unmounts_cleanly_on_session_drop() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+    let target = mountpoint.path().join("hello.txt");
+
+    // Pre-condition: file visible.
+    assert!(target.exists(), "fixture file must be visible before drop");
+
+    // Capture the mountpoint path before dropping the session so we
+    // can probe it after.
+    let mp: PathBuf = mountpoint.path().to_path_buf();
+    drop(session);
+
+    // Give the kernel a beat to tear the mount down. fuser's
+    // `BackgroundSession::Drop` signals the unmount synchronously,
+    // but the kernel may publish the namespace change a tick later.
+    wait_for(&target, false, Duration::from_secs(5));
+
+    // The captured file must no longer be visible: either the
+    // mountpoint resolves to an empty backing directory, or the
+    // dentry has gone stale and `exists()` is false.
+    assert!(
+        !target.exists(),
+        "hello.txt must disappear from {} after unmount",
+        mp.display()
+    );
+
+    // And the mountpoint directory listing must be empty (the
+    // underlying tempdir starts empty and the mount didn't write
+    // into the backing FS).
+    let listing: Vec<_> = fs::read_dir(&mp)
+        .expect("read mountpoint dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .collect();
+    assert!(
+        listing.is_empty(),
+        "mountpoint not empty after unmount: {listing:?}"
+    );
 }

--- a/crates/mount/tests/fuse_mount.rs
+++ b/crates/mount/tests/fuse_mount.rs
@@ -31,6 +31,13 @@
 //!   to `ContentAddressedMount` is safe under realistic read
 //!   parallelism (a build of any non-trivial project will issue tens
 //!   of these per second).
+//! * [`fuse_mount_serves_mmap_readers`] — `mmap(MAP_SHARED, ...)` on a
+//!   mounted file. Locks in the [`InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP`]
+//!   opt-in: without it, every `open` reply carrying
+//!   `FOPEN_DIRECT_IO` forces `mmap(MAP_SHARED, ...)` to fail with
+//!   `ENODEV`, which breaks rust-analyzer, cargo, IDEs, and
+//!   `grep --mmap` on heddle-mounted trees. Requires Linux 5.16+;
+//!   skips itself on older kernels (the cap is silently dropped).
 //! * [`fuse_mount_unmounts_cleanly_on_session_drop`] — drop semantics.
 //!   After the session is dropped the mountpoint must no longer
 //!   serve the captured file; reading should fail with `NotFound` and
@@ -180,6 +187,79 @@ fn fuse_mount_serves_concurrent_readers() {
     }
 
     drop(session);
+}
+
+/// `mmap(MAP_SHARED, ...)` against a mounted file must succeed and
+/// must return the captured bytes when the mapping is read.
+///
+/// This locks in `FUSE_DIRECT_IO_ALLOW_MMAP`: the shell unconditionally
+/// returns `FOPEN_DIRECT_IO` from `open` so kernel page-cache reads
+/// don't shadow hot-tier writes, and under default kernel semantics
+/// that disables shared `mmap` on every fd (the page cache is the
+/// mapping substrate; bypass it and the kernel refuses to map the
+/// file, returning `ENODEV` from the `mmap` syscall). The shell opts
+/// out of that restriction via `InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP`
+/// in its `init` callback — without that opt-in, this test fails
+/// with `Errno::NODEV` at the `Mmap::map(&file)` call, which is the
+/// exact failure mode rust-analyzer, cargo, and IDEs hit on
+/// heddle-mounted repos.
+///
+/// The cap requires Linux 5.16+ (when the kernel-side flag was
+/// added). Older kernels silently drop the request — fuser logs it at
+/// debug — and this test will fail there. We probe the kernel version
+/// up front and skip rather than fail on older kernels so the
+/// `fuse-smoke` CI matrix stays portable.
+#[test]
+#[ignore = "requires FUSE on host (Linux 5.16+); opt-in via --ignored"]
+fn fuse_mount_serves_mmap_readers() {
+    if !kernel_at_least(5, 16) {
+        eprintln!(
+            "skipping fuse_mount_serves_mmap_readers: \
+             FUSE_DIRECT_IO_ALLOW_MMAP requires Linux 5.16+"
+        );
+        return;
+    }
+
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+
+    let target = mountpoint.path().join("hello.txt");
+    let file = fs::File::open(&target).expect("open mounted file");
+
+    // SAFETY: `Mmap::map` is unsafe because the kernel may revoke the
+    // mapping out from under us if another process truncates the
+    // backing file. In this test we hold the only handle to the
+    // mounted file for the lifetime of `mapping`, and the FUSE shell
+    // doesn't expose `setattr(size)` (so truncation is impossible
+    // through the mount). Soundness is on us; we accept the contract.
+    let mapping = unsafe { memmap2::Mmap::map(&file) }
+        .expect("mmap(MAP_SHARED) on mounted file (FUSE_DIRECT_IO_ALLOW_MMAP must be enabled)");
+
+    assert_eq!(
+        &mapping[..],
+        b"world",
+        "mmap'd bytes must match captured content"
+    );
+
+    drop(mapping);
+    drop(file);
+    drop(session);
+}
+
+/// Parse `/proc/sys/kernel/osrelease` to skip the mmap test on
+/// kernels older than `(major, minor)`. The cap was added in 5.16; a
+/// `mount.fuse.kernel-old.smoke` CI runner on an older kernel should
+/// skip rather than fail.
+fn kernel_at_least(major: u32, minor: u32) -> bool {
+    let raw = match fs::read_to_string("/proc/sys/kernel/osrelease") {
+        Ok(s) => s,
+        Err(_) => return true, // not Linux-shaped — let the test attempt and report
+    };
+    let version_str = raw.trim().split('-').next().unwrap_or("");
+    let mut parts = version_str.split('.').filter_map(|s| s.parse::<u32>().ok());
+    let host_major = parts.next().unwrap_or(0);
+    let host_minor = parts.next().unwrap_or(0);
+    (host_major, host_minor) >= (major, minor)
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Three production-blocking bugs in the Linux FUSE shell fixed:** `AutoUnmount` rejected by fuser 0.17 (mount-time error), `DefaultPermissions` + hardcoded `uid 0/gid 0` denied all non-root writes (EACCES), and `read`/`attrs` on a captured-tree file ignored the pending overlay (post-flush reads returned the captured bytes through the same kernel-cached `NodeId`).
- **Panic recovery across every callback** via a `guard_call` wrapper — cross-pollinated from the FSKit shell's `guarded_c_int`. A poisoned mutex deep in core dispatch now translates to `reply.error(EIO)` instead of killing the fuser worker (wedging the mount) or aborting the daemon process (Rust ≥1.81 across `extern "C"`).
- **`FOPEN_DIRECT_IO` on every open** so the kernel never serves stale bytes from its page cache. Heddle's own `BlobCachePool` covers repeated-read perf.
- **`ubuntu-latest` CI matrix entry** (`fuse-smoke`) that installs `fuse3 libfuse3-dev` and runs four end-to-end integration tests covering mount → read → write-roundtrip → concurrent-reads → clean-unmount.

Closes HeddleCo/heddle#74

## Test evidence

```
$ cargo test -p heddle-mount --features fuse --lib
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p heddle-mount --features fuse --lib fuse::
running 3 tests
test fuse::tests::guard_call_passes_through_ok ... ok
test fuse::tests::panic_shell_dispatch_yields_eio ... ok
test fuse::tests::guard_call_translates_panic_to_eio ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out

$ cargo test -p heddle-mount --features fuse --test fuse_mount -- --ignored --test-threads=1
running 4 tests
test fuse_mount_round_trips_writes_to_existing_file ... ok
test fuse_mount_serves_blob_content ... ok
test fuse_mount_serves_concurrent_readers ... ok
test fuse_mount_unmounts_cleanly_on_session_drop ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test --workspace --tests
(every result: ok; full output truncated)

$ cargo clippy -p heddle-mount --features fuse --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.06s
(clean)
```

The new `captured_file_read_after_flush_through_same_node_id_serves_overlay` test pins the read-path bug: it reproduces the FUSE-kernel-cached-dentry pattern (no `lookup_path` refresh between flush and re-read) and asserts the warm tier shadows the captured blob. Without the core fix it returns `[119,111,114,108,100]` ("world") instead of `[87,79,82,76,68]` ("WORLD") — the failure mode the FUSE integration test caught.

## Manual verification

N/A — covered by the four real-FUSE integration tests in `crates/mount/tests/fuse_mount.rs`. The `fuse-smoke` CI job will run them on `ubuntu-latest` for every PR.

## Rule-7 cross-check (FSKit ↔ FUSE)

1. **Panic recovery.** FSKit has `guarded_c_int` / `guarded_drop` around every C-ABI trampoline; FUSE had nothing. Cross-pollinated to FUSE with `guard_call` returning `Result<T, MountError>`. The reasoning in the FSKit module docs applies one-for-one: Rust ≥1.81 aborts on unwind across `extern "C"` (fuser has these internally on the reply path), and even pre-1.81, a panic-killed worker thread wedges the mount until `fusermount3 -u`.
2. **Mount-crate `fuse` feature gate.** Confirmed `fuse = ["dep:fuser"]` is the only effect; non-FUSE builds (default Linux, macOS, Windows) don't pull `fuser` or any of its tree of deps. The `tests/fuse_mount.rs` test file is `#[cfg(all(target_os = "linux", feature = "fuse"))]` so non-Linux builds skip it. No build bloat.

## Deferred to follow-ups

(2-day daily-use scope; brief explicitly authorized this trade-off)

- Large file (>1 GB) streaming smoke
- Many small files (10k+) readdir perf documentation
- `setattr(size=0)` for `O_TRUNC` (current shell works for same-length overwrites; full `O_TRUNC` unblocks shorter-overwrite cases)
- `create` / `mkdir` / `unlink` / `rename` callbacks (mount is edit-existing-only)
- Symlink semantic parity test (readback works; never re-tested explicitly through the mount)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->