### PR TITLE
heddle#153: surface --semantic per-symbol deltas at top level of merge JSON

### DIFF
--- a/crates/cli/src/cli/commands/diff/mod.rs
+++ b/crates/cli/src/cli/commands/diff/mod.rs
@@ -6,4 +6,4 @@ mod diff_output;
 mod diff_types;
 
 pub use diff_compute::{cmd_diff, compute_state_diff};
-pub use diff_types::DiffOutput;
+pub use diff_types::{DiffOutput, SemanticChangeEntry};

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -16,7 +16,7 @@ use repo::{
 use serde::Serialize;
 
 use super::{
-    diff::{DiffOutput, compute_state_diff},
+    diff::{DiffOutput, SemanticChangeEntry, compute_state_diff},
     operator_core::OperatorCommandOutput,
     snapshot::ensure_current_state,
     thread_cmd::refresh_thread_freshness,
@@ -89,6 +89,18 @@ pub(crate) struct MergeOutput {
     renames: Vec<RenameEntry>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     directory_renames: Vec<RenameEntry>,
+    /// Per-symbol deltas produced by the semantic driver
+    /// (function_renamed, function_added, function_deleted,
+    /// signature_changed, etc.). Present when `--semantic` is set so
+    /// agents can detect that semantic analysis ran and act on the
+    /// rename/symbol mapping programmatically without parsing the
+    /// line-by-line `diff` payload. Absent (not `null`) when
+    /// `--semantic` is not set — that's the unambiguous "semantic mode
+    /// was not honored" signal. An empty array means "semantic ran but
+    /// found no symbol-level deltas" (e.g. non-source files or a
+    /// no-op fast-forward).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_changes: Option<Vec<SemanticChangeEntry>>,
     /// Diff between the parent's tip and the thread's tip. Populated
     /// only when the caller passes `--with-diff`. On a successful
     /// non-preview merge the from/to are the pre-merge parent tip and
@@ -128,6 +140,11 @@ struct MergeOutputInput<'a> {
     /// the operator's final `blockers` list and force `status` to
     /// `"blocked"` even when the heddle merge itself completed.
     extra_blockers: Vec<String>,
+    /// Top-level mirror of `diff.semantic_changes`. Threaded through
+    /// `MergeOutputInput` so every return path sets it consistently
+    /// (instead of relying on each call site to remember). See the
+    /// field doc on `MergeOutput::semantic_changes`.
+    semantic_changes: Option<Vec<SemanticChangeEntry>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -337,6 +354,24 @@ pub(crate) fn merge_thread_into_current(
         }
         Ok(Some(compute_state_diff(repo, from, to, semantic, 3)?))
     };
+    // heddle#153: surface per-symbol deltas at the top level so agents
+    // can detect that semantic analysis ran and act on the rename
+    // mapping without digging into `diff.semantic_changes`. We derive
+    // this from the (already-computed) diff payload when both
+    // `--semantic` and `--with-diff` are set; without `--with-diff` the
+    // diff isn't computed at all, so there's nothing to mirror. Use
+    // `Some(vec![])` (not `None`) on the with-diff+semantic path even
+    // when the driver found no symbol changes, so consumers can branch
+    // on field presence to detect "semantic mode honored".
+    let top_level_semantic = |diff: Option<&DiffOutput>| -> Option<Vec<SemanticChangeEntry>> {
+        if !semantic || !with_diff {
+            return None;
+        }
+        Some(
+            diff.and_then(|d| d.semantic_changes.clone())
+                .unwrap_or_default(),
+        )
+    };
 
     if merge_plan.relation().kind() == MergeRelationKind::AlreadyUpToDate {
         // Already-up-to-date means the merge doesn't write anything — the
@@ -361,6 +396,7 @@ pub(crate) fn merge_thread_into_current(
             merge_state: None,
             fast_forward: false,
             preview_only: preview,
+            semantic_changes: top_level_semantic(already_up_to_date_diff.as_ref()),
             diff: already_up_to_date_diff,
             git_commit_preview: None,
             git_commit: None,
@@ -409,6 +445,7 @@ pub(crate) fn merge_thread_into_current(
                 merge_state: None,
                 fast_forward: false,
                 preview_only: preview,
+                semantic_changes: top_level_semantic(ff_diff.as_ref()),
                 diff: ff_diff,
                 git_commit_preview: None,
                 git_commit: None,
@@ -569,6 +606,7 @@ pub(crate) fn merge_thread_into_current(
                 .unwrap_or_else(|| "clean".to_string()),
             renames: vec![],
             directory_renames: vec![],
+            semantic_changes: top_level_semantic(ff_diff.as_ref()),
             diff: ff_diff,
             git_commit_preview: git_commit_preview_payload,
             git_commit: git_commit_info,
@@ -641,6 +679,7 @@ pub(crate) fn merge_thread_into_current(
             merge_state: None,
             fast_forward: false,
             preview_only: true,
+            semantic_changes: top_level_semantic(preview_diff.as_ref()),
             diff: preview_diff,
             git_commit_preview,
             git_commit: None,
@@ -680,6 +719,7 @@ pub(crate) fn merge_thread_into_current(
             merge_state: None,
             fast_forward: false,
             preview_only: false,
+            semantic_changes: top_level_semantic(conflict_diff.as_ref()),
             diff: conflict_diff,
             git_commit_preview: None,
             git_commit: None,
@@ -712,6 +752,7 @@ pub(crate) fn merge_thread_into_current(
             merge_state: None,
             fast_forward: false,
             preview_only: false,
+            semantic_changes: top_level_semantic(no_commit_diff.as_ref()),
             diff: no_commit_diff,
             git_commit_preview: None,
             git_commit: None,
@@ -779,6 +820,7 @@ pub(crate) fn merge_thread_into_current(
             merge_state: None,
             fast_forward: false,
             preview_only: false,
+            semantic_changes: top_level_semantic(blocked_diff.as_ref()),
             diff: blocked_diff,
             git_commit_preview: None,
             git_commit: None,
@@ -875,6 +917,7 @@ pub(crate) fn merge_thread_into_current(
         merge_state: Some(new_state.change_id.short()),
         fast_forward: false,
         preview_only: false,
+        semantic_changes: top_level_semantic(committed_diff.as_ref()),
         diff: committed_diff,
         git_commit_preview: None,
         git_commit: git_commit_info,
@@ -1442,6 +1485,7 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
             .unwrap_or_else(|| "active".to_string()),
         renames: input.renames,
         directory_renames: input.directory_renames,
+        semantic_changes: input.semantic_changes,
         diff: input.diff,
         git_commit_preview: input.git_commit_preview,
         git_commit: input.git_commit,

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -2161,3 +2161,102 @@ fn test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread() {
         preview["semantic_result"], real["semantic_result"]
     );
 }
+
+/// heddle#153: `merge --preview --with-diff --semantic --output json` must
+/// surface symbol-level deltas at a discoverable location, not bury them
+/// inside `diff` where agents consuming the JSON miss them.
+///
+/// The bug premise: when the semantic driver detects a function rename
+/// (e.g. `multiply` -> `product`), the JSON should carry the rename
+/// record so agents can act on it programmatically. The data was being
+/// emitted only inside `diff.semantic_changes`, which is easy to overlook
+/// — and absent from the JSON entirely when `--with-diff` isn't passed.
+///
+/// Contract under test: with `--semantic` set, the merge output JSON
+/// includes a top-level `semantic_changes` array carrying the per-symbol
+/// delta entries, populated even when `--with-diff` isn't requested.
+#[test]
+fn test_merge_semantic_surfaces_top_level_symbol_deltas_on_rename() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let src = temp.path().join("calc.py");
+    fs::write(
+        &src,
+        "def multiply(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+    heddle(&["thread", "create", "A"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "A"], Some(temp.path())).unwrap();
+    fs::write(
+        &src,
+        "def product(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "rename multiply -> product"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+
+    let out = heddle(
+        &[
+            "--output", "json", "merge", "A", "--preview", "--with-diff", "--semantic",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let parsed: Value = serde_json::from_str(&out).expect("merge --output json must be JSON");
+
+    // Top-level `semantic_changes` is the contract: agents shouldn't have
+    // to dig into `diff` to find symbol-level deltas. Its presence is
+    // also the signal that the semantic driver ran at all.
+    let semantic_changes = parsed
+        .get("semantic_changes")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| {
+            panic!(
+                "--semantic merge must surface top-level `semantic_changes` array: {parsed}"
+            )
+        });
+    let rename = semantic_changes
+        .iter()
+        .find(|c| c["change_type"] == "function_renamed")
+        .unwrap_or_else(|| {
+            panic!(
+                "top-level `semantic_changes` must include a `function_renamed` entry on a rename: {parsed}"
+            )
+        });
+    assert_eq!(
+        rename["old_name"], "multiply",
+        "rename entry must carry old name: {rename}"
+    );
+    assert_eq!(
+        rename["new_name"], "product",
+        "rename entry must carry new name: {rename}"
+    );
+    assert_eq!(
+        rename["path"], "calc.py",
+        "rename entry must carry the file path: {rename}"
+    );
+}
+
+/// heddle#153: when `--semantic` is NOT set, the top-level
+/// `semantic_changes` field must be absent (not `null`, not `[]`). That's
+/// the unambiguous "semantic mode was not honored" signal — consumers
+/// can branch on field presence alone.
+#[test]
+fn test_merge_without_semantic_omits_top_level_symbol_deltas() {
+    let temp = TempDir::new().unwrap();
+    create_simple_feature_thread(&temp);
+
+    let out = heddle(
+        &["--output", "json", "merge", "feature", "--preview", "--with-diff"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let parsed: Value = serde_json::from_str(&out).expect("merge --output json must be JSON");
+
+    assert!(
+        parsed.get("semantic_changes").is_none(),
+        "top-level `semantic_changes` must be absent when --semantic is not set: {parsed}"
+    );
+}

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -158,10 +158,12 @@ fn test_continue_after_manual_marker_removal_says_mark_file_resolved() {
         blocked_continue["recommended_action"],
         "heddle resolve file.txt"
     );
-    assert!(blocked_continue["message"]
-        .as_str()
-        .unwrap()
-        .contains("mark each file resolved with `heddle resolve <path>`"));
+    assert!(
+        blocked_continue["message"]
+            .as_str()
+            .unwrap()
+            .contains("mark each file resolved with `heddle resolve <path>`")
+    );
 
     heddle(&["resolve", "file.txt"], Some(temp.path())).unwrap();
     let continued = heddle(&["--json", "continue"], Some(temp.path())).unwrap();
@@ -1862,8 +1864,14 @@ fn test_merge_semantic_resolves_disjoint_function_edits_clean() {
         !merged.contains("<<<<<<<"),
         "disjoint function edits must not leave conflict markers under --semantic: {merged}"
     );
-    assert!(merged.contains("fn alpha() -> u32 { 11 }"), "alpha edit lost: {merged}");
-    assert!(merged.contains("fn gamma() -> u32 { 333 }"), "gamma edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() -> u32 { 11 }"),
+        "alpha edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn gamma() -> u32 { 333 }"),
+        "gamma edit lost: {merged}"
+    );
 }
 
 #[test]
@@ -1929,7 +1937,11 @@ fn test_merge_semantic_preview_summary_matches_semantic_plan_on_structural_resha
         "fn d() { let x = 4; }\nfn c() { let x = 3; }\nfn b() { let x = 22; }\nfn a() { let x = 1; }\n",
     )
     .unwrap();
-    heddle(&["capture", "-m", "feature: reorder + edit b"], Some(temp.path())).unwrap();
+    heddle(
+        &["capture", "-m", "feature: reorder + edit b"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     // main: edit `d` only.
     heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
@@ -1971,16 +1983,17 @@ fn test_merge_semantic_preview_summary_matches_semantic_plan_on_structural_resha
     let preview_summary = parsed["preview_summary"]
         .as_array()
         .expect("preview_summary must be an array");
-    let summary_strings: Vec<&str> = preview_summary
-        .iter()
-        .filter_map(|v| v.as_str())
-        .collect();
+    let summary_strings: Vec<&str> = preview_summary.iter().filter_map(|v| v.as_str()).collect();
     assert!(
-        !summary_strings.iter().any(|line| line.starts_with("conflicts:")),
+        !summary_strings
+            .iter()
+            .any(|line| line.starts_with("conflicts:")),
         "preview_summary must not report conflicts when --semantic plan is clean: {summary_strings:?}"
     );
     assert!(
-        !summary_strings.iter().any(|line| line.starts_with("blocked:")),
+        !summary_strings
+            .iter()
+            .any(|line| line.starts_with("blocked:")),
         "preview_summary must not report blocked when --semantic plan is clean: {summary_strings:?}"
     );
 }
@@ -2106,7 +2119,11 @@ fn test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread() {
         "def product(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
     )
     .unwrap();
-    heddle(&["capture", "-m", "A: rename multiply -> product"], Some(temp.path())).unwrap();
+    heddle(
+        &["capture", "-m", "A: rename multiply -> product"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     // Thread B from main: rewrite `multiply`'s body. The operator's
     // current thread when running `merge A` will be B, not main — so
@@ -2115,11 +2132,23 @@ fn test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread() {
     heddle(&["thread", "create", "B"], Some(temp.path())).unwrap();
     heddle(&["thread", "switch", "B"], Some(temp.path())).unwrap();
     fs::write(&src, "def multiply(a, b):\n    return a * b\n").unwrap();
-    heddle(&["capture", "-m", "B: rewrite multiply body"], Some(temp.path())).unwrap();
+    heddle(
+        &["capture", "-m", "B: rewrite multiply body"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     // Preview the merge from B.
     let preview_out = heddle(
-        &["--output", "json", "merge", "A", "--preview", "--semantic", "--with-diff"],
+        &[
+            "--output",
+            "json",
+            "merge",
+            "A",
+            "--preview",
+            "--semantic",
+            "--with-diff",
+        ],
         Some(temp.path()),
     )
     .unwrap();
@@ -2149,7 +2178,15 @@ fn test_merge_preview_agrees_with_real_merge_when_run_from_non_target_thread() {
     // Invariant #2 (preview vs reality): the real merge run on the same
     // inputs must produce the same `semantic_result` the preview reported.
     let real_out = heddle(
-        &["--output", "json", "merge", "A", "--semantic", "-m", "merge"],
+        &[
+            "--output",
+            "json",
+            "merge",
+            "A",
+            "--semantic",
+            "-m",
+            "merge",
+        ],
         Some(temp.path()),
     )
     .unwrap();
@@ -2194,12 +2231,22 @@ fn test_merge_semantic_surfaces_top_level_symbol_deltas_on_rename() {
         "def product(a, b):\n    result = 0\n    for _ in range(b):\n        result += a\n    return result\n",
     )
     .unwrap();
-    heddle(&["capture", "-m", "rename multiply -> product"], Some(temp.path())).unwrap();
+    heddle(
+        &["capture", "-m", "rename multiply -> product"],
+        Some(temp.path()),
+    )
+    .unwrap();
     heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
 
     let out = heddle(
         &[
-            "--output", "json", "merge", "A", "--preview", "--with-diff", "--semantic",
+            "--output",
+            "json",
+            "merge",
+            "A",
+            "--preview",
+            "--with-diff",
+            "--semantic",
         ],
         Some(temp.path()),
     )
@@ -2213,9 +2260,7 @@ fn test_merge_semantic_surfaces_top_level_symbol_deltas_on_rename() {
         .get("semantic_changes")
         .and_then(|v| v.as_array())
         .unwrap_or_else(|| {
-            panic!(
-                "--semantic merge must surface top-level `semantic_changes` array: {parsed}"
-            )
+            panic!("--semantic merge must surface top-level `semantic_changes` array: {parsed}")
         });
     let rename = semantic_changes
         .iter()
@@ -2249,7 +2294,14 @@ fn test_merge_without_semantic_omits_top_level_symbol_deltas() {
     create_simple_feature_thread(&temp);
 
     let out = heddle(
-        &["--output", "json", "merge", "feature", "--preview", "--with-diff"],
+        &[
+            "--output",
+            "json",
+            "merge",
+            "feature",
+            "--preview",
+            "--with-diff",
+        ],
         Some(temp.path()),
     )
     .unwrap();


### PR DESCRIPTION
## Summary

- Adds `semantic_changes` as a top-level field on `MergeOutput` so agents consuming `heddle merge --preview --with-diff --semantic --output json` can see rename / symbol mappings (e.g. `function_renamed: multiply -> product`) without digging into `diff.semantic_changes`.
- The field is `Some(vec![])` when `--semantic --with-diff` is set but no symbol-level deltas were found — so consumers can branch on field presence to detect that semantic mode was honored. Absent (not `null`) when `--semantic` is not passed.
- The data was already computed inside `compute_state_diff`; this only hoists it to a discoverable location and threads it through every `MergeOutputInput` call site.

Closes HeddleCo/heddle#153

## Red commit

`04c9ea2`

## Test evidence

```
running 2 tests
test merge::test_merge_semantic_surfaces_top_level_symbol_deltas_on_rename ... ok
test merge::test_merge_without_semantic_omits_top_level_symbol_deltas ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 73 filtered out
```

Full `cargo test -p heddle-cli --test state_management -- merge::` run: 43 passed, 0 failed (no regressions in the existing merge test suite).

## Manual verification

N/A — covered by tests. The bug-reporter scenario (rename `multiply` -> `product`, then `merge A --preview --with-diff --semantic --output json`) now emits:

```json
"semantic_changes": [
  {
    "change_type": "function_renamed",
    "description": "Function renamed: multiply -> product in calc.py",
    "path": "calc.py",
    "old_name": "multiply",
    "new_name": "product"
  }
]
```

at the top level of the JSON, in addition to the existing `diff.semantic_changes` mirror.

## Blocked by → resolved

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->