### PR TITLE
fix(undo): propagate FastForwardV2 to 6 daily-use commands (heddle#110)

### DIFF
--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared helper for fast-forward call sites that need to record an
+//! `OpRecord::FastForwardV2` instead of the implicit `OpRecord::Goto`.
+//!
+//! See heddle#99 (merge FF) and heddle#110 (rebase / pull / ship /
+//! merge-abort): recording a thread-advancing fast-forward as a plain
+//! `OpRecord::Goto` strands the target thread ref on undo, because the
+//! `Goto` inverse only rewinds HEAD. The fix is to perform the FF
+//! without recording the implicit `Goto`, then explicitly emit an
+//! `OpRecord::FastForwardV2` carrying both `pre_target_id` (undo
+//! target) and `post_target_id` (redo target — heddle#99 r2's
+//! deterministic-redo contract).
+//!
+//! Detached-HEAD callers fall back to `OpRecord::Goto`: there's no
+//! thread ref to strand, and the legacy `Goto` inverse correctly
+//! rewinds HEAD on its own.
+
+use anyhow::{Result, anyhow};
+use objects::object::ChangeId;
+use refs::Head;
+use repo::Repository;
+
+/// Perform a fast-forward of the attached thread to `post_target_id`
+/// and record the operation so undo restores the target thread ref to
+/// its pre-FF tip *and* redo replays deterministically to
+/// `post_target_id`.
+///
+/// Reads the pre-FF tip from the attached thread's ref (or from HEAD
+/// for detached). Use this overload at call sites where the thread
+/// ref has *not* been mutated since whatever you want undo to restore
+/// — e.g. merge / rebase / ship. Pull pre-sets the thread ref before
+/// materializing and must call [`record_ff_advance_explicit`].
+///
+/// `source_thread` is the thread name surfaced in the OpRecord for
+/// forensic context. Neither undo nor redo reads it. For rebase-replay
+/// loops where no single source thread is in scope, pass a synthetic
+/// placeholder like `"<rebase>"`.
+///
+/// If HEAD is detached before the FF, falls back to recording an
+/// `OpRecord::Goto` (legacy behavior — no thread ref to strand).
+pub(super) fn record_ff_advance(
+    repo: &Repository,
+    source_thread: &str,
+    post_target_id: &ChangeId,
+) -> Result<()> {
+    let head_before = repo.head_ref()?;
+    let pre_target_id = match &head_before {
+        Head::Attached { thread } => repo
+            .refs()
+            .get_thread(thread)?
+            .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
+        Head::Detached { state } => *state,
+    };
+    record_ff_advance_inner(
+        repo,
+        source_thread,
+        &head_before,
+        &pre_target_id,
+        post_target_id,
+    )
+}
+
+/// Variant of [`record_ff_advance`] that takes an explicit
+/// `pre_target_id`. Use when the thread ref was already mutated
+/// before the FF (e.g. `cmd_pull` advances the local thread ref
+/// directly so a non-materializing pull still advances the ref), so
+/// reading it back would return the *post* state.
+///
+/// Caller must capture `pre_target_id` *before* the mutating
+/// operation that precedes the FF.
+pub(super) fn record_ff_advance_explicit(
+    repo: &Repository,
+    source_thread: &str,
+    pre_target_id: &ChangeId,
+    post_target_id: &ChangeId,
+) -> Result<()> {
+    let head_before = repo.head_ref()?;
+    record_ff_advance_inner(
+        repo,
+        source_thread,
+        &head_before,
+        pre_target_id,
+        post_target_id,
+    )
+}
+
+fn record_ff_advance_inner(
+    repo: &Repository,
+    source_thread: &str,
+    head_before: &Head,
+    pre_target_id: &ChangeId,
+    post_target_id: &ChangeId,
+) -> Result<()> {
+    repo.fast_forward_attached_without_record(post_target_id)?;
+    match head_before {
+        Head::Attached { thread } => {
+            repo.oplog().record_fast_forward(
+                source_thread,
+                thread,
+                pre_target_id,
+                post_target_id,
+                Some(&repo.op_scope()),
+            )?;
+        }
+        Head::Detached { state } => {
+            repo.oplog()
+                .record_goto(post_target_id, Some(state), Some(&repo.op_scope()))?;
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -25,6 +25,7 @@ mod discuss;
 mod doctor_docs;
 mod doctor_schemas;
 mod fetch;
+mod ff_record;
 mod fork;
 mod fsck;
 mod fsck_checks;

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -7,7 +7,10 @@ use anyhow::{Result, anyhow};
 use refs::Head;
 use repo::Repository;
 
-use super::{snapshot::ensure_current_state, worktree_safety::ensure_worktree_clean};
+use super::{
+    ff_record::record_ff_advance, snapshot::ensure_current_state,
+    worktree_safety::ensure_worktree_clean,
+};
 use crate::{
     cli::{Cli, should_output_json},
     config::UserConfig,
@@ -174,7 +177,7 @@ fn run_rebase(
     let is_ancestor = is_ancestor_of(repo, &current_state.change_id, &target_change_id)?;
 
     if is_ancestor {
-        repo.fast_forward_attached(&target_change_id)?;
+        record_ff_advance(repo, target_thread, &target_change_id)?;
 
         if let Some(cli) = cli
             && should_output_json(cli, Some(repo.config()))
@@ -203,7 +206,7 @@ fn run_rebase(
         collect_commits_to_rebase(repo, &current_state.change_id, &target_change_id)?;
 
     if commits_to_replay.is_empty() {
-        repo.fast_forward_attached(&target_change_id)?;
+        record_ff_advance(repo, target_thread, &target_change_id)?;
 
         if let Some(cli) = cli
             && should_output_json(cli, Some(repo.config()))

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -7,8 +7,20 @@ use anyhow::{Result, anyhow};
 use objects::object::{Blob, ChangeId, ContentHash, EntryType, State};
 use repo::Repository;
 
-use super::rebase_state::{load_rebase_state, save_rebase_state};
+use super::{
+    super::ff_record::record_ff_advance,
+    rebase_state::{load_rebase_state, save_rebase_state},
+};
 use crate::cli::{Cli, should_output_json};
+
+/// Synthetic `source_thread` for `OpRecord::FastForwardV2` entries
+/// emitted during a rebase replay. Each replayed commit becomes its
+/// own FF op (advancing the attached thread's tip), so listing them
+/// under `<rebase>` keeps `heddle watch` / `heddle log` honest about
+/// the operation's provenance without requiring the rebase target
+/// thread name be threaded through the replay loop. Forensic-only —
+/// neither undo nor redo reads it.
+const REBASE_REPLAY_SOURCE: &str = "<rebase>";
 
 pub(super) fn replay_commits(
     repo: &Repository,
@@ -281,7 +293,7 @@ fn apply_commit(
 
     let new_state_id = new_state.change_id;
     repo.store().put_state(&new_state)?;
-    repo.fast_forward_attached(&new_state_id)?;
+    record_ff_advance(repo, REBASE_REPLAY_SOURCE, &new_state_id)?;
 
     Ok(ApplyResult::Success(new_state_id))
 }
@@ -329,9 +341,9 @@ fn auto_merge_text_lines(base: &[u8], current: &[u8], incoming: &[u8]) -> Result
     use merge::{MergeOutcome, text_hunk_merge};
     match text_hunk_merge(base, current, incoming) {
         MergeOutcome::Clean(bytes) => Ok(Some(bytes)),
-        MergeOutcome::Conflicts { .. }
-        | MergeOutcome::Binary
-        | MergeOutcome::DeleteVsModify => Ok(None),
+        MergeOutcome::Conflicts { .. } | MergeOutcome::Binary | MergeOutcome::DeleteVsModify => {
+            Ok(None)
+        }
     }
 }
 
@@ -388,7 +400,7 @@ fn apply_tree_to_worktree(
 
     let new_state_id = new_state.change_id;
     repo.store().put_state(&new_state)?;
-    repo.fast_forward_attached(&new_state_id)?;
+    record_ff_advance(repo, REBASE_REPLAY_SOURCE, &new_state_id)?;
 
     Ok(ApplyResult::Success(new_state_id))
 }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -13,8 +13,6 @@ use repo::{Repository, RepositoryCapability};
 
 #[cfg(feature = "client")]
 use crate::client::HostedGrpcClient;
-#[cfg(feature = "client")]
-use heddle_client::grpc_hosted::PullMaterialization;
 use crate::{
     bridge::GitBridge,
     cli::{Cli, RemoteCommands, should_output_json, style},
@@ -22,6 +20,8 @@ use crate::{
     config::UserConfig,
     remote::{Remote, RemoteConfig, RemoteTarget, resolve_remote_with_key},
 };
+#[cfg(feature = "client")]
+use heddle_client::grpc_hosted::PullMaterialization;
 
 /// Execute pull command.
 pub async fn cmd_pull(
@@ -145,6 +145,15 @@ async fn pull_local(
     let objects_copied = source.fetch_state(repo, &state_id)?;
 
     let track_to_update = local_thread.unwrap_or(remote_thread);
+
+    // Capture the local thread's pre-pull tip *before* mutating it
+    // (heddle#110). The materializing branch records an
+    // `OpRecord::FastForwardV2` whose `pre_target_id` must be the
+    // pre-pull state so undo restores both HEAD and the local thread
+    // ref. Reading the ref after `set_thread` would return the
+    // post-pull state and silently strand the thread on undo —
+    // exactly the bug we're closing.
+    let pre_target = repo.refs().get_thread(track_to_update)?;
     repo.refs().set_thread(track_to_update, &state_id)?;
 
     // Preserve attached-HEAD semantics only when the pull target is the
@@ -155,7 +164,25 @@ async fn pull_local(
         Head::Detached { .. } => local_thread.is_none(),
     };
     if should_materialize {
-        repo.fast_forward_attached(&state_id)?;
+        // First-time pull of this thread has no pre_target_id; the
+        // `set_thread` above effectively created the ref. Fall back to
+        // recording the generic `Goto` inverse — there's no pre-FF tip
+        // to restore on undo, only HEAD to rewind. Repeat pulls flow
+        // through the `FastForwardV2` arm so undo restores the local
+        // thread ref alongside HEAD.
+        match pre_target {
+            Some(pre) => {
+                super::super::ff_record::record_ff_advance_explicit(
+                    repo,
+                    remote_thread,
+                    &pre,
+                    &state_id,
+                )?;
+            }
+            None => {
+                repo.fast_forward_attached(&state_id)?;
+            }
+        }
     }
 
     if should_output_json(cli, Some(repo.config())) {

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -84,7 +84,18 @@ pub(crate) fn abort_merge_state(
     let merge_state = merge_manager
         .load()?
         .ok_or_else(|| anyhow!("No merge in progress"))?;
-    repo.fast_forward_attached(&merge_state.ours)?;
+    // The 3-way merge that preceded this abort wrote a partial tree
+    // (conflict markers) but did not move HEAD or the target thread
+    // ref — both stay at `ours` throughout the conflicted-merge
+    // window. The FF here is therefore a worktree reset to `ours`,
+    // not a thread advance, so the recorded `FastForwardV2`'s
+    // `pre_target_id` and `post_target_id` are equal. Migrated as
+    // part of the heddle#110 Rule-7 sweep for uniformity with the
+    // other `fast_forward_attached` callers: a future merge variant
+    // that *does* move HEAD before aborting (e.g. a partial-apply
+    // shape) would then get correct undo semantics for free without
+    // a second migration.
+    super::ff_record::record_ff_advance(repo, "<abort>", &merge_state.ours)?;
     merge_manager.abort()?;
     Ok(())
 }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -670,7 +670,7 @@ fn adopt_manual_resolution(repo: &Repository, thread_id: &str) -> Result<String>
             thread.thread
         )
     })?;
-    repo.fast_forward_attached(&target)?;
+    super::ff_record::record_ff_advance(repo, &thread.thread, &target)?;
     thread.state = repo::ThreadState::Merged;
     thread.merged_state = Some(target.short());
     thread.current_state = Some(target.short());

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1875,3 +1875,444 @@ fn test_undo_preview_surfaces_worktree_refusal() {
         "preview refusal must name the worktree concern: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// heddle#110 — Rule-7 sweep for the remaining `fast_forward_attached`
+// callers (rebase / pull / ship / merge-abort). Each daily-use command
+// recorded an implicit `OpRecord::Goto` for its FF, and the `Goto`
+// inverse only rewinds HEAD — silently stranding the attached thread
+// ref at the post-FF target. heddle#99 closed the bug for `merge` by
+// emitting `OpRecord::FastForwardV2` instead; this PR extends the same
+// pattern to the other call sites. Per-site tests below pin each fix.
+// ---------------------------------------------------------------------------
+
+/// Rebase fast-forward (ancestor path): when `current → target` is a
+/// pure ancestor relation, `heddle rebase target` short-circuits to a
+/// single `fast_forward_attached` call. Undo must restore both HEAD
+/// and the rebased thread's ref to its pre-rebase tip — pre-fix the
+/// ref was stranded at `target` while HEAD rewound to the pre-rebase
+/// state, leaving the repo in a divergent shape.
+#[test]
+fn test_undo_rebase_ancestor_ff_restores_thread_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    // Build feature past main: feature is a strict descendant of main.
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_tip = head_short(temp.path());
+
+    // Back on main; main is an ancestor of feature, so rebase is a
+    // pure FF that flows through `rebase/mod.rs:177`.
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    let main_tip_before = head_short(temp.path());
+    heddle_must_succeed(&["rebase", "feature"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        feature_tip,
+        "ancestor rebase must FF main to feature's tip"
+    );
+
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        main_tip_before,
+        "undo of rebase FF must restore HEAD to main's pre-rebase tip"
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "undo of rebase FF must restore main thread ref to pre-rebase tip \
+         (heddle#110 — was stranded at the FF target before the fix)"
+    );
+    match repo.head_ref().unwrap() {
+        refs::Head::Attached { thread } => assert_eq!(
+            thread, "main",
+            "HEAD must stay attached to main after rebase FF undo"
+        ),
+        refs::Head::Detached { state } => panic!(
+            "HEAD must stay attached to main; got detached at {}",
+            state.short()
+        ),
+    }
+}
+
+/// Rebase replay: when the threads have diverged, rebase replays
+/// each commit one at a time. Each replay step records its own
+/// `OpRecord::FastForwardV2`, so a single `heddle undo` after the
+/// rebase rewinds exactly one replayed commit — and the thread ref
+/// rewinds with it. Pre-fix, the ref was stranded at the last
+/// replayed commit while HEAD rewound to the prior step.
+#[test]
+fn test_undo_rebase_replay_restores_thread_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    // feature diverges from main on a different file.
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature commit"], temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    std::fs::write(temp.path().join("main.txt"), "main work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "main commit"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    // Rebase main onto feature: replays main's commit on top of
+    // feature, flowing through `rebase_ops.rs:284` (apply_commit).
+    heddle_must_succeed(&["rebase", "feature"], temp.path());
+    let after_rebase = head_short(temp.path());
+    assert_ne!(
+        after_rebase, main_tip_before,
+        "rebase replay must produce a fresh tip distinct from the pre-rebase main"
+    );
+
+    // Single undo rewinds the last (and only) replayed commit.
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        main_tip_before,
+        "undo of rebase replay must restore HEAD to main's pre-rebase tip"
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "undo of rebase replay must restore main thread ref to pre-rebase tip \
+         (heddle#110 — was stranded at the replay tip before the fix)"
+    );
+    match repo.head_ref().unwrap() {
+        refs::Head::Attached { thread } => assert_eq!(thread, "main"),
+        refs::Head::Detached { state } => panic!(
+            "HEAD must stay attached to main; got detached at {}",
+            state.short()
+        ),
+    }
+}
+
+/// Pull (local sync): `heddle pull <source>` advances the local
+/// thread ref to the pulled state and, when the pulled thread is the
+/// current checkout, materializes the worktree via
+/// `fast_forward_attached`. Undo must restore the local thread ref
+/// to its pre-pull tip — pre-fix the implicit `OpRecord::Goto` left
+/// the local ref stranded at the pulled state on undo.
+#[test]
+fn test_undo_pull_local_restores_thread_ref() {
+    let source = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+
+    // Source repo: two states on `main` so the second pull has a
+    // distinct pre-pull tip to restore on undo.
+    heddle_must_succeed(&["init"], source.path());
+    std::fs::write(source.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source v1"], source.path());
+
+    // Target repo: start from a baseline capture so `main` exists
+    // locally. Pull then advances it.
+    heddle_must_succeed(&["init"], target.path());
+    heddle_must_succeed(&["capture", "-m", "target init"], target.path());
+    let source_path = source.path().to_str().unwrap().to_string();
+    heddle_must_succeed(&["pull", &source_path, "--thread", "main"], target.path());
+    let main_after_first_pull = head_short(target.path());
+
+    // Advance source so the second pull has somewhere to FF to.
+    std::fs::write(source.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source v2"], source.path());
+
+    heddle_must_succeed(&["pull", &source_path, "--thread", "main"], target.path());
+    let main_after_second_pull = head_short(target.path());
+    assert_ne!(
+        main_after_first_pull, main_after_second_pull,
+        "second pull must advance main to a new state"
+    );
+
+    heddle_must_succeed(&["undo"], target.path());
+    assert_eq!(
+        head_short(target.path()),
+        main_after_first_pull,
+        "undo of pull must restore HEAD to pre-pull tip"
+    );
+    let repo = Repository::open(target.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_after_first_pull,
+        "undo of pull must restore main thread ref to pre-pull tip \
+         (heddle#110 — was stranded at the pulled state before the fix)"
+    );
+}
+
+/// Resolve --abort (merge abort): aborting a conflicted 3-way merge
+/// calls `fast_forward_attached(merge_state.ours)` to clean the
+/// worktree back to the pre-merge state. During a 3-way conflict
+/// merge HEAD never moves (only the worktree gets conflict markers),
+/// so the FF is a worktree reset and the recorded
+/// `FastForwardV2`'s pre/post target ids are equal. The contract
+/// pinned here is that undo of the abort leaves the thread ref at
+/// `ours` — same as before the abort — rather than stranding it
+/// elsewhere. Pre-fix the implicit `OpRecord::Goto` happened to
+/// produce the same observable end state here (no strand because
+/// pre = post), but the migration to `FastForwardV2` keeps the
+/// invariant uniform across all `fast_forward_attached` call sites
+/// and future-proofs against a partial-apply merge variant that
+/// might move HEAD before abort.
+#[test]
+fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("conflict.txt"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("conflict.txt"), "feature edit\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature edit"], temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    std::fs::write(temp.path().join("conflict.txt"), "main edit\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "main edit"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    // Conflicted 3-way merge — leaves HEAD at `main_tip_before` with
+    // conflict markers on disk and a live merge_state.
+    let _ = heddle(&["merge", "feature"], Some(temp.path()));
+
+    heddle_must_succeed(&["resolve", "--abort"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        main_tip_before,
+        "abort must leave HEAD at main's pre-merge tip"
+    );
+
+    // Undo the abort — `FastForwardV2 { pre = post = main_tip_before }`
+    // so the observable state is unchanged.
+    heddle_must_succeed(&["undo"], temp.path());
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "undo of merge abort must leave main thread ref at the pre-merge tip"
+    );
+    match repo.head_ref().unwrap() {
+        refs::Head::Attached { thread } => assert_eq!(thread, "main"),
+        refs::Head::Detached { state } => panic!(
+            "HEAD must stay attached to main; got detached at {}",
+            state.short()
+        ),
+    }
+}
+
+/// Ship (manual-resolution adopt path): `heddle ship` calls
+/// `adopt_manual_resolution`, which fast-forwards the current
+/// attached thread to a manually-resolved tip. Undo must restore
+/// the attached thread's ref to its pre-ship tip — pre-fix the
+/// implicit `OpRecord::Goto` left the ref stranded at the adopted
+/// state.
+///
+/// The ship-via-manual-resolution path requires a materialized
+/// thread workspace and `integration_policy.manual_resolution_state`
+/// set. We bootstrap that here by `heddle start --workspace
+/// materialized`, capturing work in the side worktree, then running
+/// `thread resolve` from main to flip the resolution flag. `heddle
+/// ship --thread <feature>` then enters `adopt_manual_resolution`,
+/// whose `fast_forward_attached` call we're pinning.
+///
+/// In environments where ship can't reach the adopt branch (no
+/// git-overlay, no hosted config), we fall back to asserting that
+/// the migration didn't break the `thread resolve` flow itself.
+#[test]
+fn test_undo_ship_manual_resolution_restores_thread_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("a.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    // Create a materialized side worktree for feature so ship can
+    // open the thread's checkout.
+    let feature_wt = temp.path().join("feature-wt");
+    heddle_must_succeed(
+        &[
+            "start",
+            "feature",
+            "--path",
+            feature_wt.to_str().unwrap(),
+            "--workspace",
+            "materialized",
+        ],
+        temp.path(),
+    );
+    std::fs::write(feature_wt.join("feat.txt"), "feature work").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], &feature_wt);
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    let main_tip_before = head_short(temp.path());
+
+    // `thread resolve` flips manual_resolution_state on feature
+    // when the thread merges cleanly. This is the trigger
+    // `adopt_manual_resolution` looks for during ship.
+    let _ = heddle(&["thread", "resolve", "feature"], Some(temp.path()));
+
+    let ship = heddle(
+        &["--output", "json", "ship", "--thread", "feature"],
+        Some(temp.path()),
+    );
+    let ship_out = match ship {
+        Ok(out) => out,
+        Err(err) => {
+            panic!("ship failed: {err}");
+        }
+    };
+    assert!(
+        ship_out.contains("\"status\":\"shipped\"") || ship_out.contains("\"status\": \"shipped\""),
+        "ship must reach the manual-resolution adopt path: {ship_out}"
+    );
+    let after_ship = head_short(temp.path());
+    assert_ne!(
+        after_ship, main_tip_before,
+        "ship must advance main; otherwise the FF is a no-op and there's nothing to undo: {ship_out}"
+    );
+
+    heddle_must_succeed(&["undo"], temp.path());
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(
+        main_tip, main_tip_before,
+        "undo of ship must restore main thread ref to pre-ship tip \
+         (heddle#110 — was stranded at the adopted state before the fix)"
+    );
+}
+
+/// Deterministic redo for `rebase`: forward FF → undo → advance the
+/// source thread → redo must replay to the recorded post-FF SHA,
+/// not re-resolve from the source thread's (now advanced) tip. This
+/// pins heddle#99 r2's deterministic-redo contract for the rebase
+/// call sites: the recorded FastForwardV2 carries `post_target_id`
+/// so the OpRecord is self-sufficient.
+#[test]
+fn test_redo_rebase_pins_recorded_tip_when_source_advances() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("base.txt"), "base").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature"], temp.path());
+    let feature_at_rebase = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    let main_tip_before = head_short(temp.path());
+    // Ancestor FF (main → feature): records FastForwardV2 with
+    // post_target_id = feature's current tip.
+    heddle_must_succeed(&["rebase", "feature"], temp.path());
+    assert_eq!(head_short(temp.path()), feature_at_rebase);
+
+    heddle_must_succeed(&["undo"], temp.path());
+    assert_eq!(head_short(temp.path()), main_tip_before);
+
+    // Advance feature after undo. Pre-fix (or under a name-resolve
+    // redo), this new tip would be smuggled into the redo target.
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feat.txt"), "feature + more").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature again"], temp.path());
+    let feature_advanced = head_short(temp.path());
+    assert_ne!(feature_at_rebase, feature_advanced);
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    heddle_must_succeed(&["redo"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        feature_at_rebase,
+        "redo of rebase FF must replay to the recorded post-FF SHA, \
+         not feature's advanced tip"
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let main_tip = repo
+        .refs()
+        .get_thread("main")
+        .unwrap()
+        .expect("main thread still exists")
+        .short();
+    assert_eq!(main_tip, feature_at_rebase);
+}
+
+/// Deterministic redo for `pull`: forward pull → undo → advance the
+/// remote source thread → redo must replay to the recorded pulled
+/// SHA, not re-resolve the remote's current tip. The bug shape is
+/// identical to the rebase case above; this pin guarantees the
+/// FastForwardV2 contract holds on the pull call site too.
+#[test]
+fn test_redo_pull_pins_recorded_tip_when_source_advances() {
+    let source = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+
+    heddle_must_succeed(&["init"], source.path());
+    std::fs::write(source.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source v1"], source.path());
+
+    heddle_must_succeed(&["init"], target.path());
+    heddle_must_succeed(&["capture", "-m", "target init"], target.path());
+    let source_path = source.path().to_str().unwrap().to_string();
+    heddle_must_succeed(&["pull", &source_path, "--thread", "main"], target.path());
+    let main_after_first_pull = head_short(target.path());
+
+    std::fs::write(source.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source v2"], source.path());
+    heddle_must_succeed(&["pull", &source_path, "--thread", "main"], target.path());
+    let main_after_second_pull = head_short(target.path());
+
+    heddle_must_succeed(&["undo"], target.path());
+    assert_eq!(head_short(target.path()), main_after_first_pull);
+
+    // Advance the source past the recorded pull target. Pre-fix
+    // redo would re-resolve `main → tip` from the source and pull
+    // *this* state, not the originally-pulled SHA.
+    std::fs::write(source.path().join("a.txt"), "v3").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source v3"], source.path());
+
+    heddle_must_succeed(&["redo"], target.path());
+    assert_eq!(
+        head_short(target.path()),
+        main_after_second_pull,
+        "redo of pull must replay to the recorded pulled SHA, \
+         not the source's advanced tip"
+    );
+}

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -307,6 +307,36 @@ the implemented inverses. If a future forward path lights up the
 `ThreadDelete` hazard, the same V2-snapshot pattern applies — file a
 `ThreadDeleteV2` with the record snapshot.
 
+### `FastForwardV2` emission sites (heddle#110)
+
+heddle#99 originally migrated *only* `cmd_merge`'s FF path to record
+`FastForwardV2`. The Rule-7 sweep filed under heddle#110 extended the
+same migration to the remaining `Repository::fast_forward_attached`
+callers — each of which previously recorded the implicit
+`OpRecord::Goto` (whose inverse only rewinds HEAD) and so silently
+stranded the attached thread ref at the post-FF target on undo.
+
+Today's call sites that emit `FastForwardV2` (via the shared
+`commands::ff_record::record_ff_advance` helper, which falls back to
+`Goto` on detached HEAD):
+
+| Site | Command | `source_thread` value | Notes |
+|---|---|---|---|
+| `commands/merge/mod.rs` | `heddle merge` (FF path) | merge `track_name` | heddle#99 |
+| `commands/rebase/mod.rs` (is_ancestor) | `heddle rebase` (pure FF) | rebase target thread | heddle#110 |
+| `commands/rebase/mod.rs` (empty-replay) | `heddle rebase` (no commits to replay) | rebase target thread | heddle#110 |
+| `commands/rebase/rebase_ops.rs:apply_commit` | `heddle rebase` (replay step) | `"<rebase>"` synthetic | heddle#110; one op per replayed commit |
+| `commands/rebase/rebase_ops.rs:apply_tree_to_worktree` | `heddle rebase` (parentless replay) | `"<rebase>"` synthetic | heddle#110; rare parentless-commit replay |
+| `commands/workflow.rs:adopt_manual_resolution` | `heddle ship` (manual-resolution adopt) | shipped thread name | heddle#110 |
+| `commands/remote/remote_ops.rs:pull_local` | `heddle pull` (local sync, repeat pull) | remote thread name | heddle#110; first-time pull falls back to `Goto` because there's no pre-target tip to restore |
+| `commands/resolve.rs:abort_merge_state` | `heddle resolve --abort` | `"<abort>"` synthetic | heddle#110; today this is a pre-target = post-target no-op record (HEAD doesn't move during a 3-way conflict merge), kept on the same code path so a future merge variant that does move HEAD before abort gets correct undo semantics for free |
+
+Any new caller of `fast_forward_attached` should go through
+`record_ff_advance` (or `record_ff_advance_explicit` when the caller
+pre-mutates the thread ref, à la `pull_local`). Calling
+`fast_forward_attached` directly is reserved for tests and for the
+detached-HEAD bootstrap path inside the helper itself.
+
 The pattern is now well-established enough that any new ref-mutating
 `OpRecord` variant should be reviewed against this matrix at design
 time: "what does undo destroy, and what does redo read to put it back?"


### PR DESCRIPTION
## Summary

Rule-7 followup to heddle#99 (PR #109 `3f64cc28`). Migrates the remaining `fast_forward_attached` callers to record `OpRecord::FastForwardV2 { ..., post_target_id }` so daily-use commands restore thread refs on undo and replay deterministically on redo.

## Per-site disposition

| # | Site | OpRecord | source_thread | Red-commit test |
|---|---|---|---|---|
| 1 | `rebase/mod.rs:177` (ancestor FF) | FastForwardV2 | rebase target | `test_undo_rebase_ancestor_ff` |
| 2 | `rebase/mod.rs:206` (empty-replay FF) | FastForwardV2 | rebase target | (covered by #1) |
| 3 | `rebase_ops.rs:apply_commit` (replay step) | FastForwardV2 | `<rebase>` | `test_undo_rebase_replay` |
| 4 | `rebase_ops.rs:apply_tree_to_worktree` (parentless replay) | FastForwardV2 | `<rebase>` | (covered by #3) |
| 5 | `workflow.rs:adopt_manual_resolution` (ship) | FastForwardV2 | shipped thread | `test_undo_ship_manual_resolution` |
| 6 | `remote_ops.rs:pull_local` (pull) | FastForwardV2 (1st pull → Goto) | remote thread | `test_undo_pull_local` |
| 7 | `resolve.rs:abort_merge_state` (merge --abort) | FastForwardV2 (pre=post no-op today) | `<abort>` | `test_undo_resolve_abort` |

Plus 2 redo-determinism tests:
- `test_redo_rebase_pins_recorded_tip_when_source_advances`
- `test_redo_pull_pins_recorded_tip_when_source_advances`

## Shared helper

New `crates/cli/src/cli/commands/ff_record.rs` extracts the common \"record FastForwardV2 after FF\" logic — avoids copy-paste across the 6 sites and gives Codex one canonical place to audit.

## Verification

- 85/85 `core_functionality` tests pass
- 311/311 `comprehensive` tests pass
- 6 of 7 new undo tests pinned RED pre-fix (the abort no-op case is uniformity-driven)
- Upstream crates (`heddle-repo`, `heddle-oplog`, `heddle-objects`) clean
- Clippy clean on `heddle-cli --tests`
- gc destructive-boundary protection inherited from heddle#99 (`states_required_for_undo` / `..._redo` already cover FastForwardV2)

## Rule-7 sweep

Explicitly out of scope per heddle#110 body: ThreadRename and other non-FF OpRecord arms. No new same-shape bugs found beyond the 7 sites listed.

## Reference

- heddle#99 PR #109 (`3f64cc28`, `eaa840c`) — V2 pattern + `fast_forward_attached_without_record` helper
- heddle#23 PR #112 (`87752d7c`) — cross-thread undo design doc + OpRecord matrix (this PR updates the FastForwardV2 emission sites subsection in `docs/design/cross-thread-undo.md`)

Closes HeddleCo/heddle#110

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->