### PR TITLE
heddle#152: don't shell out to git status against a bare embedded .git

### DIFF
--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1014,6 +1014,20 @@ impl Repository {
         if self.capability() != RepositoryCapability::GitOverlay {
             return Ok(None);
         }
+        // heddle#152: `heddle clone <url>` writes `.git/` as a bare
+        // mirror (`gix::init_bare`), so the embedded git has no
+        // working tree. Shelling out to `git -C <root> status
+        // --porcelain` then fails with "fatal: this operation must be
+        // run in a work tree" and surfaces as
+        // `Error: configuration error: git status failed at '...'`.
+        // When the embedded git is bare, report "no overlay status
+        // available" so callers fall back to heddle's own
+        // tree-compare path.
+        if let Ok(git_repo) = gix::open(&self.root)
+            && git_repo.workdir().is_none()
+        {
+            return Ok(None);
+        }
 
         let output = Command::new("git")
             .arg("-C")

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -7,8 +7,8 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use crate::{
-    ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, ThreadFreshness,
-    ThreadManager, WorktreeIndex,
+    ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
+    ThreadFreshness, ThreadManager, WorktreeIndex,
 };
 
 fn create_test_repo() -> (TempDir, Repository) {
@@ -1034,6 +1034,38 @@ fn test_open_preserves_explicit_detached_head_in_git_overlay() {
         head
     );
     assert_eq!(reopened.head().unwrap(), Some(state1.change_id));
+}
+
+/// Regression for heddle#152: `heddle clone <url>` produces a directory
+/// whose embedded `.git/` is a bare mirror (no working tree). Shelling
+/// out to `git -C <root> status --porcelain` then fails with
+/// "fatal: this operation must be run in a work tree" and surfaces as
+/// `Error: configuration error: git status failed at '...'` on
+/// `heddle status`. The accessor must instead report "no overlay
+/// status available" (`Ok(None)`) so callers fall back to heddle's own
+/// tree-compare path.
+#[test]
+fn git_overlay_worktree_status_is_none_when_embedded_git_is_bare() {
+    let temp_dir = TempDir::new().unwrap();
+    let git_dir = temp_dir.path().join(".git");
+    gix::init_bare(&git_dir).expect("init bare .git");
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    assert_eq!(
+        repo.capability(),
+        RepositoryCapability::GitOverlay,
+        "presence of .git/HEAD flips capability to GitOverlay"
+    );
+
+    let status = repo.git_overlay_worktree_status();
+    assert!(
+        matches!(status, Ok(None)),
+        "bare embedded .git must yield Ok(None); got {}",
+        match &status {
+            Ok(Some(_)) => "Ok(Some(..))".to_string(),
+            Ok(None) => "Ok(None)".to_string(),
+            Err(error) => format!("Err({error})"),
+        }
+    );
 }
 
 /// Regression: `op_scope` must not embed the user's absolute filesystem


### PR DESCRIPTION
## Summary
- `heddle clone <url>` writes `.git/` as a bare mirror (no working tree); shelling out to `git -C <root> status --porcelain` from `Repository::git_overlay_worktree_status` then errored with `fatal: this operation must be run in a work tree`, surfacing as `Error: configuration error: git status failed at '...'` on `heddle status` (and `diff`/`ready`/`diagnose`/`snapshot`, which all call the same accessor).
- Detect the bare layout up front via `gix::open(...).workdir().is_none()` and return `Ok(None)` — existing callers already handle `None` by falling back to heddle's own tree-compare path.

Closes HeddleCo/heddle#152

## Red commit
`2e2cceb4ae258a34edb89695fd96e7014c6aefc6`

## Test evidence
```
$ cargo test -p heddle-repo git_overlay_worktree_status_is_none_when_embedded_git_is_bare

running 1 test
test repository::repository_tests::git_overlay_worktree_status_is_none_when_embedded_git_is_bare ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 287 filtered out

$ cargo test -p heddle-repo
test result: ok. 288 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Manual verification
Reproduced the issue body's repro against the new binary:

```
$ heddle clone https://github.com/BurntSushi/ripgrep x
$ cd x
$ heddle status
Heddle status for master
Repository: git-overlay (git+heddle-sidecar)
Git import: 14 other branch(es) are still Git-only (ag/bstr-migration, ag/changelog, …)

Thread: master
Health: clean
Coordination: clean
…
Next step: heddle bridge git import

Nothing to capture, worktree clean
```

Before the fix this exited with `Error: configuration error: git status failed at '/tmp/x': fatal: this operation must be run in a work tree`.

## Blocked by → resolved
N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->