### PR TITLE
heddle#154: promote clone/show/goto/thread to everyday help surface

### DIFF
--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -437,6 +437,23 @@ mod tests {
         }
     }
 
+    /// Regression: heddle#154. OSS UX review flagged that `clone`,
+    /// `show`, `goto`, and `thread` are first-reach verbs for new
+    /// users but were hidden behind `heddle help advanced`. Promote
+    /// them onto the everyday surface so a first-time user discovers
+    /// them at the top.
+    #[test]
+    fn everyday_verbs_surface_first_reach_commands() {
+        let everyday: std::collections::HashSet<&str> = everyday_verbs().iter().copied().collect();
+        for verb in ["clone", "show", "goto", "thread"] {
+            assert!(
+                everyday.contains(verb),
+                "`{verb}` is a first-reach verb but is not advertised on \
+                 the everyday surface"
+            );
+        }
+    }
+
     #[test]
     fn hidden_aliases_are_hidden() {
         for verb in ["gc", "index", "monitor"] {

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -17,8 +17,9 @@
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tier {
-    /// Front-door verbs: `init, start, capture, merge, log, status,
-    /// review, discuss, annotate, switch, undo, bridge`.
+    /// Front-door verbs: `init, clone, start, capture, merge, log,
+    /// status, show, goto, thread, review, discuss, context, undo,
+    /// bridge`. See [`everyday_verbs`] for the authoritative list.
     Everyday,
     /// Reachable via `heddle help advanced` or `heddle help <topic>`.
     /// Most agent-loop and operational verbs land here.
@@ -33,8 +34,14 @@ pub enum Tier {
 pub fn tier_of(verb: &str) -> Tier {
     match verb {
         // ── Everyday ──────────────────────────────────────────────
-        "init" | "start" | "capture" | "merge" | "log" | "status" | "review" | "discuss"
-        | "context" | "switch" | "undo" | "bridge" | "help" => Tier::Everyday,
+        // `clone`, `show`, `goto`, `thread` were promoted from
+        // Advanced after OSS UX review flagged them as first-reach
+        // verbs that a new user reaches for before reading the
+        // advanced page (heddle#154).
+        "init" | "clone" | "start" | "capture" | "merge" | "log" | "status" | "show" | "goto"
+        | "thread" | "review" | "discuss" | "context" | "switch" | "undo" | "bridge" | "help" => {
+            Tier::Everyday
+        }
         // The curated everyday set includes `annotate`. Heddle today
         // exposes annotation management under `context`
         // (set/get/list/edit). Map the missing front-door intent to
@@ -52,14 +59,13 @@ pub fn tier_of(verb: &str) -> Tier {
         // (Biscuit-gated `redact:repo`/`purge:repo` capabilities);
         // they're explicitly NOT everyday verbs.
         "abort" | "agent" | "actor" | "attempt" | "auth" | "bisect" | "blame" | "checkpoint"
-        | "cherry-pick" | "clean" | "clone" | "collapse" | "compare" | "completion"
-        | "conflict" | "continue" | "daemon" | "delegate" | "diagnose" | "diff" | "doctor"
-        | "fetch" | "fork" | "fsck" | "git-overlay" | "goto" | "hook" | "inspect"
-        | "integration" | "maintenance" | "marker" | "presence" | "pull" | "purge" | "push"
-        | "query" | "ready" | "rebase" | "redact" | "redo" | "remote" | "resolve" | "retro"
-        | "revert" | "run" | "schemas" | "semantic" | "session" | "shell" | "ship" | "show"
-        | "stash" | "store" | "support" | "sync" | "thread" | "try" | "version" | "watch"
-        | "workspace" => Tier::Advanced,
+        | "cherry-pick" | "clean" | "collapse" | "compare" | "completion" | "conflict"
+        | "continue" | "daemon" | "delegate" | "diagnose" | "diff" | "doctor" | "fetch"
+        | "fork" | "fsck" | "git-overlay" | "hook" | "inspect" | "integration" | "maintenance"
+        | "marker" | "presence" | "pull" | "purge" | "push" | "query" | "ready" | "rebase"
+        | "redact" | "redo" | "remote" | "resolve" | "retro" | "revert" | "run" | "schemas"
+        | "semantic" | "session" | "shell" | "ship" | "stash" | "store" | "support" | "sync"
+        | "try" | "version" | "watch" | "workspace" => Tier::Advanced,
 
         // ── Hidden ────────────────────────────────────────────────
         // `transaction` is hidden in alpha — buffered-op replay at
@@ -83,8 +89,8 @@ pub fn tier_of(verb: &str) -> Tier {
 /// here means there's a single source of truth for command summaries.
 pub fn everyday_verbs() -> &'static [&'static str] {
     &[
-        "init", "start", "capture", "merge", "log", "status", "review", "discuss", "context",
-        "undo", "bridge",
+        "init", "clone", "start", "capture", "merge", "log", "status", "show", "goto", "thread",
+        "review", "discuss", "context", "undo", "bridge",
     ]
 }
 
@@ -98,7 +104,6 @@ pub fn advanced_verbs() -> &'static [&'static str] {
         "agent",
         "daemon",
         "hook",
-        "thread",
         "fork",
         "collapse",
         "compare",
@@ -117,7 +122,6 @@ pub fn advanced_verbs() -> &'static [&'static str] {
         "redo",
         "revert",
         "clean",
-        "goto",
         "ready",
         "ship",
         "checkpoint",
@@ -131,10 +135,8 @@ pub fn advanced_verbs() -> &'static [&'static str] {
         "workspace",
         "integration",
         "maintenance",
-        "clone",
         "auth",
         "diagnose",
-        "show",
         "query",
         "session",
         "actor",
@@ -263,16 +265,16 @@ pub fn topic_text(topic: &str) -> Option<&'static str> {
 
 const ADVANCED_HELP: &str = "Advanced verbs — see `heddle help advanced` for the complete list.\n\
 \n\
-The default `heddle help` curates the everyday surface (init, start, capture, merge,\n\
-log, status, review, discuss, context, undo, bridge). Everything else lives behind\n\
-this topic and `heddle help <verb> --help` for the full clap-derived docs.\n\
+The default `heddle help` curates the everyday surface (init, clone, start, capture,\n\
+merge, log, status, show, goto, thread, review, discuss, context, undo, bridge).\n\
+Everything else lives behind this topic and `heddle help <verb> --help` for the full\n\
+clap-derived docs.\n\
 \n\
 This is intentional. The everyday surface stays minimal so first-time users aren't\n\
 overwhelmed; agents and power users reach for the advanced affordances when they\n\
 need them.\n";
 
-const DAEMON_TOPIC: &str =
-    "Two daemons — both have legitimate uses; they are not interchangeable.\n\
+const DAEMON_TOPIC: &str = "Two daemons — both have legitimate uses; they are not interchangeable.\n\
 \n\
 `heddle daemon`        — FUSE mount-daemon control plane. Owns FUSE sessions for\n\
                          `--workspace virtualized --daemon` threads. Linux only.\n\
@@ -286,8 +288,7 @@ const DAEMON_TOPIC: &str =
                          peer-cred check enforced. Out of scope for first ship:\n\
                          multi-user, remote, TLS.\n";
 
-const OPERATION_IDS_TOPIC: &str =
-    "Idempotency — every state-changing call accepts a `client_operation_id`.\n\
+const OPERATION_IDS_TOPIC: &str = "Idempotency — every state-changing call accepts a `client_operation_id`.\n\
 \n\
 The same id replayed with the same body returns the original outcome\n\
 bit-identical; with a different body it returns FAILED_PRECONDITION.\n\
@@ -426,8 +427,7 @@ mod tests {
     /// users unable to discover the verb they were told to run.
     #[test]
     fn advanced_verbs_lists_tip_referenced_commands() {
-        let advanced: std::collections::HashSet<&str> =
-            advanced_verbs().iter().copied().collect();
+        let advanced: std::collections::HashSet<&str> = advanced_verbs().iter().copied().collect();
         for verb in ["query", "checkpoint", "continue", "abort"] {
             assert!(
                 advanced.contains(verb),

--- a/crates/cli/tests/cli_integration/refs_and_history.rs
+++ b/crates/cli/tests/cli_integration/refs_and_history.rs
@@ -338,15 +338,20 @@ fn test_cli_help_shows_thread_surface() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
 
-    // `ready` and `thread` live in the Advanced tier; the
-    // default help is curated to the everyday surface. The thread-
-    // surface terminology guarantee is still load-bearing: neither
-    // tier should resurrect the legacy `worktree`/`lane` verbs.
-    let help = heddle(&["help", "advanced"], Some(temp.path())).unwrap();
-    assert!(help.contains("ready"));
-    assert!(help.contains("\n  thread"));
-    assert!(!help.contains("\n  worktree"));
-    assert!(!help.contains("\n  lane"));
+    // `thread` was promoted onto the everyday surface (heddle#154)
+    // because new users reach for it before reading the advanced
+    // page. `ready` remains advanced. The thread-surface
+    // terminology guarantee is still load-bearing: neither tier
+    // should resurrect the legacy `worktree`/`lane` verbs.
+    let everyday = heddle(&["help"], Some(temp.path())).unwrap();
+    assert!(everyday.contains("\n  thread"));
+    assert!(!everyday.contains("\n  worktree"));
+    assert!(!everyday.contains("\n  lane"));
+
+    let advanced = heddle(&["help", "advanced"], Some(temp.path())).unwrap();
+    assert!(advanced.contains("ready"));
+    assert!(!advanced.contains("\n  worktree"));
+    assert!(!advanced.contains("\n  lane"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Promote `clone`, `show`, `goto`, `thread` from the Advanced tier onto the everyday surface (OSS UX review, 2026-05-20).
- Retier the four verbs in `tier_of`, add them to `everyday_verbs()` in editorial order, and remove them from `advanced_verbs()` so the lists stay disjoint.
- Update the `Tier::Everyday` doc-comment and the `ADVANCED_HELP` parenthetical that names the everyday surface.
- Update the `test_cli_help_shows_thread_surface` integration assertion to expect `thread` under default help instead of under `help advanced`; keep the `worktree`/`lane` non-resurrection guard across both tiers.

Closes HeddleCo/heddle#154

## Red commit
`e0e95cf2a9974a0059218d0b4ed6378a5810ffe7`

## Test evidence
```
$ cargo test -p heddle-cli --lib cli::help
running 8 tests
test cli::help::tests::everyday_verbs_in_curated_list_have_everyday_tier ... ok
test cli::help::tests::hidden_aliases_are_hidden ... ok
test cli::help::tests::tier_of_advanced_verbs_classifies_correctly ... ok
test cli::help::tests::topic_text_returns_some_for_advertised_topics ... ok
test cli::help::tests::everyday_verbs_surface_first_reach_commands ... ok
test cli::help::tests::advanced_verbs_lists_tip_referenced_commands ... ok
test cli::help::tests::topic_text_returns_none_for_unknown ... ok
test cli::help::tests::verb_blurbs_resolve_from_clap ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 311 filtered out

$ cargo test -p heddle-cli --test cli_integration refs_and_history::test_cli_help_shows_thread_surface
test refs_and_history::test_cli_help_shows_thread_surface ... ok
test result: ok. 1 passed; 0 failed
```

The new `everyday_verbs_surface_first_reach_commands` test was the red one (e0e95cf); it asserts that `clone`, `show`, `goto`, and `thread` appear in `everyday_verbs()`. Pre-existing tier-consistency tests (`everyday_verbs_in_curated_list_have_everyday_tier`, `tier_of_advanced_verbs_classifies_correctly`) cover the retiering both ways.

## Manual verification
N/A — covered by tests.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->