### PR TITLE
heddle#141/#142/#143: clone-and-bootstrap UX bundle

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1155,7 +1155,71 @@ pub fn clone_url_to_bare(
     if filter.is_some() {
         return clone_url_to_bare_via_git(url, dest, depth, filter);
     }
-    clone_url_to_bare_via_gix(url, dest, depth)
+    clone_url_to_bare_via_gix(url, dest, depth)?;
+    // gix's `init_bare` writes `.git/HEAD = ref: refs/heads/<init.defaultBranch>`
+    // (typically "main" or "master") regardless of what the remote
+    // advertises, and the fetch above doesn't touch HEAD. If we leave
+    // that in place, downstream `select_clone_thread` and
+    // `detect_git_head` will steer the user to a branch the remote may
+    // not even have — observed: cloning ripgrep landed users on
+    // `ag/bstr-migration` (alphabetically first imported thread) when
+    // the remote's actual default is `master`. Honour the remote's
+    // `HEAD` symref when we can resolve it.
+    if let Some(branch) = resolve_remote_default_branch(url)
+        && dest.join("refs").join("heads").join(&branch).exists()
+    {
+        fs::write(dest.join("HEAD"), format!("ref: refs/heads/{branch}\n"))?;
+    }
+    Ok(())
+}
+
+/// Resolve the remote's default branch via `git ls-remote --symref <url> HEAD`.
+///
+/// Returns the short branch name (e.g. `"master"`) when the remote
+/// advertises `HEAD` as a symbolic ref under `refs/heads/`. Returns
+/// `None` on any failure — missing `git` binary, network error,
+/// detached remote HEAD, malformed output — so callers can fall back to
+/// the previous heuristic without breaking.
+///
+/// We shell out rather than re-using the gix fetch handshake because
+/// gix 0.80's high-level builder doesn't surface the symref capability
+/// through the prepare/receive API: the symref metadata is parsed into
+/// per-ref `Mapping`s only as a side-effect of capability negotiation,
+/// and the public `Prepare` doesn't expose it on the gix versions we
+/// pin. `git ls-remote --symref` is a single round trip and is
+/// available wherever the `--filter` path is.
+pub fn resolve_remote_default_branch(url: &gix::Url) -> Option<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--symref"])
+        .arg(url.to_string())
+        .arg("HEAD")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = std::str::from_utf8(&output.stdout).ok()?;
+    parse_symref_head(stdout)
+}
+
+/// Parse the first `ref: refs/heads/<branch>\tHEAD` line from
+/// `git ls-remote --symref` output. Extracted so the parsing rules
+/// (which catch malformed servers and detached HEAD) can be unit-tested
+/// without invoking the git binary.
+fn parse_symref_head(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        let rest = line.strip_prefix("ref: ")?;
+        let (target, label) = rest.split_once('\t')?;
+        if label.trim() != "HEAD" {
+            continue;
+        }
+        let branch = target.strip_prefix("refs/heads/")?;
+        if branch.is_empty() {
+            return None;
+        }
+        return Some(branch.to_string());
+    }
+    None
 }
 
 fn clone_url_to_bare_via_gix(url: &gix::Url, dest: &Path, depth: Option<u32>) -> GitResult<()> {
@@ -1539,4 +1603,111 @@ fn read_receive_pack_status(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_symref_head_reads_branch_from_typical_output() {
+        // Real `git ls-remote --symref <url> HEAD` shape: a `ref:`
+        // symref line followed by the resolved OID/HEAD line.
+        let stdout = "ref: refs/heads/master\tHEAD\n\
+                      9abc123def456\tHEAD\n";
+        assert_eq!(parse_symref_head(stdout), Some("master".to_string()));
+    }
+
+    #[test]
+    fn parse_symref_head_handles_branch_names_with_slashes() {
+        // Cloning into a non-namespaced branch like `feature/foo` is
+        // exotic for a remote default, but the parser must not split
+        // on the first `/` — only on the leading `refs/heads/` prefix.
+        let stdout = "ref: refs/heads/release/v1\tHEAD\n";
+        assert_eq!(parse_symref_head(stdout), Some("release/v1".to_string()));
+    }
+
+    #[test]
+    fn parse_symref_head_returns_none_for_detached_head() {
+        // A remote with detached HEAD doesn't emit a `ref:` line —
+        // only a raw OID. Returning `None` keeps the caller on its
+        // fallback path (alphabetical-first) rather than guessing.
+        let stdout = "9abc123def456\tHEAD\n";
+        assert_eq!(parse_symref_head(stdout), None);
+    }
+
+    #[test]
+    fn parse_symref_head_rejects_symref_to_non_heads_namespace() {
+        // A symref pointing outside `refs/heads/` (e.g. a tag) can't
+        // be honoured by our flow — `select_clone_thread` only
+        // imports `refs/heads/*` as threads, so we'd be pinning HEAD
+        // to a name with no matching thread.
+        let stdout = "ref: refs/tags/v1.0\tHEAD\n";
+        assert_eq!(parse_symref_head(stdout), None);
+    }
+
+    #[test]
+    fn parse_symref_head_returns_none_for_empty_branch_name() {
+        // Defensive: a malformed `ref: refs/heads/\tHEAD` line
+        // shouldn't crash, and shouldn't return an empty string that
+        // would later become an empty thread name.
+        let stdout = "ref: refs/heads/\tHEAD\n";
+        assert_eq!(parse_symref_head(stdout), None);
+    }
+
+    /// heddle#141 regression: when the URL-fetch path of
+    /// `clone_url_to_bare` runs against a bare repo whose `HEAD`
+    /// points at a branch that is *not* alphabetically first (and
+    /// crucially, not what gix's `init_bare` defaults to), the
+    /// resulting dest bare must have `HEAD` pointing at the remote
+    /// default — not gix's init-time guess.
+    #[test]
+    fn clone_url_to_bare_via_gix_honours_remote_head_symref() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let source = tmp.path().join("source.git");
+        let dest = tmp.path().join("dest.git");
+
+        // Build a bare source with two branches under
+        // deliberately-non-default names: `trunk` (will be the
+        // remote default — neither gix's `init.defaultBranch` nor
+        // the alphabetically-first imported ref would land here by
+        // accident) and `abc-feature` (alphabetically first — what
+        // the buggy fallback used to pick).
+        let src = gix::init_bare(&source).expect("init bare source");
+        // Empty tree (well-known OID) so we don't have to build a
+        // tree object explicitly.
+        let empty_tree_oid: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            .parse()
+            .expect("parse empty tree oid");
+        src.commit(
+            "refs/heads/trunk",
+            "seed trunk",
+            empty_tree_oid,
+            gix::commit::NO_PARENT_IDS,
+        )
+        .expect("commit trunk");
+        src.commit(
+            "refs/heads/abc-feature",
+            "seed abc-feature",
+            empty_tree_oid,
+            gix::commit::NO_PARENT_IDS,
+        )
+        .expect("commit abc-feature");
+        // Make sure HEAD on the source points at trunk so
+        // `git ls-remote --symref` reports trunk.
+        std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();
+
+        let url = gix::url::parse(format!("file://{}", source.display()).as_bytes().into())
+            .expect("parse file:// url");
+        clone_url_to_bare(&url, &dest, None, None).expect("clone url to bare");
+
+        let dest_head = std::fs::read_to_string(dest.join("HEAD")).expect("read dest HEAD");
+        assert_eq!(
+            dest_head.trim(),
+            "ref: refs/heads/trunk",
+            "dest HEAD must mirror the remote's symref (trunk), not gix's \
+             init-time default and not the alphabetically-first branch \
+             (abc-feature) — see heddle#141"
+        );
+    }
 }

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1679,20 +1679,41 @@ mod tests {
         let empty_tree_oid: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
             .parse()
             .expect("parse empty tree oid");
-        src.commit(
-            "refs/heads/trunk",
-            "seed trunk",
-            empty_tree_oid,
-            gix::commit::NO_PARENT_IDS,
-        )
-        .expect("commit trunk");
-        src.commit(
-            "refs/heads/abc-feature",
-            "seed abc-feature",
-            empty_tree_oid,
-            gix::commit::NO_PARENT_IDS,
-        )
-        .expect("commit abc-feature");
+        // Use an explicit signature via `new_commit_as` rather than
+        // `Repository::commit`. The latter reads `user.name`/`user.email`
+        // from git config, which CI runners don't set — leading to
+        // `AuthorMissing` errors. The clone path under test doesn't care
+        // who authored these seed commits.
+        let sig = gix::actor::Signature {
+            name: "Heddle Test".into(),
+            email: "heddle@test".into(),
+            time: gix::date::Time {
+                seconds: 0,
+                offset: 0,
+            },
+        };
+        let mut committer_buf = gix::date::parse::TimeBuf::default();
+        let mut author_buf = gix::date::parse::TimeBuf::default();
+        let seed = src
+            .new_commit_as(
+                sig.to_ref(&mut committer_buf),
+                sig.to_ref(&mut author_buf),
+                "seed",
+                empty_tree_oid,
+                gix::commit::NO_PARENT_IDS,
+            )
+            .expect("seed commit")
+            .id;
+        for name in ["refs/heads/trunk", "refs/heads/abc-feature"] {
+            set_reference(
+                &src,
+                name,
+                seed,
+                PreviousValue::Any,
+                "test: seed branch",
+            )
+            .expect("set ref");
+        }
         // Make sure HEAD on the source points at trunk so
         // `git ls-remote --symref` reports trunk.
         std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1056,13 +1056,19 @@ pub struct CloneArgs {
     pub depth: Option<u32>,
 
     /// Leave blob content absent by design and hydrate it explicitly later.
+    /// Supported for hosted/network remotes only; Git-overlay clones
+    /// (plain `https://…/repo.git` URLs and local-path clones) reject
+    /// this flag today and report a clear error — lazy hydration over
+    /// the Git transport is planned for v0.3.1.
     #[arg(long)]
     pub lazy: bool,
 
-    /// Partial-clone filter spec. Currently only `blob:none` is supported,
-    /// which is a synonym for `--lazy` (skip blob content; hydrate on demand
-    /// later). Other git-style filters such as `tree:0` or `blob:limit=…`
-    /// are rejected.
+    /// Partial-clone filter spec. Only `blob:none` is accepted; other
+    /// git-style filters such as `tree:0` or `blob:limit=…` are
+    /// rejected at parse time. On hosted/network remotes `blob:none`
+    /// is a synonym for `--lazy` (skip blob content; hydrate on
+    /// demand). Git-overlay clones reject the flag at runtime; this
+    /// is planned for v0.3.1.
     #[arg(long, value_name = "SPEC", value_parser = parse_clone_filter_spec)]
     pub filter: Option<String>,
 }

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -144,14 +144,18 @@ fn reject_unsupported_for_git_overlay(options: &CloneOptions) -> Result<()> {
     if let Some(filter) = options.filter.as_deref() {
         return Err(anyhow!(
             "--filter {} is not yet supported for Git-overlay clones; \
-             the import step requires all blobs locally. Run a full clone for now.",
+             the import step requires all blobs locally. Run a full clone \
+             for now — lazy hydration over the Git transport is planned \
+             for v0.3.1 (see heddle#143).",
             filter
         ));
     }
     if options.lazy {
         return Err(anyhow!(
             "--lazy is not yet supported for Git-overlay clones; \
-             the import step requires all blobs locally. Run a full clone for now."
+             the import step requires all blobs locally. Run a full clone \
+             for now — lazy hydration over the Git transport is planned \
+             for v0.3.1 (see heddle#143)."
         ));
     }
     if options.depth.is_some() {
@@ -184,15 +188,35 @@ fn finish_git_overlay_clone(
         import_all(&mut bridge, Some(&local_path.join(".git"))).map_err(anyhow::Error::msg)?
     };
 
-    let track_name = select_clone_thread(&repo, options.thread.as_deref())?;
-    repo.refs().write_head(&Head::Attached {
-        thread: track_name.clone(),
-    })?;
+    let track_name = select_clone_thread(
+        &repo,
+        options.thread.as_deref(),
+        read_git_head_branch(&local_path.join(".git")).as_deref(),
+    )?;
     let state_id = repo
         .refs()
         .get_thread(&track_name)?
         .ok_or_else(|| anyhow!("Git clone did not import branch '{}'", track_name))?;
+    // Materialize the imported tip *while HEAD is still on the
+    // init-time default* — `goto` writes `Head::Detached`, which is
+    // fine here because we re-attach immediately below. Switching to
+    // `fast_forward_attached` would mis-advance whichever thread HEAD
+    // happens to be on at this point (the seeded `main`, not the
+    // cloned thread).
     repo.goto(&state_id)?;
+    // Re-attach HEAD to the cloned thread, AND mirror the choice into
+    // `.git/HEAD`. `Repository::open` on a git-overlay repo
+    // unconditionally syncs heddle's HEAD from `.git/HEAD` via
+    // `detect_git_head`, so if we left `.git/HEAD` pointing at gix's
+    // init-time default ("main" / "master") the very next `heddle`
+    // command would silently reset HEAD to a thread that doesn't
+    // exist — and `current_state` would return `None`, causing
+    // `heddle log` to snapshot a "Bootstrap git-overlay before
+    // viewing log" state instead of walking the imported history.
+    repo.refs().write_head(&Head::Attached {
+        thread: track_name.clone(),
+    })?;
+    write_git_head_branch(&local_path.join(".git"), &track_name)?;
 
     if should_output_json(cli, Some(repo.config())) {
         println!(
@@ -240,11 +264,40 @@ fn write_git_overlay_origin(local_path: &Path, remote_label: &str) -> Result<()>
     Ok(())
 }
 
-fn select_clone_thread(repo: &Repository, requested: Option<&str>) -> Result<String> {
+/// Pick which imported branch the clone should land on.
+///
+/// Priority order:
+///
+/// 1. `--thread <name>` if the user asked for one explicitly. We
+///    trust the user even if the name doesn't match a thread yet —
+///    the subsequent `get_thread` lookup will surface a clear error.
+/// 2. The branch the remote advertises as `HEAD` (passed in via
+///    `git_head_branch_hint`, read from `.git/HEAD` after the bare
+///    clone — `git clone --bare` and our `clone_url_to_bare` +
+///    `git ls-remote --symref` path both mirror the remote's
+///    symref). This is what fixes heddle#141: cloning ripgrep should
+///    land on `master`, not the alphabetically-first imported branch
+///    `ag/bstr-migration`.
+/// 3. `"main"` if present — preserves the long-standing UX for
+///    repos that *do* have a `main` branch but somehow lack a
+///    `.git/HEAD` symref (e.g. transports that don't surface one).
+/// 4. Alphabetically first imported thread, as a last resort. We
+///    deliberately keep this fallback because erroring out on an
+///    unhinted clone would be worse than landing on a working ref.
+fn select_clone_thread(
+    repo: &Repository,
+    requested: Option<&str>,
+    git_head_branch_hint: Option<&str>,
+) -> Result<String> {
     if let Some(requested) = requested {
         return Ok(requested.to_string());
     }
     let threads = repo.refs().list_threads()?;
+    if let Some(hint) = git_head_branch_hint
+        && threads.iter().any(|thread| thread == hint)
+    {
+        return Ok(hint.to_string());
+    }
     if threads.iter().any(|thread| thread == "main") {
         return Ok("main".to_string());
     }
@@ -252,6 +305,30 @@ fn select_clone_thread(repo: &Repository, requested: Option<&str>) -> Result<Str
         .into_iter()
         .next()
         .ok_or_else(|| anyhow!("Git clone did not import any branch refs"))
+}
+
+/// Read `.git/HEAD` as a symbolic ref into `refs/heads/`, returning
+/// the bare branch name. Returns `None` for detached HEAD, malformed
+/// files, or symrefs outside `refs/heads/` — none of which can drive
+/// thread selection.
+fn read_git_head_branch(git_dir: &Path) -> Option<String> {
+    let contents = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let trimmed = contents.trim();
+    let suffix = trimmed.strip_prefix("ref: ")?;
+    let branch = suffix.strip_prefix("refs/heads/")?;
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch.to_string())
+    }
+}
+
+/// Pin `.git/HEAD` to `refs/heads/<branch>`. Called after clone so a
+/// future `Repository::open` reads the same branch heddle attached to,
+/// rather than the init-time default gix wrote (typically `main`).
+fn write_git_head_branch(git_dir: &Path, branch: &str) -> Result<()> {
+    fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n"))?;
+    Ok(())
 }
 
 async fn clone_local(

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -217,28 +217,49 @@ fn test_cli_clone_git_overlay_lands_on_remote_default_branch_and_log_walks_histo
     let empty_tree: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         .parse()
         .expect("parse empty tree oid");
-    let trunk_first = src
-        .commit(
-            "refs/heads/trunk",
-            "seed trunk",
+    // Use an explicit signature via `new_commit_as` rather than
+    // `Repository::commit`. The latter reads `user.name`/`user.email`
+    // from git config, which CI runners don't set — leading to
+    // `AuthorMissing` errors. The clone path under test doesn't care
+    // who authored these seed commits.
+    let sig = gix::actor::Signature {
+        name: "Heddle Test".into(),
+        email: "heddle@test".into(),
+        time: gix::date::Time {
+            seconds: 0,
+            offset: 0,
+        },
+    };
+    let commit_as = |message: &str, parents: Vec<gix::ObjectId>| -> gix::ObjectId {
+        let mut committer_buf = gix::date::parse::TimeBuf::default();
+        let mut author_buf = gix::date::parse::TimeBuf::default();
+        src.new_commit_as(
+            sig.to_ref(&mut committer_buf),
+            sig.to_ref(&mut author_buf),
+            message,
             empty_tree,
-            gix::commit::NO_PARENT_IDS,
+            parents,
         )
-        .expect("commit trunk seed");
-    src.commit(
+        .expect("commit succeeds")
+        .id
+    };
+    let trunk_first = commit_as("seed trunk", vec![]);
+    let trunk_tip = commit_as("advance trunk", vec![trunk_first]);
+    let abc_feature = commit_as("seed abc-feature", vec![]);
+    src.reference(
         "refs/heads/trunk",
-        "advance trunk",
-        empty_tree,
-        [trunk_first],
+        trunk_tip,
+        gix::refs::transaction::PreviousValue::Any,
+        "test: seed trunk",
     )
-    .expect("commit trunk tip");
-    src.commit(
+    .expect("set trunk ref");
+    src.reference(
         "refs/heads/abc-feature",
-        "seed abc-feature",
-        empty_tree,
-        gix::commit::NO_PARENT_IDS,
+        abc_feature,
+        gix::refs::transaction::PreviousValue::Any,
+        "test: seed abc-feature",
     )
-    .expect("commit abc-feature");
+    .expect("set abc-feature ref");
     std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();
 
     let source_arg = source.to_str().expect("source path utf8");

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -189,6 +189,105 @@ fn test_cli_clone_git_overlay_lazy_is_rejected() {
     );
 }
 
+/// heddle#141 + heddle#142 regression: cloning a git repo whose `HEAD`
+/// points at a branch that is not alphabetically first must (1) land
+/// the user on the remote's actual default branch and (2) leave
+/// `heddle log` walking the imported history, not just a freshly
+/// minted bootstrap state.
+///
+/// We exercise the local-overlay path (`copy_local_repo_to_bare`)
+/// because it's hermetic. The URL-overlay path has its own unit-level
+/// regression in `bridge::git_core::tests` that verifies
+/// `clone_url_to_bare` mirrors the remote symref into `.git/HEAD`,
+/// which is what feeds the same `select_clone_thread` selection
+/// logic this test pins.
+#[test]
+fn test_cli_clone_git_overlay_lands_on_remote_default_branch_and_log_walks_history() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.git");
+    let work = temp.path().join("work");
+
+    // Build a bare git source with `trunk` (the default, with two
+    // commits so we can confirm log walks history) and
+    // `abc-feature` (alphabetically first — the trap heddle#141 used
+    // to fall into). Branch names deliberately avoid `main`/`master`
+    // so neither gix's `init.defaultBranch` nor the previous
+    // fallback could land here by accident.
+    let src = gix::init_bare(&source).expect("init bare source");
+    let empty_tree: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        .parse()
+        .expect("parse empty tree oid");
+    let trunk_first = src
+        .commit(
+            "refs/heads/trunk",
+            "seed trunk",
+            empty_tree,
+            gix::commit::NO_PARENT_IDS,
+        )
+        .expect("commit trunk seed");
+    src.commit(
+        "refs/heads/trunk",
+        "advance trunk",
+        empty_tree,
+        [trunk_first],
+    )
+    .expect("commit trunk tip");
+    src.commit(
+        "refs/heads/abc-feature",
+        "seed abc-feature",
+        empty_tree,
+        gix::commit::NO_PARENT_IDS,
+    )
+    .expect("commit abc-feature");
+    std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();
+
+    let source_arg = source.to_str().expect("source path utf8");
+    let work_arg = work.to_str().expect("work path utf8");
+    let output = heddle(&["clone", source_arg, work_arg], None).expect("clone succeeds");
+    assert!(
+        output.contains("trunk"),
+        "clone output should advertise the chosen branch (trunk): {output}"
+    );
+
+    // heddle#141: HEAD should land on `trunk`, not the
+    // alphabetically-first `abc-feature`.
+    let heddle_head =
+        std::fs::read_to_string(work.join(".heddle").join("HEAD")).expect("read heddle HEAD");
+    assert_eq!(
+        heddle_head.trim(),
+        "ref: trunk",
+        "heddle HEAD must attach to the remote's default branch (trunk), \
+         not the alphabetically-first imported branch (abc-feature) — \
+         see heddle#141. Got: {heddle_head:?}"
+    );
+
+    // heddle#142: log must walk the imported history, not surface a
+    // freshly-minted bootstrap state. Two trunk commits → two real
+    // states (the synthetic `heddle init` root is filtered).
+    let log_json = heddle(&["log", "--output", "json"], Some(&work)).expect("log succeeds");
+    let parsed: serde_json::Value = serde_json::from_str(&log_json).expect("log json parses");
+    let states = parsed
+        .get("states")
+        .and_then(|s| s.as_array())
+        .expect("log output has a states array");
+    assert!(
+        states.len() >= 2,
+        "heddle log should walk the imported trunk history (>=2 states), \
+         not just a fresh bootstrap snapshot — see heddle#142. \
+         States: {states:#?}"
+    );
+    let bootstrap_only = states.len() == 1
+        && states[0]
+            .get("intent")
+            .and_then(|v| v.as_str())
+            .is_some_and(|intent| intent.contains("Bootstrap git-overlay"));
+    assert!(
+        !bootstrap_only,
+        "heddle log surfaced only the synthetic bootstrap state — \
+         this is the heddle#142 failure mode. States: {states:#?}"
+    );
+}
+
 #[test]
 fn test_cli_clone_git_overlay_filter_is_rejected() {
     // Issue 49 / 20b: same shape as --depth / --lazy — `--filter` is
@@ -310,12 +409,11 @@ fn test_cli_fetch_local_creates_remote_thread_and_marker() {
     assert!(heddle(&["fetch", "origin"], Some(local.path())).is_ok());
 
     let repo = Repository::open(local.path()).unwrap();
-    assert!(
-        repo.refs()
-            .get_remote_thread("origin", "main")
-            .unwrap()
-            .is_some()
-    );
+    assert!(repo
+        .refs()
+        .get_remote_thread("origin", "main")
+        .unwrap()
+        .is_some());
     assert!(repo.refs().get_marker("v1.0").unwrap().is_some());
 }
 


### PR DESCRIPTION
## Summary

Bundle three P0 findings from the 2026-05-20 OSS UX review that all hit the same `clone.rs` surface in the first 30 seconds of a new user's `heddle clone <url>` experience. Filing as one PR avoids inter-agent merge conflicts; each finding is independently testable and independently load-bearing.

### heddle#141 — picks alphabetically-first remote branch

`gix::init_bare` writes `.git/HEAD = ref: refs/heads/<init.defaultBranch>` (typically `main`), and the subsequent `prepare_fetch` doesn't touch HEAD. `select_clone_thread` then fell back to alphabetical-first (`ag/bstr-migration` on ripgrep) because the gix-written HEAD pointed at a branch that wasn't actually imported.

**Fix:** resolve the remote's `HEAD` symref via `git ls-remote --symref <url> HEAD` after the gix fetch and write the result into the bare's `HEAD`. `select_clone_thread` now consults `.git/HEAD` as a hint (priority: `--thread` flag → git HEAD hint → `main` → alphabetical first).

### heddle#142 — `heddle log` shows only the bootstrap state

Root cause discovered while wiring #141: the clone wrote heddle's `HEAD = Attached{thread}` and then called `repo.goto(state_id)` which unconditionally writes `Head::Detached`. The next `heddle` invocation hit the git-overlay branch in `Repository::open` (`repository.rs:596–610`) that re-syncs heddle's HEAD from `.git/HEAD` — which still pointed at gix's init-time default, a branch with no thread ref. `current_state` returned `None`, `cmd_log` minted a "Bootstrap git-overlay before viewing log" snapshot, and the imported 2249 commits never appeared in log.

**Fix:** after `goto`, re-attach heddle's HEAD to the chosen thread *and* pin `.git/HEAD` to match, so the open-time re-sync is a no-op.

### heddle#143 — `--filter blob:none` / `--lazy` advertised but rejected

Picked **option (b)** from the brief: clarify `--help` text and runtime error wording to call out the hosted/network-only scope, and point at v0.3.1 for Git-overlay support.

**Why not option (a)?** Implementing real lazy Git-overlay clones requires persisting a blake3↔git-OID sidecar that `GitOverlayBlobHydrator` (in `clone.rs`) already documents as future work — the in-memory `blob_oid_map` it relies on is populated only by the in-process importer, so `MissingObject` would surface on the very next `heddle <verb>` after clone. Shipping option (a) in v0.3.0 would require landing the sidecar persistence too; that's a P1-sized scope of its own. Option (b) preserves the honest UX and unblocks the v0.3.0 cut.

If the orchestrator wants to align messaging differently — e.g. drop the `--filter`/`--lazy` flags from `--help` entirely for Git-overlay-only builds, or pull the v0.3.1 promise back to "future" — happy to follow up. README/AGENTS.md/ARCHITECTURE.md already frame partial clone as Planned, so no doc sweep needed for option (b).

## Test plan

Tests added in this PR:
- [x] `bridge::git_core::tests::parse_symref_head_*` — 5 unit cases pin the `git ls-remote --symref` parser (typical, slashed branch names, detached, non-heads-namespace, malformed empty)
- [x] `bridge::git_core::tests::clone_url_to_bare_via_gix_honours_remote_head_symref` — URL-fetch path writes remote symref into bare HEAD (hermetic file:// fixture with deliberately-non-default branch names)
- [x] `remotes::test_cli_clone_git_overlay_lands_on_remote_default_branch_and_log_walks_history` — end-to-end CLI regression for both heddle#141 (HEAD lands on `trunk`, not alphabetically-first `abc-feature`) and heddle#142 (`heddle log` walks ≥2 imported states, never the bootstrap-only failure mode)

Pre-flight on this branch:
- [x] `cargo build -p heddle-cli`
- [x] `cargo test -p heddle-cli` — full suite, all tests passing
- [x] `cargo test -p heddle-cli --test cli_integration remotes::` — 15/15
- [x] `cargo clippy -p heddle-cli --tests -- -D warnings`

Manual smoke (not in CI; documented for reviewers):
- [ ] `heddle clone https://github.com/BurntSushi/ripgrep ripgrep-heddle` lands on `master`, `cat ripgrep-heddle/.heddle/HEAD` shows `ref: master`, `heddle log` walks ripgrep's history
- [ ] `heddle clone --filter blob:none https://github.com/BurntSushi/ripgrep x` rejects with the updated "planned for v0.3.1" message
- [ ] `heddle clone --help` reflects the hosted/network-only scope for `--filter`/`--lazy`

Closes #141, closes #142, closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->