### PR TITLE
fix(undo): implement OpRecord::FastForward for proper FF merge undo (heddle#99)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -313,9 +313,9 @@ Examples:
 Undoable operations:
   - heddle capture           (restores HEAD to the pre-capture parent)
   - heddle merge (non-FF)    (restores HEAD + both thread refs)
-  - heddle merge (FF)        (restores HEAD only; the merged-into thread ref
-                              stays at the FF target — run `heddle thread
-                              switch <name>` to re-attach. Data is never lost.)
+  - heddle merge (FF)        (restores HEAD + the merged-into thread ref to
+                              the pre-merge tip; the merged-in thread is
+                              untouched.)
   - heddle goto              (restores HEAD to the pre-goto state)
   - heddle thread create/drop/rename
   - heddle marker create/drop

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -396,7 +396,36 @@ pub(crate) fn merge_thread_into_current(
             // the integrated state. See `Repository::fast_forward_attached`
             // and the regression test
             // `merge_fast_forward_advances_current_thread`.
-            repo.fast_forward_attached(&merge_target_id)?;
+            //
+            // We perform the FF *without recording* an `OpRecord::Goto`
+            // and then explicitly record `OpRecord::FastForward` so undo
+            // can restore both HEAD and the target thread ref. Recording
+            // as a plain `Goto` stranded the target thread ref on undo —
+            // the bug heddle#99 closes.
+            let head_before_ff = repo.head_ref()?;
+            repo.fast_forward_attached_without_record(&merge_target_id)?;
+            match &head_before_ff {
+                Head::Attached {
+                    thread: target_thread,
+                } => {
+                    repo.oplog().record_fast_forward(
+                        track_name,
+                        target_thread,
+                        &current_state.change_id,
+                        Some(&repo.op_scope()),
+                    )?;
+                }
+                Head::Detached { state } => {
+                    // No attached thread to restore on undo. The generic
+                    // `Goto` inverse is sufficient — preserve historic
+                    // behavior for detached HEAD.
+                    repo.oplog().record_goto(
+                        &merge_target_id,
+                        Some(state),
+                        Some(&repo.op_scope()),
+                    )?;
+                }
+            }
             if let Some(entry) = &thread_entry {
                 registry.update_status(&entry.session_id, AgentStatus::Merged)?;
             }

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -398,10 +398,12 @@ pub(crate) fn merge_thread_into_current(
             // `merge_fast_forward_advances_current_thread`.
             //
             // We perform the FF *without recording* an `OpRecord::Goto`
-            // and then explicitly record `OpRecord::FastForward` so undo
-            // can restore both HEAD and the target thread ref. Recording
-            // as a plain `Goto` stranded the target thread ref on undo —
-            // the bug heddle#99 closes.
+            // and then explicitly record `OpRecord::FastForwardV2` so
+            // both ends of the FF are captured. r1 (heddle#99) added the
+            // variant to fix stranded-ref-on-undo. r2 added
+            // `post_target_id` so redo replays the recorded SHA instead
+            // of re-resolving `source_thread → tip` at apply time —
+            // closes Codex's non-determinism finding on PR #109.
             let head_before_ff = repo.head_ref()?;
             repo.fast_forward_attached_without_record(&merge_target_id)?;
             match &head_before_ff {
@@ -412,6 +414,7 @@ pub(crate) fn merge_thread_into_current(
                         track_name,
                         target_thread,
                         &current_state.change_id,
+                        &merge_target_id,
                         Some(&repo.op_scope()),
                     )?;
                 }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -346,6 +346,7 @@ fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::ThreadDelete { state, .. } => vec![*state],
         OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
         OpRecord::MarkerDelete { state, .. } => vec![*state],
+        OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
         _ => Vec::new(),
     }
 }
@@ -389,9 +390,7 @@ fn ensure_redaction_undo_safe(
     for batch in batches {
         for entry in &batch.entries {
             match &entry.operation {
-                OpRecord::Purge { redaction_id, .. } => {
-                    purge_ops.push((entry.id, *redaction_id))
-                }
+                OpRecord::Purge { redaction_id, .. } => purge_ops.push((entry.id, *redaction_id)),
                 OpRecord::Redact {
                     blob, state, path, ..
                 } => redact_ops.push(RedactSummary {
@@ -408,7 +407,9 @@ fn ensure_redaction_undo_safe(
     if !purge_ops.is_empty() {
         let shorts: Vec<String> = purge_ops
             .iter()
-            .map(|(op_id, redaction_id)| format!("op {} (redaction {})", op_id, redaction_id.short()))
+            .map(|(op_id, redaction_id)| {
+                format!("op {} (redaction {})", op_id, redaction_id.short())
+            })
             .collect();
         return Err(anyhow!(
             "Refusing to undo: `heddle purge` is irreversible by design — the blob bytes have been \

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -161,12 +161,12 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
         return Err(anyhow!("Nothing to redo"));
     }
 
-    // Same preview-honesty rule as `cmd_undo`: run the
-    // Redact/Purge-not-supported pre-flight before the `--preview`
-    // short-circuit so preview surfaces the refusal instead of
-    // advertising "Would redo …" for a chain the real command will
-    // reject.
+    // Same preview-honesty rule as `cmd_undo`: run pre-flight refusals
+    // before the `--preview` short-circuit so preview surfaces the
+    // refusal instead of advertising "Would redo …" for a chain the
+    // real command will reject.
     ensure_redaction_redo_supported(&batches)?;
+    ensure_redo_states_reachable(&repo, &batches)?;
 
     if preview {
         let output = UndoRedoOutput {
@@ -347,6 +347,56 @@ fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
         OpRecord::MarkerDelete { state, .. } => vec![*state],
         OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
+        OpRecord::FastForwardV2 { pre_target_id, .. } => vec![*pre_target_id],
+        _ => Vec::new(),
+    }
+}
+
+/// Symmetric to `ensure_undo_states_reachable`: walk every batch we'd
+/// redo and verify the post-state it would advance to is still in the
+/// object store. Without this check, a `gc --prune` that reached past
+/// the FF redo target would surface as a raw `state not found` from
+/// inside `goto`, identical in shape to the undo destructive-boundary
+/// case. The redo arms that touch the object store at apply time are
+/// `Snapshot`, `Goto`, `ThreadCreate`, `ThreadUpdate`, `MarkerCreate`,
+/// and `FastForwardV2`; all carry the post-state SHA directly. The
+/// legacy V1 `FastForward` redo re-resolves `source_thread → tip` and
+/// has its own error path, so we skip it here.
+fn ensure_redo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
+    let mut missing: Vec<(u64, ChangeId)> = Vec::new();
+    for batch in batches {
+        for entry in &batch.entries {
+            for needed in states_required_for_redo(&entry.operation) {
+                if !repo.store().has_state(&needed)? {
+                    missing.push((entry.id, needed));
+                }
+            }
+        }
+    }
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let shorts: Vec<String> = missing
+        .iter()
+        .map(|(op_id, id)| format!("op {} -> {}", op_id, id.short()))
+        .collect();
+    Err(anyhow!(
+        "Refusing to redo: post-state(s) needed to replay have been garbage-collected or are otherwise missing from the object store ({}). \
+         A destructive boundary (likely `heddle gc --prune`) has been crossed past the live oplog window — \
+         redo cannot replay here. Restore the missing states from a backup, or re-run the original operation manually.",
+        shorts.join(", "),
+    ))
+}
+
+fn states_required_for_redo(op: &OpRecord) -> Vec<ChangeId> {
+    match op {
+        OpRecord::Snapshot { new_state, .. } => vec![*new_state],
+        OpRecord::Goto { target, .. } => vec![*target],
+        OpRecord::ThreadCreate { state, .. } => vec![*state],
+        OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
+        OpRecord::MarkerCreate { state, .. } => vec![*state],
+        OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
         _ => Vec::new(),
     }
 }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -2,6 +2,7 @@
 //! Apply undo/redo operations to the repository.
 
 use anyhow::{Result, anyhow};
+use objects::object::ChangeId;
 use oplog::{OpBatch, OpEntry, OpRecord};
 use refs::Head;
 use repo::{Repository, ThreadManager};
@@ -90,25 +91,36 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         }
         // Fast-forward merge inverse: restore both HEAD and the target
         // thread ref to the pre-FF tip. The source thread never moved
-        // during the FF, so it's untouched. Closes heddle#99 — the bug
-        // where recording an FF as `OpRecord::Goto` left the target
+        // during the FF, so it's untouched. Closes heddle#99 r1 — the
+        // bug where recording an FF as `OpRecord::Goto` left the target
         // thread ref stranded at the FF target after undo.
+        //
+        // V1 and V2 share the same undo: both carry `pre_target_id`.
         OpRecord::FastForward {
             target_thread,
             pre_target_id,
             ..
+        }
+        | OpRecord::FastForwardV2 {
+            target_thread,
+            pre_target_id,
+            ..
         } => {
-            repo.goto_without_record(pre_target_id)?;
-            repo.refs().set_thread(target_thread, pre_target_id)?;
-            repo.refs().write_head(&Head::Attached {
-                thread: target_thread.clone(),
-            })?;
-            sync_thread_record_state(repo, target_thread, *pre_target_id)?;
+            apply_ff_undo(repo, target_thread, pre_target_id)?;
         }
         _ => {}
     }
 
     Ok(())
+}
+
+fn apply_ff_undo(repo: &Repository, target_thread: &str, pre_target_id: &ChangeId) -> Result<()> {
+    repo.goto_without_record(pre_target_id)?;
+    repo.refs().set_thread(target_thread, pre_target_id)?;
+    repo.refs().write_head(&Head::Attached {
+        thread: target_thread.to_string(),
+    })?;
+    sync_thread_record_state(repo, target_thread, *pre_target_id)
 }
 
 fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
@@ -145,12 +157,27 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         OpRecord::MarkerDelete { name, .. } => {
             repo.refs().delete_marker(name)?;
         }
-        // FF merge redo: re-advance both HEAD and the target thread ref
-        // to the source thread's current tip. We re-read the source
-        // thread rather than caching its tip in the OpRecord because the
-        // source thread is the authoritative pointer for "what FF means
-        // right now" — if it moved between undo and redo, we'd otherwise
-        // redo to a stale state.
+        // FF merge redo (V2): replay the *recorded* FF target. We do
+        // not re-read `source_thread` — the recorded `post_target_id`
+        // is the exact state the target advanced to at the original
+        // FF, so redo is deterministic regardless of what the source
+        // thread did between undo and redo (advanced, was deleted,
+        // etc.). Closes heddle#99 r2 — Codex's non-determinism finding
+        // on the r1 implementation.
+        OpRecord::FastForwardV2 {
+            target_thread,
+            post_target_id,
+            ..
+        } => {
+            apply_ff_redo(repo, target_thread, post_target_id)?;
+        }
+        // FF merge redo (V1, legacy): the r1 implementation didn't
+        // record `post_target_id`, so we have to re-resolve
+        // `source_thread → tip`. This is the non-deterministic redo
+        // Codex flagged; V1 records can only be written by the r1
+        // implementation and age out as the undo window slides
+        // forward. New ops are recorded as `FastForwardV2` so this
+        // path stops accumulating.
         OpRecord::FastForward {
             source_thread,
             target_thread,
@@ -158,21 +185,26 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         } => {
             let source_tip = repo.refs().get_thread(source_thread)?.ok_or_else(|| {
                 anyhow!(
-                    "cannot redo fast-forward: source thread '{}' no longer exists",
+                    "cannot redo fast-forward: source thread '{}' no longer exists \
+                     (legacy V1 oplog record; re-run the merge or `heddle gc oplog` to prune)",
                     source_thread
                 )
             })?;
-            repo.goto_without_record(&source_tip)?;
-            repo.refs().set_thread(target_thread, &source_tip)?;
-            repo.refs().write_head(&Head::Attached {
-                thread: target_thread.clone(),
-            })?;
-            sync_thread_record_state(repo, target_thread, source_tip)?;
+            apply_ff_redo(repo, target_thread, &source_tip)?;
         }
         _ => {}
     }
 
     Ok(())
+}
+
+fn apply_ff_redo(repo: &Repository, target_thread: &str, post_target_id: &ChangeId) -> Result<()> {
+    repo.goto_without_record(post_target_id)?;
+    repo.refs().set_thread(target_thread, post_target_id)?;
+    repo.refs().write_head(&Head::Attached {
+        thread: target_thread.to_string(),
+    })?;
+    sync_thread_record_state(repo, target_thread, *post_target_id)
 }
 
 fn delete_thread_safely(repo: &Repository, name: &str) -> Result<()> {

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -88,6 +88,23 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         } => {
             repo.remove_redaction(blob, state, path, redaction_id)?;
         }
+        // Fast-forward merge inverse: restore both HEAD and the target
+        // thread ref to the pre-FF tip. The source thread never moved
+        // during the FF, so it's untouched. Closes heddle#99 — the bug
+        // where recording an FF as `OpRecord::Goto` left the target
+        // thread ref stranded at the FF target after undo.
+        OpRecord::FastForward {
+            target_thread,
+            pre_target_id,
+            ..
+        } => {
+            repo.goto_without_record(pre_target_id)?;
+            repo.refs().set_thread(target_thread, pre_target_id)?;
+            repo.refs().write_head(&Head::Attached {
+                thread: target_thread.clone(),
+            })?;
+            sync_thread_record_state(repo, target_thread, *pre_target_id)?;
+        }
         _ => {}
     }
 
@@ -127,6 +144,30 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         }
         OpRecord::MarkerDelete { name, .. } => {
             repo.refs().delete_marker(name)?;
+        }
+        // FF merge redo: re-advance both HEAD and the target thread ref
+        // to the source thread's current tip. We re-read the source
+        // thread rather than caching its tip in the OpRecord because the
+        // source thread is the authoritative pointer for "what FF means
+        // right now" — if it moved between undo and redo, we'd otherwise
+        // redo to a stale state.
+        OpRecord::FastForward {
+            source_thread,
+            target_thread,
+            ..
+        } => {
+            let source_tip = repo.refs().get_thread(source_thread)?.ok_or_else(|| {
+                anyhow!(
+                    "cannot redo fast-forward: source thread '{}' no longer exists",
+                    source_thread
+                )
+            })?;
+            repo.goto_without_record(&source_tip)?;
+            repo.refs().set_thread(target_thread, &source_tip)?;
+            repo.refs().write_head(&Head::Attached {
+                thread: target_thread.clone(),
+            })?;
+            sync_thread_record_state(repo, target_thread, source_tip)?;
         }
         _ => {}
     }

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -448,7 +448,7 @@ fn kind_for(op: &OpRecord) -> String {
         OpRecord::ConflictResolved { .. } => "conflict_resolved".into(),
         OpRecord::Redact { .. } => "redact".into(),
         OpRecord::Purge { .. } => "purge".into(),
-        OpRecord::FastForward { .. } => "fast_forward".into(),
+        OpRecord::FastForward { .. } | OpRecord::FastForwardV2 { .. } => "fast_forward".into(),
     }
 }
 
