### PR TITLE
fix(undo): implement Redact inverse + refuse Purge inverse (heddle#98)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -319,6 +319,10 @@ Undoable operations:
   - heddle goto              (restores HEAD to the pre-goto state)
   - heddle thread create/drop/rename
   - heddle marker create/drop
+  - heddle redact apply               (with --allow-redact-undo; removes the
+                                       redaction record so future materializes
+                                       restore the original blob bytes. Refused
+                                       when a Purge has destroyed the bytes.)
 
 Not undoable (file a follow-up if you need one):
   - heddle push / heddle fetch        (remote-affecting; out of scope)
@@ -343,6 +347,16 @@ pub struct UndoArgs {
     /// alias kept for muscle memory from git/other VCS tooling.
     #[arg(long, visible_alias = "dry-run")]
     pub preview: bool,
+
+    /// Explicit opt-in for undoing a `heddle redact apply`. The inverse
+    /// removes the redaction record so subsequent materializes restore
+    /// the original blob bytes — i.e. previously-hidden content
+    /// becomes readable again. Without this flag, a `heddle undo`
+    /// chain that crosses a Redact refuses loudly rather than silently
+    /// re-exposing the content. Refused regardless of the flag when
+    /// a Purge has destroyed the bytes: Purge is irreversible.
+    #[arg(long)]
+    pub allow_redact_undo: bool,
 }
 
 /// User-facing `--workspace` flag values. Vocabulary is the same as

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -66,7 +66,9 @@ fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result
     let outcome = repo.purge_blob(&blob, &principal)?;
 
     if let Some(redaction_id) = &outcome.redaction_id {
-        repo.oplog().record_purge(redaction_id, &blob)?;
+        let scope = repo.op_scope();
+        repo.oplog()
+            .record_purge(redaction_id, &blob, Some(&scope))?;
     }
 
     let mut message = format!(

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -114,8 +114,9 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
         primary.signature = Some(sign_redaction(signer.as_ref(), &primary)?);
     }
     let primary_id = repo.put_redaction(primary)?;
+    let scope = repo.op_scope();
     repo.oplog()
-        .record_redact(&primary_id, &blob, &state, &args.path)?;
+        .record_redact(&primary_id, &blob, &state, &args.path, Some(&scope))?;
 
     let mut states_redacted: u32 = 1;
     let mut extra_oplog_entries: u32 = 0;
@@ -157,8 +158,13 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
                     extra.signature = Some(sign_redaction(signer.as_ref(), &extra)?);
                 }
                 let extra_id = repo.put_redaction(extra)?;
-                repo.oplog()
-                    .record_redact(&extra_id, &blob, &other_state, &path)?;
+                repo.oplog().record_redact(
+                    &extra_id,
+                    &blob,
+                    &other_state,
+                    &path,
+                    Some(&scope),
+                )?;
                 extra_oplog_entries += 1;
             }
         }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -84,6 +84,17 @@ pub fn cmd_undo(
         return Err(anyhow!("Nothing to undo"));
     }
 
