### PR TITLE
build(asserter): replace regex with syn-based AST walker (closes #103)

### DIFF
--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -51,15 +51,31 @@ jobs:
 
   no-silent-default-tree-load:
     name: no silent-default tree load (heddle#90 + #93)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 5
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
+      # The asserter is now a Rust binary (heddle-devtools subcommand)
+      # using `syn` to walk the AST — replaced the regex implementation
+      # after three rounds of bypass-and-patch (heddle#103). Rust
+      # toolchain + cache so the build is fast on warm caches.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: asserter-${{ runner.os }}
+          cache-on-failure: true
+
+      - name: Build asserter binary
+        run: cargo build -p heddle-devtools --quiet
+
       # The mutation tests run first: if a future edit defeats the
-      # asserter (e.g. by reverting --multiline or widening the
-      # allowlist back to prefix-match), the self-tests fail before
-      # the asserter has a chance to silently pass.
+      # asserter (e.g. by loosening the chain walk or widening the
+      # allowlist to prefix match), the self-tests fail before the
+      # asserter has a chance to silently pass on production code.
       - name: Asserter self-tests (mutation fixtures)
         run: bash scripts/test-check-no-silent-default-tree-load.sh
+
       - name: Assert no `get_tree(...)?.unwrap_or_default()` regressions
         run: bash scripts/check-no-silent-default-tree-load.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,8 +2881,11 @@ name = "heddle-devtools"
 version = "0.2.4"
 dependencies = [
  "anyhow",
+ "proc-macro2",
  "protoc-bin-vendored",
+ "syn 2.0.117",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ ntest = "0.9"
 proptest = "1"
 p256 = { version = "0.13", features = ["ecdsa", "pem"] }
 pkcs8 = { version = "0.10", features = ["pem", "encryption"] }
+proc-macro2 = { version = "1", features = ["span-locations"] }
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
@@ -92,6 +93,7 @@ sha2 = { version = "0.10", features = ["oid"] }
 signature = "2"
 similar = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "json"] }
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = [

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -11,5 +11,8 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+proc-macro2.workspace = true
 protoc-bin-vendored.workspace = true
+syn.workspace = true
 tempfile.workspace = true
+walkdir.workspace = true

--- a/crates/devtools/src/check_no_silent_default_tree_load.rs
+++ b/crates/devtools/src/check_no_silent_default_tree_load.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: Apache-2.0
+//! AST-based asserter for the heddle#90/#93 silent-default-tree-load bug
+//! class. Retires the `scripts/check-no-silent-default-tree-load.sh` regex
+//! after three rounds of regex-vs-edge-cases (heddle#103).
+//!
+//! The walker uses `syn::parse_file` on each `.rs` source under the search
+//! dirs, then visits every `ExprMethodCall`. A call is a hit when its method
+//! matches one of `unwrap_or_default`, `unwrap_or_else(|| Tree::new() /
+//! Tree::default())` (closure body, optionally braced), or
+//! `unwrap_or_else(Tree::new / Tree::default)` (fn-pointer arg) AND its
+//! receiver chain — peeled through `?`, parens, and intermediate method
+//! calls like `.ok()`/`.flatten()`/`.transpose()` — bottoms out at a
+//! `MethodCall` named `get_tree`.
+//!
+//! Doc-comments and string literals are exempt by construction: they are not
+//! `ExprMethodCall` nodes. Macro-call wrappers (`get_tree_macro!(x)`) are NOT
+//! peered through — the AST sees `ExprMacro`, not the expansion. This is a
+//! documented limitation; the dispatch-site fixture asserts the behavior.
+//!
+//! The env-var contract is identical to the legacy shell script so the
+//! mutation-test harness drives the same way. `HEDDLE_ASSERTER_SEARCH_DIRS`
+//! is a colon-separated list of dirs (default `crates`).
+//! `HEDDLE_ASSERTER_ALLOWLIST` is a semicolon-separated list of `path:line`
+//! entries; empty string disables the list, unset uses the built-in default.
+//! The built-in default is empty: the legacy doc-comment pins are no longer
+//! needed because the AST walker doesn't visit doc-comments.
+
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use syn::visit::Visit;
+use syn::{Expr, ExprMethodCall, Stmt};
+use walkdir::WalkDir;
+
+const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(arg) = args.first() {
+        bail!(
+            "check-no-silent-default-tree-load: unexpected argument '{arg}' (configured via env vars: HEDDLE_ASSERTER_SEARCH_DIRS, HEDDLE_ASSERTER_ALLOWLIST)"
+        );
+    }
+
+    let search_dirs = read_search_dirs();
+    let allowlist = read_allowlist();
+
+    let mut hits: Vec<Hit> = Vec::new();
+    let mut files_scanned = 0usize;
+    for dir in &search_dirs {
+        scan_dir(dir, &mut hits, &mut files_scanned)
+            .with_context(|| format!("scan {}", dir.display()))?;
+    }
+
+    let mut failed = 0usize;
+    for hit in &hits {
+        let key = format!("{}:{}", hit.path.display(), hit.line);
+        if allowlist.iter().any(|entry| entry == &key) {
+            println!("ok: exempt: {key} — {}", hit.label);
+            continue;
+        }
+        eprintln!("::error::{} at {}: {}", hit.label, key, hit.snippet.trim(),);
+        failed += 1;
+    }
+
+    if failed > 0 {
+        eprintln!(
+            "\n::error::Found {failed} `get_tree(...)?.unwrap_or_default()`-class \
+site(s) in production code. This pattern silently substitutes \
+`Tree::default()` for a missing subtree (heddle#90 merge / heddle#93 \
+non-merge). Replace with `repo.require_tree(&hash)?` so missing trees \
+surface with a `heddle fsck --full` recovery hint.\n\
+\n\
+If a site is a legitimate empty-tree sentinel (no-parent-commit marker, \
+etc.) add a `path:line` entry to HEDDLE_ASSERTER_ALLOWLIST with a \
+one-line justification."
+        );
+        bail!("asserter failed");
+    }
+
+    println!(
+        "asserter clean: no silent-default tree load sites in production code \
+({files_scanned} file(s) scanned)",
+    );
+    Ok(())
+}
+
+fn read_search_dirs() -> Vec<PathBuf> {
+    match env::var("HEDDLE_ASSERTER_SEARCH_DIRS") {
+        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
+        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
+    }
+}
+
+fn read_allowlist() -> Vec<String> {
+    match env::var("HEDDLE_ASSERTER_ALLOWLIST") {
+        Ok(value) if value.is_empty() => Vec::new(),
+        Ok(value) => value.split(';').map(str::to_string).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Debug)]
+struct Hit {
+    path: PathBuf,
+    line: usize,
+    label: &'static str,
+    snippet: String,
+}
+
+fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
+    if !dir.exists() {
+        // Mirror the shell asserter: a non-existent search dir is a no-op,
+        // not an error. The mutation harness sometimes points at empty trees.
+        return Ok(());
+    }
+    for entry in WalkDir::new(dir).follow_links(false) {
+        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("rs") {
+            continue;
+        }
+        if is_test_path(path) {
+            continue;
+        }
+        let source =
+            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        *files_scanned += 1;
+        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+        let lines: Vec<&str> = source.lines().collect();
+        let mut visitor = Finder {
+            path: path.to_path_buf(),
+            lines: &lines,
+            hits,
+        };
+        visitor.visit_file(&file);
+    }
+    Ok(())
+}
+
+/// Tests legitimately exercise the bug class — skip them. This formalizes the
+/// stated intent of the legacy shell asserter, whose `?`-requirement was an
+/// incidental filter that happened to skip the test-style `.unwrap()` chains.
+///
+/// Two shapes:
+///   - integration tests live under a `tests/` directory segment, and
+///   - unit tests by convention sit in `*_tests.rs` files under `src/`.
+fn is_test_path(path: &Path) -> bool {
+    for component in path.components() {
+        if component.as_os_str() == "tests" {
+            return true;
+        }
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .map(|name| name.ends_with("_tests.rs"))
+        .unwrap_or(false)
+}
+
+struct Finder<'a> {
+    path: PathBuf,
+    lines: &'a [&'a str],
+    hits: &'a mut Vec<Hit>,
+}
+
+impl<'a, 'ast> Visit<'ast> for Finder<'a> {
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        if let Some(label) = classify(node)
+            && chain_originates_from_get_tree(&node.receiver)
+        {
+            let line = node.method.span().start().line;
+            let snippet = self
+                .lines
+                .get(line.saturating_sub(1))
+                .copied()
+                .unwrap_or("")
+                .to_string();
+            self.hits.push(Hit {
+                path: self.path.clone(),
+                line,
+                label,
+                snippet,
+            });
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn classify(node: &ExprMethodCall) -> Option<&'static str> {
+    let method = node.method.to_string();
+    match method.as_str() {
+        "unwrap_or_default" => Some("silent-default tree load (heddle#90/#93 bug class)"),
+        "unwrap_or_else" => {
+            let arg = node.args.first()?;
+            if closure_returns_tree_default(arg) {
+                Some("silent-default tree load via unwrap_or_else(closure)")
+            } else if path_is_tree_default(arg) {
+                Some("silent-default tree load via unwrap_or_else(fn-pointer)")
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn closure_returns_tree_default(arg: &Expr) -> bool {
+    let Expr::Closure(closure) = arg else {
+        return false;
+    };
+    expr_constructs_tree(&closure.body)
+}
+
+/// Recognize an expression that constructs a default `Tree` — either
+/// `Tree::new()` / `Tree::default()` directly, or a block whose tail
+/// expression is one of those.
+fn expr_constructs_tree(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call(call) => path_is_tree_default(&call.func),
+        Expr::Block(b) => match b.block.stmts.last() {
+            Some(Stmt::Expr(tail, None)) => expr_constructs_tree(tail),
+            _ => false,
+        },
+        Expr::Paren(p) => expr_constructs_tree(&p.expr),
+        Expr::Group(g) => expr_constructs_tree(&g.expr),
+        _ => false,
+    }
+}
+
+fn path_is_tree_default(expr: &Expr) -> bool {
+    let Expr::Path(p) = expr else { return false };
+    let segs = &p.path.segments;
+    if segs.len() < 2 {
+        return false;
+    }
+    let last = segs[segs.len() - 1].ident.to_string();
+    let prev = segs[segs.len() - 2].ident.to_string();
+    prev == "Tree" && (last == "new" || last == "default")
+}
+
+/// True iff the receiver chain transitively contains a `MethodCall` whose
+/// method ident is `get_tree`. Walks through intermediate method calls
+/// (treating `.ok()`, `.flatten()`, `.transpose()`, etc. as transparent) and
+/// peels off `?`, parens, and groups. Stops when the chain hits anything that
+/// isn't one of those expression shapes — at which point we know `get_tree`
+/// is not the origin.
+fn chain_originates_from_get_tree(expr: &Expr) -> bool {
+    let mut cur = expr;
+    loop {
+        match cur {
+            Expr::MethodCall(mc) => {
+                if mc.method == "get_tree" {
+                    return true;
+                }
+                cur = &mc.receiver;
+            }
+            Expr::Try(t) => cur = &t.expr,
+            Expr::Paren(p) => cur = &p.expr,
+            Expr::Group(g) => cur = &g.expr,
+            Expr::Await(a) => cur = &a.base,
+            _ => return false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn scan_source(src: &str) -> Vec<Hit> {
+        let file = syn::parse_file(src).expect("parse");
+        let lines: Vec<&str> = src.lines().collect();
+        let mut hits = Vec::new();
+        let mut v = Finder {
+            path: PathBuf::from("test.rs"),
+            lines: &lines,
+            hits: &mut hits,
+        };
+        v.visit_file(&file);
+        hits
+    }
+
+    #[test]
+    fn flags_direct_unwrap_or_default() {
+        let hits = scan_source("fn f() -> Tree { repo.get_tree(h)?.unwrap_or_default() }");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_chain_through_ok_flatten() {
+        let hits =
+            scan_source("fn f() -> Tree { repo.get_tree(h).ok().flatten().unwrap_or_default() }");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_option_chain_transpose() {
+        let hits = scan_source(
+            "fn f() -> Tree { repo.get_tree(h).transpose()?.flatten().unwrap_or_default() }",
+        );
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_unwrap_or_else_closure_tree_new() {
+        let hits =
+            scan_source("fn f() -> Tree { repo.get_tree(h)?.unwrap_or_else(|| Tree::new()) }");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_unwrap_or_else_braced_closure() {
+        let hits = scan_source(
+            "fn f() -> Tree { repo.get_tree(h)?.unwrap_or_else(|| { Tree::default() }) }",
+        );
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_unwrap_or_else_fn_pointer() {
+        let hits =
+            scan_source("fn f() -> Tree { repo.get_tree(h)?.unwrap_or_else(Tree::default) }");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_nested_paren_args() {
+        let hits = scan_source(
+            "fn f() -> Tree { repo.get_tree(&normalize(s.tree()))?.unwrap_or_default() }",
+        );
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn flags_triple_nested_parens() {
+        let hits = scan_source("fn f() -> Tree { repo.get_tree(((id)))?.unwrap_or_default() }");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn ignores_raw_string_literal() {
+        let hits =
+            scan_source("fn f() { let s = r#\"get_tree(x)?.unwrap_or_default()\"#; let _ = s; }");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_unwrap_or_default() {
+        let hits = scan_source("fn f() -> Vec<u8> { vec.something().unwrap_or_default() }");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_unwrap_or_else_with_unrelated_default() {
+        let hits = scan_source("fn f() -> Tree { repo.get_tree(h)?.unwrap_or_else(|| other()) }");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_get_tree_without_terminal_unwrap() {
+        let hits = scan_source("fn f() { let _ = repo.get_tree(h)?; }");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn does_not_peer_through_macro() {
+        let hits = scan_source("fn f() -> Tree { get_tree_macro!(h)?.unwrap_or_default() }");
+        assert!(
+            hits.is_empty(),
+            "macro-wrapped call is a documented limitation"
+        );
+    }
+}

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -7,12 +7,17 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 
+mod check_no_silent_default_tree_load;
+
 fn main() -> Result<()> {
     let mut args = env::args().skip(1);
     match args.next().as_deref() {
         Some("web-proto") => run_web_proto(args.collect()),
         Some("audit-idempotency") => run_audit_idempotency(),
         Some("audit-coverage") => run_audit_coverage(args.collect()),
+        Some("check-no-silent-default-tree-load") => {
+            check_no_silent_default_tree_load::run(args.collect())
+        }
         Some(command) => bail!("unknown command '{command}'"),
         None => bail!("expected a command (for example: web-proto)"),
     }

--- a/scripts/check-no-silent-default-tree-load.sh
+++ b/scripts/check-no-silent-default-tree-load.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Asserter for the silent-corruption-on-missing-tree bug class
-# closed by heddle#90 (merge_algo) and heddle#93 (presentation +
-# mutation paths outside merge).
+# Asserter for the silent-corruption-on-missing-tree bug class closed
+# by heddle#90 (merge_algo) and heddle#93 (presentation + mutation
+# paths outside merge). Replaces the regex implementation that went
+# three rounds of bypass-and-patch (heddle#103) with a syn-based AST
+# walker living in `heddle-devtools`.
 #
-# The original pattern was:
+# The bug class:
 #   repo.store().get_tree(&state.tree)?.unwrap_or_default()
-#
 # A missing subtree silently became `Tree::default()`, so merges
 # erased subtrees with no conflict markers, status rendered empty
 # content, `heddle clean --force` deleted tracked files against an
@@ -13,190 +14,55 @@
 # which surfaces a `MissingObject { object_type: "tree" }` error
 # with a `heddle fsck --full` recovery hint.
 #
-# This script fails CI if any of the following bug-class shapes
-# reappear in production code:
-#   - get_tree(...)?.unwrap_or_default()
-#   - get_tree(...)?.unwrap_or_else(|| Tree::new())  / Tree::default()
-#   - get_tree(...)?.unwrap_or_else(|| { Tree::new() })  (braced body)
-#   - get_tree(...)?.unwrap_or_else(Tree::new)       / Tree::default
-#   - get_tree(...).ok().flatten().unwrap_or_default()
-#   - the .transpose()?.flatten().unwrap_or_default() Option-chain
-#     variant when the chain originates from get_tree
+# This wrapper exists for three reasons:
+#   1. It's the contract the CI workflow + mutation-test harness
+#      already use; keeping the entry point means neither needs to
+#      learn the cargo invocation.
+#   2. It pins the production allowlist in one place (DEFAULT_ALLOWLIST
+#      below), so a refactor of the production sites doesn't require
+#      touching Rust code.
+#   3. It ensures the binary is built before invocation. CI without a
+#      pre-build step would otherwise pay cargo-build latency on every
+#      run and noisy-build-output would mix with asserter output.
 #
-# Doc-comments and tests (which legitimately reference the legacy
-# pattern when describing the bug or asserting the migration) are
-# whitelisted. The list of allowed-by-design lines lives below; add
-# to it explicitly with a justification when a new legitimate
-# sentinel appears.
-#
-# Regex caveat: this script uses ripgrep regexes, not a real parser.
-# The arg-matching alternation below balances up to two levels of
-# nested parens (e.g. `get_tree(&normalize(s.tree()))`), which covers
-# every shape currently in the tree. Deeper nesting will not match;
-# heddle#NN proposes replacing the whole regex pass with an AST walk
-# (syn / tree-sitter) to close this class permanently.
+# Driving knobs (consumed by both this wrapper and the binary):
+#   HEDDLE_ASSERTER_SEARCH_DIRS — colon-separated dirs (default: `crates`)
+#   HEDDLE_ASSERTER_ALLOWLIST   — semicolon-separated `path:line`
+#                                 entries; replaces the default list
+#                                 (empty string disables the list)
 
 set -euo pipefail
 
-fail=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-err() { echo "::error::$*" >&2; fail=1; }
-ok()  { echo "ok: $*"; }
-
-# Search only production Rust source under crates/. Tests under
-# crates/*/tests/ exercise the bug class explicitly and are exempt;
-# the *_tests.rs files inside src/ are also exempt because they
-# pin the migration's intended behavior. Comments inside
-# executor.rs document the heddle#90 regression — also exempt.
+# Default allowlist for production code. AST inspection naturally
+# exempts doc-comments and string literals, so the legacy doc-comment
+# pins (executor.rs:303/776, repository.rs:1577) are no longer needed.
 #
-# Both SEARCH_DIRS and ALLOWLIST honour env overrides so the
-# companion test script (scripts/test-check-no-silent-default-tree-load.sh)
-# can point the asserter at synthetic fixtures without touching
-# production code.
-if [[ -n "${HEDDLE_ASSERTER_SEARCH_DIRS:-}" ]]; then
-  IFS=':' read -r -a SEARCH_DIRS <<< "$HEDDLE_ASSERTER_SEARCH_DIRS"
-else
-  SEARCH_DIRS=(crates)
+# crates/mount/src/core.rs:2193 is a real heddle#90/#93 bug-class site
+# that the legacy regex missed because the chain shape is
+#   store.get_tree(&e.hash).map_err(MountError::Store)?.unwrap_or_default()
+# i.e. the `?` is on `.map_err(...)`, not directly on `.get_tree(...)`,
+# so the regex's `${GET_TREE_CALL}\?\s*\.unwrap_or_default` pattern
+# never matched. The AST walker correctly flags it. Allowlisted here
+# (not fixed) to keep heddle#103's scope on the asserter swap; the
+# follow-up will replace it with a `require_tree`-style guard and
+# remove this entry.
+DEFAULT_ALLOWLIST="crates/mount/src/core.rs:2193"
+
+# Honour the env override; otherwise apply the default.
+if [[ -z "${HEDDLE_ASSERTER_ALLOWLIST+set}" ]]; then
+  export HEDDLE_ASSERTER_ALLOWLIST="$DEFAULT_ALLOWLIST"
 fi
 
-# Allowlist entries MUST be exact `path:line` pairs. A bare path was
-# accepted in r1, but `is_allowed` used prefix-matching, so any future
-# `get_tree(...).unwrap_or_default()` anywhere in the same file was
-# silently exempted — defeating the whole point of the asserter
-# (Codex r2 P2). Exact `path:line` means: when the line below moves,
-# the asserter fails CI and forces a re-justification.
-if [[ -n "${HEDDLE_ASSERTER_ALLOWLIST+set}" ]]; then
-  # Semicolon-separated list of `path:line` entries. Empty string
-  # means "no allowlist" — used by the asserter's own tests.
-  if [[ -z "$HEDDLE_ASSERTER_ALLOWLIST" ]]; then
-    ALLOWLIST=()
-  else
-    IFS=';' read -r -a ALLOWLIST <<< "$HEDDLE_ASSERTER_ALLOWLIST"
-  fi
-else
-  declare -a ALLOWLIST=(
-    # heddle#90 doc-comments quoting the pre-fix pattern.
-    "crates/cli/src/cli/commands/merge/merge_algo/executor.rs:303"
-    "crates/cli/src/cli/commands/merge/merge_algo/executor.rs:776"
-    # heddle#93 doc-comment on Repository::require_tree quoting the
-    # pre-fix pattern for context. The `///` doc-comment filter
-    # below already strips this on the current line; the explicit
-    # entry pins the location so a refactor that moves the prose
-    # into runtime code surfaces here instead of silently passing.
-    "crates/repo/src/repository.rs:1577"
-  )
-fi
+# Build the binary up front so its first-run output doesn't interleave
+# with the asserter's stdout. Quiet on success; cargo's own diagnostics
+# still go through if the build fails.
+(
+  cd "$WORKSPACE_ROOT"
+  cargo build -p heddle-devtools --quiet
+)
 
-is_allowed() {
-  local fileline="$1"
-  for entry in "${ALLOWLIST[@]}"; do
-    if [[ "$fileline" == "$entry" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-# Match an entire `get_tree(...)` call, including args that themselves
-# contain nested parens up to two levels deep. The Codex r2 P2 bypass
-# was `get_tree(&normalize(s.tree()))` — one level of nesting was
-# enough to defeat the prior `[^)]*` arg matcher. Two-level balancing
-# covers every call shape currently in the tree; deeper nesting needs
-# the AST-walker follow-up (see header).
-GET_TREE_CALL='get_tree\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*\)'
-
-# Process raw `path:lineno:content` hits from rg: strip doc/inline
-# comments, apply the allowlist, and emit an error for the rest.
-# Used by both the single-shape `run_rg` driver and the multi-line
-# Option-chain branch — the latter previously skipped this filter,
-# letting multi-line doc comments quoting the legacy pattern fire
-# as false positives (Codex r2 P2).
-process_hits() {
-  local label="$1"
-  local hits="$2"
-  if [[ -z "$hits" ]]; then
-    ok "no occurrences: $label"
-    return
-  fi
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    local key content
-    key="$(echo "$line" | awk -F: '{print $1":"$2}')"
-    content="$(echo "$line" | awk -F: '{$1=$2=""; sub(/^  /, ""); print}')"
-    if echo "$content" | grep -Eq '^[[:space:]]*(///|//!|//|\*|/\*)' ; then
-      continue
-    fi
-    if is_allowed "$key"; then
-      ok "exempt: $key — $label"
-      continue
-    fi
-    err "$label at $line"
-  done <<< "$hits"
-}
-
-run_rg() {
-  local pattern="$1"
-  local label="$2"
-  local hits
-  # --multiline + --multiline-dotall so patterns with `\s*` between
-  # `?` and `.unwrap_or_default()` catch the method-chain shape that
-  # spans lines (Codex r2 P2). Without these flags, the asserter
-  # claimed to catch multi-line chains but `rg` was actually doing
-  # single-line matching — `get_tree(x)?\n    .unwrap_or_default()`
-  # was invisible. --type rust restricts to .rs.
-  hits=$(rg --multiline --multiline-dotall \
-            --line-number --no-heading --type rust \
-            "$pattern" "${SEARCH_DIRS[@]}" 2>/dev/null || true)
-  process_hits "$label" "$hits"
-}
-
-# Bug shapes. `\s*` between `?` and the unwrap call catches both
-# single-line and multi-line chains because run_rg passes
-# --multiline --multiline-dotall (so `\s` matches newlines).
-#
-# The closure-form pattern accepts an OPTIONAL `{ ... }` block around
-# the `Tree::new()` / `Tree::default()` call body — Codex r2 P2 found
-# that `unwrap_or_else(|| { Tree::new() })` slipped past the prior
-# bare-expression matcher.
-run_rg "${GET_TREE_CALL}"'\?\s*\.unwrap_or_default\(\)' \
-       'silent-default tree load (heddle#90/#93 bug class)'
-run_rg "${GET_TREE_CALL}"'\?\s*\.unwrap_or_else\(\|\|\s*\{?\s*Tree::(new|default)\(\)\s*\}?\s*\)' \
-       'silent-default tree load via unwrap_or_else(closure)'
-run_rg "${GET_TREE_CALL}"'\?\s*\.unwrap_or_else\(\s*Tree::(new|default)\s*\)' \
-       'silent-default tree load via unwrap_or_else(fn-pointer)'
-run_rg "${GET_TREE_CALL}"'\.ok\(\)\s*\.flatten\(\)\s*\.unwrap_or_default\(\)' \
-       'silent-default tree load via .ok().flatten().unwrap_or_default()'
-
-# Multi-line Option-chain — bounded non-greedy `[\s\S]{0,1000}?` between
-# hops. Codex r2 P2 raised the prior `{0,200}` cap as defeatable by a
-# >200-char comment between hops; 1000 chars/hop comfortably covers a
-# realistic multi-line doc comment without going unbounded. Unbounded
-# was tried and produced cross-function false positives — a `get_tree`
-# in one helper would match an unrelated `.unwrap_or_default()` 100
-# lines later. The 1000-char cap keeps matches local to a single chain
-# expression while still defeating any plausible bypass-via-comment.
-# (The real fix is AST scanning; tracked in the follow-up issue.)
-ML_HITS=$(rg --multiline --multiline-dotall --line-number --no-heading --type rust \
-             '\.'"${GET_TREE_CALL}"'[\s\S]{0,1000}?\.transpose\(\)\?[\s\S]{0,1000}?\.flatten\(\)[\s\S]{0,1000}?\.unwrap_or_default\(\)' \
-             "${SEARCH_DIRS[@]}" 2>/dev/null || true)
-process_hits 'Option-chain .transpose()?.flatten().unwrap_or_default() of get_tree' "$ML_HITS"
-
-if [[ "$fail" -ne 0 ]]; then
-  cat >&2 <<'EOF'
-
-::error::Found one or more `get_tree(...)?.unwrap_or_default()`-class
-sites in production code. This pattern silently substitutes
-`Tree::default()` for a missing subtree, which is the silent-
-corruption bug class closed by heddle#90 (merge) and heddle#93
-(non-merge sweep). Replace with `repo.require_tree(&hash)?` so
-missing trees surface a clear error with a `heddle fsck --full`
-recovery hint.
-
-If a site is a legitimate empty-tree sentinel (no-parent-commit
-marker, etc.) add it to the ALLOWLIST in this script with a
-one-line justification.
-EOF
-  exit 1
-fi
-
-echo "asserter clean: no silent-default tree load sites in production code"
+exec cargo run -p heddle-devtools --quiet --manifest-path "$WORKSPACE_ROOT/Cargo.toml" -- \
+  check-no-silent-default-tree-load

--- a/scripts/test-check-no-silent-default-tree-load.sh
+++ b/scripts/test-check-no-silent-default-tree-load.sh
@@ -2,21 +2,19 @@
 # Mutation tests for scripts/check-no-silent-default-tree-load.sh.
 #
 # The asserter is itself load-bearing — if it silently passes when
-# the bug class reappears, the production lockdown means nothing. The
-# Codex r1 review of heddle#93 caught two bypasses that made the
-# asserter trivially defeatable (file-level allowlist prefix match,
-# missing --multiline on rg). This test exercises four fixtures that
-# r1's asserter would have passed but r2's must reject:
+# the bug class reappears, the production lockdown means nothing. This
+# test harness drives a synthetic fixture through the wrapper script
+# and asserts the expected pass/fail verdict.
 #
-#   1. Single-line `get_tree(x)?.unwrap_or_default()` in a
-#      non-allowlisted file → fails.
-#   2. Multi-line `get_tree(x)?\n    .unwrap_or_default()` → fails.
-#      r1 would have passed this (no --multiline on rg).
-#   3. A site at an exact `path:line` allowlist entry → passes.
-#   4. Same allowlisted file but at a different line → fails.
-#      r1 would have passed this (prefix-match allowlist).
+# Heddle#103 swapped the regex implementation for an AST walker
+# (`heddle-devtools check-no-silent-default-tree-load`). The 9 fixtures
+# below are the regression set inherited from the regex era — fixtures
+# 1..9 each map to a known regex bypass that the AST walker must continue
+# to reject. Fixtures 10..12 are the new AST-era set: shapes that the
+# regex could not have caught (or false-positived on) regardless of how
+# many edge cases were stitched on.
 #
-# The asserter exposes two env knobs to make this driveable:
+# Driving knobs (both wrapper and binary honour the same env vars):
 #   HEDDLE_ASSERTER_SEARCH_DIRS — colon-separated dirs to search
 #                                (default: `crates`)
 #   HEDDLE_ASSERTER_ALLOWLIST   — semicolon-separated `path:line`
@@ -32,6 +30,14 @@ if [[ ! -x "$ASSERTER" && ! -f "$ASSERTER" ]]; then
   echo "asserter not found at $ASSERTER" >&2
   exit 1
 fi
+
+# Pre-build the binary once so per-case invocations stay fast and the
+# first cargo-build noise doesn't drown out the test output.
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+(
+  cd "$WORKSPACE_ROOT"
+  cargo build -p heddle-devtools --quiet
+) >/dev/null
 
 fail=0
 fixtures_root="$(mktemp -d)"
@@ -78,8 +84,8 @@ run_case \
   "single/crates" "" "fail"
 
 # --- Fixture 2: multi-line bug shape, no allowlist -----------------------
-# r1's asserter (no --multiline on rg) would have passed this. r2 must
-# reject it — this is the regression Codex flagged.
+# r1's regex asserter (no --multiline on rg) passed this. AST walker
+# doesn't care about line breaks — the chain is the chain.
 mkdir -p "$fixtures_root/multi/crates/foo/src"
 cat > "$fixtures_root/multi/crates/foo/src/lib.rs" <<'EOF'
 fn load(repo: &Repository, h: &ContentHash) -> Tree {
@@ -93,8 +99,9 @@ run_case \
   "multi/crates" "" "fail"
 
 # --- Fixture 3: allowlisted exactly at the bug's line ---------------------
-# A site at the exact line in the allowlist must be exempt. We pin the
-# bug to a known line by inserting a fixed-length preamble.
+# A site at the exact line in the allowlist must be exempt. The AST
+# walker reports the line of the `unwrap_or_default` ident; the fixture
+# pins that line via a fixed-length preamble.
 mkdir -p "$fixtures_root/exact/crates/foo/src"
 {
   echo "// line 1"
@@ -110,10 +117,9 @@ run_case \
   "pass"
 
 # --- Fixture 4: allowlisted file but the bug is at a different line -----
-# r1's prefix-match allowlist would have passed this. r2 must reject:
-# moving the bug to a new line in an allowlisted file is exactly the
-# "future regression sneaks in under the prior justification" shape
-# the asserter exists to prevent.
+# r1's prefix-match allowlist passed this. Moving the bug to a new line
+# in an allowlisted file is exactly the "future regression sneaks in
+# under the prior justification" shape the asserter exists to prevent.
 mkdir -p "$fixtures_root/wrongline/crates/foo/src"
 {
   echo "// line 1"
@@ -130,6 +136,9 @@ run_case \
   "fail"
 
 # --- Fixture 5: doc-comment is still filtered (no false positive) --------
+# Doc-comments aren't `ExprMethodCall` nodes, so the AST walker can't
+# see them — they're exempt by construction, not by a comment-stripping
+# regex pass.
 mkdir -p "$fixtures_root/doccomment/crates/foo/src"
 cat > "$fixtures_root/doccomment/crates/foo/src/lib.rs" <<'EOF'
 /// The legacy pattern was `get_tree(...)?.unwrap_or_default()`,
@@ -141,9 +150,9 @@ run_case \
   "doccomment/crates" "" "pass"
 
 # --- Fixture 6: nested parens inside get_tree args (Codex r2 P2) ---------
-# r2's asserter used `get_tree\([^)]*\)` — the `[^)]*` stops at the
+# r2's regex used `get_tree\([^)]*\)` — the `[^)]*` stops at the
 # first close-paren, so any arg containing a nested call slipped past.
-# r3 must catch this.
+# AST inspection doesn't care about arg shape; `get_tree` is `get_tree`.
 mkdir -p "$fixtures_root/nested/crates/foo/src"
 cat > "$fixtures_root/nested/crates/foo/src/lib.rs" <<'EOF'
 fn load(repo: &Repository, s: &State) -> Tree {
@@ -155,8 +164,9 @@ run_case \
   "nested/crates" "" "fail"
 
 # --- Fixture 7: braced closure body (Codex r2 P2) -----------------------
-# `unwrap_or_else(|| { Tree::new() })` — the prior closure regex
-# required a bare expression with no `{ ... }` around it.
+# `unwrap_or_else(|| { Tree::new() })` — the AST classifier recognizes
+# both bare and block-bodied closures whose tail expression constructs
+# a default Tree.
 mkdir -p "$fixtures_root/braced/crates/foo/src"
 cat > "$fixtures_root/braced/crates/foo/src/lib.rs" <<'EOF'
 fn load(repo: &Repository, h: &ContentHash) -> Tree {
@@ -168,9 +178,9 @@ run_case \
   "braced/crates" "" "fail"
 
 # --- Fixture 8: long gap between Option-chain hops (Codex r2 P2) --------
-# The Option-chain matcher capped each hop's gap at 200 chars in r2.
-# A >200-char comment between `.transpose()?` and `.unwrap_or_default()`
-# slipped through. r3 raises the cap to 1000/hop.
+# The regex Option-chain matcher capped each hop's gap at 200 chars in
+# r2, then 1000 in r3 — both arbitrary bounds. AST walks the receiver
+# chain directly; gap length is irrelevant.
 mkdir -p "$fixtures_root/longgap/crates/foo/src"
 {
   echo "fn load(repo: &Repository, h: &ContentHash) -> Tree {"
@@ -183,14 +193,13 @@ mkdir -p "$fixtures_root/longgap/crates/foo/src"
   echo "}"
 } > "$fixtures_root/longgap/crates/foo/src/lib.rs"
 run_case \
-  "Option-chain with >200-char gap between hops is rejected (r2 regression)" \
+  "Option-chain with long inter-hop gap is rejected (r2 regression)" \
   "longgap/crates" "" "fail"
 
 # --- Fixture 9: multi-line doc-comment quoting the legacy chain ----------
-# r2's ML branch skipped the doc-comment filter entirely — any
-# `///`-prefixed prose mentioning the .transpose/.flatten/.unwrap_or_default
-# chain fired as a violation. r3 applies the same comment filter to
-# both branches via process_hits.
+# r2's ML regex branch skipped the comment filter — any `///`-prefixed
+# prose mentioning the chain fired as a violation. AST inspection
+# doesn't see comments at all.
 mkdir -p "$fixtures_root/mldoccomment/crates/foo/src"
 cat > "$fixtures_root/mldoccomment/crates/foo/src/lib.rs" <<'EOF'
 /// Historic bug: the legacy code did
@@ -201,6 +210,60 @@ EOF
 run_case \
   "multi-line doc-comment quoting the Option-chain is not flagged (r2 regression)" \
   "mldoccomment/crates" "" "pass"
+
+# --- Fixture 10: triple-nested parens (heddle#103 new) -------------------
+# Would have bypassed any bounded-depth `[^)]*` arg matcher: r2's regex
+# balanced exactly two levels, so three defeated it. The AST walker
+# parses arbitrary expression depth as a single `Expr::Paren` chain
+# inside the call's arg, and the method name `get_tree` is what we key
+# on — not the arg shape.
+mkdir -p "$fixtures_root/triplenested/crates/foo/src"
+cat > "$fixtures_root/triplenested/crates/foo/src/lib.rs" <<'EOF'
+fn load(repo: &Repository, id: ContentHash) -> Tree {
+    repo.store().get_tree(((id)))?.unwrap_or_default()
+}
+EOF
+run_case \
+  "triple-nested parens get_tree(((id))) is rejected (heddle#103 new)" \
+  "triplenested/crates" "" "fail"
+
+# --- Fixture 11: macro-call wrapper (heddle#103 new) ---------------------
+# Documents the limitation: `syn::parse_file` does not expand macros,
+# so a `get_tree_macro!(h)?.unwrap_or_default()` chain has the macro
+# call as its receiver root, not a `MethodCall` named `get_tree`. The
+# AST walker punts (no flag). This is acceptable: macro-wrapped
+# get_tree sites are rare and surface in code review; if one appears,
+# the macro definition itself can be audited.
+#
+# Verifying the macro-call call site is NOT flagged:
+mkdir -p "$fixtures_root/macrowrapped/crates/foo/src"
+cat > "$fixtures_root/macrowrapped/crates/foo/src/lib.rs" <<'EOF'
+macro_rules! get_tree_macro {
+    ($x:expr) => { repo.store().get_tree($x) };
+}
+
+fn load(h: &ContentHash) -> Tree {
+    get_tree_macro!(h)?.unwrap_or_default()
+}
+EOF
+run_case \
+  "macro-call wrapper is not flagged (documented limitation, heddle#103)" \
+  "macrowrapped/crates" "" "pass"
+
+# --- Fixture 12: raw-string literal embedding the bug shape (heddle#103 new)
+# The regex would false-positive: the bytes `get_tree(x)?.unwrap_or_default()`
+# inside an `r#"..."#` raw-string trip the pattern. AST inspection sees
+# the literal as `Expr::Lit(LitStr)`, not as method calls — no flag.
+mkdir -p "$fixtures_root/rawstring/crates/foo/src"
+cat > "$fixtures_root/rawstring/crates/foo/src/lib.rs" <<'EOF'
+fn describe() -> &'static str {
+    let s = r#"get_tree(x)?.unwrap_or_default()"#;
+    s
+}
+EOF
+run_case \
+  "raw-string literal containing the bug-shape text is not flagged (heddle#103 new)" \
+  "rawstring/crates" "" "pass"
 
 if (( fail )); then
   echo "asserter self-tests FAILED" >&2


### PR DESCRIPTION
## Summary

Replaces `scripts/check-no-silent-default-tree-load.sh`'s regex implementation — which went three rounds of bypass-and-patch (heddle#93 r1/r2/r3) — with a `syn`-based AST walker living in `heddle-devtools`. The walker parses every `.rs` under the search dirs with `syn::parse_file`, visits `ExprMethodCall` nodes, and flags `unwrap_or_default()` / matching `unwrap_or_else` whose receiver chain bottoms out at a `MethodCall` named `get_tree`. AST inspection naturally exempts doc-comments and string literals (they aren't `ExprMethodCall` nodes), so the entire class of regex bypasses goes away.

Closes #103.

## What changed

- **`crates/devtools/src/check_no_silent_default_tree_load.rs`** — new subcommand. ~250 LoC including unit tests for each detection shape and each documented limitation.
- **`crates/devtools/Cargo.toml`** — adds `syn`, `proc-macro2` (with `span-locations`), `walkdir`.
- **`Cargo.toml`** — workspace pins for `syn` (`full, visit, extra-traits`) and `proc-macro2` (`span-locations`).
- **`scripts/check-no-silent-default-tree-load.sh`** — wrapper now pre-builds the binary and dispatches to it. Honours the same env-var contract (`HEDDLE_ASSERTER_SEARCH_DIRS`, `HEDDLE_ASSERTER_ALLOWLIST`).
- **`scripts/test-check-no-silent-default-tree-load.sh`** — fixtures 1..9 inherit verbatim from the regex era; fixtures 10..12 are AST-era additions.
- **`.github/workflows/release-pipeline-check.yml`** — sets up Rust toolchain + cache, pre-builds the binary.

## Fixture parity

All 9 existing fixtures pass against the new tool:

| # | Shape | Verdict |
|---|---|---|
| 1 | single-line `get_tree(x)?.unwrap_or_default()` | flagged |
| 2 | multi-line method chain | flagged |
| 3 | exact `path:line` allowlist match | exempt |
| 4 | allowlist at wrong line | flagged |
| 5 | doc-comment quoting legacy pattern | not flagged |
| 6 | nested-paren arg `get_tree(&normalize(s.tree()))` | flagged |
| 7 | braced closure `unwrap_or_else(\|\| { Tree::new() })` | flagged |
| 8 | Option-chain with long inter-hop gap | flagged |
| 9 | multi-line doc-comment quoting Option-chain | not flagged |

Three new fixtures cover shapes the regex couldn't catch (or false-positived on) at any depth:

| # | Shape | Verdict |
|---|---|---|
| 10 | **triple-nested parens** `get_tree(((id)))?.unwrap_or_default()` — defeats any bounded-depth `[^)]*` arg matcher. AST doesn't care about arg shape. | flagged |
| 11 | **macro-call wrapper** `get_tree_macro!(h)?.unwrap_or_default()` — `syn::parse_file` does not expand macros, so the AST sees `ExprMacro` instead of a `get_tree` `MethodCall`. Documented limitation; the macro definition itself can be audited if one appears. | not flagged |
| 12 | **raw-string literal** embedding the bug-shape text — pre-fix regex would false-positive. AST sees `Expr::Lit(LitStr)`, not method calls. | not flagged |

## Production finding (allowlisted in this PR, follow-up tracked)

The AST walker surfaces a real heddle#90/#93 bug-class site that the regex missed:

- **`crates/mount/src/core.rs:2193`** — chain shape is `store.get_tree(&e.hash).map_err(MountError::Store)?.unwrap_or_default()`. The `?` is on `.map_err(...)`, not directly on `.get_tree(...)`, so the regex's `\${GET_TREE_CALL}\?\s*\.unwrap_or_default` pattern never matched.

To keep this PR scoped to the asserter swap (as the issue body requests), the site is allowlisted in the wrapper's `DEFAULT_ALLOWLIST` with a comment pointing at the eventual fix. **Recommend filing a follow-up issue** to replace it with a `require_tree`-style guard (mirroring the heddle#93 sweep in non-merge paths) and remove the allowlist entry.

## Test plan

- [x] `cargo test -p heddle-devtools` — 13 new unit tests for shape detection (direct, chain-through, Option-chain, closure variants, fn-pointer, nested parens, raw-string, macro punt, unrelated-default exclusion).
- [x] `bash scripts/test-check-no-silent-default-tree-load.sh` — all 12 fixtures pass.
- [x] `bash scripts/check-no-silent-default-tree-load.sh` against real `crates/` — clean (487 files scanned, 1 allowlisted site).
- [x] `cargo clippy -p heddle-devtools --all-targets -- -D warnings` — clean.
- [x] `rustfmt --edition 2024` clean on the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->