@@ -465,7 +465,8 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         OpRecord::MarkerDelete { name, .. } => Some(name.clone()),
         OpRecord::Checkpoint { thread, .. } => thread.clone(),
         OpRecord::EphemeralThreadCollapse { thread, .. } => Some(thread.clone()),
-        OpRecord::FastForward { target_thread, .. } => Some(target_thread.clone()),
+        OpRecord::FastForward { target_thread, .. }
+        | OpRecord::FastForwardV2 { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -498,7 +499,8 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. } => None,
+        | OpRecord::FastForward { .. }
+        | OpRecord::FastForwardV2 { .. } => None,
     }
 }
 

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -86,6 +86,7 @@ const FILTER_KINDS: &[&str] = &[
     "marker_create",
     "marker_delete",
     "merge", // alias for thread_update on a merge target — see kind_for
+    "fast_forward",
 ];
 
 /// Top-level entry point. Threading-wise:
@@ -447,6 +448,7 @@ fn kind_for(op: &OpRecord) -> String {
         OpRecord::ConflictResolved { .. } => "conflict_resolved".into(),
         OpRecord::Redact { .. } => "redact".into(),
         OpRecord::Purge { .. } => "purge".into(),
+        OpRecord::FastForward { .. } => "fast_forward".into(),
     }
 }
 
