### PR TITLE
fix(worktree/shared-target): cleanup partial cargo config on write/sync failure (heddle#86)

### DIFF
--- a/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
@@ -169,11 +169,24 @@ pub(crate) fn write_cargo_config(checkout: &Path, target_dir: &Path) -> Result<b
             return Err(err).with_context(|| format!("create '{}'", config_path.display()));
         }
     };
-    file.write_all(body.as_bytes())
-        .with_context(|| format!("write '{}'", config_path.display()))?;
+    write_body_or_cleanup(&mut file, body.as_bytes(), &config_path)?;
     file.sync_all()
         .with_context(|| format!("sync '{}'", config_path.display()))?;
     Ok(true)
+}
+
+/// Write `body` to `writer`; on failure remove the orphan at
+/// `cleanup_path` and return the error. Generic over `Write` so tests
+/// can inject a failing writer to exercise the cleanup branch — the
+/// production caller passes the freshly-`create_new`'d file.
+fn write_body_or_cleanup<W: Write>(
+    writer: &mut W,
+    body: &[u8],
+    cleanup_path: &Path,
+) -> Result<()> {
+    writer
+        .write_all(body)
+        .with_context(|| format!("write '{}'", cleanup_path.display()))
 }
 
 /// Count active materialized threads on the repo. "Active" means
@@ -277,6 +290,46 @@ mod tests {
         assert_eq!(
             after, user,
             "shared-target writer must not overwrite user-managed config",
+        );
+    }
+
+    /// `Write` impl whose `write` always errors. Used to drive the
+    /// partial-write cleanup branch in `write_body_or_cleanup` without
+    /// needing to actually exhaust disk space.
+    struct FailingWriter;
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("simulated write failure"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_body_or_cleanup_removes_orphan_on_write_failure() {
+        // Regression for heddle#86 (follow-up to heddle#80 r3). If
+        // `write_all` fails after `create_new` already landed the
+        // file, the partial file must be removed so a retry can
+        // re-enter `create_new` instead of hitting `AlreadyExists`
+        // and silently reporting no-op success.
+        let temp = TempDir::new().unwrap();
+        let orphan = temp.path().join(".cargo").join("config.toml");
+        std::fs::create_dir_all(orphan.parent().unwrap()).unwrap();
+        // Stand in for what `create_new(true)` would have just produced.
+        std::fs::write(&orphan, b"").unwrap();
+        assert!(orphan.exists(), "test precondition: orphan staged");
+
+        let mut writer = FailingWriter;
+        let result = write_body_or_cleanup(&mut writer, b"would-be body", &orphan);
+
+        assert!(
+            result.is_err(),
+            "writer failure must surface to caller, not be swallowed"
+        );
+        assert!(
+            !orphan.exists(),
+            "orphan file must be removed so a retry can re-create it cleanly"
         );
     }
 

--- a/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
@@ -169,9 +169,20 @@ pub(crate) fn write_cargo_config(checkout: &Path, target_dir: &Path) -> Result<b
             return Err(err).with_context(|| format!("create '{}'", config_path.display()));
         }
     };
+    // If `write_all` (or `sync_all`) fails after `create_new` already
+    // landed an empty file (ENOSPC, EIO, network FS hiccup), a naïve
+    // bail-out would leave a zero-byte or partial `config.toml` on
+    // disk. A retried `heddle start --shared-target` would then hit
+    // the `AlreadyExists` arm above and silently treat the orphan as
+    // a user-managed config, returning `Ok(false)` and never wiring
+    // the redirect. Remove the partial file so the retry can recreate
+    // it. Mirrors the cleanup pattern in `init.rs` (heddle#80 r3).
     write_body_or_cleanup(&mut file, body.as_bytes(), &config_path)?;
-    file.sync_all()
-        .with_context(|| format!("sync '{}'", config_path.display()))?;
+    if let Err(err) = file.sync_all() {
+        drop(file);
+        let _ = std::fs::remove_file(&config_path);
+        return Err(err).with_context(|| format!("sync '{}'", config_path.display()));
+    }
     Ok(true)
 }
 
@@ -184,9 +195,11 @@ fn write_body_or_cleanup<W: Write>(
     body: &[u8],
     cleanup_path: &Path,
 ) -> Result<()> {
-    writer
-        .write_all(body)
-        .with_context(|| format!("write '{}'", cleanup_path.display()))
+    if let Err(err) = writer.write_all(body) {
+        let _ = std::fs::remove_file(cleanup_path);
+        return Err(err).with_context(|| format!("write '{}'", cleanup_path.display()));
+    }
+    Ok(())
 }
 
 /// Count active materialized threads on the repo. "Active" means

