### PR TITLE
heddle#183: add grant_envelope + device_public_key to auth RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 heddle-client = { path = "../client", version = "0.2", optional = true }
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -48,7 +48,7 @@ walkdir.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 fs2.workspace = true
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.3" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -844,6 +844,9 @@ message FinishWebAuthnAuthenticationRequest {
   bytes authenticator_data = 4;
   bytes signature = 5;
   bytes user_handle = 6;
+  // Client-side device pubkey the client wants the access token bound
+  // to. Server validates this against the user's active device_roots.
+  bytes device_public_key = 7;
   // Idempotency (audit-idempotency enforces tag 15).
   string client_operation_id = 15;
 }
@@ -946,6 +949,10 @@ message AccessTokenResponse {
   // credential row (device, service-account, agent). Empty for
   // browser sessions.
   string credential_id = 6;
+  // Server-issued GrantEnvelope authenticating the client's pubkey +
+  // session for biscuit minting. Empty on legacy / unauthenticated
+  // responses.
+  bytes grant_envelope = 7;
 }
 
 message ListSessionsRequest {}


### PR DESCRIPTION
## Summary

Cross-repo proto evolution that unblocks **HeddleCo/weft#180** (server-side envelope mint) and **HeddleCo/tapestry#12** (browser biscuit minting). Pure proto + release-ops on the heddle side; no behavior change here.

## Proto diff

```diff
 message FinishWebAuthnAuthenticationRequest {
   ...
   bytes user_handle = 6;
+  // Client-side device pubkey the client wants the access token bound
+  // to. Server validates this against the user's active device_roots.
+  bytes device_public_key = 7;
   string client_operation_id = 15;
 }

 message AccessTokenResponse {
   ...
   string credential_id = 6;
+  // Server-issued GrantEnvelope authenticating the client's pubkey +
+  // session for biscuit minting. Empty on legacy / unauthenticated
+  // responses.
+  bytes grant_envelope = 7;
 }
```

Both fields use field number `7` (next free in each message) and are typed `bytes` (raw serialized envelope / raw 32-byte pubkey).

## Version diff

`crates/grpc/Cargo.toml`: `0.3.0` → `0.4.0`. The added fields are non-breaking on the wire (proto3 added-field semantics) but the generated Rust struct surface changes, so the MAJOR bump makes downstream pinning explicit. Internal path-dependent consumers (`cli`, `client`, `daemon`) were updated to require `0.4` so the workspace continues to build.

No `CHANGELOG.md` exists in `crates/grpc/`; per task brief, didn't create one.

## Release path

Auto-publish on merge to main will pick up `0.4.0` via the existing `.github/workflows/publish-crates.yml` workflow. No manual `cargo publish`.

## Test plan

- [x] `cargo build -p heddle-grpc` — clean compile of the generated bindings
- [x] `cargo test --workspace` — all green (no failures across the workspace test result lines)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-no-silent-default-tree-load.sh` — clean (heddle CI parity)

## What this does NOT do

- Server handlers (mint the envelope, validate `device_public_key`) live in **HeddleCo/weft#180**, which will pin against `0.4.0` once published.
- Browser code that consumes the envelope lives in **HeddleCo/tapestry#12**, blocked on weft#180.

Closes #183.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782090616&installation_id=132405951&pr_number=192&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F192&signature=994e7931cb907e0a90956229ed56228998398034fc0435504b742e93021c7ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->