@@ -463,6 +465,7 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         OpRecord::MarkerDelete { name, .. } => Some(name.clone()),
         OpRecord::Checkpoint { thread, .. } => thread.clone(),
         OpRecord::EphemeralThreadCollapse { thread, .. } => Some(thread.clone()),
+        OpRecord::FastForward { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -494,7 +497,8 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
-        | OpRecord::Purge { .. } => None,
+        | OpRecord::Purge { .. }
+        | OpRecord::FastForward { .. } => None,
     }
 }
 

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -469,19 +469,19 @@ fn test_undo_capture_restores_head_to_parent() {
     );
 }
 
-/// Fast-forward merge undo, current behavior: HEAD is restored to the
-/// pre-merge tip, but the *merged-into* thread ref is **stranded** at the FF
-/// target. This is a documented gap (`docs/undo.md` "Known caveats") tracked
-/// by heddle#99 — add an `OpRecord::FastForward` variant that records the
-/// pre-merge thread state so undo can reset the ref too.
+/// Fast-forward merge undo, full restoration: HEAD *and* the merged-into
+/// thread ref both rewind to the pre-merge tip. This pins the heddle#99 fix —
+/// before it landed, the FF merge recorded an `OpRecord::Goto` whose inverse
+/// only rewinds HEAD, stranding the target thread ref at the FF target. The
+/// new `OpRecord::FastForward` variant carries the pre-FF tip so undo restores
+/// both refs together.
 ///
