### PR TITLE
heddle#23: cross-thread undo (design + ThreadCreate inverse)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -327,7 +327,13 @@ Undoable operations:
 Not undoable (file a follow-up if you need one):
   - heddle push / heddle fetch        (remote-affecting; out of scope)
   - heddle purge                      (destructive by design; irreversible)
-  - cross-thread undo                 (single-thread scope today)
+  - heddle start <name> --path <dir>  (refused while the materialized worktree
+                                       still exists — run `heddle thread drop
+                                       <name> --delete-thread` first, then
+                                       re-run `heddle undo`)
+  - cross-worktree shared-backend undo (no worktree registry yet; single-
+                                        worktree usage is the supported
+                                        configuration for 0.3)
   - redo across CLI invocations       (use `heddle redo` in the same shell)
 ")]
 pub struct UndoArgs {

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -270,8 +270,19 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
         } else {
             repo.refs()
                 .set_thread_cas(&thread_name, RefExpectation::Missing, &anchor)?;
-            repo.oplog()
-                .record_thread_create(&thread_name, &anchor, Some(&repo.op_scope()))?;
+            // Agent-reservation flow writes the ThreadManager record via
+            // `ensure_thread_record` below, after this op is recorded —
+            // so there's no record to snapshot at recording time. Pass
+            // `None`; the op records as `ThreadCreateV2` with no
+            // manager snapshot. Reservations are an agent-internal API
+            // that aren't expected to participate in human undo/redo
+            // flows in 0.3. heddle#23 r2.
+            repo.oplog().record_thread_create(
+                &thread_name,
+                &anchor,
+                None,
+                Some(&repo.op_scope()),
+            )?;
         }
 
         // Ensure a Thread record exists so downstream commands

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1181,8 +1181,18 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     } else {
         repo.refs()
             .set_thread_cas(&args.name, RefExpectation::Missing, &base_state)?;
+        // `cmd_start` writes the ThreadManager record only after
+        // materializing the worktree below — there's no record yet to
+        // snapshot, so pass `None`. The `ensure_thread_worktree_undo_safe`
+        // gate (undo.rs) refuses undo whenever this create has a live
+        // materialized worktree on disk, so the only path where redo
+        // would actually run for a `start` op is one where the user has
+        // manually torn the worktree down. Redo then restores the ref
+        // only (no record body to put back); a subsequent `heddle
+        // thread start` re-establishes the record if the user wants
+        // one. heddle#23 r2.
         repo.oplog()
-            .record_thread_create(&args.name, &base_state, Some(&repo.op_scope()))?;
+            .record_thread_create(&args.name, &base_state, None, Some(&repo.op_scope()))?;
     }
 
     let thread_mode = resolve_thread_mode(repo, &args);
