### PR TITLE
heddle#186: rename simple_item -> leaf_item in merge_driver/items.rs

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -392,8 +392,8 @@ fn classify_rust_node<'a>(
                 extra_scope: Vec::new(),
             })
         }
-        "struct_item" => simple_item(source, node, "name", ItemKind::Struct),
-        "enum_item" => simple_item(source, node, "name", ItemKind::Enum),
+        "struct_item" => leaf_item(ItemKind::Struct, source, node, "name"),
+        "enum_item" => leaf_item(ItemKind::Enum, source, node, "name"),
         "trait_item" => {
             let name = name_from_field(source, node, "name")?;
             let container_body = node.child_by_field_name("body");
@@ -405,10 +405,10 @@ fn classify_rust_node<'a>(
                 extra_scope: Vec::new(),
             })
         }
-        "union_item" => simple_item(source, node, "name", ItemKind::Struct),
-        "type_item" => simple_item(source, node, "name", ItemKind::TypeAlias),
-        "const_item" => simple_item(source, node, "name", ItemKind::Const),
-        "static_item" => simple_item(source, node, "name", ItemKind::Static),
+        "union_item" => leaf_item(ItemKind::Struct, source, node, "name"),
+        "type_item" => leaf_item(ItemKind::TypeAlias, source, node, "name"),
+        "const_item" => leaf_item(ItemKind::Const, source, node, "name"),
+        "static_item" => leaf_item(ItemKind::Static, source, node, "name"),
         _ => None,
     }
 }
@@ -721,11 +721,20 @@ fn classify_java_node<'a>(
     }
 }
 
-fn simple_item<'a>(
+/// Classify a leaf item (no container body, no parameter signature, no extra
+/// scope) — the shared shape of Rust `struct` / `enum` / `union` / `type` /
+/// `const` / `static`. `name_field` names the tree-sitter field carrying the
+/// declared name.
+///
+/// Note: source is `&str` and the return type is `Classified` (not `&[u8]` /
+/// `ItemClassification` as the audit prototype sketched) — those are the
+/// names the rest of this module uses, and changing them would ripple far
+/// outside the leaf-classifier consolidation this helper is meant to do.
+fn leaf_item<'a>(
+    kind: ItemKind,
     source: &'a str,
     node: Node<'a>,
     name_field: &str,
-    kind: ItemKind,
 ) -> Option<Classified<'a>> {
     let name = name_from_field(source, node, name_field)?;
     Some(Classified {


### PR DESCRIPTION
## Summary

Tactical Win #2 from heddle#133 audit. The 6 Rust leaf classifiers in
`crates/semantic/src/merge_driver/items.rs` (`struct_item`, `enum_item`,
`union_item`, `type_item`, `const_item`, `static_item`) were already
routed through a shared `simple_item` helper. This PR finishes the
audit's polish:

- Renames `simple_item` → `leaf_item`, putting `kind` first to match the
  audit's prototype signature.
- Updates the 6 call sites accordingly (all remain one-liners).
- Adds a doc comment on the helper.

## Functions consolidated (all 6, none divergent)

| Site | Args |
|---|---|
| `struct_item` | `leaf_item(ItemKind::Struct, source, node, "name")` |
| `enum_item` | `leaf_item(ItemKind::Enum, source, node, "name")` |
| `union_item` | `leaf_item(ItemKind::Struct, source, node, "name")` |
| `type_item` | `leaf_item(ItemKind::TypeAlias, source, node, "name")` |
| `const_item` | `leaf_item(ItemKind::Const, source, node, "name")` |
| `static_item` | `leaf_item(ItemKind::Static, source, node, "name")` |

No divergent cases — every leaf fits the helper cleanly.

## Deviation from the AC's signature sketch

The AC sketched `fn leaf_item(kind: ItemKind, source: &[u8], node: Node, name_field: &str) -> Option<ItemClassification>`. I kept `source: &'a str` and `Option<Classified<'a>>` because those are the actual types used throughout `items.rs` — flipping the source representation to bytes or renaming `Classified` to `ItemClassification` would have rippled across the whole module, well outside the leaf-classifier consolidation this issue covers. Documented inline on the helper.

## Test plan

- [x] `cargo test -p heddle-semantic` — 194 passed, 0 failed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-no-silent-default-tree-load.sh` — clean.
- [x] Zero behavioral change: rename + arg-reorder only.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782094403&installation_id=132405951&pr_number=195&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F195&signature=c5b23fd1131fbf1097e4b61c82d3a9cc32c211c195172ff22462381b5edd0936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->