-/// Why pin the bug instead of skipping the test: the day the FF undo is fixed
-/// this test will start failing on the stranded-ref assertion, which is
-/// exactly the signal we want — "the gap is closed, update the docs + this
-/// test." See also `test_undo_non_ff_merge_restores_both_threads` below for
-/// the non-FF path that already works end-to-end.
+/// This test was previously named
+/// `test_undo_ff_merge_restores_head_but_strands_thread_ref` and asserted the
+/// stranded-ref behavior as a pinned bug. Renamed and the strand assertion
+/// flipped when heddle#99 closed.
 #[test]
-fn test_undo_ff_merge_restores_head_but_strands_thread_ref() {
+fn test_undo_ff_merge_restores_head_and_thread_ref() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
 
@@ -527,10 +527,113 @@ fn test_undo_ff_merge_restores_head_but_strands_thread_ref() {
         "feature thread tip must be unchanged across merge + undo"
     );
 
-    // The documented gap: the `main` thread ref is left at the FF target.
-    // Today's `OpRecord::Goto` inverse only rewinds HEAD; it carries no
-    // thread context to reset the ref. When the follow-up adds a
-    // `FastForward` op variant, flip this assertion to `main_tip_before`.
+    // The heddle#99 fix: undoing an FF merge restores BOTH HEAD and the
+    // target thread ref to the pre-merge state. Recording the FF as
+    // `OpRecord::FastForward` (instead of `OpRecord::Goto`) gives the
+    // inverse the thread context it needs.
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "undo of FF merge must restore the `main` thread ref to its pre-merge tip \
+         (heddle#99 — was stranded at the FF target before the fix)"
+    );
+
+    // HEAD must remain attached to `main` so subsequent ops record on the
+    // expected lane. Pre-fix the strand also left HEAD detached, which
+    // silently broke scope filtering on the next undo.
+    match repo.head_ref().unwrap() {
+        refs::Head::Attached { thread } => assert_eq!(
+            thread, "main",
+            "HEAD must stay attached to `main` after FF undo"
+        ),
+        refs::Head::Detached { state } => panic!(
+            "HEAD must stay attached to `main`; got detached at {}",
+            state.short()
+        ),
+    }
+}
+
+/// Destructive-boundary protection covers `OpRecord::FastForward` too: if
+/// the pre-FF state is gone from the object store (gc --prune past the live
+/// oplog window, or oplog backup restored without its objects), undo must
+/// refuse loudly with a clear message instead of half-rewinding the worktree
+/// or panicking deep inside `goto`. Mirrors the `Goto`/`Snapshot` coverage
+/// in `test_undo_refuses_when_prior_state_missing` but exercises the new
+/// FF arm specifically.
+#[test]
+fn test_undo_ff_merge_refuses_when_pre_target_state_missing() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+
+    // Simulate gc reaching past the pre-FF tip. Same shape as the
+    // Goto/Snapshot coverage above: drop the loose state file and any
+    // pack that could resolve it.
+    let state_path = locate_state_loose_file(temp.path(), &main_tip_before)
+        .expect("pre-FF state's loose file is present after merge");
+    std::fs::remove_file(&state_path).unwrap();
+    let packs_dir = temp.path().join(".heddle/packs");
+    if packs_dir.exists() {
+        for entry in std::fs::read_dir(&packs_dir).unwrap() {
+            std::fs::remove_file(entry.unwrap().path()).unwrap();
+        }
+    }
+
+    let err = heddle(&["undo"], Some(temp.path()))
+        .expect_err("undo must refuse when the pre-FF state is missing");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("missing") || lower.contains("gone") || lower.contains("garbage"),
+        "error must explain that prior state is missing: {err}"
+    );
+}
+
+/// FF merge undo + redo round-trip: redo re-applies the FF, advancing both
+/// HEAD and the target thread ref back to the source's tip. The source
+/// thread is untouched throughout.
+#[test]
+fn test_redo_ff_merge_restores_head_and_thread_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(head_short(temp.path()), main_tip_before);
+
+    heddle_must_succeed(&["redo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        feature_tip_before,
+        "redo of FF merge must re-advance HEAD to feature's tip"
+    );
+
+    let repo = Repository::open(temp.path()).unwrap();
     let main_tip = repo
         .refs()
         .get_thread("main")
@@ -539,8 +642,17 @@ fn test_undo_ff_merge_restores_head_but_strands_thread_ref() {
         .short();
     assert_eq!(
         main_tip, feature_tip_before,
-        "current behavior: `main` thread ref is stranded at the FF target \
-         after undo (see docs/undo.md 'Known caveats' + follow-up issue)"
+        "redo of FF merge must re-advance `main` thread ref to feature's tip"
+    );
+    let feature_tip = repo
+        .refs()
+        .get_thread("feature")
+        .unwrap()
+        .expect("feature thread still exists")
+        .short();
+    assert_eq!(
+        feature_tip, feature_tip_before,
+        "feature thread tip stays put across the full merge/undo/redo round-trip"
     );
 }
 
@@ -797,10 +909,8 @@ fn test_undo_redact_with_allow_flag_restores_original_content() {
     // Sanity: redact list shows the new redaction, and the underlying
     // materialize gate (the same function `materialize_blob` calls)
     // reports an active stub.
-    let blob_hash = objects::object::Blob::from_slice(
-        b"api_token = \"super-secret-leaked-value\"\n",
-    )
-    .hash();
+    let blob_hash =
+        objects::object::Blob::from_slice(b"api_token = \"super-secret-leaked-value\"\n").hash();
     {
         let repo = Repository::open(temp.path()).unwrap();
         let stub = repo
@@ -994,8 +1104,8 @@ fn test_redo_of_undone_redact_refuses() {
 
     // Redo refuses with a message that names Redact + points the user
     // at re-running `heddle redact apply`.
-    let err = heddle(&["redo"], Some(temp.path()))
-        .expect_err("redo of an undone Redact must refuse");
+    let err =
+        heddle(&["redo"], Some(temp.path())).expect_err("redo of an undone Redact must refuse");
     let lower = err.to_lowercase();
     assert!(
         lower.contains("redact"),

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -656,6 +656,185 @@ fn test_redo_ff_merge_restores_head_and_thread_ref() {
     );
 }
 
+/// Redo of an FF merge must replay the *recorded* operation, not re-derive
+/// it from the source thread's current tip. heddle#99 r1 resolved
+/// `source_thread → tip` at redo time; if the source thread had advanced
+/// between undo and redo, redo silently pulled in commits that were never
+/// part of the original merge. The fix records `post_target_id` (the FF
+/// result SHA) at recording time and uses it directly on redo, so the
+/// replay is deterministic.
+///
+/// Pinned the bug pre-fix: this test was red before `FastForwardV2` landed.
+#[test]
+fn test_redo_ff_merge_pins_recorded_tip_when_source_advances() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_at_ff = head_short(temp.path());
+
+    // FF main → feature, then undo back to main_tip_before.
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(head_short(temp.path()), main_tip_before);
+
+    // Advance the source thread after undo: a second capture on feature
+    // gives it a new tip distinct from the FF target. Pre-fix, redo would
+    // pick up *this* tip instead of the recorded FF target.
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work + more").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature again"], temp.path());
+    let feature_tip_advanced = head_short(temp.path());
+    assert_ne!(
+        feature_tip_at_ff, feature_tip_advanced,
+        "post-undo capture on feature must produce a new tip distinct from the FF target"
+    );
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["redo"], temp.path());
+
+    // The recorded FF target — not feature's current tip — is what redo must
+    // restore. HEAD and the `main` thread ref both end at the original FF SHA.
+    assert_eq!(
+        head_short(temp.path()),
+        feature_tip_at_ff,
+        "redo of FF merge must replay to the recorded FF target, not source's current tip"
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, feature_tip_at_ff,
+        "redo of FF merge must set `main` ref to the recorded FF target, not source's current tip"
+    );
+    let feature_tip = repo
+        .refs()
+        .get_thread("feature")
+        .unwrap()
+        .expect("feature thread still exists")
+        .short();
+    assert_eq!(
+        feature_tip, feature_tip_advanced,
+        "feature thread's own ref is independent of redo — it stays at its new tip"
+    );
+}
+
+/// Redo of an FF merge must succeed even when the source thread has been
+/// deleted after undo. The original merged state is fully recoverable from
+/// the recorded `post_target_id`; refusing redo here would punish the user
+/// for housekeeping a now-merged feature branch.
+///
+/// Pinned the bug pre-fix: heddle#99 r1's redo resolved `source_thread → tip`
+/// live and errored with "source thread no longer exists" when the user
+/// dropped the thread between undo and redo.
+#[test]
+fn test_redo_ff_merge_succeeds_when_source_deleted() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_at_ff = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(head_short(temp.path()), main_tip_before);
+
+    // Delete the source thread between undo and redo. The legacy CLI
+    // shape `thread delete <name>` is translated to
+    // `thread drop <name> --delete-thread` by `translate_legacy_args`.
+    heddle_must_succeed(&["thread", "delete", "feature"], temp.path());
+
+    heddle_must_succeed(&["redo"], temp.path());
+
+    assert_eq!(
+        head_short(temp.path()),
+        feature_tip_at_ff,
+        "redo must replay to the recorded FF target even when source thread is gone"
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, feature_tip_at_ff,
+        "main ref must reach the recorded FF target after redo, source-thread-deletion notwithstanding"
+    );
+}
+
+/// Symmetric to `test_undo_ff_merge_refuses_when_pre_target_state_missing`:
+/// redo also has a destructive-boundary case. The state we'd advance to
+/// (`post_target_id`) must still be in the object store; if it has been
+/// pruned, redo must refuse with a clear message rather than partially
+/// rewinding HEAD past the boundary or panicking deep in `goto`.
+#[test]
+fn test_redo_ff_merge_refuses_when_post_target_state_missing() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip_at_ff = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["merge", "feature"], temp.path());
+    // Undo first: HEAD is now back at main_tip_before, so the FF target SHA
+    // is no longer pinned by HEAD and can be removed to simulate a gc that
+    // pruned past the redo's reach.
+    heddle_must_succeed(&["undo"], temp.path());
+
+    let state_path = locate_state_loose_file(temp.path(), &feature_tip_at_ff)
+        .expect("FF target state's loose file is present after undo");
+    std::fs::remove_file(&state_path).unwrap();
+    let packs_dir = temp.path().join(".heddle/packs");
+    if packs_dir.exists() {
+        for entry in std::fs::read_dir(&packs_dir).unwrap() {
+            std::fs::remove_file(entry.unwrap().path()).unwrap();
+        }
+    }
+    // Also drop the source thread ref so a live-resolve path can't smuggle
+    // the SHA back in by reading `feature → tip`. (Belt-and-braces: the new
+    // redo arm doesn't read the source thread at all, but locking this down
+    // ensures the test fails in the right way if a regression re-introduces
+    // a live-resolve fallback.)
+    heddle_must_succeed(&["thread", "delete", "feature"], temp.path());
+
+    let err = heddle(&["redo"], Some(temp.path()))
+        .expect_err("redo must refuse when the FF target state is missing");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("missing") || lower.contains("gone") || lower.contains("garbage"),
+        "error must explain that the redo target state is missing: {err}"
+    );
+}
+
 /// Non-fast-forward merge undo: both threads have divergent work since the
 /// common ancestor. The merge synthesizes a new merge state with two parents.
 /// Undo must restore main to its pre-merge tip; feature's tip never moved.

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -204,4 +204,27 @@ pub trait OpLogBackend: Send + Sync {
         )?;
         Ok(ids[0])
     }