--- a/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/shared_target.rs
@@ -152,7 +152,7 @@ pub(crate) fn write_cargo_config(checkout: &Path, target_dir: &Path) -> Result<b
     // `create()` that would otherwise let two concurrent
     // `heddle start --shared-target` invocations race over a
     // user-managed config.
-    let mut file = match std::fs::OpenOptions::new()
+    let file = match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(&config_path)
@@ -177,7 +177,13 @@ pub(crate) fn write_cargo_config(checkout: &Path, target_dir: &Path) -> Result<b
     // a user-managed config, returning `Ok(false)` and never wiring
     // the redirect. Remove the partial file so the retry can recreate
     // it. Mirrors the cleanup pattern in `init.rs` (heddle#80 r3).
-    write_body_or_cleanup(&mut file, body.as_bytes(), &config_path)?;
+    //
+    // The helper takes the writer by value and drops it before
+    // attempting `remove_file`. On Windows, `DeleteFile` on a still-open
+    // handle (without `FILE_SHARE_DELETE`) fails with
+    // `ERROR_SHARING_VIOLATION`; the cleanup would silently no-op, the
+    // orphan would stay, and the retry would still hit `AlreadyExists`.
+    let file = write_body_or_cleanup(file, body.as_bytes(), &config_path)?;
     if let Err(err) = file.sync_all() {
         drop(file);
         let _ = std::fs::remove_file(&config_path);
@@ -186,20 +192,33 @@ pub(crate) fn write_cargo_config(checkout: &Path, target_dir: &Path) -> Result<b
     Ok(true)
 }
 
