### PR TITLE
fix(projfs): empty NUL-terminated NotificationRoot, not PCWSTR::null (heddle#108)

### DIFF
--- a/crates/mount/src/projfs.rs
+++ b/crates/mount/src/projfs.rs
@@ -213,10 +213,7 @@ impl ProjFsShell {
                 | PRJ_NOTIFICATION_FILE_HANDLE_CLOSED_NO_MODIFICATION.0
                 | PRJ_NOTIFICATION_FILE_RENAMED.0) as u32,
         );
-        let mut notification_mapping = PRJ_NOTIFICATION_MAPPING {
-            NotificationBitMask: notification_bits,
-            NotificationRoot: PCWSTR::null(),
-        };
+        let mut notification_mapping = entire_root_notification_mapping(notification_bits);
 
         let options = PRJ_STARTVIRTUALIZING_OPTIONS {
             Flags: Default::default(),
@@ -585,6 +582,23 @@ fn encode_guid(guid: &GUID) -> Vec<u8> {
     bytes.extend_from_slice(&guid.data3.to_le_bytes());
     bytes.extend_from_slice(&guid.data4);
     bytes
+}
+
+/// Build the single `PRJ_NOTIFICATION_MAPPING` we register with
+/// `PrjStartVirtualizing`, covering the entire virtualization root.
+///
+/// The `NotificationRoot` field is required to be a non-null,
+/// NUL-terminated wide string: an empty string (`L""`) means "the
+/// whole virtualization root". `PrjStartVirtualizing` dereferences
+/// this pointer synchronously to copy the relative path of the
+/// directory the mapping applies to; passing a NULL `PCWSTR` here
+/// crashed the host process with `STATUS_ACCESS_VIOLATION`
+/// (heddle#108) before any callback could fire.
+fn entire_root_notification_mapping(bits: PRJ_NOTIFY_TYPES) -> PRJ_NOTIFICATION_MAPPING {
+    PRJ_NOTIFICATION_MAPPING {
+        NotificationBitMask: bits,
+        NotificationRoot: PCWSTR::null(),
+    }
 }
 
 fn hresult_to_mount_error(hr: HRESULT) -> MountError {
@@ -1295,6 +1309,43 @@ mod tests {
             sidecar.display(),
         );
         assert_eq!(sidecar.file_name().unwrap(), ".heddle-projfs-id");
+    }
+
+    /// Regression test for heddle#108: STATUS_ACCESS_VIOLATION in
+    /// `PrjStartVirtualizing`.
+    ///
+    /// Pre-fix, `mount_background` built its single
+    /// `PRJ_NOTIFICATION_MAPPING` with `NotificationRoot:
+    /// PCWSTR::null()`. The ProjFS kernel dereferences that pointer
+    /// to copy the relative path of the directory the mapping
+    /// applies to (an empty string means "the whole virtualization
+    /// root"), so a null caused the host process to crash with
+    /// STATUS_ACCESS_VIOLATION before any callback fired — every
+    /// projfs-smoke test failed at the `mount_background` step.
+    ///
+    /// The fix points `NotificationRoot` at a NUL-terminated empty
+    /// wide string. This test pins the contract: the mapping
+    /// `mount_background` ships into the kernel must (a) have a
+    /// non-null `NotificationRoot` and (b) that pointer must point
+    /// at a NUL terminator (= empty string).
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore = "requires the projfs feature; opt-in via --features projfs"]
+    fn notification_mapping_root_is_non_null_empty_wide_string_heddle108() {
+        let mapping = entire_root_notification_mapping(PRJ_NOTIFY_TYPES(0));
+        assert!(
+            !mapping.NotificationRoot.0.is_null(),
+            "NotificationRoot must not be null — PrjStartVirtualizing \
+             STATUS_ACCESS_VIOLATIONs on null (heddle#108)",
+        );
+        // SAFETY: the fix points NotificationRoot at a 'static
+        // [u16; 1] = [0]; dereferencing one u16 is in-bounds.
+        let first = unsafe { *mapping.NotificationRoot.0 };
+        assert_eq!(
+            first, 0u16,
+            "NotificationRoot must point at a NUL terminator (= empty \
+             string, meaning 'the whole virtualization root')",
+        );
     }
 
     /// `EnumKey` is the hash-able wrapper around `GUID` we use to