+
+    /// Record a fast-forward merge. `pre_target_id` captures the target
+    /// thread's tip before the FF so undo can restore both HEAD and the
+    /// target thread ref. Recording an FF merge as a plain `Goto`
+    /// stranded the target thread ref at the FF target on undo — the
+    /// bug heddle#99 closes.
+    fn record_fast_forward(
+        &self,
+        source_thread: &str,
+        target_thread: &str,
+        pre_target_id: &ChangeId,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::FastForward {
+                source_thread: source_thread.to_string(),
+                target_thread: target_thread.to_string(),
+                pre_target_id: *pre_target_id,
+            }],
+            scope,
+        )?;
+        Ok(ids[0])
+    }
 }

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -205,23 +205,29 @@ pub trait OpLogBackend: Send + Sync {
         Ok(ids[0])
     }
 
-    /// Record a fast-forward merge. `pre_target_id` captures the target
-    /// thread's tip before the FF so undo can restore both HEAD and the
-    /// target thread ref. Recording an FF merge as a plain `Goto`
-    /// stranded the target thread ref at the FF target on undo — the
-    /// bug heddle#99 closes.
+    /// Record a fast-forward merge. `pre_target_id` is the target's tip
+    /// before the FF (undo target); `post_target_id` is the target's tip
+    /// after the FF (redo target). Both ends of the FF are recorded so
+    /// neither inverse has to re-resolve `source_thread → tip` at apply
+    /// time — closes heddle#99 r1 (stranded ref on undo) and r2 (redo
+    /// non-determinism).
+    ///
+    /// Always emits the V2 variant. V1 (`OpRecord::FastForward`) is
+    /// retained as read-back-only.
     fn record_fast_forward(
         &self,
         source_thread: &str,
         target_thread: &str,
         pre_target_id: &ChangeId,
+        post_target_id: &ChangeId,
         scope: Option<&str>,
     ) -> Result<u64> {
         let ids = self.record_batch_scoped(
-            vec![OpRecord::FastForward {
+            vec![OpRecord::FastForwardV2 {
                 source_thread: source_thread.to_string(),
                 target_thread: target_thread.to_string(),
                 pre_target_id: *pre_target_id,
+                post_target_id: *post_target_id,
             }],
             scope,
         )?;

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -170,23 +170,31 @@ impl OpLog {
         )
     }
 
-    /// Record a fast-forward merge. `pre_target_id` captures the target
-    /// thread's tip before the FF so undo can restore both HEAD and the
-    /// target thread ref. Use this *instead* of `record_goto` when an FF
-    /// merge moves an attached thread ref forward — recording the FF as a
-    /// plain `Goto` strands the thread ref on undo (heddle#99).
+    /// Record a fast-forward merge. `pre_target_id` is the target
+    /// thread's tip before the FF (undo target); `post_target_id` is
+    /// the target thread's tip after the FF (redo target). Use this
+    /// *instead* of `record_goto` when an FF merge moves an attached
+    /// thread ref forward — recording the FF as a plain `Goto` strands
+    /// the thread ref on undo (heddle#99 r1) and recording the redo
+    /// target via name-resolution is non-deterministic (heddle#99 r2).
+    ///
+    /// Always emits the V2 variant; V1 (`OpRecord::FastForward`) is
+    /// retained for read-back compatibility with records written by
+    /// the heddle#99 r1 implementation but is no longer recorded.
     pub fn record_fast_forward(
         &self,
         source_thread: &str,
         target_thread: &str,
         pre_target_id: &ChangeId,
+        post_target_id: &ChangeId,
         scope: Option<&str>,
     ) -> Result<u64> {
         self.record_single_scoped(
-            OpRecord::FastForward {
+            OpRecord::FastForwardV2 {
                 source_thread: source_thread.to_string(),
                 target_thread: target_thread.to_string(),
                 pre_target_id: *pre_target_id,
+                post_target_id: *post_target_id,
             },
             scope,
         )

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -169,4 +169,26 @@ impl OpLog {
             scope,
         )
     }
+
+    /// Record a fast-forward merge. `pre_target_id` captures the target
+    /// thread's tip before the FF so undo can restore both HEAD and the
+    /// target thread ref. Use this *instead* of `record_goto` when an FF
+    /// merge moves an attached thread ref forward — recording the FF as a
+    /// plain `Goto` strands the thread ref on undo (heddle#99).
+    pub fn record_fast_forward(
+        &self,
+        source_thread: &str,
+        target_thread: &str,
+        pre_target_id: &ChangeId,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        self.record_single_scoped(
+            OpRecord::FastForward {
+                source_thread: source_thread.to_string(),
+                target_thread: target_thread.to_string(),
+                pre_target_id: *pre_target_id,
+            },
+            scope,
+        )
+    }
 }

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -124,6 +124,26 @@ pub enum OpRecord {
         /// Blob hash whose bytes were physically removed.
         blob: ContentHash,
     },
+    /// Fast-forward merge: `target_thread` advanced from `pre_target_id`
+    /// to `source_thread`'s tip without writing a synthetic merge state.
+    /// `source_thread` is untouched.
+    ///
+    /// Distinct from `Goto` so undo can restore both HEAD *and* the
+    /// target thread ref. The `Goto` inverse only rewinds HEAD, which
+    /// stranded the merged-into thread ref at the FF target — the bug
+    /// closed by heddle#99 and previously pinned by
+    /// `test_undo_ff_merge_restores_head_but_strands_thread_ref`.
+    FastForward {
+        /// The thread that was merged in. Its ref never moves during
+        /// an FF merge — recorded only for forensic context.
+        source_thread: String,
+        /// The thread that fast-forwarded. Undo restores this ref to
+        /// `pre_target_id`.
+        target_thread: String,
+        /// `target_thread`'s tip before the FF. Undo restores both
+        /// HEAD and the target thread ref to this state.
+        pre_target_id: ChangeId,
+    },
 }
 
 impl OpRecord {
@@ -200,6 +220,18 @@ impl OpRecord {
                     "purge blob {} (redaction {})",
                     blob.short(),
                     redaction_id.short()
+                )
+            }
+            OpRecord::FastForward {
+                source_thread,
+                target_thread,
+                pre_target_id,
+            } => {
+                format!(
+                    "fast-forward {} into {} (was at {})",
+                    source_thread,
+                    target_thread,
+                    pre_target_id.short()
                 )
             }
         }

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -124,15 +124,16 @@ pub enum OpRecord {
         /// Blob hash whose bytes were physically removed.
         blob: ContentHash,
     },