-/// Write `body` to `writer`; on failure remove the orphan at
-/// `cleanup_path` and return the error. Generic over `Write` so tests
-/// can inject a failing writer to exercise the cleanup branch — the
-/// production caller passes the freshly-`create_new`'d file.
+/// Write `body` to `writer`; on failure drop the writer (closing any
+/// underlying OS handle) and remove the orphan at `cleanup_path`,
+/// returning the original write error. On success, return the writer so
+/// the caller can continue using it (e.g. for `sync_all`).
+///
+/// Generic over `Write` so tests can inject a failing writer to exercise
+/// the cleanup branch — the production caller passes the
+/// freshly-`create_new`'d file by value.
+///
+/// **Drop-before-remove is load-bearing on Windows.** Without
+/// `FILE_SHARE_DELETE`, `DeleteFile` against a still-open handle fails
+/// with `ERROR_SHARING_VIOLATION`. Taking the writer by value makes
+/// ownership obvious at the call site and forces the close to happen
+/// before `remove_file`.
 fn write_body_or_cleanup<W: Write>(
-    writer: &mut W,
+    mut writer: W,
     body: &[u8],
     cleanup_path: &Path,
-) -> Result<()> {
-    if let Err(err) = writer.write_all(body) {
-        let _ = std::fs::remove_file(cleanup_path);
-        return Err(err).with_context(|| format!("write '{}'", cleanup_path.display()));
+) -> Result<W> {
+    match writer.write_all(body) {
+        Ok(()) => Ok(writer),
+        Err(err) => {
+            drop(writer);
+            let _ = std::fs::remove_file(cleanup_path);
+            Err(err).with_context(|| format!("write '{}'", cleanup_path.display()))
+        }
     }
-    Ok(())
 }
 
 /// Count active materialized threads on the repo. "Active" means
@@ -333,8 +352,8 @@ mod tests {
         std::fs::write(&orphan, b"").unwrap();
         assert!(orphan.exists(), "test precondition: orphan staged");
 
-        let mut writer = FailingWriter;
-        let result = write_body_or_cleanup(&mut writer, b"would-be body", &orphan);
+        let writer = FailingWriter;
+        let result = write_body_or_cleanup(writer, b"would-be body", &orphan);
 
         assert!(
             result.is_err(),
@@ -344,6 +363,57 @@ mod tests {
             !orphan.exists(),
             "orphan file must be removed so a retry can re-create it cleanly"
         );
+    }
+
+    /// `Write` wrapper that flips a flag from its `Drop` impl. The
+    /// regression test below uses this to assert the writer is closed
+    /// before the helper's `remove_file` call — load-bearing on Windows,
+    /// where `DeleteFile` against a still-open handle fails with
+    /// `ERROR_SHARING_VIOLATION` and the orphan would otherwise survive.
+    struct DropTrackingFailingWriter<'a> {
+        dropped: &'a std::cell::Cell<bool>,
+    }
+    impl Write for DropTrackingFailingWriter<'_> {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("simulated write failure"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl Drop for DropTrackingFailingWriter<'_> {
+        fn drop(&mut self) {
+            self.dropped.set(true);
+        }
+    }
+
+    #[test]
+    fn write_body_or_cleanup_drops_writer_before_returning_on_failure() {
+        // Regression for the Codex r1 finding on heddle#86. On Windows,
+        // `remove_file` against a still-open handle fails with
+        // `ERROR_SHARING_VIOLATION`; the orphan stays, and the retry
+        // never installs the redirect. The helper must take the writer
+        // by value and drop it before `remove_file`. POSIX would let the
+        // unlink succeed against an open handle, so this test asserts
+        // the ownership-transfer guarantee directly: by the time the
+        // helper returns, the writer has been dropped (i.e. on a real
+        // `File`, the OS handle is closed).
+        let temp = TempDir::new().unwrap();
+        let orphan = temp.path().join(".cargo").join("config.toml");
+        std::fs::create_dir_all(orphan.parent().unwrap()).unwrap();
+        std::fs::write(&orphan, b"").unwrap();
+
+        let dropped = std::cell::Cell::new(false);
+        let writer = DropTrackingFailingWriter { dropped: &dropped };
+        let result = write_body_or_cleanup(writer, b"would-be body", &orphan);
+
+        assert!(result.is_err());
+        assert!(
+            dropped.get(),
+            "writer must be dropped before the helper returns on failure — \
+             on Windows, the file handle must be closed before remove_file"
+        );
+        assert!(!orphan.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Same-shape follow-up to heddle#80 r3 (commit `d0d5d8d`), now closing out `crates/cli/src/cli/commands/worktree_cmd/shared_target.rs`.
- `write_cargo_config` opened `<checkout>/.cargo/config.toml` with `create_new(true)` and then `write_all` + `sync_all`. On a mid-write failure the empty/partial file stayed on disk, and a retried `heddle start --shared-target` would silently treat the orphan as a user-managed config and return `Ok(false)` — never wiring the redirect.
- Apply the same drop-then-remove cleanup pattern from `init.rs` to both the write and sync branches. `create_new(true)` stays load-bearing for "user-curated file wins" semantics; tempfile+rename would clobber a concurrently-placed user config.
- Rule-7 sweep: no new `create_new` sites since heddle#80 r3 — `refs_storage.rs` already cleans up, `fs_io.rs` uses tempfile+rename, `init.rs` was fixed in #80 r3, and this issue closes the last unsafe site.

Closes HeddleCo/heddle#86

## Red commit

`af38fcb` — failing test: `cli::commands::worktree_cmd::shared_target::tests::write_body_or_cleanup_removes_orphan_on_write_failure`

Test approach: extract a small `write_body_or_cleanup` helper generic over `Write` so a `FailingWriter` (returns `ErrorKind::Other` on every `write`) can drive the cleanup branch deterministically — no need to exhaust real disk space, no fragile FS-level tricks. The orphan file is pre-staged in a tempdir to mimic what `create_new(true)` would have just produced; the test asserts both (1) the error reaches the caller and (2) the orphan is gone so a retry can re-enter `create_new`.

## Test evidence

```
$ cargo test -p heddle-cli --lib shared_target

running 5 tests
test cli::commands::worktree_cmd::shared_target::tests::fingerprint_is_stable_across_calls ... ok
test cli::commands::worktree_cmd::shared_target::tests::write_body_or_cleanup_removes_orphan_on_write_failure ... ok
test cli::commands::worktree_cmd::shared_target::tests::write_cargo_config_preserves_existing_user_config ... ok
test cli::commands::worktree_cmd::shared_target::tests::write_cargo_config_creates_file_with_target_dir ... ok
test cli::commands::worktree_cmd::shared_target::tests::write_cargo_config_escapes_quotes_in_path ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 303 filtered out; finished in 0.03s
```

`cargo clippy -p heddle-cli --lib --tests -- -D warnings` is clean.

Red-commit verification: at `af38fcb`, the same test fails with `orphan file must be removed so a retry can re-create it cleanly` at the new test's final assertion — the write_all error surfaces, but the empty file remains.

## Manual verification

N/A — covered by the unit test. The fix is a pure in-process cleanup behavior that mirrors a pattern landed three days ago in `init.rs`.

## Asserter follow-up

The issue raised whether heddle's release-pipeline asserter (heddle#56) should flag `create_new` + `write_all` without cleanup. With the inventory now down to zero violations and all three remaining `create_new` sites following one of the safe patterns (cleanup-on-error, tempfile+rename), the recurrence risk is low enough that a dedicated asserter check is probably overkill for now — recommend deferring as a follow-up unless the pattern reappears.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->