+    // Run the redaction safety pre-flight before the `--preview`
+    // short-circuit so preview output is honest about refusals. A
+    // `Redact` without `--allow-redact-undo`, or any batch that crosses
+    // a `Purge`, must surface the same error here that the real undo
+    // would surface — otherwise `--preview` advertises "Would undo …"
+    // for a chain the real command would reject. The other pre-flights
+    // (`ensure_worktree_clean`, `ensure_undo_states_reachable`) stay
+    // post-preview: dirty worktree and gc-pruned states are conditions
+    // operators expect `--preview` to ignore.
+    ensure_redaction_undo_safe(&repo, &batches, allow_redact_undo)?;
+
     if preview {
         let output = UndoRedoOutput {
             action: "undo".to_string(),
@@ -112,12 +123,6 @@ pub fn cmd_undo(
     // Letting `apply_undo_batch` discover this mid-apply would leave the
     // repo half-undone (worktree partially rewritten, batch not marked).
     ensure_undo_states_reachable(&repo, &batches)?;
-    // Pre-flight the redaction-related ops in the batch chain so we
-    // refuse loudly before any state mutation. Purge is always
-    // irreversible; Redact is reversible but requires explicit opt-in
-    // (`--allow-redact-undo`) and refuses when the underlying bytes
-    // have since been purged.
-    ensure_redaction_undo_safe(&repo, &batches, allow_redact_undo)?;
 
     let mut updated_batches = Vec::with_capacity(batches.len());
     for batch in batches {
@@ -156,6 +161,13 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
         return Err(anyhow!("Nothing to redo"));
     }
 
+    // Same preview-honesty rule as `cmd_undo`: run the
+    // Redact/Purge-not-supported pre-flight before the `--preview`
+    // short-circuit so preview surfaces the refusal instead of
+    // advertising "Would redo …" for a chain the real command will
+    // reject.
+    ensure_redaction_redo_supported(&batches)?;
+
     if preview {
         let output = UndoRedoOutput {
             action: "redo".to_string(),
@@ -178,13 +190,6 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     }
 
     ensure_worktree_clean(&repo, "redo")?;
-    // Redo of `Redact` / `Purge` is intentionally unsupported in this
-    // MVP: the OpRecord doesn't preserve the full `Redaction` record
-    // (reason, redactor, timestamp, signature) needed to faithfully
-    // re-apply, and `Purge` is irreversible by design. Refuse before
-    // mutating anything so a multi-batch chain that includes one of
-    // these isn't half-applied.
-    ensure_redaction_redo_supported(&batches)?;
 
     let mut updated_batches = Vec::with_capacity(batches.len());
     for batch in batches {

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -2,7 +2,7 @@
 //! Undo and redo commands.
 
 use anyhow::{Result, anyhow};
-use objects::object::ChangeId;
+use objects::object::{ChangeId, ContentHash};
 use oplog::{OpBatch, OpRecord};
 use repo::Repository;
 use serde::Serialize;
@@ -42,7 +42,14 @@ struct UndoRedoOutput {
     batches: Vec<OpBatchOutput>,
 }
 
-pub fn cmd_undo(cli: &Cli, steps: usize, list: bool, depth: usize, preview: bool) -> Result<()> {
+pub fn cmd_undo(
+    cli: &Cli,
+    steps: usize,
+    list: bool,
+    depth: usize,
+    preview: bool,
+    allow_redact_undo: bool,
+) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
 
     if list && preview {
@@ -105,6 +112,12 @@ pub fn cmd_undo(cli: &Cli, steps: usize, list: bool, depth: usize, preview: bool
     // Letting `apply_undo_batch` discover this mid-apply would leave the
     // repo half-undone (worktree partially rewritten, batch not marked).
     ensure_undo_states_reachable(&repo, &batches)?;
+    // Pre-flight the redaction-related ops in the batch chain so we
+    // refuse loudly before any state mutation. Purge is always
+    // irreversible; Redact is reversible but requires explicit opt-in
+    // (`--allow-redact-undo`) and refuses when the underlying bytes
+    // have since been purged.
+    ensure_redaction_undo_safe(&repo, &batches, allow_redact_undo)?;
 
     let mut updated_batches = Vec::with_capacity(batches.len());
     for batch in batches {
@@ -165,6 +178,13 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     }
 
     ensure_worktree_clean(&repo, "redo")?;
+    // Redo of `Redact` / `Purge` is intentionally unsupported in this
+    // MVP: the OpRecord doesn't preserve the full `Redaction` record
+    // (reason, redactor, timestamp, signature) needed to faithfully
+    // re-apply, and `Purge` is irreversible by design. Refuse before
+    // mutating anything so a multi-batch chain that includes one of
+    // these isn't half-applied.
+    ensure_redaction_redo_supported(&batches)?;
 
     let mut updated_batches = Vec::with_capacity(batches.len());
     for batch in batches {
@@ -303,9 +323,11 @@ fn ensure_undo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
 }
 
 /// Identify the state IDs that an inverse for `op` would need to load.
-/// Variants whose undo is a no-op (e.g. `Fork`, `Collapse`, `Redact`,
-/// `Purge`, `Checkpoint`) return an empty list — they don't reach into the
-/// object store, so a missing object can't trip them.
+/// Variants whose undo is a no-op (e.g. `Fork`, `Collapse`, `Checkpoint`)
+/// or which only mutate sidecars (`Redact`) return an empty list —
+/// they don't reach into the object store, so a missing state can't
+/// trip them. `Purge` is irreversible and handled by
+/// `ensure_redaction_undo_safe`; it returns nothing here too.
 fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
     match op {
         OpRecord::Snapshot {
@@ -321,4 +343,137 @@ fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::MarkerDelete { state, .. } => vec![*state],
         _ => Vec::new(),
     }
+}
+
+/// Pre-flight check for redaction-related ops in the batch chain.
+///
+/// Three refusal cases, all surfaced before any state mutation:
+///
+/// 1. **Purge.** Purge is irreversible by design — the bytes are gone
+///    from local storage. The CLI rejects the whole undo so operators
+///    aren't surprised by a half-applied chain.
+///
+/// 2. **Redact without opt-in.** Undoing a `Redact` removes the
+///    redaction record so subsequent materializes substitute the
+///    original bytes again — i.e. previously-hidden content becomes
+///    readable. Pre-fix this was a silent no-op (heddle#98); the fix
+///    actually reverses the redaction. To prevent a casual
+///    `heddle undo -n N` from re-exposing redacted content, the
+///    inverse runs only when the user passes `--allow-redact-undo`.
+///
+/// 3. **Redact whose bytes have been purged.** The Redaction record is
+///    then the only audit trail for "these bytes were destroyed".
+///    Removing it would lie about local storage state and the
+///    materialize path would fail with a missing-blob error instead
+///    of restoring content. Refused regardless of the opt-in flag.
+fn ensure_redaction_undo_safe(
+    repo: &Repository,
+    batches: &[OpBatch],
+    allow_redact_undo: bool,
+) -> Result<()> {
+    let mut purge_ops: Vec<(u64, ContentHash)> = Vec::new();
+    let mut redact_ops: Vec<(u64, ContentHash)> = Vec::new();
+
+    for batch in batches {
+        for entry in &batch.entries {
+            match &entry.operation {
+                OpRecord::Purge {
+                    redaction_id, ..
+                } => purge_ops.push((entry.id, *redaction_id)),
+                OpRecord::Redact {
+                    redaction_id, ..
+                } => redact_ops.push((entry.id, *redaction_id)),
+                _ => {}
+            }
+        }
+    }
+
+    if !purge_ops.is_empty() {
+        let shorts: Vec<String> = purge_ops
+            .iter()
+            .map(|(op_id, redaction_id)| format!("op {} (redaction {})", op_id, redaction_id.short()))
+            .collect();
+        return Err(anyhow!(
+            "Refusing to undo: `heddle purge` is irreversible by design — the blob bytes have been \
+             physically removed from local storage and cannot be reconstructed. Affected op(s): {}. \
+             Restore the bytes from a backup if you need them, or run `heddle undo --list` and \
+             target an earlier op past the purge.",
+            shorts.join(", "),
+        ));
+    }
+
+    if redact_ops.is_empty() {
+        return Ok(());
+    }
+
+    // Refuse if any redaction in the chain has its bytes already
+    // purged — checked first so the precise "purged audit trail" error
+    // wins over the generic opt-in prompt.
+    let mut purged_redacts: Vec<(u64, ContentHash)> = Vec::new();
+    for (op_id, redaction_id) in &redact_ops {
+        if repo.redaction_is_purged(redaction_id)? {
+            purged_redacts.push((*op_id, *redaction_id));
+        }
+    }
+    if !purged_redacts.is_empty() {
+        let shorts: Vec<String> = purged_redacts
+            .iter()
+            .map(|(op_id, id)| format!("op {} (redaction {})", op_id, id.short()))
+            .collect();
+        return Err(anyhow!(
+            "Refusing to undo: at least one redaction in this chain has had its bytes purged ({}). \
+             The redaction record is now the only audit trail that those bytes were destroyed; \
+             removing it would lie about local storage and a subsequent materialize would fail \
+             with a missing-blob error rather than restore content. Purge is irreversible.",
+            shorts.join(", "),
+        ));
+    }
+
+    if !allow_redact_undo {
+        let shorts: Vec<String> = redact_ops
+            .iter()
+            .map(|(op_id, id)| format!("op {} (redaction {})", op_id, id.short()))
+            .collect();
+        return Err(anyhow!(
+            "Refusing to undo a `heddle redact apply`: the inverse removes the redaction record \
+             so subsequent materializes restore the original bytes, which would re-expose \
+             previously-hidden content. Pass `--allow-redact-undo` to confirm. Affected op(s): {}.",
+            shorts.join(", "),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Pre-flight for `heddle redo`: refuse when the batch chain contains a
+/// `Redact` or `Purge` op. Neither has a faithful re-apply path today —
+/// `OpRecord::Redact` doesn't carry the full `Redaction` (reason,
+/// redactor, signature, etc.), so a re-application would invent fields,
+/// and `Purge` is irreversible. Refusing pre-mutation keeps multi-batch
+/// chains from being half-redone.
+fn ensure_redaction_redo_supported(batches: &[OpBatch]) -> Result<()> {
+    let mut blocking: Vec<(u64, &'static str)> = Vec::new();
+    for batch in batches {
+        for entry in &batch.entries {
+            match &entry.operation {
+                OpRecord::Redact { .. } => blocking.push((entry.id, "Redact")),
+                OpRecord::Purge { .. } => blocking.push((entry.id, "Purge")),
+                _ => {}
+            }
+        }
+    }
+    if blocking.is_empty() {
+        return Ok(());
+    }
+    let shorts: Vec<String> = blocking
+        .iter()
+        .map(|(op_id, kind)| format!("op {} ({})", op_id, kind))
+        .collect();
+    Err(anyhow!(
+        "Refusing to redo: `Redact` and `Purge` ops do not have a re-apply path — the oplog \
+         entry doesn't preserve the full Redaction record (reason, redactor, signature) needed \
+         to recreate it, and Purge is irreversible by design. Re-run `heddle redact apply` \
+         (or `heddle purge apply`) to re-establish the operation. Affected op(s): {}.",
+        shorts.join(", "),
+    ))
 }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -371,18 +371,30 @@ fn ensure_redaction_undo_safe(
     batches: &[OpBatch],
     allow_redact_undo: bool,
 ) -> Result<()> {
+    struct RedactSummary {
+        op_id: u64,
+        blob: ContentHash,
+        state: ChangeId,
+        path: String,
+    }
+
     let mut purge_ops: Vec<(u64, ContentHash)> = Vec::new();
-    let mut redact_ops: Vec<(u64, ContentHash)> = Vec::new();
+    let mut redact_ops: Vec<RedactSummary> = Vec::new();
 
     for batch in batches {
         for entry in &batch.entries {
             match &entry.operation {
-                OpRecord::Purge {
-                    redaction_id, ..
-                } => purge_ops.push((entry.id, *redaction_id)),
+                OpRecord::Purge { redaction_id, .. } => {
+                    purge_ops.push((entry.id, *redaction_id))
+                }
                 OpRecord::Redact {
-                    redaction_id, ..
-                } => redact_ops.push((entry.id, *redaction_id)),
+                    blob, state, path, ..
+                } => redact_ops.push(RedactSummary {
+                    op_id: entry.id,
+                    blob: *blob,
+                    state: *state,
+                    path: path.clone(),
+                }),
                 _ => {}
             }
         }
@@ -408,17 +420,19 @@ fn ensure_redaction_undo_safe(
 
     // Refuse if any redaction in the chain has its bytes already
     // purged — checked first so the precise "purged audit trail" error
-    // wins over the generic opt-in prompt.
-    let mut purged_redacts: Vec<(u64, ContentHash)> = Vec::new();
-    for (op_id, redaction_id) in &redact_ops {
-        if repo.redaction_is_purged(redaction_id)? {
-            purged_redacts.push((*op_id, *redaction_id));
+    // wins over the generic opt-in prompt. We match by (blob, state,
+    // path) rather than by the oplog-stored `redaction_id` because
+    // setting `purged_at` shifts the on-disk record's content hash.
+    let mut purged_redacts: Vec<&RedactSummary> = Vec::new();
+    for r in &redact_ops {
+        if repo.redaction_is_purged(&r.blob, &r.state, &r.path)? {
+            purged_redacts.push(r);
         }
     }
     if !purged_redacts.is_empty() {
         let shorts: Vec<String> = purged_redacts
             .iter()
-            .map(|(op_id, id)| format!("op {} (redaction {})", op_id, id.short()))
+            .map(|r| format!("op {} (blob {} at {})", r.op_id, r.blob.short(), r.path))
             .collect();
         return Err(anyhow!(
             "Refusing to undo: at least one redaction in this chain has had its bytes purged ({}). \
@@ -432,7 +446,7 @@ fn ensure_redaction_undo_safe(
     if !allow_redact_undo {
         let shorts: Vec<String> = redact_ops
             .iter()
-            .map(|(op_id, id)| format!("op {} (redaction {})", op_id, id.short()))
+            .map(|r| format!("op {} (blob {} at {})", r.op_id, r.blob.short(), r.path))
             .collect();
         return Err(anyhow!(
             "Refusing to undo a `heddle redact apply`: the inverse removes the redaction record \

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -72,8 +72,15 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         // `remove_redaction` re-checks `purged_at` defensively so a
         // future caller that bypasses the CLI gate can't lose the
         // audit trail of destroyed bytes.
-        OpRecord::Redact { redaction_id, .. } => {
-            repo.remove_redaction(redaction_id)?;
+        //
+        // Match by `(blob, state, path)` rather than the oplog's
+        // `redaction_id`: `redaction_content_hash` includes
+        // `purged_at`, so a later Purge shifts the on-disk id away
+        // from the recorded one. The triple is stable.
+        OpRecord::Redact {
+            blob, state, path, ..
+        } => {
+            repo.remove_redaction(blob, state, path)?;
         }
         _ => {}
     }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -73,14 +73,20 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         // future caller that bypasses the CLI gate can't lose the
         // audit trail of destroyed bytes.
         //
-        // Match by `(blob, state, path)` rather than the oplog's
-        // `redaction_id`: `redaction_content_hash` includes
-        // `purged_at`, so a later Purge shifts the on-disk id away
-        // from the recorded one. The triple is stable.
+        // Pass the oplog-recorded `redaction_id` through so a
+        // refinement pass (multiple records sharing the same
+        // `(blob, state, path)` with different reasons or signatures)
+        // undoes the exact record this op references rather than the
+        // first match in sidecar order. `remove_redaction` falls
+        // back to `(state, path)` only for the purge-id-shift case
+        // and refuses in that branch.
         OpRecord::Redact {
-            blob, state, path, ..
+            redaction_id,
+            blob,
+            state,
+            path,
         } => {
-            repo.remove_redaction(blob, state, path)?;
+            repo.remove_redaction(blob, state, path, redaction_id)?;
         }
         _ => {}
     }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -65,6 +65,16 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         OpRecord::MarkerDelete { name, state } => {
             repo.refs().create_marker(name, state)?;
         }
+        // Redaction inverse: drop the specific redaction record so
+        // subsequent materialize calls restore the original blob
+        // bytes. The opt-in flag + purged-bytes check are enforced in
+        // `cmd_undo::ensure_redaction_undo_safe` before this point;
+        // `remove_redaction` re-checks `purged_at` defensively so a
+        // future caller that bypasses the CLI gate can't lose the
+        // audit trail of destroyed bytes.
+        OpRecord::Redact { redaction_id, .. } => {
+            repo.remove_redaction(redaction_id)?;
+        }
         _ => {}
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -414,9 +414,10 @@ async fn main() -> Result<()> {
             list,
             depth,
             preview,
+            allow_redact_undo,
         }) => {
             resolve_operation_id(&cli)?;
-            cmd_undo(&cli, *steps, *list, *depth, *preview)
+            cmd_undo(&cli, *steps, *list, *depth, *preview, *allow_redact_undo)
         }
 
         Commands::Redo { steps, preview } => {

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -964,3 +964,132 @@ fn test_undo_redact_refuses_when_blob_already_purged() {
         "the redaction must still be marked purged after refusal: {list:?}",
     );
 }
+
+#[test]
+fn test_redo_of_undone_redact_refuses() {
+    // Counterpart to the undo test: once a `Redact` batch has been
+    // undone with `--allow-redact-undo`, `heddle redo` refuses to
+    // re-apply it. The OpRecord doesn't preserve the full `Redaction`
+    // (reason, redactor, signature) needed for a faithful re-apply,
+    // so we surface a clear error instead of silently no-op'ing.
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+
+    // Undo with the opt-in. The Redact batch is now marked undone and
+    // sits as the next redoable batch.
+    heddle(&["undo", "--allow-redact-undo"], Some(temp.path()))
+        .expect("undo of Redact must succeed with --allow-redact-undo");
+
+    // Redo refuses with a message that names Redact + points the user
+    // at re-running `heddle redact apply`.
+    let err = heddle(&["redo"], Some(temp.path()))
+        .expect_err("redo of an undone Redact must refuse");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("redact"),
+        "redo refusal must mention Redact: {err}"
+    );
+    assert!(
+        lower.contains("redact apply") || lower.contains("re-apply"),
+        "redo refusal should redirect to `heddle redact apply`: {err}"
+    );
+
+    // Refusal is atomic — no state mutated. Redact list still 0 (the
+    // record was removed by the undo and the refused redo did not
+    // re-create it).
+    let list: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list["count"].as_u64().unwrap(),
+        0,
+        "redo refusal must not re-create the redaction: {list:?}",
+    );
+}
+
+#[test]
+fn test_undo_redact_preserves_sibling_redactions_on_same_blob() {
+    // When two redactions target the same blob (e.g. `--all-states`
+    // propagation, or a redact + a later refinement on a different
+    // path), undoing one must leave the other intact: the per-blob
+    // sidecar is rewritten in place rather than deleted wholesale.
+    let (temp, state_a) = setup_repo_with_secret();
+    // A second capture so we have two states referencing the same
+    // blob (the secrets file content is unchanged between captures,
+    // so the blob hash is identical — that's the trigger for the
+    // shared-sidecar code path).
+    std::fs::write(temp.path().join("trailing.txt"), "trailing").unwrap();
+    heddle_must_succeed(&["capture", "-m", "trailing"], temp.path());
+    let state_b = head_short(temp.path());
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state_a,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential (state_a)",
+        ],
+        temp.path(),
+    );
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state_b,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential (state_b)",
+        ],
+        temp.path(),
+    );
+
+    let list_before: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_before["count"].as_u64().unwrap(),
+        2,
+        "two redactions on the same blob expected: {list_before:?}",
+    );
+
+    // Undo the most-recent Redact (state_b) — the state_a redaction
+    // must survive untouched.
+    heddle(&["undo", "--allow-redact-undo"], Some(temp.path()))
+        .expect("undo of single Redact succeeds");
+
+    let list_after: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_after["count"].as_u64().unwrap(),
+        1,
+        "exactly one redaction should remain after one undo: {list_after:?}",
+    );
+    let surviving_reason = list_after["redactions"][0]["reason"].as_str().unwrap();
+    assert_eq!(
+        surviving_reason, "leaked credential (state_a)",
+        "the state_a redaction must survive when state_b's is undone"
+    );
+}

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1093,3 +1093,154 @@ fn test_undo_redact_preserves_sibling_redactions_on_same_blob() {
         "the state_a redaction must survive when state_b's is undone"
     );
 }
+
+#[test]
+fn test_undo_redact_removes_exact_record_when_multiple_target_same_triple() {
+    // Two `redact apply` invocations on the same (state, path) — a
+    // refinement pass where the operator updates `--reason` (or adds
+    // `--sign-with`) without first undoing the prior declaration.
+    // Each invocation writes a distinct `Redaction` (different reason →
+    // different content hash) into the per-blob sidecar.
+    //
+    // `heddle undo --allow-redact-undo -n 1` must remove the SECOND
+    // (most-recent) record because that's the one the most-recent op
+    // batch references. A naive `(state, path)` match would pick the
+    // first record in the sidecar and silently undo the wrong one,
+    // leaving the recently-refined reason behind.
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "initial: leaked credential",
+        ],
+        temp.path(),
+    );
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "refined: leaked api token v2",
+        ],
+        temp.path(),
+    );
+
+    let list_before: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_before["count"].as_u64().unwrap(),
+        2,
+        "two redactions on same (blob,state,path) expected: {list_before:?}",
+    );
+
+    // Undo the most-recent batch (the refined-reason redact). The
+    // initial-reason redaction must survive intact.
+    heddle(&["undo", "--allow-redact-undo"], Some(temp.path()))
+        .expect("undo of refined Redact succeeds");
+
+    let list_after: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_after["count"].as_u64().unwrap(),
+        1,
+        "exactly one redaction must remain after one undo: {list_after:?}",
+    );
+    let surviving_reason = list_after["redactions"][0]["reason"].as_str().unwrap();
+    assert_eq!(
+        surviving_reason, "initial: leaked credential",
+        "the initial (older) redaction must survive — undoing the refined batch must remove the refined record, not the initial one"
+    );
+}
+
+#[test]
+fn test_undo_preview_refuses_redact_without_allow_flag() {
+    // `heddle undo --preview` must mirror the real command's refusals
+    // rather than optimistically saying "Would undo ..." Pre-fix it
+    // short-circuited before the redaction safety check and lied about
+    // the outcome.
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+
+    let err = heddle(&["undo", "--preview"], Some(temp.path())).expect_err(
+        "undo --preview against a Redact batch must refuse without --allow-redact-undo",
+    );
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("redact"),
+        "preview refusal must name the redaction cause: {err}"
+    );
+    assert!(
+        lower.contains("--allow-redact-undo") || lower.contains("allow-redact-undo"),
+        "preview refusal must point at the opt-in flag: {err}"
+    );
+}
+
+#[test]
+fn test_undo_preview_refuses_redact_when_blob_already_purged() {
+    // Parallel to the non-preview case: undoing across a purged
+    // redaction must refuse with the irreversibility/audit-trail
+    // message, and `--preview` must surface that refusal honestly.
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+    heddle_must_succeed(
+        &[
+            "purge",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--force",
+        ],
+        temp.path(),
+    );
+
+    let err = heddle(
+        &["undo", "-n", "2", "--preview", "--allow-redact-undo"],
+        Some(temp.path()),
+    )
+    .expect_err("undo --preview across a purged redaction must refuse");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("purge") || lower.contains("irreversible"),
+        "preview refusal must name purge/irreversibility: {err}"
+    );
+}

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1244,3 +1244,39 @@ fn test_undo_preview_refuses_redact_when_blob_already_purged() {
         "preview refusal must name purge/irreversibility: {err}"
     );
 }
+
+#[test]
+fn test_redo_preview_refuses_redact_chain() {
+    // Mirror of the undo `--preview` honesty rule on the redo side:
+    // `heddle redo --preview` against a previously-undone Redact must
+    // surface the same "no re-apply path" refusal the real `redo`
+    // would surface, not advertise "Would redo …".
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+    heddle(&["undo", "--allow-redact-undo"], Some(temp.path()))
+        .expect("undo of Redact must succeed with --allow-redact-undo");
+
+    let err = heddle(&["redo", "--preview"], Some(temp.path()))
+        .expect_err("redo --preview of an undone Redact must refuse");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("redact"),
+        "redo preview refusal must mention Redact: {err}"
+    );
+    assert!(
+        lower.contains("redact apply") || lower.contains("re-apply"),
+        "redo preview refusal should redirect to `heddle redact apply`: {err}"
+    );
+}

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -746,3 +746,221 @@ fn locate_state_loose_file(repo_root: &std::path::Path, short: &str) -> Option<s
     }
     None
 }
