### PR TITLE
ci(projfs-smoke): install sccache to fix silently-red Windows job

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -159,6 +159,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
       # Enable the ProjFS optional feature. `Client-ProjFS` is the
       # canonical name on Windows 10/11 client SKUs; `Projected-FS`
       # is the Server variant. Try Client first (matches the docs we
@@ -214,6 +216,10 @@ jobs:
         run: |
           cargo test --locked -p heddle-mount --features projfs --lib projfs:: `
             -- --ignored --test-threads=1
+
+      - name: sccache stats
+        shell: pwsh
+        run: sccache --show-stats
 
   # Coverage requires an instrumented build that can't share `target/`
   # with the regular profile, so it stays as its own job.


### PR DESCRIPTION
## Summary
- The Windows ProjFS smoke job (`projfs-smoke` in `.github/workflows/rust-tests.yml`) inherits the workflow-level `RUSTC_WRAPPER: sccache` env (line 17) but was missing the `mozilla-actions/sccache-action@v0.0.9` step. Every PR's Windows job has been failing with "sccache program not found" since heddle#75 — silently red, defeating the smoke gate.
- Added the sccache install step right after `dtolnay/rust-toolchain@stable`, matching every other Rust job in the file.
- Added an `sccache --show-stats` step at the end of the job to mirror `check-and-test` and `fuse-smoke`.

**Chosen approach: (a) install sccache, not (b) strip the env.** Justification: the projfs build of `heddle-mount --features projfs` pulls in the `windows` crate and links against ProjectedFSLib — non-trivial compile work. Cache hits across PRs are worth keeping, and (a) keeps Windows consistent with every other Rust job (single config to reason about). (b) would have been simpler but would slow every Windows CI run and diverge the Windows job's env from the rest of the file.

Closes HeddleCo/heddle#102

## Red commit
N/A — this is a CI config fix, not a TDD-Rust task.

## Test evidence
```
N/A locally — the fix is a workflow change. Evidence lives in this PR's CI run:
the `ProjFS mount smoke (Windows)` job must reach the `cargo test` step and
report green (or self-skipped via the runtime guard, which still exits 0),
where previously it failed at the first cargo invocation with
"error: process didn't exit successfully: ... sccache program not found".
```

## Manual verification
N/A — covered by the CI run on this PR. Watch the `ProjFS mount smoke (Windows)` job: it should now install sccache, run `cargo test` for both the integration smoke and the panic-recovery unit tests, and print sccache stats at the end.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->