-    /// Fast-forward merge: `target_thread` advanced from `pre_target_id`
-    /// to `source_thread`'s tip without writing a synthetic merge state.
-    /// `source_thread` is untouched.
+    /// Fast-forward merge — **legacy V1, read-only.** Predates the
+    /// heddle#99 r2 redo-determinism fix and is no longer emitted; new
+    /// recordings use [`FastForwardV2`].
     ///
-    /// Distinct from `Goto` so undo can restore both HEAD *and* the
-    /// target thread ref. The `Goto` inverse only rewinds HEAD, which
-    /// stranded the merged-into thread ref at the FF target — the bug
-    /// closed by heddle#99 and previously pinned by
-    /// `test_undo_ff_merge_restores_head_but_strands_thread_ref`.
+    /// Lacks `post_target_id`, so a redo of this variant has to
+    /// re-resolve `source_thread → tip` at apply time — non-deterministic
+    /// if the source thread advanced or was deleted between undo and
+    /// redo. The undo direction is fine (uses `pre_target_id` directly).
+    /// Records of this shape age out as the live oplog window slides
+    /// forward.
     FastForward {
         /// The thread that was merged in. Its ref never moves during
         /// an FF merge — recorded only for forensic context.
@@ -143,6 +144,40 @@ pub enum OpRecord {
         /// `target_thread`'s tip before the FF. Undo restores both
         /// HEAD and the target thread ref to this state.
         pre_target_id: ChangeId,
+    },
+    /// Fast-forward merge: `target_thread` advanced from `pre_target_id`
+    /// to `post_target_id` (the source's tip at the time of the FF)
+    /// without writing a synthetic merge state. `source_thread` is
+    /// untouched throughout.
+    ///
+    /// Distinct from `Goto` so undo can restore both HEAD *and* the
+    /// target thread ref. The `Goto` inverse only rewinds HEAD, which
+    /// stranded the merged-into thread ref at the FF target — the bug
+    /// closed by heddle#99 r1.
+    ///
+    /// V2 (heddle#99 r2) adds `post_target_id` so redo replays the
+    /// recorded operation byte-for-byte instead of re-resolving
+    /// `source_thread → tip` at apply time. The r1 redo was
+    /// non-deterministic: if the source thread had advanced after
+    /// undo, redo silently pulled in commits that were never part of
+    /// the original merge; if the source thread had been deleted,
+    /// redo errored even though the merged state is recoverable from
+    /// the recorded SHA. `source_thread` is kept for forensic context
+    /// only — neither inverse reads it.
+    FastForwardV2 {
+        /// The thread that was merged in. Forensic-only — neither
+        /// undo nor redo reads it.
+        source_thread: String,
+        /// The thread that fast-forwarded. Undo restores this ref to
+        /// `pre_target_id`; redo advances it to `post_target_id`.
+        target_thread: String,
+        /// `target_thread`'s tip before the FF. Undo target.
+        pre_target_id: ChangeId,
+        /// `target_thread`'s tip after the FF (the source's tip at
+        /// recording time). Redo target — recorded so replay is
+        /// deterministic regardless of what `source_thread` does
+        /// later.
+        post_target_id: ChangeId,
     },
 }
 