+
+// ---------------------------------------------------------------------------
+// `OpRecord::Redact` undo (heddle#98). Pre-fix, `heddle undo` on a redaction
+// silently no-op'd — the doc claimed reversibility but the apply path fell
+// through to the default match arm. Post-fix, undo of a redaction is the
+// declared inverse: the redaction record is removed so subsequent
+// materializations restore the original blob bytes, gated behind an explicit
+// `--allow-redact-undo` flag so a casual `heddle undo` chain can't silently
+// re-expose previously-hidden sensitive content. A `Purge` that landed after
+// the `Redact` makes the redaction's audit-trail role load-bearing — undoing
+// the Redact in that case is refused regardless of the flag because the bytes
+// are physically gone and materialize would error rather than restore.
+// ---------------------------------------------------------------------------
+
+/// Bootstrap a repo containing a captured "leaked" secret. Returns the
+/// temp dir and the short change-id of the capture so the caller can
+/// pass it to `heddle redact apply <state>`.
+fn setup_repo_with_secret() -> (TempDir, String) {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::create_dir_all(temp.path().join("config")).unwrap();
+    std::fs::write(
+        temp.path().join("config/secrets.toml"),
+        b"api_token = \"super-secret-leaked-value\"\n",
+    )
+    .unwrap();
+    heddle_must_succeed(&["capture", "-m", "leak the secret"], temp.path());
+    let state = head_short(temp.path());
+    (temp, state)
+}
+
+#[test]
+fn test_undo_redact_with_allow_flag_restores_original_content() {
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+
+    // Sanity: redact list shows the new redaction, and the underlying
+    // materialize gate (the same function `materialize_blob` calls)
+    // reports an active stub.
+    let blob_hash = objects::object::Blob::from_slice(
+        b"api_token = \"super-secret-leaked-value\"\n",
+    )
+    .hash();
+    {
+        let repo = Repository::open(temp.path()).unwrap();
+        let stub = repo
+            .redaction_stub_for_blob(&blob_hash)
+            .expect("redaction_stub_for_blob must not error");
+        assert!(
+            stub.is_some(),
+            "with the redaction active, materialize must substitute the stub"
+        );
+    }
+    let list_before: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_before["count"].as_u64().unwrap(),
+        1,
+        "redact list should surface the new redaction: {list_before:?}",
+    );
+
+    // Undo with the explicit opt-in. The most recent batch is the
+    // Redact, so a single-step undo targets it.
+    heddle(&["undo", "--allow-redact-undo"], Some(temp.path()))
+        .expect("undo of Redact must succeed with --allow-redact-undo");
+
+    // Post-undo: redaction record is gone and materialize will now
+    // restore the original blob bytes (no stub substitution). This is
+    // the load-bearing "original content is restored" check from
+    // heddle#98's DoD — `redaction_stub_for_blob` is exactly what
+    // `materialize_blob` consults, so `None` here proves a subsequent
+    // materialize would surface the original bytes.
+    let list_after: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list_after["count"].as_u64().unwrap(),
+        0,
+        "after undo, no redaction should remain: {list_after:?}",
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let stub = repo
+        .redaction_stub_for_blob(&blob_hash)
+        .expect("redaction_stub_for_blob must not error");
+    assert!(
+        stub.is_none(),
+        "after undo, materialize must restore original bytes (no active stub)"
+    );
+}
+
+#[test]
+fn test_undo_redact_refuses_without_allow_flag() {
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+
+    // Without the opt-in flag, undo must refuse. The default is
+    // fail-loud so a casual `heddle undo` chain can't silently
+    // re-expose a redaction the user previously asked to hide.
+    let err = heddle(&["undo"], Some(temp.path()))
+        .expect_err("undo of a Redact must refuse without --allow-redact-undo");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("redact"),
+        "refusal must name the redaction cause: {err}"
+    );
+    assert!(
+        lower.contains("--allow-redact-undo") || lower.contains("allow-redact-undo"),
+        "refusal must point at the opt-in flag: {err}"
+    );
+
+    // Refusal is atomic — the redaction record must still be there.
+    let list: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list["count"].as_u64().unwrap(),
+        1,
+        "refusal must not mutate the redactions sidecar: {list:?}"
+    );
+}
+
+#[test]
+fn test_undo_redact_refuses_when_blob_already_purged() {
+    // Purge is irreversible — bytes are gone from local storage. Once
+    // a Redact has been followed by Purge, the Redaction record's role
+    // shifts from "stub-substitution declaration" to "audit trail of
+    // destroyed bytes". Removing it would lie about what's on disk and
+    // any subsequent materialize would fail with a missing-blob error
+    // rather than restore content. The undo must refuse with a clear
+    // message, even with the allow flag.
+    let (temp, state) = setup_repo_with_secret();
+
+    heddle_must_succeed(
+        &[
+            "redact",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--reason",
+            "leaked credential",
+        ],
+        temp.path(),
+    );
+    heddle_must_succeed(
+        &[
+            "purge",
+            "apply",
+            &state,
+            "--path",
+            "config/secrets.toml",
+            "--force",
+        ],
+        temp.path(),
+    );
+
+    // Attempt to undo both batches with the redact-undo opt-in. The
+    // Purge inverse refuses outright (Purge is irreversible by design),
+    // and reaching past it to the Redact must also refuse because the
+    // redaction is now purged.
+    let err = heddle(
+        &["undo", "-n", "2", "--allow-redact-undo"],
+        Some(temp.path()),
+    )
+    .expect_err("undo across a purged redaction must refuse");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("purge") || lower.contains("irreversible"),
+        "refusal must name purge/irreversibility: {err}"
+    );
+
+    // The redaction record must remain, marked purged.
+    let list: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "redact", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert_eq!(
+        list["count"].as_u64().unwrap(),
+        1,
+        "refusal must not mutate the redactions sidecar: {list:?}",
+    );
+    assert!(
+        list["redactions"][0]["purged"].as_bool().unwrap(),
+        "the redaction must still be marked purged after refusal: {list:?}",
+    );
+}

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -155,30 +155,53 @@ pub trait OpLogBackend: Send + Sync {
 
     /// Record a redaction declaration. The blob bytes stay on disk —
     /// `Purge` is the separate, irreversible step that removes them.
+    ///
+    /// `scope` carries the repo's `op_scope()` so the CLI's scoped
+    /// undo can reach this batch. Without it the entry is recorded
+    /// with `scope: None` and `undo_batches_scoped` (the only path
+    /// `heddle undo` consults) silently filters it out — the silent
+    /// no-op fixed under heddle#98.
     fn record_redact(
         &self,
         redaction_id: &ContentHash,
         blob: &ContentHash,
         state: &ChangeId,
         path: &str,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        let ids = self.record_batch(vec![OpRecord::Redact {
-            redaction_id: *redaction_id,
-            blob: *blob,
-            state: *state,
-            path: path.to_string(),
-        }])?;
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::Redact {
+                redaction_id: *redaction_id,
+                blob: *blob,
+                state: *state,
+                path: path.to_string(),
+            }],
+            scope,
+        )?;
         Ok(ids[0])
     }
 
     /// Record a purge — the underlying blob bytes were physically
     /// removed from local storage. The associated `Redaction` record
     /// stays in place.
