### PR TITLE
heddle#180: mount/fuse — implement write-side ops to unblock virtualized dispatch

### DIFF
--- a/crates/mount/README.md
+++ b/crates/mount/README.md
@@ -300,6 +300,98 @@ The smoke tests will skip themselves unless
 `HEDDLE_PROJFS_AVAILABLE=1` is set, so a Windows host without the
 optional feature won't fail them accidentally.
 
+## Per-thread overlay semantics (write path)
+
+Every mount is bound to exactly one thread (`mount.thread`). All
+writes the kernel issues against the mountpoint land in a
+**per-thread overlay** layered on top of the underlying CAS; the
+captured tree is never mutated in place. The overlay is the diff
+between "what the thread looked like at mount time" and "what the
+agent has written since".
+
+The overlay has six pieces, all in process memory until
+[`ContentAddressedMount::capture`] folds them into a new heddle
+state:
+
+| Piece                  | What it holds                                       | Promoted on `capture` as                              |
+|------------------------|-----------------------------------------------------|-------------------------------------------------------|
+| `hot` buffer           | In-flight `pwrite` bytes per open NodeId            | Drained to `warm` first, then folded as a file blob   |
+| `warm` tier            | Path → CAS-promoted blob (post-`flush`/`close`)     | File blob in the destination tree                     |
+| `tombstones`           | Paths the mount has `unlink`'d                      | Removes the captured entry; prunes empty parent dirs  |
+| `dir_tombstones`       | Captured-tree directories the mount has `rmdir`'d   | Drops the whole subtree from the destination tree     |
+| `explicit_dirs`        | Empty `mkdir`s with no children yet                 | Materialized as 0-entry subtree                       |
+| `symlinks`             | Path → link target bytes                            | Hashed once, planted as a `Symlink` tree entry        |
+
+Lock ordering inside the mount is **state → pending → inodes**;
+every write-side op holds them in that order to avoid the deadlock
+shapes Codex caught early in development. See the `MountInner`
+docstring in `src/core.rs`.
+
+### What `capture` does
+
+When the agent runs `heddle capture`, the orchestrator calls
+[`ContentAddressedMount::capture`] which:
+
+1. Drains every open hot buffer to the warm tier (no agent ever
+   "loses" an in-flight write — the close handshake is the only
+   point of fragility, and the safety-sweep thread covers the
+   process-killed-without-close case via the `idle_after` window).
+2. Folds the warm tier + tombstones + dir_tombstones +
+   explicit_dirs + symlinks into a fresh root tree, descending into
+   each pending sub-path and merging against the captured
+   counterpart. Empty captured-dir entries prune naturally.
+3. Records a new `State` referencing that root tree and advances
+   the thread's HEAD. Attribution comes from the repo's default
+   path (`HEDDLE_AGENT_*` env + repo config + principal).
+4. Clears the entire pending tier. The next write starts with a
+   fresh overlay.
+
+The whole pass is one walk of the pending map — no worktree-scan,
+no re-hash of any blob the agent already wrote through `flush`.
+The result is content-addressed: two agents that wrote identical
+bytes to different paths produce **one** CAS blob, not two.
+
+### What does NOT persist across capture
+
+The overlay is intentionally lightweight; some kernel-side concepts
+don't have a tree-level home and surface as no-ops or
+approximations:
+
+- **`chmod` other than `+x`.** Heddle's [`FileMode`] is a three-way
+  enum (`Normal` / `Executable` / `Symlink`); arbitrary 9-bit perm
+  masks fold into the closest mode at capture time. The
+  user-executable bit (`0o100`) flips Normal ↔ Executable; the
+  rest of the bits (group/other read/write, setuid, sticky) are
+  not modelled and don't survive `capture`.
+- **`chown` / uid / gid.** The mount reports every node as owned by
+  the mount-owner's uid + primary gid. `setattr(uid)` /
+  `setattr(gid)` are accepted as no-ops so callers don't get
+  `EPERM` from a chown that wouldn't have had a visible effect
+  anyway.
+- **Per-node mtime / atime / ctime.** Every node reports the
+  mount's `mounted_at` timestamp. `setattr(mtime)` / `utimensat`
+  are accepted as no-ops.
+- **Hard links.** `link(2)` returns `EPERM`. The CAS already
+  de-duplicates by content hash, so two paths with the same bytes
+  share one blob — but they're independent tree entries, not
+  aliased inodes.
+- **`mknod` for device / FIFO / socket nodes.** Only regular files
+  (`S_IFREG`) are accepted; everything else returns `EPERM`.
+  Heddle's tree doesn't model device files.
+- **Captured-directory rename.** Renaming an entirely overlay-only
+  directory (one that the agent `mkdir`'d in this session) works;
+  renaming a captured directory returns `EINVAL`. Cross-tree
+  directory renames would need a recursive tombstone + warm-tier
+  rewrite pass that's out of scope for the cargo / git / npm
+  daily-use path.
+
+### What about `inotify` / `fanotify`?
+
+Not delivered. The mount doesn't emit filesystem-change events
+for editors / file-watchers / `cargo watch`-style tooling. This
+is a separate substrate decision tracked in a follow-up issue;
+the cargo / git path doesn't need it.
+
 ## Status
 
 - Linux FUSE shell: production. Used by the heddle CLI when

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -2011,9 +2011,29 @@ impl ContentAddressedMount {
     /// `setattr` / etc. Returns post-update [`Attrs`] for an
     /// inline reply.
     pub fn set_attrs(&self, node: NodeId, update: AttrUpdate) -> Result<Attrs> {
+        // Codex r13 thread 3293733165 (P1): every mutating branch of
+        // `set_attrs` must serialize against `rename` / `create` /
+        // `unlink` / `rmdir` under `write_mu`. Without it, a
+        // `setattr(size=...)` racing with a `rename` re-uses the
+        // pre-rename pathname in `apply_truncate`'s phase-2
+        // bookkeeping — `tombstones.remove(old)` clears the rename's
+        // tombstone and `hot_by_path.insert(old, node)` resurrects
+        // the file at the old name. The mode-mutation branch has the
+        // same shape (touches `hot_by_path[path]` / `warm[id]` derived
+        // from `inodes.by_path[path]`), so we hold the lock for the
+        // whole mutating prologue.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
+
         // Mode mutation: only meaningful for file-kind records.
         if let Some(raw_mode) = update.mode {
-            let new_mode = if (raw_mode & 0o111) != 0 {
+            // Codex r13 thread 3293733164 (P2): the Normal↔Executable
+            // fold is gated on the user execute bit (S_IXUSR = 0o100)
+            // only, not on any of the three execute bits. A
+            // `chmod 0o010` (group execute only) must leave the record
+            // as Normal — otherwise capture would persist a
+            // `FileMode::Executable` and grant owner+other execute
+            // bits the agent never requested.
+            let new_mode = if (raw_mode & 0o100) != 0 {
                 FileMode::Executable
             } else {
                 FileMode::Normal
@@ -2502,29 +2522,29 @@ impl ContentAddressedMount {
 }
 
 /// Reject FUSE entry names that wouldn't survive a `TreeEntry`'s
-/// validator: empty, the `.`/`..` pseudo-entries, anything with a
-/// path separator, anything with a NUL byte. Returns the validated
-/// name as a `&str` so callers can build paths without re-decoding.
+/// validator. Delegates to [`objects::object::validate_tree_entry_name`]
+/// so the mount's write-side reject set stays in lockstep with the
+/// tree serializer's — Codex r13 thread 3293733163 (P2) caught the
+/// drift where the overlay accepted backslash and control bytes that
+/// the serializer later rejected at capture with a confusing
+/// "invalid object" error. The NUL pre-check is here (not in the
+/// shared validator) because `OsStr` on Unix can carry interior NUL
+/// bytes that `to_str()` would otherwise round-trip through to the
+/// validator as an unmarked control byte; we surface a more specific
+/// error.
 fn validate_entry_name(name: &OsStr) -> Result<&str> {
     let bytes = name.as_encoded_bytes();
-    if bytes.is_empty() {
-        return Err(MountError::InvalidArgument("empty entry name".into()));
-    }
-    if bytes == b"." || bytes == b".." {
+    if bytes.contains(&0) {
         return Err(MountError::InvalidArgument(format!(
-            "'{}' is not a valid entry name",
-            name.to_string_lossy()
+            "entry name {name:?} contains NUL"
         )));
     }
-    if bytes.iter().any(|&b| b == 0 || b == b'/') {
-        return Err(MountError::InvalidArgument(format!(
-            "entry name {:?} contains NUL or '/'",
-            name
-        )));
-    }
-    name.to_str().ok_or_else(|| {
+    let name_str = name.to_str().ok_or_else(|| {
         MountError::InvalidArgument(format!("entry name {name:?} is not valid UTF-8"))
-    })
+    })?;
+    objects::object::validate_tree_entry_name(name_str)
+        .map_err(|e| MountError::InvalidArgument(e.to_string()))?;
+    Ok(name_str)
 }
 
 /// Mount-relative path for a warm-tier entry, derived from its

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1372,15 +1372,13 @@ impl ContentAddressedMount {
             // this, every read against the rebased dentry sees the
             // stale path and returns ESTALE.
             if let Some(src_id) = inodes.by_path.remove(&old_path) {
-                if let Some(record) = inodes.by_id.get_mut(&src_id) {
-                    match record {
-                        NodeRecord::PendingFile { path, .. }
-                        | NodeRecord::File { path, .. }
-                        | NodeRecord::PendingSymlink { path } => {
-                            *path = new_path.clone();
-                        }
-                        _ => {}
-                    }
+                if let Some(
+                    NodeRecord::PendingFile { path, .. }
+                    | NodeRecord::File { path, .. }
+                    | NodeRecord::PendingSymlink { path },
+                ) = inodes.by_id.get_mut(&src_id)
+                {
+                    *path = new_path.clone();
                 }
                 inodes.by_path.insert(new_path.clone(), src_id);
                 drop(inodes);
@@ -1419,18 +1417,18 @@ impl ContentAddressedMount {
             Warm { blob: ContentHash, mode: FileMode, size: u64 },
             Captured { blob: ContentHash, mode: FileMode, size: u64 },
         }
-        let source = {
-            let pending = self.inner.pending.lock().expect("pending lock");
-            if let Some(entry) = pending.warm.get(old_path) {
-                Some(Source::Warm {
-                    blob: entry.blob,
-                    mode: entry.mode,
-                    size: entry.size,
-                })
-            } else {
-                None
-            }
-        };
+        let source = self
+            .inner
+            .pending
+            .lock()
+            .expect("pending lock")
+            .warm
+            .get(old_path)
+            .map(|entry| Source::Warm {
+                blob: entry.blob,
+                mode: entry.mode,
+                size: entry.size,
+            });
         let source = match source {
             Some(s) => s,
             None => {
@@ -1661,13 +1659,11 @@ impl ContentAddressedMount {
                 FileMode::Normal
             };
             let mut inodes = self.inner.inodes.lock().expect("inode lock");
-            if let Some(record) = inodes.by_id.get_mut(&node.0) {
-                match record {
-                    NodeRecord::File { mode, .. } | NodeRecord::PendingFile { mode, .. } => {
-                        *mode = new_mode;
-                    }
-                    _ => {}
-                }
+            if let Some(
+                NodeRecord::File { mode, .. } | NodeRecord::PendingFile { mode, .. },
+            ) = inodes.by_id.get_mut(&node.0)
+            {
+                *mode = new_mode;
             }
             drop(inodes);
             // Reflect the mode in any open hot buffer + warm-tier
@@ -2023,7 +2019,7 @@ impl ContentAddressedMount {
 /// validator: empty, the `.`/`..` pseudo-entries, anything with a
 /// path separator, anything with a NUL byte. Returns the validated
 /// name as a `&str` so callers can build paths without re-decoding.
-fn validate_entry_name<'a>(name: &'a OsStr) -> Result<&'a str> {
+fn validate_entry_name(name: &OsStr) -> Result<&str> {
     use std::os::unix::ffi::OsStrExt;
     let bytes = name.as_bytes();
     if bytes.is_empty() {

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -3329,7 +3329,12 @@ fn apply_pending_to_tree(
                 Some(e) if e.is_tree() => store
                     .get_tree(&e.hash)
                     .map_err(MountError::Store)?
-                    .unwrap_or_default(),
+                    .ok_or_else(|| {
+                        MountError::Store(objects::error::HeddleError::MissingObject {
+                            object_type: "tree".to_string(),
+                            id: e.hash.to_string(),
+                        })
+                    })?,
                 _ => Tree::new(),
             };
             let force_empty = v.explicit_empty.contains(name);

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -80,7 +80,7 @@ use tracing::{debug, instrument, warn};
 
 use crate::{
     error::{MountError, Result},
-    shell::{Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell, kind_for_mode},
+    shell::{AttrUpdate, Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell, kind_for_mode},
 };
 
 /// Default promotion idle window: a buffer with no writes for this
@@ -159,6 +159,12 @@ enum NodeRecord {
         path: PathBuf,
         mode: FileMode,
     },
+    /// A symlink created through the mount. Target bytes live in
+    /// [`Pending::symlinks`]; we don't promote the symlink to a CAS
+    /// blob until [`ContentAddressedMount::capture`].
+    PendingSymlink {
+        path: PathBuf,
+    },
 }
 
 impl NodeRecord {
@@ -170,7 +176,7 @@ impl NodeRecord {
             NodeRecord::File { mode, .. } | NodeRecord::PendingFile { mode, .. } => {
                 kind_for_mode(*mode)
             }
-            NodeRecord::Symlink { .. } => NodeKind::Symlink,
+            NodeRecord::Symlink { .. } | NodeRecord::PendingSymlink { .. } => NodeKind::Symlink,
         }
     }
 
@@ -182,7 +188,9 @@ impl NodeRecord {
             NodeRecord::File { mode, .. } | NodeRecord::PendingFile { mode, .. } => {
                 mode.to_unix_mode()
             }
-            NodeRecord::Symlink { .. } => FileMode::Symlink.to_unix_mode(),
+            NodeRecord::Symlink { .. } | NodeRecord::PendingSymlink { .. } => {
+                FileMode::Symlink.to_unix_mode()
+            }
         }
     }
 }
@@ -269,7 +277,9 @@ impl Inodes {
                 self.by_id.insert(id, record);
                 NodeId(id)
             }
-            NodeRecord::File { path, .. } | NodeRecord::PendingFile { path, .. } => {
+            NodeRecord::File { path, .. }
+            | NodeRecord::PendingFile { path, .. }
+            | NodeRecord::PendingSymlink { path } => {
                 if let Some(&id) = self.by_path.get(path) {
                     // If the path's record is being upgraded
                     // (e.g. PendingFile -> File after capture, or
@@ -319,7 +329,9 @@ impl Inodes {
                 NodeRecord::Dir { path, .. } | NodeRecord::PendingDir { path } => {
                     self.by_path.remove(&path);
                 }
-                NodeRecord::File { path, .. } | NodeRecord::PendingFile { path, .. } => {
+                NodeRecord::File { path, .. }
+                | NodeRecord::PendingFile { path, .. }
+                | NodeRecord::PendingSymlink { path } => {
                     self.by_path.remove(&path);
                 }
                 NodeRecord::Symlink { blob } => {
@@ -367,8 +379,24 @@ struct Pending {
     /// Warm tier: paths whose latest content has been promoted.
     warm: BTreeMap<PathBuf, PendingEntry>,
     /// Tombstones — paths the mount has deleted. Suppress the
-    /// underlying state's entry on reads.
+    /// underlying state's entry on reads. File-only; directories
+    /// use [`Self::dir_tombstones`].
     tombstones: BTreeSet<PathBuf>,
+    /// Directory tombstones — captured-tree directories the mount
+    /// has `rmdir`'d. Distinct from file tombstones because the
+    /// capture-time `apply_pending_to_tree` walk has to drop the
+    /// whole subtree, not a single leaf.
+    dir_tombstones: BTreeSet<PathBuf>,
+    /// Directories the mount has `mkdir`'d into the overlay that
+    /// don't (yet) have any children. Without this, an empty
+    /// `mkdir target/` wouldn't survive across a `lookup` /
+    /// `enumerate` round-trip (nothing under it means
+    /// [`pending_dir_exists`] would return false).
+    explicit_dirs: BTreeSet<PathBuf>,
+    /// Symlinks created through the mount, keyed by mount-relative
+    /// path. The bytes are the target as the kernel handed them to
+    /// `symlink`; capture hashes them into a CAS blob.
+    symlinks: BTreeMap<PathBuf, Vec<u8>>,
 }
 
 /// In-mount overlay: a snapshot-time view of the parent state plus
@@ -1038,6 +1066,7 @@ impl ContentAddressedMount {
                 Some(path.clone())
             }
             NodeRecord::Dir { path, .. } | NodeRecord::PendingDir { path } => Some(path.clone()),
+            NodeRecord::PendingSymlink { path } => Some(path.clone()),
             _ => None,
         }
     }
@@ -1070,6 +1099,703 @@ impl ContentAddressedMount {
         Ok(())
     }
 
+    // --- Write-side overlay ops (heddle#180) -----------------------------------
+    //
+    // Each method below corresponds to one FUSE callback the kernel
+    // emits on cargo / git / npm style workloads:
+    //
+    //   create  → `create_file`      open(O_CREAT)
+    //   mkdir   → `make_dir`
+    //   unlink  → `unlink_entry`
+    //   rmdir   → `rmdir_entry`
+    //   rename  → `rename_entry`
+    //   setattr → `set_attrs`        chmod / ftruncate / O_TRUNC
+    //   symlink → `create_symlink`
+    //   readlink→ `read_link`
+    //
+    // All mutations land in the per-thread overlay (pending tier):
+    //
+    //   * `Pending::hot` / `Pending::warm` — file bytes (existing).
+    //   * `Pending::tombstones`            — file deletions (existing).
+    //   * `Pending::dir_tombstones`        — `rmdir` of a captured dir.
+    //   * `Pending::explicit_dirs`         — empty mkdirs.
+    //   * `Pending::symlinks`              — link target bytes.
+    //
+    // None of these touch the underlying CAS until `capture()` folds
+    // the overlay into a real heddle state.
+
+    /// Open-or-create a regular file under `parent`, mirroring
+    /// `open(O_CREAT[|O_EXCL])` from userspace.
+    ///
+    /// When the named entry doesn't exist, mints a fresh
+    /// [`NodeRecord::PendingFile`] inode + an empty hot buffer so the
+    /// new path is immediately visible to [`lookup`](Self::lookup) /
+    /// [`attrs`](Self::attrs) and the first
+    /// [`write`](Self::write) drops cleanly into the existing
+    /// two-tier model.
+    ///
+    /// When the named entry already exists:
+    ///   * `exclusive=true` ⇒ [`MountError::AlreadyExists`] (errno
+    ///     `EEXIST`).
+    ///   * `exclusive=false` ⇒ returns the existing entry. The kernel
+    ///     follows up with `setattr(size=0)` for `O_TRUNC` callers,
+    ///     which we honour in [`set_attrs`](Self::set_attrs).
+    pub fn create_file(
+        &self,
+        parent: NodeId,
+        name: &OsStr,
+        mode: FileMode,
+        exclusive: bool,
+    ) -> Result<Entry> {
+        let name_str = validate_entry_name(name)?;
+        if let Some(existing) = self.lookup(parent, name)? {
+            if exclusive {
+                return Err(MountError::AlreadyExists(name_str.to_string()));
+            }
+            return Ok(existing);
+        }
+        let parent_record = self.record_for(parent)?;
+        let parent_path = self
+            .dir_path_of(&parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
+        let child_path = join_child(&parent_path, name_str);
+
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            // A prior unlink left a tombstone — clear it; the file
+            // exists again.
+            pending.tombstones.remove(&child_path);
+            // An overlay-only directory used to live here; it's gone.
+            pending.explicit_dirs.remove(&child_path);
+        }
+
+        let node = self.intern(NodeRecord::PendingFile {
+            path: child_path.clone(),
+            mode,
+        });
+
+        // Seed an empty hot buffer so the freshly-minted inode reads
+        // as a 0-byte file even before any `write` callback fires.
+        // Mirrors what userspace expects from `open(O_CREAT)`: the
+        // file exists at length 0 immediately on return.
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            pending.hot.insert(
+                node.0,
+                HotBuffer {
+                    path: child_path.clone(),
+                    mode,
+                    bytes: Vec::new(),
+                    last_touched: Instant::now(),
+                },
+            );
+            pending.hot_by_path.insert(child_path, node.0);
+        }
+
+        Ok(Entry {
+            node,
+            name: name.to_os_string(),
+            kind: kind_for_mode(mode),
+            size: 0,
+            unix_mode: mode.to_unix_mode(),
+        })
+    }
+
+    /// Create an empty directory under `parent`. Recorded as an
+    /// [`Pending::explicit_dirs`] entry so the new path is visible to
+    /// lookup/enumerate even when no child has been written yet.
+    pub fn make_dir(&self, parent: NodeId, name: &OsStr) -> Result<Entry> {
+        let name_str = validate_entry_name(name)?;
+        if self.lookup(parent, name)?.is_some() {
+            return Err(MountError::AlreadyExists(name_str.to_string()));
+        }
+        let parent_record = self.record_for(parent)?;
+        let parent_path = self
+            .dir_path_of(&parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
+        let child_path = join_child(&parent_path, name_str);
+
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            // A rmdir of this exact path now reverts to "present".
+            pending.dir_tombstones.remove(&child_path);
+            // Clear any colliding file tombstone too.
+            pending.tombstones.remove(&child_path);
+            pending.explicit_dirs.insert(child_path.clone());
+        }
+
+        let node = self.intern(NodeRecord::PendingDir {
+            path: child_path,
+        });
+        Ok(Entry {
+            node,
+            name: name.to_os_string(),
+            kind: NodeKind::Directory,
+            size: 0,
+            unix_mode: DIR_UNIX_MODE,
+        })
+    }
+
+    /// Delete a regular file (or symlink) named `name` under `parent`.
+    /// Drops any hot buffer / warm-tier blob / symlink entry for the
+    /// path and records a tombstone so the captured-tree entry (if
+    /// any) is hidden until capture folds the deletion in.
+    pub fn unlink_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        let name_str = validate_entry_name(name)?;
+        let entry = self
+            .lookup(parent, name)?
+            .ok_or_else(|| MountError::NotFound(name_str.to_string()))?;
+        if entry.kind == NodeKind::Directory {
+            return Err(MountError::IsADirectory(name_str.to_string()));
+        }
+        let parent_record = self.record_for(parent)?;
+        let parent_path = self
+            .dir_path_of(&parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
+        let child_path = join_child(&parent_path, name_str);
+
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        if let Some(node_id) = pending.hot_by_path.remove(&child_path) {
+            pending.hot.remove(&node_id);
+        }
+        pending.warm.remove(&child_path);
+        pending.symlinks.remove(&child_path);
+        pending.tombstones.insert(child_path);
+        Ok(())
+    }
+
+    /// Remove the empty directory `name` under `parent`. Fails with
+    /// `ENOTEMPTY` if any child resolves through the mount.
+    pub fn rmdir_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        let name_str = validate_entry_name(name)?;
+        let entry = self
+            .lookup(parent, name)?
+            .ok_or_else(|| MountError::NotFound(name_str.to_string()))?;
+        if entry.kind != NodeKind::Directory {
+            return Err(MountError::NotADirectory(name_str.to_string()));
+        }
+        // Empty check via enumerate — already overlay-aware (hot,
+        // warm, symlinks, captured-with-pending-overlay).
+        let children = self.enumerate(entry.node)?;
+        if !children.is_empty() {
+            return Err(MountError::NotEmpty(name_str.to_string()));
+        }
+        let parent_record = self.record_for(parent)?;
+        let parent_path = self
+            .dir_path_of(&parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
+        let child_path = join_child(&parent_path, name_str);
+
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        pending.explicit_dirs.remove(&child_path);
+        pending.dir_tombstones.insert(child_path);
+        Ok(())
+    }
+
+    /// Move `(old_parent, old_name)` to `(new_parent, new_name)`.
+    /// Handles file + symlink renames across any pair of overlay /
+    /// captured paths, and overlay-only directory rename (a captured
+    /// directory rename would require recursively rewriting the
+    /// tombstone/warm map — out of scope for the cargo / git path).
+    pub fn rename_entry(
+        &self,
+        old_parent: NodeId,
+        old_name: &OsStr,
+        new_parent: NodeId,
+        new_name: &OsStr,
+    ) -> Result<()> {
+        let old_name_str = validate_entry_name(old_name)?;
+        let new_name_str = validate_entry_name(new_name)?;
+        let src = self
+            .lookup(old_parent, old_name)?
+            .ok_or_else(|| MountError::NotFound(format!("rename src {old_name_str}")))?;
+        let old_parent_record = self.record_for(old_parent)?;
+        let new_parent_record = self.record_for(new_parent)?;
+        let old_parent_path = self
+            .dir_path_of(&old_parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{old_parent_record:?}")))?;
+        let new_parent_path = self
+            .dir_path_of(&new_parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{new_parent_record:?}")))?;
+        let old_path = join_child(&old_parent_path, old_name_str);
+        let new_path = join_child(&new_parent_path, new_name_str);
+        if old_path == new_path {
+            return Ok(());
+        }
+
+        // POSIX: destination of a different kind is an error.
+        if let Some(dst) = self.lookup(new_parent, new_name)? {
+            match (src.kind, dst.kind) {
+                (NodeKind::Directory, NodeKind::Directory) => {
+                    let dst_children = self.enumerate(dst.node)?;
+                    if !dst_children.is_empty() {
+                        return Err(MountError::NotEmpty(new_name_str.to_string()));
+                    }
+                }
+                (NodeKind::Directory, _) => {
+                    return Err(MountError::NotADirectory(new_name_str.to_string()));
+                }
+                (_, NodeKind::Directory) => {
+                    return Err(MountError::IsADirectory(new_name_str.to_string()));
+                }
+                _ => {}
+            }
+        }
+
+        match src.kind {
+            NodeKind::File => self.move_file(&old_path, &new_path)?,
+            NodeKind::Symlink => self.move_symlink(&old_path, &new_path)?,
+            NodeKind::Directory => self.move_overlay_dir(&old_path, &new_path)?,
+        }
+        // Invalidate the inode cached for the destination, so its next
+        // `lookup` re-mints with the moved record.
+        self.inner
+            .inodes
+            .lock()
+            .expect("inode lock")
+            .by_path
+            .remove(&new_path);
+        Ok(())
+    }
+
+    /// Promote the source's hot buffer (if any), then rewrite the
+    /// warm-tier entry / captured-blob reference at the new path.
+    fn move_file(&self, old_path: &Path, new_path: &Path) -> Result<()> {
+        // Promote any in-flight buffer at the source so the move is
+        // entirely a warm-tier operation.
+        let pending_node = self
+            .inner
+            .pending
+            .lock()
+            .expect("pending lock")
+            .hot_by_path
+            .get(old_path)
+            .copied();
+        if let Some(id) = pending_node {
+            self.flush_node(NodeId(id))?;
+        }
+
+        // Resolve the source's durable identity (warm-tier promotion
+        // wins over captured-tree blob — that's the priority used
+        // everywhere else in read).
+        enum Source {
+            Warm { blob: ContentHash, mode: FileMode, size: u64 },
+            Captured { blob: ContentHash, mode: FileMode, size: u64 },
+        }
+        let source = {
+            let pending = self.inner.pending.lock().expect("pending lock");
+            if let Some(entry) = pending.warm.get(old_path) {
+                Some(Source::Warm {
+                    blob: entry.blob,
+                    mode: entry.mode,
+                    size: entry.size,
+                })
+            } else {
+                None
+            }
+        };
+        let source = match source {
+            Some(s) => s,
+            None => {
+                // Walk the captured tree by path.
+                let (blob, mode, size) = self.captured_file_at(old_path)?;
+                Source::Captured { blob, mode, size }
+            }
+        };
+        let (blob, mode, size) = match source {
+            Source::Warm { blob, mode, size } | Source::Captured { blob, mode, size } => {
+                (blob, mode, size)
+            }
+        };
+
+        // Apply.
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        // Drop any old destination state.
+        if let Some(id) = pending.hot_by_path.remove(new_path) {
+            pending.hot.remove(&id);
+        }
+        pending.warm.remove(new_path);
+        pending.symlinks.remove(new_path);
+        pending.tombstones.remove(new_path);
+        // Move source.
+        pending.warm.remove(old_path);
+        pending.symlinks.remove(old_path);
+        pending.warm.insert(
+            new_path.to_path_buf(),
+            PendingEntry { blob, mode, size },
+        );
+        // Tombstone the source so a captured-tree entry there gets
+        // hidden post-capture.
+        pending.tombstones.insert(old_path.to_path_buf());
+        // Clear any tombstone covering the destination.
+        pending.tombstones.remove(new_path);
+        Ok(())
+    }
+
+    fn move_symlink(&self, old_path: &Path, new_path: &Path) -> Result<()> {
+        // Resolve target bytes from pending overlay, else from a
+        // captured-tree symlink blob.
+        let target_bytes = {
+            let pending = self.inner.pending.lock().expect("pending lock");
+            pending.symlinks.get(old_path).cloned()
+        };
+        let target_bytes = match target_bytes {
+            Some(b) => b,
+            None => {
+                let blob = self.captured_symlink_at(old_path)?;
+                (*self.load_blob_bytes(&blob)?).to_vec()
+            }
+        };
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        if let Some(id) = pending.hot_by_path.remove(new_path) {
+            pending.hot.remove(&id);
+        }
+        pending.warm.remove(new_path);
+        pending.symlinks.remove(new_path);
+        pending.tombstones.remove(new_path);
+        pending.symlinks.remove(old_path);
+        pending.symlinks.insert(new_path.to_path_buf(), target_bytes);
+        pending.tombstones.insert(old_path.to_path_buf());
+        Ok(())
+    }
+
+    fn move_overlay_dir(&self, old_path: &Path, new_path: &Path) -> Result<()> {
+        // We only support overlay-only directory renames here. If the
+        // source dir has any captured-tree backing, refuse — a full
+        // captured-tree rename would need to rewrite every descendant
+        // tombstone/warm entry.
+        if self.captured_dir_exists(old_path)? {
+            return Err(MountError::InvalidArgument(format!(
+                "cross-tree directory rename {} → {} not supported by the overlay",
+                old_path.display(),
+                new_path.display()
+            )));
+        }
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        // Move explicit_dirs and any deeper overlay entries under
+        // old_path/ to new_path/. Symlinks, warm, hot_by_path,
+        // tombstones, explicit_dirs all need rewriting.
+        fn rebase(p: &Path, old: &Path, new: &Path) -> Option<PathBuf> {
+            let tail = p.strip_prefix(old).ok()?;
+            Some(new.join(tail))
+        }
+        let mut new_explicit: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut new_warm: BTreeMap<PathBuf, PendingEntry> = BTreeMap::new();
+        let mut new_symlinks: BTreeMap<PathBuf, Vec<u8>> = BTreeMap::new();
+        let mut new_tombstones: BTreeSet<PathBuf> = BTreeSet::new();
+        let mut new_hot_by_path: BTreeMap<PathBuf, u64> = BTreeMap::new();
+        let mut hot_path_updates: Vec<(u64, PathBuf)> = Vec::new();
+        for explicit in std::mem::take(&mut pending.explicit_dirs) {
+            match rebase(&explicit, old_path, new_path) {
+                Some(rebased) => {
+                    new_explicit.insert(rebased);
+                }
+                None => {
+                    if explicit != old_path {
+                        new_explicit.insert(explicit);
+                    }
+                }
+            }
+        }
+        for (path, entry) in std::mem::take(&mut pending.warm) {
+            match rebase(&path, old_path, new_path) {
+                Some(rebased) => {
+                    new_warm.insert(rebased, entry);
+                }
+                None => {
+                    new_warm.insert(path, entry);
+                }
+            }
+        }
+        for (path, target) in std::mem::take(&mut pending.symlinks) {
+            match rebase(&path, old_path, new_path) {
+                Some(rebased) => {
+                    new_symlinks.insert(rebased, target);
+                }
+                None => {
+                    new_symlinks.insert(path, target);
+                }
+            }
+        }
+        for path in std::mem::take(&mut pending.tombstones) {
+            match rebase(&path, old_path, new_path) {
+                Some(rebased) => {
+                    new_tombstones.insert(rebased);
+                }
+                None => {
+                    new_tombstones.insert(path);
+                }
+            }
+        }
+        for (path, id) in std::mem::take(&mut pending.hot_by_path) {
+            match rebase(&path, old_path, new_path) {
+                Some(rebased) => {
+                    hot_path_updates.push((id, rebased.clone()));
+                    new_hot_by_path.insert(rebased, id);
+                }
+                None => {
+                    new_hot_by_path.insert(path, id);
+                }
+            }
+        }
+        // Rewrite hot-buffer path fields to match.
+        for (id, new_p) in hot_path_updates {
+            if let Some(buf) = pending.hot.get_mut(&id) {
+                buf.path = new_p;
+            }
+        }
+        // Ensure the destination directory itself is registered.
+        new_explicit.insert(new_path.to_path_buf());
+        pending.explicit_dirs = new_explicit;
+        pending.warm = new_warm;
+        pending.symlinks = new_symlinks;
+        pending.tombstones = new_tombstones;
+        pending.hot_by_path = new_hot_by_path;
+        Ok(())
+    }
+
+    /// Resolve a captured-tree file at `path`; returns its
+    /// `(blob, mode, size)`. Errors with `NotFound` if no captured
+    /// entry exists.
+    fn captured_file_at(&self, path: &Path) -> Result<(ContentHash, FileMode, u64)> {
+        let entry = self.captured_tree_entry(path)?;
+        let mode = entry.mode;
+        let size = self.blob_size(&entry.hash)?;
+        Ok((entry.hash, mode, size))
+    }
+
+    fn captured_symlink_at(&self, path: &Path) -> Result<ContentHash> {
+        let entry = self.captured_tree_entry(path)?;
+        if !matches!(entry.entry_type, objects::object::EntryType::Symlink) {
+            return Err(MountError::InvalidArgument(format!(
+                "{} is not a symlink in the captured tree",
+                path.display()
+            )));
+        }
+        Ok(entry.hash)
+    }
+
+    fn captured_tree_entry(&self, path: &Path) -> Result<TreeEntry> {
+        let root_record = self.record_for(NodeId::ROOT)?;
+        let mut tree = self.tree_for_record(&root_record)?;
+        let comps: Vec<&str> = path
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(n) => n.to_str(),
+                _ => None,
+            })
+            .collect();
+        let (leaf, dirs) = comps
+            .split_last()
+            .ok_or_else(|| MountError::NotFound(path.display().to_string()))?;
+        for d in dirs {
+            let e = tree
+                .get(d)
+                .ok_or_else(|| MountError::NotFound(path.display().to_string()))?;
+            if !e.is_tree() {
+                return Err(MountError::NotADirectory(d.to_string()));
+            }
+            tree = self.load_tree(&e.hash)?;
+        }
+        let entry = tree
+            .get(leaf)
+            .cloned()
+            .ok_or_else(|| MountError::NotFound(path.display().to_string()))?;
+        Ok(entry)
+    }
+
+    fn captured_dir_exists(&self, path: &Path) -> Result<bool> {
+        match self.captured_tree_entry(path) {
+            Ok(e) => Ok(e.is_tree()),
+            Err(MountError::NotFound(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Apply attribute updates from a FUSE `setattr` / FSKit
+    /// `setattr` / etc. Returns post-update [`Attrs`] for an
+    /// inline reply.
+    pub fn set_attrs(&self, node: NodeId, update: AttrUpdate) -> Result<Attrs> {
+        // Mode mutation: only meaningful for file-kind records.
+        if let Some(raw_mode) = update.mode {
+            let new_mode = if (raw_mode & 0o111) != 0 {
+                FileMode::Executable
+            } else {
+                FileMode::Normal
+            };
+            let mut inodes = self.inner.inodes.lock().expect("inode lock");
+            if let Some(record) = inodes.by_id.get_mut(&node.0) {
+                match record {
+                    NodeRecord::File { mode, .. } | NodeRecord::PendingFile { mode, .. } => {
+                        *mode = new_mode;
+                    }
+                    _ => {}
+                }
+            }
+            drop(inodes);
+            // Reflect the mode in any open hot buffer + warm-tier
+            // entry so a subsequent `capture` keeps the new mode.
+            let record = self.record_for(node)?;
+            if let Some(path) = match &record {
+                NodeRecord::File { path, .. } | NodeRecord::PendingFile { path, .. } => Some(path),
+                _ => None,
+            } {
+                let path = path.clone();
+                let mut pending = self.inner.pending.lock().expect("pending lock");
+                if let Some(buf) = pending.hot.get_mut(&node.0) {
+                    buf.mode = new_mode;
+                }
+                if let Some(other_id) = pending.hot_by_path.get(&path).copied()
+                    && let Some(buf) = pending.hot.get_mut(&other_id)
+                {
+                    buf.mode = new_mode;
+                }
+                if let Some(entry) = pending.warm.get_mut(&path) {
+                    entry.mode = new_mode;
+                }
+            }
+        }
+
+        // Size mutation: O_TRUNC, ftruncate, etc.
+        if let Some(new_size) = update.size {
+            self.apply_truncate(node, new_size)?;
+        }
+        // uid/gid/mtime: accepted as no-ops. The overlay doesn't carry
+        // per-node ownership / timestamps yet (capture re-derives both
+        // from the agent's principal + mount mtime).
+        self.attrs(node)
+    }
+
+    fn apply_truncate(&self, node: NodeId, new_size: u64) -> Result<()> {
+        let record = self.record_for(node)?;
+        let (path, mode, captured_blob) = match &record {
+            NodeRecord::File {
+                path, mode, blob, ..
+            } => (path.clone(), *mode, Some(*blob)),
+            NodeRecord::PendingFile { path, mode } => (path.clone(), *mode, None),
+            _ => {
+                return Err(MountError::IsADirectory(format!(
+                    "setattr(size) on non-file {record:?}"
+                )));
+            }
+        };
+
+        // If a hot buffer already exists for this node or path,
+        // resize in place.
+        let resized_in_place = {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            let id = if pending.hot.contains_key(&node.0) {
+                Some(node.0)
+            } else {
+                pending.hot_by_path.get(&path).copied()
+            };
+            if let Some(id) = id
+                && let Some(buf) = pending.hot.get_mut(&id)
+            {
+                buf.bytes.resize(new_size as usize, 0);
+                buf.last_touched = Instant::now();
+                true
+            } else {
+                false
+            }
+        };
+        if resized_in_place {
+            return Ok(());
+        }
+
+        // No hot buffer — seed from the durable predecessor (warm
+        // tier wins over captured tree) and resize.
+        let seed_blob = {
+            let pending = self.inner.pending.lock().expect("pending lock");
+            pending
+                .warm
+                .get(&path)
+                .map(|e| e.blob)
+                .or(captured_blob)
+        };
+        let mut bytes = match seed_blob {
+            Some(hash) => (*self.load_blob_bytes(&hash)?).to_vec(),
+            None => Vec::new(),
+        };
+        bytes.resize(new_size as usize, 0);
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        pending.tombstones.remove(&path);
+        pending.hot.insert(
+            node.0,
+            HotBuffer {
+                path: path.clone(),
+                mode,
+                bytes,
+                last_touched: Instant::now(),
+            },
+        );
+        pending.hot_by_path.insert(path, node.0);
+        Ok(())
+    }
+
+    /// Create a symbolic link under `parent`. Target bytes are kept
+    /// in the pending tier verbatim; `capture` writes them as a CAS
+    /// blob and emits a `Symlink` tree entry.
+    pub fn create_symlink(
+        &self,
+        parent: NodeId,
+        name: &OsStr,
+        target: &Path,
+    ) -> Result<Entry> {
+        use std::os::unix::ffi::OsStrExt;
+        let name_str = validate_entry_name(name)?;
+        if self.lookup(parent, name)?.is_some() {
+            return Err(MountError::AlreadyExists(name_str.to_string()));
+        }
+        let parent_record = self.record_for(parent)?;
+        let parent_path = self
+            .dir_path_of(&parent_record)
+            .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
+        let child_path = join_child(&parent_path, name_str);
+        let target_bytes = target.as_os_str().as_bytes().to_vec();
+        let target_len = target_bytes.len() as u64;
+
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            pending.tombstones.remove(&child_path);
+            pending.symlinks.insert(child_path.clone(), target_bytes);
+        }
+        let node = self.intern(NodeRecord::PendingSymlink {
+            path: child_path,
+        });
+        Ok(Entry {
+            node,
+            name: name.to_os_string(),
+            kind: NodeKind::Symlink,
+            size: target_len,
+            unix_mode: FileMode::Symlink.to_unix_mode(),
+        })
+    }
+
+    /// Read the target of a symlink `node`. Works for both overlay
+    /// (`PendingSymlink`) and captured (`Symlink`) records.
+    pub fn read_link(&self, node: NodeId) -> Result<OsString> {
+        use std::os::unix::ffi::OsStrExt;
+        let record = self.record_for(node)?;
+        match record {
+            NodeRecord::PendingSymlink { path } => {
+                let pending = self.inner.pending.lock().expect("pending lock");
+                let bytes = pending
+                    .symlinks
+                    .get(&path)
+                    .ok_or_else(|| MountError::Stale(format!("symlink {}", path.display())))?;
+                Ok(OsStr::from_bytes(bytes).to_os_string())
+            }
+            NodeRecord::Symlink { blob } => {
+                let bytes = self.load_blob_bytes(&blob)?;
+                Ok(OsStr::from_bytes(&bytes).to_os_string())
+            }
+            other => Err(MountError::InvalidArgument(format!(
+                "read_link on non-symlink record: {other:?}"
+            ))),
+        }
+    }
+
     /// Flush all hot buffers to CAS. Useful at the start of `capture`
     /// or when tests want a deterministic warm state.
     pub fn flush_all(&self) -> Result<()> {
@@ -1096,6 +1822,11 @@ impl ContentAddressedMount {
         if pending.tombstones.contains(path) {
             return Some(PendingHit::Tombstone);
         }
+        if let Some(target) = pending.symlinks.get(path) {
+            return Some(PendingHit::Symlink {
+                target_len: target.len() as u64,
+            });
+        }
         if let Some(node_id) = pending.hot_by_path.get(path)
             && let Some(buf) = pending.hot.get(node_id)
         {
@@ -1115,14 +1846,36 @@ impl ContentAddressedMount {
         None
     }
 
+    /// True if the parent dir or any ancestor of `path` has been
+    /// `rmdir`'d through the mount. Used by lookup/enumerate so the
+    /// kernel never sees stale captured children of a directory the
+    /// agent removed.
+    fn ancestor_is_dir_tombstoned(&self, pending: &Pending, path: &Path) -> bool {
+        let mut cursor = path.parent();
+        while let Some(p) = cursor {
+            if p.as_os_str().is_empty() {
+                break;
+            }
+            if pending.dir_tombstones.contains(p) {
+                return true;
+            }
+            cursor = p.parent();
+        }
+        false
+    }
+
     /// Does any pending entry sit *under* `dir` as a strict prefix?
     /// I.e. has an agent created `dir/something` even though `dir`
-    /// itself isn't in the captured tree yet?
+    /// itself isn't in the captured tree yet? An explicit `mkdir dir`
+    /// also counts (so an empty mkdir survives without children).
     fn pending_dir_exists(&self, dir: &Path) -> bool {
         if dir.as_os_str().is_empty() {
             return false;
         }
         let pending = self.inner.pending.lock().expect("pending lock");
+        if pending.explicit_dirs.contains(dir) {
+            return true;
+        }
         let prefix = dir;
         let probe = |path: &Path| -> bool {
             path.strip_prefix(prefix)
@@ -1138,6 +1891,7 @@ impl ContentAddressedMount {
                 .hot_by_path
                 .keys()
                 .any(|p| !pending.tombstones.contains(p) && probe(p))
+            || pending.symlinks.keys().any(|p| probe(p))
     }
 
     /// Direct children of `dir` that exist purely in the pending
@@ -1202,7 +1956,67 @@ impl ContentAddressedMount {
                 });
             }
         }
+        for (path, target) in pending.symlinks.iter() {
+            let Some((name, is_dir)) = project(path) else {
+                continue;
+            };
+            if is_dir {
+                out.entry(name).or_insert(PendingChildKind::Dir);
+            } else {
+                out.entry(name).or_insert(PendingChildKind::Symlink {
+                    size: target.len() as u64,
+                });
+            }
+        }
+        // Explicit empty mkdirs that haven't picked up any pending
+        // children yet. Surface them as direct children when their
+        // parent matches `dir`, and as transitive implicit dirs when
+        // an ancestor matches.
+        for explicit in pending.explicit_dirs.iter() {
+            let Some((name, _is_deeper)) = project(explicit) else {
+                continue;
+            };
+            out.entry(name).or_insert(PendingChildKind::Dir);
+        }
         out.into_iter().collect()
+    }
+}
+
+/// Reject FUSE entry names that wouldn't survive a `TreeEntry`'s
+/// validator: empty, the `.`/`..` pseudo-entries, anything with a
+/// path separator, anything with a NUL byte. Returns the validated
+/// name as a `&str` so callers can build paths without re-decoding.
+fn validate_entry_name<'a>(name: &'a OsStr) -> Result<&'a str> {
+    use std::os::unix::ffi::OsStrExt;
+    let bytes = name.as_bytes();
+    if bytes.is_empty() {
+        return Err(MountError::InvalidArgument("empty entry name".into()));
+    }
+    if bytes == b"." || bytes == b".." {
+        return Err(MountError::InvalidArgument(format!(
+            "'{}' is not a valid entry name",
+            name.to_string_lossy()
+        )));
+    }
+    if bytes.iter().any(|&b| b == 0 || b == b'/') {
+        return Err(MountError::InvalidArgument(format!(
+            "entry name {:?} contains NUL or '/'",
+            name
+        )));
+    }
+    name.to_str().ok_or_else(|| {
+        MountError::InvalidArgument(format!("entry name {name:?} is not valid UTF-8"))
+    })
+}
+
+/// Join a parent mount-relative path with a leaf name. Mirrors the
+/// shape every write-side op uses, so the construction stays
+/// consistent across the file.
+fn join_child(parent: &Path, name: &str) -> PathBuf {
+    if parent.as_os_str().is_empty() {
+        PathBuf::from(name)
+    } else {
+        parent.join(name)
     }
 }
 
@@ -1253,6 +2067,9 @@ enum PendingHit {
         size: u64,
         mode: FileMode,
     },
+    Symlink {
+        target_len: u64,
+    },
     Tombstone,
 }
 
@@ -1269,6 +2086,9 @@ enum PendingChildKind {
     WarmFile {
         size: u64,
         mode: FileMode,
+    },
+    Symlink {
+        size: u64,
     },
     Dir,
 }
@@ -1446,7 +2266,30 @@ impl PlatformShell for ContentAddressedMount {
                     unix_mode: mode.to_unix_mode(),
                 }));
             }
+            Some(PendingHit::Symlink { target_len }) => {
+                let node = self.intern(NodeRecord::PendingSymlink {
+                    path: child_path.clone(),
+                });
+                return Ok(Some(Entry {
+                    node,
+                    name: OsString::from(name_str),
+                    kind: NodeKind::Symlink,
+                    size: target_len,
+                    unix_mode: FileMode::Symlink.to_unix_mode(),
+                }));
+            }
             None => {}
+        }
+
+        // Did an ancestor get rmdir'd? Then the captured-tree entry
+        // is no longer addressable through this mount.
+        {
+            let pending = self.inner.pending.lock().expect("pending lock");
+            if pending.dir_tombstones.contains(&child_path)
+                || self.ancestor_is_dir_tombstoned(&pending, &child_path)
+            {
+                return Ok(None);
+            }
         }
 
         // Captured tree wins over implicit pending dirs: if both
@@ -1693,6 +2536,19 @@ impl PlatformShell for ContentAddressedMount {
         let tree = self.tree_for_record(&record)?;
         let mut by_name: BTreeMap<String, Entry> = BTreeMap::new();
 
+        // If this directory itself is dir-tombstoned, enumerate
+        // returns empty regardless of any captured children. (A
+        // child rmdir doesn't affect us — only an ancestor or self
+        // tombstone does.)
+        {
+            let pending = self.inner.pending.lock().expect("pending lock");
+            if pending.dir_tombstones.contains(&parent_path)
+                || self.ancestor_is_dir_tombstoned(&pending, &parent_path)
+            {
+                return Ok(vec![]);
+            }
+        }
+
         // Pass 1: captured-tree entries, with pending overlay.
         for tree_entry in tree.entries() {
             let entry_path = if parent_path.as_os_str().is_empty() {
@@ -1700,6 +2556,13 @@ impl PlatformShell for ContentAddressedMount {
             } else {
                 parent_path.join(&tree_entry.name)
             };
+            // Whole-subtree rmdir on a captured dir entry.
+            {
+                let pending = self.inner.pending.lock().expect("pending lock");
+                if pending.dir_tombstones.contains(&entry_path) {
+                    continue;
+                }
+            }
             match self.pending_lookup(&entry_path) {
                 Some(PendingHit::Tombstone) => continue,
                 Some(PendingHit::Hot { node, size, mode }) => {
@@ -1732,6 +2595,22 @@ impl PlatformShell for ContentAddressedMount {
                             kind: kind_for_mode(mode),
                             size,
                             unix_mode: mode.to_unix_mode(),
+                        },
+                    );
+                    continue;
+                }
+                Some(PendingHit::Symlink { target_len }) => {
+                    let node = self.intern(NodeRecord::PendingSymlink {
+                        path: entry_path,
+                    });
+                    by_name.insert(
+                        tree_entry.name.clone(),
+                        Entry {
+                            node,
+                            name: OsString::from(&tree_entry.name),
+                            kind: NodeKind::Symlink,
+                            size: target_len,
+                            unix_mode: FileMode::Symlink.to_unix_mode(),
                         },
                     );
                     continue;
@@ -1796,6 +2675,21 @@ impl PlatformShell for ContentAddressedMount {
                             kind: NodeKind::Directory,
                             size: child_count,
                             unix_mode: DIR_UNIX_MODE,
+                        },
+                    );
+                }
+                PendingChildKind::Symlink { size } => {
+                    let node = self.intern(NodeRecord::PendingSymlink {
+                        path: full_path,
+                    });
+                    by_name.insert(
+                        name.clone(),
+                        Entry {
+                            node,
+                            name: OsString::from(&name),
+                            kind: NodeKind::Symlink,
+                            size,
+                            unix_mode: FileMode::Symlink.to_unix_mode(),
                         },
                     );
                 }
@@ -1865,8 +2759,20 @@ impl PlatformShell for ContentAddressedMount {
                     .ok_or_else(|| MountError::Stale(format!("pending file {}", path.display())))?;
                 let size = match hit {
                     PendingHit::Hot { size, .. } | PendingHit::Warm { size, .. } => size,
+                    PendingHit::Symlink { target_len } => target_len,
                     PendingHit::Tombstone => 0,
                 };
+                (size, 1)
+            }
+            NodeRecord::PendingSymlink { path } => {
+                let pending = self.inner.pending.lock().expect("pending lock");
+                let size = pending
+                    .symlinks
+                    .get(path)
+                    .map(|t| t.len() as u64)
+                    .ok_or_else(|| {
+                        MountError::Stale(format!("pending symlink {}", path.display()))
+                    })?;
                 (size, 1)
             }
         };
@@ -1901,6 +2807,55 @@ impl PlatformShell for ContentAddressedMount {
 
     fn release(&self, node: NodeId) -> Result<()> {
         self.flush_node(node)
+    }
+
+    fn create_file(
+        &self,
+        parent: NodeId,
+        name: &OsStr,
+        mode: FileMode,
+        exclusive: bool,
+    ) -> Result<Entry> {
+        ContentAddressedMount::create_file(self, parent, name, mode, exclusive)
+    }
+
+    fn make_dir(&self, parent: NodeId, name: &OsStr) -> Result<Entry> {
+        ContentAddressedMount::make_dir(self, parent, name)
+    }
+
+    fn unlink_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        ContentAddressedMount::unlink_entry(self, parent, name)
+    }
+
+    fn rmdir_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        ContentAddressedMount::rmdir_entry(self, parent, name)
+    }
+
+    fn rename_entry(
+        &self,
+        old_parent: NodeId,
+        old_name: &OsStr,
+        new_parent: NodeId,
+        new_name: &OsStr,
+    ) -> Result<()> {
+        ContentAddressedMount::rename_entry(self, old_parent, old_name, new_parent, new_name)
+    }
+
+    fn set_attrs(&self, node: NodeId, update: AttrUpdate) -> Result<Attrs> {
+        ContentAddressedMount::set_attrs(self, node, update)
+    }
+
+    fn create_symlink(
+        &self,
+        parent: NodeId,
+        name: &OsStr,
+        target: &Path,
+    ) -> Result<Entry> {
+        ContentAddressedMount::create_symlink(self, parent, name, target)
+    }
+
+    fn read_link(&self, node: NodeId) -> Result<OsString> {
+        ContentAddressedMount::read_link(self, node)
     }
 }
 
@@ -2045,6 +3000,9 @@ impl ContentAddressedMount {
             pending.hot_by_path.clear();
             pending.warm.clear();
             pending.tombstones.clear();
+            pending.dir_tombstones.clear();
+            pending.explicit_dirs.clear();
+            pending.symlinks.clear();
         }
         let mut state_lock = self.inner.state.write().expect("mount state lock");
         *state_lock = MountState {
@@ -2096,8 +3054,21 @@ fn apply_pending_to_tree(
         /// File leaves to plant in this directory (overrides any
         /// captured entry of the same name).
         files: BTreeMap<String, (ContentHash, FileMode)>,
+        /// Symlink leaves: name → (blob_oid, target_len). The blob
+        /// is hashed + written at apply time so empty-symlink rename
+        /// flows just need to point at the same hash.
+        symlinks: BTreeMap<String, ContentHash>,
         /// Names to tombstone (file or subdirectory).
         deletions: BTreeSet<String>,
+        /// Subtrees to drop entirely (captured-dir `rmdir`). The
+        /// materialize pass removes both the captured entry and any
+        /// pending children planted by a deeper write under it.
+        dir_deletions: BTreeSet<String>,
+        /// Empty mkdirs that should survive even when no child was
+        /// written. Captured-dir collision is impossible here: an
+        /// existing captured dir would have made the `mkdir` itself
+        /// fail with EEXIST.
+        explicit_empty: BTreeSet<String>,
         /// Named child directories that have pending content.
         children: BTreeMap<String, VDir>,
     }
@@ -2130,6 +3101,50 @@ fn apply_pending_to_tree(
         dir.deletions.remove(*leaf_name);
     }
 
+    // Plant symlinks. Their target bytes get written as a CAS blob
+    // here (lazily) so we never duplicate the hashing cost in the
+    // hot path of `symlink`.
+    for (path, target_bytes) in &pending.symlinks {
+        let comps: Vec<&str> = path
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(n) => n.to_str(),
+                _ => None,
+            })
+            .collect();
+        let Some((leaf_name, dir_components)) = comps.split_last() else {
+            continue;
+        };
+        let blob = Blob::new(target_bytes.clone());
+        let blob_oid = store.put_blob(&blob).map_err(MountError::Store)?;
+        let dir = descend(&mut root, dir_components);
+        dir.symlinks.insert((*leaf_name).to_string(), blob_oid);
+        dir.deletions.remove(*leaf_name);
+    }
+
+    // Plant explicit-empty directories. We descend to the leaf dir
+    // and mark its name in the *parent*'s `explicit_empty` set, so
+    // materialize emits a zero-entry subtree even with no children.
+    for explicit in &pending.explicit_dirs {
+        let comps: Vec<&str> = explicit
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(n) => n.to_str(),
+                _ => None,
+            })
+            .collect();
+        let Some((leaf_name, dir_components)) = comps.split_last() else {
+            continue;
+        };
+        let parent_dir = descend(&mut root, dir_components);
+        parent_dir
+            .explicit_empty
+            .insert((*leaf_name).to_string());
+        // Also ensure the dir's own VDir exists so materialize
+        // visits it (descend into the leaf one extra step).
+        parent_dir.children.entry((*leaf_name).to_string()).or_default();
+    }
+
     // Plant tombstones. Each tombstone names a *file* the agent
     // deleted; we record it on the leaf directory so materialization
     // skips both any pre-existing entry and any virtual file with
@@ -2147,7 +3162,30 @@ fn apply_pending_to_tree(
         };
         let dir = descend(&mut root, dir_components);
         dir.files.remove(*leaf_name);
+        dir.symlinks.remove(*leaf_name);
         dir.deletions.insert((*leaf_name).to_string());
+    }
+
+    // Plant directory tombstones. Each names a captured-tree
+    // directory the agent `rmdir`'d. The materialize pass deletes
+    // both the captured entry and any virtual children that ended
+    // up under it (a pathological case — `rmdir` requires empty —
+    // but cheap to guard against).
+    for tomb in &pending.dir_tombstones {
+        let comps: Vec<&str> = tomb
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(n) => n.to_str(),
+                _ => None,
+            })
+            .collect();
+        let Some((leaf_name, dir_components)) = comps.split_last() else {
+            continue;
+        };
+        let dir = descend(&mut root, dir_components);
+        dir.children.remove(*leaf_name);
+        dir.explicit_empty.remove(*leaf_name);
+        dir.dir_deletions.insert((*leaf_name).to_string());
     }
 
     /// Materialize a virtual directory against its captured counterpart
@@ -2171,6 +3209,9 @@ fn apply_pending_to_tree(
         for name in &v.deletions {
             entries.remove(name);
         }
+        for name in &v.dir_deletions {
+            entries.remove(name);
+        }
 
         // File overrides.
         for (name, (blob, mode)) in &v.files {
@@ -2181,8 +3222,24 @@ fn apply_pending_to_tree(
             entries.insert(name.clone(), entry);
         }
 
+        // Symlink overrides.
+        for (name, blob) in &v.symlinks {
+            let entry = TreeEntry::symlink(name.clone(), *blob).map_err(|e| {
+                MountError::Store(objects::error::HeddleError::InvalidObject(e.to_string()))
+            })?;
+            entries.insert(name.clone(), entry);
+        }
+
         // Recurse into each pending subdirectory.
         for (name, child) in &v.children {
+            // dir_deletions wins: if the agent `rmdir`'d this name,
+            // drop the whole subtree regardless of any pending
+            // virtual children (which `rmdir` requires to be empty
+            // — this branch is the belt + braces).
+            if v.dir_deletions.contains(name) {
+                entries.remove(name);
+                continue;
+            }
             // Captured counterpart: if `captured` already has a
             // subdir under this name, load it; otherwise start from
             // an empty tree.
@@ -2193,8 +3250,19 @@ fn apply_pending_to_tree(
                     .unwrap_or_default(),
                 _ => Tree::new(),
             };
+            let force_empty = v.explicit_empty.contains(name);
             match materialize(child, &child_captured, store)? {
                 Some(hash) => {
+                    let entry = TreeEntry::directory(name.clone(), hash).map_err(|e| {
+                        MountError::Store(objects::error::HeddleError::InvalidObject(e.to_string()))
+                    })?;
+                    entries.insert(name.clone(), entry);
+                }
+                None if force_empty => {
+                    // Empty mkdir survives capture as a 0-entry tree.
+                    let hash = store
+                        .put_tree(&Tree::new())
+                        .map_err(MountError::Store)?;
                     let entry = TreeEntry::directory(name.clone(), hash).map_err(|e| {
                         MountError::Store(objects::error::HeddleError::InvalidObject(e.to_string()))
                     })?;

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -330,12 +330,22 @@ impl Inodes {
                     });
                 }
                 NodeRecord::Dir { path, .. } | NodeRecord::PendingDir { path } => {
-                    self.by_path.remove(&path);
+                    // Codex r12 thread 3293680448 (P1): only drop the
+                    // path mapping if it still points at *this* inode.
+                    // After unlink-then-recreate or rename-over, `path`
+                    // may already be rebound to a live inode at a
+                    // different NodeId; a blind `remove` would yank
+                    // that fresh inode's binding too.
+                    if self.by_path.get(&path) == Some(&id.0) {
+                        self.by_path.remove(&path);
+                    }
                 }
                 NodeRecord::File { path, .. }
                 | NodeRecord::PendingFile { path, .. }
                 | NodeRecord::PendingSymlink { path } => {
-                    self.by_path.remove(&path);
+                    if self.by_path.get(&path) == Some(&id.0) {
+                        self.by_path.remove(&path);
+                    }
                 }
                 NodeRecord::Symlink { blob } => {
                     self.by_hash.remove(&HashKey {
@@ -1434,11 +1444,22 @@ impl ContentAddressedMount {
             // tracked until `release` / `invalidate` / `capture`
             // drops it (matching pre-spike orphan-set semantics for
             // tests that skip the explicit `on_open`).
-            let open_count = pending.open_count(node_id);
-            pending
-                .state
-                .insert(node_id, NodeState::Orphan { open_count });
-            // Symlinks are not openable; no orphan story applies.
+            //
+            // Codex r12 thread 3293510317 (P3): symlinks have no
+            // `open`/`release` lifecycle (they're not openable for
+            // IO), so we MUST NOT orphan them — no event would ever
+            // clear the state entry, and `pending.state` would grow
+            // under symlink churn until capture/invalidate. Files
+            // (regular + executable) do receive open/release events
+            // and take the Orphan branch.
+            if entry.kind != NodeKind::Symlink {
+                let open_count = pending.open_count(node_id);
+                pending
+                    .state
+                    .insert(node_id, NodeState::Orphan { open_count });
+            }
+            // Symlinks are path-keyed; their overlay goes when the
+            // directory entry goes.
             pending.symlinks.remove(&child_path);
             pending.tombstones.insert(child_path.clone());
         }
@@ -1478,9 +1499,23 @@ impl ContentAddressedMount {
             .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
         let child_path = join_child(&parent_path, name_str);
 
-        let mut pending = self.inner.pending.lock().expect("pending lock");
-        pending.explicit_dirs.remove(&child_path);
-        pending.dir_tombstones.insert(child_path);
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            pending.explicit_dirs.remove(&child_path);
+            pending.dir_tombstones.insert(child_path.clone());
+        }
+        // Codex r12 thread 3293510310 (P1): retire the path → inode
+        // mapping. Otherwise `Inodes::intern` would coalesce a
+        // subsequent `create_file` / `make_dir` at this path onto the
+        // removed directory's NodeId, rebinding a cached directory
+        // inode to a different object type — the same stale-handle
+        // class `unlink_entry` already guards against. The `by_id`
+        // record stays so any kernel handle the FS still holds keeps
+        // resolving until `forget`.
+        {
+            let mut inodes = self.inner.inodes.lock().expect("inode lock");
+            inodes.by_path.remove(&child_path);
+        }
         Ok(())
     }
 
@@ -2213,6 +2248,16 @@ impl ContentAddressedMount {
 
     /// Read the target of a symlink `node`. Works for both overlay
     /// (`PendingSymlink`) and captured (`Symlink`) records.
+    ///
+    /// Codex r12 thread 3293510316 (P1): the prior implementation
+    /// used `OsStr::from_encoded_bytes_unchecked` on bytes loaded
+    /// from the object store, which is unsound — that API's safety
+    /// contract requires bytes minted by `OsStr::as_encoded_bytes`
+    /// in *this* process and Rust version, but captured-tree blobs
+    /// can come from any process and version. The corrected path
+    /// delegates to [`symlink_target_from_bytes`], which uses
+    /// platform-safe APIs (`OsStrExt::from_bytes` on Unix, UTF-8
+    /// validation on Windows).
     pub fn read_link(&self, node: NodeId) -> Result<OsString> {
         let record = self.record_for(node)?;
         match record {
@@ -2222,16 +2267,11 @@ impl ContentAddressedMount {
                     .symlinks
                     .get(&path)
                     .ok_or_else(|| MountError::Stale(format!("symlink {}", path.display())))?;
-                // SAFETY: bytes were written via `OsStr::as_encoded_bytes()` in
-                // `create_symlink`, which is the documented inverse of
-                // `from_encoded_bytes_unchecked`.
-                Ok(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) }.to_os_string())
+                symlink_target_from_bytes(bytes)
             }
             NodeRecord::Symlink { blob } => {
                 let bytes = self.load_blob_bytes(&blob)?;
-                // SAFETY: same provenance as above — the blob was minted from
-                // `as_encoded_bytes()` at capture time.
-                Ok(unsafe { OsStr::from_encoded_bytes_unchecked(&bytes) }.to_os_string())
+                symlink_target_from_bytes(&bytes)
             }
             other => Err(MountError::InvalidArgument(format!(
                 "read_link on non-symlink record: {other:?}"
@@ -2497,6 +2537,32 @@ fn warm_path_of_record(record: &NodeRecord) -> Option<PathBuf> {
     match record {
         NodeRecord::File { path, .. } | NodeRecord::PendingFile { path, .. } => Some(path.clone()),
         _ => None,
+    }
+}
+
+/// Decode symlink target bytes back into an `OsString`. The Unix
+/// branch uses `OsStrExt::from_bytes`, which is sound for any byte
+/// sequence (the inverse of `OsStrExt::as_bytes`). The Windows branch
+/// validates as UTF-8 and returns [`MountError::InvalidArgument`]
+/// otherwise — `OsStr` on Windows is a process-internal encoding
+/// (WTF-8 today, but not promised), so accepting arbitrary captured
+/// bytes is unsound. Replaces a prior
+/// `unsafe { OsStr::from_encoded_bytes_unchecked(bytes) }` call site
+/// (Codex r12 thread 3293510316).
+fn symlink_target_from_bytes(bytes: &[u8]) -> Result<OsString> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        Ok(OsStr::from_bytes(bytes).to_os_string())
+    }
+    #[cfg(not(unix))]
+    {
+        match std::str::from_utf8(bytes) {
+            Ok(s) => Ok(OsString::from(s)),
+            Err(_) => Err(MountError::InvalidArgument(
+                "captured symlink target bytes are not valid UTF-8".into(),
+            )),
+        }
     }
 }
 
@@ -3528,21 +3594,36 @@ impl PlatformShell for ContentAddressedMount {
         // at us; an unlink-then-recreate sequence may have moved
         // the live mapping to a fresh inode at the same name, and
         // a blind `remove` would yank that fresh inode's entry.
-        {
+        //
+        // Codex r12 threads 3293484634 / 3293510311 (P1): FUSE
+        // `forget` only signals that the kernel released its cached
+        // identity for this inode — it does NOT say the file's
+        // pending overlay data is stale. Warm is the only durable
+        // pre-capture copy of flushed writes; dropping it silently
+        // loses the user's committed-in-session data. Preserve
+        // `warm[node]` here, and only retire the inode record when
+        // nothing in the overlay still references the NodeId —
+        // otherwise capture loses the NodeId → path chain it needs
+        // to plant the warm bytes back into the new tree.
+        let still_referenced = {
             let mut pending = self.inner.pending.lock().expect("pending lock");
             if let Some(buf) = pending.hot.remove(&node.0)
                 && pending.hot_by_path.get(&buf.path) == Some(&node.0)
             {
                 pending.hot_by_path.remove(&buf.path);
             }
-            // The kernel is forgetting this inode; any lifecycle
-            // tracking we kept for it is now dead weight. Drop the
-            // state entry and any NodeId-keyed warm bytes so a
-            // long-running mount doesn't accumulate dead entries.
+            // State tracks the per-inode open-handle refcount; FUSE
+            // `forget` is a kernel-side cache eviction (not a close),
+            // so the refcount is already at 0 by the time we see it.
+            // Drop the state entry so a long-running mount doesn't
+            // accumulate dead lifecycle records. Warm preservation
+            // (above) is the load-bearing change here.
             pending.state.remove(&node.0);
-            pending.warm.remove(&node.0);
+            pending.warm.contains_key(&node.0)
+        };
+        if !still_referenced {
+            self.inner.inodes.lock().expect("inode lock").forget(node);
         }
-        self.inner.inodes.lock().expect("inode lock").forget(node);
         Ok(())
     }
 
@@ -3761,20 +3842,46 @@ impl ContentAddressedMount {
             warn!(?err, "thread metadata refresh from mount capture failed");
         }
 
-        // Step 4: clear the pending tier and refresh state. The new
-        // state's tree is canonical, so any open fds the kernel still
-        // holds against pre-capture inodes will get refreshed via
-        // `forget` / re-lookup as normal.
+        // Step 4: drain the pending tier. Codex r12 thread 3293484633
+        // (P1): the prior wholesale `state.clear()` here dropped
+        // Orphan entries for inodes with still-open fds; the next
+        // write through those fds would then take the Live branch
+        // (`is_orphan` returns false → republish path / clear
+        // tombstone / coalesce hot_by_path), republishing a pathname
+        // that POSIX says must remain detached until final close.
+        // It also dropped `hot[id]` / `warm[id]` for those Orphan
+        // entries, losing the surviving fd's own bytes.
+        //
+        // The correct drain retires only Live entries plus all of
+        // the path-keyed bookkeeping (the new tree owns those paths
+        // now). Orphan entries — and their per-NodeId `hot[id]` /
+        // `warm[id]` bytes — survive so the orphan branches in
+        // `read` / `write` / `attrs` / `apply_truncate` keep serving
+        // the surviving fd, and `unlink_entry` / `rename`'s T1/T3
+        // transition stays in effect across capture.
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            pending.hot.clear();
+            let orphan_ids: BTreeSet<u64> = pending
+                .state
+                .iter()
+                .filter_map(|(id, s)| match s {
+                    NodeState::Orphan { .. } => Some(*id),
+                    NodeState::Live { .. } => None,
+                })
+                .collect();
+            pending.hot.retain(|id, _| orphan_ids.contains(id));
+            pending.warm.retain(|id, _| orphan_ids.contains(id));
+            pending.state.retain(|id, _| orphan_ids.contains(id));
+            // Path-keyed bookkeeping is for the Live tree, which is
+            // now folded into the captured state; the orphan path
+            // overlays are gone by definition (T1/T3 already removed
+            // their `hot_by_path` / `symlinks` / `inodes.by_path`
+            // bindings) so wholesale clear is safe.
             pending.hot_by_path.clear();
-            pending.warm.clear();
             pending.tombstones.clear();
             pending.dir_tombstones.clear();
             pending.explicit_dirs.clear();
             pending.symlinks.clear();
-            pending.state.clear();
         }
         let mut state_lock = self.inner.state.write().expect("mount state lock");
         *state_lock = MountState {

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1400,14 +1400,14 @@ impl ContentAddressedMount {
             // for the replaced file keeps resolving (the kernel cleans
             // up via `forget` on close). POSIX semantics: rename-over
             // must not invalidate an already-open dest descriptor.
-            inodes.by_path.remove(&new_path);
+            let displaced_dest = inodes.by_path.remove(&new_path);
             // Rewrite the source inode's stored path so subsequent
             // reads/attrs against it serve the new-path overlay.
             // The kernel keeps using the source's NodeId after rename
             // (it's just a dentry-table rewrite on its side) — without
             // this, every read against the rebased dentry sees the
             // stale path and returns ESTALE.
-            if let Some(src_id) = inodes.by_path.remove(&old_path) {
+            let rebased_src = if let Some(src_id) = inodes.by_path.remove(&old_path) {
                 if let Some(
                     NodeRecord::PendingFile { path, .. }
                     | NodeRecord::File { path, .. }
@@ -1455,15 +1455,33 @@ impl ContentAddressedMount {
                         inodes.by_path.insert(new_key, id);
                     }
                 }
-                drop(inodes);
-                // Same for any cached hot buffer keyed on the source
-                // node — its `path` field must follow. (Descendant
-                // hot-buffer paths are already rebased in
-                // `move_overlay_dir`'s `hot_path_updates` pass.)
-                let mut pending = self.inner.pending.lock().expect("pending lock");
-                if let Some(buf) = pending.hot.get_mut(&src_id) {
-                    buf.path = new_path.clone();
-                }
+                Some(src_id)
+            } else {
+                None
+            };
+            drop(inodes);
+            // Reach into pending for two cleanups under one lock:
+            //   * The source's hot buffer (if any) carries the old
+            //     path; rebase it. Descendant hot-buffer paths are
+            //     already handled by `move_overlay_dir`'s
+            //     `hot_path_updates` pass.
+            //   * The displaced destination (if any) becomes an
+            //     orphan: its directory entry is gone but the inode
+            //     id may still be held by a kernel fd. Subsequent
+            //     `write` / `apply_truncate` / `set_attrs` /
+            //     `read` / `attrs` calls through that fd consult
+            //     `Pending::orphans` and take the per-NodeId branch
+            //     instead of the rebased path overlay. The companion
+            //     orphan branch in `flush_node` drops any preserved
+            //     buffer without warm-promoting.
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            if let Some(src_id) = rebased_src
+                && let Some(buf) = pending.hot.get_mut(&src_id)
+            {
+                buf.path = new_path.clone();
+            }
+            if let Some(dest_id) = displaced_dest {
+                pending.orphans.insert(dest_id);
             }
         }
         Ok(())
@@ -1521,10 +1539,15 @@ impl ContentAddressedMount {
 
         // Apply.
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Drop any old destination state.
-        if let Some(id) = pending.hot_by_path.remove(new_path) {
-            pending.hot.remove(&id);
-        }
+        // Detach the destination's path overlay. The hot buffer keyed
+        // by the displaced inode id is preserved — `rename_entry`
+        // marks that inode as orphan so its still-open fd keeps
+        // reading via the per-NodeId buffer (and any further write
+        // through that fd takes the orphan branch in `write`, which
+        // does not republish `hot_by_path`). POSIX rename-over: open
+        // dest descriptors must keep referencing the displaced inode
+        // until close.
+        pending.hot_by_path.remove(new_path);
         pending.warm.remove(new_path);
         pending.symlinks.remove(new_path);
         pending.tombstones.remove(new_path);
@@ -1558,9 +1581,12 @@ impl ContentAddressedMount {
             }
         };
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        if let Some(id) = pending.hot_by_path.remove(new_path) {
-            pending.hot.remove(&id);
-        }
+        // Same rename-over discipline as `move_file`: detach the
+        // destination path overlay but preserve the displaced inode's
+        // hot buffer (if any). The caller orphans the inode so reads
+        // through its still-open fd consult the per-NodeId buffer and
+        // subsequent writes/setattrs take the orphan branch.
+        pending.hot_by_path.remove(new_path);
         pending.warm.remove(new_path);
         pending.symlinks.remove(new_path);
         pending.tombstones.remove(new_path);
@@ -1751,16 +1777,31 @@ impl ContentAddressedMount {
             } {
                 let path = path.clone();
                 let mut pending = self.inner.pending.lock().expect("pending lock");
+                // Always flip the per-NodeId buffer's mode — that's
+                // the orphan's own bookkeeping when fd-based, and
+                // the live buffer for non-orphan callers.
                 if let Some(buf) = pending.hot.get_mut(&node.0) {
                     buf.mode = new_mode;
                 }
-                if let Some(other_id) = pending.hot_by_path.get(&path).copied()
-                    && let Some(buf) = pending.hot.get_mut(&other_id)
-                {
-                    buf.mode = new_mode;
-                }
-                if let Some(entry) = pending.warm.get_mut(&path) {
-                    entry.mode = new_mode;
+                // Orphan branch: `unlink_entry` / `rename_entry`
+                // recorded this NodeId because the kernel still
+                // holds an fd to it, but the directory entry is
+                // gone (or rebound to a sibling). POSIX is explicit:
+                // an fd-based attribute change applies only to the
+                // file referenced by that fd. Touching
+                // `hot_by_path[path]` would mutate the fresh inode
+                // now living at the same name; touching
+                // `warm[path]` would land the change on the sibling
+                // at capture time.
+                if !pending.orphans.contains(&node.0) {
+                    if let Some(other_id) = pending.hot_by_path.get(&path).copied()
+                        && let Some(buf) = pending.hot.get_mut(&other_id)
+                    {
+                        buf.mode = new_mode;
+                    }
+                    if let Some(entry) = pending.warm.get_mut(&path) {
+                        entry.mode = new_mode;
+                    }
                 }
             }
         }
@@ -1789,12 +1830,34 @@ impl ContentAddressedMount {
             }
         };
 
-        // If a hot buffer already exists for this node or path,
-        // resize in place.
-        let resized_in_place = {
+        // Phase 1: under the lock, decide whether a buffer already
+        // exists (resize in place), and otherwise record orphan-ness
+        // + the seed source. Drop the lock for the CAS read.
+        //
+        // POSIX `ftruncate` on an open-unlinked / rename-displaced fd
+        // (an orphan in our terminology) must touch only the
+        // anonymous open inode. The orphan branch never resizes a
+        // sibling buffer at the rebased path, never seeds from
+        // `warm[path]` (now owned by the sibling), and in Phase 2
+        // never republishes `hot_by_path[path]` nor clears the
+        // tombstone.
+        enum Phase1 {
+            ResizedInPlace,
+            NeedSeed {
+                orphan: bool,
+                seed: Option<ContentHash>,
+            },
+        }
+        let phase1 = {
             let mut pending = self.inner.pending.lock().expect("pending lock");
+            let orphan = pending.orphans.contains(&node.0);
             let id = if pending.hot.contains_key(&node.0) {
                 Some(node.0)
+            } else if orphan {
+                // Never resize a sibling buffer through the orphan
+                // fd — that buffer belongs to a fresh inode at the
+                // rebound name.
+                None
             } else {
                 pending.hot_by_path.get(&path).copied()
             };
@@ -1803,42 +1866,60 @@ impl ContentAddressedMount {
             {
                 buf.bytes.resize(new_size as usize, 0);
                 buf.last_touched = Instant::now();
-                true
+                Phase1::ResizedInPlace
             } else {
-                false
+                let seed = if orphan {
+                    // Orphan: only the inode's pre-displacement
+                    // content is valid. For a captured-file orphan
+                    // that's `captured_blob`; a PendingFile orphan
+                    // with no warm fallback starts empty.
+                    captured_blob
+                } else {
+                    pending.warm.get(&path).map(|e| e.blob).or(captured_blob)
+                };
+                Phase1::NeedSeed { orphan, seed }
             }
         };
-        if resized_in_place {
-            return Ok(());
-        }
-
-        // No hot buffer — seed from the durable predecessor (warm
-        // tier wins over captured tree) and resize.
-        let seed_blob = {
-            let pending = self.inner.pending.lock().expect("pending lock");
-            pending
-                .warm
-                .get(&path)
-                .map(|e| e.blob)
-                .or(captured_blob)
+        let (orphan, seed_blob) = match phase1 {
+            Phase1::ResizedInPlace => return Ok(()),
+            Phase1::NeedSeed { orphan, seed } => (orphan, seed),
         };
+
         let mut bytes = match seed_blob {
             Some(hash) => (*self.load_blob_bytes(&hash)?).to_vec(),
             None => Vec::new(),
         };
         bytes.resize(new_size as usize, 0);
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        pending.tombstones.remove(&path);
-        pending.hot.insert(
-            node.0,
-            HotBuffer {
-                path: path.clone(),
-                mode,
-                bytes,
-                last_touched: Instant::now(),
-            },
-        );
-        pending.hot_by_path.insert(path, node.0);
+        if orphan {
+            // Per-NodeId buffer only. Skip the tombstone-clear and
+            // the `hot_by_path` rebind — the directory entry must
+            // stay gone (open-unlinked) or stay rebound to the
+            // sibling (rename-over). The companion orphan branch in
+            // `flush_node` drops this buffer on release without
+            // warm-promoting it.
+            pending.hot.insert(
+                node.0,
+                HotBuffer {
+                    path,
+                    mode,
+                    bytes,
+                    last_touched: Instant::now(),
+                },
+            );
+        } else {
+            pending.tombstones.remove(&path);
+            pending.hot.insert(
+                node.0,
+                HotBuffer {
+                    path: path.clone(),
+                    mode,
+                    bytes,
+                    last_touched: Instant::now(),
+                },
+            );
+            pending.hot_by_path.insert(path, node.0);
+        }
         Ok(())
     }
 
@@ -2469,9 +2550,18 @@ impl PlatformShell for ContentAddressedMount {
         match &record {
             NodeRecord::PendingFile { path, .. } => {
                 // Same shape, keyed by path: another NodeId may own
-                // the buffer (e.g. after rename/coalesce).
+                // the buffer (e.g. after rename/coalesce). Orphan
+                // PendingFiles skip the path overlay — the path is
+                // gone (open-unlinked) or rebound (rename-over) and
+                // there is no captured-tier fallback to serve.
                 let warm_blob = {
                     let pending = self.inner.pending.lock().expect("pending lock");
+                    if pending.orphans.contains(&node.0) {
+                        return Err(MountError::Stale(format!(
+                            "orphan pending file {} has no readable bytes",
+                            path.display()
+                        )));
+                    }
                     if let Some(id) = pending.hot_by_path.get(path).copied()
                         && let Some(hot) = pending.hot.get(&id)
                     {
@@ -2504,9 +2594,20 @@ impl PlatformShell for ContentAddressedMount {
                 //
                 // Priority: hot @ another NodeId → warm → tombstone
                 // (ENOENT-shaped Stale) → captured blob.
+                //
+                // Orphan exception: an open-unlinked or
+                // rename-displaced inode must skip the path overlay
+                // entirely. `tombstones[path]` / `hot_by_path[path]`
+                // / `warm[path]` now reflect a sibling at the same
+                // name; serving them would let the open fd observe
+                // (or even modify, via Overlay::Hot) bytes that
+                // POSIX assigns to the sibling. Fall through to the
+                // captured blob — that's the inode's own data.
                 let overlay = {
                     let pending = self.inner.pending.lock().expect("pending lock");
-                    if pending.tombstones.contains(path) {
+                    if pending.orphans.contains(&node.0) {
+                        None
+                    } else if pending.tombstones.contains(path) {
                         Some(Overlay::Gone)
                     } else if let Some(other_id) = pending.hot_by_path.get(path).copied()
                         && let Some(hot) = pending.hot.get(&other_id)
@@ -2878,10 +2979,19 @@ impl PlatformShell for ContentAddressedMount {
                 // (so `WORLD` shadows `world`), and a stale `attrs`
                 // that still reports the captured size would clip the
                 // returned bytes in the kernel's read buffer.
+                //
+                // Orphan exception: same as `read`. An open-unlinked
+                // or rename-displaced inode skips the path overlay
+                // and reports the captured blob's size (or the
+                // per-NodeId hot buffer's length, checked first).
                 let overlay_size = {
                     let pending = self.inner.pending.lock().expect("pending lock");
                     if let Some(buf) = pending.hot.get(&node.0) {
                         Some(Some(buf.bytes.len() as u64))
+                    } else if pending.orphans.contains(&node.0) {
+                        // Fall through to `blob_size(blob)` — the
+                        // captured size is the orphan's own.
+                        None
                     } else if pending.tombstones.contains(path) {
                         // Tombstoned via the mount: treat as
                         // not-yet-collected. The path is gone but the
@@ -2908,15 +3018,38 @@ impl PlatformShell for ContentAddressedMount {
             }
             NodeRecord::Symlink { blob } => (self.blob_size(blob)?, 1),
             NodeRecord::PendingFile { path, .. } => {
-                let hit = self
-                    .pending_lookup(path)
-                    .ok_or_else(|| MountError::Stale(format!("pending file {}", path.display())))?;
-                let size = match hit {
-                    PendingHit::Hot { size, .. } | PendingHit::Warm { size, .. } => size,
-                    PendingHit::Symlink { target_len } => target_len,
-                    PendingHit::Tombstone => 0,
+                // Orphan branch: a rename-displaced or
+                // unlinked-but-still-open PendingFile only has its
+                // per-NodeId buffer to report — `pending_lookup`
+                // would consult the rebound path overlay and serve
+                // the sibling's size.
+                let orphan_size = {
+                    let pending = self.inner.pending.lock().expect("pending lock");
+                    if pending.orphans.contains(&node.0) {
+                        Some(pending.hot.get(&node.0).map(|buf| buf.bytes.len() as u64))
+                    } else {
+                        None
+                    }
                 };
-                (size, 1)
+                if let Some(opt) = orphan_size {
+                    let size = opt.ok_or_else(|| {
+                        MountError::Stale(format!(
+                            "orphan pending file {} has no buffered bytes",
+                            path.display()
+                        ))
+                    })?;
+                    (size, 1)
+                } else {
+                    let hit = self.pending_lookup(path).ok_or_else(|| {
+                        MountError::Stale(format!("pending file {}", path.display()))
+                    })?;
+                    let size = match hit {
+                        PendingHit::Hot { size, .. } | PendingHit::Warm { size, .. } => size,
+                        PendingHit::Symlink { target_len } => target_len,
+                        PendingHit::Tombstone => 0,
+                    };
+                    (size, 1)
+                }
             }
             NodeRecord::PendingSymlink { path } => {
                 let pending = self.inner.pending.lock().expect("pending lock");

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1347,14 +1347,51 @@ impl ContentAddressedMount {
             NodeKind::Symlink => self.move_symlink(&old_path, &new_path)?,
             NodeKind::Directory => self.move_overlay_dir(&old_path, &new_path)?,
         }
-        // Invalidate the inode cached for the destination, so its next
-        // `lookup` re-mints with the moved record.
-        self.inner
-            .inodes
-            .lock()
-            .expect("inode lock")
-            .by_path
-            .remove(&new_path);
+        // Maintain the inode↔path invariant for both the source and
+        // destination: the kernel may have cached either dentry from
+        // a prior lookup, and (for FUSE) it does not re-issue lookup
+        // after `rename` — it just rewrites its own dentry → inode
+        // table. So the source inode now resolves through dentry
+        // `new_name`, and any read against it must serve the new
+        // path's overlay state. Rewriting the source record's stored
+        // path is what keeps that consistent. The dest's old inode
+        // (which the kernel will issue `forget` for) gets dropped
+        // from `by_path` so the next lookup mints a fresh id.
+        {
+            let mut inodes = self.inner.inodes.lock().expect("inode lock");
+            // Drop any cached inode for the destination so the next
+            // lookup mints fresh (the old inode there pointed at the
+            // *captured* file, which is now logically replaced).
+            if let Some(dest_id) = inodes.by_path.remove(&new_path) {
+                inodes.by_id.remove(&dest_id);
+            }
+            // Rewrite the source inode's stored path so subsequent
+            // reads/attrs against it serve the new-path overlay.
+            // The kernel keeps using the source's NodeId after rename
+            // (it's just a dentry-table rewrite on its side) — without
+            // this, every read against the rebased dentry sees the
+            // stale path and returns ESTALE.
+            if let Some(src_id) = inodes.by_path.remove(&old_path) {
+                if let Some(record) = inodes.by_id.get_mut(&src_id) {
+                    match record {
+                        NodeRecord::PendingFile { path, .. }
+                        | NodeRecord::File { path, .. }
+                        | NodeRecord::PendingSymlink { path } => {
+                            *path = new_path.clone();
+                        }
+                        _ => {}
+                    }
+                }
+                inodes.by_path.insert(new_path.clone(), src_id);
+                drop(inodes);
+                // Same for any cached hot buffer keyed on the source
+                // node — its `path` field must follow.
+                let mut pending = self.inner.pending.lock().expect("pending lock");
+                if let Some(buf) = pending.hot.get_mut(&src_id) {
+                    buf.path = new_path.clone();
+                }
+            }
+        }
         Ok(())
     }
 
@@ -2220,8 +2257,6 @@ fn resolve_thread(repo: &Repository, thread: &str) -> Result<MountState> {
 
 impl PlatformShell for ContentAddressedMount {
     fn lookup(&self, parent: NodeId, name: &OsStr) -> Result<Option<Entry>> {
-        // Re-derive the parent's authoritative state from the registry,
-        // so callers can't make us walk a tree we haven't blessed.
         let record = self.record_for(parent)?;
         let parent_path = match self.dir_path_of(&record) {
             Some(p) => p,

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -397,6 +397,21 @@ struct Pending {
     /// path. The bytes are the target as the kernel handed them to
     /// `symlink`; capture hashes them into a CAS blob.
     symlinks: BTreeMap<PathBuf, Vec<u8>>,
+    /// Inodes whose directory entry has been removed (`unlink`) but
+    /// whose `NodeId` may still be held by a kernel fd. Set at
+    /// `unlink_entry` time and consulted by `write` / `flush_node`:
+    /// any further write through one of these `NodeId`s must update
+    /// only the per-`NodeId` buffer — NOT republish `hot_by_path`
+    /// nor clear the tombstone — and the buffer must be discarded
+    /// (rather than warm-promoted) when the kernel finally calls
+    /// `release` / `forget`. POSIX: the inode lives behind the fd,
+    /// but the directory entry stays gone until the last close.
+    ///
+    /// A fresh inode minted at the same name (`create_file` after
+    /// the unlink) gets a brand-new `NodeId` via
+    /// [`Inodes::intern`], so it is *not* in this set and takes
+    /// the normal write/flush path.
+    orphans: BTreeSet<u64>,
 }
 
 /// In-mount overlay: a snapshot-time view of the parent state plus
@@ -1258,7 +1273,17 @@ impl ContentAddressedMount {
             let mut pending = self.inner.pending.lock().expect("pending lock");
             if let Some(node_id) = pending.hot_by_path.remove(&child_path) {
                 pending.hot.remove(&node_id);
+                // Any subsequent write through this NodeId — the
+                // kernel may still hold an fd to it — must not
+                // republish the path or clear the tombstone. See
+                // `Pending::orphans` and the orphan branches in
+                // `write` / `flush_node`.
+                pending.orphans.insert(node_id);
             }
+            // The lookup-returned inode is also a candidate orphan
+            // (an open captured-file fd that was unlinked but never
+            // had an in-flight hot buffer). Insert is idempotent.
+            pending.orphans.insert(entry.node.0);
             pending.warm.remove(&child_path);
             pending.symlinks.remove(&child_path);
             pending.tombstones.insert(child_path.clone());
@@ -2211,7 +2236,28 @@ impl MountInner {
             let Some(buf) = pending.hot.remove(&node.0) else {
                 return Ok(());
             };
-            pending.hot_by_path.remove(&buf.path);
+            // Orphan check: `unlink_entry` recorded this NodeId
+            // because the kernel still held an fd to it. Any
+            // accumulated bytes belong to the open handle only;
+            // POSIX says they die with the last close, so we must
+            // drop the buffer without warm-promoting it and without
+            // touching the tombstone or any `hot_by_path` mapping a
+            // fresh inode at the same name may have installed.
+            if pending.orphans.remove(&node.0) {
+                debug_assert!(
+                    pending.hot_by_path.get(&buf.path) != Some(&node.0),
+                    "orphan buffer must not own its path mapping",
+                );
+                return Ok(());
+            }
+            // Only retract the path mapping if it still points at
+            // us; an unlink-then-recreate that happened between
+            // write and flush may have moved the live mapping to a
+            // fresh inode (whose path coincidentally matches), and
+            // a blind `remove` would yank that fresh entry.
+            if pending.hot_by_path.get(&buf.path) == Some(&node.0) {
+                pending.hot_by_path.remove(&buf.path);
+            }
             (buf.path, buf.mode, buf.bytes)
         };
         let size = bytes.len() as u64;
@@ -2573,21 +2619,45 @@ impl PlatformShell for ContentAddressedMount {
         // phases (e.g. a coalesce from another NodeId), prefer the
         // existing buffer's bytes — our `seed_bytes` are stale.
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Coalesce two NodeIds for the same path onto the same buffer.
-        if let Some(existing_id) = pending.hot_by_path.get(&path).copied()
-            && existing_id != node.0
-            && let Some(buf) = pending.hot.remove(&existing_id)
-        {
-            pending.hot.insert(node.0, buf);
+        // POSIX unlink+open semantics. Two write shapes share this
+        // method and must be kept separate:
+        //
+        //   * unlink-then-create (`unlink P; open(P, O_CREAT); write`)
+        //     — `create_file` minted a fresh `NodeId` and cleared the
+        //     tombstone for P. Our `node.0` is not in `orphans` and
+        //     the write republishes the name normally.
+        //
+        //   * open-then-unlink (`open(P); unlink P; write through old
+        //     fd`) — `unlink_entry` recorded `node.0` in `orphans`
+        //     and left the tombstone in place. POSIX is explicit:
+        //     the inode lives behind the fd, but the directory entry
+        //     must stay gone. Republishing `hot_by_path[P] = node.0`
+        //     or clearing the tombstone would resurrect the pathname
+        //     for every other observer (lookup, enumerate, capture).
+        //     The orphan branch updates only the per-NodeId buffer;
+        //     `flush_node` reads the same `orphans` signal at
+        //     promotion time and drops the buffer instead of warming
+        //     it.
+        let orphan = pending.orphans.contains(&node.0);
+        if !orphan {
+            // Coalesce two NodeIds for the same path onto the same buffer.
+            if let Some(existing_id) = pending.hot_by_path.get(&path).copied()
+                && existing_id != node.0
+                && let Some(buf) = pending.hot.remove(&existing_id)
+            {
+                pending.hot.insert(node.0, buf);
+            }
+            pending.hot_by_path.insert(path.clone(), node.0);
+            // A live hot buffer means the file exists again — clear
+            // any tombstone for this path so subsequent
+            // `pending_lookup` calls see the buffer instead of a
+            // "deleted" sentinel. POSIX:
+            // unlink+open(O_CREAT)+pwrite reborns the path. The seed
+            // logic above already starts the buffer empty when a
+            // tombstone is present, so we don't need to inspect the
+            // tombstone here.
+            pending.tombstones.remove(&path);
         }
-        pending.hot_by_path.insert(path.clone(), node.0);
-        // A live hot buffer means the file exists again — clear any
-        // tombstone for this path so subsequent `pending_lookup` calls
-        // see the buffer instead of a "deleted" sentinel. POSIX:
-        // unlink+open(O_CREAT)+pwrite reborns the path. The seed
-        // logic above already starts the buffer empty when a tombstone
-        // is present, so we don't need to inspect the tombstone here.
-        pending.tombstones.remove(&path);
         let buf = pending.hot.entry(node.0).or_insert_with(|| HotBuffer {
             path: path.clone(),
             mode,
@@ -2875,11 +2945,21 @@ impl PlatformShell for ContentAddressedMount {
         // Drop any hot buffer attached to this NodeId — the kernel
         // is telling us our cached identity is no longer valid, and
         // we don't want a stale buffer surviving the inode flip.
+        // Only retract the path → inode mapping if it still points
+        // at us; an unlink-then-recreate sequence may have moved
+        // the live mapping to a fresh inode at the same name, and
+        // a blind `remove` would yank that fresh inode's entry.
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            if let Some(buf) = pending.hot.remove(&node.0) {
+            if let Some(buf) = pending.hot.remove(&node.0)
+                && pending.hot_by_path.get(&buf.path) == Some(&node.0)
+            {
                 pending.hot_by_path.remove(&buf.path);
             }
+            // The kernel is forgetting this inode; any orphan
+            // tracking we kept for it is now dead weight. Drop it
+            // so the set doesn't accumulate across long sessions.
+            pending.orphans.remove(&node.0);
         }
         self.inner.inodes.lock().expect("inode lock").forget(node);
         Ok(())

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -369,18 +369,65 @@ struct PendingEntry {
     size: u64,
 }
 
+/// Per-NodeId lifecycle state. Tracks both whether an inode is still
+/// resolvable via `inodes.by_path` (Live) or has had its directory
+/// entry removed but is still held by an open fd (Orphan), and the
+/// open-handle refcount that drives the final-close cleanup.
+///
+/// Absence from [`Pending::state`] is the third state — Released —
+/// matching the spike model (`docs/design/mount-posix-semantics.md`
+/// §1.1). The type system makes "orphaned with no open count" and
+/// "open count without orphan flag" unrepresentable, replacing the
+/// old `orphans: BTreeSet<u64>` + `open_handles: BTreeMap<u64, u32>`
+/// pair with one map and forcing every callback that branches on
+/// lifecycle to `match`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NodeState {
+    /// Live: the inode owns a binding in `inodes.by_path`. The
+    /// refcount tracks how many FUSE `open` / `create` callbacks
+    /// have minted handles to it; `release` drives it back down.
+    /// At T1 (unlink with N ≥ 0), the count is carried over into
+    /// `Orphan { open_count }`.
+    Live { open_count: u32 },
+    /// Orphan: directory entry gone (`unlink_entry` or `rename`-over
+    /// of the displaced destination) but `open_count` kernel fds
+    /// still hold the NodeId. Bytes in `hot[node]` / `warm[node]`
+    /// outlive the transition; the cleanup happens on the final
+    /// `release` (count drops to 0 → state entry removed + bytes
+    /// dropped).
+    Orphan { open_count: u32 },
+}
+
 /// The two-tier write state for a mount.
+///
+/// Post-spike (`docs/design/mount-posix-semantics.md` §2.1) the cache
+/// is **NodeId-keyed throughout**: `hot[id]` and `warm[id]` carry the
+/// bytes; path-keyed helpers (`hot_by_path`, `tombstones`,
+/// `dir_tombstones`, `explicit_dirs`, `symlinks`) are
+/// directory-entry-level concepts only. The Live → Orphan transition
+/// never moves bytes — it just rewrites `state[id]` and the path-side
+/// bookkeeping. That collapse eliminates the cache-layer asymmetry
+/// (Bug Class A in the spike doc §4) that produced every Codex
+/// finding r6 → r9 on PR #182.
 #[derive(Default)]
 struct Pending {
     /// Hot tier: per-`NodeId` open-file buffers.
     hot: BTreeMap<u64, HotBuffer>,
-    /// Reverse: which NodeId currently owns a buffer for `path`. We
-    /// only allow one at a time — opening the same file twice from
-    /// different node ids resolves to the same buffer because the
-    /// inode registry coalesces by path for pending files.
+    /// Reverse-index for the hot tier: which NodeId currently owns a
+    /// buffer for `path`. Path-keyed because FUSE `lookup` arrives
+    /// with paths, not NodeIds. Only one at a time — opening the
+    /// same file twice from different node ids resolves to the same
+    /// buffer because the inode registry coalesces by path for
+    /// pending files. Removed on `unlink_entry` / rebound on
+    /// `rename_entry`.
     hot_by_path: BTreeMap<PathBuf, u64>,
-    /// Warm tier: paths whose latest content has been promoted.
-    warm: BTreeMap<PathBuf, PendingEntry>,
+    /// Warm tier: per-`NodeId` promoted bytes. Bytes survive the
+    /// Live → Orphan transition without a migration step — that's
+    /// Decision A of the spike. `pending_lookup` resolves a path to
+    /// its current Live NodeId via `inodes.by_path` and then reads
+    /// `warm[id]`; orphan branches in `read` / `attrs` / `write` /
+    /// `apply_truncate` consult `warm[node]` directly.
+    warm: BTreeMap<u64, PendingEntry>,
     /// Tombstones — paths the mount has deleted. Suppress the
     /// underlying state's entry on reads. File-only; directories
     /// use [`Self::dir_tombstones`].
@@ -398,41 +445,37 @@ struct Pending {
     explicit_dirs: BTreeSet<PathBuf>,
     /// Symlinks created through the mount, keyed by mount-relative
     /// path. The bytes are the target as the kernel handed them to
-    /// `symlink`; capture hashes them into a CAS blob.
+    /// `symlink`; capture hashes them into a CAS blob. Symlinks are
+    /// not openable for IO; no orphan story applies.
     symlinks: BTreeMap<PathBuf, Vec<u8>>,
-    /// Inodes whose directory entry has been removed (`unlink`) but
-    /// whose `NodeId` may still be held by a kernel fd. Set at
-    /// `unlink_entry` time and consulted by `write` / `flush_node`:
-    /// any further write through one of these `NodeId`s must update
-    /// only the per-`NodeId` buffer — NOT republish `hot_by_path`
-    /// nor clear the tombstone — and the buffer must be discarded
-    /// (rather than warm-promoted) when the kernel finally calls
-    /// `release` / `forget`. POSIX: the inode lives behind the fd,
-    /// but the directory entry stays gone until the last close.
-    ///
-    /// A fresh inode minted at the same name (`create_file` after
-    /// the unlink) gets a brand-new `NodeId` via
-    /// [`Inodes::intern`], so it is *not* in this set and takes
-    /// the normal write/flush path.
-    orphans: BTreeSet<u64>,
-    /// Warm-tier bytes preserved on behalf of an orphaned NodeId. The
-    /// path-keyed `warm[path]` map is mutated by directory operations
-    /// (unlink drops it, rename-over replaces it with the source's
-    /// bytes); both routes would otherwise lose the bytes a surviving
-    /// fd needs. When orphaning a node whose path had warm-tier bytes,
-    /// we relocate the entry here keyed by NodeId so reads/writes/
-    /// truncates against that fd keep seeing the inode's own data.
-    /// Cleared on final `release`, on `invalidate`/`forget`, and on
-    /// `capture` (which empties the whole pending tier).
-    orphan_warm: BTreeMap<u64, PendingEntry>,
-    /// Per-inode open-handle refcount. Bumped on the FUSE `open` /
-    /// `create` callback (via [`PlatformShell::on_open`]); decremented
-    /// on the FUSE `release` callback. The orphan marker — and any
-    /// preserved orphan bytes — clear only when this count reaches
-    /// zero on a `release`, NOT on the per-descriptor-close `flush`.
-    /// See the lifecycle distinction documented on
-    /// [`PlatformShell::flush`] and [`PlatformShell::release`].
-    open_handles: BTreeMap<u64, u32>,
+    /// Per-NodeId lifecycle state. See [`NodeState`]. Replaces the
+    /// pre-spike `orphans: BTreeSet<u64>` + `open_handles:
+    /// BTreeMap<u64, u32>` pair. Absence from this map is the third
+    /// state (Released) — entries are removed on final `release`,
+    /// `invalidate`, and `capture`.
+    state: BTreeMap<u64, NodeState>,
+}
+
+impl Pending {
+    /// True iff the NodeId is currently Orphan (directory entry gone
+    /// but `open_count >= 0` fds still reference the inode). Every
+    /// callback that branches on lifecycle goes through this helper
+    /// (or matches `state` directly) so the "implicitly assume Live"
+    /// failure mode is hard to write.
+    fn is_orphan(&self, id: u64) -> bool {
+        matches!(self.state.get(&id), Some(NodeState::Orphan { .. }))
+    }
+
+    /// Current open-handle refcount for the NodeId, or zero if
+    /// untracked. Used by [`MountInner::release_node`] to drive the
+    /// final-close cleanup and by [`unlink_entry`] / [`rename_entry`]
+    /// to carry the count over into `Orphan { open_count }` at T1/T3.
+    fn open_count(&self, id: u64) -> u32 {
+        match self.state.get(&id) {
+            Some(NodeState::Live { open_count } | NodeState::Orphan { open_count }) => *open_count,
+            None => 0,
+        }
+    }
 }
 
 /// In-mount overlay: a snapshot-time view of the parent state plus
@@ -1143,9 +1186,24 @@ impl ContentAddressedMount {
     /// (FUSE `open` / `create` callback). Used to time the orphan
     /// cleanup against the *final* close (see
     /// [`Self::release_node`] / [`MountInner::release_node`]).
+    ///
+    /// Bumps the open count on the existing `NodeState`, minting a
+    /// `Live { open_count: 1 }` entry if the node is untracked. An
+    /// Orphan can also be opened (rare — only via an fh the kernel
+    /// still holds across a re-lookup race); we bump its refcount so
+    /// the final release fires correctly.
     pub fn on_open(&self, node: NodeId) -> Result<()> {
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        *pending.open_handles.entry(node.0).or_insert(0) += 1;
+        let next = match pending.state.get(&node.0).copied() {
+            None => NodeState::Live { open_count: 1 },
+            Some(NodeState::Live { open_count }) => NodeState::Live {
+                open_count: open_count.saturating_add(1),
+            },
+            Some(NodeState::Orphan { open_count }) => NodeState::Orphan {
+                open_count: open_count.saturating_add(1),
+            },
+        };
+        pending.state.insert(node.0, next);
         Ok(())
     }
 
@@ -1153,15 +1211,38 @@ impl ContentAddressedMount {
     /// `lookup`/`enumerate` calls will skip the underlying captured
     /// entry, and `capture()` will fold the deletion into the new
     /// state's tree (pruning empty parent dirs as needed).
+    ///
+    /// Low-level (path-based) helper — unlike [`Self::unlink_entry`]
+    /// it does not honour POSIX open-unlinked semantics. Used by
+    /// tests that bypass the FUSE-callback lifecycle. The
+    /// NodeId-keyed buffers for the path's current owner are dropped
+    /// (no orphan tracking).
     pub fn unlink_path(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref().to_path_buf();
+        // Resolve path → NodeId via the inode registry so we can drop
+        // the per-NodeId warm/hot bytes.
+        let bound_id = {
+            let inodes = self.inner.inodes.lock().expect("inode lock");
+            inodes.by_path.get(&path).copied()
+        };
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Drop any in-flight buffer for this path.
         if let Some(node_id) = pending.hot_by_path.remove(&path) {
             pending.hot.remove(&node_id);
+            pending.warm.remove(&node_id);
+            pending.state.remove(&node_id);
         }
-        pending.warm.remove(&path);
-        pending.tombstones.insert(path);
+        if let Some(node_id) = bound_id {
+            pending.hot.remove(&node_id);
+            pending.warm.remove(&node_id);
+            pending.state.remove(&node_id);
+        }
+        pending.symlinks.remove(&path);
+        pending.tombstones.insert(path.clone());
+        drop(pending);
+        if bound_id.is_some() {
+            let mut inodes = self.inner.inodes.lock().expect("inode lock");
+            inodes.by_path.remove(&path);
+        }
         Ok(())
     }
 
@@ -1310,9 +1391,17 @@ impl ContentAddressedMount {
     }
 
     /// Delete a regular file (or symlink) named `name` under `parent`.
-    /// Drops any hot buffer / warm-tier blob / symlink entry for the
-    /// path and records a tombstone so the captured-tree entry (if
-    /// any) is hidden until capture folds the deletion in.
+    ///
+    /// POSIX open-unlinked semantics: the directory entry goes (path
+    /// tombstoned, `inodes.by_path[path]` retired), but if any fd
+    /// still references the inode, the bytes survive in `hot[node]` /
+    /// `warm[node]` until the final `release`. Under the post-spike
+    /// unified NodeId-keyed model
+    /// (`docs/design/mount-posix-semantics.md` §1.2 T1/T2), this is a
+    /// state transition only — no byte migration. Pre-spike code
+    /// dropped `pending.hot[node_id]` here (Codex thread 3293307302
+    /// r9) and migrated `warm[path]` into `orphan_warm[node]` (r8);
+    /// both steps go away.
     pub fn unlink_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
         // R8: serialize with other write-side mutations.
         let _write_guard = self.inner.write_mu.lock().expect("write mu");
@@ -1328,32 +1417,28 @@ impl ContentAddressedMount {
             .dir_path_of(&parent_record)
             .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
         let child_path = join_child(&parent_path, name_str);
+        let node_id = entry.node.0;
 
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            if let Some(node_id) = pending.hot_by_path.remove(&child_path) {
-                pending.hot.remove(&node_id);
-                // Any subsequent write through this NodeId — the
-                // kernel may still hold an fd to it — must not
-                // republish the path or clear the tombstone. See
-                // `Pending::orphans` and the orphan branches in
-                // `write` / `flush_node`.
-                pending.orphans.insert(node_id);
-            }
-            // The lookup-returned inode is also a candidate orphan
-            // (an open captured-file fd that was unlinked but never
-            // had an in-flight hot buffer). Insert is idempotent.
-            pending.orphans.insert(entry.node.0);
-            // R8 (Codex Thread 3293235164): preserve any path-keyed
-            // warm bytes for the surviving fd. The path tombstones
-            // immediately below would otherwise make the bytes
-            // unreachable. `orphan_warm[entry.node.0]` is consulted
-            // by the orphan branches of `read` / `attrs` / `write` /
-            // `apply_truncate` so the open-unlinked inode keeps
-            // seeing its own bytes until the final `release`.
-            if let Some(warm_entry) = pending.warm.remove(&child_path) {
-                pending.orphan_warm.insert(entry.node.0, warm_entry);
-            }
+            // Detach the path-level hot binding. The bytes follow the
+            // NodeId, so `hot[node_id]` / `warm[node_id]` stay put —
+            // the surviving fd reads them via the orphan branches in
+            // `read` / `attrs` / `write` / `apply_truncate`.
+            // (r9 fix: pre-spike code called `pending.hot.remove(&node_id)`
+            // here and the unflushed bytes vanished.)
+            pending.hot_by_path.remove(&child_path);
+            // Transition T1: Live → Orphan { open_count: N }. Carry
+            // the current open count over so the final `release`
+            // fires correctly. N == 0 is permitted; the inode stays
+            // tracked until `release` / `invalidate` / `capture`
+            // drops it (matching pre-spike orphan-set semantics for
+            // tests that skip the explicit `on_open`).
+            let open_count = pending.open_count(node_id);
+            pending
+                .state
+                .insert(node_id, NodeState::Orphan { open_count });
+            // Symlinks are not openable; no orphan story applies.
             pending.symlinks.remove(&child_path);
             pending.tombstones.insert(child_path.clone());
         }
@@ -1594,32 +1679,46 @@ impl ContentAddressedMount {
                 buf.path = new_path.clone();
             }
             if let Some(dest_id) = displaced_dest {
-                pending.orphans.insert(dest_id);
+                // T3: the displaced destination transitions to Orphan.
+                // Bytes (hot[dest_id], warm[dest_id]) stay put so the
+                // surviving fd keeps reading the inode's own data
+                // (spike doc §1.2 T3).
+                let open_count = pending.open_count(dest_id);
+                pending
+                    .state
+                    .insert(dest_id, NodeState::Orphan { open_count });
             }
         }
         Ok(())
     }
 
-    /// Promote the source's hot buffer (if any), then rewrite the
-    /// warm-tier entry / captured-blob reference at the new path.
+    /// Rename a regular file. Under the post-spike unified
+    /// NodeId-keyed model
+    /// (`docs/design/mount-posix-semantics.md` §2.4), the source's
+    /// bytes follow its NodeId — no byte migration step. The displaced
+    /// destination keeps its own `hot[id]` / `warm[id]` so the
+    /// surviving fd reads its own data. The work here is path-level:
+    /// retire the destination's path-keyed hot binding, rebase the
+    /// source's hot buffer's `path` field (so a subsequent `flush`
+    /// promotes under the new path), seed warm if the source had only
+    /// captured-tree bytes (so capture can plant the file at the new
+    /// path), and tombstone the old path.
     ///
-    /// `displaced_inode_id` names the inode that *was* at `new_path`
-    /// before this rename (None if the destination was empty). When
-    /// present, the displaced inode is becoming an orphan — its
-    /// surviving fds need access to its pre-rename bytes. R8 (Codex
-    /// Thread 3293235162): we relocate `pending.warm[new_path]` (if
-    /// any) into `orphan_warm[displaced_inode_id]` rather than
-    /// dropping it; the orphan read/attrs/write paths consult that
-    /// per-NodeId map.
+    /// `displaced_inode_id` is no longer used as a side-channel for
+    /// byte preservation — the caller (`rename_entry_with_options`)
+    /// handles the orphan state transition independently.
     fn move_file(
         &self,
         old_path: &Path,
         new_path: &Path,
         displaced_inode_id: Option<u64>,
     ) -> Result<()> {
-        // Promote any in-flight buffer at the source so the move is
-        // entirely a warm-tier operation.
-        let pending_node = self
+        // Snapshot whether the source has a hot buffer (drain it to
+        // warm so the warm tier becomes authoritative for capture
+        // under the new path) and whether the source is captured-only
+        // (then synthesize a warm entry so capture plants the bytes
+        // at new_path).
+        let src_id_opt = self
             .inner
             .pending
             .lock()
@@ -1627,76 +1726,73 @@ impl ContentAddressedMount {
             .hot_by_path
             .get(old_path)
             .copied();
-        if let Some(id) = pending_node {
+        if let Some(id) = src_id_opt {
             self.flush_node(NodeId(id))?;
         }
-
-        // Resolve the source's durable identity (warm-tier promotion
-        // wins over captured-tree blob — that's the priority used
-        // everywhere else in read).
-        enum Source {
-            Warm { blob: ContentHash, mode: FileMode, size: u64 },
-            Captured { blob: ContentHash, mode: FileMode, size: u64 },
-        }
-        let source = self
-            .inner
-            .pending
-            .lock()
-            .expect("pending lock")
-            .warm
-            .get(old_path)
-            .map(|entry| Source::Warm {
-                blob: entry.blob,
-                mode: entry.mode,
-                size: entry.size,
-            });
-        let source = match source {
-            Some(s) => s,
-            None => {
-                // Walk the captured tree by path.
-                let (blob, mode, size) = self.captured_file_at(old_path)?;
-                Source::Captured { blob, mode, size }
-            }
+        // After the flush, the source's bytes (if any) live in
+        // `warm[src_id]`. If the source had no warm entry — captured
+        // only — synthesize one keyed by the source's NodeId so
+        // `apply_pending_to_tree` plants the file under new_path. We
+        // resolve src_id via the path → inode reverse-index (or via
+        // the captured-tree walk for a captured-only source).
+        let src_id = {
+            let inodes = self.inner.inodes.lock().expect("inode lock");
+            inodes.by_path.get(old_path).copied()
         };
-        let (blob, mode, size) = match source {
-            Source::Warm { blob, mode, size } | Source::Captured { blob, mode, size } => {
-                (blob, mode, size)
-            }
+        let needs_synth = match src_id {
+            Some(id) => !self
+                .inner
+                .pending
+                .lock()
+                .expect("pending lock")
+                .warm
+                .contains_key(&id),
+            None => true,
+        };
+        let captured_seed = if needs_synth {
+            // Captured-only source: pull (blob, mode, size) from the
+            // captured tree so the rename survives `capture`.
+            Some(self.captured_file_at(old_path)?)
+        } else {
+            None
         };
 
-        // Apply.
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Detach the destination's path overlay. The hot buffer keyed
-        // by the displaced inode id is preserved — `rename_entry`
-        // marks that inode as orphan so its still-open fd keeps
-        // reading via the per-NodeId buffer (and any further write
-        // through that fd takes the orphan branch in `write`, which
-        // does not republish `hot_by_path`). POSIX rename-over: open
-        // dest descriptors must keep referencing the displaced inode
-        // until close.
+        // Detach the destination's path-keyed hot binding. The
+        // displaced inode's bytes are keyed by NodeId — they stay put
+        // for the surviving fd. POSIX rename-over: open destination
+        // descriptors keep referencing the displaced inode until close.
         pending.hot_by_path.remove(new_path);
-        // R8 (Codex Thread 3293235162): preserve the displaced
-        // inode's warm bytes for surviving fds. Without this, an open
-        // fd on a warm-promoted dest reads the source's replacement
-        // bytes via the now-rebound `warm[new_path]`.
-        let displaced_warm = pending.warm.remove(new_path);
-        if let (Some(id), Some(entry)) = (displaced_inode_id, displaced_warm) {
-            pending.orphan_warm.insert(id, entry);
-        }
+        // Symlinks are path-keyed; clear at both endpoints.
         pending.symlinks.remove(new_path);
-        pending.tombstones.remove(new_path);
-        // Move source.
-        pending.warm.remove(old_path);
         pending.symlinks.remove(old_path);
-        pending.warm.insert(
-            new_path.to_path_buf(),
-            PendingEntry { blob, mode, size },
-        );
-        // Tombstone the source so a captured-tree entry there gets
-        // hidden post-capture.
+        // Source: if a hot buffer survived the flush above (only
+        // possible if the source was Orphan, which can't happen for
+        // a valid rename source — but be defensive), rebase its
+        // path-binding.
+        if let Some(id) = pending.hot_by_path.remove(old_path) {
+            if let Some(buf) = pending.hot.get_mut(&id) {
+                buf.path = new_path.to_path_buf();
+            }
+            pending.hot_by_path.insert(new_path.to_path_buf(), id);
+        }
+        // Captured-only source: synthesize a warm entry so capture
+        // plants the bytes at new_path. The entry is keyed by the
+        // source's NodeId; `apply_pending_to_tree` resolves its
+        // current path through `inodes.by_path`.
+        if let (Some(id), Some((blob, mode, size))) = (src_id, captured_seed) {
+            pending
+                .warm
+                .insert(id, PendingEntry { blob, mode, size });
+        }
+        // Path-level bookkeeping: tombstone old_path so the captured
+        // tree's old entry is hidden; clear any tombstone at
+        // new_path (rename made it valid again).
         pending.tombstones.insert(old_path.to_path_buf());
-        // Clear any tombstone covering the destination.
         pending.tombstones.remove(new_path);
+        // The displaced inode is handled by the caller via the
+        // NodeState transition; no byte work here.
+        let _ = displaced_inode_id;
         Ok(())
     }
 
@@ -1706,8 +1802,9 @@ impl ContentAddressedMount {
         new_path: &Path,
         displaced_inode_id: Option<u64>,
     ) -> Result<()> {
-        // Resolve target bytes from pending overlay, else from a
-        // captured-tree symlink blob.
+        // Resolve target bytes from the pending overlay or the
+        // captured-tree blob — symlinks are path-keyed (not openable
+        // for IO; no orphan story applies).
         let target_bytes = {
             let pending = self.inner.pending.lock().expect("pending lock");
             pending.symlinks.get(old_path).cloned()
@@ -1720,24 +1817,16 @@ impl ContentAddressedMount {
             }
         };
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Same rename-over discipline as `move_file`: detach the
-        // destination path overlay but preserve the displaced inode's
-        // hot buffer (if any). The caller orphans the inode so reads
-        // through its still-open fd consult the per-NodeId buffer and
-        // subsequent writes/setattrs take the orphan branch.
+        // Detach the displaced destination's path-keyed hot binding.
+        // Its NodeId-keyed bytes stay put for the surviving fd; the
+        // caller's NodeState transition handles the orphan tracking.
         pending.hot_by_path.remove(new_path);
-        // R8 (Codex Thread 3293235162): symlink-over-file rename
-        // displaces a file inode with warm bytes; preserve them for
-        // the surviving fd via `orphan_warm`.
-        let displaced_warm = pending.warm.remove(new_path);
-        if let (Some(id), Some(entry)) = (displaced_inode_id, displaced_warm) {
-            pending.orphan_warm.insert(id, entry);
-        }
         pending.symlinks.remove(new_path);
-        pending.tombstones.remove(new_path);
         pending.symlinks.remove(old_path);
         pending.symlinks.insert(new_path.to_path_buf(), target_bytes);
+        pending.tombstones.remove(new_path);
         pending.tombstones.insert(old_path.to_path_buf());
+        let _ = displaced_inode_id;
         Ok(())
     }
 
@@ -1745,7 +1834,7 @@ impl ContentAddressedMount {
         // We only support overlay-only directory renames here. If the
         // source dir has any captured-tree backing, refuse — a full
         // captured-tree rename would need to rewrite every descendant
-        // tombstone/warm entry.
+        // tombstone entry.
         if self.captured_dir_exists(old_path)? {
             return Err(MountError::InvalidArgument(format!(
                 "cross-tree directory rename {} → {} not supported by the overlay",
@@ -1754,15 +1843,15 @@ impl ContentAddressedMount {
             )));
         }
         let mut pending = self.inner.pending.lock().expect("pending lock");
-        // Move explicit_dirs and any deeper overlay entries under
-        // old_path/ to new_path/. Symlinks, warm, hot_by_path,
-        // tombstones, explicit_dirs all need rewriting.
+        // Path-keyed structures under `old_path/` need to be rebased
+        // to `new_path/`. Warm bytes follow the NodeId (unified shape)
+        // so warm[id] is unaffected by this rewrite — descendant
+        // NodeRecord paths get rebased in `rename_entry_with_options`.
         fn rebase(p: &Path, old: &Path, new: &Path) -> Option<PathBuf> {
             let tail = p.strip_prefix(old).ok()?;
             Some(new.join(tail))
         }
         let mut new_explicit: BTreeSet<PathBuf> = BTreeSet::new();
-        let mut new_warm: BTreeMap<PathBuf, PendingEntry> = BTreeMap::new();
         let mut new_symlinks: BTreeMap<PathBuf, Vec<u8>> = BTreeMap::new();
         let mut new_tombstones: BTreeSet<PathBuf> = BTreeSet::new();
         let mut new_hot_by_path: BTreeMap<PathBuf, u64> = BTreeMap::new();
@@ -1776,16 +1865,6 @@ impl ContentAddressedMount {
                     if explicit != old_path {
                         new_explicit.insert(explicit);
                     }
-                }
-            }
-        }
-        for (path, entry) in std::mem::take(&mut pending.warm) {
-            match rebase(&path, old_path, new_path) {
-                Some(rebased) => {
-                    new_warm.insert(rebased, entry);
-                }
-                None => {
-                    new_warm.insert(path, entry);
                 }
             }
         }
@@ -1829,7 +1908,6 @@ impl ContentAddressedMount {
         // Ensure the destination directory itself is registered.
         new_explicit.insert(new_path.to_path_buf());
         pending.explicit_dirs = new_explicit;
-        pending.warm = new_warm;
         pending.symlinks = new_symlinks;
         pending.tombstones = new_tombstones;
         pending.hot_by_path = new_hot_by_path;
@@ -1938,13 +2016,21 @@ impl ContentAddressedMount {
                 // now living at the same name; touching
                 // `warm[path]` would land the change on the sibling
                 // at capture time.
-                if !pending.orphans.contains(&node.0) {
+                if !pending.is_orphan(node.0) {
                     if let Some(other_id) = pending.hot_by_path.get(&path).copied()
                         && let Some(buf) = pending.hot.get_mut(&other_id)
                     {
                         buf.mode = new_mode;
                     }
-                    if let Some(entry) = pending.warm.get_mut(&path) {
+                    // Warm is NodeId-keyed: rebind via inodes if the
+                    // path still resolves Live to a tracked NodeId.
+                    let warm_id = {
+                        let inodes = self.inner.inodes.lock().expect("inode lock");
+                        inodes.by_path.get(&path).copied()
+                    };
+                    if let Some(id) = warm_id
+                        && let Some(entry) = pending.warm.get_mut(&id)
+                    {
                         entry.mode = new_mode;
                     }
                 }
@@ -1994,8 +2080,16 @@ impl ContentAddressedMount {
             },
         }
         let phase1 = {
+            // Resolve the path's current Live NodeId via the inode
+            // registry — under the unified shape `warm` is
+            // NodeId-keyed, and the Live owner of `path` is the
+            // sibling we'd seed from when no per-inode buffer exists.
+            let path_owner = {
+                let inodes = self.inner.inodes.lock().expect("inode lock");
+                inodes.by_path.get(&path).copied()
+            };
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            let orphan = pending.orphans.contains(&node.0);
+            let orphan = pending.is_orphan(node.0);
             let id = if pending.hot.contains_key(&node.0) {
                 Some(node.0)
             } else if orphan {
@@ -2015,20 +2109,21 @@ impl ContentAddressedMount {
             } else {
                 let seed = if orphan {
                     // Orphan: only the inode's pre-displacement
-                    // content is valid. R8 — prefer the inode's
-                    // preserved warm bytes (`orphan_warm[node.0]`)
-                    // over the captured-blob fallback. The path-
-                    // keyed `warm[path]` now belongs to the sibling
-                    // at the rebound name (rename-over) or is gone
-                    // (unlink); the relocated copy in `orphan_warm`
-                    // is the authoritative source for this inode.
+                    // content is valid. Under the unified shape its
+                    // own warm bytes live at `warm[node.0]`; fall
+                    // back to the captured blob (this inode's own,
+                    // not the sibling at the rebound name).
                     pending
-                        .orphan_warm
+                        .warm
                         .get(&node.0)
                         .map(|e| e.blob)
                         .or(captured_blob)
                 } else {
-                    pending.warm.get(&path).map(|e| e.blob).or(captured_blob)
+                    // Live: the path's bytes live at `warm[id]` where
+                    // id is the Live owner via `inodes.by_path`.
+                    path_owner
+                        .and_then(|id| pending.warm.get(&id).map(|e| e.blob))
+                        .or(captured_blob)
                 };
                 Phase1::NeedSeed { orphan, seed }
             }
@@ -2165,6 +2260,10 @@ impl ContentAddressedMount {
     /// Look up a path in the pending tier. Order: hot buffer (in-flight
     /// writes), then warm tier (promoted blob), then None (caller must
     /// fall back to the immutable state's tree).
+    ///
+    /// Under the unified NodeId-keyed model warm bytes live at
+    /// `warm[id]`; the path → id resolution goes through
+    /// `inodes.by_path` (lock order: pending ⊐ inodes).
     fn pending_lookup(&self, path: &Path) -> Option<PendingHit> {
         let pending = self.inner.pending.lock().expect("pending lock");
         if pending.tombstones.contains(path) {
@@ -2184,14 +2283,16 @@ impl ContentAddressedMount {
                 mode: buf.mode,
             });
         }
-        if let Some(entry) = pending.warm.get(path) {
-            return Some(PendingHit::Warm {
-                blob: entry.blob,
-                size: entry.size,
-                mode: entry.mode,
-            });
-        }
-        None
+        // Warm needs path → NodeId resolution. Acquire inodes inside
+        // the pending lock (lock order: pending ⊐ inodes).
+        let inodes = self.inner.inodes.lock().expect("inode lock");
+        let id = *inodes.by_path.get(path)?;
+        let entry = pending.warm.get(&id)?;
+        Some(PendingHit::Warm {
+            blob: entry.blob,
+            size: entry.size,
+            mode: entry.mode,
+        })
     }
 
     /// True if the parent dir or any ancestor of `path` has been
@@ -2231,10 +2332,26 @@ impl ContentAddressedMount {
                 .and_then(|tail| tail.components().next())
                 .is_some()
         };
-        pending
-            .warm
-            .keys()
-            .any(|p| !pending.tombstones.contains(p) && probe(p))
+        // Warm is NodeId-keyed under the unified shape; resolve paths
+        // via the inode registry. Skip orphans (their NodeRecord may
+        // still carry the pre-orphan path, but bytes are unreachable
+        // by path post-T1/T3).
+        let warm_under = {
+            let inodes = self.inner.inodes.lock().expect("inode lock");
+            pending.warm.keys().any(|id| {
+                if pending.is_orphan(*id) {
+                    return false;
+                }
+                let Some(record) = inodes.by_id.get(id) else {
+                    return false;
+                };
+                match warm_path_of_record(record) {
+                    Some(p) => !pending.tombstones.contains(&p) && probe(&p),
+                    None => false,
+                }
+            })
+        };
+        warm_under
             || pending
                 .hot_by_path
                 .keys()
@@ -2288,11 +2405,24 @@ impl ContentAddressedMount {
                 );
             }
         }
-        for (path, entry) in pending.warm.iter() {
-            if pending.tombstones.contains(path) {
+        // Warm is NodeId-keyed; resolve each entry's current path via
+        // the inode registry. Skip orphans (no path identity) and
+        // skip entries whose path tombstones (deleted overlays).
+        let inodes = self.inner.inodes.lock().expect("inode lock");
+        for (id, entry) in pending.warm.iter() {
+            if pending.is_orphan(*id) {
                 continue;
             }
-            let Some((name, is_dir)) = project(path) else {
+            let Some(record) = inodes.by_id.get(id) else {
+                continue;
+            };
+            let Some(path) = warm_path_of_record(record) else {
+                continue;
+            };
+            if pending.tombstones.contains(&path) {
+                continue;
+            }
+            let Some((name, is_dir)) = project(&path) else {
                 continue;
             };
             if is_dir {
@@ -2304,6 +2434,7 @@ impl ContentAddressedMount {
                 });
             }
         }
+        drop(inodes);
         for (path, target) in pending.symlinks.iter() {
             let Some((name, is_dir)) = project(path) else {
                 continue;
@@ -2354,6 +2485,19 @@ fn validate_entry_name(name: &OsStr) -> Result<&str> {
     name.to_str().ok_or_else(|| {
         MountError::InvalidArgument(format!("entry name {name:?} is not valid UTF-8"))
     })
+}
+
+/// Mount-relative path for a warm-tier entry, derived from its
+/// [`NodeRecord`]. The NodeId-keyed warm tier doesn't store the path
+/// directly; `apply_pending_to_tree` / `pending_dir_exists` /
+/// `pending_children_at` resolve it via the inode registry. Only
+/// file-like records (`File`, `PendingFile`) carry warm bytes; the
+/// other variants return `None`.
+fn warm_path_of_record(record: &NodeRecord) -> Option<PathBuf> {
+    match record {
+        NodeRecord::File { path, .. } | NodeRecord::PendingFile { path, .. } => Some(path.clone()),
+        _ => None,
+    }
 }
 
 /// Join a parent mount-relative path with a leaf name. Mirrors the
@@ -2478,11 +2622,11 @@ impl MountInner {
             let mut pending = self.pending.lock().expect("pending lock");
             // Orphan: keep the buffer alive across `flush` events.
             // POSIX open-unlinked semantics: bytes persist for the
-            // surviving fds; the marker survives so subsequent writes
+            // surviving fds; the state survives so subsequent writes
             // through those fds keep taking the orphan branch (no
             // path republish, no warm promotion). The final clear
             // happens in `release_node`.
-            if pending.orphans.contains(&node.0) {
+            if pending.is_orphan(node.0) {
                 return Ok(());
             }
             let Some(buf) = pending.hot.remove(&node.0) else {
@@ -2507,8 +2651,10 @@ impl MountInner {
             .map_err(MountError::Store)?;
         debug!(?path, %blob_oid, size, "promoted hot buffer to CAS");
         let mut pending = self.pending.lock().expect("pending lock");
+        // Warm is NodeId-keyed. The path-keyed tombstone clear below
+        // is a separate concern (directory-entry level).
         pending.warm.insert(
-            path.clone(),
+            node.0,
             PendingEntry {
                 blob: blob_oid,
                 mode,
@@ -2520,61 +2666,71 @@ impl MountInner {
         Ok(())
     }
 
-    /// Final close of `node` from a FUSE `release` callback. Decrements
-    /// the open-handle refcount; when it reaches zero, retires any
-    /// orphan-tracking state for the inode. Non-orphan paths are
-    /// indistinguishable from `flush_node` (a non-orphan release still
-    /// promotes any hot buffer to CAS).
+    /// Final close of `node` from a FUSE `release` callback. Drives
+    /// the per-NodeId lifecycle: decrement the open count carried on
+    /// `state[node]`; on the final close of an Orphan, drop bytes
+    /// and remove the state entry; on the final close of a Live
+    /// (or untracked) node, promote any hot buffer to warm via
+    /// `flush_node`.
+    ///
+    /// The orphan branch never warm-promotes — an orphan's bytes are
+    /// unreachable by path post-T1/T3, so promoting them would leak
+    /// data into the captured tree at a now-tombstoned path.
     fn release_node(&self, node: NodeId) -> Result<()> {
-        // Step 1: decide whether this is the *final* release. We
-        // track the open count separately from any lifecycle state
-        // so the bookkeeping is cheap (no allocation, no lookup
-        // beyond `BTreeMap::entry`).
-        let final_release = {
+        // Action determined under the lock so we don't re-read state
+        // after dropping bytes.
+        enum Outcome {
+            /// Mid-life (non-final) close OR final close of a Live
+            /// node. Either way: forward to `flush_node`. (`flush_node`
+            /// is a no-op for Orphan, so the mid-life Orphan case is
+            /// also safe to forward.)
+            Flush,
+            /// Final close of an Orphan. Bytes were dropped under the
+            /// lock; nothing else to do (no warm promotion — see the
+            /// doc comment above).
+            OrphanFinalDone,
+        }
+        let outcome = {
             let mut pending = self.pending.lock().expect("pending lock");
-            let entry = pending.open_handles.entry(node.0).or_insert(0);
-            if *entry > 0 {
-                *entry -= 1;
-            }
-            if *entry == 0 {
-                pending.open_handles.remove(&node.0);
-                true
-            } else {
-                false
+            match pending.state.get(&node.0).copied() {
+                None => {
+                    // Untracked release (no on_open was ever
+                    // recorded). Treat as Live final-close — flush
+                    // any hot buffer.
+                    Outcome::Flush
+                }
+                Some(NodeState::Live { open_count }) => {
+                    let n = open_count.saturating_sub(1);
+                    if n == 0 {
+                        pending.state.remove(&node.0);
+                    } else {
+                        pending.state.insert(node.0, NodeState::Live { open_count: n });
+                    }
+                    Outcome::Flush
+                }
+                Some(NodeState::Orphan { open_count }) => {
+                    let n = open_count.saturating_sub(1);
+                    if n == 0 {
+                        // Final release of an Orphan — POSIX "inode
+                        // lives until last close" ends here. Drop
+                        // bytes and the state entry.
+                        pending.state.remove(&node.0);
+                        pending.hot.remove(&node.0);
+                        pending.warm.remove(&node.0);
+                        Outcome::OrphanFinalDone
+                    } else {
+                        pending.state.insert(node.0, NodeState::Orphan { open_count: n });
+                        // Mid-life Orphan release: forward to
+                        // flush_node (which no-ops for orphans).
+                        Outcome::Flush
+                    }
+                }
             }
         };
-
-        if !final_release {
-            // Mid-life release (multiple opens still hold the
-            // inode). Equivalent to `flush` for promotion: don't
-            // disturb the orphan marker or its preserved bytes; let
-            // any non-orphan hot buffer flow through the normal
-            // path. `flush_node`'s orphan branch is a no-op so
-            // calling it here is safe in both cases.
-            return self.flush_node(node);
+        match outcome {
+            Outcome::Flush => self.flush_node(node),
+            Outcome::OrphanFinalDone => Ok(()),
         }
-
-        // Step 2: final release. If the inode is orphaned, drop all
-        // its state (hot buffer, preserved warm bytes, marker). The
-        // POSIX promise — "the inode lives until the last close" —
-        // ends right here. We do this BEFORE the promotion attempt
-        // so an orphan never lands in the warm tier.
-        let was_orphan = {
-            let mut pending = self.pending.lock().expect("pending lock");
-            if pending.orphans.remove(&node.0) {
-                pending.hot.remove(&node.0);
-                pending.orphan_warm.remove(&node.0);
-                true
-            } else {
-                false
-            }
-        };
-        if was_orphan {
-            return Ok(());
-        }
-
-        // Step 3: non-orphan final release — same as flush.
-        self.flush_node(node)
     }
 }
 
@@ -2767,14 +2923,14 @@ impl PlatformShell for ContentAddressedMount {
                 // the buffer (e.g. after rename/coalesce). Orphan
                 // PendingFiles skip the path overlay — the path is
                 // gone (open-unlinked) or rebound (rename-over) — but
-                // r8 preserves the inode's own warm bytes (if any) in
-                // `orphan_warm[node.0]`. With no warm fallback there
-                // is no captured-tier source either, so the read
-                // errors with Stale.
+                // the unified shape preserves the inode's own warm
+                // bytes (if any) at `warm[node.0]`. With no warm
+                // fallback there is no captured-tier source either,
+                // so the read errors with Stale.
                 let warm_blob = {
                     let pending = self.inner.pending.lock().expect("pending lock");
-                    if pending.orphans.contains(&node.0) {
-                        return match pending.orphan_warm.get(&node.0).map(|e| e.blob) {
+                    if pending.is_orphan(node.0) {
+                        return match pending.warm.get(&node.0).map(|e| e.blob) {
                             Some(blob) => {
                                 drop(pending);
                                 let bytes = self.load_blob_bytes(&blob)?;
@@ -2791,7 +2947,14 @@ impl PlatformShell for ContentAddressedMount {
                     {
                         return Ok(copy_into(&hot.bytes, offset, buf));
                     }
-                    pending.warm.get(path).map(|e| e.blob)
+                    // Warm is NodeId-keyed; resolve path → id via the
+                    // inode registry.
+                    let inodes = self.inner.inodes.lock().expect("inode lock");
+                    inodes
+                        .by_path
+                        .get(path)
+                        .copied()
+                        .and_then(|id| pending.warm.get(&id).map(|e| e.blob))
                 };
                 match warm_blob {
                     Some(blob) => {
@@ -2829,14 +2992,14 @@ impl PlatformShell for ContentAddressedMount {
                 // captured blob — that's the inode's own data.
                 let overlay = {
                     let pending = self.inner.pending.lock().expect("pending lock");
-                    if pending.orphans.contains(&node.0) {
-                        // R8: serve the inode's preserved warm bytes
-                        // first if any. With none, fall through to
-                        // the captured blob — that's still the
-                        // orphan's own data (rename-over of a
-                        // captured-only file).
+                    if pending.is_orphan(node.0) {
+                        // Serve the inode's own warm bytes first
+                        // (unified shape: `warm[node.0]`). With none,
+                        // fall through to the captured blob — that's
+                        // still the orphan's own data (rename-over of
+                        // a captured-only file).
                         pending
-                            .orphan_warm
+                            .warm
                             .get(&node.0)
                             .map(|warm| Overlay::Warm(warm.blob))
                     } else if pending.tombstones.contains(path) {
@@ -2846,7 +3009,14 @@ impl PlatformShell for ContentAddressedMount {
                     {
                         Some(Overlay::Hot(hot.bytes.clone()))
                     } else {
-                        pending.warm.get(path).map(|warm| Overlay::Warm(warm.blob))
+                        // Warm is NodeId-keyed; resolve path → id via
+                        // the inode registry.
+                        let inodes = self.inner.inodes.lock().expect("inode lock");
+                        inodes
+                            .by_path
+                            .get(path)
+                            .copied()
+                            .and_then(|id| pending.warm.get(&id).map(|warm| Overlay::Warm(warm.blob)))
                     }
                 };
                 match overlay {
@@ -2918,8 +3088,15 @@ impl PlatformShell for ContentAddressedMount {
             Blob(ContentHash),
         }
         let seed = {
+            // Resolve the path's current Live owner via the inode
+            // registry — warm bytes for the path live at
+            // `warm[live_id]` under the unified shape.
+            let path_owner = {
+                let inodes = self.inner.inodes.lock().expect("inode lock");
+                inodes.by_path.get(&path).copied()
+            };
             let pending = self.inner.pending.lock().expect("pending lock");
-            let orphan = pending.orphans.contains(&node.0);
+            let orphan = pending.is_orphan(node.0);
             if pending.hot.contains_key(&node.0) {
                 // The per-NodeId buffer is always authoritative —
                 // both for live writes (this fd's accumulated bytes)
@@ -2938,13 +3115,12 @@ impl PlatformShell for ContentAddressedMount {
                 // inode, not us).
                 Seed::None
             } else if orphan {
-                // R8: orphan-aware seeding. The path's overlay
-                // (`warm[path]`) belongs to the sibling at the
-                // rebound name. Prefer the inode's preserved warm
-                // bytes (`orphan_warm[node.0]`), then its captured
-                // blob, then empty.
+                // Orphan-aware seeding. The path's overlay belongs
+                // to the sibling at the rebound name; this inode's
+                // own bytes live at `warm[node.0]` (or in the
+                // captured blob).
                 pending
-                    .orphan_warm
+                    .warm
                     .get(&node.0)
                     .map(|e| Seed::Blob(e.blob))
                     .or_else(|| captured_blob.map(Seed::Blob))
@@ -2953,7 +3129,7 @@ impl PlatformShell for ContentAddressedMount {
                 // Unlink-then-write through a fresh inode (POSIX
                 // unlink+open(O_CREAT)): start from empty.
                 Seed::None
-            } else if let Some(entry) = pending.warm.get(&path) {
+            } else if let Some(entry) = path_owner.and_then(|id| pending.warm.get(&id)) {
                 Seed::Blob(entry.blob)
             } else if let Some(blob) = captured_blob {
                 Seed::Blob(blob)
@@ -2993,7 +3169,7 @@ impl PlatformShell for ContentAddressedMount {
         //     `flush_node` reads the same `orphans` signal at
         //     promotion time and drops the buffer instead of warming
         //     it.
-        let orphan = pending.orphans.contains(&node.0);
+        let orphan = pending.is_orphan(node.0);
         if !orphan {
             // Coalesce two NodeIds for the same path onto the same buffer.
             if let Some(existing_id) = pending.hot_by_path.get(&path).copied()
@@ -3242,13 +3418,12 @@ impl PlatformShell for ContentAddressedMount {
                     let pending = self.inner.pending.lock().expect("pending lock");
                     if let Some(buf) = pending.hot.get(&node.0) {
                         Some(Some(buf.bytes.len() as u64))
-                    } else if pending.orphans.contains(&node.0) {
-                        // R8: prefer the preserved orphan warm size
-                        // (if any) over the captured fallback. With
-                        // no preserved warm, `None` falls through to
-                        // `blob_size(blob)` — the captured size is
-                        // the orphan's own.
-                        pending.orphan_warm.get(&node.0).map(|e| Some(e.size))
+                    } else if pending.is_orphan(node.0) {
+                        // Prefer the orphan's own warm size (unified
+                        // shape: `warm[node.0]`). With no warm, fall
+                        // through to `blob_size(blob)` — the captured
+                        // size is the orphan's own.
+                        pending.warm.get(&node.0).map(|e| Some(e.size))
                     } else if pending.tombstones.contains(path) {
                         // Tombstoned via the mount: treat as
                         // not-yet-collected. The path is gone but the
@@ -3259,7 +3434,14 @@ impl PlatformShell for ContentAddressedMount {
                     {
                         Some(Some(hot.bytes.len() as u64))
                     } else {
-                        pending.warm.get(path).map(|warm| Some(warm.size))
+                        // Warm is NodeId-keyed; resolve path → id via
+                        // the inode registry.
+                        let inodes = self.inner.inodes.lock().expect("inode lock");
+                        inodes
+                            .by_path
+                            .get(path)
+                            .copied()
+                            .and_then(|id| pending.warm.get(&id).map(|warm| Some(warm.size)))
                     }
                 };
                 match overlay_size {
@@ -3277,19 +3459,19 @@ impl PlatformShell for ContentAddressedMount {
             NodeRecord::PendingFile { path, .. } => {
                 // Orphan branch: a rename-displaced or
                 // unlinked-but-still-open PendingFile reports either
-                // its per-NodeId hot buffer length, or its preserved
-                // `orphan_warm[node.0]` size (R8). `pending_lookup`
-                // would otherwise consult the rebound path overlay
-                // and serve the sibling's size.
+                // its per-NodeId hot buffer length, or its own
+                // `warm[node.0]` size. `pending_lookup` would
+                // otherwise consult the rebound path overlay and
+                // serve the sibling's size.
                 let orphan_size = {
                     let pending = self.inner.pending.lock().expect("pending lock");
-                    if pending.orphans.contains(&node.0) {
+                    if pending.is_orphan(node.0) {
                         Some(
                             pending
                                 .hot
                                 .get(&node.0)
                                 .map(|buf| buf.bytes.len() as u64)
-                                .or_else(|| pending.orphan_warm.get(&node.0).map(|e| e.size)),
+                                .or_else(|| pending.warm.get(&node.0).map(|e| e.size)),
                         )
                     } else {
                         None
@@ -3353,15 +3535,12 @@ impl PlatformShell for ContentAddressedMount {
             {
                 pending.hot_by_path.remove(&buf.path);
             }
-            // The kernel is forgetting this inode; any orphan
-            // tracking we kept for it is now dead weight. Drop it
-            // so the set doesn't accumulate across long sessions.
-            // R8: also clear orphan-preserved warm bytes and the
-            // open-handle refcount so a long-running mount doesn't
-            // accumulate dead entries.
-            pending.orphans.remove(&node.0);
-            pending.orphan_warm.remove(&node.0);
-            pending.open_handles.remove(&node.0);
+            // The kernel is forgetting this inode; any lifecycle
+            // tracking we kept for it is now dead weight. Drop the
+            // state entry and any NodeId-keyed warm bytes so a
+            // long-running mount doesn't accumulate dead entries.
+            pending.state.remove(&node.0);
+            pending.warm.remove(&node.0);
         }
         self.inner.inodes.lock().expect("inode lock").forget(node);
         Ok(())
@@ -3502,7 +3681,8 @@ impl ContentAddressedMount {
         // dirs prune naturally.
         let tree_hash = {
             let pending = self.inner.pending.lock().expect("pending lock");
-            apply_pending_to_tree(self.store(), &parent_tree, &pending)?
+            let inodes = self.inner.inodes.lock().expect("inode lock");
+            apply_pending_to_tree(self.store(), &parent_tree, &pending, &inodes)?
         };
 
         // Step 2: record a new state. Mirrors
@@ -3581,11 +3761,10 @@ impl ContentAddressedMount {
             warn!(?err, "thread metadata refresh from mount capture failed");
         }
 
-        // Step 4: clear the pending tier and refresh state. R8: also
-        // clear orphan bookkeeping — the new state's tree is
-        // canonical, so any open fds the kernel still holds against
-        // pre-capture inodes will get refreshed via `forget` /
-        // re-lookup as normal.
+        // Step 4: clear the pending tier and refresh state. The new
+        // state's tree is canonical, so any open fds the kernel still
+        // holds against pre-capture inodes will get refreshed via
+        // `forget` / re-lookup as normal.
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
             pending.hot.clear();
@@ -3595,9 +3774,7 @@ impl ContentAddressedMount {
             pending.dir_tombstones.clear();
             pending.explicit_dirs.clear();
             pending.symlinks.clear();
-            pending.orphans.clear();
-            pending.orphan_warm.clear();
-            pending.open_handles.clear();
+            pending.state.clear();
         }
         let mut state_lock = self.inner.state.write().expect("mount state lock");
         *state_lock = MountState {
@@ -3640,6 +3817,7 @@ fn apply_pending_to_tree(
     store: &dyn ObjectStore,
     parent: &Tree,
     pending: &Pending,
+    inodes: &Inodes,
 ) -> Result<ContentHash> {
     /// In-memory virtual tree: a directory's local file overrides,
     /// tombstones, and named child directories. Built lazily during
@@ -3678,8 +3856,28 @@ fn apply_pending_to_tree(
         cursor
     }
 
-    // Plant warm entries.
-    for (path, entry) in &pending.warm {
+    // Plant warm entries. Warm is NodeId-keyed; resolve each entry's
+    // current Live path via the inode registry. Skip Orphan entries —
+    // their bytes are unreachable by path post-T1/T3 and must not
+    // resurface in the captured tree.
+    for (id, entry) in &pending.warm {
+        if pending.is_orphan(*id) {
+            continue;
+        }
+        let Some(record) = inodes.by_id.get(id) else {
+            continue;
+        };
+        let Some(path) = warm_path_of_record(record) else {
+            continue;
+        };
+        // Sanity: the record's stored path must still bind to this
+        // NodeId in `by_path`. If `inodes.by_path[path]` resolves to
+        // a different inode the record is stale (e.g. a Live → Orphan
+        // transition that didn't update the state map yet) and we
+        // skip rather than plant phantom bytes.
+        if inodes.by_path.get(&path) != Some(id) {
+            continue;
+        }
         let comps: Vec<&str> = path
             .components()
             .filter_map(|c| match c {
@@ -3894,16 +4092,18 @@ fn apply_pending_to_tree(
 
 impl ContentAddressedMount {
     /// Test-only accessor for the warm tier so unit tests can verify
-    /// promotions landed without going through `read`.
+    /// promotions landed without going through `read`. Returns paths
+    /// resolved via the inode registry (warm is NodeId-keyed under
+    /// the unified shape).
     #[cfg(test)]
     pub(crate) fn warm_keys(&self) -> Vec<PathBuf> {
-        self.inner
-            .pending
-            .lock()
-            .expect("pending lock")
+        let pending = self.inner.pending.lock().expect("pending lock");
+        let inodes = self.inner.inodes.lock().expect("inode lock");
+        pending
             .warm
             .keys()
-            .cloned()
+            .filter(|id| !pending.is_orphan(**id))
+            .filter_map(|id| inodes.by_id.get(id).and_then(warm_path_of_record))
             .collect()
     }
 
@@ -3911,12 +4111,21 @@ impl ContentAddressedMount {
     /// the blob oid so dedup tests can compare across mounts.
     #[cfg(test)]
     pub(crate) fn warm_blob(&self, path: impl AsRef<Path>) -> Option<ContentHash> {
+        let path = path.as_ref();
+        let id = self
+            .inner
+            .inodes
+            .lock()
+            .expect("inode lock")
+            .by_path
+            .get(path)
+            .copied()?;
         self.inner
             .pending
             .lock()
             .expect("pending lock")
             .warm
-            .get(path.as_ref())
+            .get(&id)
             .map(|e| e.blob)
     }
 
@@ -3954,23 +4163,7 @@ impl ContentAddressedMount {
             .pending
             .lock()
             .expect("pending lock")
-            .orphans
-            .contains(&node.0)
-    }
-
-    /// Test-only accessor: orphan-preserved warm-tier blob for `node`,
-    /// if any. Mirrors [`Self::warm_blob`] but keyed by NodeId rather
-    /// than path.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn orphan_warm_blob(&self, node: NodeId) -> Option<ContentHash> {
-        self.inner
-            .pending
-            .lock()
-            .expect("pending lock")
-            .orphan_warm
-            .get(&node.0)
-            .map(|e| e.blob)
+            .is_orphan(node.0)
     }
 }
 

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -80,7 +80,10 @@ use tracing::{debug, instrument, warn};
 
 use crate::{
     error::{MountError, Result},
-    shell::{AttrUpdate, Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell, kind_for_mode},
+    shell::{
+        AttrUpdate, Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell, RenameOptions,
+        kind_for_mode,
+    },
 };
 
 /// Default promotion idle window: a buffer with no writes for this
@@ -412,6 +415,24 @@ struct Pending {
     /// [`Inodes::intern`], so it is *not* in this set and takes
     /// the normal write/flush path.
     orphans: BTreeSet<u64>,
+    /// Warm-tier bytes preserved on behalf of an orphaned NodeId. The
+    /// path-keyed `warm[path]` map is mutated by directory operations
+    /// (unlink drops it, rename-over replaces it with the source's
+    /// bytes); both routes would otherwise lose the bytes a surviving
+    /// fd needs. When orphaning a node whose path had warm-tier bytes,
+    /// we relocate the entry here keyed by NodeId so reads/writes/
+    /// truncates against that fd keep seeing the inode's own data.
+    /// Cleared on final `release`, on `invalidate`/`forget`, and on
+    /// `capture` (which empties the whole pending tier).
+    orphan_warm: BTreeMap<u64, PendingEntry>,
+    /// Per-inode open-handle refcount. Bumped on the FUSE `open` /
+    /// `create` callback (via [`PlatformShell::on_open`]); decremented
+    /// on the FUSE `release` callback. The orphan marker — and any
+    /// preserved orphan bytes — clear only when this count reaches
+    /// zero on a `release`, NOT on the per-descriptor-close `flush`.
+    /// See the lifecycle distinction documented on
+    /// [`PlatformShell::flush`] and [`PlatformShell::release`].
+    open_handles: BTreeMap<u64, u32>,
 }
 
 /// In-mount overlay: a snapshot-time view of the parent state plus
@@ -475,6 +496,15 @@ pub(crate) struct MountInner {
     pending: Mutex<Pending>,
     promotion: RwLock<PromotionPolicy>,
     mounted_at: SystemTime,
+    /// Write-side serialization. Acquired by structural-mutation
+    /// methods (rename, create, mkdir, symlink) that need their
+    /// existence-check + mutation pair to land atomically against
+    /// other writers — see [`ContentAddressedMount::rename_entry_with_options`]
+    /// and the RENAME_NOREPLACE atomicity contract (Codex r8 Thread
+    /// 3293235163). Lock order: `write_mu` precedes every other lock
+    /// in [`MountInner`]; never take it while holding `state`,
+    /// `pending`, or `inodes`.
+    write_mu: Mutex<()>,
     /// Shared materialised-blob cache. Without this every kernel
     /// `read` syscall re-decompresses the full blob from the object
     /// store, which makes chunked + mmap reads ~200× slower than
@@ -835,6 +865,7 @@ impl ContentAddressedMount {
             promotion: RwLock::new(PromotionPolicy::default()),
             mounted_at: SystemTime::now(),
             blob_cache,
+            write_mu: Mutex::new(()),
         });
         let sweeper = spawn_sweep_worker(&inner);
         Ok(Self {
@@ -1093,9 +1124,29 @@ impl ContentAddressedMount {
     }
 
     /// Promote the hot buffer for `node` (if any) to a CAS blob and
-    /// record it in the pending tree.
+    /// record it in the pending tree. Routed from the FUSE `flush`
+    /// callback (per-descriptor-close). Orphaned nodes deliberately
+    /// do nothing here — see [`MountInner::flush_node`] for the
+    /// lifecycle rationale.
     pub fn flush_node(&self, node: NodeId) -> Result<()> {
         self.inner.flush_node(node)
+    }
+
+    /// Final close of `node` from a FUSE `release` callback. Decrements
+    /// the open-handle refcount; on the last close, drops orphan
+    /// state and (for non-orphans) promotes any surviving hot buffer.
+    pub fn release_node(&self, node: NodeId) -> Result<()> {
+        self.inner.release_node(node)
+    }
+
+    /// Notify the mount that a new open handle for `node` was minted
+    /// (FUSE `open` / `create` callback). Used to time the orphan
+    /// cleanup against the *final* close (see
+    /// [`Self::release_node`] / [`MountInner::release_node`]).
+    pub fn on_open(&self, node: NodeId) -> Result<()> {
+        let mut pending = self.inner.pending.lock().expect("pending lock");
+        *pending.open_handles.entry(node.0).or_insert(0) += 1;
+        Ok(())
     }
 
     /// Mark `path` as deleted in the pending tier. Subsequent
@@ -1162,6 +1213,11 @@ impl ContentAddressedMount {
         mode: FileMode,
         exclusive: bool,
     ) -> Result<Entry> {
+        // R8: serialize against rename / mkdir / symlink so an
+        // exclusivity check (O_EXCL or rename-noreplace) lands its
+        // existence-test and its mutation under the same write-side
+        // critical section.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
         let name_str = validate_entry_name(name)?;
         if let Some(existing) = self.lookup(parent, name)? {
             if exclusive {
@@ -1220,6 +1276,8 @@ impl ContentAddressedMount {
     /// [`Pending::explicit_dirs`] entry so the new path is visible to
     /// lookup/enumerate even when no child has been written yet.
     pub fn make_dir(&self, parent: NodeId, name: &OsStr) -> Result<Entry> {
+        // R8: serialize with other write-side mutations.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
         let name_str = validate_entry_name(name)?;
         if self.lookup(parent, name)?.is_some() {
             return Err(MountError::AlreadyExists(name_str.to_string()));
@@ -1256,6 +1314,8 @@ impl ContentAddressedMount {
     /// path and records a tombstone so the captured-tree entry (if
     /// any) is hidden until capture folds the deletion in.
     pub fn unlink_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        // R8: serialize with other write-side mutations.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
         let name_str = validate_entry_name(name)?;
         let entry = self
             .lookup(parent, name)?
@@ -1284,7 +1344,16 @@ impl ContentAddressedMount {
             // (an open captured-file fd that was unlinked but never
             // had an in-flight hot buffer). Insert is idempotent.
             pending.orphans.insert(entry.node.0);
-            pending.warm.remove(&child_path);
+            // R8 (Codex Thread 3293235164): preserve any path-keyed
+            // warm bytes for the surviving fd. The path tombstones
+            // immediately below would otherwise make the bytes
+            // unreachable. `orphan_warm[entry.node.0]` is consulted
+            // by the orphan branches of `read` / `attrs` / `write` /
+            // `apply_truncate` so the open-unlinked inode keeps
+            // seeing its own bytes until the final `release`.
+            if let Some(warm_entry) = pending.warm.remove(&child_path) {
+                pending.orphan_warm.insert(entry.node.0, warm_entry);
+            }
             pending.symlinks.remove(&child_path);
             pending.tombstones.insert(child_path.clone());
         }
@@ -1303,6 +1372,8 @@ impl ContentAddressedMount {
     /// Remove the empty directory `name` under `parent`. Fails with
     /// `ENOTEMPTY` if any child resolves through the mount.
     pub fn rmdir_entry(&self, parent: NodeId, name: &OsStr) -> Result<()> {
+        // R8: serialize with other write-side mutations.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
         let name_str = validate_entry_name(name)?;
         let entry = self
             .lookup(parent, name)?
@@ -1340,6 +1411,38 @@ impl ContentAddressedMount {
         new_parent: NodeId,
         new_name: &OsStr,
     ) -> Result<()> {
+        self.rename_entry_with_options(
+            old_parent,
+            old_name,
+            new_parent,
+            new_name,
+            RenameOptions::default(),
+        )
+    }
+
+    /// Same as [`Self::rename_entry`] but honours [`RenameOptions`].
+    /// `no_replace` (Linux `RENAME_NOREPLACE`) refuses the rename when
+    /// the destination already resolves; the check is performed inside
+    /// the same write-side critical section as the mutation, so a
+    /// concurrent writer cannot install the destination between the
+    /// check and the rename.
+    pub fn rename_entry_with_options(
+        &self,
+        old_parent: NodeId,
+        old_name: &OsStr,
+        new_parent: NodeId,
+        new_name: &OsStr,
+        options: RenameOptions,
+    ) -> Result<()> {
+        // R8 (Codex Thread 3293235163): the existence-check + the
+        // directory-entry mutation must land under the same mutation
+        // lock. Holding `write_mu` for the duration of this method
+        // serializes the rename against every other write-side op
+        // that could install the destination (create_file, make_dir,
+        // create_symlink, another rename) — that's the atomicity the
+        // POSIX NOREPLACE flag promises.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
+
         let old_name_str = validate_entry_name(old_name)?;
         let new_name_str = validate_entry_name(new_name)?;
         let src = self
@@ -1359,11 +1462,20 @@ impl ContentAddressedMount {
             return Ok(());
         }
 
-        // POSIX: destination of a different kind is an error.
-        if let Some(dst) = self.lookup(new_parent, new_name)? {
-            match (src.kind, dst.kind) {
+        // POSIX: destination of a different kind is an error. We also
+        // honour NOREPLACE here while still holding `write_mu` so the
+        // check + the subsequent move are atomic against concurrent
+        // writers. `dst` is shadowed for the kind-mismatch arm and
+        // hoisted into `displaced_inode_id` so the move primitives
+        // can preserve the displaced inode's warm bytes (r8).
+        let dst = self.lookup(new_parent, new_name)?;
+        if dst.is_some() && options.no_replace {
+            return Err(MountError::AlreadyExists(new_name_str.to_string()));
+        }
+        if let Some(ref d) = dst {
+            match (src.kind, d.kind) {
                 (NodeKind::Directory, NodeKind::Directory) => {
-                    let dst_children = self.enumerate(dst.node)?;
+                    let dst_children = self.enumerate(d.node)?;
                     if !dst_children.is_empty() {
                         return Err(MountError::NotEmpty(new_name_str.to_string()));
                     }
@@ -1377,10 +1489,11 @@ impl ContentAddressedMount {
                 _ => {}
             }
         }
+        let displaced_inode_id = dst.as_ref().map(|d| d.node.0);
 
         match src.kind {
-            NodeKind::File => self.move_file(&old_path, &new_path)?,
-            NodeKind::Symlink => self.move_symlink(&old_path, &new_path)?,
+            NodeKind::File => self.move_file(&old_path, &new_path, displaced_inode_id)?,
+            NodeKind::Symlink => self.move_symlink(&old_path, &new_path, displaced_inode_id)?,
             NodeKind::Directory => self.move_overlay_dir(&old_path, &new_path)?,
         }
         // Maintain the inode↔path invariant for both the source and
@@ -1489,7 +1602,21 @@ impl ContentAddressedMount {
 
     /// Promote the source's hot buffer (if any), then rewrite the
     /// warm-tier entry / captured-blob reference at the new path.
-    fn move_file(&self, old_path: &Path, new_path: &Path) -> Result<()> {
+    ///
+    /// `displaced_inode_id` names the inode that *was* at `new_path`
+    /// before this rename (None if the destination was empty). When
+    /// present, the displaced inode is becoming an orphan — its
+    /// surviving fds need access to its pre-rename bytes. R8 (Codex
+    /// Thread 3293235162): we relocate `pending.warm[new_path]` (if
+    /// any) into `orphan_warm[displaced_inode_id]` rather than
+    /// dropping it; the orphan read/attrs/write paths consult that
+    /// per-NodeId map.
+    fn move_file(
+        &self,
+        old_path: &Path,
+        new_path: &Path,
+        displaced_inode_id: Option<u64>,
+    ) -> Result<()> {
         // Promote any in-flight buffer at the source so the move is
         // entirely a warm-tier operation.
         let pending_node = self
@@ -1548,7 +1675,14 @@ impl ContentAddressedMount {
         // dest descriptors must keep referencing the displaced inode
         // until close.
         pending.hot_by_path.remove(new_path);
-        pending.warm.remove(new_path);
+        // R8 (Codex Thread 3293235162): preserve the displaced
+        // inode's warm bytes for surviving fds. Without this, an open
+        // fd on a warm-promoted dest reads the source's replacement
+        // bytes via the now-rebound `warm[new_path]`.
+        let displaced_warm = pending.warm.remove(new_path);
+        if let (Some(id), Some(entry)) = (displaced_inode_id, displaced_warm) {
+            pending.orphan_warm.insert(id, entry);
+        }
         pending.symlinks.remove(new_path);
         pending.tombstones.remove(new_path);
         // Move source.
@@ -1566,7 +1700,12 @@ impl ContentAddressedMount {
         Ok(())
     }
 
-    fn move_symlink(&self, old_path: &Path, new_path: &Path) -> Result<()> {
+    fn move_symlink(
+        &self,
+        old_path: &Path,
+        new_path: &Path,
+        displaced_inode_id: Option<u64>,
+    ) -> Result<()> {
         // Resolve target bytes from pending overlay, else from a
         // captured-tree symlink blob.
         let target_bytes = {
@@ -1587,7 +1726,13 @@ impl ContentAddressedMount {
         // through its still-open fd consult the per-NodeId buffer and
         // subsequent writes/setattrs take the orphan branch.
         pending.hot_by_path.remove(new_path);
-        pending.warm.remove(new_path);
+        // R8 (Codex Thread 3293235162): symlink-over-file rename
+        // displaces a file inode with warm bytes; preserve them for
+        // the surviving fd via `orphan_warm`.
+        let displaced_warm = pending.warm.remove(new_path);
+        if let (Some(id), Some(entry)) = (displaced_inode_id, displaced_warm) {
+            pending.orphan_warm.insert(id, entry);
+        }
         pending.symlinks.remove(new_path);
         pending.tombstones.remove(new_path);
         pending.symlinks.remove(old_path);
@@ -1870,10 +2015,18 @@ impl ContentAddressedMount {
             } else {
                 let seed = if orphan {
                     // Orphan: only the inode's pre-displacement
-                    // content is valid. For a captured-file orphan
-                    // that's `captured_blob`; a PendingFile orphan
-                    // with no warm fallback starts empty.
-                    captured_blob
+                    // content is valid. R8 — prefer the inode's
+                    // preserved warm bytes (`orphan_warm[node.0]`)
+                    // over the captured-blob fallback. The path-
+                    // keyed `warm[path]` now belongs to the sibling
+                    // at the rebound name (rename-over) or is gone
+                    // (unlink); the relocated copy in `orphan_warm`
+                    // is the authoritative source for this inode.
+                    pending
+                        .orphan_warm
+                        .get(&node.0)
+                        .map(|e| e.blob)
+                        .or(captured_blob)
                 } else {
                     pending.warm.get(&path).map(|e| e.blob).or(captured_blob)
                 };
@@ -1932,6 +2085,8 @@ impl ContentAddressedMount {
         name: &OsStr,
         target: &Path,
     ) -> Result<Entry> {
+        // R8: serialize with other write-side mutations.
+        let _write_guard = self.inner.write_mu.lock().expect("write mu");
         let name_str = validate_entry_name(name)?;
         if self.lookup(parent, name)?.is_some() {
             return Err(MountError::AlreadyExists(name_str.to_string()));
@@ -2311,26 +2466,28 @@ impl MountInner {
     /// Promote a single hot buffer to CAS. Inner-side flush so the
     /// sweep worker can drain idle buffers without bouncing back
     /// through `ContentAddressedMount`.
+    ///
+    /// Lifecycle note (R8 — Codex Thread 3293235165): FUSE `flush`
+    /// fires on every descriptor close including each close of a
+    /// `dup`-derived fd. For an orphaned node we must NOT touch the
+    /// orphan marker here and must NOT drop the hot buffer (surviving
+    /// fds need both). Only [`Self::release_node`] — invoked on the
+    /// last-close-per-FUSE-open — clears the marker.
     fn flush_node(&self, node: NodeId) -> Result<()> {
         let (path, mode, bytes) = {
             let mut pending = self.pending.lock().expect("pending lock");
+            // Orphan: keep the buffer alive across `flush` events.
+            // POSIX open-unlinked semantics: bytes persist for the
+            // surviving fds; the marker survives so subsequent writes
+            // through those fds keep taking the orphan branch (no
+            // path republish, no warm promotion). The final clear
+            // happens in `release_node`.
+            if pending.orphans.contains(&node.0) {
+                return Ok(());
+            }
             let Some(buf) = pending.hot.remove(&node.0) else {
                 return Ok(());
             };
-            // Orphan check: `unlink_entry` recorded this NodeId
-            // because the kernel still held an fd to it. Any
-            // accumulated bytes belong to the open handle only;
-            // POSIX says they die with the last close, so we must
-            // drop the buffer without warm-promoting it and without
-            // touching the tombstone or any `hot_by_path` mapping a
-            // fresh inode at the same name may have installed.
-            if pending.orphans.remove(&node.0) {
-                debug_assert!(
-                    pending.hot_by_path.get(&buf.path) != Some(&node.0),
-                    "orphan buffer must not own its path mapping",
-                );
-                return Ok(());
-            }
             // Only retract the path mapping if it still points at
             // us; an unlink-then-recreate that happened between
             // write and flush may have moved the live mapping to a
@@ -2361,6 +2518,63 @@ impl MountInner {
         // Promotion supersedes any prior tombstone for this path.
         pending.tombstones.remove(&path);
         Ok(())
+    }
+
+    /// Final close of `node` from a FUSE `release` callback. Decrements
+    /// the open-handle refcount; when it reaches zero, retires any
+    /// orphan-tracking state for the inode. Non-orphan paths are
+    /// indistinguishable from `flush_node` (a non-orphan release still
+    /// promotes any hot buffer to CAS).
+    fn release_node(&self, node: NodeId) -> Result<()> {
+        // Step 1: decide whether this is the *final* release. We
+        // track the open count separately from any lifecycle state
+        // so the bookkeeping is cheap (no allocation, no lookup
+        // beyond `BTreeMap::entry`).
+        let final_release = {
+            let mut pending = self.pending.lock().expect("pending lock");
+            let entry = pending.open_handles.entry(node.0).or_insert(0);
+            if *entry > 0 {
+                *entry -= 1;
+            }
+            if *entry == 0 {
+                pending.open_handles.remove(&node.0);
+                true
+            } else {
+                false
+            }
+        };
+
+        if !final_release {
+            // Mid-life release (multiple opens still hold the
+            // inode). Equivalent to `flush` for promotion: don't
+            // disturb the orphan marker or its preserved bytes; let
+            // any non-orphan hot buffer flow through the normal
+            // path. `flush_node`'s orphan branch is a no-op so
+            // calling it here is safe in both cases.
+            return self.flush_node(node);
+        }
+
+        // Step 2: final release. If the inode is orphaned, drop all
+        // its state (hot buffer, preserved warm bytes, marker). The
+        // POSIX promise — "the inode lives until the last close" —
+        // ends right here. We do this BEFORE the promotion attempt
+        // so an orphan never lands in the warm tier.
+        let was_orphan = {
+            let mut pending = self.pending.lock().expect("pending lock");
+            if pending.orphans.remove(&node.0) {
+                pending.hot.remove(&node.0);
+                pending.orphan_warm.remove(&node.0);
+                true
+            } else {
+                false
+            }
+        };
+        if was_orphan {
+            return Ok(());
+        }
+
+        // Step 3: non-orphan final release — same as flush.
+        self.flush_node(node)
     }
 }
 
@@ -2552,15 +2766,25 @@ impl PlatformShell for ContentAddressedMount {
                 // Same shape, keyed by path: another NodeId may own
                 // the buffer (e.g. after rename/coalesce). Orphan
                 // PendingFiles skip the path overlay — the path is
-                // gone (open-unlinked) or rebound (rename-over) and
-                // there is no captured-tier fallback to serve.
+                // gone (open-unlinked) or rebound (rename-over) — but
+                // r8 preserves the inode's own warm bytes (if any) in
+                // `orphan_warm[node.0]`. With no warm fallback there
+                // is no captured-tier source either, so the read
+                // errors with Stale.
                 let warm_blob = {
                     let pending = self.inner.pending.lock().expect("pending lock");
                     if pending.orphans.contains(&node.0) {
-                        return Err(MountError::Stale(format!(
-                            "orphan pending file {} has no readable bytes",
-                            path.display()
-                        )));
+                        return match pending.orphan_warm.get(&node.0).map(|e| e.blob) {
+                            Some(blob) => {
+                                drop(pending);
+                                let bytes = self.load_blob_bytes(&blob)?;
+                                Ok(copy_into(&bytes, offset, buf))
+                            }
+                            None => Err(MountError::Stale(format!(
+                                "orphan pending file {} has no readable bytes",
+                                path.display()
+                            ))),
+                        };
                     }
                     if let Some(id) = pending.hot_by_path.get(path).copied()
                         && let Some(hot) = pending.hot.get(&id)
@@ -2606,7 +2830,15 @@ impl PlatformShell for ContentAddressedMount {
                 let overlay = {
                     let pending = self.inner.pending.lock().expect("pending lock");
                     if pending.orphans.contains(&node.0) {
-                        None
+                        // R8: serve the inode's preserved warm bytes
+                        // first if any. With none, fall through to
+                        // the captured blob — that's still the
+                        // orphan's own data (rename-over of a
+                        // captured-only file).
+                        pending
+                            .orphan_warm
+                            .get(&node.0)
+                            .map(|warm| Overlay::Warm(warm.blob))
                     } else if pending.tombstones.contains(path) {
                         Some(Overlay::Gone)
                     } else if let Some(other_id) = pending.hot_by_path.get(path).copied()
@@ -2687,17 +2919,39 @@ impl PlatformShell for ContentAddressedMount {
         }
         let seed = {
             let pending = self.inner.pending.lock().expect("pending lock");
-            if pending.hot.contains_key(&node.0)
-                || pending
+            let orphan = pending.orphans.contains(&node.0);
+            if pending.hot.contains_key(&node.0) {
+                // The per-NodeId buffer is always authoritative —
+                // both for live writes (this fd's accumulated bytes)
+                // and for orphan writes (POSIX says the bytes belong
+                // to the open handle).
+                Seed::None
+            } else if !orphan
+                && pending
                     .hot_by_path
                     .get(&path)
                     .is_some_and(|id| pending.hot.contains_key(id))
             {
-                // A buffer already exists — no seed needed; the
-                // existing buffer's bytes are authoritative.
+                // Sibling at the same path has a buffer — coalesce
+                // onto it. Orphans never look at the path's overlay
+                // (the sibling at `hot_by_path[path]` is a different
+                // inode, not us).
                 Seed::None
+            } else if orphan {
+                // R8: orphan-aware seeding. The path's overlay
+                // (`warm[path]`) belongs to the sibling at the
+                // rebound name. Prefer the inode's preserved warm
+                // bytes (`orphan_warm[node.0]`), then its captured
+                // blob, then empty.
+                pending
+                    .orphan_warm
+                    .get(&node.0)
+                    .map(|e| Seed::Blob(e.blob))
+                    .or_else(|| captured_blob.map(Seed::Blob))
+                    .unwrap_or(Seed::None)
             } else if pending.tombstones.contains(&path) {
-                // Unlink-then-write: start from empty.
+                // Unlink-then-write through a fresh inode (POSIX
+                // unlink+open(O_CREAT)): start from empty.
                 Seed::None
             } else if let Some(entry) = pending.warm.get(&path) {
                 Seed::Blob(entry.blob)
@@ -2989,9 +3243,12 @@ impl PlatformShell for ContentAddressedMount {
                     if let Some(buf) = pending.hot.get(&node.0) {
                         Some(Some(buf.bytes.len() as u64))
                     } else if pending.orphans.contains(&node.0) {
-                        // Fall through to `blob_size(blob)` — the
-                        // captured size is the orphan's own.
-                        None
+                        // R8: prefer the preserved orphan warm size
+                        // (if any) over the captured fallback. With
+                        // no preserved warm, `None` falls through to
+                        // `blob_size(blob)` — the captured size is
+                        // the orphan's own.
+                        pending.orphan_warm.get(&node.0).map(|e| Some(e.size))
                     } else if pending.tombstones.contains(path) {
                         // Tombstoned via the mount: treat as
                         // not-yet-collected. The path is gone but the
@@ -3019,14 +3276,21 @@ impl PlatformShell for ContentAddressedMount {
             NodeRecord::Symlink { blob } => (self.blob_size(blob)?, 1),
             NodeRecord::PendingFile { path, .. } => {
                 // Orphan branch: a rename-displaced or
-                // unlinked-but-still-open PendingFile only has its
-                // per-NodeId buffer to report — `pending_lookup`
-                // would consult the rebound path overlay and serve
-                // the sibling's size.
+                // unlinked-but-still-open PendingFile reports either
+                // its per-NodeId hot buffer length, or its preserved
+                // `orphan_warm[node.0]` size (R8). `pending_lookup`
+                // would otherwise consult the rebound path overlay
+                // and serve the sibling's size.
                 let orphan_size = {
                     let pending = self.inner.pending.lock().expect("pending lock");
                     if pending.orphans.contains(&node.0) {
-                        Some(pending.hot.get(&node.0).map(|buf| buf.bytes.len() as u64))
+                        Some(
+                            pending
+                                .hot
+                                .get(&node.0)
+                                .map(|buf| buf.bytes.len() as u64)
+                                .or_else(|| pending.orphan_warm.get(&node.0).map(|e| e.size)),
+                        )
                     } else {
                         None
                     }
@@ -3092,7 +3356,12 @@ impl PlatformShell for ContentAddressedMount {
             // The kernel is forgetting this inode; any orphan
             // tracking we kept for it is now dead weight. Drop it
             // so the set doesn't accumulate across long sessions.
+            // R8: also clear orphan-preserved warm bytes and the
+            // open-handle refcount so a long-running mount doesn't
+            // accumulate dead entries.
             pending.orphans.remove(&node.0);
+            pending.orphan_warm.remove(&node.0);
+            pending.open_handles.remove(&node.0);
         }
         self.inner.inodes.lock().expect("inode lock").forget(node);
         Ok(())
@@ -3103,7 +3372,11 @@ impl PlatformShell for ContentAddressedMount {
     }
 
     fn release(&self, node: NodeId) -> Result<()> {
-        self.flush_node(node)
+        self.release_node(node)
+    }
+
+    fn on_open(&self, node: NodeId) -> Result<()> {
+        ContentAddressedMount::on_open(self, node)
     }
 
     fn create_file(
@@ -3136,6 +3409,24 @@ impl PlatformShell for ContentAddressedMount {
         new_name: &OsStr,
     ) -> Result<()> {
         ContentAddressedMount::rename_entry(self, old_parent, old_name, new_parent, new_name)
+    }
+
+    fn rename_entry_with_options(
+        &self,
+        old_parent: NodeId,
+        old_name: &OsStr,
+        new_parent: NodeId,
+        new_name: &OsStr,
+        options: RenameOptions,
+    ) -> Result<()> {
+        ContentAddressedMount::rename_entry_with_options(
+            self,
+            old_parent,
+            old_name,
+            new_parent,
+            new_name,
+            options,
+        )
     }
 
     fn set_attrs(&self, node: NodeId, update: AttrUpdate) -> Result<Attrs> {
@@ -3290,7 +3581,11 @@ impl ContentAddressedMount {
             warn!(?err, "thread metadata refresh from mount capture failed");
         }
 
-        // Step 4: clear the pending tier and refresh state.
+        // Step 4: clear the pending tier and refresh state. R8: also
+        // clear orphan bookkeeping — the new state's tree is
+        // canonical, so any open fds the kernel still holds against
+        // pre-capture inodes will get refreshed via `forget` /
+        // re-lookup as normal.
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
             pending.hot.clear();
@@ -3300,6 +3595,9 @@ impl ContentAddressedMount {
             pending.dir_tombstones.clear();
             pending.explicit_dirs.clear();
             pending.symlinks.clear();
+            pending.orphans.clear();
+            pending.orphan_warm.clear();
+            pending.open_handles.clear();
         }
         let mut state_lock = self.inner.state.write().expect("mount state lock");
         *state_lock = MountState {
@@ -3646,6 +3944,33 @@ impl ContentAddressedMount {
     #[cfg(test)]
     pub(crate) fn repo_handle(&self) -> &Repository {
         &self.inner.repo
+    }
+
+    /// Test-only accessor: is `node` currently marked as an orphaned
+    /// inode (open-unlinked or rename-displaced with surviving fds)?
+    #[cfg(test)]
+    pub(crate) fn orphans_contains(&self, node: NodeId) -> bool {
+        self.inner
+            .pending
+            .lock()
+            .expect("pending lock")
+            .orphans
+            .contains(&node.0)
+    }
+
+    /// Test-only accessor: orphan-preserved warm-tier blob for `node`,
+    /// if any. Mirrors [`Self::warm_blob`] but keyed by NodeId rather
+    /// than path.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn orphan_warm_blob(&self, node: NodeId) -> Option<ContentHash> {
+        self.inner
+            .pending
+            .lock()
+            .expect("pending lock")
+            .orphan_warm
+            .get(&node.0)
+            .map(|e| e.blob)
     }
 }
 

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1254,13 +1254,24 @@ impl ContentAddressedMount {
             .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
         let child_path = join_child(&parent_path, name_str);
 
-        let mut pending = self.inner.pending.lock().expect("pending lock");
-        if let Some(node_id) = pending.hot_by_path.remove(&child_path) {
-            pending.hot.remove(&node_id);
+        {
+            let mut pending = self.inner.pending.lock().expect("pending lock");
+            if let Some(node_id) = pending.hot_by_path.remove(&child_path) {
+                pending.hot.remove(&node_id);
+            }
+            pending.warm.remove(&child_path);
+            pending.symlinks.remove(&child_path);
+            pending.tombstones.insert(child_path.clone());
         }
-        pending.warm.remove(&child_path);
-        pending.symlinks.remove(&child_path);
-        pending.tombstones.insert(child_path);
+        // Retire the path→inode mapping so a subsequent `create_file`
+        // at the same name mints a fresh inode (POSIX unlink/recreate
+        // isolation — open-unlinked temp files must not be aliased by
+        // a replacement at the same path). The `by_id` record stays so
+        // any still-open kernel handle keeps resolving until `forget`.
+        {
+            let mut inodes = self.inner.inodes.lock().expect("inode lock");
+            inodes.by_path.remove(&child_path);
+        }
         Ok(())
     }
 
@@ -1359,12 +1370,12 @@ impl ContentAddressedMount {
         // from `by_path` so the next lookup mints a fresh id.
         {
             let mut inodes = self.inner.inodes.lock().expect("inode lock");
-            // Drop any cached inode for the destination so the next
-            // lookup mints fresh (the old inode there pointed at the
-            // *captured* file, which is now logically replaced).
-            if let Some(dest_id) = inodes.by_path.remove(&new_path) {
-                inodes.by_id.remove(&dest_id);
-            }
+            // Detach the destination's path mapping. The inode record
+            // stays in `by_id` so any kernel handle the FS still holds
+            // for the replaced file keeps resolving (the kernel cleans
+            // up via `forget` on close). POSIX semantics: rename-over
+            // must not invalidate an already-open dest descriptor.
+            inodes.by_path.remove(&new_path);
             // Rewrite the source inode's stored path so subsequent
             // reads/attrs against it serve the new-path overlay.
             // The kernel keeps using the source's NodeId after rename
@@ -1375,15 +1386,55 @@ impl ContentAddressedMount {
                 if let Some(
                     NodeRecord::PendingFile { path, .. }
                     | NodeRecord::File { path, .. }
-                    | NodeRecord::PendingSymlink { path },
+                    | NodeRecord::PendingSymlink { path }
+                    | NodeRecord::Dir { path, .. }
+                    | NodeRecord::PendingDir { path },
                 ) = inodes.by_id.get_mut(&src_id)
                 {
                     *path = new_path.clone();
                 }
                 inodes.by_path.insert(new_path.clone(), src_id);
+                // For a directory rename, also rebase every cached
+                // descendant inode. The kernel may already hold dentry
+                // → inode bindings for `old_path/<child>` from prior
+                // lookups, and reads against those inodes would
+                // otherwise resolve through the stale path (ESTALE on
+                // PendingFile, or the wrong overlay on File). Walk
+                // by_path once, collect the entries under the old
+                // prefix, then rewrite both the mapping and the
+                // NodeRecord's stored path.
+                if src.kind == NodeKind::Directory {
+                    let descendants: Vec<(PathBuf, PathBuf, u64)> = inodes
+                        .by_path
+                        .iter()
+                        .filter_map(|(p, id)| {
+                            let tail = p.strip_prefix(&old_path).ok()?;
+                            if tail.as_os_str().is_empty() {
+                                return None;
+                            }
+                            Some((p.clone(), new_path.join(tail), *id))
+                        })
+                        .collect();
+                    for (old_key, new_key, id) in descendants {
+                        inodes.by_path.remove(&old_key);
+                        if let Some(
+                            NodeRecord::PendingFile { path, .. }
+                            | NodeRecord::File { path, .. }
+                            | NodeRecord::PendingSymlink { path }
+                            | NodeRecord::Dir { path, .. }
+                            | NodeRecord::PendingDir { path },
+                        ) = inodes.by_id.get_mut(&id)
+                        {
+                            *path = new_key.clone();
+                        }
+                        inodes.by_path.insert(new_key, id);
+                    }
+                }
                 drop(inodes);
                 // Same for any cached hot buffer keyed on the source
-                // node — its `path` field must follow.
+                // node — its `path` field must follow. (Descendant
+                // hot-buffer paths are already rebased in
+                // `move_overlay_dir`'s `hot_path_updates` pass.)
                 let mut pending = self.inner.pending.lock().expect("pending lock");
                 if let Some(buf) = pending.hot.get_mut(&src_id) {
                     buf.path = new_path.clone();

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1826,7 +1826,6 @@ impl ContentAddressedMount {
         name: &OsStr,
         target: &Path,
     ) -> Result<Entry> {
-        use std::os::unix::ffi::OsStrExt;
         let name_str = validate_entry_name(name)?;
         if self.lookup(parent, name)?.is_some() {
             return Err(MountError::AlreadyExists(name_str.to_string()));
@@ -1836,7 +1835,7 @@ impl ContentAddressedMount {
             .dir_path_of(&parent_record)
             .ok_or_else(|| MountError::NotADirectory(format!("{parent_record:?}")))?;
         let child_path = join_child(&parent_path, name_str);
-        let target_bytes = target.as_os_str().as_bytes().to_vec();
+        let target_bytes = target.as_os_str().as_encoded_bytes().to_vec();
         let target_len = target_bytes.len() as u64;
 
         {
@@ -1859,7 +1858,6 @@ impl ContentAddressedMount {
     /// Read the target of a symlink `node`. Works for both overlay
     /// (`PendingSymlink`) and captured (`Symlink`) records.
     pub fn read_link(&self, node: NodeId) -> Result<OsString> {
-        use std::os::unix::ffi::OsStrExt;
         let record = self.record_for(node)?;
         match record {
             NodeRecord::PendingSymlink { path } => {
@@ -1868,11 +1866,16 @@ impl ContentAddressedMount {
                     .symlinks
                     .get(&path)
                     .ok_or_else(|| MountError::Stale(format!("symlink {}", path.display())))?;
-                Ok(OsStr::from_bytes(bytes).to_os_string())
+                // SAFETY: bytes were written via `OsStr::as_encoded_bytes()` in
+                // `create_symlink`, which is the documented inverse of
+                // `from_encoded_bytes_unchecked`.
+                Ok(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) }.to_os_string())
             }
             NodeRecord::Symlink { blob } => {
                 let bytes = self.load_blob_bytes(&blob)?;
-                Ok(OsStr::from_bytes(&bytes).to_os_string())
+                // SAFETY: same provenance as above — the blob was minted from
+                // `as_encoded_bytes()` at capture time.
+                Ok(unsafe { OsStr::from_encoded_bytes_unchecked(&bytes) }.to_os_string())
             }
             other => Err(MountError::InvalidArgument(format!(
                 "read_link on non-symlink record: {other:?}"
@@ -2071,8 +2074,7 @@ impl ContentAddressedMount {
 /// path separator, anything with a NUL byte. Returns the validated
 /// name as a `&str` so callers can build paths without re-decoding.
 fn validate_entry_name(name: &OsStr) -> Result<&str> {
-    use std::os::unix::ffi::OsStrExt;
-    let bytes = name.as_bytes();
+    let bytes = name.as_encoded_bytes();
     if bytes.is_empty() {
         return Err(MountError::InvalidArgument("empty entry name".into()));
     }

--- a/crates/mount/src/error.rs
+++ b/crates/mount/src/error.rs
@@ -34,6 +34,31 @@ pub enum MountError {
     #[error("read-only filesystem")]
     ReadOnly,
 
+    /// An entry with this name already exists (e.g. `O_CREAT|O_EXCL`
+    /// against an existing file, or `mkdir` against an existing dir).
+    /// Maps to `EEXIST` so userspace tooling that exercises atomic
+    /// "create-or-skip" semantics (cargo's lockfile lease, git's
+    /// `objects/<n>/<n>.tmp` placement) sees the conventional errno.
+    #[error("already exists: {0}")]
+    AlreadyExists(String),
+
+    /// Tried to operate on a file as if it were a directory
+    /// (e.g. `unlink` against a path that resolves to a directory).
+    /// Maps to `EISDIR`.
+    #[error("is a directory: {0}")]
+    IsADirectory(String),
+
+    /// Tried to `rmdir` a directory that still has visible children
+    /// (across the captured tree + pending overlay). Maps to
+    /// `ENOTEMPTY`.
+    #[error("directory not empty: {0}")]
+    NotEmpty(String),
+
+    /// Invalid argument from the caller (e.g. a name containing
+    /// `/`, `\0`, or `.`/`..`). Maps to `EINVAL`.
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
     /// Errors bubbling up from the underlying object store / repo.
     #[error(transparent)]
     Store(#[from] HeddleError),
@@ -55,6 +80,10 @@ impl MountError {
             MountError::Stale(_) => stale_errno(),
             MountError::NotADirectory(_) => libc::ENOTDIR,
             MountError::ReadOnly => libc::EROFS,
+            MountError::AlreadyExists(_) => libc::EEXIST,
+            MountError::IsADirectory(_) => libc::EISDIR,
+            MountError::NotEmpty(_) => libc::ENOTEMPTY,
+            MountError::InvalidArgument(_) => libc::EINVAL,
             MountError::Store(HeddleError::NotFound(_))
             | MountError::Store(HeddleError::StateNotFound(_))
             | MountError::Store(HeddleError::MissingObject { .. }) => libc::ENOENT,

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -85,7 +85,7 @@ use tracing::{debug, warn};
 use crate::{
     core::ContentAddressedMount,
     error::Result,
-    shell::{AttrUpdate, Attrs, Entry, NodeId, NodeKind, PlatformShell},
+    shell::{AttrUpdate, Attrs, Entry, NodeId, NodeKind, PlatformShell, RenameOptions},
 };
 
 /// FUSE attribute timeout. Heddle's mount is content-addressed —
@@ -353,7 +353,18 @@ impl Filesystem for FuseShell {
         Ok(())
     }
 
-    fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        // R8 (Codex Thread 3293235165): notify the core that an open
+        // handle was minted. The core's open-handle refcount times
+        // the orphan cleanup against the final `release` rather than
+        // the first `flush` — without this hook, a kernel that opens
+        // an inode twice (rather than dup'ing) clears the marker on
+        // the first close. Errors here can only come from the panic
+        // guard; the cost of skipping the bookkeeping is correctness
+        // under that pathological case, so we log and fail open.
+        if let Err(err) = guard_call("open", || self.inner.on_open(NodeId(ino.0))) {
+            warn!(?err, "on_open bookkeeping failed; orphan cleanup may misfire");
+        }
         // Open every file in `direct_io` mode so the kernel never
         // serves bytes from its page cache. The content-addressed
         // mount maintains its own blob cache ([`BlobCachePool`]),
@@ -562,6 +573,15 @@ impl Filesystem for FuseShell {
         });
         match result {
             Ok(entry) => {
+                // R8: bump the open-handle refcount the same as
+                // `Self::open` does. The kernel won't issue a
+                // separate `open` callback after `create`.
+                if let Err(err) = guard_call("create", || self.inner.on_open(entry.node)) {
+                    warn!(
+                        ?err,
+                        "on_open bookkeeping failed; orphan cleanup may misfire"
+                    );
+                }
                 // Mirror the `open` callback: opt the new fd into
                 // FOPEN_DIRECT_IO so kernel page-cache reads don't
                 // shadow hot-tier writes (see `Self::open` for the
@@ -672,9 +692,13 @@ impl Filesystem for FuseShell {
         //     overlay would have to journal both halves.
         //   * RENAME_WHITEOUT — overlayfs-specific, not meaningful
         //     for a CAS-backed mount.
-        // `RENAME_NOREPLACE` we honour the easy way: if the
-        // destination exists, refuse with EEXIST before invoking
-        // the overlay rename.
+        // R8 (Codex Thread 3293235163): `RENAME_NOREPLACE` is plumbed
+        // through the core's `rename_entry_with_options` so the
+        // existence-check + the directory-entry mutation land under
+        // the same write-side critical section. The old shell-side
+        // pre-check left a TOCTOU window between the lookup and the
+        // rename — a concurrent writer could install the
+        // destination in between and the rename would clobber it.
         #[cfg(target_os = "linux")]
         if flags.contains(RenameFlags::RENAME_EXCHANGE)
             || flags.contains(RenameFlags::RENAME_WHITEOUT)
@@ -683,30 +707,20 @@ impl Filesystem for FuseShell {
             return;
         }
         #[cfg(target_os = "linux")]
-        if flags.contains(RenameFlags::RENAME_NOREPLACE) {
-            let probe = guard_call("rename", || {
-                self.inner.lookup(NodeId(newparent.0), newname)
-            });
-            match probe {
-                Ok(Some(_)) => {
-                    reply.error(Errno::from_i32(libc::EEXIST));
-                    return;
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    reply.error(errno_from_mount_error(err));
-                    return;
-                }
-            }
-        }
+        let no_replace = flags.contains(RenameFlags::RENAME_NOREPLACE);
         #[cfg(not(target_os = "linux"))]
-        let _ = flags;
+        let no_replace = {
+            let _ = flags;
+            false
+        };
+        let options = RenameOptions { no_replace };
         match guard_call("rename", || {
-            self.inner.rename_entry(
+            self.inner.rename_entry_with_options(
                 NodeId(parent.0),
                 name,
                 NodeId(newparent.0),
                 newname,
+                options,
             )
         }) {
             Ok(()) => reply.ok(),

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -40,21 +40,22 @@ use std::{
     panic::AssertUnwindSafe,
     path::Path,
     sync::Arc,
-    time::{Duration, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use fuser::{
-    BackgroundSession, Config, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
-    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, MountOption, OpenFlags, ReplyAttr,
-    ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request, Session,
-    WriteFlags,
+    BackgroundSession, BsdFileFlags, Config, Errno, FileAttr, FileHandle, FileType, Filesystem,
+    FopenFlags, Generation, INodeNo, InitFlags, KernelConfig, LockOwner, MountOption, OpenFlags,
+    RenameFlags, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry,
+    ReplyOpen, ReplyWrite, Request, Session, TimeOrNow, WriteFlags,
 };
+use objects::object::FileMode;
 use tracing::{debug, warn};
 
 use crate::{
     core::ContentAddressedMount,
     error::Result,
-    shell::{Attrs, Entry, NodeId, NodeKind, PlatformShell},
+    shell::{AttrUpdate, Attrs, Entry, NodeId, NodeKind, PlatformShell},
 };
 
 /// FUSE attribute timeout. Heddle's mount is content-addressed —
@@ -81,6 +82,19 @@ impl FuseShell {
         Self {
             inner: Arc::new(mount),
         }
+    }
+
+    /// Best-effort mtime to attach to entry replies for newly
+    /// created paths. The core hands out a fixed `mounted_at`
+    /// timestamp for every attrs call, but ReplyEntry needs one
+    /// inline before the kernel has issued any followup `getattr`.
+    /// We approximate by reading the root's attrs (a hash-table
+    /// hit) and falling back to UNIX_EPOCH on any error.
+    fn inner_mtime(&self) -> std::time::SystemTime {
+        self.inner
+            .attrs(NodeId::ROOT)
+            .map(|a| a.mtime)
+            .unwrap_or(UNIX_EPOCH)
     }
 
     /// Hand out a shared handle to the underlying mount.
@@ -170,6 +184,20 @@ fn process_uid() -> u32 {
 fn process_gid() -> u32 {
     // SAFETY: `getgid` is async-signal-safe and has no preconditions.
     unsafe { libc::getgid() }
+}
+
+/// Fold the unix mode bits the kernel passes to `create` / `mknod`
+/// into the closest [`FileMode`] heddle tracks. Only the `+x` bit
+/// is preserved across capture; the rest of the permission bits
+/// don't survive (see `crates/objects/src/object/tree_types.rs` —
+/// FileMode is a three-way enum, not a u16). Document this in the
+/// README's "what writes persist" section.
+fn file_mode_from_unix(mode: u32) -> FileMode {
+    if (mode & 0o111) != 0 {
+        FileMode::Executable
+    } else {
+        FileMode::Normal
+    }
 }
 
 fn file_type_for_kind(kind: NodeKind) -> FileType {
@@ -481,6 +509,268 @@ impl Filesystem for FuseShell {
             Ok(()) => reply.ok(),
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
+    }
+
+    fn create(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        mode: u32,
+        _umask: u32,
+        flags: i32,
+        reply: ReplyCreate,
+    ) {
+        // The kernel calls `create` for `open(O_CREAT)`. `O_EXCL`
+        // requires us to fail with EEXIST when the entry already
+        // exists; without it we return-or-create.
+        let exclusive = (flags & libc::O_EXCL) != 0;
+        let file_mode = file_mode_from_unix(mode);
+        let result = guard_call("create", || {
+            self.inner
+                .create_file(NodeId(parent.0), name, file_mode, exclusive)
+        });
+        match result {
+            Ok(entry) => {
+                // Mirror the `open` callback: opt the new fd into
+                // FOPEN_DIRECT_IO so kernel page-cache reads don't
+                // shadow hot-tier writes (see `Self::open` for the
+                // full reasoning).
+                let attr = match guard_call("create", || self.inner.attrs(entry.node)) {
+                    Ok(attrs) => file_attr_from(attrs),
+                    Err(err) => {
+                        reply.error(errno_from_mount_error(err));
+                        return;
+                    }
+                };
+                reply.created(
+                    &TTL,
+                    &attr,
+                    GENERATION,
+                    FileHandle(0),
+                    FopenFlags::FOPEN_DIRECT_IO,
+                );
+            }
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn mkdir(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: ReplyEntry,
+    ) {
+        let result = guard_call("mkdir", || self.inner.make_dir(NodeId(parent.0), name));
+        match result {
+            Ok(entry) => {
+                let attr = entry_attr_from(&entry, self.inner_mtime());
+                reply.entry(&TTL, &attr, GENERATION);
+            }
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    /// `mknod` for regular files routes through `create_file`. Heddle
+    /// doesn't model device / FIFO / socket nodes — those return
+    /// `EPERM`, which is what fuse's default mknod handler also does
+    /// for the unsupported types. cargo / git / npm only ever issue
+    /// `mknod` with `S_IFREG`, so the supported subset is enough for
+    /// the issue's acceptance criteria. See README ("per-thread
+    /// overlay semantics") for the full enumeration.
+    fn mknod(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        mode: u32,
+        _umask: u32,
+        _rdev: u32,
+        reply: ReplyEntry,
+    ) {
+        let kind = mode & libc::S_IFMT as u32;
+        if kind != libc::S_IFREG as u32 && kind != 0 {
+            reply.error(Errno::from_i32(libc::EPERM));
+            return;
+        }
+        let file_mode = file_mode_from_unix(mode);
+        let result = guard_call("mknod", || {
+            self.inner.create_file(NodeId(parent.0), name, file_mode, true)
+        });
+        match result {
+            Ok(entry) => {
+                let attr = entry_attr_from(&entry, self.inner_mtime());
+                reply.entry(&TTL, &attr, GENERATION);
+            }
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        match guard_call("unlink", || {
+            self.inner.unlink_entry(NodeId(parent.0), name)
+        }) {
+            Ok(()) => reply.ok(),
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        match guard_call("rmdir", || {
+            self.inner.rmdir_entry(NodeId(parent.0), name)
+        }) {
+            Ok(()) => reply.ok(),
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn rename(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        newparent: INodeNo,
+        newname: &OsStr,
+        flags: RenameFlags,
+        reply: ReplyEmpty,
+    ) {
+        // `renameat2` flags we don't support yet:
+        //   * RENAME_EXCHANGE — needs an atomic swap primitive; the
+        //     overlay would have to journal both halves.
+        //   * RENAME_WHITEOUT — overlayfs-specific, not meaningful
+        //     for a CAS-backed mount.
+        // `RENAME_NOREPLACE` we honour the easy way: if the
+        // destination exists, refuse with EEXIST before invoking
+        // the overlay rename.
+        #[cfg(target_os = "linux")]
+        if flags.contains(RenameFlags::RENAME_EXCHANGE)
+            || flags.contains(RenameFlags::RENAME_WHITEOUT)
+        {
+            reply.error(Errno::from_i32(libc::EINVAL));
+            return;
+        }
+        #[cfg(target_os = "linux")]
+        if flags.contains(RenameFlags::RENAME_NOREPLACE) {
+            let probe = guard_call("rename", || {
+                self.inner.lookup(NodeId(newparent.0), newname)
+            });
+            match probe {
+                Ok(Some(_)) => {
+                    reply.error(Errno::from_i32(libc::EEXIST));
+                    return;
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    reply.error(errno_from_mount_error(err));
+                    return;
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = flags;
+        match guard_call("rename", || {
+            self.inner.rename_entry(
+                NodeId(parent.0),
+                name,
+                NodeId(newparent.0),
+                newname,
+            )
+        }) {
+            Ok(()) => reply.ok(),
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn setattr(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+        size: Option<u64>,
+        _atime: Option<TimeOrNow>,
+        mtime: Option<TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<FileHandle>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<BsdFileFlags>,
+        reply: ReplyAttr,
+    ) {
+        let mtime_sec = mtime.and_then(|t| match t {
+            TimeOrNow::SpecificTime(st) => st
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .ok(),
+            TimeOrNow::Now => SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .ok(),
+        });
+        let update = AttrUpdate {
+            mode,
+            uid,
+            gid,
+            size,
+            mtime_sec,
+        };
+        match guard_call("setattr", || self.inner.set_attrs(NodeId(ino.0), update)) {
+            Ok(attrs) => reply.attr(&TTL, &file_attr_from(attrs)),
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn symlink(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        link_name: &OsStr,
+        target: &Path,
+        reply: ReplyEntry,
+    ) {
+        let result = guard_call("symlink", || {
+            self.inner.create_symlink(NodeId(parent.0), link_name, target)
+        });
+        match result {
+            Ok(entry) => {
+                let attr = entry_attr_from(&entry, self.inner_mtime());
+                reply.entry(&TTL, &attr, GENERATION);
+            }
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    fn readlink(&self, _req: &Request, ino: INodeNo, reply: ReplyData) {
+        use std::os::unix::ffi::OsStrExt;
+        match guard_call("readlink", || self.inner.read_link(NodeId(ino.0))) {
+            Ok(target) => reply.data(target.as_os_str().as_bytes()),
+            Err(err) => reply.error(errno_from_mount_error(err)),
+        }
+    }
+
+    /// Hard links would alias two paths onto the same inode; the
+    /// per-thread CAS overlay (and heddle's tree model) addresses
+    /// blobs by content-hash but identifies *entries* by path, with
+    /// no nlink fan-out. Refuse with `EPERM` to match POSIX's
+    /// behaviour for filesystems that don't support hard links. The
+    /// fuser default already returns `EPERM`; we override only to
+    /// route through the same panic-guard wrapper for consistency
+    /// with the other write-side callbacks.
+    fn link(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _newparent: INodeNo,
+        _newname: &OsStr,
+        reply: ReplyEntry,
+    ) {
+        reply.error(Errno::from_i32(libc::EPERM));
     }
 
     fn destroy(&mut self) {

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -8,6 +8,36 @@
 //! /`release`, and folded into a real heddle state by
 //! [`ContentAddressedMount::capture`].
 //!
+//! ## Implemented kernel callbacks
+//!
+//! Read path:
+//! * `init` — opts into `FUSE_DIRECT_IO_ALLOW_MMAP` so mmap works
+//!   alongside `FOPEN_DIRECT_IO`.
+//! * `lookup` / `getattr` / `open` / `read` / `readdir` / `flush` /
+//!   `release` / `opendir` / `releasedir` / `destroy`.
+//!
+//! Write path (heddle#180):
+//! * `create` — `open(O_CREAT[|O_EXCL|O_TRUNC])`. EEXIST on O_EXCL
+//!   clash. Returns `FOPEN_DIRECT_IO`.
+//! * `mkdir` — empty directory in the overlay.
+//! * `mknod` — regular files only; non-`S_IFREG` returns EPERM.
+//! * `unlink` / `rmdir`.
+//! * `rename` — overlay+captured file/symlink + overlay-only dir.
+//!   RENAME_NOREPLACE honoured; EXCHANGE and WHITEOUT return EINVAL.
+//! * `setattr` — chmod (folded to FileMode), ftruncate / O_TRUNC,
+//!   mtime / uid / gid accepted as no-ops.
+//! * `symlink` / `readlink`.
+//! * `link` — returns EPERM (no nlink in heddle's tree model).
+//! * `write` — already implemented; the freshly created file inherits
+//!   the same hot-tier behaviour as a write to a captured file.
+//!
+//! Anything not listed (xattrs, locks, statfs, ioctl, fsync,
+//! fsyncdir, copy_file_range, lseek, fallocate, etc.) inherits
+//! fuser's default reply (ENOSYS / OK depending on the op) and is
+//! out of scope until a real workload needs it. See
+//! `crates/mount/README.md` ("Per-thread overlay semantics") for
+//! the matching write-side state model.
+//!
 //! ## Panic safety
 //!
 //! Every callback body runs inside [`std::panic::catch_unwind`] via
@@ -591,8 +621,8 @@ impl Filesystem for FuseShell {
         _rdev: u32,
         reply: ReplyEntry,
     ) {
-        let kind = mode & libc::S_IFMT as u32;
-        if kind != libc::S_IFREG as u32 && kind != 0 {
+        let kind = mode & libc::S_IFMT;
+        if kind != libc::S_IFREG && kind != 0 {
             reply.error(Errno::from_i32(libc::EPERM));
             return;
         }

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -62,7 +62,7 @@ pub use crate::{
     cache::{BlobCachePool, BlobCacheStats, DEFAULT_BLOB_CACHE_BYTES},
     core::{ContentAddressedMount, MountOptions, PrewarmHandle, PrewarmStats, PromotionPolicy},
     error::{MountError, Result},
-    shell::{Attrs, Entry, NodeId, NodeKind, PlatformShell},
+    shell::{AttrUpdate, Attrs, Entry, NodeId, NodeKind, PlatformShell},
 };
 
 #[cfg(test)]

--- a/crates/mount/src/shell.rs
+++ b/crates/mount/src/shell.rs
@@ -142,16 +142,38 @@ pub trait PlatformShell {
     /// Promote any hot-tier buffer for `node` into a CAS blob. The
     /// FUSE `flush` callback dispatches here (fires on `close(2)`
     /// and explicit fsync). Default: no-op for read-only mounts.
+    ///
+    /// Lifecycle note: FUSE `flush` fires on *every* descriptor close
+    /// — including the close of a `dup`-derived fd — so it can be
+    /// invoked multiple times before the last open handle is gone.
+    /// Implementations that maintain per-inode "is the directory
+    /// entry still gone?" state (orphan tracking) MUST defer the
+    /// final clear to [`Self::release`]; touching it here would let a
+    /// surviving fd's next write republish the unlinked pathname.
     fn flush(&self, _node: NodeId) -> Result<()> {
         Ok(())
     }
 
-    /// Final close of `node`. Adapters call this on FUSE `release`
-    /// so a buffer that survived a missed `flush` still gets
-    /// promoted before the inode handle is retired. Default:
-    /// identical to flush.
+    /// Final close of `node`. The FUSE `release` callback dispatches
+    /// here; it fires once per `open(2)` after the last fd derived
+    /// from that open is closed. This is the canonical "last close of
+    /// the inode" signal — it is the right hook (NOT [`Self::flush`])
+    /// for retiring per-inode lifecycle state like orphan-tracking
+    /// markers or open-handle refcounts. Default: identical to flush
+    /// so shells that do not maintain per-inode lifecycle state
+    /// inherit a uniform contract.
     fn release(&self, node: NodeId) -> Result<()> {
         self.flush(node)
+    }
+
+    /// Notify the shell that a new open file handle for `node` has
+    /// been minted. FUSE adapters call this on the `open` / `create`
+    /// callbacks so the shell can maintain a per-inode open-handle
+    /// refcount — used to time the [`Self::release`] cleanup against
+    /// the *final* close instead of the first one. Default: no-op so
+    /// shells without lifecycle state are unaffected.
+    fn on_open(&self, _node: NodeId) -> Result<()> {
+        Ok(())
     }
 
     /// Create a fresh regular file under `parent`. Mints a [`NodeId`]
@@ -218,6 +240,25 @@ pub trait PlatformShell {
         _new_name: &OsStr,
     ) -> Result<()> {
         Err(MountError::ReadOnly)
+    }
+
+    /// Same as [`Self::rename_entry`] but honours [`RenameOptions`] —
+    /// in particular `no_replace`, which atomically refuses the rename
+    /// when the destination already resolves. The check + the
+    /// directory-entry mutation MUST happen under a single critical
+    /// section to avoid a TOCTOU window between the existence check
+    /// and the rename itself. Default: ignore options and dispatch to
+    /// `rename_entry` (preserving the existing trait surface for
+    /// shells that do not yet support flags).
+    fn rename_entry_with_options(
+        &self,
+        old_parent: NodeId,
+        old_name: &OsStr,
+        new_parent: NodeId,
+        new_name: &OsStr,
+        _options: RenameOptions,
+    ) -> Result<()> {
+        self.rename_entry(old_parent, old_name, new_parent, new_name)
     }
 
     /// Apply attribute updates to `node`. Returns the post-update
@@ -294,3 +335,17 @@ pub(crate) fn kind_for_mode(mode: FileMode) -> NodeKind {
 /// their own — they're synthesised at materialization time — so we
 /// keep one canonical value here.
 pub(crate) const DIR_UNIX_MODE: u32 = 0o040755;
+
+/// Optional flags for [`PlatformShell::rename_entry_with_options`].
+/// Mirrors the subset of Linux `renameat2(2)` flags the mount
+/// supports; non-applicable flags on non-Linux adapters can be left
+/// as their defaults.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RenameOptions {
+    /// `RENAME_NOREPLACE`: refuse the rename with [`MountError::AlreadyExists`]
+    /// when the destination already resolves. Must be enforced inside
+    /// the same critical section as the rename so a concurrent writer
+    /// cannot install the destination between the check and the
+    /// mutation.
+    pub no_replace: bool,
+}

--- a/crates/mount/src/shell.rs
+++ b/crates/mount/src/shell.rs
@@ -14,12 +14,13 @@
 
 use std::{
     ffi::{OsStr, OsString},
+    path::Path,
     time::SystemTime,
 };
 
 use objects::object::FileMode;
 
-use crate::error::Result;
+use crate::error::{MountError, Result};
 
 /// Identifier for a filesystem node within a single mount session.
 ///
@@ -152,6 +153,133 @@ pub trait PlatformShell {
     fn release(&self, node: NodeId) -> Result<()> {
         self.flush(node)
     }
+
+    /// Create a fresh regular file under `parent`. Mints a [`NodeId`]
+    /// for the new file in the writable overlay and returns its
+    /// [`Entry`]; subsequent [`write`](PlatformShell::write) calls
+    /// land in the per-thread hot tier.
+    ///
+    /// When `exclusive` is true (`O_CREAT|O_EXCL`), the call must
+    /// fail with [`MountError::AlreadyExists`] if `name` already
+    /// resolves under `parent` (either in the captured tree or the
+    /// pending tier). When `exclusive` is false, a hit on an
+    /// existing entry is returned as-is (same shape as `lookup`).
+    ///
+    /// Default: [`MountError::ReadOnly`] — implementations that
+    /// don't support mutation inherit a uniform errno.
+    fn create_file(
+        &self,
+        _parent: NodeId,
+        _name: &OsStr,
+        _mode: FileMode,
+        _exclusive: bool,
+    ) -> Result<Entry> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Create an empty directory under `parent` in the overlay.
+    /// Returns the new directory's [`Entry`]. Fails with
+    /// [`MountError::AlreadyExists`] when `name` already resolves.
+    fn make_dir(&self, _parent: NodeId, _name: &OsStr) -> Result<Entry> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Delete the file named `name` under `parent`. The captured-tree
+    /// entry (if any) is tombstoned so [`lookup`](Self::lookup) /
+    /// [`enumerate`](Self::enumerate) skip it; any pending-tier hot
+    /// buffer or warm blob for the path is dropped.
+    ///
+    /// Fails with [`MountError::NotFound`] if `name` doesn't resolve,
+    /// or [`MountError::IsADirectory`] if it resolves to a directory.
+    fn unlink_entry(&self, _parent: NodeId, _name: &OsStr) -> Result<()> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Remove the empty directory named `name` under `parent`. Fails
+    /// with [`MountError::NotADirectory`] for a file, with
+    /// [`MountError::NotEmpty`] when the directory still has visible
+    /// children (across captured tree + pending tier), or
+    /// [`MountError::NotFound`] when nothing resolves.
+    fn rmdir_entry(&self, _parent: NodeId, _name: &OsStr) -> Result<()> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Atomically rename `(old_parent, old_name)` to
+    /// `(new_parent, new_name)`. Handles both same-directory and
+    /// cross-directory cases. Replacing an existing entry of the
+    /// same kind is allowed (POSIX semantics); replacing a directory
+    /// with a file (or vice-versa) fails with
+    /// [`MountError::IsADirectory`] / [`MountError::NotADirectory`].
+    fn rename_entry(
+        &self,
+        _old_parent: NodeId,
+        _old_name: &OsStr,
+        _new_parent: NodeId,
+        _new_name: &OsStr,
+    ) -> Result<()> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Apply attribute updates to `node`. Returns the post-update
+    /// [`Attrs`] so callers can reply without a second `getattr`
+    /// round trip. See [`AttrUpdate`] for which fields the overlay
+    /// actually persists; unsupported fields are no-ops.
+    fn set_attrs(&self, _node: NodeId, _update: AttrUpdate) -> Result<Attrs> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Create a symbolic link named `name` under `parent` whose
+    /// target is the byte-equivalent of `target`. Returns the new
+    /// link's [`Entry`].
+    fn create_symlink(
+        &self,
+        _parent: NodeId,
+        _name: &OsStr,
+        _target: &Path,
+    ) -> Result<Entry> {
+        Err(MountError::ReadOnly)
+    }
+
+    /// Read the target of a symbolic link `node`. Returns the raw
+    /// bytes of the link target (which may not be valid UTF-8 on
+    /// some systems, hence [`OsString`]).
+    fn read_link(&self, _node: NodeId) -> Result<OsString> {
+        Err(MountError::ReadOnly)
+    }
+}
+
+/// Optional fields a caller may update via
+/// [`PlatformShell::set_attrs`]. Every field is `Option<_>`; `None`
+/// means "leave alone" (the kernel passes `None` for slots the
+/// `chmod`/`chown`/`truncate`/`utimensat` call didn't touch).
+///
+/// Heddle's tree model only carries three modes ([`FileMode::Normal`],
+/// [`FileMode::Executable`], [`FileMode::Symlink`]) — see
+/// `crates/objects/src/object/tree_types.rs`. A `chmod` that flips
+/// the user-executable bit (`0o100`) maps to the closest mode; bits
+/// outside that don't persist across `capture`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AttrUpdate {
+    /// New unix mode bits (including the type bits). When set, the
+    /// shell folds the user-executable bit into the captured
+    /// [`FileMode`]; other bits don't persist.
+    pub mode: Option<u32>,
+    /// New uid. The mount has no per-node uid storage (every node
+    /// reports the mount-owner's uid); shells may accept this as a
+    /// no-op so `chown` doesn't return an error to callers that
+    /// don't actually need ownership tracking.
+    pub uid: Option<u32>,
+    /// New gid. Same no-op contract as `uid`.
+    pub gid: Option<u32>,
+    /// New size. Truncates the hot-tier buffer (or seeds one from
+    /// the durable predecessor and truncates) when set. `O_TRUNC`
+    /// on the kernel side delivers `setattr(size=0)` before the
+    /// first `write`.
+    pub size: Option<u64>,
+    /// New mtime in seconds since the UNIX epoch. The overlay has
+    /// no per-node mtime storage today; shells accept this as a
+    /// no-op so the kernel's `utimensat` doesn't return an error.
+    pub mtime_sec: Option<i64>,
 }
 
 /// Convert a Heddle [`FileMode`] into a node kind.

--- a/crates/mount/src/shell.rs
+++ b/crates/mount/src/shell.rs
@@ -349,3 +349,136 @@ pub struct RenameOptions {
     /// mutation.
     pub no_replace: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::ffi::OsStr;
+    use std::time::UNIX_EPOCH;
+
+    /// Minimal `PlatformShell` impl that supplies only the required
+    /// methods, so the test pins the *default* trait bodies for
+    /// every optional write-side hook. Tracks how often `flush` and
+    /// `rename_entry` are invoked so the delegation defaults
+    /// (`release` → `flush`, `rename_entry_with_options` →
+    /// `rename_entry`) can be observed.
+    #[derive(Default)]
+    struct StubShell {
+        flush_calls: Cell<u32>,
+        rename_calls: Cell<u32>,
+    }
+
+    impl PlatformShell for StubShell {
+        fn lookup(&self, _parent: NodeId, _name: &OsStr) -> Result<Option<Entry>> {
+            Ok(None)
+        }
+        fn read(&self, _node: NodeId, _offset: u64, _buf: &mut [u8]) -> Result<usize> {
+            Ok(0)
+        }
+        fn write(&self, _node: NodeId, _offset: u64, data: &[u8]) -> Result<usize> {
+            Ok(data.len())
+        }
+        fn enumerate(&self, _dir: NodeId) -> Result<Vec<Entry>> {
+            Ok(Vec::new())
+        }
+        fn attrs(&self, node: NodeId) -> Result<Attrs> {
+            Ok(Attrs {
+                node,
+                kind: NodeKind::File,
+                size: 0,
+                unix_mode: 0o100644,
+                nlink: 1,
+                mtime: UNIX_EPOCH,
+            })
+        }
+        fn invalidate(&self, _node: NodeId) -> Result<()> {
+            Ok(())
+        }
+        // Override flush so we can observe that `release`'s default
+        // delegates here. Everything else stays on the trait default.
+        fn flush(&self, _node: NodeId) -> Result<()> {
+            self.flush_calls.set(self.flush_calls.get() + 1);
+            Ok(())
+        }
+        // Override rename_entry so we can observe that
+        // `rename_entry_with_options`'s default delegates here.
+        fn rename_entry(
+            &self,
+            _op: NodeId,
+            _on: &OsStr,
+            _np: NodeId,
+            _nn: &OsStr,
+        ) -> Result<()> {
+            self.rename_calls.set(self.rename_calls.get() + 1);
+            Ok(())
+        }
+    }
+
+    fn is_read_only<T>(r: Result<T>) -> bool {
+        matches!(r, Err(MountError::ReadOnly))
+    }
+
+    #[test]
+    fn write_side_defaults_return_read_only() {
+        let s = StubShell::default();
+        let p = NodeId::ROOT;
+        let name = OsStr::new("x");
+
+        assert!(is_read_only(
+            s.create_file(p, name, FileMode::Normal, false),
+        ));
+        assert!(is_read_only(s.make_dir(p, name)));
+        assert!(is_read_only(s.unlink_entry(p, name)));
+        assert!(is_read_only(s.rmdir_entry(p, name)));
+        assert!(is_read_only(s.set_attrs(NodeId(2), AttrUpdate::default())));
+        assert!(is_read_only(
+            s.create_symlink(p, name, Path::new("target")),
+        ));
+        assert!(is_read_only(s.read_link(NodeId(2))));
+    }
+
+    #[test]
+    fn on_open_default_is_noop() {
+        let s = StubShell::default();
+        assert!(s.on_open(NodeId(7)).is_ok());
+    }
+
+    #[test]
+    fn release_default_delegates_to_flush() {
+        let s = StubShell::default();
+        assert_eq!(s.flush_calls.get(), 0);
+        s.release(NodeId(3)).expect("release");
+        assert_eq!(
+            s.flush_calls.get(),
+            1,
+            "release default must invoke flush exactly once",
+        );
+    }
+
+    #[test]
+    fn rename_with_options_default_delegates_to_rename_entry() {
+        let s = StubShell::default();
+        let opts = RenameOptions { no_replace: true };
+        // Default impl ignores the options and forwards to
+        // `rename_entry` — observe the delegation via the call count.
+        s.rename_entry_with_options(
+            NodeId(1),
+            OsStr::new("a"),
+            NodeId(1),
+            OsStr::new("b"),
+            opts,
+        )
+        .expect("rename");
+        assert_eq!(s.rename_calls.get(), 1);
+        assert!(opts.no_replace, "RenameOptions field survives copy");
+        assert_eq!(RenameOptions::default(), RenameOptions { no_replace: false });
+    }
+
+    #[test]
+    fn kind_for_mode_maps_each_file_mode() {
+        assert_eq!(kind_for_mode(FileMode::Normal), NodeKind::File);
+        assert_eq!(kind_for_mode(FileMode::Executable), NodeKind::File);
+        assert_eq!(kind_for_mode(FileMode::Symlink), NodeKind::Symlink);
+    }
+}

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2509,6 +2509,328 @@ mod write_ops {
             entry.mode,
         );
     }
+
+    // --- Codex round 8 findings: 3-axis sweep (warm tier + lifecycle + atomicity)
+    //
+    // r7 made the write-side ops orphan-aware against `pending.hot` /
+    // `hot_by_path` / `tombstones` / `inodes.by_path`. r8 closes the
+    // remaining three same-shape misses:
+    //
+    //   1. `pending.warm` was dropped unconditionally on unlink and
+    //      rename-over, even when the inode had surviving open fds. The
+    //      bytes those fds want to read disappeared with the path.
+    //   2. The orphan marker cleared on the FIRST `flush`. FUSE `flush`
+    //      fires on EACH descriptor close (incl. `dup`-derived fds);
+    //      only `release` is the last-close-per-inode signal. A
+    //      premature clear lets a surviving fd's next write republish
+    //      the unlinked path.
+    //   3. `RENAME_NOREPLACE` did the existence-check in the FUSE shell
+    //      and the rename in the core — separate locks, classic TOCTOU.
+    //      Concurrent writers could create the destination between the
+    //      two operations and the rename would clobber it.
+
+    /// An open fd to a captured file whose warm-tier bytes are present
+    /// must still serve those bytes after the path is unlinked. POSIX
+    /// open-unlinked semantics: the inode survives behind the fd, and
+    /// `pending.warm[path]` is the most-recently-promoted bytes the fd
+    /// owns. r7's `unlink_entry` dropped `pending.warm[path]`
+    /// unconditionally — orphan reads through the surviving fd lost
+    /// the latest writes.
+    #[test]
+    fn unlink_then_read_warm_via_open_fd() {
+        let (_temp, mount) = open_mount();
+        // Open hello.txt and write through it. Flush promotes to warm
+        // so the bytes are at `pending.warm["hello.txt"]`, not in any
+        // hot buffer.
+        let node = mount.lookup_path("hello.txt").unwrap();
+        mount.write(node, 0, b"WARM-BYTES").expect("write");
+        mount.flush(node).expect("flush — promote to warm");
+        // Sanity: warm tier holds the bytes.
+        assert!(
+            mount.warm_blob("hello.txt").is_some(),
+            "warm should hold the flushed bytes"
+        );
+        // `unlink("hello.txt")` while the fd lives on. POSIX: the
+        // inode survives; the directory entry is gone.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        // Read via the orphaned fd. The most recent durable bytes for
+        // this inode are the warm-tier bytes; they must still be
+        // reachable.
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(node, 0, &mut buf)
+            .expect("read via orphan fd after warm-promoted unlink");
+        assert_eq!(
+            &buf[..n],
+            b"WARM-BYTES",
+            "orphan read must serve preserved warm bytes, not captured fallback"
+        );
+        // attrs must report the warm size too — a stale captured size
+        // would clip the kernel's read buffer.
+        let attrs = mount.attrs(node).expect("attrs via orphan fd");
+        assert_eq!(
+            attrs.size, 10,
+            "attrs on orphan must report warm size, not captured"
+        );
+    }
+
+    /// `ftruncate` through an unlinked-but-still-open fd whose only
+    /// durable bytes are warm-tier (no captured-tree predecessor) must
+    /// seed the truncated buffer from those warm bytes. Without the
+    /// warm-preservation fix, the seed lookup falls through to "empty"
+    /// and the surviving fd's `ftruncate` followed by `read` returns
+    /// zeros — POSIX requires the truncate to start from the inode's
+    /// current bytes.
+    #[test]
+    fn truncate_unlinked_open_keeps_warm_bytes() {
+        let (_temp, mount) = open_mount();
+        // Pending file (no captured-tree backing) so the orphan has
+        // nothing but warm bytes to fall back on.
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .expect("create");
+        mount.write(entry.node, 0, b"hello-world").expect("write");
+        mount.flush(entry.node).expect("flush — promote to warm");
+        assert!(
+            mount.warm_blob("scratch").is_some(),
+            "warm should hold the flushed bytes"
+        );
+        // Unlink while the fd lives on.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("unlink");
+        // ftruncate(fd, 5) through the orphaned NodeId.
+        mount
+            .set_attrs(
+                entry.node,
+                AttrUpdate {
+                    size: Some(5),
+                    ..Default::default()
+                },
+            )
+            .expect("ftruncate orphan");
+        // Read the truncated bytes. Without the warm-preservation
+        // fix, this returns "\0\0\0\0\0" instead of "hello".
+        let mut buf = vec![0u8; 16];
+        let n = mount
+            .read(entry.node, 0, &mut buf)
+            .expect("read truncated orphan");
+        assert_eq!(
+            &buf[..n],
+            b"hello",
+            "truncate-then-read on orphan must seed from preserved warm bytes"
+        );
+        // Path stays gone.
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("scratch"))
+                .unwrap()
+                .is_none(),
+            "truncate after unlink must not resurrect the path"
+        );
+    }
+
+    /// Rename-over when the displaced destination has warm-tier bytes
+    /// (no in-flight hot buffer) must preserve those bytes for the
+    /// still-open fd. Without the fix, `move_file`'s blind
+    /// `pending.warm.remove(new_path)` dropped them; the surviving fd
+    /// either sees the source's replacement bytes or an empty file.
+    #[test]
+    fn rename_over_preserves_warm_for_open_fd() {
+        let (_temp, mount) = open_mount();
+        // Open hello.txt and write+flush so its bytes live in warm,
+        // not hot. r7's existing rename-over preservation fix is for
+        // hot buffers; this one exercises the warm-tier preservation.
+        let dest_id = mount.lookup_path("hello.txt").unwrap();
+        mount.write(dest_id, 0, b"DEST-WARM-BYTES").expect("write dest");
+        mount.flush(dest_id).expect("flush dest — promote to warm");
+        assert!(
+            mount.warm_blob("hello.txt").is_some(),
+            "dest must be warm-promoted at rename time"
+        );
+        // Build a source file with replacement payload and flush.
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .expect("create src");
+        mount.write(src.node, 0, b"REPLACE-DATA").expect("write src");
+        mount.flush(src.node).expect("flush src");
+        // Rename src over dest. dest's pathname is rebound to src.
+        // dest's open fd must keep seeing the displaced WARM bytes.
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("rename-over");
+        // Read via the displaced inode id. Without the fix, this
+        // returns "REPLACE-DATA" (source's bytes via `warm[new_path]`)
+        // or captured "world" (fallback after warm drop).
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(dest_id, 0, &mut buf)
+            .expect("read via replaced dest fd");
+        assert_eq!(
+            &buf[..n],
+            b"DEST-WARM-BYTES",
+            "open fd on replaced dest must see pre-rename WARM bytes"
+        );
+        // attrs must match.
+        let attrs = mount.attrs(dest_id).expect("attrs via replaced dest fd");
+        assert_eq!(
+            attrs.size, 15,
+            "attrs must report preserved warm size, not replacement or captured"
+        );
+    }
+
+    /// FUSE `flush` fires on every descriptor close (including dup'd
+    /// fds); only `release` is the last-close-per-inode signal. r7
+    /// cleared the orphan marker in `flush_node`, so the FIRST close of
+    /// a dup'd unlinked fd cleared the marker prematurely. A subsequent
+    /// write through the surviving dup would then take the non-orphan
+    /// branch and republish the unlinked path.
+    ///
+    /// We exercise the contract by simulating the two-open lifecycle:
+    /// `on_open` twice (representing 2 fds), `unlink`, `flush` (orphan
+    /// marker must stay), `release` once (one fd closed; marker stays),
+    /// `release` again (last close; marker clears).
+    #[test]
+    fn flush_keeps_orphan_marker_until_release() {
+        let (_temp, mount) = open_mount();
+        // Capture-backed file, opened twice (e.g. one fd then dup —
+        // FUSE would track these as a single open + multiple flushes
+        // + one release; or two opens + two releases. Either way the
+        // marker must persist across the non-final close.)
+        let node = mount.lookup_path("hello.txt").unwrap();
+        // Two opens → refcount 2.
+        mount.on_open(node).expect("open 1");
+        mount.on_open(node).expect("open 2");
+        // Unlink while both fds live on.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        assert!(
+            mount.orphans_contains(node),
+            "unlink-while-open must set the orphan marker"
+        );
+        // `flush` fires on each close (per FUSE protocol). It MUST NOT
+        // clear the orphan marker — the surviving fd needs to keep
+        // taking the orphan branch on writes.
+        mount.flush(node).expect("flush #1");
+        assert!(
+            mount.orphans_contains(node),
+            "flush must not clear the orphan marker"
+        );
+        // First `release` — represents one of the two fds closing.
+        // Marker still present because the other fd holds the inode.
+        mount.release(node).expect("release #1");
+        assert!(
+            mount.orphans_contains(node),
+            "non-final release must not clear orphan marker"
+        );
+        // Second `release` — the last close. Now the marker must
+        // clear, the orphan buffer (if any) drops, and the inode's
+        // bookkeeping is freed.
+        mount.release(node).expect("release #2");
+        assert!(
+            !mount.orphans_contains(node),
+            "final release must clear the orphan marker"
+        );
+    }
+
+    /// `RENAME_NOREPLACE` must be honoured atomically by the core. r6/r7
+    /// did the existence-check in the FUSE shell and the rename in the
+    /// core under separate locks — between the two, a concurrent writer
+    /// could create the destination and the rename would silently
+    /// clobber it. r8 plumbs the flag into the core's mutation
+    /// critical section so the check + rename land under the same
+    /// write-side lock.
+    ///
+    /// Deterministic shape: with the flag set, `rename_entry_with_options`
+    /// must return `AlreadyExists` when the destination resolves. The
+    /// caller is responsible for not racing — but with the core
+    /// honouring the flag inside its own critical section, sequential
+    /// callers (FUSE serializes write callbacks per inode anyway) get
+    /// strict NOREPLACE semantics.
+    #[test]
+    fn rename_noreplace_is_atomic() {
+        use crate::shell::RenameOptions;
+        let (_temp, mount) = open_mount();
+        // Build a source file with bytes; flush so the rename works
+        // entirely from warm tier.
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .expect("create src");
+        mount.write(src.node, 0, b"draft-bytes").expect("write src");
+        mount.flush(src.node).expect("flush src");
+        // Destination already exists in the captured tree. With
+        // NOREPLACE the rename must refuse with `EEXIST`/`AlreadyExists`
+        // BEFORE making any mutation.
+        let err = mount
+            .rename_entry_with_options(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+                RenameOptions { no_replace: true },
+            )
+            .expect_err("NOREPLACE over existing dest must fail");
+        assert!(
+            matches!(err, MountError::AlreadyExists(_)),
+            "got unexpected error: {err:?}"
+        );
+        assert_eq!(err.to_errno(), libc::EEXIST);
+        // The source must still be intact — NOREPLACE failure must not
+        // leave the source in a half-renamed state.
+        let src_after = mount
+            .lookup(NodeId::ROOT, OsStr::new("draft"))
+            .unwrap()
+            .expect("source intact after NOREPLACE rejection");
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(src_after.node, 0, &mut buf).unwrap();
+        assert_eq!(
+            &buf[..n],
+            b"draft-bytes",
+            "source bytes intact after NOREPLACE rejection"
+        );
+        // And the destination must still be the captured "world".
+        let dst = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .expect("dest still resolves");
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(dst.node, 0, &mut buf).unwrap();
+        assert_eq!(
+            &buf[..n],
+            b"world",
+            "dest bytes unchanged after NOREPLACE rejection"
+        );
+
+        // Same call WITHOUT the flag must succeed (and replace).
+        mount
+            .rename_entry_with_options(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+                RenameOptions::default(),
+            )
+            .expect("rename without NOREPLACE replaces");
+        let dst2 = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .expect("dst still resolves");
+        let mut buf = vec![0u8; 32];
+        let n = mount.read(dst2.node, 0, &mut buf).unwrap();
+        assert_eq!(
+            &buf[..n],
+            b"draft-bytes",
+            "non-NOREPLACE rename replaces dest"
+        );
+    }
 }
 
 // D1. Property test for two-tier semantics.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2831,6 +2831,68 @@ mod write_ops {
             "non-NOREPLACE rename replaces dest"
         );
     }
+
+    // --- Codex round 9 finding: hot bytes lost on unlink-of-open ------------
+    //
+    // r8 closed the warm-tier / lifecycle / atomicity sweep. r9 surfaced a
+    // remaining same-shape regression: `unlink_entry` removes
+    // `pending.hot[node_id]` for the orphan branch, so an open fd whose only
+    // bytes lived in the hot buffer (write then unlink, no flush in between)
+    // loses them. Codex thread 3293307302.
+    //
+    // Under the post-spike unified NodeId-keyed model, hot[node_id] survives
+    // the Live → Orphan transition by construction — bytes follow the NodeId,
+    // not the path. This test pins the contract: write to an open fd, unlink
+    // the path, read through the surviving fd → original bytes.
+
+    /// `open(path) → write(fd, "DIRTY") → unlink(path) → read(fd)` must
+    /// return `"DIRTY"`. POSIX open-unlinked semantics: the inode lives
+    /// behind the fd until the last close. The pre-spike code dropped
+    /// `pending.hot[node_id]` inside `unlink_entry`, so the read fell
+    /// through to the captured blob (`"world"`) instead of the dirty hot
+    /// bytes the fd had written.
+    #[test]
+    fn unlink_open_fd_preserves_unflushed_hot_bytes() {
+        let (_temp, mount) = open_mount();
+        // `fd = open("hello.txt")` — captured file with bytes "world".
+        let node = mount.lookup_path("hello.txt").unwrap();
+        mount.on_open(node).expect("on_open");
+        // Write through the fd, do NOT flush. The bytes live only in
+        // `pending.hot[node]`.
+        mount
+            .write(node, 0, b"DIRTY-BYTES")
+            .expect("write through open fd");
+        // `unlink("hello.txt")` while the fd lives on.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink while open");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_none(),
+            "post-unlink lookup must be gone"
+        );
+        // Read via the orphaned fd. The bytes the fd wrote must survive
+        // the unlink — POSIX open-unlinked. Pre-fix, hot[node] was
+        // dropped at unlink and this returned "world" (captured blob).
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(node, 0, &mut buf)
+            .expect("read via orphan fd");
+        assert_eq!(
+            &buf[..n],
+            b"DIRTY-BYTES",
+            "open fd → write → unlink → read must return the unflushed bytes \
+             (regression: pre-spike code dropped hot[node_id] in unlink_entry)"
+        );
+        // attrs must report the dirty-buffer size, not the captured size.
+        let attrs = mount.attrs(node).expect("attrs via orphan fd");
+        assert_eq!(
+            attrs.size, 11,
+            "attrs on orphan must report hot-buffer size, not captured"
+        );
+    }
 }
 
 // D1. Property test for two-tier semantics.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2893,6 +2893,252 @@ mod write_ops {
             "attrs on orphan must report hot-buffer size, not captured"
         );
     }
+
+    // --- Codex round 12 findings: capture / invalidate / forget / rmdir / -----
+    // --- symlinks / read_link ------------------------------------------------
+    //
+    // Six P1 + one P3 findings on the post-spike base (`58a30b2`). Each test
+    // pins the contract from one Codex review thread on PR #182.
+
+    /// Codex thread 3293484633 (P1). `capture_with_attribution` clears
+    /// `pending.state` unconditionally → drops Orphan tracking for inodes
+    /// with still-open fds. Post-capture writes through such an fd then take
+    /// the non-orphan branch and republish the (tombstoned) pathname. The
+    /// fix retains Orphan entries (and their per-NodeId hot/warm bytes) and
+    /// only retires Live entries.
+    #[test]
+    fn capture_preserves_orphan_state_for_open_inodes() {
+        let (_temp, mount) = open_mount();
+        // Create a fresh file, open it (refcount = 1), write through the
+        // fd, then unlink. The directory entry goes; the inode lives on
+        // behind the fd as an Orphan with open_count = 1.
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .expect("create");
+        mount.on_open(entry.node).expect("on_open");
+        mount.write(entry.node, 0, b"BYTES").expect("write");
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("unlink");
+        assert!(
+            mount.orphans_contains(entry.node),
+            "pre-capture sanity: unlink-while-open must orphan the inode"
+        );
+
+        // Capture. Pre-fix, this wipes `state` (and `hot` + `warm`),
+        // losing the orphan tracking + the surviving fd's bytes.
+        mount
+            .capture(Some("capture with orphan open".into()))
+            .expect("capture");
+
+        // The fd is still in the kernel's hands; the inode must remain
+        // Orphan so a subsequent write through the fd takes the orphan
+        // branch and does not republish the deleted pathname.
+        assert!(
+            mount.orphans_contains(entry.node),
+            "capture must preserve Orphan state for inodes with surviving fds"
+        );
+        mount
+            .write(entry.node, 0, b"AFTER")
+            .expect("write through orphan fd survives capture");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("scratch"))
+                .unwrap()
+                .is_none(),
+            "post-capture write through orphan fd must not republish the path"
+        );
+        // The per-NodeId hot bytes must also survive capture so reads via
+        // the orphan fd serve the inode's own data (POSIX open-unlinked).
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(entry.node, 0, &mut buf)
+            .expect("read via orphan fd after capture");
+        assert_eq!(
+            &buf[..n],
+            b"AFTER",
+            "orphan hot bytes must survive capture so the fd's own writes are readable"
+        );
+    }
+
+    /// Codex threads 3293484634 + 3293510311 (P1). `invalidate` (FUSE
+    /// `forget`) drops `pending.warm[node]` unconditionally, but `forget`
+    /// only signals that the kernel released its cached inode reference —
+    /// not that the file's pending overlay data can be discarded. Warm is
+    /// the only durable pre-capture copy of flushed writes; dropping it
+    /// silently loses the user's committed-in-session data.
+    #[test]
+    fn invalidate_preserves_warm_bytes_for_live_inode() {
+        let (_temp, mount) = open_mount();
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("durable"), FileMode::Normal, false)
+            .expect("create");
+        mount.write(entry.node, 0, b"DURABLE-WARM").expect("write");
+        mount
+            .flush(entry.node)
+            .expect("flush — promote bytes to warm tier");
+        assert!(
+            mount.warm_blob("durable").is_some(),
+            "pre-invalidate: warm tier holds the flushed bytes"
+        );
+
+        // Kernel drops its cached inode reference. The file's path still
+        // exists from the user's POV; capture must still plant its bytes.
+        mount.invalidate(entry.node).expect("invalidate (kernel forget)");
+
+        let change_id = mount
+            .capture(Some("post-invalidate capture".into()))
+            .expect("capture");
+        let bytes = read_captured_blob(&mount, &change_id, "durable");
+        assert_eq!(
+            &bytes[..],
+            b"DURABLE-WARM",
+            "warm bytes must survive invalidate so capture can plant them"
+        );
+    }
+
+    /// Codex thread 3293510310 (P1). `rmdir_entry` plants a
+    /// `dir_tombstones` entry but leaves `inodes.by_path[child_path]`
+    /// intact. A subsequent `create_file` / `make_dir` at the same path
+    /// then coalesces onto the removed directory's NodeId via
+    /// `Inodes::intern`'s path-keyed reverse index — that's a stale-handle
+    /// class identical to the one `unlink_entry` already guards against
+    /// by retiring `by_path`.
+    #[test]
+    fn rmdir_retires_path_to_inode_binding() {
+        let (_temp, mount) = open_mount();
+        let dir = mount
+            .make_dir(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("mkdir");
+        mount
+            .rmdir_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("rmdir");
+        // Recreate the name as a regular file. The fresh inode must NOT
+        // be the removed directory's NodeId — POSIX remove-and-recreate
+        // isolation forbids rebinding a cached dir inode to a different
+        // object type.
+        let file = mount
+            .create_file(
+                NodeId::ROOT,
+                OsStr::new("scratch"),
+                FileMode::Normal,
+                false,
+            )
+            .expect("recreate as file");
+        assert_ne!(
+            file.node, dir.node,
+            "remove-and-recreate at same path must mint a fresh inode \
+             (rmdir must retire inodes.by_path so intern does not coalesce)"
+        );
+    }
+
+    /// Codex thread 3293510316 (P1). `read_link` on a captured `Symlink`
+    /// record reconstructs an `OsStr` with `OsStr::from_encoded_bytes_unchecked`
+    /// from blob bytes loaded from the store. That call's safety contract
+    /// requires bytes minted by `OsStr::as_encoded_bytes` in *this*
+    /// process and Rust version — captured-tree bytes can come from any
+    /// process and any version, so the call is unsound.
+    ///
+    /// On Unix, the platform-safe replacement is `OsStrExt::from_bytes`
+    /// (sound for any byte sequence); on Windows, the bytes must be UTF-8
+    /// validated and rejected otherwise (the encoding contract for `OsStr`
+    /// is process-internal). This test pins the round-trip contract: a
+    /// captured symlink's target is recoverable byte-for-byte.
+    #[test]
+    fn read_link_safe_for_captured_symlink_bytes() {
+        let (_temp, mount) = open_mount();
+        // Create + capture a symlink so the next read_link goes through
+        // the captured-blob branch (the unsound site).
+        mount
+            .create_symlink(NodeId::ROOT, OsStr::new("link"), Path::new("hello.txt"))
+            .expect("create_symlink");
+        let _ = mount
+            .capture(Some("plant link".into()))
+            .expect("capture");
+        let entry = mount
+            .lookup(NodeId::ROOT, OsStr::new("link"))
+            .unwrap()
+            .expect("captured symlink resolves");
+        let resolved = mount.read_link(entry.node).expect("read_link");
+        assert_eq!(
+            resolved,
+            std::ffi::OsString::from("hello.txt"),
+            "captured symlink must decode via a sound platform-safe path"
+        );
+    }
+
+    /// Codex thread 3293510317 (P3). `unlink_entry` always transitions
+    /// the removed node into `NodeState::Orphan`, but symlinks are not
+    /// openable for IO — they never receive `open`/`release` lifecycle
+    /// events to clear the state. The entry accumulates in `pending.state`
+    /// until capture/invalidate. The fix gates the orphan transition on
+    /// `entry.kind != Symlink`.
+    #[test]
+    fn unlink_of_symlink_does_not_create_orphan_state() {
+        let (_temp, mount) = open_mount();
+        let link = mount
+            .create_symlink(NodeId::ROOT, OsStr::new("link"), Path::new("hello.txt"))
+            .expect("create_symlink");
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("link"))
+            .expect("unlink symlink");
+        assert!(
+            !mount.orphans_contains(link.node),
+            "symlinks have no open/release lifecycle; unlink must not orphan them"
+        );
+    }
+
+    /// Codex thread 3293680448 (P1). `Inodes::forget` unconditionally
+    /// removes `by_path[path]` for the retired record. After an
+    /// unlink-then-recreate cycle, the stored `path` may be rebound to
+    /// a *different* live inode. A late kernel `forget` for the old
+    /// inode then deletes the live inode's path binding — capture's
+    /// warm-entry path check skips the entry, breaking lookup/read/write
+    /// routing for the replacement.
+    #[test]
+    fn forget_after_unlink_recreate_preserves_new_path_binding() {
+        let (_temp, mount) = open_mount();
+        // v1 minted and opened. unlink while open → v1 orphans; by_path
+        // is detached. v2 created at the same name → mints fresh inode.
+        let v1 = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .expect("create v1");
+        mount.on_open(v1.node).expect("on_open v1");
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("unlink v1");
+        let v2 = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .expect("recreate as v2");
+        assert_ne!(v1.node, v2.node, "recreate must mint a fresh inode");
+        mount.write(v2.node, 0, b"v2-bytes").expect("write v2");
+        mount.flush(v2.node).expect("flush v2 to warm");
+
+        // Kernel forgets v1 (the orphan). Pre-fix, `Inodes::forget`'s
+        // blind `by_path.remove("scratch")` wipes v2's binding.
+        mount.invalidate(v1.node).expect("forget v1");
+
+        // Lookup via warm must still resolve via v2.
+        let hit = mount
+            .lookup(NodeId::ROOT, OsStr::new("scratch"))
+            .unwrap()
+            .expect("scratch still resolves after old-inode forget");
+        assert_eq!(hit.node, v2.node, "lookup must return v2's NodeId");
+
+        // Capture must plant v2's bytes. Pre-fix the by_path binding is
+        // wiped → apply_pending_to_tree's path check skips v2 → captured
+        // tree is missing scratch.
+        let change_id = mount
+            .capture(Some("post-forget capture".into()))
+            .expect("capture");
+        let captured = read_captured_blob(&mount, &change_id, "scratch");
+        assert_eq!(
+            &captured[..],
+            b"v2-bytes",
+            "captured tree must contain v2's bytes — forget of the old \
+             inode must not wipe the new inode's path binding"
+        );
+    }
 }
 
 // D1. Property test for two-tier semantics.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -1737,6 +1737,110 @@ mod write_ops {
         );
     }
 
+    /// POSIX `unlink(2)` semantics: if a file is open when it's
+    /// unlinked, the kernel keeps the inode alive behind the open
+    /// fd, but the *directory entry* is gone — `lookup` returns
+    /// `ENOENT` and `readdir` skips the name. A subsequent write
+    /// through the open fd updates the orphaned inode's data, but
+    /// it must NOT republish the name. Tools that depend on this:
+    /// `mkstemp` + `unlink` for private scratch space, sqlite's WAL
+    /// shadow files, cargo's atomic-replace pattern. Without the
+    /// guard, the unlinked pathname unexpectedly reappears once a
+    /// late write hits the open fd.
+    #[test]
+    fn write_to_unlinked_open_inode_does_not_resurrect_path() {
+        let (_temp, mount) = open_mount();
+        // `fd = open("temp", O_CREAT|O_RDWR)` — fresh pending file.
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("temp"), FileMode::Normal, false)
+            .expect("create");
+        mount.write(entry.node, 0, b"v1").expect("first write");
+        // `unlink("temp")` while the handle is still in use.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("temp"))
+            .expect("unlink");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("temp"))
+                .unwrap()
+                .is_none(),
+            "post-unlink lookup must return None"
+        );
+
+        // Write through the original handle. POSIX says this is
+        // legal — the inode survives behind the fd — but the
+        // pathname must not come back.
+        mount
+            .write(entry.node, 0, b"v2-after-unlink")
+            .expect("write through unlinked-open fd");
+
+        // The data is accessible through the open handle.
+        let mut buf = vec![0u8; 64];
+        let n = mount
+            .read(entry.node, 0, &mut buf)
+            .expect("read via unlinked-open fd");
+        assert_eq!(&buf[..n], b"v2-after-unlink");
+
+        // The decisive check: the path must still be gone.
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("temp"))
+                .unwrap()
+                .is_none(),
+            "write after unlink must not resurrect the path"
+        );
+        let entries = mount.enumerate(NodeId::ROOT).unwrap();
+        assert!(
+            !entries.iter().any(|e| e.name == "temp"),
+            "enumerate must not surface the unlinked path: {entries:?}"
+        );
+        // Flushing the orphan must not promote it to the warm tier
+        // (a subsequent capture would resurrect the path in the
+        // captured tree otherwise). Drive the flush explicitly so
+        // the test pins the contract; orphaned buffers must drop.
+        mount.flush(entry.node).expect("flush orphan");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("temp"))
+                .unwrap()
+                .is_none(),
+            "post-flush lookup must still be gone (orphan must not warm-promote)"
+        );
+    }
+
+    /// Companion to the orphan-write test: after an unlink, if a
+    /// fresh `create_file` mints a new inode at the same name,
+    /// writes through the *new* fd must surface normally. The
+    /// orphan-write fix must not regress the unlink-then-recreate
+    /// path the kernel actually emits for `open(O_CREAT)`.
+    #[test]
+    fn write_to_recreated_inode_after_unlink_still_publishes_path() {
+        let (_temp, mount) = open_mount();
+        let original = mount
+            .create_file(NodeId::ROOT, OsStr::new("temp"), FileMode::Normal, false)
+            .expect("create v1");
+        mount.write(original.node, 0, b"v1").expect("write v1");
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("temp"))
+            .expect("unlink");
+
+        let recreated = mount
+            .create_file(NodeId::ROOT, OsStr::new("temp"), FileMode::Normal, false)
+            .expect("recreate");
+        assert_ne!(original.node, recreated.node);
+        mount.write(recreated.node, 0, b"v2-fresh").expect("write v2");
+
+        // The new inode is the one that owns the path now.
+        let hit = mount
+            .lookup(NodeId::ROOT, OsStr::new("temp"))
+            .unwrap()
+            .expect("recreated path must resolve");
+        assert_eq!(hit.node, recreated.node);
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(recreated.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"v2-fresh");
+    }
+
     /// Rename-over must keep the replaced destination's inode record
     /// resolvable — only the path→inode link is detached. Without this
     /// any FD still holding the dest inode surfaces as ESTALE on the

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -1712,6 +1712,119 @@ mod write_ops {
         assert_eq!(&buf[..n], b"draft body");
     }
 
+    /// After `unlink_entry` the path→inode mapping must be retired so
+    /// a subsequent `create_file` at the same name mints a *fresh*
+    /// inode. Otherwise a still-open handle to the unlinked file would
+    /// silently start resolving to the freshly created replacement —
+    /// breaks unlink-then-recreate isolation (POSIX open-unlinked temp
+    /// files).
+    #[test]
+    fn unlink_then_recreate_mints_fresh_inode() {
+        let (_temp, mount) = open_mount();
+        let original = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .expect("captured hello.txt");
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        let recreated = mount
+            .create_file(NodeId::ROOT, OsStr::new("hello.txt"), FileMode::Normal, false)
+            .expect("recreate");
+        assert_ne!(
+            original.node, recreated.node,
+            "recreated inode must be distinct from the unlinked one"
+        );
+    }
+
+    /// Rename-over must keep the replaced destination's inode record
+    /// resolvable — only the path→inode link is detached. Without this
+    /// any FD still holding the dest inode surfaces as ESTALE on the
+    /// next callback. POSIX requires open handles to the replaced file
+    /// to remain valid.
+    #[test]
+    fn rename_over_preserves_replaced_destination_inode() {
+        let (_temp, mount) = open_mount();
+        let dest_orig = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .expect("captured hello.txt");
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(src.node, 0, b"replacement").unwrap();
+        mount.flush(src.node).unwrap();
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("rename-over");
+        // The old destination inode must still resolve — not ESTALE.
+        let attrs = mount
+            .attrs(dest_orig.node)
+            .expect("orphaned dest inode must remain valid");
+        assert_eq!(attrs.kind, NodeKind::File);
+    }
+
+    /// A directory rename must rebase the `by_path` mapping for every
+    /// already-cached descendant inode (not just the directory's own
+    /// record). Otherwise an open handle to `old_dir/leaf` still
+    /// references the stale path and post-rename reads return ESTALE
+    /// — even though the leaf is reachable through the new directory.
+    #[test]
+    fn directory_rename_rebases_descendant_inode_paths() {
+        let (_temp, mount) = open_mount();
+        // Build an overlay-only directory with a leaf so the rename
+        // exercises `move_overlay_dir` + the inode rebase pass.
+        mount.make_dir(NodeId::ROOT, OsStr::new("from_dir")).unwrap();
+        let from = mount
+            .lookup(NodeId::ROOT, OsStr::new("from_dir"))
+            .unwrap()
+            .unwrap();
+        let leaf = mount
+            .create_file(from.node, OsStr::new("leaf.txt"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(leaf.node, 0, b"payload").unwrap();
+        mount.flush(leaf.node).unwrap();
+        // Cache the leaf inode by looking it up explicitly — this is
+        // what the kernel does for any FD-holding lookup.
+        let cached = mount
+            .lookup(from.node, OsStr::new("leaf.txt"))
+            .unwrap()
+            .expect("leaf resolves pre-rename");
+        assert_eq!(cached.node, leaf.node);
+
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("from_dir"),
+                NodeId::ROOT,
+                OsStr::new("to_dir"),
+            )
+            .expect("dir rename");
+
+        // The cached leaf inode must still resolve — its stored path
+        // should now be `to_dir/leaf.txt`.
+        let mut buf = vec![0u8; 16];
+        let n = mount
+            .read(cached.node, 0, &mut buf)
+            .expect("read via descendant inode after dir rename");
+        assert_eq!(&buf[..n], b"payload");
+        // And the new path resolves to the same inode.
+        let to_dir = mount
+            .lookup(NodeId::ROOT, OsStr::new("to_dir"))
+            .unwrap()
+            .unwrap();
+        let via_new = mount
+            .lookup(to_dir.node, OsStr::new("leaf.txt"))
+            .unwrap()
+            .expect("leaf resolves via new dir");
+        assert_eq!(via_new.node, cached.node);
+    }
+
     /// `set_attrs(size=0)` truncates the file's hot buffer to zero,
     /// which is what the kernel issues for `O_TRUNC` before any
     /// `write`. cargo writes use `O_CREAT|O_WRONLY|O_TRUNC`; without

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2220,3 +2220,242 @@ mod fuse_smoke {
         drop(session);
     }
 }
+
+// ---------------------------------------------------------------------------
+// PlatformShell default-impl coverage.
+//
+// Every write-side method on the trait has a default body that returns
+// `MountError::ReadOnly`. A read-only adapter (e.g. a future "snapshot
+// browser" shell that only implements the six required methods) inherits
+// those defaults. These tests exercise the default bodies so the contract
+// stays observable: read-only shells uniformly surface `ReadOnly` rather
+// than panicking or silently succeeding.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod platform_shell_defaults {
+    use std::{
+        ffi::{OsStr, OsString},
+        path::Path,
+        time::SystemTime,
+    };
+
+    use objects::object::FileMode;
+
+    use crate::{
+        error::{MountError, Result},
+        shell::{AttrUpdate, Attrs, Entry, NodeId, NodeKind, PlatformShell},
+    };
+
+    /// Minimal read-only shell that implements only the required
+    /// methods. Every write-side default kicks in.
+    struct ReadOnlyStub;
+
+    impl PlatformShell for ReadOnlyStub {
+        fn lookup(&self, _parent: NodeId, _name: &OsStr) -> Result<Option<Entry>> {
+            Ok(None)
+        }
+        fn read(&self, _node: NodeId, _offset: u64, _buf: &mut [u8]) -> Result<usize> {
+            Ok(0)
+        }
+        fn write(&self, _node: NodeId, _offset: u64, _data: &[u8]) -> Result<usize> {
+            Err(MountError::ReadOnly)
+        }
+        fn enumerate(&self, _dir: NodeId) -> Result<Vec<Entry>> {
+            Ok(vec![])
+        }
+        fn attrs(&self, _node: NodeId) -> Result<Attrs> {
+            Ok(Attrs {
+                node: NodeId::ROOT,
+                kind: NodeKind::Directory,
+                size: 0,
+                unix_mode: 0o040755,
+                nlink: 1,
+                mtime: SystemTime::UNIX_EPOCH,
+            })
+        }
+        fn invalidate(&self, _node: NodeId) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn is_readonly<T>(r: Result<T>) -> bool {
+        matches!(r, Err(MountError::ReadOnly))
+    }
+
+    #[test]
+    fn defaults_uniformly_surface_readonly() {
+        let s = ReadOnlyStub;
+        assert!(is_readonly(s.create_file(
+            NodeId::ROOT,
+            OsStr::new("x"),
+            FileMode::Normal,
+            false,
+        )));
+        assert!(is_readonly(s.make_dir(NodeId::ROOT, OsStr::new("d"))));
+        assert!(is_readonly(s.unlink_entry(NodeId::ROOT, OsStr::new("x"))));
+        assert!(is_readonly(s.rmdir_entry(NodeId::ROOT, OsStr::new("d"))));
+        assert!(is_readonly(s.rename_entry(
+            NodeId::ROOT,
+            OsStr::new("a"),
+            NodeId::ROOT,
+            OsStr::new("b"),
+        )));
+        assert!(is_readonly(s.set_attrs(NodeId::ROOT, AttrUpdate::default())));
+        assert!(is_readonly(s.create_symlink(
+            NodeId::ROOT,
+            OsStr::new("ln"),
+            Path::new("target"),
+        )));
+        let read_link_result: Result<OsString> = s.read_link(NodeId::ROOT);
+        assert!(is_readonly(read_link_result));
+    }
+
+    /// The default `release` body delegates to `flush`. A shell that
+    /// overrides only `flush` should see `release` follow through.
+    #[test]
+    fn release_default_delegates_to_flush() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        struct CountFlush(AtomicUsize);
+        impl PlatformShell for CountFlush {
+            fn lookup(&self, _p: NodeId, _n: &OsStr) -> Result<Option<Entry>> {
+                Ok(None)
+            }
+            fn read(&self, _n: NodeId, _o: u64, _b: &mut [u8]) -> Result<usize> {
+                Ok(0)
+            }
+            fn write(&self, _n: NodeId, _o: u64, _b: &[u8]) -> Result<usize> {
+                Ok(0)
+            }
+            fn enumerate(&self, _d: NodeId) -> Result<Vec<Entry>> {
+                Ok(vec![])
+            }
+            fn attrs(&self, _n: NodeId) -> Result<Attrs> {
+                Ok(Attrs {
+                    node: NodeId::ROOT,
+                    kind: NodeKind::Directory,
+                    size: 0,
+                    unix_mode: 0o040755,
+                    nlink: 1,
+                    mtime: SystemTime::UNIX_EPOCH,
+                })
+            }
+            fn invalidate(&self, _n: NodeId) -> Result<()> {
+                Ok(())
+            }
+            fn flush(&self, _n: NodeId) -> Result<()> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+        let s = CountFlush(AtomicUsize::new(0));
+        s.release(NodeId::ROOT).unwrap();
+        assert_eq!(s.0.load(Ordering::SeqCst), 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Capture-after-write-op coverage.
+//
+// The materialize pass in `core::capture` has distinct branches for
+// pending file overrides, symlink overrides, dir tombstones, explicit
+// empty dirs, and the captured-counterpart-load path. The unit-level
+// write-op tests in `mod write_ops` exercise the pre-capture state;
+// these add coverage for what the captured tree actually looks like
+// once those overlay actions flow through capture.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod capture_write_ops {
+    use super::*;
+    use objects::object::FileMode;
+    use std::path::Path;
+
+    fn dump_tree(store: &dyn ObjectStore, hash: &ContentHash) -> Tree {
+        store.get_tree(hash).unwrap().unwrap()
+    }
+
+    /// `make_dir` followed by `capture` must materialize the empty
+    /// directory as a zero-entry tree under the parent (the
+    /// `force_empty` arm of `materialize`).
+    #[test]
+    fn capture_after_make_dir_materializes_empty_subtree() {
+        let (_temp, mount) = open_mount();
+        mount.make_dir(NodeId::ROOT, OsStr::new("blank")).unwrap();
+        let id = mount.capture(Some("empty dir".into())).unwrap();
+        let store = mount.repo_handle().store();
+        let state = store.get_state(&id).unwrap().unwrap();
+        let root = dump_tree(store, &state.tree);
+        let blank = root.get("blank").expect("blank dir survives capture");
+        assert!(blank.is_tree());
+        let blank_tree = dump_tree(store, &blank.hash);
+        assert_eq!(blank_tree.entries().len(), 0);
+    }
+
+    /// `create_symlink` then `capture` writes the target as a CAS blob
+    /// and emits a Symlink tree entry referring to it.
+    #[test]
+    fn capture_after_create_symlink_emits_symlink_entry() {
+        let (_temp, mount) = open_mount();
+        mount
+            .create_symlink(
+                NodeId::ROOT,
+                OsStr::new("alias.txt"),
+                Path::new("hello.txt"),
+            )
+            .unwrap();
+        let id = mount.capture(Some("symlink".into())).unwrap();
+        let store = mount.repo_handle().store();
+        let state = store.get_state(&id).unwrap().unwrap();
+        let root = dump_tree(store, &state.tree);
+        let alias = root.get("alias.txt").expect("symlink lands in tree");
+        assert!(matches!(
+            alias.mode,
+            objects::object::FileMode::Symlink
+        ));
+    }
+
+    /// A rmdir tombstone for a captured dir must drop the whole subtree
+    /// from the next capture (the `dir_deletions` branch).
+    #[test]
+    fn capture_after_rmdir_drops_subtree() {
+        // Build a fresh repo with a `dir/` containing one file; capture
+        // it; remount; rmdir+capture should produce a root without `dir/`.
+        let (_temp, mount) = fresh_mount();
+        let node = create_pending_file(&mount, "dir/only.rs", FileMode::Normal);
+        mount.write(node, 0, b"x").unwrap();
+        mount.flush_all().unwrap();
+        mount.capture(Some("plant".into())).unwrap();
+        // Unlink the file then rmdir the now-empty dir.
+        mount.unlink_path("dir/only.rs").unwrap();
+        let id = mount.capture(Some("delete".into())).unwrap();
+        let store = mount.repo_handle().store();
+        let state = store.get_state(&id).unwrap().unwrap();
+        let root = dump_tree(store, &state.tree);
+        assert!(root.get("dir").is_none(), "dir/ should be pruned");
+    }
+
+    /// `rename_entry` across an overlay-only file followed by capture
+    /// materializes the renamed name (and not the old name).
+    #[test]
+    fn capture_after_rename_overlay_file_uses_new_name() {
+        let (_temp, mount) = open_mount();
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(src.node, 0, b"body").unwrap();
+        mount.flush(src.node).unwrap();
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("final.txt"),
+            )
+            .unwrap();
+        let id = mount.capture(Some("rename".into())).unwrap();
+        let store = mount.repo_handle().store();
+        let state = store.get_state(&id).unwrap().unwrap();
+        let root = dump_tree(store, &state.tree);
+        assert!(root.get("draft").is_none(), "old name must be gone");
+        assert!(root.get("final.txt").is_some(), "new name must exist");
+    }
+}

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2001,6 +2001,40 @@ mod write_ops {
         assert_eq!(again.unix_mode & 0o111, 0o111);
     }
 
+    /// `enumerate` surfaces overlay symlinks both as standalone
+    /// pending-only children (pass-2 `PendingChildKind::Symlink`)
+    /// and as overrides on captured-tree entries (pass-1 hit on
+    /// `PendingHit::Symlink`). One enumerate exercises both arms.
+    #[test]
+    fn enumerate_surfaces_overlay_symlinks_in_both_passes() {
+        let (_temp, mount) = open_mount();
+        // Pass-2 path: brand-new symlink at a name with no captured
+        // counterpart.
+        mount
+            .create_symlink(NodeId::ROOT, OsStr::new("alias"), Path::new("hello.txt"))
+            .expect("fresh symlink");
+        // Pass-1 path: overlay symlink replaces a captured file.
+        // (`run.sh` is in the fixture as an executable file.)
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("run.sh"))
+            .expect("clear captured run.sh");
+        mount
+            .create_symlink(NodeId::ROOT, OsStr::new("run.sh"), Path::new("hello.txt"))
+            .expect("symlink overrides captured file");
+
+        let entries = mount.enumerate(NodeId::ROOT).unwrap();
+        let alias = entries
+            .iter()
+            .find(|e| e.name == "alias")
+            .expect("fresh symlink missing from enumerate");
+        assert_eq!(alias.kind, NodeKind::Symlink);
+        let run = entries
+            .iter()
+            .find(|e| e.name == "run.sh")
+            .expect("overlay symlink override missing from enumerate");
+        assert_eq!(run.kind, NodeKind::Symlink);
+    }
+
     /// `create_symlink` records a link in the overlay; `read_link`
     /// returns its target bytes.
     #[test]
@@ -2016,6 +2050,256 @@ mod write_ops {
         assert_eq!(entry.kind, NodeKind::Symlink);
         let target = mount.read_link(entry.node).expect("read_link");
         assert_eq!(target.as_os_str(), OsStr::new("hello.txt"));
+    }
+
+    /// `rename_entry` over a symlink in the overlay moves the target
+    /// bytes and tombstones the source — `move_symlink`'s overlay-only
+    /// path. Existing capture/diff tests don't reach this branch, so
+    /// it's the main contributor to uncovered patch lines.
+    #[test]
+    fn rename_entry_moves_overlay_symlink() {
+        let (_temp, mount) = open_mount();
+        mount
+            .create_symlink(
+                NodeId::ROOT,
+                OsStr::new("alias"),
+                Path::new("hello.txt"),
+            )
+            .expect("create symlink");
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("alias"),
+                NodeId::ROOT,
+                OsStr::new("alias2"),
+            )
+            .expect("rename symlink");
+        assert!(
+            mount.lookup(NodeId::ROOT, OsStr::new("alias")).unwrap().is_none(),
+            "source symlink path must be gone after rename",
+        );
+        let dst = mount
+            .lookup(NodeId::ROOT, OsStr::new("alias2"))
+            .unwrap()
+            .expect("renamed symlink resolves");
+        assert_eq!(dst.kind, NodeKind::Symlink);
+        let target = mount.read_link(dst.node).expect("read_link via new path");
+        assert_eq!(target.as_os_str(), OsStr::new("hello.txt"));
+    }
+
+    /// Cross-tree directory rename — i.e. renaming a captured-tree
+    /// directory — is intentionally refused by `move_overlay_dir`;
+    /// the overlay would otherwise need to rewrite every descendant
+    /// tombstone/warm key. Exercises the error path explicitly so
+    /// the refusal isn't accidentally relaxed by a later change.
+    #[test]
+    fn rename_entry_refuses_captured_directory_rename() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("nested"),
+                NodeId::ROOT,
+                OsStr::new("nested2"),
+            )
+            .expect_err("captured-dir rename must be refused");
+        assert!(matches!(err, MountError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(err.to_errno(), libc::EINVAL);
+    }
+
+    /// `move_overlay_dir` rebases every overlay slot under the source
+    /// dir, but slots OUTSIDE the source must survive unchanged. This
+    /// hits the `None` arms of each `rebase` match — the largest
+    /// untouched cluster of patch-uncovered lines in this PR.
+    #[test]
+    fn rename_overlay_dir_preserves_sibling_overlay_state() {
+        let (_temp, mount) = open_mount();
+        // Two overlay dirs side by side; rename one. The other's
+        // children/state — explicit_dirs, warm (via flushed write),
+        // a symlink, and a tombstone — must all stay put.
+        mount.make_dir(NodeId::ROOT, OsStr::new("from_dir")).unwrap();
+        mount.make_dir(NodeId::ROOT, OsStr::new("keep_dir")).unwrap();
+        let keep = mount.lookup(NodeId::ROOT, OsStr::new("keep_dir")).unwrap().unwrap();
+        // Warm (flushed) leaf under `keep_dir/`.
+        let kept_file = mount
+            .create_file(keep.node, OsStr::new("warm.txt"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(kept_file.node, 0, b"persist").unwrap();
+        mount.flush(kept_file.node).unwrap();
+        // Symlink under `keep_dir/`.
+        mount
+            .create_symlink(keep.node, OsStr::new("alias"), Path::new("warm.txt"))
+            .unwrap();
+        // Tombstone the captured `hello.txt` so the tombstone-rebase
+        // branch is exercised against a non-prefixed path.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink captured file");
+
+        // The actual rename.
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("from_dir"),
+                NodeId::ROOT,
+                OsStr::new("to_dir"),
+            )
+            .expect("dir rename");
+
+        // The sibling's children survive.
+        let keep_after = mount.lookup(NodeId::ROOT, OsStr::new("keep_dir")).unwrap().unwrap();
+        assert_eq!(keep_after.node, keep.node);
+        let warm_after = mount
+            .lookup(keep_after.node, OsStr::new("warm.txt"))
+            .unwrap()
+            .expect("warm leaf must remain at sibling dir");
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(warm_after.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"persist");
+        let alias_after = mount
+            .lookup(keep_after.node, OsStr::new("alias"))
+            .unwrap()
+            .expect("sibling symlink must remain");
+        assert_eq!(alias_after.kind, NodeKind::Symlink);
+        // The unrelated tombstone survives.
+        assert!(
+            mount.lookup(NodeId::ROOT, OsStr::new("hello.txt")).unwrap().is_none(),
+            "unrelated tombstone must survive the rename pass",
+        );
+        // And the rename itself landed.
+        assert!(
+            mount.lookup(NodeId::ROOT, OsStr::new("from_dir")).unwrap().is_none(),
+            "source dir must be gone",
+        );
+        assert!(
+            mount.lookup(NodeId::ROOT, OsStr::new("to_dir")).unwrap().is_some(),
+            "destination dir must be present",
+        );
+    }
+
+    /// Self-rename (same source and destination) is a POSIX no-op:
+    /// returns success without touching any state. Without the early
+    /// return, the move + tombstone-source path would actually delete
+    /// the file.
+    #[test]
+    fn rename_entry_self_rename_is_noop() {
+        let (_temp, mount) = open_mount();
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("self-rename succeeds");
+        // The file remains addressable + readable.
+        let hit = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .expect("self-rename did not delete the file");
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(hit.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"world");
+    }
+
+    /// POSIX: renaming a directory over a regular file is `ENOTDIR`
+    /// (the destination must also be a directory). Catches the
+    /// `(Directory, _)` arm of the kind-mismatch guard.
+    #[test]
+    fn rename_entry_directory_over_file_returns_enotdir() {
+        let (_temp, mount) = open_mount();
+        mount.make_dir(NodeId::ROOT, OsStr::new("srcdir")).unwrap();
+        let err = mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("srcdir"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect_err("dir-over-file must fail");
+        assert!(matches!(err, MountError::NotADirectory(_)), "got {err:?}");
+        assert_eq!(err.to_errno(), libc::ENOTDIR);
+    }
+
+    /// POSIX: renaming a regular file over a directory is `EISDIR`.
+    /// Catches the `(_, Directory)` arm of the kind-mismatch guard.
+    #[test]
+    fn rename_entry_file_over_directory_returns_eisdir() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+                NodeId::ROOT,
+                OsStr::new("nested"),
+            )
+            .expect_err("file-over-dir must fail");
+        assert!(matches!(err, MountError::IsADirectory(_)), "got {err:?}");
+        assert_eq!(err.to_errno(), libc::EISDIR);
+    }
+
+    /// POSIX: directory-over-directory rename only succeeds if the
+    /// destination is empty; a non-empty destination is `ENOTEMPTY`.
+    /// Catches the inner branch of the (Directory, Directory) arm.
+    #[test]
+    fn rename_entry_directory_over_nonempty_directory_returns_enotempty() {
+        let (_temp, mount) = open_mount();
+        mount.make_dir(NodeId::ROOT, OsStr::new("srcdir")).unwrap();
+        mount.make_dir(NodeId::ROOT, OsStr::new("dstdir")).unwrap();
+        let dstdir = mount.lookup(NodeId::ROOT, OsStr::new("dstdir")).unwrap().unwrap();
+        mount
+            .create_file(dstdir.node, OsStr::new("child.txt"), FileMode::Normal, false)
+            .unwrap();
+        let err = mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("srcdir"),
+                NodeId::ROOT,
+                OsStr::new("dstdir"),
+            )
+            .expect_err("non-empty dest must fail");
+        assert!(matches!(err, MountError::NotEmpty(_)), "got {err:?}");
+        assert_eq!(err.to_errno(), libc::ENOTEMPTY);
+    }
+
+    /// `invalidate` on an orphaned NodeId (an inode the kernel forgets
+    /// after `unlink + release`) must retire the orphan tracking entry
+    /// — otherwise the `orphans` set accumulates dead IDs across the
+    /// session. Indirectly observed via a follow-up unlink+write cycle
+    /// on a new NodeId at the same name: that write must take the
+    /// normal (republishing) branch, not the orphan branch.
+    #[test]
+    fn invalidate_clears_orphan_tracking_for_forgotten_inode() {
+        let (_temp, mount) = open_mount();
+        // Round 1: create, write, unlink — orphans the inode.
+        let v1 = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(v1.node, 0, b"v1").unwrap();
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .unwrap();
+        // The kernel issues `release` then `forget`; both flow
+        // through `invalidate` in our trait surface.
+        mount.invalidate(v1.node).expect("invalidate orphan");
+
+        // Round 2: a fresh inode at the same name. Its writes must
+        // republish the path normally — the orphan-cleanup pass in
+        // `invalidate` is what keeps the orphan set from making this
+        // node mistakenly take the orphan branch.
+        let v2 = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .unwrap();
+        assert_ne!(v1.node, v2.node);
+        mount.write(v2.node, 0, b"v2-fresh").expect("normal write");
+        let hit = mount
+            .lookup(NodeId::ROOT, OsStr::new("scratch"))
+            .unwrap()
+            .expect("recreated path resolves");
+        assert_eq!(hit.node, v2.node);
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(v2.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"v2-fresh");
     }
 }
 

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -3139,6 +3139,233 @@ mod write_ops {
              inode must not wipe the new inode's path binding"
         );
     }
+
+    // --- Codex round 13 findings: setattr lock discipline + name/mode pickiness
+    //
+    // r12 closed the post-spike NodeId-keyed refactor's residual surgical
+    // gaps. r13 surfaces three more same-class issues that all live in the
+    // write-side `set_attrs` / `validate_entry_name` surface:
+    //
+    //   1. `set_attrs(size=...)` routes into `apply_truncate` without taking
+    //      `write_mu`. Concurrent with `rename`, the truncate's final
+    //      bookkeeping uses the pre-rename pathname — republishing
+    //      `hot_by_path[old]` and clearing the rename's tombstone, so the
+    //      old name resurrects. (Codex thread 3293733165, P1.)
+    //   2. `validate_entry_name` rejects only NUL and `/`, but the tree
+    //      serializer additionally rejects `\` and control bytes
+    //      (0x01..=0x1F, 0x7F). Names that pass the FUSE-side check then
+    //      fail at capture with a confusing "invalid object" error rather
+    //      than a clean EINVAL at write time. (Codex thread 3293733163, P2.)
+    //   3. `set_attrs`'s Normal↔Executable fold treats any of the three
+    //      execute bits as executable (`mode & 0o111 != 0`). The contract
+    //      is "user execute only" — a `chmod 0o010` (group execute) must
+    //      stay Normal. (Codex thread 3293733164, P2.)
+
+    /// Codex r13 thread 3293733165 (P1). `set_attrs(size=...)` racing
+    /// with `rename_entry` must not republish the pre-rename pathname.
+    ///
+    /// Mechanism without `write_mu` in `set_attrs`: `apply_truncate`
+    /// captures `path` at the top via `record_for`, then drops every
+    /// lock for the seed `load_blob_bytes` call. A concurrent rename
+    /// fits entirely in that lock-free window — it inserts
+    /// `tombstones[old]`, removes `hot_by_path[old]`, and rebases the
+    /// inode's stored path. When `apply_truncate`'s phase-2 mutation
+    /// re-acquires the pending lock and runs `tombstones.remove(&path)
+    /// + hot_by_path.insert(path, node)` with the stale `path = old`,
+    /// the rename's tombstone is wiped and `lookup(old)` resurrects
+    /// the file.
+    ///
+    /// Stress shape: 200 trials, two threads sync on a barrier and
+    /// then run their op concurrently. Even a single observation of
+    /// `lookup(old).is_some()` after both complete fails the test.
+    /// With the fix (`write_mu` held around the mutating `set_attrs`
+    /// paths), the race is structurally impossible.
+    #[test]
+    fn setattr_truncate_serializes_against_rename() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+        const TRIALS: usize = 200;
+        let mut resurrected: Vec<usize> = Vec::new();
+        for trial in 0..TRIALS {
+            let (_temp, mount) = open_mount();
+            let mount = Arc::new(mount);
+            // `hello.txt` is a captured 5-byte file; `apply_truncate`'s
+            // NeedSeed branch will fetch the blob and widen the
+            // lock-free window during the race.
+            let node = mount.lookup_path("hello.txt").unwrap();
+            let barrier = Arc::new(Barrier::new(2));
+
+            let b_a = barrier.clone();
+            let m_a = mount.clone();
+            let h_a = thread::spawn(move || {
+                b_a.wait();
+                m_a.set_attrs(
+                    node,
+                    AttrUpdate {
+                        size: Some(2),
+                        ..Default::default()
+                    },
+                )
+                .expect("setattr(size=2)");
+            });
+            let b_b = barrier.clone();
+            let m_b = mount.clone();
+            let h_b = thread::spawn(move || {
+                b_b.wait();
+                m_b.rename_entry(
+                    NodeId::ROOT,
+                    OsStr::new("hello.txt"),
+                    NodeId::ROOT,
+                    OsStr::new("renamed.txt"),
+                )
+                .expect("rename");
+            });
+            h_a.join().unwrap();
+            h_b.join().unwrap();
+
+            // Invariant: regardless of interleaving, the pre-rename
+            // path must not resolve after both ops complete.
+            if mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_some()
+            {
+                resurrected.push(trial);
+            }
+        }
+        assert!(
+            resurrected.is_empty(),
+            "setattr(size)+rename race resurrected pre-rename path \
+             in {} of {} trials (trials: {:?})",
+            resurrected.len(),
+            TRIALS,
+            resurrected,
+        );
+    }
+
+    /// Codex r13 thread 3293733163 (P2). `validate_entry_name` must
+    /// reject every name the tree serializer would reject — otherwise
+    /// the overlay accepts a create/rename that later blows up at
+    /// `capture` with a confusing "invalid object" error.
+    ///
+    /// The tree serializer's rule (objects::object::tree_entry::
+    /// validate_name) rejects: empty, `.`, `..`, anything containing
+    /// `/` or `\`, anything with a byte < 0x20 or == 0x7F. The mount's
+    /// `validate_entry_name` previously rejected only NUL + `/`.
+    ///
+    /// Each name in this list pins one rule the mount must enforce up
+    /// front. Without the fix, `create_file` / `rename` accept these
+    /// and the failure surfaces later (or not at all, leaking a stale
+    /// pending entry).
+    #[test]
+    fn create_rejects_names_tree_cannot_serialize() {
+        let (_temp, mount) = open_mount();
+        // Each (name, why) tuple is rejected by the tree serializer.
+        let cases: &[(&[u8], &str)] = &[
+            (b"with\\backslash", "backslash (path separator on Windows)"),
+            (b"bel\x07", "BEL (0x07) is a control char"),
+            (b"esc\x1b", "ESC (0x1B) is a control char"),
+            (b"tab\there", "TAB (0x09) is a control char"),
+            (b"newline\nhere", "LF (0x0A) is a control char"),
+            (b"cr\rhere", "CR (0x0D) is a control char"),
+            (b"del\x7f", "DEL (0x7F) is the upper control char"),
+        ];
+        for (bytes, why) in cases {
+            // Build the OsStr from raw bytes so we can include non-UTF-8
+            // tricks (the safe path here is all-ASCII, but the helper
+            // is byte-oriented to match the tree serializer's reject
+            // set).
+            #[cfg(unix)]
+            let name = {
+                use std::os::unix::ffi::OsStrExt;
+                std::ffi::OsString::from(OsStr::from_bytes(bytes))
+            };
+            #[cfg(not(unix))]
+            let name = std::ffi::OsString::from(
+                std::str::from_utf8(bytes).expect("ascii test inputs"),
+            );
+
+            let err = mount
+                .create_file(NodeId::ROOT, &name, FileMode::Normal, false)
+                .expect_err(&format!(
+                    "create_file must reject {name:?} ({why}) up front"
+                ));
+            assert!(
+                matches!(err, MountError::InvalidArgument(_)),
+                "expected InvalidArgument for {name:?} ({why}), got {err:?}"
+            );
+        }
+    }
+
+    /// Codex r13 thread 3293733164 (P2). The Normal↔Executable mode
+    /// fold must trigger on the user execute bit (S_IXUSR = 0o100)
+    /// only, not on any of the three execute bits (0o111). A
+    /// `chmod 0o010` (group execute only) must NOT promote a Normal
+    /// file to Executable — that would unexpectedly grant owner
+    /// execute at capture time.
+    #[test]
+    fn chmod_group_execute_alone_doesnt_promote_to_executable() {
+        let (_temp, mount) = open_mount();
+        let node = mount.lookup_path("hello.txt").unwrap();
+        // chmod 0o010: group execute only. Per the contract, this
+        // must NOT promote to Executable.
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    mode: Some(0o100_010),
+                    ..Default::default()
+                },
+            )
+            .expect("chmod 0o010");
+        // FileMode::Normal serializes to 0o644 (no execute anywhere);
+        // FileMode::Executable serializes to 0o755 (all execute bits).
+        // The fix gates the fold on S_IXUSR (0o100), so 0o010 leaves
+        // the record as Normal → unix_mode has no execute bits at all.
+        assert_eq!(
+            attrs.unix_mode & 0o111,
+            0,
+            "chmod 0o010 must NOT promote to Executable (got unix_mode={:o})",
+            attrs.unix_mode
+        );
+
+        // Companion assertion (anti-regression): chmod 0o100 (user
+        // execute only) DOES promote to Executable.
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    mode: Some(0o100_100),
+                    ..Default::default()
+                },
+            )
+            .expect("chmod 0o100");
+        assert_eq!(
+            attrs.unix_mode & 0o111,
+            0o111,
+            "chmod 0o100 must promote to Executable (got unix_mode={:o})",
+            attrs.unix_mode
+        );
+
+        // And chmod 0o755 (the canonical Executable path) still
+        // works — this is the path the r12 baseline already covers
+        // and we don't want to regress.
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    mode: Some(0o100_755),
+                    ..Default::default()
+                },
+            )
+            .expect("chmod 0o755");
+        assert_eq!(
+            attrs.unix_mode & 0o111,
+            0o111,
+            "chmod 0o755 must keep Executable (got unix_mode={:o})",
+            attrs.unix_mode
+        );
+    }
 }
 
 // D1. Property test for two-tier semantics.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2301,6 +2301,214 @@ mod write_ops {
         let n = mount.read(v2.node, 0, &mut buf).unwrap();
         assert_eq!(&buf[..n], b"v2-fresh");
     }
+
+    // --- Codex round 7 findings: orphan-aware write-side ops ----------------
+    //
+    // r6 fixed `write` so a write through an unlinked-but-still-open fd
+    // does not republish the path. Codex r7 surfaced four more write-side
+    // ops with the same shape — operations that touch `hot_by_path`,
+    // `tombstones`, or path-keyed `warm` entries without consulting the
+    // orphan set. Each test below pins one contract from the brief.
+
+    /// `ftruncate` through an unlinked-but-still-open captured fd must
+    /// affect only the anonymous open inode. POSIX unlink semantics:
+    /// the directory entry stays gone until the last close, and a
+    /// flush of the orphan must not warm-promote its buffer. Without
+    /// the fix, `apply_truncate`'s tombstone-clear + `hot_by_path`
+    /// rebind republished the name to every other observer.
+    #[test]
+    fn truncate_unlinked_open_doesnt_resurrect_path() {
+        let (_temp, mount) = open_mount();
+        // `fd = open("hello.txt")` — captured file, no overlay yet.
+        let node = mount.lookup_path("hello.txt").unwrap();
+        // `unlink("hello.txt")` while the handle is still in use.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_none(),
+            "post-unlink lookup must return None"
+        );
+        // `ftruncate(fd, 2)` through the now-orphaned NodeId.
+        mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    size: Some(2),
+                    ..Default::default()
+                },
+            )
+            .expect("ftruncate through unlinked-open fd");
+        // Decisive check: the path must still be gone.
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_none(),
+            "truncate after unlink must not resurrect the path"
+        );
+        let entries = mount.enumerate(NodeId::ROOT).unwrap();
+        assert!(
+            !entries.iter().any(|e| e.name == "hello.txt"),
+            "enumerate must not surface the unlinked path: {entries:?}"
+        );
+        // Flushing the orphan must not warm-promote it — a subsequent
+        // capture would otherwise resurrect the path in the captured
+        // tree.
+        mount.flush(node).expect("flush orphan");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_none(),
+            "post-flush lookup must still be gone (orphan must not warm-promote)"
+        );
+    }
+
+    /// Rename-over with the destination still open + holding a hot
+    /// buffer must preserve the buffer. Reads through the original
+    /// NodeId must continue to see the pre-rename bytes. Without the
+    /// fix, `move_file`'s blind `pending.hot.remove(&dest_id)` dropped
+    /// the buffer, and reads through the still-open fd then routed
+    /// through the rebased path overlay and observed the replacement.
+    #[test]
+    fn rename_over_preserves_replaced_open_fd() {
+        let (_temp, mount) = open_mount();
+        // Open the captured "hello.txt", write through it, do NOT
+        // flush. The hot buffer keyed by dest_id holds "ORIG-DATA".
+        let dest_id = mount.lookup_path("hello.txt").unwrap();
+        mount.write(dest_id, 0, b"ORIG-DATA").expect("write to dest");
+        // Build a source file with replacement bytes; flush so the
+        // rename's start-of-move flush_node is a no-op.
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .expect("create src");
+        mount.write(src.node, 0, b"REPLACE-DATA").expect("write src");
+        mount.flush(src.node).expect("flush src");
+        // Rename src over dest. dest's pathname is rebound to src;
+        // dest's open fd must continue to see "ORIG-DATA".
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("rename-over");
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(dest_id, 0, &mut buf)
+            .expect("read via replaced dest fd");
+        assert_eq!(
+            &buf[..n],
+            b"ORIG-DATA",
+            "open fd on replaced dest must see pre-rename bytes",
+        );
+    }
+
+    /// Captured-file rename-over: dest has no hot buffer at the time
+    /// of the rename, only the captured-tree blob. Reads/attrs through
+    /// the still-open fd must serve the captured bytes, not the
+    /// source's replacement. Without the fix, the captured-file branch
+    /// of `read` consulted `warm[new_path]` (now the source's data)
+    /// before falling through to the captured blob.
+    #[test]
+    fn rename_over_destination_data_via_old_fd() {
+        let (_temp, mount) = open_mount();
+        // `fd = open("hello.txt")` — captured file, no overlay.
+        let dest_id = mount.lookup_path("hello.txt").unwrap();
+        // Source file with replacement payload; flush so move_file's
+        // flush_node returns immediately.
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .expect("create src");
+        mount.write(src.node, 0, b"REPLACE-DATA").expect("write src");
+        mount.flush(src.node).expect("flush src");
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("rename-over");
+        // Read via the displaced inode id must serve the original
+        // captured bytes ("world", 5 bytes) — not the source's
+        // "REPLACE-DATA" (12 bytes).
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(dest_id, 0, &mut buf)
+            .expect("read via replaced dest fd");
+        assert_eq!(
+            &buf[..n],
+            b"world",
+            "open fd on replaced captured dest must see captured bytes, not replacement",
+        );
+        // attrs must report the captured size too — a stale size from
+        // the path overlay would clip the kernel's read buffer.
+        let attrs = mount.attrs(dest_id).expect("attrs via replaced dest fd");
+        assert_eq!(
+            attrs.size, 5,
+            "attrs on replaced captured dest must report captured size, not replacement",
+        );
+    }
+
+    /// `fchmod` on an unlinked-but-still-open fd must affect only the
+    /// inode behind that fd. The brief's threat model:
+    /// `open(old) → unlink(old) → create(old) → fchmod(orphan_fd, +x)`.
+    /// Without the fix, `set_attrs`'s mode mutation updated
+    /// `hot_by_path[path]` and `warm[path]` too, flipping the
+    /// newly-created file's mode at the same pathname.
+    #[test]
+    fn fchmod_on_unlinked_open_doesnt_leak_to_recreated() {
+        let (_temp, mount) = open_mount();
+        // `fd = open("hello.txt")` — captured Normal-mode file.
+        let orphan_id = mount.lookup_path("hello.txt").unwrap();
+        // `unlink("hello.txt")` while the fd lives on.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        // `create("hello.txt")` mints a fresh inode at the same
+        // pathname. Writing some bytes guarantees the hot buffer
+        // exists so a leak via `hot_by_path[path]` is visible.
+        let fresh = mount
+            .create_file(NodeId::ROOT, OsStr::new("hello.txt"), FileMode::Normal, false)
+            .expect("recreate at same name");
+        assert_ne!(orphan_id, fresh.node);
+        mount
+            .write(fresh.node, 0, b"REBORN")
+            .expect("write to recreated file");
+        // `fchmod(orphan_fd, 0o755)` — the orphan inode's mode flip
+        // must not propagate to the fresh inode at the same pathname.
+        mount
+            .set_attrs(
+                orphan_id,
+                AttrUpdate {
+                    mode: Some(0o100755),
+                    ..Default::default()
+                },
+            )
+            .expect("chmod on orphan");
+        // Drive the recreated file through flush + capture so the
+        // buffer's `mode` field — which gets persisted into the
+        // warm-tier entry and ultimately the captured tree — is
+        // observable. A leak shows up as Executable at the new
+        // path; the contract says Normal.
+        mount.flush(fresh.node).expect("flush fresh");
+        let change_id = mount.capture(Some("orphan chmod".into())).unwrap();
+        let store = mount.repo_handle().store();
+        let state = store.get_state(&change_id).unwrap().unwrap();
+        let root_tree = store.get_tree(&state.tree).unwrap().unwrap();
+        let entry = root_tree.get("hello.txt").expect("recreated file in tree");
+        assert!(
+            matches!(entry.mode, objects::object::FileMode::Normal),
+            "chmod on orphan must not leak to recreated file: got mode {:?}",
+            entry.mode,
+        );
+    }
 }
 
 // D1. Property test for two-tier semantics.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -1382,6 +1382,426 @@ fn cross_thread_blob_dedup_at_scale() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Part 5: write-side overlay ops — create / mkdir / unlink / rmdir / rename /
+// setattr / symlink. Each op exercises the PlatformShell trait method on a
+// real ContentAddressedMount, so the test catches both the core implementation
+// and the trait dispatch (it's the same path FUSE / FSKit / ProjFS callbacks
+// take). Issue: heddle#180 — unblocks `open(O_CREAT)` and friends on the
+// Linux FUSE shell.
+// ---------------------------------------------------------------------------
+mod write_ops {
+    use super::*;
+    use crate::shell::AttrUpdate;
+    use objects::object::FileMode;
+    use std::path::Path;
+
+    /// `create_file` mints a fresh PendingFile under root, visible to
+    /// subsequent `lookup` / `read` calls. The first `write` against
+    /// the returned NodeId seeds an empty buffer; the byte stream
+    /// flows through the existing two-tier write model.
+    #[test]
+    fn create_file_in_root_then_write_and_read_back() {
+        let (_temp, mount) = open_mount();
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("Cargo.lock"), FileMode::Normal, false)
+            .expect("create_file");
+        assert_eq!(entry.kind, NodeKind::File);
+        assert_eq!(entry.name, "Cargo.lock");
+
+        // Lookup must now resolve the same path.
+        let looked_up = mount
+            .lookup(NodeId::ROOT, OsStr::new("Cargo.lock"))
+            .expect("lookup ok")
+            .expect("lookup hit");
+        assert_eq!(looked_up.node, entry.node);
+
+        // Write + read-back through the freshly minted NodeId.
+        mount.write(entry.node, 0, b"[package]\n").expect("write");
+        let mut buf = vec![0u8; 32];
+        let n = mount.read(entry.node, 0, &mut buf).expect("read");
+        assert_eq!(&buf[..n], b"[package]\n");
+    }
+
+    /// `create_file` with `exclusive=true` (`O_CREAT|O_EXCL`) against
+    /// an already-existing captured path must fail with
+    /// `AlreadyExists` (errno `EEXIST`).
+    #[test]
+    fn create_file_exclusive_against_existing_returns_eexist() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .create_file(NodeId::ROOT, OsStr::new("hello.txt"), FileMode::Normal, true)
+            .expect_err("exclusive create on existing must fail");
+        assert!(matches!(err, MountError::AlreadyExists(_)), "got {err:?}");
+        assert_eq!(err.to_errno(), libc::EEXIST);
+    }
+
+    /// `create_file` with `exclusive=false` (`O_CREAT` without
+    /// `O_EXCL`) against an existing captured path returns the
+    /// existing entry — that's the POSIX `open(O_CREAT)` shape, and
+    /// what cargo / rustc rely on when re-opening an artifact for
+    /// rewrite.
+    #[test]
+    fn create_file_non_exclusive_returns_existing_entry() {
+        let (_temp, mount) = open_mount();
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("hello.txt"), FileMode::Normal, false)
+            .expect("non-exclusive create on existing returns entry");
+        assert_eq!(entry.name, "hello.txt");
+        let captured = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(captured.node, entry.node);
+    }
+
+    /// Names containing `/` or `\0`, or the reserved `.` / `..`
+    /// pseudo-entries, must be rejected at the create boundary with
+    /// `EINVAL` — not silently shoved into the overlay.
+    #[test]
+    fn create_file_rejects_invalid_names() {
+        let (_temp, mount) = open_mount();
+        for bad in ["", ".", "..", "a/b", "with\0nul"] {
+            let err = mount
+                .create_file(NodeId::ROOT, OsStr::new(bad), FileMode::Normal, false)
+                .expect_err(&format!("name {bad:?} must be rejected"));
+            assert!(matches!(err, MountError::InvalidArgument(_)), "{bad}: {err:?}");
+            assert_eq!(err.to_errno(), libc::EINVAL);
+        }
+    }
+
+    /// `make_dir` creates an empty pending directory under root that
+    /// shows up in lookup + enumerate immediately. Subsequent
+    /// `create_file` calls under it must work.
+    #[test]
+    fn make_dir_creates_empty_visible_dir() {
+        let (_temp, mount) = open_mount();
+        let dir_entry = mount
+            .make_dir(NodeId::ROOT, OsStr::new("target"))
+            .expect("make_dir");
+        assert_eq!(dir_entry.kind, NodeKind::Directory);
+
+        // Visible via lookup.
+        let looked = mount
+            .lookup(NodeId::ROOT, OsStr::new("target"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(looked.node, dir_entry.node);
+
+        // Root enumerate must include the new directory.
+        let root_entries = mount.enumerate(NodeId::ROOT).unwrap();
+        assert!(
+            root_entries.iter().any(|e| e.name == "target"
+                && e.kind == NodeKind::Directory),
+            "root enumerate did not include the new dir: {root_entries:?}"
+        );
+
+        // Create a file inside it; visible via lookup under the dir.
+        let file = mount
+            .create_file(dir_entry.node, OsStr::new("out.bin"), FileMode::Normal, false)
+            .expect("create_file under new dir");
+        let from_lookup = mount
+            .lookup(dir_entry.node, OsStr::new("out.bin"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(from_lookup.node, file.node);
+    }
+
+    /// `make_dir` against an existing path (captured or pending) is
+    /// `EEXIST`. POSIX `mkdir(2)` shape.
+    #[test]
+    fn make_dir_existing_returns_eexist() {
+        let (_temp, mount) = open_mount();
+        // `nested/` already exists in the fixture's captured tree.
+        let err = mount
+            .make_dir(NodeId::ROOT, OsStr::new("nested"))
+            .expect_err("mkdir on existing must fail");
+        assert_eq!(err.to_errno(), libc::EEXIST);
+    }
+
+    /// `unlink_entry` against a captured file tombstones it: post-
+    /// unlink lookup returns `None`, enumerate skips it, and a
+    /// subsequent `create_file` (POSIX `unlink+open(O_CREAT)`) mints
+    /// a fresh empty inode at the same path.
+    #[test]
+    fn unlink_entry_removes_captured_file_and_allows_recreate() {
+        let (_temp, mount) = open_mount();
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect("unlink");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+                .unwrap()
+                .is_none(),
+            "post-unlink lookup must return None"
+        );
+        let entries = mount.enumerate(NodeId::ROOT).unwrap();
+        assert!(
+            !entries.iter().any(|e| e.name == "hello.txt"),
+            "enumerate still surfaces unlinked file"
+        );
+
+        // Recreate.
+        let recreated = mount
+            .create_file(NodeId::ROOT, OsStr::new("hello.txt"), FileMode::Normal, false)
+            .expect("recreate after unlink");
+        mount.write(recreated.node, 0, b"REBORN").unwrap();
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(recreated.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"REBORN");
+    }
+
+    /// `unlink_entry` on a directory is `EISDIR` (POSIX `unlink(2)`).
+    #[test]
+    fn unlink_entry_on_directory_returns_eisdir() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("nested"))
+            .expect_err("unlink on dir must fail");
+        assert_eq!(err.to_errno(), libc::EISDIR);
+    }
+
+    /// `unlink_entry` on a name that doesn't exist is `ENOENT`.
+    #[test]
+    fn unlink_entry_missing_returns_enoent() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("nonexistent"))
+            .expect_err("unlink missing must fail");
+        assert_eq!(err.to_errno(), libc::ENOENT);
+    }
+
+    /// `rmdir_entry` removes an empty pending directory. Subsequent
+    /// lookup returns `None`.
+    #[test]
+    fn rmdir_entry_removes_empty_pending_dir() {
+        let (_temp, mount) = open_mount();
+        let dir = mount.make_dir(NodeId::ROOT, OsStr::new("scratch")).unwrap();
+        let _ = dir; // keep alive
+        mount
+            .rmdir_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("rmdir");
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("scratch"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// `rmdir_entry` on a directory that has any visible child (pending
+    /// or captured) must fail with `ENOTEMPTY`.
+    #[test]
+    fn rmdir_entry_non_empty_returns_enotempty() {
+        let (_temp, mount) = open_mount();
+        // The fixture's `nested/` has captured children.
+        let err = mount
+            .rmdir_entry(NodeId::ROOT, OsStr::new("nested"))
+            .expect_err("rmdir on non-empty must fail");
+        assert_eq!(err.to_errno(), libc::ENOTEMPTY);
+    }
+
+    /// `rmdir_entry` on a regular file is `ENOTDIR`.
+    #[test]
+    fn rmdir_entry_on_file_returns_enotdir() {
+        let (_temp, mount) = open_mount();
+        let err = mount
+            .rmdir_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+            .expect_err("rmdir on file must fail");
+        assert_eq!(err.to_errno(), libc::ENOTDIR);
+    }
+
+    /// File rename within the same directory: source disappears,
+    /// destination resolves to the renamed file with the same bytes.
+    /// This is the cargo / git path: write `foo.tmp` then rename to
+    /// `foo`.
+    #[test]
+    fn rename_entry_file_same_dir() {
+        let (_temp, mount) = open_mount();
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("Cargo.lock.tmp"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(src.node, 0, b"[atomic]\n").unwrap();
+        mount.flush(src.node).unwrap();
+
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("Cargo.lock.tmp"),
+                NodeId::ROOT,
+                OsStr::new("Cargo.lock"),
+            )
+            .expect("rename");
+
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("Cargo.lock.tmp"))
+                .unwrap()
+                .is_none(),
+            "source path must be gone after rename"
+        );
+        let dst = mount
+            .lookup(NodeId::ROOT, OsStr::new("Cargo.lock"))
+            .unwrap()
+            .expect("dst resolves");
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(dst.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"[atomic]\n");
+    }
+
+    /// Rename across directories: src in `nested/`, dst in root.
+    #[test]
+    fn rename_entry_cross_dir() {
+        let (_temp, mount) = open_mount();
+        // Source lives in the captured tree at `nested/inner.txt`.
+        let nested = mount
+            .lookup(NodeId::ROOT, OsStr::new("nested"))
+            .unwrap()
+            .unwrap();
+        mount
+            .rename_entry(
+                nested.node,
+                OsStr::new("inner.txt"),
+                NodeId::ROOT,
+                OsStr::new("moved.txt"),
+            )
+            .expect("cross-dir rename");
+
+        assert!(
+            mount
+                .lookup(nested.node, OsStr::new("inner.txt"))
+                .unwrap()
+                .is_none(),
+            "source path must be gone after rename"
+        );
+        let dst = mount
+            .lookup(NodeId::ROOT, OsStr::new("moved.txt"))
+            .unwrap()
+            .expect("dst resolves");
+        let mut buf = vec![0u8; 32];
+        let n = mount.read(dst.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"deep");
+    }
+
+    /// Rename onto an existing file of the same kind: POSIX allows it
+    /// (atomic replace). The destination's prior content is gone.
+    #[test]
+    fn rename_entry_replaces_existing_file() {
+        let (_temp, mount) = open_mount();
+        let src = mount
+            .create_file(NodeId::ROOT, OsStr::new("draft"), FileMode::Normal, false)
+            .unwrap();
+        mount.write(src.node, 0, b"draft body").unwrap();
+        mount.flush(src.node).unwrap();
+        // hello.txt exists in the fixture; rename overwrites it.
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("draft"),
+                NodeId::ROOT,
+                OsStr::new("hello.txt"),
+            )
+            .expect("rename-over");
+        let dst = mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .unwrap();
+        let mut buf = vec![0u8; 32];
+        let n = mount.read(dst.node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"draft body");
+    }
+
+    /// `set_attrs(size=0)` truncates the file's hot buffer to zero,
+    /// which is what the kernel issues for `O_TRUNC` before any
+    /// `write`. cargo writes use `O_CREAT|O_WRONLY|O_TRUNC`; without
+    /// this the second build cycle overlays bytes on top of the
+    /// previous artifact.
+    #[test]
+    fn set_attrs_truncate_zero_clears_buffer() {
+        let (_temp, mount) = open_mount();
+        let node = mount.lookup_path("hello.txt").unwrap();
+        // Seed a buffer first.
+        mount.write(node, 0, b"world-plus").unwrap();
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    size: Some(0),
+                    ..Default::default()
+                },
+            )
+            .expect("setattr size=0");
+        assert_eq!(attrs.size, 0);
+        // Subsequent read returns nothing.
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(node, 0, &mut buf).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    /// `set_attrs(size=N)` larger than the current buffer zero-fills
+    /// the gap (POSIX `ftruncate(2)`).
+    #[test]
+    fn set_attrs_truncate_grow_zero_fills() {
+        let (_temp, mount) = open_mount();
+        let node = mount.lookup_path("hello.txt").unwrap(); // "world", 5 bytes
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    size: Some(8),
+                    ..Default::default()
+                },
+            )
+            .expect("setattr grow");
+        assert_eq!(attrs.size, 8);
+        let mut buf = vec![0u8; 16];
+        let n = mount.read(node, 0, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"world\0\0\0");
+    }
+
+    /// `set_attrs(mode=0o755)` flips a Normal file to Executable in
+    /// the overlay; the change is visible on `attrs` immediately and
+    /// surfaces in `capture` output (so a freshly-built binary keeps
+    /// its `+x` bit).
+    #[test]
+    fn set_attrs_mode_sets_executable_bit() {
+        let (_temp, mount) = open_mount();
+        let node = mount.lookup_path("hello.txt").unwrap();
+        let attrs = mount
+            .set_attrs(
+                node,
+                AttrUpdate {
+                    mode: Some(0o100755),
+                    ..Default::default()
+                },
+            )
+            .expect("setattr chmod");
+        assert_eq!(attrs.unix_mode & 0o111, 0o111);
+
+        // Refetched attrs preserve the override.
+        let again = mount.attrs(node).unwrap();
+        assert_eq!(again.unix_mode & 0o111, 0o111);
+    }
+
+    /// `create_symlink` records a link in the overlay; `read_link`
+    /// returns its target bytes.
+    #[test]
+    fn create_and_read_symlink() {
+        let (_temp, mount) = open_mount();
+        let entry = mount
+            .create_symlink(
+                NodeId::ROOT,
+                OsStr::new("alias.txt"),
+                Path::new("hello.txt"),
+            )
+            .expect("symlink");
+        assert_eq!(entry.kind, NodeKind::Symlink);
+        let target = mount.read_link(entry.node).expect("read_link");
+        assert_eq!(target.as_os_str(), OsStr::new("hello.txt"));
+    }
+}
+
 // D1. Property test for two-tier semantics.
 mod proptests {
     use std::collections::BTreeMap;

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -3170,10 +3170,10 @@ mod write_ops {
     /// fits entirely in that lock-free window — it inserts
     /// `tombstones[old]`, removes `hot_by_path[old]`, and rebases the
     /// inode's stored path. When `apply_truncate`'s phase-2 mutation
-    /// re-acquires the pending lock and runs `tombstones.remove(&path)
-    /// + hot_by_path.insert(path, node)` with the stale `path = old`,
-    /// the rename's tombstone is wiped and `lookup(old)` resurrects
-    /// the file.
+    /// re-acquires the pending lock and runs
+    /// `tombstones.remove(&path) + hot_by_path.insert(path, node)`
+    /// with the stale `path = old`, the rename's tombstone is wiped
+    /// and `lookup(old)` resurrects the file.
     ///
     /// Stress shape: 200 trials, two threads sync on a barrier and
     /// then run their op concurrently. Even a single observation of

--- a/crates/mount/tests/cargo_build_smoke.rs
+++ b/crates/mount/tests/cargo_build_smoke.rs
@@ -193,3 +193,95 @@ fn cargo_build_succeeds_against_virtualized_mount() {
     // dir and the source tempdirs.
     drop(session);
 }
+
+/// End-to-end canary for heddle#180: `cargo build` with cargo's
+/// `target/` dropped *inside* the mount, so the build exercises
+/// every new write-side callback (`mkdir target/`, `create
+/// target/debug/...`, `rename .tmp → final`, `setattr(size=0)` for
+/// O_TRUNC, `unlink` of stale dep-info files, etc).
+///
+/// This is the canonical "did this actually unblock the use case"
+/// check the issue's acceptance criteria call for. Before heddle#180
+/// landed, the very first `mkdir target/` returned `ENOSYS` and
+/// cargo aborted with a build error. Now it succeeds end-to-end.
+///
+/// Distinct from `cargo_build_succeeds_against_virtualized_mount`,
+/// which redirects `CARGO_TARGET_DIR` *outside* the mount (to lock
+/// in the read path under direct-io + mmap).
+#[test]
+#[ignore = "requires FUSE + cargo on host; opt-in via --ignored"]
+fn cargo_build_in_mount_target_dir_exercises_write_side_ops() {
+    if !Path::new("/dev/fuse").exists() {
+        eprintln!("skipping: /dev/fuse not present on this host");
+        return;
+    }
+    if Command::new("cargo").arg("--version").output().is_err() {
+        eprintln!("skipping: `cargo` not on PATH");
+        return;
+    }
+
+    let repo_dir = TempDir::new().expect("repo tempdir");
+    let crate_root = repo_dir.path();
+    fs::create_dir_all(crate_root.join("src")).expect("create src/");
+    fs::write(crate_root.join("Cargo.toml"), FIXTURE_CARGO_TOML).expect("write Cargo.toml");
+    fs::write(crate_root.join("src").join("main.rs"), FIXTURE_MAIN_RS).expect("write main.rs");
+
+    let repo = Repository::init_default(crate_root).expect("init heddle repo");
+    repo.snapshot(Some("calc-fixture".into()), None)
+        .expect("snapshot fixture");
+
+    let mount = ContentAddressedMount::new(repo, "main").expect("build mount");
+    let mountpoint = TempDir::new().expect("mount tempdir");
+    let session = FuseShell::new(mount)
+        .mount_background(mountpoint.path())
+        .expect("spawn FUSE background session");
+
+    let cargo_toml_in_mount = mountpoint.path().join("Cargo.toml");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !cargo_toml_in_mount.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        cargo_toml_in_mount.exists(),
+        "Cargo.toml never appeared in mount — FUSE worker may not have started",
+    );
+
+    // Pin CARGO_TARGET_DIR inside the mount to force cargo's target/
+    // emit into the writable overlay. (Without an explicit env, cargo
+    // would inherit the workspace-root `.cargo/config.toml`'s
+    // shared target dir and the write side of the mount never gets
+    // exercised.)
+    let in_mount_target = mountpoint.path().join("target");
+    let output = Command::new("cargo")
+        .arg("build")
+        .arg("--offline")
+        .arg("--manifest-path")
+        .arg(mountpoint.path().join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", &in_mount_target)
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_BUILD_RUSTFLAGS")
+        .output()
+        .expect("invoke cargo build");
+
+    if !output.status.success() {
+        panic!(
+            "cargo build with target/ in-mount failed (status={:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    // The binary should be visible through the mount at the
+    // conventional target/debug/<crate-name> path. Reading it through
+    // the mount one more time also exercises the read-after-create-
+    // after-flush path.
+    let bin_in_mount = mountpoint.path().join("target/debug/calc");
+    assert!(
+        bin_in_mount.exists(),
+        "cargo build claimed success but binary missing in mount at {}",
+        bin_in_mount.display(),
+    );
+
+    drop(session);
+}

--- a/crates/mount/tests/fuse_mount.rs
+++ b/crates/mount/tests/fuse_mount.rs
@@ -262,6 +262,113 @@ fn kernel_at_least(major: u32, minor: u32) -> bool {
     (host_major, host_minor) >= (major, minor)
 }
 
+/// End-to-end verification of the write-side overlay ops added in
+/// heddle#180. Each kernel op the issue called out (`create`,
+/// `mkdir`, `unlink`, `rmdir`, `rename`, `setattr`/truncate,
+/// `symlink`) is exercised in sequence against a single mounted
+/// fixture, and the resulting state is read back through the same
+/// mount to confirm overlay visibility. This is the FUSE-layer
+/// analogue of the `tests::write_ops::*` unit tests — same
+/// behavior, but driven through the real kernel-userspace round
+/// trip so a regression in the trampoline / errno mapping / direct-
+/// io flag is caught even when the core remains correct.
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_round_trips_write_side_ops() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+    let root = mountpoint.path();
+
+    // create + write — the cargo `open(O_CREAT)` path. Before the
+    // shell wired this up, the very first cargo invocation hit
+    // ENOSYS on `Cargo.lock`.
+    let lock_path = root.join("Cargo.lock");
+    {
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&lock_path)
+            .expect("create + open Cargo.lock");
+        f.write_all(b"[package]\nname=\"x\"\n").expect("write");
+    }
+    let read_back = fs::read_to_string(&lock_path).expect("read created file");
+    assert_eq!(read_back, "[package]\nname=\"x\"\n");
+
+    // O_CREAT|O_EXCL against the same path must fail with EEXIST.
+    let excl_err = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&lock_path)
+        .expect_err("O_CREAT|O_EXCL on existing must fail");
+    assert_eq!(
+        excl_err.kind(),
+        std::io::ErrorKind::AlreadyExists,
+        "exclusive create surfaced wrong errno: {excl_err:?}"
+    );
+
+    // mkdir + nested create.
+    let target_dir = root.join("target");
+    fs::create_dir(&target_dir).expect("mkdir target/");
+    assert!(target_dir.is_dir(), "mkdir didn't make a directory");
+    let nested_file = target_dir.join("output.bin");
+    fs::write(&nested_file, b"build artifact").expect("write under new dir");
+    assert_eq!(fs::read(&nested_file).unwrap(), b"build artifact");
+
+    // rename — cargo's `.tmp → atomic-final` shape.
+    let tmp = root.join("hello.txt.tmp");
+    fs::write(&tmp, b"NEW\n").expect("write tmp");
+    fs::rename(&tmp, root.join("hello.txt")).expect("rename over existing");
+    assert!(!tmp.exists(), "tmp source still visible after rename");
+    let after_rename = fs::read_to_string(root.join("hello.txt")).expect("read renamed");
+    assert_eq!(after_rename, "NEW\n");
+
+    // setattr (truncate) — O_TRUNC against an existing overlay file
+    // (the just-renamed hello.txt). The kernel issues
+    // `setattr(size=0)` before the first write, which must clear the
+    // buffer; otherwise the next write would tack onto the existing
+    // bytes.
+    let trunc_path = root.join("hello.txt");
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&trunc_path)
+            .expect("open O_TRUNC");
+        f.write_all(b"TRUNCATED").expect("write after truncate");
+    }
+    assert_eq!(
+        fs::read_to_string(&trunc_path).unwrap(),
+        "TRUNCATED",
+        "O_TRUNC didn't clear the prior content"
+    );
+
+    // symlink + readlink.
+    let link_path = root.join("hello.lnk");
+    std::os::unix::fs::symlink("hello.txt", &link_path).expect("symlink");
+    let resolved = fs::read_link(&link_path).expect("readlink");
+    assert_eq!(resolved.as_os_str(), "hello.txt");
+
+    // unlink — drop a captured file through the mount. Cargo.lock
+    // is the file we created at the top of the test; the captured
+    // hello.txt was already replaced via rename, so unlinking it now
+    // would only touch the overlay-only entry. Unlinking the freshly
+    // created Cargo.lock exercises the warm-tier-only deletion path.
+    fs::remove_file(root.join("Cargo.lock")).expect("unlink");
+    assert!(
+        !root.join("Cargo.lock").exists(),
+        "unlinked file still visible to the mount"
+    );
+
+    // rmdir empty pending dir (target/ had output.bin, so unlink it
+    // first to make rmdir succeed).
+    fs::remove_file(&nested_file).expect("unlink before rmdir");
+    fs::remove_dir(&target_dir).expect("rmdir of empty pending dir");
+    assert!(!target_dir.exists(), "rmdir didn't remove the directory");
+
+    drop(session);
+}
+
 #[test]
 #[ignore = "requires FUSE on host; opt-in via --ignored"]
 fn fuse_mount_unmounts_cleanly_on_session_drop() {

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -65,6 +65,6 @@ pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
 };
 pub use tree_diff::diff_trees;
-pub use tree_entry::TreeEntry;
+pub use tree_entry::{TreeEntry, validate_name as validate_tree_entry_name};
 pub use tree_struct::Tree;
 pub use tree_types::{EntryType, FileMode, TreeError};

--- a/crates/objects/src/object/tree_entry.rs
+++ b/crates/objects/src/object/tree_entry.rs
@@ -5,8 +5,14 @@ use serde::{Deserialize, Serialize};
 
 use super::{ContentHash, EntryType, FileMode, TreeError};
 
-/// Validates that a tree entry name is valid.
-pub(crate) fn validate_name(name: &str) -> Result<(), TreeError> {
+/// Validates that a tree entry name is valid. Exposed publicly so
+/// callers that build entries at higher layers (the FUSE mount's
+/// write-side ops in particular) can fail-fast with the same reject
+/// set the tree serializer enforces — otherwise the overlay accepts
+/// a name that later blows up at capture with an "invalid object"
+/// error rather than a clean EINVAL at write time. Codex heddle#180
+/// r13 thread 3293733163 (P2).
+pub fn validate_name(name: &str) -> Result<(), TreeError> {
     if name.is_empty() {
         return Err(TreeError::InvalidName("entry name cannot be empty".into()));
     }


### PR DESCRIPTION
## Summary

- Wires the eight missing FUSE write-side callbacks (`create`, `mkdir`, `mknod`, `unlink`, `rmdir`, `rename`, `setattr`, `symlink` + `readlink`; `link` returns EPERM) on top of a new per-thread overlay layer (`PendingSymlink`, `dir_tombstones`, `explicit_dirs`, `symlinks`) folded into a real heddle state by `capture()`.
- Cargo can now build inside a virtualized-mode mount end-to-end (mkdir target/, write artifacts, rename .tmp → final, O_TRUNC, unlink stale dep-info). Locked in by `cargo_build_in_mount_target_dir_exercises_write_side_ops`.
- Fixes a stale-inode bug in `rename`: the FUSE kernel does NOT re-issue `lookup` after a rename — it rewrites its own dentry → inode table — so the source inode's stored path field must be rebased to the destination, otherwise the next read against the rebased dentry returns ESTALE.
- After four rounds of Codex review (r6 → r9), this PR also lands the **post-spike unified NodeId-keyed cache layer** specified in [`docs/design/mount-posix-semantics.md`](docs/design/mount-posix-semantics.md) (heddle#199, merged as `9b83192`). The dual representation (path-keyed `warm` + NodeId-keyed `orphan_warm`; `orphans: BTreeSet` + `open_handles: BTreeMap`) collapses to one per-NodeId byte store + a typed `NodeState` lifecycle FSM. The whole cache-layer-asymmetry bug class (Class A in the spike §4 taxonomy) is structurally absent post-refactor.

Closes HeddleCo/heddle#180

## Red commit

`532009b` — 19 failing tests across `tests::write_ops::*` before any implementation lands. All pass on `290f952`. The Codex review rounds added more red commits (`3e6b6c8`, `a39327c`, `3d66ed7`, `c2cb5cc`, `4508b96`); each preceded its own green commit so the bug → fix correspondence is visible in `git log`.

## Test evidence

```
$ cargo test -p heddle-mount --lib
test result: ok. 93 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.45s

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 291 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 18.92s

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.18s

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (495 file(s) scanned)
```

## Manual verification

N/A — covered by integration tests above. The cargo-smoke is the manual-verification analogue (real downstream tool through the real FUSE path).

## Codex round 9 + post-spike refactor (`4508b96` red, `58a30b2` green)

Codex r8 surfaced one more r9 finding alongside the r8 sweep — [thread 3293307302](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293307302): `unlink_entry` dropped `pending.hot[node_id]` for orphans, so an open fd whose bytes had not yet been promoted to warm lost them. r8's fix would have been another targeted patch in the same shape as r6 / r7 / r8 — but the recurrence (four rounds of the same class) motivated a **structural fix**.

heddle#199 captured the design contract for the mount POSIX-semantics layer: `docs/design/mount-posix-semantics.md`. Locked decisions from that spike:

* **Decision A** — cache layer is NodeId-keyed throughout. `warm: BTreeMap<NodeId, PendingEntry>` (was path-keyed); `orphan_warm` deleted (its bytes live in `warm[node_id]` post-orphan). `hot_by_path` stays as the path → NodeId reverse-index for hot.
* **Decision B** — land the refactor in PR #182. This commit (`58a30b2`) is the impl.
* **Decision C** — `NodeState { Live { open_count }, Orphan { open_count } }` enum. Replaces `orphans: BTreeSet<u64>` + `open_handles: BTreeMap<u64, u32>`. The type system makes "orphaned with no open count" and "open count without orphan flag" unrepresentable.

Cascade simplifications enabled by Decision A — code paths that previously had to remember to maintain a parallel byte view simply go away:

* `move_file` no longer migrates `warm[old_path] → warm[new_path]` or relocates displaced `warm[new_path] → orphan_warm[displaced_id]`. Source bytes follow the source NodeId; displaced bytes stay at `warm[displaced_id]`. Path-level work only.
* `move_symlink` simplifies likewise.
* `move_overlay_dir` no longer rewrites the warm map (their NodeRecord paths get rebased in `rename_entry_with_options`'s descendant pass).
* `apply_pending_to_tree` iterates warm by NodeId, resolves the path via `inodes.by_id[id]`, and skips Orphans (their bytes never enter the captured tree).
* `unlink_entry`'s orphan branch no longer drops `pending.hot[node_id]` — bytes follow the NodeId, full stop. The r9 fix is one line absent.

The r9 contract is pinned by a new test `tests::write_ops::unlink_open_fd_preserves_unflushed_hot_bytes` (red in `4508b96`, green in `58a30b2`): `open(path) → write(fd, "DIRTY") → unlink(path) → read(fd) == "DIRTY"`.

Per the spike §4 bug-class taxonomy:

| Class | Description | Status post-refactor |
|---|---|---|
| A. Cache-layer asymmetry | Two parallel cache views (warm path-keyed vs orphan_warm NodeId-keyed) — every directory op had to migrate bytes between maps | **Structurally gone.** No dual byte-storage views exist. |
| B. Lifetime-event confusion | `flush` (per-descriptor close) vs `release` (per-inode final close) | Discipline preserved from r8 — `flush_node` is a no-op for Orphan; `release_node` drives the final-close cleanup. |
| C. TOCTOU on atomicity flags | Existence-check in FUSE shell, mutation in core, under separate locks | Discipline preserved from r8 — `write_mu` serializes structural mutations. |
| D. Orphan-state ignorance | Code takes a NodeId and applies Live-only side effects without consulting `orphans` | Exhaustiveness on `NodeState` makes "forgot to handle Orphan" a compile-time miss for any callback that matches on lifecycle. |

Self-audit greps (clean post-refactor — only doc-comment historical references remain):

```
$ grep -n 'orphan_warm' crates/mount/src/
crates/mount/src/core.rs:1403:    /// r9) and migrated `warm[path]` into `orphan_warm[node]` (r8);

$ grep -n 'pending\.orphans\b' crates/mount/src/
(empty)

$ grep -n 'open_handles' crates/mount/src/
crates/mount/src/core.rs:381:/// old `orphans: BTreeSet<u64>` + `open_handles: BTreeMap<u64, u32>`
crates/mount/src/core.rs:452:    /// pre-spike `orphans: BTreeSet<u64>` + `open_handles:
```

All r6 / r7 / r8 contract tests continue to pass unchanged — they tested behaviors that the new model still supports, just via different internal code paths.

## Codex review rounds (historical context)

Three earlier rounds of Codex review surfaced bugs in the open-fd / rename-displaced inode handling, each structurally identical: a write-side op touched `pending.hot_by_path`, `pending.tombstones`, or path-keyed `pending.warm` entries without consulting the orphan set. The post-spike refactor above makes this whole class structurally impossible. The historical fixes (kept in `git log` so the bug → fix correspondence is preserved):

### Round 6 (`a39327c` red, `8a21773` green)

`write` through an open-but-unlinked fd unconditionally re-inserted `hot_by_path[path] = node` and cleared the tombstone. POSIX says the inode lives behind the fd but the directory entry must stay gone. Fixed by adding orphan tracking populated at `unlink_entry` time, consulted by `write` and `flush_node`.

### Round 7 (`3d66ed7` red, `5e16861` green)

Same shape in four more ops: `apply_truncate`, `move_file` / `move_symlink`, `rename_entry` (displaced-orphan tracking), and `set_attrs` (mode). Each became orphan-aware against `hot_by_path` / `tombstones` / `inodes.by_path`.

### Round 8 (`c2cb5cc` red, `3d8cd69` green) — three-axis sweep

Codex r7 reviewed the r7 sweep and found four more same-shape misses along three orthogonal dimensions:

1. **Cache layer.** `pending.warm` was dropped on unlink and rename-over, even when surviving fds needed the bytes. Fixed by adding `orphan_warm: BTreeMap<u64, PendingEntry>` (later collapsed into NodeId-keyed `warm` in r9).
2. **Lifecycle stage.** The orphan marker cleared on the FIRST `flush`. FUSE `flush` fires per descriptor close; only `release` is the per-inode final close. Fixed by adding `open_handles` refcount + `release_node` (later collapsed into `NodeState` in r9).
3. **Concurrency.** `RENAME_NOREPLACE` did the existence check and the rename under separate locks. Fixed by introducing `write_mu` — a coarse write-side serialization mutex held across check + mutation.

### Round 9 (`4508b96` red, `58a30b2` green) — post-spike refactor

Detailed above. The r9 finding triggered the spike (heddle#199) which produced the design doc that this commit implements.

### Round 10 — superseded

Initially landed as `8a1129c` (encapsulation of `Pending` + a `check-no-direct-pending-mutation.sh` static gate). Force-reset off this branch and replaced by the type-state substrate in heddle#208/#209/#210/#211/#212 (plan: `docs/design/mount-pending-api-contracts.md`). The six Codex findings r10 surfaced still need fixing on the `58a30b2` base — see Round 12 below.

### Round 12 (`0884818` red, `1cc90cb` green) — surgical fixes on the post-spike base

After force-resetting `8a1129c` (Round 10 encapsulation) off this branch, Codex re-reviewed `58a30b2` and re-surfaced six P1 + one P3 findings that r10 had been fixing. r12 lands surgical fixes for those on the `58a30b2` base — **without** re-introducing r10's encapsulation work. The type-state substrate (heddle#208) is the strategic fix; this round just clears the immediate semantic bugs so the PR can ship.

| Thread | Severity | Site | Old behaviour | Fix |
|---|---|---|---|---|
| [3293484633](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293484633) | P1 | `capture_with_attribution` | Wholesale `state.clear()` / `hot.clear()` / `warm.clear()` dropped Orphan entries (and their per-NodeId bytes) for inodes with still-open fds; next write took the Live branch and republished the deleted path. | Retain Orphan entries + their per-NodeId `hot[id]` / `warm[id]` bytes during the drain; retire only Live entries. Path-keyed bookkeeping is still cleared wholesale (it's directory-entry-level, owned by the new captured tree). |
| [3293484634](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293484634) + [3293510311](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293510311) | P1 | `invalidate` | `pending.warm.remove(node)` on FUSE forget silently lost the only durable pre-capture copy of flushed writes. | Preserve `warm[node]`; gate `Inodes::forget(node)` on whether the overlay still references the NodeId. Hot buffer + path binding still drop (the kernel's cached identity is gone). |
| [3293510310](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293510310) | P1 | `rmdir_entry` | Left `inodes.by_path[child_path]` intact; subsequent `create_file` / `make_dir` at the same path coalesced onto the removed dir's NodeId via `Inodes::intern`. | Retire the path → inode mapping during rmdir (mirrors `unlink_entry`). |
| [3293510316](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293510316) | P1 | `read_link` | `unsafe { OsStr::from_encoded_bytes_unchecked(bytes) }` on blob bytes loaded from the store violates the API's safety precondition — captured-tree bytes can come from any process / Rust version, not just `as_encoded_bytes` in this process. | New `symlink_target_from_bytes` helper: `OsStrExt::from_bytes` on Unix (sound for any byte sequence), UTF-8 validation on Windows (`InvalidArgument` on non-UTF-8 — `OsStr` Windows encoding is process-internal). |
| [3293510317](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293510317) | P3 | `unlink_entry` | Symlinks transitioned to `NodeState::Orphan` but never receive `open`/`release` events → state entry never clears, `pending.state` grows under symlink churn. | Gate the orphan transition on `entry.kind != NodeKind::Symlink`. |
| [3293680448](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293680448) | P1 | `Inodes::forget` | Unconditional `by_path.remove(&path)` for the retired inode; after unlink-then-recreate or rename-over, `path` may be rebound to a *different* live inode → a late kernel `forget` for the old inode wipes the new inode's binding. | Remove the path mapping only when `by_path[path] == Some(retiring_id)`. |

**Tests (red `0884818`, green `1cc90cb`):**

* `capture_preserves_orphan_state_for_open_inodes` (3293484633)
* `invalidate_preserves_warm_bytes_for_live_inode` (3293484634 / 3293510311)
* `rmdir_retires_path_to_inode_binding` (3293510310)
* `unlink_of_symlink_does_not_create_orphan_state` (3293510317)
* `forget_after_unlink_recreate_preserves_new_path_binding` (3293680448)
* `read_link_safe_for_captured_symlink_bytes` (3293510316) — round-trip regression; passes both sides on Unix because `from_encoded_bytes_unchecked` and `OsStrExt::from_bytes` are operationally equivalent there. The fix is the soundness change (removing the `unsafe`).

**What r12 deliberately does NOT do:** no `Pending` encapsulation API, no per-method state-aware mutation wrappers, no `check-no-direct-pending-mutation.sh` static gate. That structural work is being replaced by heddle#208's type-state substrate, which is the long-term fix for the "callsite forgets the lifecycle" bug class. Direct field mutations on `Pending` stay in this PR; the `58a30b2` shape is preserved.

**Test evidence (post-r12):**

```
$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (495 file(s) scanned)

$ cargo test -p heddle-mount
test result: ok. 99 passed; 0 failed; 0 ignored; ...
test result: ok. 1 passed; 0 failed; 0 ignored; ...   # cargo-build-in-mount smoke

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 291 passed; 0 failed; 13 ignored; ...

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.27s
```

### Round 13 (`00af71b` red, `c616d89` green) — `set_attrs` lock discipline + name/mode pickiness

Codex re-reviewed the r12 green (`1cc90cb` plus the `ff03c18` coverage lift) and surfaced three new findings — one P1 race against `rename`, two P2 contract gaps in `set_attrs` / `validate_entry_name`. All three are surgical fixes on the same `58a30b2`-shaped base.

| Thread | Severity | Site | Old behaviour | Fix |
|---|---|---|---|---|
| [3293733165](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293733165) | P1 | `set_attrs` → `apply_truncate` | Routed size updates into `apply_truncate` without `write_mu`. A concurrent `rename` rebased the inode's path during the lock-free `load_blob_bytes` window; phase 2 then ran `tombstones.remove(old) + hot_by_path.insert(old, node)` with the stale pathname, wiping the rename's tombstone and resurrecting the file at the old name. | Take `write_mu` at the top of `set_attrs` so both the mode-mutation prologue *and* `apply_truncate` serialize against `rename` / `create` / `unlink` / `rmdir`. The mode branch had the same path-captured-then-mutated shape, so a single guard covers both. |
| [3293733163](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293733163) | P2 | `validate_entry_name` | Rejected only NUL + `/`. The tree serializer additionally rejects `\`, control bytes `0x00..=0x1F`, and `0x7F` — so the overlay accepted names that later blew up at `capture` with a confusing "invalid object" error. | Expose `objects::object::tree_entry::validate_name` as `pub` (re-exported as `validate_tree_entry_name`); the mount delegates to it after a fast NUL pre-check on the raw `OsStr` bytes. Single source of truth for the reject set. |
| [3293733164](https://github.com/HeddleCo/heddle/pull/182#discussion_r3293733164) | P2 | `set_attrs` exec-bit fold | `mode & 0o111 != 0` promoted any execute bit (incl. group-only `0o010`) to `FileMode::Executable`, which serializes as `0o755` — unexpectedly granting owner + other execute the agent never requested. | Gate the fold on `mode & 0o100` (S_IXUSR) only, matching the contract documented in the r12 commit. |

**Tests (red `00af71b`, green `c616d89`):**

* `setattr_truncate_serializes_against_rename` (3293733165) — 200-trial stress loop. Pre-fix observed 19/200 trials resurrecting `hello.txt` after the rename's tombstone landed; post-fix 0/200.
* `create_rejects_names_tree_cannot_serialize` (3293733163) — covers `\`, BEL, ESC, TAB, LF, CR, DEL.
* `chmod_group_execute_alone_doesnt_promote_to_executable` (3293733164) — `0o010` stays Normal; `0o100` and `0o755` still promote (anti-regression).

**Follow-up for a future round (not fixed here):** `pub fn write` has the same path-captured-then-mutated shape as `apply_truncate` (line 3140: `record_for(node)` captures `path`; then a CAS read drops the lock; then pending mutations use the stale `path`). It's a candidate for the same `write_mu` discipline, but the brief asked me to keep r13 scoped to the three Codex threads, so I'm flagging it here rather than fixing it.

**Test evidence (post-r13):**

```
$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (495 file(s) scanned)

$ cargo test -p heddle-mount
test result: ok. 107 passed; 0 failed; 0 ignored; ...

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 291 passed; 0 failed; 13 ignored; ...

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.68s
```

## Deferred from acceptance

The issue's acceptance list mentions rerunning `heddle-devtools fuse-dispatch-bench` from heddle#164 and updating `docs/benchmarks/linux-fuse-dispatch.md`. Both #164 and its implementing PR #179 are still open — the bench tool and the markdown writeup don't exist on `main` yet. Per AGENTS.md doc-truth rules I haven't fabricated either; this acceptance item should land in a follow-up PR after #179 merges.

The FUSE adapter docstring and `crates/mount/README.md` "Per-thread overlay semantics" section both ship in this PR per the other acceptance items.

## Blocked by → resolved

None directly; this PR unblocks the orchestrator-dispatch migration from git worktrees → heddle threads for any Rust workload that needs cargo (which is most of them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



