### PR TITLE
heddle#149: heddle history as visible alias for heddle log

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -215,6 +215,7 @@ Examples:
     /// --first-parent <branch>`. To see every ancestor reachable through
     /// merge commits, pass `--graph` (which renders the full DAG) or
     /// `--all` (which lists every state regardless of ancestry).
+    #[command(visible_alias = "history")]
     Log(LogArgs),
 
     /// Show state details.

--- a/crates/cli/tests/core_functionality/log_and_errors.rs
+++ b/crates/cli/tests/core_functionality/log_and_errors.rs
@@ -91,3 +91,24 @@ fn test_log_path_filter_rejects_parent_traversal() {
     let result = heddle(&["log", "--path", "../secret"], Some(temp.path()));
     assert!(result.is_err());
 }
+
+/// `heddle history` is a discoverability alias for `heddle log`.
+///
+/// `history` is the verb users reach for first when they want to see
+/// state history; the OSS UX review (heddle#149) caught that it was
+/// missing and clap suggested unrelated commands. The alias keeps the
+/// natural verb working without splitting the implementation.
+#[test]
+fn test_history_alias_for_log() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "first").unwrap();
+    heddle_must_succeed(&["capture", "-m", "First"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "second").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Second"], temp.path());
+
+    let log_out = heddle(&["log", "--json"], Some(temp.path())).unwrap();
+    let history_out = heddle(&["history", "--json"], Some(temp.path()))
+        .expect("`heddle history` should be accepted as an alias for `heddle log`");
+    assert_eq!(log_out, history_out);
+}


### PR DESCRIPTION
## Summary
- Add `#[command(visible_alias = "history")]` on the `Log` variant in `crates/cli/src/cli/cli_args/commands_main.rs` so `heddle history` is accepted as the natural verb for state history.
- Resolves the OSS UX-review repro: `heddle history` previously bounced with `unrecognized subcommand 'history'` and clap's similarity suggestions pointed at unrelated verbs (`monitor`, `git-overlay`, `store`).
- Implementation is shared with `heddle log` — no code duplication, no schema/JSON surface change.

Closes HeddleCo/heddle#149

## Red commit
`d73b224`

## Test evidence
```
$ cargo test -p heddle-cli --test core_functionality log_and_errors
running 8 tests
test log_and_errors::test_operations_outside_repo ... ok
test log_and_errors::test_log_path_filter_rejects_parent_traversal ... ok
test log_and_errors::test_invalid_command_arguments ... ok
test log_and_errors::test_snapshot_empty_repo ... ok
test log_and_errors::test_log_json_output ... ok
test log_and_errors::test_log_reverse_order ... ok
test log_and_errors::test_history_alias_for_log ... ok
test log_and_errors::test_log_path_filter_shows_only_matching_history ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out
```

Full suite: 86 passed in core_functionality, clippy clean with `-D warnings`.

## Manual verification
N/A — covered by `test_history_alias_for_log`, which asserts `heddle history --json` succeeds and produces byte-identical output to `heddle log --json` against the same repo state.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->