### PR TITLE
feat(undo): production-harden MVP scope for daily safety net (heddle#23)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -312,7 +312,10 @@ Examples:
 
 Undoable operations:
   - heddle capture           (restores HEAD to the pre-capture parent)
-  - heddle merge             (FF and non-FF; restores HEAD + thread refs)
+  - heddle merge (non-FF)    (restores HEAD + both thread refs)
+  - heddle merge (FF)        (restores HEAD only; the merged-into thread ref
+                              stays at the FF target — run `heddle thread
+                              switch <name>` to re-attach. Data is never lost.)
   - heddle goto              (restores HEAD to the pre-goto state)
   - heddle thread create/drop/rename
   - heddle marker create/drop

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -308,7 +308,20 @@ Examples:
   heddle undo                # roll back the most recent operation
   heddle undo -n 3           # roll back the last three operations
   heddle undo --list         # preview undoable operations on this thread
-  heddle undo --preview      # show what would change without applying
+  heddle undo --dry-run      # show what would change without applying
+
+Undoable operations:
+  - heddle capture           (restores HEAD to the pre-capture parent)
+  - heddle merge             (FF and non-FF; restores HEAD + thread refs)
+  - heddle goto              (restores HEAD to the pre-goto state)
+  - heddle thread create/drop/rename
+  - heddle marker create/drop
+
+Not undoable (file a follow-up if you need one):
+  - heddle push / heddle fetch        (remote-affecting; out of scope)
+  - heddle purge                      (destructive by design; irreversible)
+  - cross-thread undo                 (single-thread scope today)
+  - redo across CLI invocations       (use `heddle redo` in the same shell)
 ")]
 pub struct UndoArgs {
     /// Undo N operations.
@@ -323,8 +336,9 @@ pub struct UndoArgs {
     #[arg(long, default_value = "20")]
     pub depth: usize,
 
-    /// Preview operations without undoing.
-    #[arg(long)]
+    /// Preview operations without undoing. `--dry-run` is an accepted
+    /// alias kept for muscle memory from git/other VCS tooling.
+    #[arg(long, visible_alias = "dry-run")]
     pub preview: bool,
 }
 

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -2,7 +2,8 @@
 //! Undo and redo commands.
 
 use anyhow::{Result, anyhow};
-use oplog::OpBatch;
+use objects::object::ChangeId;
+use oplog::{OpBatch, OpRecord};
 use repo::Repository;
 use serde::Serialize;
 
@@ -98,6 +99,12 @@ pub fn cmd_undo(cli: &Cli, steps: usize, list: bool, depth: usize, preview: bool
     }
 
     ensure_worktree_clean(&repo, "undo")?;
+    // Refuse before mutating anything when a state the batch needs to
+    // restore is missing from the object store — typically because `gc
+    // --prune` or a truncated oplog has reached past the live window.
+    // Letting `apply_undo_batch` discover this mid-apply would leave the
+    // repo half-undone (worktree partially rewritten, batch not marked).
+    ensure_undo_states_reachable(&repo, &batches)?;
 
     let mut updated_batches = Vec::with_capacity(batches.len());
     for batch in batches {
@@ -256,4 +263,62 @@ fn print_head(repo: &Repository) -> Result<()> {
         println!("Now at: {}", id.short());
     }
     Ok(())
+}
+
+/// Walk every batch we're about to undo and verify that each state the
+/// inverse would restore is still present in the object store. If any state
+/// is missing we refuse before touching the worktree or marking batches
+/// undone — letting the apply path discover the gap mid-flight would leave
+/// the repository half-rewound (partial worktree apply, batch unmarked).
+///
+/// "Missing" here means a destructive boundary has been crossed: typically
+/// `gc --prune` reached past the live oplog window, or an oplog backup was
+/// restored without its underlying objects. The user gets a single clear
+/// message instead of a raw `state not found` from deep in `goto`.
+fn ensure_undo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
+    let mut missing: Vec<(u64, ChangeId)> = Vec::new();
+    for batch in batches {
+        for entry in &batch.entries {
+            for needed in states_required_for_undo(&entry.operation) {
+                if !repo.store().has_state(&needed)? {
+                    missing.push((entry.id, needed));
+                }
+            }
+        }
+    }
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let shorts: Vec<String> = missing
+        .iter()
+        .map(|(op_id, id)| format!("op {} -> {}", op_id, id.short()))
+        .collect();
+    Err(anyhow!(
+        "Refusing to undo: prior state(s) needed to restore have been garbage-collected or are otherwise missing from the object store ({}). \
+         A destructive boundary (likely `heddle gc --prune`) has been crossed past the live oplog window — \
+         undo cannot rewind here. Restore the missing states from a backup, or run `heddle undo --list` and pick an entry past the boundary.",
+        shorts.join(", "),
+    ))
+}
+
+/// Identify the state IDs that an inverse for `op` would need to load.
+/// Variants whose undo is a no-op (e.g. `Fork`, `Collapse`, `Redact`,
+/// `Purge`, `Checkpoint`) return an empty list — they don't reach into the
+/// object store, so a missing object can't trip them.
+fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
+    match op {
+        OpRecord::Snapshot {
+            prev_head: Some(prev),
+            ..
+        } => vec![*prev],
+        OpRecord::Goto {
+            prev_head: Some(prev),
+            ..
+        } => vec![*prev],
+        OpRecord::ThreadDelete { state, .. } => vec![*state],
+        OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
+        OpRecord::MarkerDelete { state, .. } => vec![*state],
+        _ => Vec::new(),
+    }
 }

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+/// Convenience: read the current state's short change-id by opening the repo
+/// directly. Used by undo tests that assert HEAD has moved to a specific state.
+fn head_short(root: &std::path::Path) -> String {
+    let repo = Repository::open(root).unwrap();
+    repo.head()
+        .unwrap()
+        .expect("repo has HEAD")
+        .short()
+}
+
 #[test]
 fn test_undo_at_beginning() {
     let temp = TempDir::new().unwrap();
@@ -418,4 +428,288 @@ fn test_undo_with_dotgit_directory_present() {
             .is_clean(),
         "worktree must match HEAD after undo"
     );
+}
+
+// ---------------------------------------------------------------------------
+// MVP undo coverage for the three operations daily users will reach for:
+// `heddle capture`, `heddle merge` (FF and non-FF), plus the safety contracts
+// the MVP must satisfy (--dry-run alias, refusal across destructive boundaries,
+// discoverable --help surface).
+// ---------------------------------------------------------------------------
+
+/// `heddle capture` followed by `heddle undo` must restore HEAD to the
+/// pre-capture parent state — not "some earlier state", not "the empty state",
+/// the exact parent. This is the load-bearing invariant for daily use: after a
+/// botched capture, the user expects to be exactly where they were one
+/// operation ago.
+#[test]
+fn test_undo_capture_restores_head_to_parent() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "first"], temp.path());
+    let parent = head_short(temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "second"], temp.path());
+    let after_second = head_short(temp.path());
+    assert_ne!(
+        parent, after_second,
+        "second capture must produce a fresh state"
+    );
+
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        parent,
+        "undo of capture must restore HEAD to the immediate parent state"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
+        "v1",
+        "worktree must reflect the parent state's tree after undo"
+    );
+}
+
+/// Fast-forward merge undo: capture on main, branch off, capture on the
+/// feature thread, switch back to main (which is still at the original tip),
+/// `heddle merge feature` (fast-forwards main to feature's tip), `heddle
+/// undo`, and assert both thread refs are back at their pre-merge state.
+///
+/// The pre-merge contract is: main's tip is the original capture, feature's
+/// tip is the feature capture. After FF merge, main advances to feature's tip
+/// while feature stays put. After undo, both must be back where they started.
+#[test]
+fn test_undo_merge_ff_restores_both_threads() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_before = head_short(temp.path());
+    assert_ne!(main_tip_before, feature_tip_before);
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    assert_eq!(head_short(temp.path()), main_tip_before);
+
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        feature_tip_before,
+        "FF merge must advance main to feature's tip"
+    );
+
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        main_tip_before,
+        "undo of FF merge must restore HEAD to main's pre-merge tip"
+    );
+
+    // The feature thread's tip must be unchanged across merge + undo (FF
+    // doesn't move feature, so undo has nothing to do for it).
+    let repo = Repository::open(temp.path()).unwrap();
+    let feature_tip = repo
+        .refs()
+        .get_thread("feature")
+        .unwrap()
+        .expect("feature thread still exists")
+        .short();
+    assert_eq!(
+        feature_tip, feature_tip_before,
+        "feature thread tip must be unchanged across merge + undo"
+    );
+}
+
+/// Non-fast-forward merge undo: both threads have divergent work since the
+/// common ancestor. The merge synthesizes a new merge state with two parents.
+/// Undo must restore main to its pre-merge tip; feature's tip never moved.
+#[test]
+fn test_undo_merge_non_ff_restores_state() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    // Diverge feature.
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_before = head_short(temp.path());
+
+    // Diverge main (independent file so the merge is conflict-free but non-FF).
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    std::fs::write(temp.path().join("main.txt"), "main work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "main work"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    let merge_state = head_short(temp.path());
+    assert_ne!(
+        merge_state, main_tip_before,
+        "non-FF merge must produce a fresh merge state"
+    );
+    assert_ne!(
+        merge_state, feature_tip_before,
+        "non-FF merge must not collapse to feature's tip"
+    );
+
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        main_tip_before,
+        "undo of non-FF merge must restore HEAD to main's pre-merge tip"
+    );
+
+    // Feature is untouched throughout — its tip stays put.
+    let repo = Repository::open(temp.path()).unwrap();
+    let feature_tip = repo
+        .refs()
+        .get_thread("feature")
+        .unwrap()
+        .expect("feature thread still exists")
+        .short();
+    assert_eq!(feature_tip, feature_tip_before);
+}
+
+/// `--dry-run` is the discoverable spelling of `--preview` documented in
+/// `heddle undo --help`. It must not mutate state.
+#[test]
+fn test_undo_dry_run_alias_does_not_apply() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "first"], temp.path());
+    std::fs::write(temp.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "second"], temp.path());
+    let before = head_short(temp.path());
+
+    let out = heddle_must_succeed(&["undo", "--dry-run"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        before,
+        "--dry-run must not move HEAD"
+    );
+    assert!(
+        out.to_lowercase().contains("would undo"),
+        "--dry-run output must announce the dry-run shape: {out}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
+        "v2",
+        "--dry-run must not touch the worktree"
+    );
+
+    // The same operation under the original `--preview` spelling still works
+    // (we kept the existing flag rather than renaming it).
+    let out_preview = heddle_must_succeed(&["undo", "--preview"], temp.path());
+    assert!(
+        out_preview.to_lowercase().contains("would undo"),
+        "--preview must keep working: {out_preview}"
+    );
+    assert_eq!(head_short(temp.path()), before);
+}
+
+/// When the state that undo would restore to has been removed from the object
+/// store (gc, oplog truncation, etc.), undo must refuse with a clear,
+/// actionable error rather than partially applying or surfacing a raw
+/// `StateNotFound` panic. The user must be told why we refused.
+#[test]
+fn test_undo_refuses_when_prior_state_missing() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "first"], temp.path());
+    let first_state_short = head_short(temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "second"], temp.path());
+
+    // Simulate the destructive-boundary case: the prior state object file is
+    // gone from the loose store. (Mirrors a `gc --prune` having reached past
+    // the live oplog, or an oplog backup restored without its objects.)
+    let state_path = locate_state_loose_file(temp.path(), &first_state_short)
+        .expect("prior state's loose file is present after capture");
+    std::fs::remove_file(&state_path).unwrap();
+
+    let err = heddle(&["undo"], Some(temp.path()))
+        .expect_err("undo must refuse when the prior state is missing");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("missing") || lower.contains("gone") || lower.contains("garbage"),
+        "error must explain that prior state is missing: {err}"
+    );
+    // Worktree and HEAD must not have moved.
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
+        "v2",
+        "refusal must not touch the worktree"
+    );
+}
+
+/// `heddle undo --help` must surface the MVP scope: what's undoable today and
+/// what is NOT (cross-thread, push/fetch, redo, purge). Without this, users
+/// have to read the source to know when undo will help.
+#[test]
+fn test_undo_help_lists_undoable_and_unsupported() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    let help = heddle_must_succeed(&["undo", "--help"], temp.path());
+    let lower = help.to_lowercase();
+    assert!(
+        lower.contains("undoable") || lower.contains("undo "),
+        "--help should describe what undo does: {help}"
+    );
+    assert!(
+        lower.contains("capture"),
+        "--help should list capture as undoable: {help}"
+    );
+    assert!(
+        lower.contains("merge"),
+        "--help should list merge as undoable: {help}"
+    );
+    assert!(
+        lower.contains("push") || lower.contains("fetch") || lower.contains("cross-thread"),
+        "--help should call out what is NOT undoable: {help}"
+    );
+}
+
+/// Locate a state's loose object file within `.heddle/objectstore/states/`.
+/// Returns the path if exactly one matching file is found. The state directory
+/// layout is `states/<aa>/<rest>` where `<aa><rest>` is the full content hash
+/// — we match by the short prefix to keep the helper independent of the full
+/// hash, which the test doesn't know.
+fn locate_state_loose_file(repo_root: &std::path::Path, short: &str) -> Option<std::path::PathBuf> {
+    let states_dir = repo_root.join(".heddle/objectstore/states");
+    if !states_dir.exists() {
+        return None;
+    }
+    for shard in std::fs::read_dir(&states_dir).ok()? {
+        let shard = shard.ok()?;
+        if !shard.file_type().ok()?.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(shard.path()).ok()? {
+            let entry = entry.ok()?;
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            let combined = format!("{}{}", shard.file_name().to_string_lossy(), name_str);
+            if combined.starts_with(short) {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
 }

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -5,10 +5,7 @@ use super::*;
 /// directly. Used by undo tests that assert HEAD has moved to a specific state.
 fn head_short(root: &std::path::Path) -> String {
     let repo = Repository::open(root).unwrap();
-    repo.head()
-        .unwrap()
-        .expect("repo has HEAD")
-        .short()
+    repo.head().unwrap().expect("repo has HEAD").short()
 }
 
 #[test]
@@ -637,11 +634,21 @@ fn test_undo_refuses_when_prior_state_missing() {
     heddle_must_succeed(&["capture", "-m", "second"], temp.path());
 
     // Simulate the destructive-boundary case: the prior state object file is
-    // gone from the loose store. (Mirrors a `gc --prune` having reached past
-    // the live oplog, or an oplog backup restored without its objects.)
+    // gone from the loose store *and* any pack that might contain it.
+    // Mirrors a `gc --prune` having reached past the live oplog, or an oplog
+    // backup restored without its objects.
     let state_path = locate_state_loose_file(temp.path(), &first_state_short)
         .expect("prior state's loose file is present after capture");
     std::fs::remove_file(&state_path).unwrap();
+    // Drop every pack in the repo too; heddle writes packs eagerly and a
+    // surviving pack would still resolve the state, masking the test's
+    // destructive-boundary intent.
+    let packs_dir = temp.path().join(".heddle/packs");
+    if packs_dir.exists() {
+        for entry in std::fs::read_dir(&packs_dir).unwrap() {
+            std::fs::remove_file(entry.unwrap().path()).unwrap();
+        }
+    }
 
     let err = heddle(&["undo"], Some(temp.path()))
         .expect_err("undo must refuse when the prior state is missing");
@@ -686,29 +693,19 @@ fn test_undo_help_lists_undoable_and_unsupported() {
     );
 }
 
-/// Locate a state's loose object file within `.heddle/objectstore/states/`.
-/// Returns the path if exactly one matching file is found. The state directory
-/// layout is `states/<aa>/<rest>` where `<aa><rest>` is the full content hash
-/// — we match by the short prefix to keep the helper independent of the full
-/// hash, which the test doesn't know.
+/// Locate a state's on-disk object file inside `.heddle/objects/states/` by
+/// the short change-id prefix. Heddle stores each captured state as
+/// `<full-change-id>.state` in that directory; the short id is the first
+/// component of the filename. Returns `None` when no matching file exists
+/// (e.g. the state lives only in a packfile).
 fn locate_state_loose_file(repo_root: &std::path::Path, short: &str) -> Option<std::path::PathBuf> {
-    let states_dir = repo_root.join(".heddle/objectstore/states");
-    if !states_dir.exists() {
-        return None;
-    }
-    for shard in std::fs::read_dir(&states_dir).ok()? {
-        let shard = shard.ok()?;
-        if !shard.file_type().ok()?.is_dir() {
-            continue;
-        }
-        for entry in std::fs::read_dir(shard.path()).ok()? {
-            let entry = entry.ok()?;
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            let combined = format!("{}{}", shard.file_name().to_string_lossy(), name_str);
-            if combined.starts_with(short) {
-                return Some(entry.path());
-            }
+    let states_dir = repo_root.join(".heddle/objects/states");
+    for entry in std::fs::read_dir(&states_dir).ok()? {
+        let entry = entry.ok()?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with(short) {
+            return Some(entry.path());
         }
     }
     None

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -469,16 +469,19 @@ fn test_undo_capture_restores_head_to_parent() {
     );
 }
 
-/// Fast-forward merge undo: capture on main, branch off, capture on the
-/// feature thread, switch back to main (which is still at the original tip),
-/// `heddle merge feature` (fast-forwards main to feature's tip), `heddle
-/// undo`, and assert both thread refs are back at their pre-merge state.
+/// Fast-forward merge undo, current behavior: HEAD is restored to the
+/// pre-merge tip, but the *merged-into* thread ref is **stranded** at the FF
+/// target. This is a documented gap (`docs/undo.md` "Known caveats") tracked
+/// by heddle#99 — add an `OpRecord::FastForward` variant that records the
+/// pre-merge thread state so undo can reset the ref too.
 ///
-/// The pre-merge contract is: main's tip is the original capture, feature's
-/// tip is the feature capture. After FF merge, main advances to feature's tip
-/// while feature stays put. After undo, both must be back where they started.
+/// Why pin the bug instead of skipping the test: the day the FF undo is fixed
+/// this test will start failing on the stranded-ref assertion, which is
+/// exactly the signal we want — "the gap is closed, update the docs + this
+/// test." See also `test_undo_non_ff_merge_restores_both_threads` below for
+/// the non-FF path that already works end-to-end.
 #[test]
-fn test_undo_merge_ff_restores_both_threads() {
+fn test_undo_ff_merge_restores_head_but_strands_thread_ref() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
 
@@ -510,9 +513,9 @@ fn test_undo_merge_ff_restores_both_threads() {
         "undo of FF merge must restore HEAD to main's pre-merge tip"
     );
 
-    // The feature thread's tip must be unchanged across merge + undo (FF
-    // doesn't move feature, so undo has nothing to do for it).
     let repo = Repository::open(temp.path()).unwrap();
+
+    // Feature thread never moved during FF merge, so its tip is unchanged.
     let feature_tip = repo
         .refs()
         .get_thread("feature")
@@ -523,13 +526,32 @@ fn test_undo_merge_ff_restores_both_threads() {
         feature_tip, feature_tip_before,
         "feature thread tip must be unchanged across merge + undo"
     );
+
+    // The documented gap: the `main` thread ref is left at the FF target.
+    // Today's `OpRecord::Goto` inverse only rewinds HEAD; it carries no
+    // thread context to reset the ref. When the follow-up adds a
+    // `FastForward` op variant, flip this assertion to `main_tip_before`.
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, feature_tip_before,
+        "current behavior: `main` thread ref is stranded at the FF target \
+         after undo (see docs/undo.md 'Known caveats' + follow-up issue)"
+    );
 }
 
 /// Non-fast-forward merge undo: both threads have divergent work since the
 /// common ancestor. The merge synthesizes a new merge state with two parents.
 /// Undo must restore main to its pre-merge tip; feature's tip never moved.
+/// Unlike the FF path, this case exercises the `Snapshot` inverse (the merge
+/// records a new state with `thread = Some("main")`), so the thread ref *is*
+/// reset alongside HEAD.
 #[test]
-fn test_undo_merge_non_ff_restores_state() {
+fn test_undo_non_ff_merge_restores_both_threads() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
 
@@ -567,8 +589,22 @@ fn test_undo_merge_non_ff_restores_state() {
         "undo of non-FF merge must restore HEAD to main's pre-merge tip"
     );
 
-    // Feature is untouched throughout — its tip stays put.
     let repo = Repository::open(temp.path()).unwrap();
+
+    // The `main` thread ref must be reset too (not just HEAD): the `Snapshot`
+    // inverse for a merge carries the thread name so the ref rewinds with it.
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "non-FF undo must reset the `main` thread ref to its pre-merge tip"
+    );
+
+    // Feature is untouched throughout — its tip stays put.
     let feature_tip = repo
         .refs()
         .get_thread("feature")

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -12,7 +12,8 @@ follow-ups.
 | Operation        | What undo does                                                          |
 |------------------|-------------------------------------------------------------------------|
 | `heddle capture` | Restores `HEAD` and the worktree to the immediate parent state.         |
-| `heddle merge`   | Restores `HEAD` to the pre-merge tip; for non-FF, drops the merge state. |
+| `heddle merge` (non-FF) | Restores `HEAD` **and** both thread refs; drops the merge state.  |
+| `heddle merge` (FF)     | Restores `HEAD` to the pre-merge tip. **Caveat:** the merged-into thread ref is left at the FF target — see "Known caveats" below. |
 | `heddle goto`    | Restores `HEAD` to the pre-`goto` state.                                |
 | `heddle thread create`   | Deletes the thread (if no further work landed on it).           |
 | `heddle thread drop`     | Recreates the thread at its pre-drop tip.                       |
@@ -81,8 +82,10 @@ Run `heddle undo --help` for the curated list with examples and the explicit
 - After a **fast-forward** merge undo, `HEAD` is restored to the pre-merge
   state but the *thread ref* you merged into is left at the FF target. A
   `heddle thread switch <name>` re-attaches; data is never lost. Fixing
-  this end-to-end needs a new `OpRecord` variant carrying the thread
-  context — out of scope for the MVP (see follow-up issue).
+  this end-to-end needs a new `OpRecord::FastForward` variant carrying the
+  thread context — out of scope for the MVP. Tracked in
+  [heddle#99](https://github.com/HeddleCo/heddle/issues/99) and pinned by
+  `test_undo_ff_merge_restores_head_but_strands_thread_ref`.
 - `OpRecord::Checkpoint` is defined but no current code path emits it; the
   variant exists for the agent-frequent-saves work in flight. When it lands
   it will need its own inverse arm in `undo_apply.rs`.

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -1,0 +1,91 @@
+# `heddle undo`
+
+A safety net for the operations a daily user is most likely to want to roll back.
+
+This document describes the MVP scope shipped under
+[HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). Cross-thread
+undo, remote-affecting undo, and persistent cross-invocation redo are tracked as
+follow-ups.
+
+## Undoable operations
+
+| Operation        | What undo does                                                          |
+|------------------|-------------------------------------------------------------------------|
+| `heddle capture` | Restores `HEAD` and the worktree to the immediate parent state.         |
+| `heddle merge`   | Restores `HEAD` to the pre-merge tip; for non-FF, drops the merge state. |
+| `heddle goto`    | Restores `HEAD` to the pre-`goto` state.                                |
+| `heddle thread create`   | Deletes the thread (if no further work landed on it).           |
+| `heddle thread drop`     | Recreates the thread at its pre-drop tip.                       |
+| `heddle thread rename`   | Renames back.                                                   |
+| `heddle marker create`   | Deletes the marker.                                             |
+| `heddle marker drop`     | Recreates the marker at its prior state.                        |
+
+The list above is the **shipped** surface for v0.2. The inverses live in
+`crates/cli/src/cli/commands/undo_apply.rs`; the oplog records that drive them
+live in `crates/oplog/src/oplog/oplog_types.rs::OpRecord`.
+
+## Not undoable (today)
+
+These intentionally fall outside the MVP — they either touch state we don't
+own, are destructive by design, or need a substrate change we haven't shipped:
+
+- **`heddle push` / `heddle fetch`** — remote-affecting. Reverting them would
+  require coordinating with the other side. File a follow-up if you need this.
+- **`heddle purge`** — physically removes blob bytes. Documented irreversible
+  in `OpRecord::Purge` (the `Redact` declaration that preceded it can still
+  be undone separately when that path lands).
+- **Cross-thread undo** — today's undo only rewinds operations recorded on the
+  current checkout's HEAD path. Undoing an op that mutated a different thread
+  is the design problem heddle#23's title points at; the MVP ships the
+  single-thread safety net first.
+- **Redo across CLI invocations** — `heddle redo` works within the same shell
+  session but is not yet persisted across processes.
+
+## Safety contracts
+
+The CLI is designed to **fail loud** instead of silently corrupting state. The
+contracts below are enforced by integration tests in
+`crates/cli/tests/core_functionality/undo_and_special.rs`.
+
+- **Dirty worktree refusal.** If you have uncommitted changes (modified
+  tracked files, untracked files), `heddle undo` refuses and surfaces the
+  dirty paths. Capture the changes with `heddle capture -m "..."` (or remove
+  them) and retry. The check is shared with `cherry-pick` and `rebase`.
+- **Destructive-boundary refusal.** If the state the inverse would restore
+  has been removed from the object store — typically by `heddle gc --prune`
+  reaching past the live oplog window — `heddle undo` refuses with a single
+  clear message naming the missing op id. Restore from a backup or list past
+  the boundary with `heddle undo --list`.
+- **Idempotent re-run.** Once a batch is marked undone, the next `heddle
+  undo` picks the next still-active batch (or refuses if none remain). Re-
+  running `heddle undo` is never destructive.
+- **`--dry-run` is non-mutating.** `heddle undo --dry-run` (alias of
+  `--preview`) prints the batches it would undo without touching the
+  worktree, ref refs, or oplog state.
+
+## Flags
+
+| Flag                       | Purpose                                                     |
+|----------------------------|-------------------------------------------------------------|
+| `-n, --steps <N>`          | Roll back the last `N` batches (default 1).                 |
+| `--list`                   | Print the recent batches without undoing.                   |
+| `--depth <N>`              | How many batches `--list` shows (default 20).               |
+| `--preview` / `--dry-run`  | Print what would change without applying.                   |
+| `--output {auto,json,text}`| Force output format. JSON is the structured contract.        |
+
+Run `heddle undo --help` for the curated list with examples and the explicit
+"NOT undoable" reminder.
+
+## Known caveats (filed as follow-ups)
+
+- After a **fast-forward** merge undo, `HEAD` is restored to the pre-merge
+  state but the *thread ref* you merged into is left at the FF target. A
+  `heddle thread switch <name>` re-attaches; data is never lost. Fixing
+  this end-to-end needs a new `OpRecord` variant carrying the thread
+  context — out of scope for the MVP (see follow-up issue).
+- `OpRecord::Checkpoint` is defined but no current code path emits it; the
+  variant exists for the agent-frequent-saves work in flight. When it lands
+  it will need its own inverse arm in `undo_apply.rs`.
+- `OpRecord::Redact` is documented as reversible but currently no-ops on
+  undo (`undo_apply.rs` falls through to the default arm). A follow-up
+  will reverse the materialize-substitution side effect.


### PR DESCRIPTION
## Summary

Production-hardens `heddle undo` for the v0.2 daily safety-net story tracked
under HeddleCo/heddle#23. The state-level plumbing already worked; this PR
turns it into a user-facing surface with the safety contracts a daily user
needs to trust the command.

The MVP intentionally scopes to **single-thread undo for the three
most-common operations**:

- `heddle capture` — restores HEAD to the immediate parent state
- `heddle merge` (FF + non-FF) — restores HEAD to the pre-merge tip
- `heddle goto` — restores HEAD to the pre-`goto` state

Cross-thread undo, redo across CLI invocations, `push`/`fetch` undo, and a
persistent oplog window are explicitly **out of scope** and filed as
follow-ups in `docs/undo.md` and the rule-7 notes below.

## What landed

- **`--dry-run` alias** for `--preview` via clap `visible_alias`. Same code
  path; both spellings non-mutating.
- **Destructive-boundary refusal.** Before `apply_undo_batch`, walk the
  batch entries and assert every state the inverse would need
  (`Snapshot.prev_head`, `Goto.prev_head`, `ThreadDelete.state`,
  `ThreadUpdate.old_state`, `MarkerDelete.state`) is still in the object
  store. If any is missing — typically `gc --prune` reached past the live
  oplog window, or an oplog backup landed without its objects — refuse
  with a single message naming the missing op ids and pointing at
  `heddle undo --list`. We never half-undo.
- **Discoverable `--help`.** The after-help block now lists what is and
  isn't undoable so users don't have to read source to know when undo
  will help.
- **`docs/undo.md`** documents the MVP scope, safety contracts, flags,
  and known caveats (with follow-ups).
- **Six integration tests** in `crates/cli/tests/core_functionality/undo_and_special.rs`
  pin the contract: capture undo restores HEAD to parent; FF merge undo
  restores HEAD; non-FF merge undo restores HEAD; `--dry-run` doesn't
  mutate; refusal-on-missing-state surfaces the right error; `--help`
  lists what's (un)supported.

## Existing surface, surveyed

The undo plumbing was already largely wired (`crates/cli/src/cli/commands/undo_apply.rs`):
`Snapshot` has the right thread-aware inverse, `Goto` restores HEAD,
`Thread*` and `Marker*` ops have full inverses. `ensure_worktree_clean`
already refuses dirty-worktree undo. Idempotency via `mark_batch_undone`
is already in place. The gap was the user-facing wrapper around all that.

## Rule-7 / scope-cross-check findings (filed as follow-ups, not blockers)

1. **FF merge thread-ref left at target.** After `heddle merge X`
   fast-forwards `main` to `X`'s tip and `heddle undo` runs, HEAD's
   state is restored to the pre-merge tip but `main`'s thread ref is
   left at the FF target (= `feature`'s tip). User runs `heddle thread
   switch main` to re-attach; no data loss. Proper fix needs a new
   `OpRecord::FastForward { thread, prev_state, target }` variant
   appended to the OpRecord tail, with a Snapshot-style inverse that
   restores worktree + thread ref + Head::Attached atomically. Out of
   the 2-day MVP window; tracked in `docs/undo.md` and proposed as
   `heddle#XXX FF merge undo leaves thread ref at target`.

2. **`OpRecord::Checkpoint` defined but never emitted.** The variant
   exists in `oplog_types.rs` for the agent-frequent-saves work in
   flight, but no current code path writes it. `apply_undo_entry` has
   no arm for it (falls through to the default no-op). When
   `Checkpoint` lands in earnest it must add its own inverse arm and
   destructive-boundary check (`states_required_for_undo`).

3. **`OpRecord::Redact` undo is a silent no-op.** The variant's doc
   says it's reversible (the redaction declaration can be lifted so
   `materialize` stops substituting the stub) but `apply_undo_entry`
   has no arm. Today `heddle undo` on a redact entry reports "undone"
   while the redaction stays live. Track as
   `heddle#XXX redact undo: implement the documented inverse`.

4. **`gc --prune` does not preserve states reachable via the live oplog
   undo window.** `crates/cli/src/cli/commands/gc.rs` walks `prune_loose_objects`
   without checking whether the oplog's undoable tail still references
   any of them. The destructive-boundary refusal added in this PR is
   the safety net for users who hit this; the structural fix is
   "extend gc reachability with the active undo window." Out of scope
   for #23; track as `heddle#XXX gc must consider live oplog undo window`.

## Test plan

- [x] `cargo build -p heddle-cli` clean
- [x] `cargo clippy -p heddle-cli --tests --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean on changed files
- [x] `cargo test -p heddle-cli` — 1000+ tests pass, 0 failures (run in isolated `CARGO_TARGET_DIR` to avoid shared-target races between sibling worktrees)
- [x] `cargo test -p heddle-oplog -p heddle-repo` — 285 tests, 0 failures
- [x] Manual: `heddle undo --help` shows undoable/not-undoable listing
- [x] Manual: `heddle undo --dry-run` prints "Would undo …", does not mutate
- [x] Manual: simulate gc-past-oplog by removing the state file + packs, `heddle undo` refuses with the destructive-boundary message

## Red / green commits

- Red baseline (3 failing tests, others already passing on existing plumbing): `73e5963`
- Green (all 59 core_functionality tests pass): `7f77f3d`

## Confidence

0.9 — build/clippy/fmt/tests all clean, manual smoke covered, scope discipline held, follow-ups itemized. Subtracting 0.1 because the FF merge thread-ref caveat is a real user-experience papercut shipping with this MVP (with a known mitigation: `thread switch`).



## Follow-ups filed

- heddle#99 — `merge: implement OpRecord::FastForward for proper FF merge undo`. Closes the FF merge thread-ref strand gap documented in `docs/undo.md` and pinned by `test_undo_ff_merge_restores_head_but_strands_thread_ref`.

Implements HeddleCo/heddle#23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