--- a/crates/mount/src/projfs.rs
+++ b/crates/mount/src/projfs.rs
@@ -594,10 +594,16 @@ fn encode_guid(guid: &GUID) -> Vec<u8> {
 /// directory the mapping applies to; passing a NULL `PCWSTR` here
 /// crashed the host process with `STATUS_ACCESS_VIOLATION`
 /// (heddle#108) before any callback could fire.
+///
+/// The empty string lives in `'static` storage so the pointer is
+/// trivially valid for the duration of the `PrjStartVirtualizing`
+/// call (and well beyond — the kernel copies the contents).
 fn entire_root_notification_mapping(bits: PRJ_NOTIFY_TYPES) -> PRJ_NOTIFICATION_MAPPING {
+    // A single NUL terminator — the wide-string form of `""`.
+    static EMPTY_NOTIFICATION_ROOT: [u16; 1] = [0u16];
     PRJ_NOTIFICATION_MAPPING {
         NotificationBitMask: bits,
-        NotificationRoot: PCWSTR::null(),
+        NotificationRoot: PCWSTR(EMPTY_NOTIFICATION_ROOT.as_ptr()),
     }
 }
 


### PR DESCRIPTION
## Summary
- `mount_background` shipped its single `PRJ_NOTIFICATION_MAPPING` with `NotificationRoot: PCWSTR::null()`; the ProjFS kernel dereferences that pointer in `PrjStartVirtualizing` to copy the relative path of the directory the mapping applies to, so a NULL crashed the host process with STATUS_ACCESS_VIOLATION before any callback could fire. Every projfs-smoke test was failing at the `mount_background` step.
- Factor the mapping into `entire_root_notification_mapping(bits)` and point `NotificationRoot` at a `'static [u16; 1] = [0]` — the wide-string form of `""`, which per the ProjFS contract means "subscribe to the entire virtualization root". Static storage keeps the pointer valid past the kernel's synchronous copy.
- Add a unit test (`notification_mapping_root_is_non_null_empty_wide_string_heddle108`) in `src/projfs.rs::tests` that pins the contract — non-null `NotificationRoot`, first u16 is a NUL terminator. The CI projfs-smoke job already runs the lib unit tests via `cargo test ... --lib projfs:: -- --ignored`, so this regression is caught at the unit level (the integration smoke is still the load-bearing end-to-end check).

Closes HeddleCo/heddle#108

## Root cause

`PRJ_NOTIFICATION_MAPPING::NotificationRoot` is documented as a NUL-terminated Unicode string. An empty string (`L""`) is the special value that subscribes to the whole virtualization root; passing a NULL `PCWSTR` is **not** valid — `PrjStartVirtualizing` follows the pointer to copy the path during the synchronous setup phase.

Pre-fix, `mount_background` constructed:

```rust
let mut notification_mapping = PRJ_NOTIFICATION_MAPPING {
    NotificationBitMask: notification_bits,
    NotificationRoot: PCWSTR::null(),   // <-- AV here
};
```

This matched the issue body's first likely candidate ("Null pointer deref in ProjFS callback (windows-rs API takes `*const` / `*mut` — easy to misuse)"), though the deref happened kernel-side rather than in one of our trampolines: ProjFS's setup path reads `NotificationRoot` before any callback registers.

## Red commit
`27cca774` — adds the regression test on top of the pre-fix `PCWSTR::null()` shape (extracted into a helper so the test has something to call). The unit test fails on this commit; the fix in `ceb2696` makes it pass.

## Test evidence

Local cross-checks (Linux host, `--target x86_64-pc-windows-gnu`):

```
$ cargo check -p heddle-mount --features projfs --target x86_64-pc-windows-gnu --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.81s

$ cargo clippy -p heddle-mount --features projfs --target x86_64-pc-windows-gnu --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.30s

$ cargo clippy -p heddle-mount --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
```

CI projfs-smoke (Windows) is the load-bearing test — the existing five smoke tests all set up a mount via `mount_background`, so all of them act as integration-level regression catchers for this AV. Watching for the `ProjFS mount smoke (Windows)` and `ProjFS panic-recovery unit tests` job steps to go green here.

## Manual verification
N/A — covered by the unit test + the existing projfs-smoke integration suite. The bug only repros on Windows with ProjFS enabled; CI is the only place this code path is exercised.

## File scope
- `crates/mount/src/projfs.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->