### PR TITLE
heddle#160: label freshly-initialized worktree 'uncaptured', not 'dirty_worktree'

### DIFF
--- a/crates/cli/src/cli/commands/diagnose.rs
+++ b/crates/cli/src/cli/commands/diagnose.rs
@@ -8,7 +8,8 @@ use chrono::Utc;
 use objects::object::Tree;
 use repo::{
     GitRemoteTrackingStatus, Repository, RepositoryOperationStatus, Thread, ThreadFreshness,
-    ThreadImpactCategory, ThreadMode, ThreadState, describe_thread_advice,
+    ThreadImpactCategory, ThreadMode, ThreadState, describe_thread_advice_with_initial,
+    is_synthetic_root,
 };
 use serde::Serialize;
 
@@ -178,7 +179,11 @@ pub(crate) fn build_diagnose_output(cli: &Cli, include_profile: bool) -> Result<
         });
     let thread_summary_ms = thread_summary_start.elapsed().as_millis();
 
-    let health = diagnose_health(&repo, current_summary, changes.total > 0);
+    let initial_state = current_state
+        .as_ref()
+        .map(is_synthetic_root)
+        .unwrap_or(true);
+    let health = diagnose_health(&repo, current_summary, changes.total > 0, initial_state);
     let workspace = diagnose_workspace(&summaries);
     let thread = current_summary.map(diagnose_thread);
     let state = current_state.as_ref().map(|state| DiagnoseStateOutput {
@@ -296,10 +301,13 @@ fn diagnose_health(
     repo: &Repository,
     current_summary: Option<&ThreadSummary>,
     worktree_dirty: bool,
+    initial_state: bool,
 ) -> DiagnoseHealthOutput {
     let Some(summary) = current_summary else {
         return DiagnoseHealthOutput {
-            status: if worktree_dirty {
+            status: if worktree_dirty && initial_state {
+                "uncaptured"
+            } else if worktree_dirty {
                 "dirty_worktree"
             } else {
                 "detached"
@@ -352,7 +360,8 @@ fn diagnose_health(
         auto: false,
         shared_target_dir: None,
     };
-    let advice = describe_thread_advice(&thread, worktree_dirty, 0, false);
+    let advice =
+        describe_thread_advice_with_initial(&thread, worktree_dirty, 0, false, initial_state);
     DiagnoseHealthOutput {
         status: advice.thread_health,
         blockers: advice.blockers,

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -12,7 +12,8 @@ use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use repo::{
     AgentUsageSummary, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus, Thread,
-    ThreadFreshness, ThreadImpactCategory, ThreadMode, ThreadState, describe_thread_advice,
+    ThreadFreshness, ThreadImpactCategory, ThreadMode, ThreadState,
+    describe_thread_advice_with_initial, is_synthetic_root,
 };
 #[cfg(feature = "client")]
 use serde::Deserialize;
@@ -540,9 +541,13 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         auto: false,
         shared_target_dir: None,
     });
-    let advice = thread_stub
+    let initial_state = current_state
         .as_ref()
-        .map(|thread| describe_thread_advice(thread, has_changes, 0, false));
+        .map(is_synthetic_root)
+        .unwrap_or(true);
+    let advice = thread_stub.as_ref().map(|thread| {
+        describe_thread_advice_with_initial(thread, has_changes, 0, false, initial_state)
+    });
     let output = StatusOutput {
         blockers: advice
             .as_ref()

--- a/crates/cli/tests/cli_integration/misc.rs
+++ b/crates/cli/tests/cli_integration/misc.rs
@@ -50,11 +50,63 @@ fn test_cli_diagnose_json_profile() {
     assert_eq!(parsed["thread"]["name"], "main");
     assert_eq!(parsed["changes"]["added"].as_array().unwrap().len(), 1);
     assert_eq!(parsed["changes"]["total"], 1);
-    assert_eq!(parsed["health"]["status"], "dirty_worktree");
+    assert_eq!(parsed["health"]["status"], "uncaptured");
     assert_eq!(parsed["health"]["recommended_action"], "heddle capture");
     assert!(
         parsed["profile"]["total_ms"].is_number(),
         "profile should include total_ms: {parsed}"
+    );
+}
+
+/// After `heddle init` on a fresh repo, the worktree differs from the
+/// (empty) seeded state purely because nothing has been captured yet —
+/// reporting that as `dirty_worktree` reads as a problem on first
+/// impression. Label it `uncaptured` instead. The recommended action
+/// (`heddle capture`) stays the same. See heddle#160.
+#[test]
+fn status_reports_uncaptured_for_freshly_initialized_repo() {
+    let temp = TempDir::new().unwrap();
+
+    let status = Command::new("git")
+        .arg("init")
+        .current_dir(temp.path())
+        .status()
+        .expect("git init should run");
+    assert!(status.success());
+    for (key, value) in [("user.name", "Heddle Test"), ("user.email", "h@example.com")]
+    {
+        let status = Command::new("git")
+            .args(["config", key, value])
+            .current_dir(temp.path())
+            .status()
+            .expect("git config should run");
+        assert!(status.success());
+    }
+    std::fs::write(temp.path().join("a"), "").unwrap();
+    let status = Command::new("git")
+        .args(["add", "."])
+        .current_dir(temp.path())
+        .status()
+        .expect("git add should run");
+    assert!(status.success());
+    let status = Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(temp.path())
+        .status()
+        .expect("git commit should run");
+    assert!(status.success());
+
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let json = heddle(&["status", "--json"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&json).expect("status JSON parses");
+    assert_eq!(
+        parsed["thread_health"], "uncaptured",
+        "freshly-initialized worktree should read as uncaptured, not dirty_worktree: {parsed}"
+    );
+    assert_eq!(
+        parsed["recommended_action"], "heddle capture",
+        "uncaptured state should still recommend `heddle capture`: {parsed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -41,8 +41,8 @@ fn doctor_uses_recovery_language_without_breaking_json() {
         "doctor should render a human header: {text}"
     );
     assert!(
-        text.contains("Health: dirty_worktree"),
-        "doctor should show health: {text}"
+        text.contains("Health: uncaptured"),
+        "doctor should label the freshly-initialized worktree as uncaptured: {text}"
     );
     assert!(
         text.contains("Next step: heddle capture"),

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -79,7 +79,9 @@ pub use snapshot_metadata::{
     summarize_verification, update_thread_state_from_state,
 };
 pub use stash::{StashEntry, StashManager};
-pub use thread_advice::{RecommendedAction, ThreadAdvice, describe_thread_advice};
+pub use thread_advice::{
+    RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
+};
 pub use thread_model::{
     ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
     ThreadImpactCategory, ThreadIntegrationPolicy, ThreadLifecycleState, ThreadMode, ThreadRecord,

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -44,6 +44,32 @@ pub fn describe_thread_advice(
     conflicts: usize,
     clean_ready_merges_to_apply: bool,
 ) -> ThreadAdvice {
+    describe_thread_advice_with_initial(
+        thread,
+        worktree_dirty,
+        conflicts,
+        clean_ready_merges_to_apply,
+        false,
+    )
+}
+
+/// Variant that distinguishes a worktree that diverges from the
+/// seeded genesis state (no user capture has happened yet) from one
+/// that has accumulated changes since a real capture.
+///
+/// When `initial_state` is true and the worktree is dirty, the thread
+/// is labeled `"uncaptured"` instead of `"dirty_worktree"`. The
+/// recommended action stays `heddle capture` — only the label
+/// changes, so the user-facing first impression matches the actual
+/// situation (nothing has been captured yet) rather than implying
+/// that something has drifted. See heddle#160.
+pub fn describe_thread_advice_with_initial(
+    thread: &Thread,
+    worktree_dirty: bool,
+    conflicts: usize,
+    clean_ready_merges_to_apply: bool,
+    initial_state: bool,
+) -> ThreadAdvice {
     // A freshly-initialized active thread with no work, no conflicts, no
     // merges pending, and no promotion warning is healthy. The advice
     // cascade below otherwise falls through to a misleading
@@ -101,7 +127,9 @@ pub fn describe_thread_advice(
         RecommendedAction::Ready
     };
 
-    let thread_health = if worktree_dirty {
+    let thread_health = if worktree_dirty && initial_state {
+        "uncaptured"
+    } else if worktree_dirty {
         "dirty_worktree"
     } else if !blockers.is_empty() {
         "blocked"


### PR DESCRIPTION
## Summary
- After `heddle init` on an existing git repo, `heddle status` reported `Health: dirty_worktree` even when the worktree matched git HEAD exactly — the comparison was against the seeded empty-tree state. Reads as "something is broken" on first impression.
- Distinguish the seed-state case (`is_synthetic_root` on the current state) from a real post-capture diff. Surface the label as `uncaptured` in that case. Recommended action (`heddle capture`) is unchanged.
- Threaded through `describe_thread_advice_with_initial` so both `heddle status` and `heddle diagnose` / `heddle doctor` get the new label consistently.

Closes #160

## Red commit
`d732271f8dbc5e77987d638bbed72fc336a0d560`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- status_reports_uncaptured doctor_uses_recovery_language test_cli_diagnose_json_profile status_text_counts_dirty
running 4 tests
test misc::test_cli_diagnose_json_profile ... ok
test cli_premium_output::status_text_counts_dirty_worktree_paths ... ok
test oss_cli_polish::doctor_uses_recovery_language_without_breaking_json ... ok
test misc::status_reports_uncaptured_for_freshly_initialized_repo ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 295 filtered out

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 286 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out
```

Manual repro per the issue:
```
$ cd /tmp/h160 && git init -q && touch a && git add . && git commit -q -m initial
$ heddle init . && heddle status --json | jq .thread_health
"uncaptured"
```

## Manual verification
N/A — covered by tests.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->