@@ -1562,8 +1572,6 @@ pub(crate) fn cmd_thread_create(
 
     repo.refs()
         .set_thread_cas(&name, RefExpectation::Missing, &current)?;
-    repo.oplog()
-        .record_thread_create(&name, &current, Some(&repo.op_scope()))?;
 
     // Persist a Thread record so subsequent commands that go through
     // `ThreadManager::load` (delegate, ship, integration policy,
@@ -1634,6 +1642,24 @@ pub(crate) fn cmd_thread_create(
         shared_target_dir: None,
     };
     thread_manager.save(&thread_state)?;
+
+    // Snapshot the just-saved record into the OpRecord so `heddle redo`
+    // can recreate it after `heddle undo` destroys it. Without this,
+    // redo restores only the ref and record-backed commands (`thread
+    // cd`, delegate, integration policy) silently degrade. heddle#23 r2
+    // Codex P1 (mirrors the heddle#99 r2 FastForwardV2 pattern — record
+    // what redo needs).
+    //
+    // Snapshot failure is fatal here: we just wrote the record, so a
+    // round-trip-encode that can't read its own write is a serde
+    // contract bug, not a runtime condition.
+    let manager_snapshot = thread_manager.snapshot_thread_record(&name)?;
+    repo.oplog().record_thread_create(
+        &name,
+        &current,
+        manager_snapshot,
+        Some(&repo.op_scope()),
+    )?;
 
     let output = ThreadOpOutput {
         name: name.clone(),

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -4,7 +4,7 @@
 use anyhow::{Result, anyhow};
 use objects::object::{ChangeId, ContentHash};
 use oplog::{OpBatch, OpRecord};
-use repo::Repository;
+use repo::{Repository, ThreadManager};
 use serde::Serialize;
 
 use super::{
@@ -94,6 +94,13 @@ pub fn cmd_undo(
     // post-preview: dirty worktree and gc-pruned states are conditions
     // operators expect `--preview` to ignore.
     ensure_redaction_undo_safe(&repo, &batches, allow_redact_undo)?;
+    // Cross-thread safety: refuse to undo a `ThreadCreate` whose
+    // ThreadManager record still has a materialized worktree on disk.
+    // The inverse only deletes the ref, so silently proceeding would
+    // leave the worktree directory orphaned with a broken `.heddle/HEAD`
+    // and a phantom ThreadManager record. Pre-preview for the same
+    // honesty reason as the redaction gate.
+    ensure_thread_worktree_undo_safe(&repo, &batches)?;
 
     if preview {
         let output = UndoRedoOutput {
@@ -544,6 +551,68 @@ fn ensure_redaction_redo_supported(batches: &[OpBatch]) -> Result<()> {
          entry doesn't preserve the full Redaction record (reason, redactor, signature) needed \
          to recreate it, and Purge is irreversible by design. Re-run `heddle redact apply` \
          (or `heddle purge apply`) to re-establish the operation. Affected op(s): {}.",
+        shorts.join(", "),
+    ))
+}
+
+/// Cross-thread undo safety: refuse to undo any `ThreadCreate` whose
+/// ThreadManager record carries a materialized worktree path that still
+/// exists on disk. The undo inverse only deletes the thread ref — without
+/// the matching worktree teardown the directory at `materialized_path` is
+/// left orphaned with a broken `.heddle/HEAD` and a phantom record. The
+/// canonical teardown verb is `heddle thread drop <name> --delete-thread`,
+/// which goes through `drop_thread_silent` (thread_cmd.rs:562) to unmount
+/// virtualized threads, rm the execution path, mark the record Abandoned,
+/// strip agent registry entries, and finally remove the ref. Once that
+/// has run the path no longer exists and a subsequent `heddle undo` of
+/// the original create proceeds.
+///
+/// A stale record whose `materialized_path` points at a non-existent
+/// directory is *not* a refusal — the user has already torn the worktree
+/// down by hand and the undo's record-cleanup pass will sweep the orphan
+/// up. See docs/design/cross-thread-undo.md "Contract" rule 5.
+fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let mut blocking: Vec<(u64, String, std::path::PathBuf)> = Vec::new();
+
+    for batch in batches {
+        for entry in &batch.entries {
+            let OpRecord::ThreadCreate { name, .. } = &entry.operation else {
+                continue;
+            };
+            let Some(record) = manager.find_by_thread(name)? else {
+                continue;
+            };
+            let Some(path) = record.materialized_path.as_ref() else {
+                continue;
+            };
+            if path.exists() {
+                blocking.push((entry.id, name.clone(), path.clone()));
+            }
+        }
+    }
+
+    if blocking.is_empty() {
+        return Ok(());
+    }
+
+    let shorts: Vec<String> = blocking
+        .iter()
+        .map(|(op_id, name, path)| {
+            format!(
+                "op {} (thread '{}', worktree {})",
+                op_id,
+                name,
+                path.display()
+            )
+        })
+        .collect();
+    Err(anyhow!(
+        "Refusing to undo: at least one `thread create` in this chain has an attached \
+         materialized worktree that would be orphaned by the inverse ({}). The undo only \
+         removes the thread ref; the worktree directory and its `.heddle/HEAD` would be left \
+         pointing at a thread that no longer exists. Tear the worktree down first with \
+         `heddle thread drop <name> --delete-thread`, then re-run `heddle undo`.",
         shorts.join(", "),
     ))
 }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -401,6 +401,7 @@ fn states_required_for_redo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::Snapshot { new_state, .. } => vec![*new_state],
         OpRecord::Goto { target, .. } => vec![*target],
         OpRecord::ThreadCreate { state, .. } => vec![*state],
+        OpRecord::ThreadCreateV2 { state, .. } => vec![*state],
         OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
         OpRecord::MarkerCreate { state, .. } => vec![*state],
         OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
@@ -577,8 +578,13 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
 
     for batch in batches {
         for entry in &batch.entries {
-            let OpRecord::ThreadCreate { name, .. } = &entry.operation else {
-                continue;
+            // Match V1 and V2 — the rename batch's new-name arm and all
+            // post-heddle#23-r2 creates record as V2. Both have the
+            // same worktree-orphan hazard on undo.
+            let name = match &entry.operation {
+                OpRecord::ThreadCreate { name, .. }
+                | OpRecord::ThreadCreateV2 { name, .. } => name,
+                _ => continue,
             };
             let Some(record) = manager.find_by_thread(name)? else {
                 continue;

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -49,7 +49,7 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         | OpRecord::Goto {
             prev_head: None, ..
         } => {}
-        OpRecord::ThreadCreate { name, .. } => {
+        OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
             delete_thread_safely(repo, name)?;
             // Cross-thread contract rule 4 (docs/design/cross-thread-undo.md):
             // the inverse of `ThreadCreate` must also remove the matching
@@ -62,6 +62,11 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             // safe. Missing record is fine: not every `ThreadCreate` path
             // writes one (legacy oplog entries may predate the record
             // store).
+            //
+            // Both V1 and V2 use the same undo: V2's `manager_snapshot`
+            // is recorded for redo, so undo can still destroy the live
+            // record without losing the data needed to put it back.
+            // Matches the FastForward/V2 shared-undo shape.
             remove_thread_manager_record(repo, name)?;
         }
         OpRecord::ThreadDelete { name, state } => {
@@ -152,8 +157,57 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         OpRecord::Goto { target, .. } => {
             repo.goto_without_record(target)?;
         }
+        // V1 ThreadCreate redo: ref-only, with a stderr note that the
+        // ThreadManager record is not being restored. V1 records were
+        // written by code pre-heddle#23 r2 that didn't carry a record
+        // snapshot in the OpRecord; redo can't reconstruct the body
+        // (mode, base_state, base_root, …) from `(name, state)` alone.
+        // Record-backed commands (`thread cd`, delegate, integration
+        // policy) will silently degrade on this thread — pointed out
+        // on stderr so the operator can rerun `heddle thread start
+        // <name>` if they want the record back. V1 ages out as the
+        // live oplog window slides forward.
         OpRecord::ThreadCreate { name, state } => {
             repo.refs().set_thread(name, state)?;
+            eprintln!(
+                "warning: redo of legacy V1 `ThreadCreate` for '{}' restores the ref only — \
+                 the matching ThreadManager record body was not snapshotted by this oplog entry. \
+                 Run `heddle thread start {}` to re-establish the record if record-backed \
+                 commands (`thread cd`, delegate, integration policy) misbehave.",
+                name, name
+            );
+        }
+        // V2 ThreadCreate redo (heddle#23 r2): restore both the thread
+        // ref and the ThreadManager record body from the snapshot
+        // captured at recording time. Mirrors the FastForwardV2 redo
+        // pattern (record what redo needs).
+        //
+        // `manager_snapshot = None` means the forward path didn't have
+        // a record to snapshot (cmd_start before materialization, the
+        // rename batch's new-name arm, ingest, harness/agent stubs).
+        // Restore the ref only in that case — no record to put back.
+        OpRecord::ThreadCreateV2 {
+            name,
+            state,
+            manager_snapshot,
+        } => {
+            repo.refs().set_thread(name, state)?;
+            if let Some(bytes) = manager_snapshot {
+                let manager = ThreadManager::new(repo.heddle_dir());
+                match manager.restore_thread_record_from_snapshot(bytes) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "warning: redo of `ThreadCreate` for '{}' restored the ref but \
+                             failed to decode the ThreadManager record snapshot ({}). \
+                             Record-backed commands (`thread cd`, delegate) may degrade \
+                             on this thread — run `heddle thread start {}` to recreate \
+                             the record.",
+                            name, e, name
+                        );
+                    }
+                }
+            }
         }
         OpRecord::ThreadDelete { name, .. } => {
             delete_thread_safely(repo, name)?;

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -51,6 +51,18 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         } => {}
         OpRecord::ThreadCreate { name, .. } => {
             delete_thread_safely(repo, name)?;
+            // Cross-thread contract rule 4 (docs/design/cross-thread-undo.md):
+            // the inverse of `ThreadCreate` must also remove the matching
+            // ThreadManager record so `heddle thread show` and the record-
+            // store readers don't surface a phantom entry for a thread
+            // whose ref no longer exists. The worktree-attached refusal in
+            // `ensure_thread_worktree_undo_safe` already gated us, so any
+            // record we hit here has `materialized_path = None` or a path
+            // that no longer exists — either way, dropping the record is
+            // safe. Missing record is fine: not every `ThreadCreate` path
+            // writes one (legacy oplog entries may predate the record
+            // store).
+            remove_thread_manager_record(repo, name)?;
         }
         OpRecord::ThreadDelete { name, state } => {
             repo.refs().set_thread(name, state)?;
@@ -232,6 +244,17 @@ fn sync_thread_record_state(
         thread.current_state = Some(state.short());
         thread.updated_at = chrono::Utc::now();
         manager.save(&thread)?;
+    }
+    Ok(())
+}
+
+/// Remove the ThreadManager record matching `thread_name`. No-op when no
+/// record exists. Used by the `ThreadCreate` inverse to keep refs and
+/// record-store state in lockstep (cross-thread undo contract rule 4).
+fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<()> {
+    let manager = ThreadManager::new(repo.heddle_dir());
+    if let Some(thread) = manager.find_by_thread(thread_name)? {
+        manager.delete(&thread.id)?;
     }
     Ok(())
 }

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -434,7 +434,7 @@ fn kind_for(op: &OpRecord) -> String {
     match op {
         OpRecord::Snapshot { .. } => "snapshot".into(),
         OpRecord::Goto { .. } => "goto".into(),
-        OpRecord::ThreadCreate { .. } => "thread_create".into(),
+        OpRecord::ThreadCreate { .. } | OpRecord::ThreadCreateV2 { .. } => "thread_create".into(),
         OpRecord::ThreadDelete { .. } => "thread_delete".into(),
         OpRecord::ThreadUpdate { .. } => "thread_update".into(),
         OpRecord::Fork { .. } => "fork".into(),
@@ -458,7 +458,9 @@ fn kind_for(op: &OpRecord) -> String {
 fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
     match op {
         OpRecord::Snapshot { thread, .. } => thread.clone(),
-        OpRecord::ThreadCreate { name, .. } => Some(name.clone()),
+        OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
+            Some(name.clone())
+        }
         OpRecord::ThreadDelete { name, .. } => Some(name.clone()),
         OpRecord::ThreadUpdate { name, .. } => Some(name.clone()),
         OpRecord::MarkerCreate { name, .. } => Some(name.clone()),
@@ -485,7 +487,9 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
     match op {
         OpRecord::Snapshot { new_state, .. } => Some(*new_state),
         OpRecord::Goto { target, .. } => Some(*target),
-        OpRecord::ThreadCreate { state, .. } => Some(*state),
+        OpRecord::ThreadCreate { state, .. } | OpRecord::ThreadCreateV2 { state, .. } => {
+            Some(*state)
+        }
         OpRecord::ThreadDelete { state, .. } => Some(*state),
         OpRecord::ThreadUpdate { new_state, .. } => Some(*new_state),
         OpRecord::Fork { new_state, .. } => Some(*new_state),

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -916,9 +916,14 @@ impl HarnessBridgeRuntime {
             self.repo
                 .refs()
                 .set_thread_cas(name, refs::RefExpectation::Missing, &base_state)?;
+            // Harness writes the ThreadManager record later in this
+            // function (after materializing); no record exists to
+            // snapshot at recording time. `None` matches the pattern
+            // used by `cmd_start` / agent reservation. heddle#23 r2.
             self.repo.oplog().record_thread_create(
                 name,
                 &base_state,
+                None,
                 Some(&self.repo.op_scope()),
             )?;
         }

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1569,3 +1569,229 @@ fn test_redo_preview_refuses_redact_chain() {
         "redo preview refusal should redirect to `heddle redact apply`: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Cross-thread undo coverage (heddle#23 r2)
+//
+// These tests pin the contract laid out in docs/design/cross-thread-undo.md:
+// undo of `ThreadCreate` must keep ref state and ThreadManager metadata in
+// lockstep, and must refuse rather than orphan a materialized sibling
+// worktree.
+// ---------------------------------------------------------------------------
+
+/// Bootstrap a repo with an initial snapshot so `ensure_current_state` is
+/// happy when we go on to `heddle thread create`. Returns the temp dir so
+/// the caller keeps it alive for the rest of the test.
+fn bootstrap_repo_with_initial_state() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    temp
+}
+
+/// After undoing a plain `heddle thread create`, the ref must be gone *and*
+/// the ThreadManager record that `cmd_thread_create` wrote alongside the
+/// ref must be removed. Pre-fix the inverse only deleted the ref; the
+/// record lingered and surfaced as a phantom entry in `heddle thread show`
+/// (which reads from the record store, not the ref store). Cross-thread
+/// contract rule 4 (refs and ThreadManager metadata must mirror each
+/// other) — see docs/design/cross-thread-undo.md.
+#[test]
+fn test_undo_thread_create_removes_record_when_no_worktree() {
+    use repo::ThreadManager;
+
+    let temp = bootstrap_repo_with_initial_state();
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+
+    // Sanity: the record was written by `cmd_thread_create` (thread.rs:1636).
+    {
+        let repo = Repository::open(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let record = manager
+            .find_by_thread("feature")
+            .unwrap()
+            .expect("`thread create` writes a ThreadManager record");
+        assert!(
+            record.materialized_path.is_none(),
+            "plain `thread create` must not materialize a worktree"
+        );
+    }
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    let repo = Repository::open(temp.path()).unwrap();
+
+    // The ref is gone — that part already worked pre-fix.
+    assert!(
+        repo.refs().get_thread("feature").unwrap().is_none(),
+        "undo of `thread create` must delete the thread ref"
+    );
+
+    // The fix: the ThreadManager record must also be gone so subsequent
+    // `heddle thread show` / `thread list` don't surface a phantom entry.
+    let manager = ThreadManager::new(repo.heddle_dir());
+    assert!(
+        manager.find_by_thread("feature").unwrap().is_none(),
+        "undo of `thread create` must remove the matching ThreadManager record \
+         (heddle#23 r2 — cross-thread undo contract rule 4)"
+    );
+}
+
+/// Undoing `heddle start <name> --path <wt>` would orphan the materialized
+/// worktree directory at `<wt>` — the inverse deletes the thread ref but
+/// has no way to atomically tear the worktree down (it lives in another
+/// directory and may have uncommitted work in flight). Per the cross-thread
+/// contract rule 5, undo refuses with a clear message pointing the user at
+/// the manual teardown path (`heddle thread drop --delete-thread`).
+#[test]
+fn test_undo_thread_create_refuses_with_materialized_worktree() {
+    let temp = bootstrap_repo_with_initial_state();
+
+    let wt_path = temp.path().join("feature-wt");
+    heddle_must_succeed(
+        &[
+            "start",
+            "feature",
+            "--path",
+            wt_path.to_str().unwrap(),
+            "--workspace",
+            "solid",
+        ],
+        temp.path(),
+    );
+
+    // Sanity: the worktree was materialized.
+    assert!(
+        wt_path.exists(),
+        "`heddle start --path` must materialize the requested worktree"
+    );
+    {
+        let repo = Repository::open(temp.path()).unwrap();
+        assert!(
+            repo.refs().get_thread("feature").unwrap().is_some(),
+            "feature thread ref must exist after `start --path`"
+        );
+    }
+
+    let err = heddle(&["undo"], Some(temp.path()))
+        .expect_err("undo of `start --path` must refuse so the worktree isn't orphaned");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("worktree") || lower.contains("materialized"),
+        "refusal must name the worktree concern: {err}"
+    );
+    assert!(
+        err.contains("feature-wt") || err.contains("feature"),
+        "refusal must surface the affected thread or worktree path: {err}"
+    );
+    assert!(
+        lower.contains("thread drop") || lower.contains("--delete-thread"),
+        "refusal must point at the teardown command: {err}"
+    );
+
+    // Refusal must be pre-flight: nothing was mutated.
+    let repo = Repository::open(temp.path()).unwrap();
+    assert!(
+        repo.refs().get_thread("feature").unwrap().is_some(),
+        "thread ref must survive a refused undo (pre-flight refusal — \
+         consistent with the redaction/dirty-worktree gates)"
+    );
+    assert!(
+        wt_path.exists(),
+        "worktree directory must survive a refused undo"
+    );
+}
+
+/// `heddle thread rename` is a batch `[ThreadCreate(new), ThreadDelete(old)]`
+/// (see oplog_records.rs::record_thread_rename). The cross-thread inverse
+/// must round-trip both halves: the new name's ref deleted, the old name's
+/// ref restored, no orphan ThreadManager record under the new name.
+///
+/// Regression guard: passes today because `cmd_thread_rename` never writes
+/// a record under the new name in the first place, so the inverse vacuously
+/// satisfies the "no orphan under new name" assertion. Catches a future
+/// regression that introduced a forward-path record write without a
+/// matching inverse cleanup.
+#[test]
+fn test_undo_thread_rename_round_trips_refs_and_record() {
+    use repo::ThreadManager;
+
+    let temp = bootstrap_repo_with_initial_state();
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "rename", "feature", "feature-v2"], temp.path());
+
+    {
+        let repo = Repository::open(temp.path()).unwrap();
+        assert!(
+            repo.refs().get_thread("feature-v2").unwrap().is_some(),
+            "rename forward path must create `feature-v2`"
+        );
+        assert!(
+            repo.refs().get_thread("feature").unwrap().is_none(),
+            "rename forward path must remove `feature`"
+        );
+    }
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    let repo = Repository::open(temp.path()).unwrap();
+
+    // Refs: rename rolled back.
+    assert!(
+        repo.refs().get_thread("feature").unwrap().is_some(),
+        "undo of rename must restore the old name's ref"
+    );
+    assert!(
+        repo.refs().get_thread("feature-v2").unwrap().is_none(),
+        "undo of rename must delete the new name's ref"
+    );
+
+    // ThreadManager: no orphan under the new name. (The record under the
+    // old name is a separate pre-existing concern: `cmd_thread_rename`
+    // doesn't update the record forward, so the record is still keyed at
+    // `feature` throughout. The contract here is just "the inverse mustn't
+    // *introduce* a divergence" — we don't try to heal forward-path bugs.)
+    let manager = ThreadManager::new(repo.heddle_dir());
+    assert!(
+        manager.find_by_thread("feature-v2").unwrap().is_none(),
+        "undo of rename must not leave a ThreadManager record under the new name \
+         (heddle#23 r2 — cross-thread undo contract rule 4)"
+    );
+}
+
+/// `heddle undo --preview` (alias `--dry-run`) must surface the
+/// worktree-attached refusal pre-mutation, matching the same
+/// preview-honesty rule used by the redaction gate at undo.rs:88.
+/// Pre-fix `--preview` would happily print "Would undo …" for a chain
+/// the real `undo` would reject, then the user runs the real command
+/// and is surprised by the refusal.
+#[test]
+fn test_undo_preview_surfaces_worktree_refusal() {
+    let temp = bootstrap_repo_with_initial_state();
+
+    let wt_path = temp.path().join("feature-wt");
+    heddle_must_succeed(
+        &[
+            "start",
+            "feature",
+            "--path",
+            wt_path.to_str().unwrap(),
+            "--workspace",
+            "solid",
+        ],
+        temp.path(),
+    );
+
+    let err = heddle(&["undo", "--preview"], Some(temp.path())).expect_err(
+        "`undo --preview` must refuse a worktree-attached ThreadCreate \
+                     instead of advertising 'Would undo …'",
+    );
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("worktree") || lower.contains("materialized"),
+        "preview refusal must name the worktree concern: {err}"
+    );
+}

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1773,6 +1773,75 @@ fn test_undo_thread_rename_round_trips_refs_and_record() {
     );
 }
 
+/// After `thread create` → `undo` → `redo`, the ThreadManager record must
+/// be present again with the same structural metadata (mode, base_state,
+/// id) it had pre-undo. Pre-fix `apply_redo_entry`'s `ThreadCreate` arm
+/// only restored the ref via `set_thread`; the record stayed gone because
+/// undo had destroyed it with no snapshot for redo to read back. Phantom
+/// shape: post-redo the thread ref exists but `heddle thread show`,
+/// `thread cd`, and any record-keyed command (delegate, integration
+/// policy) silently degrade. heddle#23 r2 Codex P1 (thread 3254698975).
+#[test]
+fn test_redo_thread_create_restores_manager_record() {
+    use repo::ThreadManager;
+
+    let temp = bootstrap_repo_with_initial_state();
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+
+    // Capture the structurally load-bearing fields the redo must restore.
+    let (orig_id, orig_mode, orig_base_state, orig_target_thread) = {
+        let repo = Repository::open(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let record = manager
+            .find_by_thread("feature")
+            .unwrap()
+            .expect("`thread create` writes a ThreadManager record");
+        (
+            record.id.clone(),
+            record.mode.clone(),
+            record.base_state.clone(),
+            record.target_thread.clone(),
+        )
+    };
+
+    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["redo"], temp.path());
+
+    let repo = Repository::open(temp.path()).unwrap();
+
+    // The ref is back — that part already worked pre-fix.
+    assert!(
+        repo.refs().get_thread("feature").unwrap().is_some(),
+        "redo of `thread create` must restore the thread ref"
+    );
+
+    // The fix: the ThreadManager record must also be back, with the
+    // structural fields the original record had. Without this, record-
+    // backed commands (`thread cd`, delegate, integration policy)
+    // silently degrade after an undo/redo round-trip.
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let restored = manager.find_by_thread("feature").unwrap().expect(
+        "redo of `thread create` must recreate the ThreadManager record \
+         (heddle#23 r2 Codex P1 — record/redo symmetry, cross-thread \
+         undo contract rule 4)",
+    );
+    assert_eq!(restored.id, orig_id, "id must round-trip");
+    assert_eq!(
+        format!("{:?}", restored.mode),
+        format!("{:?}", orig_mode),
+        "mode must round-trip"
+    );
+    assert_eq!(
+        restored.base_state, orig_base_state,
+        "base_state must round-trip"
+    );
+    assert_eq!(
+        restored.target_thread, orig_target_thread,
+        "target_thread must round-trip"
+    );
+}
+
 /// `heddle undo --preview` (alias `--dry-run`) must surface the
 /// worktree-attached refusal pre-mutation, matching the same
 /// preview-honesty rule used by the redaction gate at undo.rs:88.

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1015,8 +1015,19 @@ fn test_undo_help_lists_undoable_and_unsupported() {
         "--help should list merge as undoable: {help}"
     );
     assert!(
-        lower.contains("push") || lower.contains("fetch") || lower.contains("cross-thread"),
+        lower.contains("push") || lower.contains("fetch") || lower.contains("cross-worktree"),
         "--help should call out what is NOT undoable: {help}"
+    );
+    // The worktree-attached refusal is a 0.3 contract — `--help` must
+    // surface it so users hit by the refusal can find the teardown
+    // path without reading source. See docs/design/cross-thread-undo.md.
+    assert!(
+        lower.contains("worktree") || lower.contains("--path"),
+        "--help should mention the worktree-attached ThreadCreate refusal: {help}"
+    );
+    assert!(
+        lower.contains("thread drop") || lower.contains("--delete-thread"),
+        "--help should redirect users to the teardown command for the worktree case: {help}"
     );
 }
 

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -690,6 +690,7 @@ mod tests {
         for entry in &recent {
             match &entry.operation {
                 OpRecord::ThreadCreate { .. }
+                | OpRecord::ThreadCreateV2 { .. }
                 | OpRecord::ThreadUpdate { .. }
                 | OpRecord::ThreadDelete { .. }
                 | OpRecord::MarkerCreate { .. }

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -170,8 +170,13 @@ impl<'a> OplogEmitter<'a> {
                     stats.skipped_unmapped += 1;
                     return Ok(());
                 };
+                // Git-history ingest does not write a ThreadManager
+                // record — those exist for native heddle threads. Pass
+                // `None` for the snapshot; the recorded
+                // `ThreadCreateV2` carries no record body to restore
+                // on redo. heddle#23 r2.
                 self.oplog
-                    .record_thread_create(short_name, &cid, scope)
+                    .record_thread_create(short_name, &cid, None, scope)
                     .map_err(IngestError::from)?;
                 stats.thread_creates += 1;
             }
@@ -377,7 +382,7 @@ mod tests {
         let ops = all_ops(&log);
         assert_eq!(ops.len(), 3);
         assert!(
-            matches!(ops[0], OpRecord::ThreadCreate { ref name, state } if name == "main" && state == cid_a)
+            matches!(ops[0], OpRecord::ThreadCreateV2 { ref name, state, manager_snapshot: None } if name == "main" && state == cid_a)
         );
         assert!(matches!(
             &ops[1],
@@ -408,7 +413,7 @@ mod tests {
         let ops = all_ops(&log);
         assert!(matches!(
             &ops[0],
-            OpRecord::ThreadCreate { name, .. } if name == "feature/ingest"
+            OpRecord::ThreadCreateV2 { name, .. } if name == "feature/ingest"
         ));
     }
 

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -67,16 +67,30 @@ pub trait OpLogBackend: Send + Sync {
         Ok(ids[0])
     }
 
+    /// Record a thread creation.
+    ///
+    /// `manager_snapshot` is opaque rmp-serde bytes of the matching
+    /// `Thread` record body (see `repo::ThreadManager::snapshot_thread_record`)
+    /// so redo can recreate the record after undo destroyed it. Pass
+    /// `None` for callsites that don't write a `ThreadManager` record
+    /// alongside the create (rename batch's new-name arm, ingest,
+    /// harness/agent stubs that write the record later or not at all).
+    ///
+    /// Always emits `OpRecord::ThreadCreateV2`. V1
+    /// (`OpRecord::ThreadCreate`) is retained as read-back-only for
+    /// legacy oplog entries written before heddle#23 r2.
     fn record_thread_create(
         &self,
         name: &str,
         state: &ChangeId,
+        manager_snapshot: Option<Vec<u8>>,
         scope: Option<&str>,
     ) -> Result<u64> {
         let ids = self.record_batch_scoped(
-            vec![OpRecord::ThreadCreate {
+            vec![OpRecord::ThreadCreateV2 {
                 name: name.to_string(),
                 state: *state,
+                manager_snapshot,
             }],
             scope,
         )?;
@@ -99,6 +113,16 @@ pub trait OpLogBackend: Send + Sync {
         Ok(ids[0])
     }
 
+    /// Record a thread rename as a batch.
+    ///
+    /// Emits the new-name arm as `ThreadCreateV2 { manager_snapshot: None }`
+    /// — `cmd_thread_rename`'s forward path does not re-key the
+    /// ThreadManager record under the new name (a pre-existing
+    /// forward-path bug filed as a follow-up in
+    /// docs/design/cross-thread-undo.md), so there is no record to
+    /// snapshot. The undo gate (`ensure_thread_worktree_undo_safe`)
+    /// matches both V1 and V2 ThreadCreate arms, so the rename undo
+    /// still refuses on a materialized worktree under either name.
     fn record_thread_rename(
         &self,
         old_name: &str,
@@ -108,9 +132,10 @@ pub trait OpLogBackend: Send + Sync {
     ) -> Result<Vec<u64>> {
         self.record_batch_scoped(
             vec![
-                OpRecord::ThreadCreate {
+                OpRecord::ThreadCreateV2 {
                     name: new_name.to_string(),
                     state: *state,
+                    manager_snapshot: None,
                 },
                 OpRecord::ThreadDelete {
                     name: old_name.to_string(),

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -43,17 +43,25 @@ impl OpLog {
         )
     }
 
-    /// Record a thread creation.
+    /// Record a thread creation. See `OpLogBackend::record_thread_create`
+    /// for the contract — `manager_snapshot` carries the rmp-serde bytes
+    /// of the matching `Thread` record body so redo can recreate the
+    /// record after undo destroyed it (heddle#23 r2). Pass `None` for
+    /// callsites that don't write a record alongside the op.
+    ///
+    /// Always emits `OpRecord::ThreadCreateV2`.
     pub fn record_thread_create(
         &self,
         name: &str,
         state: &ChangeId,
+        manager_snapshot: Option<Vec<u8>>,
         scope: Option<&str>,
     ) -> Result<u64> {
         self.record_single_scoped(
-            OpRecord::ThreadCreate {
+            OpRecord::ThreadCreateV2 {
                 name: name.to_string(),
                 state: *state,
+                manager_snapshot,
             },
             scope,
         )
@@ -75,7 +83,9 @@ impl OpLog {
         )
     }
 
-    /// Record a thread rename as a batch of operations.
+    /// Record a thread rename as a batch of operations. See
+    /// `OpLogBackend::record_thread_rename` for why the new-name arm
+    /// carries `manager_snapshot: None`.
     pub fn record_thread_rename(
         &self,
         old_name: &str,
@@ -85,9 +95,10 @@ impl OpLog {
     ) -> Result<Vec<u64>> {
         self.record_batch_scoped(
             vec![
-                OpRecord::ThreadCreate {
+                OpRecord::ThreadCreateV2 {
                     name: new_name.to_string(),
                     state: *state,
+                    manager_snapshot: None,
                 },
                 OpRecord::ThreadDelete {
                     name: old_name.to_string(),

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -179,6 +179,44 @@ pub enum OpRecord {
         /// later.
         post_target_id: ChangeId,
     },
+    /// Thread creation — V2 with a ThreadManager record snapshot so redo
+    /// can recreate the record body after undo destroyed it.
+    ///
+    /// V1 (`ThreadCreate`) carried only `(name, state)`. The undo inverse
+    /// added under heddle#23 r1 also deletes the matching ThreadManager
+    /// record so refs and record-store state stay in lockstep (contract
+    /// rule 4). That left redo broken: `apply_redo_entry` could only
+    /// restore the ref via `set_thread` — the record body (mode,
+    /// execution_path, materialized_path, base_state, base_root, …) was
+    /// gone and not reconstructible from V1's `(name, state)`. Record-
+    /// backed commands (`thread cd`, delegate, integration policy) then
+    /// silently degraded after an undo→redo round-trip. heddle#23 r2
+    /// Codex P1 (PR #112, thread 3254698975).
+    ///
+    /// Same hazard shape as heddle#99 r2 (FastForward → FastForwardV2
+    /// with `post_target_id`): undo destroys state that redo cannot
+    /// reconstruct from the OpRecord alone. The fix is the same — record
+    /// what redo needs.
+    ///
+    /// `manager_snapshot` is opaque rmp-serde bytes of the `Thread`
+    /// record body. Opaque to keep the `oplog` crate independent of
+    /// `repo`-level types; the `repo` crate owns the encoding via
+    /// `ThreadManager::snapshot_thread_record` /
+    /// `ThreadManager::restore_thread_record_from_snapshot`. `None` for
+    /// callsites that don't write a ThreadManager record alongside the
+    /// op (rename batch's new-name arm, ingest, harness/agent stubs).
+    ///
+    /// V1 records remain readable: `apply_undo_entry` keeps its V1 arm,
+    /// and `apply_redo_entry` falls back to ref-only restore with a
+    /// stderr warning so legacy oplog entries don't error — they
+    /// degrade gracefully as the live window slides forward.
+    ThreadCreateV2 {
+        name: String,
+        state: ChangeId,
+        /// rmp-serde-encoded `Thread` record body, or `None` when no
+        /// record was written by the forward path.
+        manager_snapshot: Option<Vec<u8>>,
+    },
 }
 
 impl OpRecord {
@@ -282,6 +320,9 @@ impl OpRecord {
                     pre_target_id.short(),
                     post_target_id.short()
                 )
+            }
+            OpRecord::ThreadCreateV2 { name, .. } => {
+                format!("create thread {}", name)
             }
         }
     }

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -360,6 +360,50 @@ impl ThreadManager {
         let _lock = self.write_lock()?;
         self.record_store.delete_value(record_id)
     }
+
+    /// Encode the `Thread` record matching `thread_name` to opaque
+    /// rmp-serde bytes for inclusion in `OpRecord::ThreadCreateV2`'s
+    /// `manager_snapshot` field. Returns `Ok(None)` when no record
+    /// exists for that thread (the caller doesn't have a record to
+    /// snapshot — e.g. `cmd_start --path` writes the record only after
+    /// materialization, and the rename batch's new-name arm never has
+    /// one). heddle#23 r2.
+    ///
+    /// The encoding is opaque to the `oplog` crate: it stores the bytes
+    /// without interpreting them. The shape is `Thread`'s serde form,
+    /// which has `#[serde(default)]` on every optional field, so
+    /// records written by future versions of heddle remain decodable
+    /// by older readers and vice versa.
+    pub fn snapshot_thread_record(&self, thread_name: &str) -> Result<Option<Vec<u8>>> {
+        let Some(thread) = self.find_by_thread(thread_name)? else {
+            return Ok(None);
+        };
+        let bytes = rmp_serde::to_vec_named(&thread).map_err(|e| {
+            HeddleError::Serialization(format!(
+                "encode thread record snapshot for '{}': {}",
+                thread_name, e
+            ))
+        })?;
+        Ok(Some(bytes))
+    }
+
+    /// Decode and persist a `Thread` record from rmp-serde bytes
+    /// produced by `snapshot_thread_record`. Used by `heddle redo` of a
+    /// `ThreadCreateV2` to restore the record body that undo destroyed
+    /// (heddle#23 r2 Codex P1, mirroring the FastForwardV2 pattern from
+    /// heddle#99 r2 — record what redo needs).
+    ///
+    /// Returns the restored `Thread` for callers that want to inspect
+    /// it (e.g. for stderr summaries). An empty/invalid snapshot
+    /// surfaces as `HeddleError::Other` — the redo arm logs and falls
+    /// back to ref-only restore rather than failing the whole batch.
+    pub fn restore_thread_record_from_snapshot(&self, bytes: &[u8]) -> Result<Thread> {
+        let thread: Thread = rmp_serde::from_slice(bytes).map_err(|e| {
+            HeddleError::Serialization(format!("decode thread record snapshot: {}", e))
+        })?;
+        self.save(&thread)?;
+        Ok(thread)
+    }
 }
 
 impl ThreadRecordStore for ThreadManager {

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -1,0 +1,274 @@
+# Cross-thread undo — design + 0.3 scope
+
+This doc covers what `heddle undo` does (and refuses to do) when the operation
+being inverted touched a thread other than the one HEAD is currently attached
+to. It builds on the single-thread MVP shipped under
+[heddle#23](https://github.com/HeddleCo/heddle/issues/23), the `Redact` inverse
+[heddle#98](https://github.com/HeddleCo/heddle/issues/98), and the
+fast-forward inverse [heddle#99](https://github.com/HeddleCo/heddle/issues/99).
+Audience: anyone touching `crates/cli/src/cli/commands/undo*` or adding a new
+`OpRecord` variant that mutates more than one thread's ref.
+
+## Semantic model
+
+A "thread" in heddle is a named ref that points at a state ChangeId. HEAD
+either attaches to a thread (and rides its ref) or detaches to a specific
+state. An op is **cross-thread** when it mutates the *ref* of any thread that
+is not the one HEAD is attached to at the moment the op runs.
+
+Within a single worktree the undo stream is per-worktree (`Repository::op_scope()`
+hashes `<root>/.heddle/HEAD`'s canonical path; see crates/repo/src/repository.rs:1329).
+So "cross-thread" within one worktree means an op recorded by *this* checkout
+that moved a thread ref the user wasn't sitting on. Multi-worktree shared-
+backend cases are addressed below under "Danger zone — multi-worktree".
+
+`heddle undo X` means: "make every persistent piece of state that X mutated
+look the way it looked before X ran". For a cross-thread op that has three
+layers of state:
+
+1. **Refs** — thread tip pointers in the ref store (canonical).
+2. **HEAD** — only the originating worktree's, never another worktree's.
+3. **ThreadManager records** — `.heddle/threads/*` (lifecycle metadata read by
+   `heddle thread list`, `heddle thread show`, `heddle delegate`, etc.).
+
+Worktree *file contents* — the materialized files on disk — are only rewritten
+when undo restores HEAD. We never reach into another checkout's filesystem.
+
+## Variant matrix
+
+For each `OpRecord` variant: does today's forward path touch a thread other
+than HEAD's? Does today's inverse correctly restore it?
+
+| Variant | Forward touches non-HEAD thread? | Inverse correct? | Notes |
+|---|---|---|---|
+| `Snapshot` | No — snapshot is on HEAD's thread by construction | ✅ | Single-thread by definition |
+| `Goto` | No — only moves HEAD | ✅ | Single-thread by definition |
+| `ThreadCreate` | **Yes** — creates a ref for a thread the user is not (necessarily) on; also writes a ThreadManager record | ❌ before this doc — inverse deletes ref but leaves ThreadManager record (and any attached worktree) orphaned | See "In scope" below |
+| `ThreadDelete` | **Yes** when emitted — but the user-facing `heddle thread drop --delete-thread` path does *not* record this variant (drop tears the worktree down through `drop_thread_silent` in thread_cmd.rs:562 without touching the oplog); it is emitted only by the `rename` batch and a legacy `cmd_thread_delete` helper no longer wired to the CLI verb | Ref-only restore via `set_thread`. Sufficient for the rename round-trip path; no record-cleanup work is reachable here because `cmd_thread_rename` doesn't write a record under the new name | See "Out of scope" |
+| `ThreadUpdate` | Defined but never emitted today | n/a | Inverse code path exists; unused |
+| `Fork`, `Collapse` | n/a — never emitted today | n/a | Reserved for future thread-graph ops |
+| `MarkerCreate`, `MarkerDelete` | No — markers attach to states, not threads | ✅ | Not cross-thread |
+| `Checkpoint` | No (single-thread, agent-frequent-save) | n/a — no inverse arm yet | Tracked separately; see docs/undo.md |
+| `Redact`, `Purge` | No — sidecar mutation on a specific (blob, state, path) | ✅ (`Redact` with `--allow-redact-undo`; `Purge` irreversible) | Documented in heddle#98 |
+| `FastForward` (V1, legacy read-only) | **Yes** — advances target_thread ref | ✅ — inverse restores both HEAD and target_thread to `pre_target_id` | heddle#99 r1 fix |
+| `FastForwardV2` | **Yes** — same as V1; carries `post_target_id` for deterministic redo | ✅ | heddle#99 r2 fix |
+| `EphemeralThreadCollapse` | Touches a thread but only to retire its pointer | n/a — no inverse arm | Out of scope; thread auto-expired |
+| `TransactionAbort`, `TransactionCommit`, `ConflictResolved` | No ref mutation | n/a — no inverse arm | Forensic-only records |
+
+The two **already-correct** cross-thread cases are `FastForward` and
+`FastForwardV2`. Their inverses restore HEAD *and* the target thread ref. They
+work because both variants carry the thread name and the pre-state explicitly;
+the inverse has everything it needs.
+
+The **gap** case is `ThreadCreate`. Its forward path writes a ThreadManager
+record (cmd_thread_create at thread.rs:1539 and cmd_start at thread.rs:1185)
+and — when invoked as `heddle start --path` — materializes a worktree on
+disk. Its inverse only deletes the ref. That gap is the in-scope work below.
+`ThreadDelete` is not in scope because the user-facing delete path goes
+through `cmd_thread_drop` / `drop_thread_silent`, which tears the worktree
+down and marks the record Abandoned *without* recording an oplog entry —
+there is nothing for undo to inverse on that path. The remaining recorder
+(the rename batch) emits `ThreadDelete` only for the *old* name, which has
+no orphan to clean up because the rename forward path never re-keyed the
+record (see follow-ups below).
+
+## Contract
+
+For every cross-thread op the inverse follows these rules. These are checked
+by integration tests in `crates/cli/tests/core_functionality/undo_and_special.rs`.
+
+1. **Refs are the source of truth.** The inverse always restores any thread
+   ref the forward op mutated to the recorded prior value. This holds even
+   when HEAD is not on that thread.
+2. **HEAD only moves when the recorded op moved it.** A cross-thread inverse
+   does not detach, re-attach, or otherwise touch HEAD unless the original op
+   did. (`FastForward[V2]` is the only cross-thread variant that recorded a
+   HEAD move; its inverse correctly restores HEAD too.)
+3. **No worktree file rewrites in another checkout.** The originating
+   worktree's files may be rewritten when HEAD moves; another worktree's
+   files are never touched.
+4. **ThreadManager metadata mirrors refs.** When an inverse deletes a thread
+   ref, the matching ThreadManager record is deleted **iff** there's no
+   attached materialized worktree (see rule 5). We do not attempt to *refresh*
+   `current_state` on the inverse, because no forward path in 0.3 keeps
+   `current_state` fresh either — `cmd_thread_create` writes the initial value
+   and nothing else updates it. Fixing the broader `current_state` staleness
+   is a forward-path concern tracked separately (see follow-ups).
+5. **Refuse rather than orphan a materialized worktree.** Undoing a
+   `ThreadCreate` whose ThreadManager record has `materialized_path = Some(_)`
+   refuses with a clear message naming the worktree path. The user must tear
+   the worktree down manually before the undo can proceed. Same on the redo
+   side for `ThreadDelete` (which would re-delete the ref). Rationale: the
+   detached worktree is in another directory — possibly with uncommitted
+   work, possibly being used by a long-running agent. The dirty-worktree
+   refusal already governs the *current* worktree; the orphan-worktree
+   refusal extends the same "fail loud" pattern to materialized siblings.
+6. **Symmetry.** Redo follows the same rules. Where an undo refuses, the
+   corresponding redo refuses for the same reason.
+7. **Atomic per batch.** All refusals are enforced as pre-flight checks
+   (see `crates/cli/src/cli/commands/undo.rs:88` for the analogous redaction
+   gate) so a refusal happens *before* any state mutation. No half-applied
+   chains.
+
+## 0.3 scope
+
+### In scope
+
+1. **ThreadCreate inverse: clean ThreadManager record.** Undo of `ThreadCreate`
+   removes the matching ThreadManager record alongside deleting the ref.
+   Forward `cmd_thread_create` (thread.rs:1539) and `cmd_start` (thread.rs:1185)
+   write the record; the inverse must remove it to avoid orphan entries
+   surfaced by `heddle thread list` and `heddle thread show`.
+
+2. **ThreadCreate inverse: refuse on materialized worktree.** If the
+   ThreadManager record has `materialized_path = Some(path)` and that path
+   still exists on disk, refuse with a message naming `path` and pointing the
+   user at `heddle thread drop <name> --delete-thread`. The refusal is a
+   pre-flight check (parallel to the redaction gate at undo.rs:88) so multi-
+   batch undos don't half-apply, and so `--preview` surfaces the refusal
+   instead of advertising "Would undo …".
+
+3. **Thread rename (batch of `[ThreadCreate(new), ThreadDelete(old)]`)
+   inherits the above rules.** Undo applies arms in reverse: undo
+   `ThreadDelete(old)` first (restores `old`'s ref), then undo
+   `ThreadCreate(new)` (deletes `new`'s ref + cleans any record under `new`).
+   In practice no record exists under `new` because the forward
+   `cmd_thread_rename` doesn't re-key the record — that pre-existing
+   forward-path bug is filed as a follow-up; the inverse stays safe today.
+
+4. **Tests (red-commit first).** `test_undo_thread_create_removes_record_when_no_worktree`,
+   `test_undo_thread_create_refuses_with_materialized_worktree`,
+   `test_undo_thread_rename_round_trips_refs_and_record`,
+   `test_undo_preview_surfaces_worktree_refusal`. The rename test is a
+   regression guard — it already passes today because the rename forward
+   path never writes an orphan under the new name; it would catch a future
+   regression that introduced one.
+
+### Out of scope — filed as follow-ups in the PR description
+
+These are real concerns but each requires substrate work beyond a per-batch
+inverse. Filing them keeps 0.3 surgical.
+
+- **Cross-worktree shared-backend safety.** When two checkouts share an
+  oplog/refs backend (`heddle start --path` siblings), W1 can undo an op that
+  moves a thread ref W2 has HEAD attached to. W2's HEAD then points at a
+  stale state. Detection needs a worktree registry, which doesn't exist
+  today (audit: `worktrees.toml` and equivalents not present;
+  `WorktreeIndex` is a per-worktree stat cache, not a multi-worktree
+  registry). Follow-up: design + ship a registry, then add a cross-worktree
+  refusal mirroring the materialized-worktree case.
+- **Daemon thread-tip cache invalidation.** No daemon-side thread cache
+  exists today (audit: `crates/daemon/src/` reads refs on every RPC). When
+  one lands, undo must broadcast invalidation. Until then this is a
+  documented assumption, not a TODO.
+- **Remote-affecting undo.** `heddle push`/`pull`/`fetch` cannot be rolled
+  back unilaterally. Documented in `docs/undo.md` already; no in-scope work.
+- **Worktree teardown command.** Today there's no `heddle thread drop
+  --with-worktree` that atomically removes a thread and its materialized
+  worktree. The refusal in this design points at manual teardown. A real
+  teardown command is its own design.
+- **Pre-existing forward-path ThreadManager bugs.** `cmd_thread_rename`
+  (thread.rs:2119) does not re-key the ThreadManager record under the new
+  name. `cmd_thread_delete` (thread.rs:2091) does not delete the
+  ThreadManager record, and is no longer wired to the CLI verb anyway
+  (`thread delete` translates to `thread drop --delete-thread` per
+  core_functionality.rs:30–41, which goes through `drop_thread_silent`).
+  `ThreadManager.current_state` is never refreshed by any forward path
+  after the initial `cmd_thread_create` write — the field is functionally
+  always-stale. These are forward-path bugs that predate this work; undo
+  correctness for cross-thread cases is designed around the current
+  forward behavior, not around fixing forward. Filing separately.
+- **`heddle pull` rollback semantics.** Even setting aside remote effects,
+  `pull` records ops on multiple threads. Out of scope for 0.3.
+
+### Intentionally not supported in 0.3
+
+These will be documented under "Not undoable" in `docs/undo.md` and surfaced
+in `heddle undo --help`:
+
+- Undoing `ThreadCreate` of a thread with an attached materialized worktree.
+  Tear down the worktree first.
+- Cross-worktree shared-backend safety. Single-worktree usage is the
+  documented supported configuration for 0.3 undo.
+
+## Danger zone
+
+Patterns that *appear* single-thread but mutate state observable from
+another vantage point. Each is either covered by an in-scope refusal, listed
+as an out-of-scope follow-up, or documented as a known limitation.
+
+- **Shared refs.** Two worktrees sharing one `.heddle/refstore` (the
+  `heddle start --path` setup) see each other's ref writes immediately. The
+  refusal in §5 of the contract covers the most common path (orphaning a
+  materialized worktree by undoing the create that built it). The general
+  case — W2 has HEAD on a thread W1 is undoing — is the out-of-scope
+  follow-up above.
+- **Materialized worktrees.** Same as above — these are the manifestation
+  of "shared refs across two filesystems".
+- **Daemon-cached thread tips.** No daemon cache today. When one ships,
+  undo must invalidate. Audit recorded in `crates/daemon/src/`.
+- **Rebase / ship internals recording `Goto` on thread movement.** The
+  brief flags `rebase_ops.rs`, `workflow.rs`, `remote/remote_ops.rs`,
+  `resolve.rs`. These emit `Goto`/`Snapshot`/`FastForward` on the current
+  thread; per the variant matrix, none of them are cross-thread except the
+  FF case, which is already correct. The systemic FF-strand pattern from
+  heddle#110 is tracked there, not here.
+
+## Implementation notes
+
+The change is concentrated in `crates/cli/src/cli/commands/undo_apply.rs` and
+`crates/cli/src/cli/commands/undo.rs`:
+
+- New pre-flight helper `ensure_thread_worktree_undo_safe` in `undo.rs`,
+  shaped like `ensure_redaction_undo_safe`. Walks batches, collects
+  `ThreadCreate` ops, looks each up in ThreadManager, refuses if any have
+  `materialized_path = Some(path)` where `path` still exists on disk.
+  Called from `cmd_undo` before the worktree-clean check and before the
+  `--preview` short-circuit so preview output stays honest.
+- `apply_undo_entry`'s `ThreadCreate` arm gains a ThreadManager record
+  deletion after `delete_thread_safely`. The deletion is best-effort: a
+  missing record is not an error (some ThreadCreate paths might predate
+  the record-writing change, or have had their record removed by a
+  preceding `drop` op).
+- `apply_redo_entry`'s `ThreadCreate` arm intentionally does **not**
+  re-create the ThreadManager record on redo. The forward op carried only
+  `(name, state)`; the record body (`execution_path`, `materialized_path`,
+  workflow metadata, …) isn't reconstructible from the OpRecord. Redo
+  restores the ref so subsequent operations behave correctly; a follow-up
+  forward `heddle thread start <name>` or equivalent can re-establish the
+  record if the user wants one.
+
+No new `OpRecord` variant. No new public Repository API beyond what
+ThreadManager already exposes.
+
+## Test plan
+
+All in `crates/cli/tests/core_functionality/undo_and_special.rs`, written
+red-commit-first.
+
+1. `test_undo_thread_create_removes_record_when_no_worktree` —
+   `heddle thread create foo` → `heddle undo` → ref gone *and*
+   `ThreadManager::find_by_thread("foo")` returns `None`. **Red today.**
+2. `test_undo_thread_create_refuses_with_materialized_worktree` —
+   `heddle start foo --path <tmp>` → `heddle undo` errors with a message
+   naming the worktree path; ref and worktree both still present.
+   **Red today.**
+3. `test_undo_thread_rename_round_trips_refs_and_record` —
+   `heddle thread create foo` → `heddle thread rename foo bar` →
+   `heddle undo` → `foo` exists in refs, `bar` does not, no orphan record
+   under `bar`. Regression guard; passes today vacuously because
+   `cmd_thread_rename` never wrote a record under `bar`.
+4. `test_undo_preview_surfaces_worktree_refusal` —
+   `heddle undo --preview` against a worktree-attached ThreadCreate must
+   surface the refusal instead of advertising "Would undo …", matching
+   the preview-honesty pattern at undo.rs:88. **Red today.**
+
+## Open questions deferred to follow-ups
+
+- Should the worktree-attached refusal accept an `--allow-worktree-orphan`
+  override? Today the answer is no — see the contract rationale. If user
+  feedback shows the strict refusal is too aggressive, revisit.
+- When ThreadManager record exists but the ref is missing (forward bug
+  rooted in `cmd_thread_rename` not updating records), should undo heal the
+  divergence? Today: no — undo only handles divergence introduced by ops in
+  the undo window. Forward-path cleanup is a separate follow-up.

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -43,7 +43,8 @@ than HEAD's? Does today's inverse correctly restore it?
 |---|---|---|---|
 | `Snapshot` | No — snapshot is on HEAD's thread by construction | ✅ | Single-thread by definition |
 | `Goto` | No — only moves HEAD | ✅ | Single-thread by definition |
-| `ThreadCreate` | **Yes** — creates a ref for a thread the user is not (necessarily) on; also writes a ThreadManager record | ❌ before this doc — inverse deletes ref but leaves ThreadManager record (and any attached worktree) orphaned | See "In scope" below |
+| `ThreadCreate` (V1, legacy read-only) | **Yes** — creates a ref for a thread the user is not (necessarily) on; also writes a ThreadManager record | Undo: delete ref + delete record. Redo: ref-only + stderr warning (V1 doesn't carry a snapshot for redo to read back). | V1 records age out as the live oplog window slides forward |
+| `ThreadCreateV2` | **Yes** — same as V1; carries `manager_snapshot` for symmetric undo/redo | ✅ — undo deletes ref + record; redo restores both from `manager_snapshot` | heddle#23 r2 Codex P1 fix; same shape as `FastForwardV2` |
 | `ThreadDelete` | **Yes** when emitted — but the user-facing `heddle thread drop --delete-thread` path does *not* record this variant (drop tears the worktree down through `drop_thread_silent` in thread_cmd.rs:562 without touching the oplog); it is emitted only by the `rename` batch and a legacy `cmd_thread_delete` helper no longer wired to the CLI verb | Ref-only restore via `set_thread`. Sufficient for the rename round-trip path; no record-cleanup work is reachable here because `cmd_thread_rename` doesn't write a record under the new name | See "Out of scope" |
 | `ThreadUpdate` | Defined but never emitted today | n/a | Inverse code path exists; unused |
 | `Fork`, `Collapse` | n/a — never emitted today | n/a | Reserved for future thread-graph ops |
@@ -225,21 +226,33 @@ The change is concentrated in `crates/cli/src/cli/commands/undo_apply.rs` and
   `materialized_path = Some(path)` where `path` still exists on disk.
   Called from `cmd_undo` before the worktree-clean check and before the
   `--preview` short-circuit so preview output stays honest.
-- `apply_undo_entry`'s `ThreadCreate` arm gains a ThreadManager record
-  deletion after `delete_thread_safely`. The deletion is best-effort: a
-  missing record is not an error (some ThreadCreate paths might predate
-  the record-writing change, or have had their record removed by a
-  preceding `drop` op).
-- `apply_redo_entry`'s `ThreadCreate` arm intentionally does **not**
-  re-create the ThreadManager record on redo. The forward op carried only
-  `(name, state)`; the record body (`execution_path`, `materialized_path`,
-  workflow metadata, …) isn't reconstructible from the OpRecord. Redo
-  restores the ref so subsequent operations behave correctly; a follow-up
-  forward `heddle thread start <name>` or equivalent can re-establish the
-  record if the user wants one.
+- `apply_undo_entry`'s `ThreadCreate`/`ThreadCreateV2` arms share a
+  single body: delete the ref via `delete_thread_safely`, then delete
+  the matching ThreadManager record (best-effort — a missing record is
+  not an error). V2 is fine to destroy alongside the live record because
+  the OpRecord retains `manager_snapshot` for redo (see below).
+- `apply_redo_entry`'s `ThreadCreateV2` arm restores **both** the ref
+  and the ThreadManager record from `manager_snapshot`. Without the
+  record body restored, record-backed commands (`thread cd`, delegate,
+  integration policy) silently degrade after an undo→redo round-trip —
+  the Codex P1 finding closed under heddle#23 r2 (PR #112, thread
+  3254698975). Same hazard class as heddle#99 r2 (FF redo
+  non-determinism); same fix shape (record what redo needs).
+- `apply_redo_entry`'s legacy V1 `ThreadCreate` arm restores the ref
+  only and prints a stderr warning pointing the operator at
+  `heddle thread start <name>` to re-establish the record. V1 records
+  age out as the live oplog window slides forward.
 
-No new `OpRecord` variant. No new public Repository API beyond what
-ThreadManager already exposes.
+**New `OpRecord` variant**: `ThreadCreateV2 { name, state,
+manager_snapshot: Option<Vec<u8>> }`. The snapshot is opaque rmp-serde
+bytes of the `Thread` record body — kept opaque so the `oplog` crate
+stays independent of `repo`-level types. The `repo` crate owns the
+encoding via two new helpers on `ThreadManager`:
+`snapshot_thread_record(thread_name) -> Option<Vec<u8>>` and
+`restore_thread_record_from_snapshot(bytes) -> Thread`. `manager_snapshot`
+is `None` for callsites that don't write a `ThreadManager` record
+alongside the op (rename batch's new-name arm, ingest, harness/agent
+stubs).
 
 ## Test plan
 
@@ -262,6 +275,43 @@ red-commit-first.
    `heddle undo --preview` against a worktree-attached ThreadCreate must
    surface the refusal instead of advertising "Would undo …", matching
    the preview-honesty pattern at undo.rs:88. **Red today.**
+
+## Rule-7 sweep — undo/redo symmetry across all `OpRecord` arms
+
+After heddle#23 r2 closed the second instance of "undo destroys state
+that redo can't reconstruct from the OpRecord alone" (the first was
+heddle#99 r2's FastForward → FastForwardV2 fix), we walked every
+`OpRecord` arm in `apply_undo_entry` / `apply_redo_entry` and asked: does
+undo destroy state that redo re-derives by *name* (which can change), or
+which isn't reconstructible from the OpRecord fields?
+
+| Variant | Undo destroys | Redo source | Hazard? | Disposition |
+|---|---|---|---|---|
+| `Snapshot { prev_head: Some, … }` | HEAD position, thread ref | `new_state` field | No | OK |
+| `Goto { prev_head: Some, … }` | HEAD position | `target` field | No | OK |
+| `ThreadCreate` (V1) | ref + record body | ref-only + warning | **Latent** | V1 read-back-only; ages out. New ops emit V2. |
+| `ThreadCreateV2` | ref + record body | `manager_snapshot` bytes | No | **Fixed this PR** |
+| `ThreadDelete` | ref | `state` field (ref restored); record body **not** restored | **Latent** | No forward callsite exercises the hazard today: the user-facing delete (`thread drop --delete-thread`) records no oplog entry, and the rename batch's `ThreadDelete` half deletes the old name under which no record exists anyway (the forward rename doesn't re-key the record). Becomes load-bearing if a future forward path records `ThreadDelete` against a thread with a live record. Tracked alongside `cmd_thread_rename`'s pre-existing forward-path bug. |
+| `ThreadUpdate` | thread ref | `new_state`/`old_state` | No | Not emitted today; symmetric on paper. |
+| `MarkerCreate` / `MarkerDelete` | marker ref | recorded `state` | No | OK — markers have no record-store sidecar. |
+| `Redact` | redaction sidecar entry | redo refuses (no `Redaction` snapshot in OpRecord — reason, redactor, signature missing) | **Yes — loud refusal** | Documented under heddle#98. A future `RedactV2` carrying the full `Redaction` snapshot would close it; today the loud refusal is the contract. |
+| `Purge` | blob bytes | irreversible by design | n/a | Intentional; `cmd_undo` refuses pre-mutation. |
+| `FastForward` (V1) | HEAD + target ref | re-resolves `source_thread → tip` (non-deterministic) | **Latent** | V1 read-back-only; FastForwardV2 fixes. heddle#99 r2. |
+| `FastForwardV2` | HEAD + target ref | `post_target_id` field | No | OK. |
+| `Fork` / `Collapse` / `Checkpoint` / `TransactionAbort` / `TransactionCommit` / `EphemeralThreadCollapse` / `ConflictResolved` | (no inverse arm) | n/a | n/a | Forensic-only or not yet wired. |
+
+Net: two fixed instances of the hazard class (`FastForwardV2`,
+`ThreadCreateV2`), one loud-refusal'd (`Redact`), and one dormant-by-
+construction (`ThreadDelete`). No silent corruption paths remain across
+the implemented inverses. If a future forward path lights up the
+`ThreadDelete` hazard, the same V2-snapshot pattern applies — file a
+`ThreadDeleteV2` with the record snapshot.
+
+The pattern is now well-established enough that any new ref-mutating
+`OpRecord` variant should be reviewed against this matrix at design
+time: "what does undo destroy, and what does redo read to put it back?"
+If the answer to the second question is "a name we'll re-resolve" or
+"defaults", the variant needs a snapshot field.
 
 ## Open questions deferred to follow-ups
 

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -2,9 +2,11 @@
 
 A safety net for the operations a daily user is most likely to want to roll back.
 
-This document describes the MVP scope shipped under
-[HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). Cross-thread
-undo, remote-affecting undo, and persistent cross-invocation redo are tracked as
+This document describes the user-facing surface shipped under
+[HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). The
+design + 0.3 scope cut for cross-thread cases lives in
+[docs/design/cross-thread-undo.md](design/cross-thread-undo.md). Remote-
+affecting undo and persistent cross-invocation redo are tracked as
 follow-ups.
 
 ## Undoable operations
@@ -39,10 +41,18 @@ own, are destructive by design, or need a substrate change we haven't shipped:
   reaches across a purged redaction is refused: the `Redaction` record is
   the only on-disk audit trail that the bytes were destroyed, and removing
   it would lie about local storage.
-- **Cross-thread undo** — today's undo only rewinds operations recorded on the
-  current checkout's HEAD path. Undoing an op that mutated a different thread
-  is the design problem heddle#23's title points at; the MVP ships the
-  single-thread safety net first.
+- **`heddle start <name> --path <dir>`** — refused while the materialized
+  worktree at `<dir>` still exists. The undo inverse only deletes the
+  thread ref; without first tearing the worktree down, the directory would
+  be left with a `.heddle/HEAD` pointing at a thread that no longer
+  exists. Tear it down explicitly with `heddle thread drop <name>
+  --delete-thread`, then re-run `heddle undo`. See
+  [docs/design/cross-thread-undo.md](design/cross-thread-undo.md) for
+  the full design.
+- **Cross-worktree shared-backend undo** — two checkouts sharing one
+  `.heddle/refstore` (the `heddle start --path` setup) can step on each
+  other's threads. 0.3 supports single-worktree usage only; cross-
+  worktree safety is filed as a follow-up. See the design doc.
 - **Redo across CLI invocations** — `heddle redo` works within the same shell
   session but is not yet persisted across processes.
 
@@ -70,6 +80,14 @@ contracts below are enforced by integration tests in
   reaching past the live oplog window — `heddle undo` refuses with a single
   clear message naming the missing op id. Restore from a backup or list past
   the boundary with `heddle undo --list`.
+- **Worktree-attached `ThreadCreate` refusal.** `heddle undo` refuses to
+  roll back a `heddle start <name> --path <dir>` while the materialized
+  worktree at `<dir>` is still on disk. The inverse only deletes the
+  thread ref; silently proceeding would orphan the worktree directory
+  with a broken `.heddle/HEAD`. Run `heddle thread drop <name>
+  --delete-thread` first, then re-run `heddle undo`. Same refusal fires
+  for `heddle undo --preview` so preview output is honest about what the
+  real command would do.
 - **Idempotent re-run.** Once a batch is marked undone, the next `heddle
   undo` picks the next still-active batch (or refuses if none remain). Re-
   running `heddle undo` is never destructive.


### PR DESCRIPTION
## Summary

Builds on the single-thread undo MVP (#97) + Redact undo (#100) + FastForwardV2 (#109) by extending cross-thread coverage.

- **Design doc** at `docs/design/cross-thread-undo.md`: semantic model for cross-thread undo, contract, scope decisions for 0.3, follow-ups for out-of-scope work, **Rule-7 sweep matrix** (every OpRecord arm audited for undo/redo symmetry).
- **`ThreadCreate` inverse**: clean orphan `ThreadManager` records + refuse if attached materialized worktree still exists on disk. Refusal points at `heddle thread drop <name> --delete-thread`.
- **`ThreadCreateV2`** (Codex P1 closure): new OpRecord variant carries `manager_snapshot` (opaque rmp-serde bytes of the `Thread` record) so redo can restore the record body after undo destroyed it. Mirrors the heddle#99 r2 FastForwardV2 pattern (record what redo needs).

## Scope cut (0.3)

**In:** `ThreadCreate` inverse — orphan record cleanup + worktree refusal + symmetric redo via `ThreadCreateV2`.

**Out** (filed as follow-ups in the design doc): cross-worktree shared-backend safety; daemon thread-tip cache invalidation (no cache today); remote-affecting undo; atomic worktree teardown command; pre-existing forward-path `ThreadManager` bugs.

`ThreadDelete` inverse work was dropped after the audit found the canonical `thread drop --delete-thread` path doesn't record `OpRecord::ThreadDelete` — only the rename batch emits it, and that path has no orphan to clean.

## Commits

- `202c615` — **Red (r1)**: design doc + 4 failing tests pinning the in-scope contract (3 reds + 1 regression guard).
- `52bc1b3` — **Green (r1)**: `ensure_thread_worktree_undo_safe` pre-flight, `remove_thread_manager_record` in the `ThreadCreate` inverse, `undo --help` + `docs/undo.md` updates.
- `72013b0` — **Red (r2)**: `test_redo_thread_create_restores_manager_record` pins the Codex P1 asymmetry (undo→redo loses the record body).
- `66f3e21` — **Green (r2)**: `OpRecord::ThreadCreateV2` with `manager_snapshot`, `ThreadManager::snapshot_thread_record` / `restore_thread_record_from_snapshot` helpers, redo arm wires both. V1 stays read-back-only with stderr-warned ref-only redo. Rule-7 sweep recorded in the design doc.

## Rule-7 sweep — undo/redo symmetry across all `OpRecord` arms

Walked every variant against the "undo destroys state redo can't reconstruct from the OpRecord alone" hazard class (now a known systemic pattern after heddle#99 r2 and heddle#23 r2 — two fixed instances).

| Variant | Hazard | Disposition |
|---|---|---|
| `Snapshot`, `Goto`, `ThreadUpdate`, `MarkerCreate`, `MarkerDelete` | None | OK — redo reads post-state directly |
| `ThreadCreate` (V1) | Latent — redo can't restore record body | Read-back-only; warns on redo; ages out |
| `ThreadCreateV2` | None | **Fixed this PR** — `manager_snapshot` |
| `ThreadDelete` | Latent on paper; dormant in practice | No live forward callsite writes `ThreadDelete` against a thread with a record. If one is added, file `ThreadDeleteV2`. |
| `Redact` | Yes — loud refusal on redo (no full `Redaction` in OpRecord) | Documented under heddle#98; potential `RedactV2` follow-up |
| `Purge` | Irreversible by design | Loud refusal pre-mutation |
| `FastForward` (V1) | Non-deterministic redo | Read-back-only; FastForwardV2 fixes (heddle#99 r2) |
| `FastForwardV2` | None | OK |
| `Fork`, `Collapse`, `Checkpoint`, `Transaction*`, `EphemeralThreadCollapse`, `ConflictResolved` | n/a — forensic-only / no inverse arm | n/a |

Net: no silent-corruption paths remain across implemented inverses. The V2-snapshot pattern is the documented playbook for new ref-mutating variants (full matrix + reasoning in `docs/design/cross-thread-undo.md`).

## Test plan

- [x] 40/40 `undo_and_special` (was 36 + 4 r1 new + 1 r2 new = 40)
- [x] Full workspace test suite green
- [x] `cargo clippy` clean on touched crates (`-D warnings`)
- [x] `rustfmt` (edition 2024) clean on touched files

Closes HeddleCo/heddle#23

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