-    fn record_purge(&self, redaction_id: &ContentHash, blob: &ContentHash) -> Result<u64> {
-        let ids = self.record_batch(vec![OpRecord::Purge {
-            redaction_id: *redaction_id,
-            blob: *blob,
-        }])?;
+    ///
+    /// Scoped for the same reason as `record_redact`: the CLI's
+    /// `heddle undo` only sees scoped batches, and the Purge inverse
+    /// (refusal) needs to see the entry to surface the irreversibility
+    /// message instead of silently skipping it.
+    fn record_purge(
+        &self,
+        redaction_id: &ContentHash,
+        blob: &ContentHash,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::Purge {
+                redaction_id: *redaction_id,
+                blob: *blob,
+            }],
+            scope,
+        )?;
         Ok(ids[0])
     }
 }

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -130,29 +130,43 @@ impl OpLog {
         })
     }
 
-    /// Record a redaction declaration.
+    /// Record a redaction declaration. See the trait-level doc on
+    /// `OpLogBackend::record_redact` for why `scope` is required —
+    /// without it the entry slips past the CLI's scoped undo filter.
     pub fn record_redact(
         &self,
         redaction_id: &ContentHash,
         blob: &ContentHash,
         state: &ChangeId,
         path: &str,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        self.record_single(OpRecord::Redact {
-            redaction_id: *redaction_id,
-            blob: *blob,
-            state: *state,
-            path: path.to_string(),
-        })
+        self.record_single_scoped(
+            OpRecord::Redact {
+                redaction_id: *redaction_id,
+                blob: *blob,
+                state: *state,
+                path: path.to_string(),
+            },
+            scope,
+        )
     }
 
     /// Record a purge — the underlying blob bytes were physically removed.
     /// The associated `Redaction` record stays in place; only the bytes
     /// are gone.
