### PR TITLE
heddle#188: unify c_function_name + c_function_scope via walk_c_declarator

### DIFF
--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -802,23 +802,65 @@ impl LanguageRules for CppRules {
     }
 }
 
-/// Resolve the actual function name from a C/C++ `function_declarator`.
-/// `identifier_in_subtree` over the declarator subtree picks up the
-/// FIRST matching identifier in DFS order — for a templated qualified
-/// name like `Foo<U>::bar()` the scope's inner `type_identifier`
-/// ("Foo") wins and all methods on the same scope collide on
-/// name="Foo" (Codex r5 P1 #2).
+/// Event surfaced by [`walk_c_declarator`] for each node along the
+/// C/C++ declarator chain that carries function-identity signal. The
+/// walker hides the chain mechanics (pointer / reference /
+/// parenthesized / nested `function_declarator` wrappers, descent
+/// through `qualified_identifier.name` and `template_function.name`)
+/// and emits only the structural events consumers act on: scope
+/// components and the terminal name leaf.
+enum DeclaratorEvent<'a> {
+    /// A `qualified_identifier`'s `scope` sub-node — one component of
+    /// the qualified-name chain. Emitted outermost-first as the walker
+    /// descends through nested qualifications.
+    Scope(Node<'a>),
+    /// The identifier-ish leaf at the bottom of the declarator chain
+    /// — the function's plain name (`identifier`, `field_identifier`,
+    /// `type_identifier`, `property_identifier`, `operator_name`, or
+    /// `destructor_name`). Always the last event emitted on a given
+    /// walk.
+    Name(Node<'a>),
+}
+
+/// Walk a C/C++ `function_declarator`'s declarator chain and invoke
+/// `callback` for each structural event affecting function identity.
 ///
-/// Instead, walk the declarator's `declarator` field, stripping layers
-/// (`pointer_declarator`, `reference_declarator`, nested
-/// `function_declarator`) and recursing into `qualified_identifier`'s
-/// `name` field until a plain identifier-ish leaf is reached. That
-/// yields the actual method name regardless of how complex the scope
-/// prefix is (`Foo::Bar::baz` → "baz"; `Foo<U>::bar` → "bar";
-/// `ns::operator+` → "operator+"; `Foo::~Foo` → "~Foo").
-fn c_function_name(source: &str, function_declarator: Node<'_>) -> Option<String> {
-    let mut current = function_declarator.child_by_field_name("declarator")?;
-    // Cap traversal so a pathological wrapper chain doesn't loop.
+/// Centralises the chain-traversal rules that
+/// [`c_function_name`] and [`c_function_scope`] previously duplicated.
+/// The two consumers had to keep their `match` arms in lockstep — the
+/// r11 finding on PR #114 was exactly a `template_function` arm
+/// present on the name side but forgotten on the scope side — so the
+/// walker turns that mirror-or-diverge tax into symmetry by
+/// construction.
+///
+/// Traversal rules:
+/// * `pointer_declarator`, `reference_declarator`,
+///   `parenthesized_declarator`, and nested `function_declarator`
+///   wrappers are stripped via their `declarator` field. No event.
+/// * `qualified_identifier` emits a [`DeclaratorEvent::Scope`] for its
+///   `scope` field (when present) and descends into its `name` field.
+/// * `template_function` emits nothing of its own and descends into
+///   its `name` field. The grammar can place a `qualified_identifier`
+///   underneath `template_function.name` in some shapes, so descending
+///   here is required to surface nested qualification (Codex r10 P2,
+///   cid 3256487046).
+/// * An identifier-ish leaf (`identifier`, `field_identifier`,
+///   `type_identifier`, `property_identifier`, `operator_name`,
+///   `destructor_name`) emits a single [`DeclaratorEvent::Name`] and
+///   terminates the walk.
+///
+/// Bounded at [`WALK_LIMIT`] iterations so a pathological declarator
+/// chain cannot loop. Any unrecognised node kind, missing required
+/// field, or walk-limit exhaustion ends the walk silently without
+/// emitting a Name event — matching the legacy behaviour of returning
+/// `None`/`Vec::new()` on those conditions.
+fn walk_c_declarator<'tree, F>(function_declarator: Node<'tree>, mut callback: F)
+where
+    F: FnMut(DeclaratorEvent<'tree>),
+{
+    let Some(mut current) = function_declarator.child_by_field_name("declarator") else {
+        return;
+    };
     for _ in 0..WALK_LIMIT {
         match current.kind() {
             "identifier"
@@ -827,25 +869,61 @@ fn c_function_name(source: &str, function_declarator: Node<'_>) -> Option<String
             | "property_identifier"
             | "operator_name"
             | "destructor_name" => {
-                return Some(source[current.byte_range()].to_string());
+                callback(DeclaratorEvent::Name(current));
+                return;
             }
-            // Scope-qualified names: descend to the name field so the
-            // scope's identifier never wins.
-            "qualified_identifier" | "template_function" => {
-                current = current.child_by_field_name("name")?;
+            "qualified_identifier" => {
+                if let Some(scope_node) = current.child_by_field_name("scope") {
+                    callback(DeclaratorEvent::Scope(scope_node));
+                }
+                let Some(next) = current.child_by_field_name("name") else {
+                    return;
+                };
+                current = next;
             }
-            // Wrappers that don't bear the name themselves; the name
-            // sits one level deeper in `declarator`.
+            "template_function" => {
+                let Some(next) = current.child_by_field_name("name") else {
+                    return;
+                };
+                current = next;
+            }
             "pointer_declarator"
             | "reference_declarator"
             | "function_declarator"
             | "parenthesized_declarator" => {
-                current = current.child_by_field_name("declarator")?;
+                let Some(next) = current.child_by_field_name("declarator") else {
+                    return;
+                };
+                current = next;
             }
-            _ => return None,
+            _ => return,
         }
     }
-    None
+}
+
+/// Resolve the actual function name from a C/C++ `function_declarator`
+/// by running [`walk_c_declarator`] and capturing the terminal
+/// [`DeclaratorEvent::Name`]. The walker owns the chain mechanics —
+/// wrapper stripping and descent through `qualified_identifier` /
+/// `template_function` — so this consumer only converts the leaf node
+/// to a `String`.
+///
+/// Returning the FIRST identifier-ish leaf reached (rather than e.g.
+/// `identifier_in_subtree`'s DFS-first match over the whole declarator
+/// subtree) avoids the hazard where, for a templated qualified name
+/// like `Foo<U>::bar()`, the scope's inner `type_identifier` ("Foo")
+/// wins and collapses all methods on the same scope onto `name="Foo"`
+/// (Codex r5 P1 #2). The walker yields names regardless of how complex
+/// the scope prefix is (`Foo::Bar::baz` → "baz"; `Foo<U>::bar` →
+/// "bar"; `ns::operator+` → "operator+"; `Foo::~Foo` → "~Foo").
+fn c_function_name(source: &str, function_declarator: Node<'_>) -> Option<String> {
+    let mut name = None;
+    walk_c_declarator(function_declarator, |event| {
+        if let DeclaratorEvent::Name(node) = event {
+            name = Some(source[node.byte_range()].to_string());
+        }
+    });
+    name
 }
 
 /// Extract the qualified scope chain from a C/C++ `function_declarator`,
@@ -877,13 +955,16 @@ fn c_function_name(source: &str, function_declarator: Node<'_>) -> Option<String
 ///     `["A<T*>"]` distinct from `template<class T> void A<T&>::foo()`'s
 ///     `["A<T&>"]` (Codex r11 P1 #3, cid 3256623807).
 ///
-/// The walk mirrors `c_function_name`: strip pointer/reference/
-/// parenthesized wrappers via the `declarator` field, and at each
-/// `qualified_identifier` record its `scope` field and descend into
-/// its `name` field. `template_function` doesn't bear scope but its
-/// `name` field can be a qualified_identifier in some grammar shapes —
-/// descend through it (parity with `c_function_name`) so we never miss
-/// nested qualification (Codex r10 P2, cid 3256487046).
+/// Traversal is shared with [`c_function_name`] via
+/// [`walk_c_declarator`]: pointer / reference / parenthesized / nested
+/// `function_declarator` wrappers are stripped, `template_function` is
+/// descended through its `name` field (the walker may surface a
+/// `qualified_identifier` underneath — Codex r10 P2, cid 3256487046),
+/// and each `qualified_identifier`'s `scope` sub-node is surfaced as a
+/// [`DeclaratorEvent::Scope`] for this consumer to collect. Sharing
+/// the walker eliminates the "forgot to mirror `template_function`"
+/// class of bug that previously required this function and
+/// [`c_function_name`] to be kept in lockstep (Codex r11 finding).
 fn c_function_scope(
     source: &str,
     function_definition: Node<'_>,
@@ -891,38 +972,11 @@ fn c_function_scope(
 ) -> Vec<String> {
     let mut scope = Vec::new();
     let param_lists = enclosing_template_param_lists(function_definition, source);
-    let Some(mut current) = function_declarator.child_by_field_name("declarator") else {
-        return scope;
-    };
-    for _ in 0..WALK_LIMIT {
-        match current.kind() {
-            "qualified_identifier" => {
-                if let Some(s) = current.child_by_field_name("scope") {
-                    scope.push(scope_component_text(source, s, &param_lists));
-                }
-                let Some(next) = current.child_by_field_name("name") else {
-                    return scope;
-                };
-                current = next;
-            }
-            "template_function" => {
-                let Some(next) = current.child_by_field_name("name") else {
-                    return scope;
-                };
-                current = next;
-            }
-            "pointer_declarator"
-            | "reference_declarator"
-            | "function_declarator"
-            | "parenthesized_declarator" => {
-                let Some(next) = current.child_by_field_name("declarator") else {
-                    return scope;
-                };
-                current = next;
-            }
-            _ => return scope,
+    walk_c_declarator(function_declarator, |event| {
+        if let DeclaratorEvent::Scope(node) = event {
+            scope.push(scope_component_text(source, node, &param_lists));
         }
-    }
+    });
     scope
 }
 


### PR DESCRIPTION
## Summary

- Introduce `walk_c_declarator`, a single callback-based traversal over the C/C++ declarator chain in `CppRules`. Wrapper stripping (`pointer_declarator`, `reference_declarator`, `parenthesized_declarator`, nested `function_declarator`), `qualified_identifier` descent through `.name`, and `template_function` descent through `.name` now live in exactly one function.
- Rewrite `c_function_name` and `c_function_scope` as consumers that match on a `DeclaratorEvent` enum (`Scope(Node)` outermost-first, terminal `Name(Node)`). Neither consumer touches the declarator chain directly anymore.
- Zero behavioural change: all 208 `--features extended-languages` lib tests and all 204 default-features lib tests pass unchanged, including the 15 `cpp_*` overload-identity tests.
- C++ scope walker stays inside `CppRules` / `language_rules.rs` per the audit's biggest-risk guard (HeddleCo/heddle#133) — no lift into the `LanguageRules` trait or `super::items`.

Closes HeddleCo/heddle#188

## Motivation

Tactical Win #4 from the heddle#133 audit cluster. The Codex r11 finding on PR #114 (at the pre-#196 `items.rs:1123`) was exactly *"you forgot to mirror `template_function` handling between the two."* The two functions walked the same declarator chain via parallel `match` arms, so any change to one had to be mirrored to the other or the keys diverged. Unifying the walk eliminates the mirror-or-diverge tax by construction — the `template_function` arm now exists in `walk_c_declarator` only, and the same arm services both consumers.

## Where the code lives post-#196

PR #196 (heddle#184) moved the C/C++ machinery from `crates/semantic/src/merge_driver/items.rs` into `CppRules` in `crates/semantic/src/merge_driver/language_rules.rs`. Both consumers and the new walker now sit in that file:

| Symbol | Location |
|---|---|
| `walk_c_declarator` | `crates/semantic/src/merge_driver/language_rules.rs:857` |
| `DeclaratorEvent` enum | `crates/semantic/src/merge_driver/language_rules.rs:805` |
| `c_function_name` (consumer) | `crates/semantic/src/merge_driver/language_rules.rs:919` |
| `c_function_scope` (consumer) | `crates/semantic/src/merge_driver/language_rules.rs:968` |

Pre-#196 locations referenced by the original issue body: `items.rs:1019-1049` (`c_function_name`) and `items.rs:1087-1127` (`c_function_scope`); r11 finding at `items.rs:1123`. Those line numbers are stale — the functions migrated as a unit when heddle#184 extracted `CppRules`.

## Behavioural equivalence

The walker preserves the exact traversal contract of the prior implementations:

- Starts at `function_declarator.child_by_field_name("declarator")`; absent → walk yields no events. (Old: name returns `None`, scope returns `Vec::new()`.)
- Each `qualified_identifier`: emits `Scope(scope_field_node)` if the scope field is present, then descends `.name`. (Old: scope pushed before descent on scope side; no-op on name side. Same order.)
- Each `template_function`: descends `.name` with no event. (Old: same in both consumers — exactly the symmetry the r11 finding caught when it was forgotten.)
- Each wrapper (`pointer_declarator` / `reference_declarator` / `parenthesized_declarator` / nested `function_declarator`): descends `.declarator` with no event.
- Identifier-ish leaf (`identifier`, `field_identifier`, `type_identifier`, `property_identifier`, `operator_name`, `destructor_name`): emits `Name(leaf)` and terminates.
- Missing required field, unrecognised kind, or `WALK_LIMIT` exhaustion: terminates silently, no Name event. (Old: same on both sides.)

`c_function_name` collects the first `Name` event into a `String`; `c_function_scope` collects each `Scope` event via `scope_component_text(source, node, &param_lists)`. Neither consumer reaches into the chain itself — the callback signature surfaces nodes, not pre-computed strings, so the scope consumer can keep its parameter-list-stripping logic local.

## Self-audit

- `template_function` as a code arm appears in exactly one function in this diff: `walk_c_declarator`. (Pre-existing `c_name_bearing_function_declarator` — used by the signature-hash path, not the name/scope path — also still references it, but is untouched by this PR.)
- Both consumers use the callback exclusively; no direct `child_by_field_name(\"declarator\")` / `.kind() match` chains remain in either body.
- Callback shape: `FnMut(DeclaratorEvent<'tree>)`. `c_function_name` builds an `Option<String>`; `c_function_scope` builds a `Vec<String>`. No state hacks — both consumers just match the variant they care about and collect.
- C++ scope walker stayed in `CppRules`. The module's discipline-guard comment forbidding generalisation into the `LanguageRules` trait or `super::items` is preserved unchanged.

## Test evidence

Extended-languages (C/C++ enabled — covers all `cpp_*` tests):

```
$ cargo test --locked -p heddle-semantic --features extended-languages --lib
running 209 tests
test result: ok. 208 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.11s
```

C++ overload-identity slice (the regression guard that pins the contract — every test below exercises a code path that goes through the unified walker):

```
$ cargo test --locked -p heddle-semantic --features extended-languages --lib cpp_
running 15 tests
test merge_driver::tests::cpp_const_qualified_overload_distinct_from_unqualified ... ok
test merge_driver::tests::cpp_noexcept_addition_does_not_split_function_identity ... ok
test merge_driver::tests::cpp_inline_same_named_methods_in_different_classes_keep_distinct_identities ... ok
test merge_driver::language_rules::tests::cpp_leading_metadata_is_empty ... ok
test merge_driver::tests::cpp_explicit_specializations_keep_distinct_scopes_under_reorder ... ok
test merge_driver::tests::cpp_pointer_overload_distinct_from_value_overload ... ok
test merge_driver::tests::cpp_template_method_refactor_inline_to_out_of_class_merges_cleanly ... ok
test merge_driver::tests::cpp_overloads_with_function_pointer_in_scope_template_arg_stay_distinct ... ok
test merge_driver::tests::cpp_noexcept_clause_with_param_name_survives_pure_rename ... ok
test merge_driver::tests::cpp_same_named_methods_in_different_classes_keep_distinct_identities ... ok
test merge_driver::tests::cpp_partial_specializations_keep_distinct_scopes_under_reorder ... ok
test merge_driver::tests::cpp_template_template_param_method_refactor_inline_to_out_of_class_merges_cleanly ... ok
test parser::parser_tests::test_cpp_templated_qualified_function_names ... ok
test merge_driver::tests::cpp_variadic_template_method_refactor_inline_to_out_of_class_merges_cleanly ... ok
test merge_driver::tests::cpp_templated_out_of_class_methods_keyed_by_their_own_name_not_template_scope ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 194 filtered out; finished in 0.00s
```

The `template_function`-sensitive tests in particular — `cpp_template_method_refactor_inline_to_out_of_class_merges_cleanly`, `cpp_variadic_template_method_refactor_inline_to_out_of_class_merges_cleanly`, `cpp_template_template_param_method_refactor_inline_to_out_of_class_merges_cleanly`, `cpp_explicit_specializations_keep_distinct_scopes_under_reorder`, `cpp_partial_specializations_keep_distinct_scopes_under_reorder` — exercise the exact `template_function`-descent path that the r11 finding originally caught as asymmetric. They pin the symmetric behaviour the unified walker provides by construction.

Default-features (matches CI's `cargo test --locked --workspace` for this crate):

```
$ cargo test --locked -p heddle-semantic --lib
running 205 tests
test result: ok. 204 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.13s
```

Clippy clean (`cargo clippy --locked --workspace --all-targets -- -D warnings`); silent-default-tree-load asserter clean (`bash scripts/check-no-silent-default-tree-load.sh`).

## Manual verification

N/A — covered by the existing C++ overload-identity test suite. The refactor adds no new production behaviour; the walker is a structural reorganisation that preserves every transition of the prior `match` arms.

## Reference

- HeddleCo/heddle#133 — audit + Tactical Win #4 description.
- HeddleCo/heddle#184 (PR #196) — extracted `CppRules`; this PR finishes the deferred TW4 inside `CppRules`.
- PR #114 r11 finding (`items.rs:1123` in pre-#196 numbering) — the mirror-or-diverge bug this unification prevents permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782097418&installation_id=132405951&pr_number=197&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F197&signature=30f71c03290a820a5061b7844cc9eff08ff78da1e35d25dddfaebdeab3a6dccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->