### PR TITLE
heddle#158: drop internal context from bridge git import --ref help

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_bridge.rs
+++ b/crates/cli/src/cli/cli_args/commands_bridge.rs
@@ -98,10 +98,9 @@ pub enum GitCommands {
         #[arg(short, long, value_parser = parse_git_source)]
         path: Option<GitSource>,
 
-        /// Optional ref names to import (default: all branches/tags).
-        /// Codex's git-overlay foundation added this flag to scope
-        /// imports to a specific branch or remote-tracking ref —
-        /// kept here on the rebase onto main.
+        /// Ref names to import (repeatable). Scopes the import to the
+        /// listed branches or remote-tracking refs; omit to import all
+        /// branches and tags.
         #[arg(long = "ref", value_name = "REF")]
         refs: Vec<String>,
     },

--- a/crates/cli/src/cli/cli_args/commands_bridge.rs
+++ b/crates/cli/src/cli/cli_args/commands_bridge.rs
@@ -99,8 +99,8 @@ pub enum GitCommands {
         path: Option<GitSource>,
 
         /// Ref names to import (repeatable). Scopes the import to the
-        /// listed branches or remote-tracking refs; omit to import all
-        /// branches and tags.
+        /// listed branches, tags, or remote-tracking refs; omit to
+        /// import all branches and tags.
         #[arg(long = "ref", value_name = "REF")]
         refs: Vec<String>,
     },


### PR DESCRIPTION
## Summary
- Rewrite the `--ref` clap doc-comment on `heddle bridge git import` to describe what the flag does, dropping the internal references to "Codex's git-overlay foundation" and "the rebase onto main".
- Behavior unchanged; this is a help-string-only change.

Closes HeddleCo/heddle#158

## Red commit
N/A — docs-only change (clap doc-comment).

## Test evidence
\`\`\`
$ cargo run -p heddle-cli --quiet -- bridge git import --help | grep -A1 '\-\-ref'
      --ref <REF>
          Ref names to import (repeatable). Scopes the import to the listed branches or remote-tracking refs; omit to import all branches and tags
\`\`\`

Full \`cargo build -p heddle-cli\` succeeds.

## Manual verification
Ran \`heddle bridge git import --help\` and confirmed the new wording is free of internal team / process references and accurately describes the flag.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->