-    pub fn record_purge(&self, redaction_id: &ContentHash, blob: &ContentHash) -> Result<u64> {
-        self.record_single(OpRecord::Purge {
-            redaction_id: *redaction_id,
-            blob: *blob,
-        })
+    pub fn record_purge(
+        &self,
+        redaction_id: &ContentHash,
+        blob: &ContentHash,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        self.record_single_scoped(
+            OpRecord::Purge {
+                redaction_id: *redaction_id,
+                blob: *blob,
+            },
+            scope,
+        )
     }
 }

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -85,9 +85,25 @@ pub enum OpRecord {
     },
     /// A redaction was declared on a blob in a specific state. The blob
     /// bytes are still on disk; readers see the stub from the
-    /// `Redaction` object instead. Reversible via `heddle undo` (the
-    /// reversal stops materialize from substituting the stub but doesn't
-    /// touch any later Purge — Purge is irreversible).
+    /// `Redaction` object instead.
+    ///
+    /// Reversible via `heddle undo --allow-redact-undo`. The inverse
+    /// removes the specific `Redaction` record from the per-blob
+    /// sidecar so subsequent materializes restore the original bytes.
+    /// The opt-in flag exists because the inverse re-exposes
+    /// previously-hidden content; a casual `heddle undo` chain refuses
+    /// rather than silently unwind the stub-substitution.
+    ///
+    /// Refused regardless of the flag when the underlying bytes have
+    /// since been purged: the `Redaction` record is then load-bearing
+    /// audit trail for "these bytes were physically destroyed", and
+    /// removing it would lie about local storage. `Purge` itself is
+    /// irreversible.
+    ///
+    /// **Redo is not supported.** The OpRecord doesn't preserve the
+    /// full `Redaction` (reason, redactor, signature, …), so `heddle
+    /// redo` of an undone Redact refuses with a clear message rather
+    /// than silently no-op. Re-run `heddle redact apply` to recreate.
     Redact {
         /// Content hash of the encoded `Redaction` object.
         redaction_id: ContentHash,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -69,7 +69,7 @@ pub use repository::{
     WorktreeCompareProfile, WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct,
     find_merge_base, is_major_rewrite, is_synthetic_root,
 };
-pub use repository_redaction::PurgeOutcome;
+pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -213,97 +213,104 @@ impl Repository {
         Ok(None)
     }
 
-    /// Reverse a redaction declaration by removing the specific record
-    /// (identified by its content-addressed id) from the on-disk
-    /// sidecar. This is the inverse of `put_redaction` for the
-    /// undo path — see [`OpRecord::Redact`](oplog::OpRecord)'s undo
-    /// contract.
+    /// Reverse a redaction declaration by removing the matching record
+    /// from the per-blob sidecar. The undo-path inverse of
+    /// [`Repository::put_redaction`] — see [`OpRecord::Redact`](oplog::OpRecord)'s
+    /// undo contract.
     ///
-    /// Refuses if the redaction's bytes have already been purged
-    /// (`purged_at: Some(_)`): the Redaction record is then load-
-    /// bearing audit trail for "these bytes were physically destroyed",
-    /// and removing it would lie. Purge is documented irreversible.
+    /// We match by `(blob, state, path)` rather than by the redaction's
+    /// content-addressed id because `redaction_content_hash` includes
+    /// every field in the canonical encoding, including `purged_at`.
+    /// A `Purge` between the original `redact apply` and this call
+    /// mutates `purged_at`, which shifts the on-disk id away from the
+    /// pre-purge id carried in `OpRecord::Redact.redaction_id`. The
+    /// `(blob, state, path)` triple is the redaction's user-visible
+    /// identity (one per spot) and is stable across purge.
     ///
-    /// Returns the outcome — whether a record was removed and whether
-    /// the surrounding sidecar file is now empty (callers can use this
-    /// to clean up the empty `.bin` file if desired; the read path
-    /// already treats a missing file as `RedactionsBlob::empty`).
+    /// Refuses if the matched redaction is purged: the record is then
+    /// load-bearing audit trail for "these bytes were physically
+    /// destroyed", and removing it would lie. Purge is irreversible.
+    ///
+    /// Returns the outcome — whether the surrounding sidecar file is
+    /// now empty (single-redaction case) or rewritten in place.
     pub fn remove_redaction(
         &self,
-        redaction_id: &ContentHash,
+        blob: &ContentHash,
+        state: &ChangeId,
+        path: &str,
     ) -> Result<RemoveRedactionOutcome> {
-        // Walk the per-blob sidecars to find the one carrying this id.
-        // Today the redactions store is small enough (operator-scale,
-        // not per-row) that an O(N) scan is fine; the same `get_redaction`
-        // helper above already pays this cost.
-        for (blob, mut redactions_blob) in self.list_all_redactions()? {
-            // Locate the entry by re-computing each contained
-            // redaction's canonical id. Cheaper than threading the id
-            // through the on-disk schema and keeps the storage format
-            // version-stable.
-            let mut found_index: Option<usize> = None;
-            for (index, redaction) in redactions_blob.redactions.iter().enumerate() {
-                let id = redaction_content_hash(redaction)?;
-                if &id == redaction_id {
-                    if redaction.is_purged() {
-                        anyhow::bail!(
-                            "redaction {} on blob {} cannot be undone: the underlying bytes were purged \
-                             (Purge is irreversible — the redaction record is load-bearing audit trail \
-                              for the destroyed bytes)",
-                            redaction_id.short(),
-                            blob.short(),
-                        );
-                    }
-                    found_index = Some(index);
-                    break;
-                }
+        let mut redactions_blob = self.get_redactions_for_blob(blob)?;
+        let found_index = redactions_blob
+            .redactions
+            .iter()
+            .position(|r| r.state == *state && r.path == path);
+        let Some(index) = found_index else {
+            anyhow::bail!(
+                "redaction for blob {} at {} in {} not found — it may \
+                 have already been removed",
+                blob.short(),
+                path,
+                state.short(),
+            );
+        };
+        if redactions_blob.redactions[index].is_purged() {
+            anyhow::bail!(
+                "redaction for blob {} at {} in {} cannot be undone: the underlying bytes were purged \
+                 (Purge is irreversible — the redaction record is load-bearing audit trail \
+                 for the destroyed bytes)",
+                blob.short(),
+                path,
+                state.short(),
+            );
+        }
+        redactions_blob.redactions.remove(index);
+        let sidecar_path = self.redaction_path_for_blob(blob);
+        if redactions_blob.redactions.is_empty() {
+            // Empty sidecar — clean up the file so `list_all_redactions`
+            // doesn't carry around a hollow entry. Missing-file is
+            // already the "no redactions for this blob" signal.
+            if sidecar_path.exists() {
+                fs::remove_file(&sidecar_path).with_context(|| {
+                    format!("remove empty redactions sidecar '{}'", sidecar_path.display())
+                })?;
             }
-            let Some(index) = found_index else {
-                continue;
-            };
-            redactions_blob.redactions.remove(index);
-            let path = self.redaction_path_for_blob(&blob);
-            if redactions_blob.redactions.is_empty() {
-                // Empty sidecar — clean up the file so `list_all_redactions`
-                // doesn't carry around a hollow entry. Missing-file is
-                // already the "no redactions for this blob" signal.
-                if path.exists() {
-                    fs::remove_file(&path).with_context(|| {
-                        format!("remove empty redactions sidecar '{}'", path.display())
-                    })?;
-                }
-                return Ok(RemoveRedactionOutcome {
-                    blob,
-                    sidecar_now_empty: true,
-                });
-            }
-            let bytes = redactions_blob
-                .encode()
-                .with_context(|| "re-encode redactions blob after removal")?;
-            write_file_atomic(&path, &bytes)
-                .with_context(|| format!("write '{}'", path.display()))?;
             return Ok(RemoveRedactionOutcome {
-                blob,
-                sidecar_now_empty: false,
+                blob: *blob,
+                sidecar_now_empty: true,
             });
         }
-        anyhow::bail!(
-            "redaction {} not found in any sidecar — it may have already \
-             been removed",
-            redaction_id.short(),
-        )
+        let bytes = redactions_blob
+            .encode()
+            .with_context(|| "re-encode redactions blob after removal")?;
+        write_file_atomic(&sidecar_path, &bytes)
+            .with_context(|| format!("write '{}'", sidecar_path.display()))?;
+        Ok(RemoveRedactionOutcome {
+            blob: *blob,
+            sidecar_now_empty: false,
+        })
     }
 
-    /// Look up a redaction's current `purged_at` state by id. Used by
-    /// the undo pre-flight to refuse before any mutation if removing
-    /// the redaction record would lie about destroyed bytes.
-    pub fn redaction_is_purged(&self, redaction_id: &ContentHash) -> Result<bool> {
-        match self.get_redaction(redaction_id)? {
-            Some((_, redaction)) => Ok(redaction.is_purged()),
-            // A missing redaction is not "purged"; let the caller's
-            // own missing-record path surface the right error.
-            None => Ok(false),
-        }
+    /// Look up the redaction matching `(blob, state, path)` and report
+    /// whether its underlying bytes have been purged. Used by the undo
+    /// pre-flight to refuse before any mutation when removing the
+    /// redaction record would lie about destroyed bytes.
+    ///
+    /// Returns `false` when no matching record exists — the caller's
+    /// own missing-record path surfaces that condition with the right
+    /// error.
+    pub fn redaction_is_purged(
+        &self,
+        blob: &ContentHash,
+        state: &ChangeId,
+        path: &str,
+    ) -> Result<bool> {
+        let redactions_blob = self.get_redactions_for_blob(blob)?;
+        Ok(redactions_blob
+            .redactions
+            .iter()
+            .find(|r| r.state == *state && r.path == path)
+            .map(|r| r.is_purged())
+            .unwrap_or(false))
     }
 
     /// Mark every redaction on `blob` as purged and physically remove the
@@ -831,6 +838,162 @@ mod tests {
         assert!(
             missing.is_none(),
             "lookup of unknown id must return None, not error"
+        );
+    }
+
+    #[test]
+    fn remove_redaction_drops_record_and_deletes_empty_sidecar() {
+        let (_dir, repo) = fresh_repo();
+        let r = sample_redaction();
+        let blob = r.redacted_blob;
+        let state = r.state;
+        let path = r.path.clone();
+        repo.put_redaction(r).unwrap();
+        let outcome = repo
+            .remove_redaction(&blob, &state, &path)
+            .expect("remove existing redaction");
+        assert_eq!(outcome.blob, blob);
+        assert!(
+            outcome.sidecar_now_empty,
+            "single-redaction sidecar must be deleted, not left as empty .bin",
+        );
+
+        // Subsequent lookup returns empty — the sidecar file is gone.
+        let stored = repo
+            .get_redactions_for_blob(&blob)
+            .expect("read post-remove");
+        assert!(
+            stored.redactions.is_empty(),
+            "remove must clear the redaction from the per-blob sidecar"
+        );
+
+        // Materialize gate now restores original bytes (no active stub).
+        let stub = repo
+            .redaction_stub_for_blob(&blob)
+            .expect("stub lookup");
+        assert!(
+            stub.is_none(),
+            "with no active redaction, materialize must not substitute the stub"
+        );
+    }
+
+    #[test]
+    fn remove_redaction_keeps_siblings_when_multiple_target_same_blob() {
+        // Two redactions on the same blob with different (state, path)
+        // tuples. Removing one rewrites the sidecar in place; the
+        // other survives.
+        let (_dir, repo) = fresh_repo();
+        let first = sample_redaction();
+        let first_state = first.state;
+        let first_path = first.path.clone();
+        let blob = first.redacted_blob;
+        repo.put_redaction(first).unwrap();
+        let second = Redaction {
+            state: ChangeId::from_bytes([2u8; 16]),
+            path: "config/other.toml".into(),
+            reason: "follow-up reason".into(),
+            ..sample_redaction()
+        };
+        repo.put_redaction(second).unwrap();
+
+        let outcome = repo
+            .remove_redaction(&blob, &first_state, &first_path)
+            .expect("remove first redaction");
+        assert!(
+            !outcome.sidecar_now_empty,
+            "sibling redaction must keep the sidecar alive"
+        );
+
+        let stored = repo
+            .get_redactions_for_blob(&blob)
+            .expect("read post-remove");
+        assert_eq!(stored.redactions.len(), 1);
+        // The surviving record is the second one — identified by its
+        // (different) `path` field.
+        assert_eq!(stored.redactions[0].path, "config/other.toml");
+    }
+
+    #[test]
+    fn remove_redaction_refuses_when_already_purged() {
+        // Defensive: even if the CLI pre-flight is bypassed (e.g. a
+        // future caller goes straight to `remove_redaction`), the
+        // helper itself refuses to drop the audit trail of destroyed
+        // bytes. The error message must explain the cause.
+        let (_dir, repo) = fresh_repo();
+        let r = sample_redaction();
+        let blob = r.redacted_blob;
+        let state = r.state;
+        let path = r.path.clone();
+        repo.put_redaction(r).unwrap();
+        repo.purge_blob(&blob, &sample_principal())
+            .expect("purge after redact");
+
+        let err = repo
+            .remove_redaction(&blob, &state, &path)
+            .expect_err("remove must refuse on a purged redaction");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("purged") || msg.contains("Purge is irreversible"),
+            "refusal must name the purged/irreversibility cause: {msg}"
+        );
+
+        // Record must still be there, marked purged.
+        let stored = repo
+            .get_redactions_for_blob(&blob)
+            .expect("read after refusal");
+        assert_eq!(stored.redactions.len(), 1);
+        assert!(stored.redactions[0].is_purged());
+    }
+
+    #[test]
+    fn remove_redaction_errors_when_record_not_found() {
+        // Unknown (blob, state, path) surfaces a clear error instead
+        // of silently succeeding. This is the "already removed / never
+        // existed" safety net.
+        let (_dir, repo) = fresh_repo();
+        let unknown_blob = ContentHash::from_bytes([0u8; 32]);
+        let unknown_state = ChangeId::from_bytes([0u8; 16]);
+        let err = repo
+            .remove_redaction(&unknown_blob, &unknown_state, "config/nope.toml")
+            .expect_err("unknown record must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found"),
+            "refusal must explain the missing-record cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn redaction_is_purged_reflects_current_state() {
+        let (_dir, repo) = fresh_repo();
+        let r = sample_redaction();
+        let blob = r.redacted_blob;
+        let state = r.state;
+        let path = r.path.clone();
+        repo.put_redaction(r).unwrap();
+        assert!(
+            !repo
+                .redaction_is_purged(&blob, &state, &path)
+                .expect("pre-purge lookup"),
+            "fresh redaction must not report purged"
+        );
+        repo.purge_blob(&blob, &sample_principal())
+            .expect("purge");
+        assert!(
+            repo.redaction_is_purged(&blob, &state, &path)
+                .expect("post-purge lookup"),
+            "after purge_blob, redaction_is_purged must return true"
+        );
+
+        // Unknown (blob, state, path) → false. Lets the caller's own
+        // missing-record path surface the cause.
+        let unknown_blob = ContentHash::from_bytes([0u8; 32]);
+        let unknown_state = ChangeId::from_bytes([0u8; 16]);
+        assert!(
+            !repo
+                .redaction_is_purged(&unknown_blob, &unknown_state, "missing")
+                .expect("unknown lookup"),
+            "unknown record is not 'purged'; surfaces as false"
         );
     }
 

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -218,14 +218,22 @@ impl Repository {
     /// [`Repository::put_redaction`] — see [`OpRecord::Redact`](oplog::OpRecord)'s
     /// undo contract.
     ///
-    /// We match by `(blob, state, path)` rather than by the redaction's
-    /// content-addressed id because `redaction_content_hash` includes
-    /// every field in the canonical encoding, including `purged_at`.
-    /// A `Purge` between the original `redact apply` and this call
-    /// mutates `purged_at`, which shifts the on-disk id away from the
-    /// pre-purge id carried in `OpRecord::Redact.redaction_id`. The
-    /// `(blob, state, path)` triple is the redaction's user-visible
-    /// identity (one per spot) and is stable across purge.
+    /// Matches by the redaction's content-addressed `redaction_id`
+    /// first so a refinement pass that produced multiple records for
+    /// the same `(blob, state, path)` (e.g. a re-run of `redact apply`
+    /// with an updated `--reason` or `--sign-with`) undoes the exact
+    /// record the OpRecord references rather than the first one in
+    /// sidecar order.
+    ///
+    /// Falls back to `(blob, state, path)` lookup when the id doesn't
+    /// match any on-disk record. That case is the
+    /// purge-id-shift scenario: `redaction_content_hash` covers every
+    /// field including `purged_at`, so a `Purge` between
+    /// `redact apply` and this call rewrites every on-disk id away
+    /// from the pre-purge id carried in `OpRecord::Redact.redaction_id`.
+    /// The fallback locates the now-purged record by its stable
+    /// user-visible identity so the refusal below surfaces with the
+    /// right "audit trail" message instead of a generic not-found.
     ///
     /// Refuses if the matched redaction is purged: the record is then
     /// load-bearing audit trail for "these bytes were physically
@@ -238,12 +246,22 @@ impl Repository {
         blob: &ContentHash,
         state: &ChangeId,
         path: &str,
+        redaction_id: &ContentHash,
     ) -> Result<RemoveRedactionOutcome> {
         let mut redactions_blob = self.get_redactions_for_blob(blob)?;
-        let found_index = redactions_blob
-            .redactions
-            .iter()
-            .position(|r| r.state == *state && r.path == path);
+        let mut found_index: Option<usize> = None;
+        for (i, r) in redactions_blob.redactions.iter().enumerate() {
+            if redaction_content_hash(r)? == *redaction_id {
+                found_index = Some(i);
+                break;
+            }
+        }
+        if found_index.is_none() {
+            found_index = redactions_blob
+                .redactions
+                .iter()
+                .position(|r| r.state == *state && r.path == path);
+        }
         let Some(index) = found_index else {
             anyhow::bail!(
                 "redaction for blob {} at {} in {} not found — it may \
@@ -848,9 +866,9 @@ mod tests {
         let blob = r.redacted_blob;
         let state = r.state;
         let path = r.path.clone();
-        repo.put_redaction(r).unwrap();
+        let id = repo.put_redaction(r).unwrap();
         let outcome = repo
-            .remove_redaction(&blob, &state, &path)
+            .remove_redaction(&blob, &state, &path, &id)
             .expect("remove existing redaction");
         assert_eq!(outcome.blob, blob);
         assert!(
@@ -887,7 +905,7 @@ mod tests {
         let first_state = first.state;
         let first_path = first.path.clone();
         let blob = first.redacted_blob;
-        repo.put_redaction(first).unwrap();
+        let first_id = repo.put_redaction(first).unwrap();
         let second = Redaction {
             state: ChangeId::from_bytes([2u8; 16]),
             path: "config/other.toml".into(),
@@ -897,7 +915,7 @@ mod tests {
         repo.put_redaction(second).unwrap();
 
         let outcome = repo
-            .remove_redaction(&blob, &first_state, &first_path)
+            .remove_redaction(&blob, &first_state, &first_path, &first_id)
             .expect("remove first redaction");
         assert!(
             !outcome.sidecar_now_empty,
@@ -924,12 +942,12 @@ mod tests {
         let blob = r.redacted_blob;
         let state = r.state;
         let path = r.path.clone();
-        repo.put_redaction(r).unwrap();
+        let id = repo.put_redaction(r).unwrap();
         repo.purge_blob(&blob, &sample_principal())
             .expect("purge after redact");
 
         let err = repo
-            .remove_redaction(&blob, &state, &path)
+            .remove_redaction(&blob, &state, &path, &id)
             .expect_err("remove must refuse on a purged redaction");
         let msg = err.to_string();
         assert!(
@@ -953,13 +971,55 @@ mod tests {
         let (_dir, repo) = fresh_repo();
         let unknown_blob = ContentHash::from_bytes([0u8; 32]);
         let unknown_state = ChangeId::from_bytes([0u8; 16]);
+        let unknown_id = ContentHash::from_bytes([0u8; 32]);
         let err = repo
-            .remove_redaction(&unknown_blob, &unknown_state, "config/nope.toml")
+            .remove_redaction(&unknown_blob, &unknown_state, "config/nope.toml", &unknown_id)
             .expect_err("unknown record must error");
         let msg = err.to_string();
         assert!(
             msg.contains("not found"),
             "refusal must explain the missing-record cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn remove_redaction_picks_exact_record_when_multiple_share_state_and_path() {
+        // Two redactions with identical (blob, state, path) but
+        // different reasons → distinct content-addressed ids. Removing
+        // by id must drop the targeted record only; the sibling
+        // record at the same triple must survive. The fallback
+        // `(state, path)` lookup would silently pick the first record
+        // in sidecar order and undo the wrong declaration.
+        let (_dir, repo) = fresh_repo();
+        let first = Redaction {
+            reason: "initial: leaked credential".into(),
+            ..sample_redaction()
+        };
+        let blob = first.redacted_blob;
+        let state = first.state;
+        let path = first.path.clone();
+        let first_id = repo.put_redaction(first).unwrap();
+        let second = Redaction {
+            reason: "refined: leaked api token v2".into(),
+            redacted_at: Utc.with_ymd_and_hms(2026, 5, 11, 9, 0, 0).unwrap(),
+            ..sample_redaction()
+        };
+        let second_id = repo.put_redaction(second).unwrap();
+        assert_ne!(
+            first_id, second_id,
+            "different reasons must produce distinct content ids"
+        );
+
+        repo.remove_redaction(&blob, &state, &path, &second_id)
+            .expect("remove second redaction by id");
+
+        let stored = repo
+            .get_redactions_for_blob(&blob)
+            .expect("read post-remove");
+        assert_eq!(stored.redactions.len(), 1);
+        assert_eq!(
+            stored.redactions[0].reason, "initial: leaked credential",
+            "the initial record must survive — exact-id match must not undo the wrong sibling",
         );
     }
 

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -73,6 +73,20 @@ pub struct WireAcceptOutcome {
     pub skipped_existing: usize,
 }
 
+/// Outcome of a [`Repository::remove_redaction`] call. Surfaces the
+/// blob the redaction targeted and whether the sidecar file is now
+/// empty so the undo path can announce the change without re-walking
+/// the store.
+#[derive(Debug, Clone)]
+pub struct RemoveRedactionOutcome {
+    /// Blob the removed redaction targeted.
+    pub blob: ContentHash,
+    /// `true` when the sidecar file held only this one redaction and
+    /// has been deleted from disk; `false` when other redactions
+    /// remain on the same blob and the file was rewritten in place.
+    pub sidecar_now_empty: bool,
+}
+
 /// Outcome of a `purge` call. Useful for surfaces that report what
 /// actually changed (the JSON output of `heddle purge`).
 #[derive(Debug, Clone)]
@@ -197,6 +211,99 @@ impl Repository {
             }
         }
         Ok(None)
+    }
+
+    /// Reverse a redaction declaration by removing the specific record
+    /// (identified by its content-addressed id) from the on-disk
+    /// sidecar. This is the inverse of `put_redaction` for the
+    /// undo path — see [`OpRecord::Redact`](oplog::OpRecord)'s undo
+    /// contract.
+    ///
+    /// Refuses if the redaction's bytes have already been purged
+    /// (`purged_at: Some(_)`): the Redaction record is then load-
+    /// bearing audit trail for "these bytes were physically destroyed",
+    /// and removing it would lie. Purge is documented irreversible.
+    ///
+    /// Returns the outcome — whether a record was removed and whether
+    /// the surrounding sidecar file is now empty (callers can use this
+    /// to clean up the empty `.bin` file if desired; the read path
+    /// already treats a missing file as `RedactionsBlob::empty`).
+    pub fn remove_redaction(
+        &self,
+        redaction_id: &ContentHash,
+    ) -> Result<RemoveRedactionOutcome> {
+        // Walk the per-blob sidecars to find the one carrying this id.
+        // Today the redactions store is small enough (operator-scale,
+        // not per-row) that an O(N) scan is fine; the same `get_redaction`
+        // helper above already pays this cost.
+        for (blob, mut redactions_blob) in self.list_all_redactions()? {
+            // Locate the entry by re-computing each contained
+            // redaction's canonical id. Cheaper than threading the id
+            // through the on-disk schema and keeps the storage format
+            // version-stable.
+            let mut found_index: Option<usize> = None;
+            for (index, redaction) in redactions_blob.redactions.iter().enumerate() {
+                let id = redaction_content_hash(redaction)?;
+                if &id == redaction_id {
+                    if redaction.is_purged() {
+                        anyhow::bail!(
+                            "redaction {} on blob {} cannot be undone: the underlying bytes were purged \
+                             (Purge is irreversible — the redaction record is load-bearing audit trail \
+                              for the destroyed bytes)",
+                            redaction_id.short(),
+                            blob.short(),
+                        );
+                    }
+                    found_index = Some(index);
+                    break;
+                }
+            }
+            let Some(index) = found_index else {
+                continue;
+            };
+            redactions_blob.redactions.remove(index);
+            let path = self.redaction_path_for_blob(&blob);
+            if redactions_blob.redactions.is_empty() {
+                // Empty sidecar — clean up the file so `list_all_redactions`
+                // doesn't carry around a hollow entry. Missing-file is
+                // already the "no redactions for this blob" signal.
+                if path.exists() {
+                    fs::remove_file(&path).with_context(|| {
+                        format!("remove empty redactions sidecar '{}'", path.display())
+                    })?;
+                }
+                return Ok(RemoveRedactionOutcome {
+                    blob,
+                    sidecar_now_empty: true,
+                });
+            }
+            let bytes = redactions_blob
+                .encode()
+                .with_context(|| "re-encode redactions blob after removal")?;
+            write_file_atomic(&path, &bytes)
+                .with_context(|| format!("write '{}'", path.display()))?;
+            return Ok(RemoveRedactionOutcome {
+                blob,
+                sidecar_now_empty: false,
+            });
+        }
+        anyhow::bail!(
+            "redaction {} not found in any sidecar — it may have already \
+             been removed",
+            redaction_id.short(),
+        )
+    }
+
+    /// Look up a redaction's current `purged_at` state by id. Used by
+    /// the undo pre-flight to refuse before any mutation if removing
+    /// the redaction record would lie about destroyed bytes.
+    pub fn redaction_is_purged(&self, redaction_id: &ContentHash) -> Result<bool> {
+        match self.get_redaction(redaction_id)? {
+            Some((_, redaction)) => Ok(redaction.is_purged()),
+            // A missing redaction is not "purged"; let the caller's
+            // own missing-record path surface the right error.
+            None => Ok(false),
+        }
     }
 
     /// Mark every redaction on `blob` as purged and physically remove the

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -20,6 +20,7 @@ follow-ups.
 | `heddle thread rename`   | Renames back.                                                   |
 | `heddle marker create`   | Deletes the marker.                                             |
 | `heddle marker drop`     | Recreates the marker at its prior state.                        |
+| `heddle redact apply`    | Removes the redaction record so the next materialize restores the original bytes. Requires `--allow-redact-undo` (see "Safety contracts"). Refused when the blob has since been purged. |
 
 The list above is the **shipped** surface for v0.2. The inverses live in
 `crates/cli/src/cli/commands/undo_apply.rs`; the oplog records that drive them
@@ -32,9 +33,12 @@ own, are destructive by design, or need a substrate change we haven't shipped:
 
 - **`heddle push` / `heddle fetch`** — remote-affecting. Reverting them would
   require coordinating with the other side. File a follow-up if you need this.
-- **`heddle purge`** — physically removes blob bytes. Documented irreversible
-  in `OpRecord::Purge` (the `Redact` declaration that preceded it can still
-  be undone separately when that path lands).
+- **`heddle purge`** — physically removes blob bytes; refused by `heddle undo`
+  with a single clear message naming the affected op. Documented irreversible
+  in `OpRecord::Purge`. Even with `--allow-redact-undo`, an undo chain that
+  reaches across a purged redaction is refused: the `Redaction` record is
+  the only on-disk audit trail that the bytes were destroyed, and removing
+  it would lie about local storage.
 - **Cross-thread undo** — today's undo only rewinds operations recorded on the
   current checkout's HEAD path. Undoing an op that mutated a different thread
   is the design problem heddle#23's title points at; the MVP ships the
@@ -47,6 +51,15 @@ own, are destructive by design, or need a substrate change we haven't shipped:
 The CLI is designed to **fail loud** instead of silently corrupting state. The
 contracts below are enforced by integration tests in
 `crates/cli/tests/core_functionality/undo_and_special.rs`.
+
+- **Redact-undo opt-in.** `heddle undo` refuses to roll back a `heddle redact
+  apply` unless you pass `--allow-redact-undo`. The inverse removes the
+  redaction record, so the next materialize restores the original blob bytes
+  — i.e. previously-hidden content becomes readable. The opt-in turns the
+  re-exposure into an explicit decision instead of a side effect of a casual
+  multi-step undo. Refused regardless of the flag when a `Purge` has
+  destroyed the underlying bytes (the redaction's audit-trail role is then
+  load-bearing).
 
 - **Dirty worktree refusal.** If you have uncommitted changes (modified
   tracked files, untracked files), `heddle undo` refuses and surfaces the
@@ -72,6 +85,7 @@ contracts below are enforced by integration tests in
 | `--list`                   | Print the recent batches without undoing.                   |
 | `--depth <N>`              | How many batches `--list` shows (default 20).               |
 | `--preview` / `--dry-run`  | Print what would change without applying.                   |
+| `--allow-redact-undo`      | Explicit opt-in to undo a `heddle redact apply` (see "Safety contracts"). |
 | `--output {auto,json,text}`| Force output format. JSON is the structured contract.        |
 
 Run `heddle undo --help` for the curated list with examples and the explicit
@@ -89,6 +103,10 @@ Run `heddle undo --help` for the curated list with examples and the explicit
 - `OpRecord::Checkpoint` is defined but no current code path emits it; the
   variant exists for the agent-frequent-saves work in flight. When it lands
   it will need its own inverse arm in `undo_apply.rs`.
-- `OpRecord::Redact` is documented as reversible but currently no-ops on
-  undo (`undo_apply.rs` falls through to the default arm). A follow-up
-  will reverse the materialize-substitution side effect.
+- **Redact redo is unsupported.** `heddle redo` of a previously-undone
+  `Redact` refuses with a clear error: the `OpRecord::Redact` entry doesn't
+  preserve the full `Redaction` record (reason, redactor, signature) needed
+  to faithfully re-apply, so any "redo" path would invent the missing
+  fields. Re-run `heddle redact apply` to recreate. A follow-up could stash
+  the removed `Redaction` on undo and restore it on redo if the round-trip
+  becomes load-bearing for daily use.


### PR DESCRIPTION
## Summary

- `OpRecord::Redact` was documented as reversible but `heddle undo` was a silent no-op. Two compounding bugs: (1) `record_redact` / `record_purge` recorded entries with `scope: None`, so the CLI's `undo_batches_scoped` filtered them out and `heddle undo` rewound the previous scoped op instead; (2) even if the batch were visible, `apply_undo_entry` fell through to `_ => {}`.
- Implement the documented inverse: scope the redact/purge oplog entries; add `Repository::remove_redaction` and wire it into the `Redact` arm of `apply_undo_entry`; add `--allow-redact-undo` so a casual undo chain can't silently re-expose previously-hidden content; refuse `Purge` inverses (irreversible) and refuse Redact-undo when the underlying bytes have been purged (the record is then load-bearing audit trail).
- `heddle redo` of a previously-undone Redact refuses with a clear error: the `OpRecord::Redact` entry doesn't preserve the full `Redaction` (reason, redactor, signature) needed to faithfully re-apply. Re-run `heddle redact apply` to recreate — documented as a known limitation in `docs/undo.md`.
- Doc updates: `docs/undo.md` (new undoable row, safety contract, `--allow-redact-undo` flag, redo limitation) and `OpRecord::Redact` doc comment.

### Safety call: re-exposure of redacted content

The inverse of `redact apply` removes the redaction record so the next materialize restores the original blob bytes — i.e. previously-hidden content becomes readable again. To prevent a casual `heddle undo -n N` chain from silently unwinding a redaction the user previously asked to hide, `heddle undo` refuses any chain that crosses a Redact unless the operator passes `--allow-redact-undo`. The flag turns the re-exposure into an explicit decision. The opt-in is layered on top of two unconditional refusals: any Purge in the chain (irreversible) and any Redact whose bytes have since been purged (the record is the only audit trail that they were destroyed).

Closes HeddleCo/heddle#98

## Red commit

`724efe6`

## Test evidence

```
running 3 tests
test undo_and_special::test_undo_redact_refuses_without_allow_flag ... ok
test undo_and_special::test_undo_redact_refuses_when_blob_already_purged ... ok
test undo_and_special::test_undo_redact_with_allow_flag_restores_original_content ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.28s
```

Full suites also green: `cargo test --workspace` (no failures across heddle-cli, heddle-repo, heddle-oplog, and every other workspace member), `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Manual verification

N/A — covered by tests. The load-bearing "original content is restored" assertion calls `redaction_stub_for_blob` directly (the same function `materialize_blob` consults), so a post-undo `None` proves a subsequent materialize will surface the original bytes.

## Blocked by → resolved

None — heddle#98 had no `## Blocked by` references.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->