@@ -232,6 +267,20 @@ impl OpRecord {
                     source_thread,
                     target_thread,
                     pre_target_id.short()
+                )
+            }
+            OpRecord::FastForwardV2 {
+                source_thread,
+                target_thread,
+                pre_target_id,
+                post_target_id,
+            } => {
+                format!(
+                    "fast-forward {} into {} ({} -> {})",
+                    source_thread,
+                    target_thread,
+                    pre_target_id.short(),
+                    post_target_id.short()
                 )
             }
         }

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -34,8 +34,27 @@ impl Repository {
     /// pre-op state — this helper preserves attached-HEAD semantics so the
     /// thread's ref and metadata advance with the worktree.
     pub fn fast_forward_attached(&self, target: &ChangeId) -> Result<()> {
+        self.fast_forward_attached_internal(target, true)
+    }
+
+    /// Variant of [`Self::fast_forward_attached`] that performs the
+    /// fast-forward without recording an `OpRecord::Goto`. The merge
+    /// command uses this so it can record an `OpRecord::FastForward`
+    /// instead — the FF-specific variant carries the pre-FF thread tip,
+    /// so undo can restore both HEAD and the target thread ref. The
+    /// generic `Goto` inverse only rewinds HEAD, which stranded the
+    /// merged-into thread ref (heddle#99).
+    pub fn fast_forward_attached_without_record(&self, target: &ChangeId) -> Result<()> {
+        self.fast_forward_attached_internal(target, false)
+    }
+
+    fn fast_forward_attached_internal(&self, target: &ChangeId, record: bool) -> Result<()> {
         let head_before = self.refs.read_head()?;
-        self.goto(target)?;
+        if record {
+            self.goto(target)?;
+        } else {
+            self.goto_without_record(target)?;
+        }
         if let Head::Attached {
             thread: current_thread,
         } = &head_before

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -39,11 +39,12 @@ impl Repository {
 
     /// Variant of [`Self::fast_forward_attached`] that performs the
     /// fast-forward without recording an `OpRecord::Goto`. The merge
-    /// command uses this so it can record an `OpRecord::FastForward`
-    /// instead — the FF-specific variant carries the pre-FF thread tip,
-    /// so undo can restore both HEAD and the target thread ref. The
+    /// command uses this so it can record an `OpRecord::FastForwardV2`
+    /// instead — the FF-specific variant carries both `pre_target_id`
+    /// (for undo) and `post_target_id` (for deterministic redo). The
     /// generic `Goto` inverse only rewinds HEAD, which stranded the
-    /// merged-into thread ref (heddle#99).
+    /// merged-into thread ref (heddle#99 r1); a name-resolved redo was
+    /// also non-deterministic if the source thread moved (heddle#99 r2).
     pub fn fast_forward_attached_without_record(&self, target: &ChangeId) -> Result<()> {
         self.fast_forward_attached_internal(target, false)
     }

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -13,7 +13,7 @@ follow-ups.
 |------------------|-------------------------------------------------------------------------|
 | `heddle capture` | Restores `HEAD` and the worktree to the immediate parent state.         |
 | `heddle merge` (non-FF) | Restores `HEAD` **and** both thread refs; drops the merge state.  |
-| `heddle merge` (FF)     | Restores `HEAD` to the pre-merge tip. **Caveat:** the merged-into thread ref is left at the FF target — see "Known caveats" below. |
+| `heddle merge` (FF)     | Restores `HEAD` **and** the merged-into thread ref to the pre-merge tip; the merged-in thread is untouched. |
 | `heddle goto`    | Restores `HEAD` to the pre-`goto` state.                                |
 | `heddle thread create`   | Deletes the thread (if no further work landed on it).           |
 | `heddle thread drop`     | Recreates the thread at its pre-drop tip.                       |
@@ -93,13 +93,6 @@ Run `heddle undo --help` for the curated list with examples and the explicit
 
 ## Known caveats (filed as follow-ups)
 
-- After a **fast-forward** merge undo, `HEAD` is restored to the pre-merge
-  state but the *thread ref* you merged into is left at the FF target. A
-  `heddle thread switch <name>` re-attaches; data is never lost. Fixing
-  this end-to-end needs a new `OpRecord::FastForward` variant carrying the
-  thread context — out of scope for the MVP. Tracked in
-  [heddle#99](https://github.com/HeddleCo/heddle/issues/99) and pinned by
-  `test_undo_ff_merge_restores_head_but_strands_thread_ref`.
 - `OpRecord::Checkpoint` is defined but no current code path emits it; the
   variant exists for the agent-frequent-saves work in flight. When it lands
   it will need its own inverse arm in `undo_apply.rs`.


### PR DESCRIPTION
## Summary

Closes the FF merge undo gap heddle#23 r2 documented and pinned with
`test_undo_ff_merge_restores_head_but_strands_thread_ref`. The new
`OpRecord::FastForward` variant carries the pre-FF target tip so undo
can restore both HEAD and the target thread ref, rather than leaving
the ref stranded at the FF target.

- Adds `OpRecord::FastForward { source_thread, target_thread, pre_target_id }`
  at the tail of the variant list (rmp-serde discriminant compatibility).
- Adds `Repository::fast_forward_attached_without_record` and uses it in
  the FF merge path; records `FastForward` explicitly (or `Goto` when
  HEAD is detached and there's no thread to restore).
- Implements the new undo + redo arms, plus gc destructive-boundary
  protection for `pre_target_id`.
- Flips the pinning test from heddle#23 r2 to assert the correct fix and
  adds two new red-commit tests: a full FF-merge → undo → redo round-trip
  and an FF-merge gc-pruned-undo refusal.
- Updates `docs/undo.md` and `heddle undo --help` to drop the "FF merge
  undo strands ref" caveat.

Rule-7 findings:
1. Other `fast_forward_attached` callers (rebase, workflow ship,
   pull/fetch) still record `Goto` and have the same strand-on-undo
   shape for thread refs. Out of scope for heddle#99 (which scopes to
   `heddle merge`); worth a follow-up if those operations need proper
   undo semantics for the thread-ref move.
2. All "FF merge undo strands ref" references updated (docs, help text,
   test docstring).
3. gc interaction: `pre_target_id` is registered with
   `states_required_for_undo` and pinned by
   `test_undo_ff_merge_refuses_when_pre_target_state_missing`.

Closes HeddleCo/heddle#99

## Test plan

- [x] `cargo test -p heddle-cli --test core_functionality 'undo_and_special::'` — 32 passed, including the flipped pinning test, new red-commit + redo + gc-refusal tests.
- [x] `cargo test -p heddle-cli --test state_management` — 70 passed.
- [x] `cargo test -p heddle-cli --test production_features` — 91 passed.
- [x] `cargo test -p heddle-oplog` — 11 passed.
- [x] `cargo test -p heddle-repo` — 286 passed.
- [x] `cargo clippy -p heddle-oplog -p heddle-repo -p heddle-cli --tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->