### PR TITLE
heddle#144: preview merges against current HEAD, not thread.target_thread

### DIFF
--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -281,6 +281,16 @@ pub(crate) fn merge_thread_into_current(
     } else {
         merge_algo::MergeStrategy::HunkOnly
     };
+    let current_thread = repo
+        .current_lane()?
+        .unwrap_or_else(|| "detached".to_string());
+    // heddle#144: the inner preview report MUST compute its 3-way merge
+    // against the actual destination of *this* merge (the operator's
+    // current HEAD), not `thread.target_thread`. Otherwise running
+    // `heddle merge A` from a thread B whose tip diverges from A's
+    // recorded target (often `main`) yields a preview whose
+    // `preview_summary` line claims one outcome while the apply path
+    // produces another.
     let preview_report = match thread.as_mut() {
         Some(thread) => Some(build_thread_preview_report_with_graph(
             repo,
@@ -288,13 +298,14 @@ pub(crate) fn merge_thread_into_current(
             thread,
             preview,
             preview_strategy,
+            Some(PreviewTarget {
+                label: &current_thread,
+                change_id: current_state.change_id,
+            }),
         )?),
         None => None,
     };
     let preview_summary = build_preview_summary(preview_report.as_ref());
-    let current_thread = repo
-        .current_lane()?
-        .unwrap_or_else(|| "detached".to_string());
     let current_label = format!("CURRENT ({current_thread})");
     let incoming_label = format!("INCOMING ({track_name})");
     let merge_plan = MergePlan::for_merge_command(
@@ -1185,7 +1196,21 @@ pub(crate) fn build_thread_preview_report(
         thread,
         prefer_apply_recommendation,
         merge_algo::MergeStrategy::HunkOnly,
+        None,
     )
+}
+
+/// Caller-supplied override for the destination side of the preview's
+/// 3-way merge. When `Some`, the inner preview MUST compute against
+/// this `(label, change_id)` instead of `thread.target_thread`. Used by
+/// `merge_thread_into_current` so the preview matches the actual merge
+/// — `heddle merge A` from thread B merges A → B, but A's
+/// `target_thread` is whatever A was created from (often `main`), so
+/// without an override the inner report computes A → main and
+/// contradicts the real outcome (heddle#144).
+pub(crate) struct PreviewTarget<'a> {
+    pub label: &'a str,
+    pub change_id: ChangeId,
 }
 
 fn build_thread_preview_report_with_graph(
@@ -1194,19 +1219,32 @@ fn build_thread_preview_report_with_graph(
     thread: &mut Thread,
     prefer_apply_recommendation: bool,
     strategy: MergeStrategy,
+    target_override: Option<PreviewTarget<'_>>,
 ) -> Result<ThreadPreviewReport> {
     refresh_thread_freshness(repo, thread)?;
     let mut conflicts = Vec::new();
-    let semantic_result = if let Some(target_thread) = thread.target_thread.as_deref() {
-        let target_id = repo
+    // Resolve the destination side. Prefer the caller's override (the
+    // merge command supplies the actual current HEAD); otherwise fall
+    // back to `thread.target_thread` for callers like `ready` / `sync` /
+    // `ship` that don't carry an explicit merge destination.
+    let resolved_target: Option<(String, ChangeId)> = if let Some(ovr) = target_override {
+        Some((ovr.label.to_string(), ovr.change_id))
+    } else if let Some(name) = thread.target_thread.as_deref() {
+        let id = repo
             .refs()
-            .get_thread(target_thread)?
-            .ok_or_else(|| anyhow!("Target thread '{}' not found", target_thread))?;
+            .get_thread(name)?
+            .ok_or_else(|| anyhow!("Target thread '{}' not found", name))?;
+        Some((name.to_string(), id))
+    } else {
+        None
+    };
+
+    let semantic_result = if let Some((target_label, target_id)) = resolved_target {
         let thread_id = repo
             .refs()
             .get_thread(&thread.thread)?
             .ok_or_else(|| anyhow!("Thread '{}' not found", thread.thread))?;
-        let current_label = format!("CURRENT ({target_thread})");
+        let current_label = format!("CURRENT ({target_label})");
         let incoming_label = format!("INCOMING ({})", thread.thread);
         let merge_plan = MergePlan::for_thread_preview(
             repo,

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -2066,3 +2066,98 @@ fn test_thread_refresh_routes_through_semantic_driver_on_structural_reshape() {
         "thread refresh with disjoint AST-level edits must succeed via the semantic merge driver: {refresh:?}"
     );
 }
+
+/// heddle#144: `heddle merge X --preview` must agree with the real merge
+/// outcome on the same inputs. Prior to the fix, the preview report's
+/// inner merge plan was computed against `thread X`'s `target_thread`
+/// (the destination thread *X intends to merge into*, i.e. the thread X
+/// was created from). When the operator runs `merge X` from a DIFFERENT
+/// current thread — e.g. on `B`, merging `A` whose `target_thread` is
+/// `main` — the inner preview computed `A → main` (often a clean
+/// fast-forward) while the actual merge_plan and apply path computed
+/// `A → B`. The two halves of the preview output disagreed:
+/// `preview_summary` line `semantic preview: <inner-result>` said one
+/// thing while the top-level `semantic_result` / `conflicts` said
+/// another. Worst case the inner-side claim of "clean / fast_forward"
+/// led an operator to expect a successful merge that then surfaced
+/// path conflicts at apply time.
+///
+/// The invariant under test: within a single `--preview` run, the
+/// `preview_summary` semantic-preview line MUST agree with the
+/// top-level `semantic_result`. And running the same merge for real
+/// must produce the same `semantic_result` the preview reported.
+#[test]
+fn test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let src = temp.path().join("calc.py");
+    fs::write(
+        &src,
+        "def multiply(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+    // Thread A: rename `multiply` -> `product`. target_thread = main.
+    heddle(&["thread", "create", "A"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "A"], Some(temp.path())).unwrap();
+    fs::write(
+        &src,
+        "def product(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "A: rename multiply -> product"], Some(temp.path())).unwrap();
+
+    // Thread B from main: rewrite `multiply`'s body. The operator's
+    // current thread when running `merge A` will be B, not main — so
+    // `A.target_thread` (main) differs from the real destination (B).
+    heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+    heddle(&["thread", "create", "B"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "B"], Some(temp.path())).unwrap();
+    fs::write(&src, "def multiply(a, b):\n    return a * b\n").unwrap();
+    heddle(&["capture", "-m", "B: rewrite multiply body"], Some(temp.path())).unwrap();
+
+    // Preview the merge from B.
+    let preview_out = heddle(
+        &["--output", "json", "merge", "A", "--preview", "--semantic", "--with-diff"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let preview: Value = serde_json::from_str(&preview_out).expect("preview must emit JSON");
+    let preview_semantic = preview["semantic_result"].as_str().unwrap_or("");
+    let preview_summary: Vec<&str> = preview["preview_summary"]
+        .as_array()
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    let semantic_preview_line = preview_summary
+        .iter()
+        .find_map(|line| line.strip_prefix("semantic preview: "))
+        .unwrap_or("");
+
+    // Invariant #1 (internal consistency): the `semantic preview: X` line
+    // emitted by the preview MUST match the top-level `semantic_result`
+    // on the same preview. Pre-fix this fails: the inner report keys off
+    // `thread.target_thread` (main) so it says `fast_forward` while the
+    // outer plan correctly says `path_conflicts` (or vice versa).
+    assert_eq!(
+        semantic_preview_line, preview_semantic,
+        "preview_summary's semantic-preview line must agree with top-level semantic_result; \
+         got summary line {semantic_preview_line:?} but top-level {preview_semantic:?}. \
+         Full preview: {preview}"
+    );
+
+    // Invariant #2 (preview vs reality): the real merge run on the same
+    // inputs must produce the same `semantic_result` the preview reported.
+    let real_out = heddle(
+        &["--output", "json", "merge", "A", "--semantic", "-m", "merge"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let real: Value = serde_json::from_str(&real_out).expect("real merge must emit JSON");
+    assert_eq!(
+        preview["semantic_result"], real["semantic_result"],
+        "preview's semantic_result must equal the real merge's semantic_result on identical inputs. \
+         preview={}, real={}",
+        preview["semantic_result"], real["semantic_result"]
+    );
+}


### PR DESCRIPTION
## Summary

- `heddle merge A --preview` was running two parallel 3-way merges with different destinations: an inner one keyed off `thread.target_thread` and an outer one keyed off the real current HEAD.
- When the operator wasn't sitting on A's recorded target, the two halves of the same preview disagreed — `preview_summary: ["semantic preview: fast_forward"]` next to `semantic_result: "path_conflicts"` is the shape the issue reports.
- Threading the merge command's real destination into `build_thread_preview_report_with_graph` via an optional `PreviewTarget` override makes the inner preview compute the same merge as the apply path. Other callers (`ready`, `sync`, `ship`) keep their `thread.target_thread` fallback — they don't carry an explicit merge destination.

Closes HeddleCo/heddle#144

## Red commit

`b6206a9fc288e26c7e00e7f7c03cbc1e27fe60ab`

## Test evidence

```
$ cargo test --package heddle-cli --test state_management --features semantic merge::
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out; finished in 3.77s
```

Pre-fix the new test `test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread` failed with:
```
left:  "fast_forward"
right: "path_conflicts"
```
Post-fix it passes alongside the rest of the suite.

Full `cargo test -p heddle-cli --features semantic` run: all 311 unit + every integration test green; `cargo clippy --features semantic --all-targets -- -D warnings` clean.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None — independent fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->