### PR TITLE
heddle#159: alias `capture --message` to `--intent`

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1352,6 +1352,41 @@ pub struct WatchArgs {
 // originals and we re-added them mid-rebase). Removed.
 
 #[cfg(test)]
+mod capture_message_alias_tests {
+    use clap::Parser;
+
+    use crate::cli::{Cli, Commands, SnapshotArgs};
+
+    fn parse_capture(extra: &[&str]) -> Result<SnapshotArgs, clap::Error> {
+        let mut argv: Vec<&str> = vec!["heddle", "capture"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(argv)?;
+        match cli.command {
+            Commands::Capture(args) => Ok(args),
+            _ => panic!("expected Commands::Capture"),
+        }
+    }
+
+    #[test]
+    fn capture_accepts_message_alias() {
+        let args = parse_capture(&["--message", "my change"]).expect("--message should parse");
+        assert_eq!(args.intent.as_deref(), Some("my change"));
+    }
+
+    #[test]
+    fn capture_accepts_intent_long_form() {
+        let args = parse_capture(&["--intent", "my change"]).expect("--intent should parse");
+        assert_eq!(args.intent.as_deref(), Some("my change"));
+    }
+
+    #[test]
+    fn capture_accepts_short_m() {
+        let args = parse_capture(&["-m", "my change"]).expect("-m should parse");
+        assert_eq!(args.intent.as_deref(), Some("my change"));
+    }
+}
+
+#[cfg(test)]
 mod clone_filter_tests {
     use clap::Parser;
 

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -118,7 +118,7 @@ Examples:
 ")]
 pub struct SnapshotArgs {
     /// Natural language intent for this recoverable step.
-    #[arg(short = 'm', long)]
+    #[arg(short = 'm', long, visible_alias = "message")]
     pub intent: Option<String>,
 
     /// Confidence level (0.0-1.0).


### PR DESCRIPTION
## Summary
- `heddle capture --message "my change"` previously failed with `UnknownArgument`; only `-m` and `--intent` were accepted.
- Add `visible_alias = "message"` to `SnapshotArgs.intent` so git muscle memory works.
- Brings the surface in line with the `-m`/`--message`/`--intent` row in the short-flag table in `crates/cli/src/cli/cli_args/cli_base.rs:15`.

Closes HeddleCo/heddle#159

## Red commit
`6e0a8834a77f1e07284d8a50f356287db2c98b84`

## Test evidence
```
running 3 tests
test cli::cli_args::commands_args::capture_message_alias_tests::capture_accepts_intent_long_form ... ok
test cli::cli_args::commands_args::capture_message_alias_tests::capture_accepts_short_m ... ok
test cli::cli_args::commands_args::capture_message_alias_tests::capture_accepts_message_alias ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 318 filtered out; finished in 0.01s
```

Full `cargo test -p heddle-cli --lib`: `321 passed; 0 failed`.

## Manual verification
N/A — covered by tests.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->