### PR TITLE
heddle#187: hoist walk-limit consts in merge_driver/items

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -16,6 +16,16 @@ use tree_sitter::Node;
 
 use crate::parser::{Language, ParsedFile};
 
+/// Cap on per-traversal iterations. **If you bump this, audit every walk for
+/// cycle safety** — tree-sitter nodes form a DAG in practice but pathological
+/// inputs can create cycle-shaped traversals.
+const WALK_LIMIT: usize = 32;
+
+/// Cap on parent-chain traversal depth. **If you bump this, audit every walk
+/// for cycle safety** — tree-sitter nodes form a DAG in practice but
+/// pathological inputs can create cycle-shaped traversals.
+const MAX_PARENT_WALK_DEPTH: usize = 64;
+
 /// Categorisation of an item. Used as part of [`ItemKey`] so two items with
 /// the same name but different shapes (e.g. a struct `Foo` and a function
 /// `Foo`) don't collide.
@@ -912,7 +922,7 @@ fn c_signature_hash(language: Language, source: &str, declarator: Node<'_>) -> u
 fn c_name_bearing_function_declarator<'a>(declarator: Node<'a>) -> Option<Node<'a>> {
     let mut current = declarator;
     let mut last_fd: Option<Node<'a>> = None;
-    for _ in 0..32 {
+    for _ in 0..WALK_LIMIT {
         match current.kind() {
             "function_declarator" => {
                 last_fd = Some(current);
@@ -1021,7 +1031,7 @@ fn stripped_name(source: &str, node: Node<'_>, field: &str) -> Option<String> {
 fn c_function_name(source: &str, function_declarator: Node<'_>) -> Option<String> {
     let mut current = function_declarator.child_by_field_name("declarator")?;
     // Cap traversal so a pathological wrapper chain doesn't loop.
-    for _ in 0..32 {
+    for _ in 0..WALK_LIMIT {
         match current.kind() {
             "identifier"
             | "field_identifier"
@@ -1096,7 +1106,7 @@ fn c_function_scope(
     let Some(mut current) = function_declarator.child_by_field_name("declarator") else {
         return scope;
     };
-    for _ in 0..32 {
+    for _ in 0..WALK_LIMIT {
         match current.kind() {
             "qualified_identifier" => {
                 if let Some(s) = current.child_by_field_name("scope") {
@@ -1174,7 +1184,7 @@ fn scope_component_text(
 fn enclosing_template_param_lists(node: Node<'_>, source: &str) -> Vec<Vec<String>> {
     let mut lists = Vec::new();
     let mut current = node;
-    for _ in 0..64 {
+    for _ in 0..MAX_PARENT_WALK_DEPTH {
         let Some(parent) = current.parent() else {
             break;
         };


### PR DESCRIPTION
## Summary
- Introduce `WALK_LIMIT: usize = 32` and `MAX_PARENT_WALK_DEPTH: usize = 64` at the top of `crates/semantic/src/merge_driver/items.rs` with cycle-safety discipline comments.
- Replace four magic-number sites in the C/C++ tree-sitter walks:
  - `items.rs:925` (`c_name_bearing_function_declarator`) — 32 → `WALK_LIMIT`
  - `items.rs:1034` (`c_function_name`) — 32 → `WALK_LIMIT`
  - `items.rs:1109` (template-scope walker) — 32 → `WALK_LIMIT`
  - `items.rs:1187` (`enclosing_template_param_lists`) — 64 → `MAX_PARENT_WALK_DEPTH`
- Pure refactor; zero behavioral change.

Closes #187

### Naming note
The original brief proposed `MAX_TRAVERSAL_DEPTH` for the 64-cap, but a const of that name already exists in the same module (`items.rs:123`, value `256`, the cap on child-AST traversal). Used `MAX_PARENT_WALK_DEPTH` instead — the 64-cap is specifically parent-chain depth, so the rename clarifies intent and avoids collision.

## Test evidence

```
$ cargo test -p heddle-semantic
...
test result: ok. 193 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.22s
```

```
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 21s
```

```
$ bash scripts/check-no-silent-default-tree-load.sh
ok: exempt: crates/mount/src/core.rs:2193 — silent-default tree load (heddle#90/#93 bug class)
asserter clean: no silent-default tree load sites in production code (494 file(s) scanned)
```

## Manual verification
N/A — pure refactor covered by the existing semantic test suite (193 tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782092529&installation_id=132405951&pr_number=194&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F194&signature=6de7c7babc98335c6c03c6ca11ffbe4394f4827693a64d4c8156f0e689096dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->