### PR TITLE
heddle#185: extract stripped_name helper in merge_driver/items

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -648,8 +648,7 @@ fn classify_c_node<'a>(
         // anonymous types — their methods are rare and any disambiguation
         // we'd invent would diverge between sides.
         "class_specifier" | "struct_specifier" | "union_specifier" => {
-            let name = name_from_field(source, node, "name")
-                .map(|n| strip_whitespace(&n))?;
+            let name = stripped_name(source, node, "name")?;
             let container_body = node.child_by_field_name("body");
             Some(Classified {
                 kind: ItemKind::Module,
@@ -665,8 +664,7 @@ fn classify_c_node<'a>(
             // at file scope (consistent with C++ semantics where
             // anonymous-namespace symbols have internal linkage at
             // translation-unit scope).
-            let name = name_from_field(source, node, "name")
-                .map(|n| strip_whitespace(&n))?;
+            let name = stripped_name(source, node, "name")?;
             let container_body = node.child_by_field_name("body");
             Some(Classified {
                 kind: ItemKind::Module,
@@ -1000,6 +998,10 @@ fn emit_c_declarator_shape(node: Node<'_>, out: &mut String) {
 fn name_from_field(source: &str, node: Node<'_>, field: &str) -> Option<String> {
     let name_node = node.child_by_field_name(field)?;
     Some(source[name_node.byte_range()].to_string())
+}
+
+fn stripped_name(source: &str, node: Node<'_>, field: &str) -> Option<String> {
+    name_from_field(source, node, field).map(|n| strip_whitespace(&n))
 }
 
 /// Resolve the actual function name from a C/C++ `function_declarator`.


### PR DESCRIPTION
## Summary
- Extract `stripped_name(source, node, field)` helper composing `name_from_field` + `strip_whitespace` in `crates/semantic/src/merge_driver/items.rs`.
- Switch the two `name_from_field(..).map(|n| strip_whitespace(&n))` call sites to the new helper (covers the 4 node kinds the audit flagged: `class_specifier`, `struct_specifier`, `union_specifier`, `namespace_definition`).
- Zero behavioral change — helper body is the literal composition.

Closes HeddleCo/heddle#185

## Red commit
N/A — pure refactor, DoD Type ≠ TDD-Rust (TW from heddle#133 audit).

## Call sites switched

- `crates/semantic/src/merge_driver/items.rs:650-651` — the `class_specifier | struct_specifier | union_specifier` arm (covers 3 of the 4 node kinds the audit cited).
- `crates/semantic/src/merge_driver/items.rs:667-668` — the `namespace_definition` arm (the 4th).

Helper defined at `crates/semantic/src/merge_driver/items.rs:1005-1007`, immediately below `name_from_field`.

## Test evidence
```
$ cargo test -p heddle-semantic
test result: ok. 193 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.12s

   Doc-tests semantic
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 38s
```

```
$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (494 file(s) scanned)
```

## Manual verification
N/A — covered by tests (193 passing, unchanged).

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782089645&installation_id=132405951&pr_number=191&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F191&signature=3484ac8d7bdd13738e71d500aa56807c171afcbefa8077919f1dc62c498d394f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->