### PR TITLE
fix(refs/refs_storage): drop file handle before removing leaked lock (Windows) (heddle#95)

### DIFF
--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -151,13 +151,14 @@ impl RefManager {
             }
 
             match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(mut file) => {
+                Ok(file) => {
                     let now = Utc::now().timestamp();
                     let content = format!("{} {}", current_pid, now);
-                    if let Err(err) = write_lock_body_or_cleanup(&mut file, content.as_bytes(), &path) {
-                        return Err(err);
-                    }
+                    let file = write_lock_body_or_cleanup(file, content.as_bytes(), &path)?;
                     if let Err(err) = file.sync_all() {
+                        // Drop-before-remove is load-bearing on Windows.
+                        // See `write_lock_body_or_cleanup` doc-comment.
+                        drop(file);
                         let _ = fs::remove_file(&path);
                         return Err(err.into());
                     }
@@ -234,24 +235,30 @@ impl RefManager {
     }
 }
 
-/// Write `body` to `writer`; on failure, remove the orphan at
-/// `cleanup_path` and surface the write error.
+/// Write `body` to `writer`; on failure drop the writer (closing any
+/// underlying OS handle) and remove the orphan at `cleanup_path`,
+/// returning the original write error. On success, return the writer
+/// so the caller can continue using it (e.g. for `sync_all`).
 ///
-/// **NOTE (red commit):** this version takes `&mut W` and leaves the
-/// caller's writer alive across the cleanup call. On Windows,
-/// `DeleteFile` against a still-open handle (without
-/// `FILE_SHARE_DELETE`) fails with `ERROR_SHARING_VIOLATION`, so the
-/// `remove_file` silently no-ops and the orphan stays. The fix commit
-/// switches this to ownership-transfer (`mut writer: W` + explicit
-/// `drop(writer)` before `remove_file`) per heddle#86 r2.
+/// Generic over `Write` so tests can inject a failing writer to
+/// exercise the cleanup branch — the production caller passes the
+/// freshly-`create_new`'d lock file by value.
+///
+/// **Drop-before-remove is load-bearing on Windows.** Without
+/// `FILE_SHARE_DELETE`, `DeleteFile` against a still-open handle fails
+/// with `ERROR_SHARING_VIOLATION`. Taking the writer by value makes
+/// ownership obvious at the call site and forces the close to happen
+/// before `remove_file`. Lifted from the heddle#86 r2 helper in
+/// `shared_target.rs`.
 fn write_lock_body_or_cleanup<W: Write>(
-    writer: &mut W,
+    mut writer: W,
     body: &[u8],
     cleanup_path: &Path,
-) -> Result<()> {
+) -> Result<W> {
     match writer.write_all(body) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(writer),
         Err(err) => {
+            drop(writer);
             let _ = fs::remove_file(cleanup_path);
             Err(err.into())
         }
@@ -352,8 +359,8 @@ mod tests {
         fs::write(&orphan, b"").unwrap();
 
         let dropped = std::cell::Cell::new(false);
-        let mut writer = DropTrackingFailingWriter { dropped: &dropped };
-        let result = write_lock_body_or_cleanup(&mut writer, b"would-be body", &orphan);
+        let writer = DropTrackingFailingWriter { dropped: &dropped };
+        let result = write_lock_body_or_cleanup(writer, b"would-be body", &orphan);
 
         assert!(result.is_err());
         assert!(

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -154,9 +154,8 @@ impl RefManager {
                 Ok(mut file) => {
                     let now = Utc::now().timestamp();
                     let content = format!("{} {}", current_pid, now);
-                    if let Err(err) = file.write_all(content.as_bytes()) {
-                        let _ = fs::remove_file(&path);
-                        return Err(err.into());
+                    if let Err(err) = write_lock_body_or_cleanup(&mut file, content.as_bytes(), &path) {
+                        return Err(err);
                     }
                     if let Err(err) = file.sync_all() {
                         let _ = fs::remove_file(&path);
@@ -235,6 +234,30 @@ impl RefManager {
     }
 }
 
+/// Write `body` to `writer`; on failure, remove the orphan at
+/// `cleanup_path` and surface the write error.
+///
+/// **NOTE (red commit):** this version takes `&mut W` and leaves the
+/// caller's writer alive across the cleanup call. On Windows,
+/// `DeleteFile` against a still-open handle (without
+/// `FILE_SHARE_DELETE`) fails with `ERROR_SHARING_VIOLATION`, so the
+/// `remove_file` silently no-ops and the orphan stays. The fix commit
+/// switches this to ownership-transfer (`mut writer: W` + explicit
+/// `drop(writer)` before `remove_file`) per heddle#86 r2.
+fn write_lock_body_or_cleanup<W: Write>(
+    writer: &mut W,
+    body: &[u8],
+    cleanup_path: &Path,
+) -> Result<()> {
+    match writer.write_all(body) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = fs::remove_file(cleanup_path);
+            Err(err.into())
+        }
+    }
+}
+
 fn encode_flat_thread_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len() * 2 + FLAT_THREAD_SUFFIX.len());
     for byte in name.as_bytes() {
@@ -286,6 +309,59 @@ mod tests {
         assert!(repo.lock_path().exists());
         drop(lock);
         assert!(!repo.lock_path().exists());
+    }
+
+    /// `Write` wrapper that flips a flag from its `Drop` impl. The
+    /// regression test below uses this to assert the writer is closed
+    /// before the helper's `remove_file` call — load-bearing on Windows,
+    /// where `DeleteFile` against a still-open handle fails with
+    /// `ERROR_SHARING_VIOLATION` and the orphan would otherwise survive.
+    /// Mirrors `DropTrackingFailingWriter` from
+    /// `shared_target.rs` (heddle#86 r2).
+    struct DropTrackingFailingWriter<'a> {
+        dropped: &'a std::cell::Cell<bool>,
+    }
+    impl Write for DropTrackingFailingWriter<'_> {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("simulated write failure"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl Drop for DropTrackingFailingWriter<'_> {
+        fn drop(&mut self) {
+            self.dropped.set(true);
+        }
+    }
+
+    #[test]
+    fn write_lock_body_or_cleanup_drops_writer_before_returning_on_failure() {
+        // Regression for heddle#95 (sweep follow-up to heddle#86 r2). On
+        // Windows, `remove_file` against a still-open handle fails with
+        // `ERROR_SHARING_VIOLATION`; the lock file stays, and the next
+        // operation waits the full 5-minute stale-lock timeout. The
+        // helper must take the writer by value and drop it before
+        // `remove_file`. POSIX would let the unlink succeed against an
+        // open handle, so this test asserts the ownership-transfer
+        // guarantee directly: by the time the helper returns on the
+        // failure path, the writer has been dropped (i.e. on a real
+        // `File`, the OS handle is closed).
+        let temp = TempDir::new().unwrap();
+        let orphan = temp.path().join("LOCK");
+        fs::write(&orphan, b"").unwrap();
+
+        let dropped = std::cell::Cell::new(false);
+        let mut writer = DropTrackingFailingWriter { dropped: &dropped };
+        let result = write_lock_body_or_cleanup(&mut writer, b"would-be body", &orphan);
+
+        assert!(result.is_err());
+        assert!(
+            dropped.get(),
+            "writer must be dropped before the helper returns on failure — \
+             on Windows, the file handle must be closed before remove_file"
+        );
+        assert!(!orphan.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Sweep follow-up to heddle#86 r2: `crates/refs/src/refs/refs_storage.rs:153-163` held the lock-file handle live across `fs::remove_file(&path)` in both the `write_all` and `sync_all` error arms.
- On Windows, `DeleteFile` against a still-open handle (no `FILE_SHARE_DELETE`) fails with `ERROR_SHARING_VIOLATION` → LOCK leaks → next operation eats the full 5-minute `STALE_LOCK_TIMEOUT_SECS` cliff before the reaper at line 147 evicts it.
- Lifted the `write_body_or_cleanup` ownership-transfer pattern from heddle#86 r2 (`shared_target.rs`): helper takes `mut writer: W -> Result<W>`, drops the writer before `remove_file` on the Err path, returns it on Ok so the caller can `sync_all`. The `sync_all` failure path uses the same drop-before-remove inline.
- DropTracker test asserts the ownership-transfer guarantee directly (POSIX would let unlink-on-open succeed, so the cross-platform fix is the drop-ordering, not the cleanup itself).

Closes HeddleCo/heddle#95

## Red commit

`08eb3f6` — `refs::refs_storage::tests::write_lock_body_or_cleanup_drops_writer_before_returning_on_failure`. Helper introduced in its broken `&mut W` shape; DropTracker fails because the writer outlives the helper return.

## Test evidence

```
$ cargo test -p heddle-refs --lib refs_storage
running 5 tests
test refs::refs_storage::tests::test_parse_lock_content_invalid ... ok
test refs::refs_storage::tests::test_parse_lock_content_valid ... ok
test refs::refs_storage::tests::write_lock_body_or_cleanup_drops_writer_before_returning_on_failure ... ok
test refs::refs_storage::tests::test_lock_refs_basic ... ok
test refs::refs_storage::tests::test_lock_refs_stale_removal ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 52 filtered out; finished in 0.01s

$ cargo test -p heddle-refs --lib
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
```

## Manual verification

N/A — covered by tests. The DropTracker assertion is the cross-platform proxy for the Windows `ERROR_SHARING_VIOLATION` behavior (POSIX dev hosts cannot exercise the real failure mode directly).

## Rule-7 sweep

Searched all `create_new(true)` call-sites in `crates/`:

| File | Status |
|---|---|
| `crates/refs/src/refs/refs_storage.rs` | **Fixed here.** |
| `crates/cli/src/cli/commands/worktree_cmd/shared_target.rs` | Fixed in heddle#86 r2 (commit `38e3552`). |
| `crates/cli/src/cli/commands/init.rs:106` | Safe — explicit `drop(f)` before `remove_file` at lines 130-131 (heddle#80 r3). |
| `crates/objects/src/store/fs/fs_io.rs:95` | Safe — `file` is owned by the inner closure at line 85, dropped on early return before the outer `remove_file(&temp_path)` at line 146. |

This closes the last known site in the Windows-file-handle-cleanup class.

## Blocked by → resolved

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->