### PR TITLE
fix(parser_core): walk C++ declarator name for templated qualified functions (closes #126)

### DIFF
--- a/crates/semantic/src/parser/parser_core.rs
+++ b/crates/semantic/src/parser/parser_core.rs
@@ -138,10 +138,13 @@ impl ParsedFile {
         if let Some(name) = node.child_by_field_name("name") {
             return Some(&self.source[name.byte_range()]);
         }
-        if let Some(declarator) = node.child_by_field_name("declarator")
-            && let Some(name) = self.find_identifier_in_subtree(declarator)
-        {
-            return Some(name);
+        if let Some(declarator) = node.child_by_field_name("declarator") {
+            if let Some(name) = self.c_function_name(declarator) {
+                return Some(name);
+            }
+            if let Some(name) = self.find_identifier_in_subtree(declarator) {
+                return Some(name);
+            }
         }
 
         for i in 0..node.child_count() {
@@ -152,6 +155,49 @@ impl ParsedFile {
                 )
             {
                 return Some(&self.source[child.byte_range()]);
+            }
+        }
+        None
+    }
+
+    /// Resolve the actual function name from a C/C++ declarator.
+    ///
+    /// Mirrors `merge_driver::items::c_function_name` (heddle#114
+    /// commit `dc37af8`, Codex r5 P1 #2). A plain DFS over the
+    /// declarator subtree returns the FIRST identifier-ish leaf — for
+    /// a templated qualified name like `void Foo<U>::bar()` the
+    /// scope's inner `type_identifier` ("Foo") wins, so every method
+    /// on the same scope collapses to name="Foo". Instead, walk the
+    /// declarator's `declarator` field, peel wrapper layers, and
+    /// recurse into `qualified_identifier` / `template_function`'s
+    /// `name` field so the scope's identifier never wins.
+    ///
+    /// Duplicated rather than lifted to a shared module: the function
+    /// is short, and `parser_core` vs `merge_driver` are different
+    /// concerns. Lift if a third caller appears.
+    fn c_function_name(&self, function_declarator: Node<'_>) -> Option<&str> {
+        let mut current = function_declarator.child_by_field_name("declarator")?;
+        // Cap traversal so a pathological wrapper chain doesn't loop.
+        for _ in 0..32 {
+            match current.kind() {
+                "identifier"
+                | "field_identifier"
+                | "type_identifier"
+                | "property_identifier"
+                | "operator_name"
+                | "destructor_name" => {
+                    return Some(&self.source[current.byte_range()]);
+                }
+                "qualified_identifier" | "template_function" => {
+                    current = current.child_by_field_name("name")?;
+                }
+                "pointer_declarator"
+                | "reference_declarator"
+                | "function_declarator"
+                | "parenthesized_declarator" => {
+                    current = current.child_by_field_name("declarator")?;
+                }
+                _ => return None,
             }
         }
         None

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -245,3 +245,47 @@ fn test_extract_functions_handles_deeply_nested_modules() {
     assert_eq!(functions.len(), 1);
     assert_eq!(functions[0].name, "deeply_nested");
 }
+
+#[cfg(feature = "lang-cpp")]
+#[test]
+fn test_cpp_templated_qualified_function_names() {
+    // For `void Foo<U>::bar()` the declarator subtree's first
+    // identifier in DFS order is the scope's `type_identifier` ("Foo"),
+    // so a plain DFS walk reports every method on the same templated
+    // scope as "Foo" and collides them. The fix walks the declarator's
+    // `declarator` field and recurses into `qualified_identifier` /
+    // `template_function`'s `name` field — see heddle#114 commit
+    // dc37af8 for the proven pattern (mirrored from
+    // `merge_driver::items::c_function_name`).
+    let source = r#"
+template <typename U>
+struct Foo {
+    void bar();
+    void baz();
+};
+
+template <typename U>
+void Foo<U>::bar() {}
+
+template <typename U>
+void Foo<U>::baz() {}
+"#;
+
+    let parsed = ParsedFile::parse(source, Language::Cpp).expect("Should parse");
+    let functions = parsed.extract_functions();
+    let names: Vec<&str> = functions.iter().map(|f| f.name.as_str()).collect();
+
+    assert!(
+        names.contains(&"bar"),
+        "expected templated qualified def to resolve as `bar`, got {names:?}"
+    );
+    assert!(
+        names.contains(&"baz"),
+        "expected templated qualified def to resolve as `baz`, got {names:?}"
+    );
+    let foo_count = names.iter().filter(|n| **n == "Foo").count();
+    assert_eq!(
+        foo_count, 0,
+        "templated qualified method defs should not resolve to scope name `Foo`: {names:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`ParsedFile::get_function_name` falls back to `find_identifier_in_subtree` over the function's declarator for C/C++. That's a first-DFS walk, so for a templated qualified def like `void Foo<U>::bar()` the scope's inner `type_identifier` ("Foo") wins and every method on the same templated scope resolves as "Foo" — collapsing distinct functions into one edge in `extract_dependencies`, semantic diff, and reference analysis.

Mirror the proven pattern from heddle#114 commit `dc37af8` (Codex r5 P1 #2 for `merge_driver::items::classify_c_node`): add a `c_function_name` helper that walks the declarator's `declarator` field, peels wrapper layers (`pointer_declarator`, `reference_declarator`, nested `function_declarator`, `parenthesized_declarator`), and recurses into `qualified_identifier` / `template_function`'s `name` field. The scope's identifier never wins.

Duplicated as a private helper rather than lifted — the function is ~30 lines and `parser_core` vs `merge_driver` are different concerns. Lift when a third caller appears.

## Commits

- **Red** `388cb71` — test pinning `void Foo<U>::bar()` / `void Foo<U>::baz()` misresolving as `["Foo", "Foo"]`.
- **Green** `7d1f772` — declarator-walking `c_function_name`; falls back to the old DFS for shapes the walk can't resolve.

## Test plan

- [x] Red commit fails: `expected templated qualified def to resolve as bar, got ["Foo", "Foo"]`.
- [x] Green commit: new test passes; all 103 `heddle-semantic` tests pass (`--features lang-cpp,lang-c,lang-go,lang-java`).
- [x] Existing parser tests still pass (Rust / Python / C / C++ / Go / Java function extraction unchanged).

## Reference

- heddle#114 commit `dc37af8` — proven pattern.
- Codex r5 P1 #2 (cid 3256038652).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->