### PR TITLE
heddle#121: rust_impl_name pointer-whitespace regression test

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -1325,8 +1325,7 @@ fn rust_impl_name(source: &str, node: Node<'_>) -> Option<String> {
     } else {
         type_name
     };
-    // Strip ALL whitespace from the key so cosmetic reformatting around
-    // `::`, `<>`, etc. doesn't turn into a "different impl"
-    // misclassification (r3 fix `021ed8e`).
-    Some(strip_whitespace(&key))
+    // Normalize whitespace within the key so cosmetic reformatting doesn't
+    // turn into a "different impl" misclassification.
+    Some(key.split_whitespace().collect::<Vec<_>>().join(" "))
 }

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -1325,7 +1325,8 @@ fn rust_impl_name(source: &str, node: Node<'_>) -> Option<String> {
     } else {
         type_name
     };
-    // Normalize whitespace within the key so cosmetic reformatting doesn't
-    // turn into a "different impl" misclassification.
-    Some(key.split_whitespace().collect::<Vec<_>>().join(" "))
+    // Strip ALL whitespace from the key so cosmetic reformatting around
+    // `::`, `<>`, etc. doesn't turn into a "different impl"
+    // misclassification (r3 fix `021ed8e`).
+    Some(strip_whitespace(&key))
 }

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -2107,6 +2107,50 @@ impl std::vec::Vec<T> {
     );
 }
 
+// =====================================================================
+// heddle#121: rust_impl_name's old `split_whitespace().join(" ")` shape
+// kept whitespace attached to punctuation, so reformatting around `*`
+// or `&` (pointer/reference receivers in the `for <type>` slot) yielded
+// distinct impl keys. The `_path_punctuation` sibling above covers
+// `::`/`<>`; this exercises the pointer/reference case the r2-sweep
+// follow-up specifically called out.
+// =====================================================================
+#[test]
+fn rust_impl_name_ignores_whitespace_around_pointer_punctuation() {
+    let base = "\
+struct Foo;
+impl MyTrait for *const Foo {
+    fn alpha() { 1 }
+}
+";
+    // ours reformats whitespace around the `*` in the pointer type —
+    // semantically identical impl, same method body.
+    let ours = "\
+struct Foo;
+impl MyTrait for * const Foo {
+    fn alpha() { 1 }
+}
+";
+    // theirs modifies alpha's body.
+    let theirs = "\
+struct Foo;
+impl MyTrait for *const Foo {
+    fn alpha() { 2 }
+}
+";
+    let outcome = merge_rust(base, ours, theirs);
+    let text = assert_clean(outcome);
+    assert!(
+        text.contains("{ 2 }"),
+        "alpha body should be `2`: {text}"
+    );
+    let alpha_count = text.matches("fn alpha").count();
+    assert_eq!(
+        alpha_count, 1,
+        "expected fn alpha exactly once, got {alpha_count}: {text}"
+    );
+}
+
 #[test]
 fn rust_outer_attribute_does_not_duplicate_when_adjacent_item_deleted() {
     // When one side deletes an item that immediately precedes an


### PR DESCRIPTION
## Summary
- Adds `rust_impl_name_ignores_whitespace_around_pointer_punctuation` regression test covering pointer-receiver whitespace (`*const Foo` vs `* const Foo`) — the r2-sweep case the existing `_path_punctuation` test (covering `::`/`<>`) didn't exercise.
- AC #1 of the issue (replace `split_whitespace().join(" ")` with `strip_whitespace` in `rust_impl_name`) already landed in #114 r3 (commit `841acbf`). This PR demonstrates the fix holds for the pointer/reference case via a proper red→green ceremony: red commit reverts to `split_whitespace` to show the test fails as the issue describes, green commit restores `strip_whitespace`.

Closes HeddleCo/heddle#121

## Red commit
`c8b9253`

## Test evidence
```
$ cargo test -p heddle-semantic --lib rust_impl_name_ignores_whitespace
running 2 tests
test merge_driver::tests::rust_impl_name_ignores_whitespace_around_pointer_punctuation ... ok
test merge_driver::tests::rust_impl_name_ignores_whitespace_around_path_punctuation ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 192 filtered out; finished in 0.00s

$ cargo test -p heddle-semantic --lib
test result: ok. 193 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.14s
```

At red `c8b9253`, both whitespace tests fail with `Conflicts { conflict_count: 1 }` — `*const Foo` and `* const Foo` key to distinct impl scopes, so alpha fragments into add+delete and surfaces as a spurious conflict. At green `20be867`, restoring `strip_whitespace(&key)` collapses both spellings to the same key and the merge resolves cleanly.

## Manual verification
N/A — covered by tests.

## Blocked by → resolved
None — this PR is regression coverage for a fix already in main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->