### PR TITLE
heddle#214: add MintAnonBiscuit RPC + heddle-grpc 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 heddle-client = { path = "../client", version = "0.2", optional = true }
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -48,7 +48,7 @@ walkdir.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 fs2.workspace = true
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.4" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -139,6 +139,20 @@ service AuthService {
   // minutes — and revoking the parent session kills it via cascade
   // rev-id rejection.
   rpc IssuePresenceToken(IssuePresenceTokenRequest) returns (IssuePresenceTokenResponse);
+
+  // Mint a fresh anonymous Biscuit for a browser that has no
+  // session cookie yet. Unauthenticated — the response IS the
+  // identity. The returned biscuit carries `subject_kind("anon")`
+  // and a fresh `Anon(uuid)` subject; tapestry base64-encodes the
+  // bytes and emits `Set-Cookie: weft_auth=<…>; HttpOnly; Secure;
+  // SameSite=Lax`. Subsequent calls from the same browser ride on
+  // this biscuit as a normal bearer; later sign-in is an
+  // anon→user promotion (mint a new user-subject biscuit, revoke
+  // the anon rev_id). Per-IP rate-limited; when
+  // `WEFT_MINT_TURNSTILE_REQUIRED=true`, requires a valid
+  // Turnstile token. See HeddleCo/weft#189 and
+  // `docs/auth/anon-biscuit-spike.md` §3 + §7.1.
+  rpc MintAnonBiscuit(MintAnonBiscuitRequest) returns (MintAnonBiscuitResponse);
 }
 
 service ContentService {
@@ -1078,6 +1092,32 @@ message DeviceAuthProof {
   // device's private key. Replaces the old proof field on
   // `ExchangeDeviceAuthorizationRequest`.
   bytes signature = 3;
+}
+
+// Mint a fresh anonymous Biscuit. Unauthenticated; per-IP
+// rate-limited server-side (see `docs/auth/anon-biscuit-spike.md`
+// §7.1: 10/hour/IP). When `WEFT_MINT_TURNSTILE_REQUIRED=true` on
+// the server, `turnstile_token` MUST be a valid Cloudflare
+// Turnstile token; otherwise the field is ignored. See
+// HeddleCo/weft#189 and HeddleCo/weft#192.
+message MintAnonBiscuitRequest {
+  // Cloudflare Turnstile token captured by the caller's frontend.
+  // Required when the server has `WEFT_MINT_TURNSTILE_REQUIRED=true`
+  // (operator-flippable break-glass under coordinated abuse). Empty
+  // / omitted when the flag is off.
+  optional string turnstile_token = 1;
+}
+
+message MintAnonBiscuitResponse {
+  // Raw biscuit bytes carrying `subject_kind("anon")` + a fresh
+  // `Anon(uuid)` subject. The caller (tapestry's worker) base64-
+  // encodes these for the `weft_auth` cookie value. See
+  // `docs/auth/anon-biscuit-spike.md` §3.3 for the cookie shape.
+  bytes biscuit = 1;
+  // Hard expiry the biscuit was minted with. Same value as the
+  // biscuit's internal `expires_at` fact; surfaced so callers can
+  // set `Max-Age` on the cookie without parsing the token.
+  google.protobuf.Timestamp expires_at = 2;
 }
 
 message IssuedCredentialResponse {


### PR DESCRIPTION
## Summary

Cross-repo proto evolution to unblock **HeddleCo/weft#192** (anon-biscuit substrate). Adds the unauthenticated `MintAnonBiscuit` RPC tapestry's worker calls on first browser touch to obtain the anon biscuit cookie value.

Pattern mirrors heddle#183 / PR #192 (the prior `grant_envelope` + `device_public_key` evolution): proto edit + MAJOR version bump + path-dep consumer pins. Same shape, smaller scope.

## Proto diff

Added to `AuthService` (in `crates/grpc/proto/heddle/v1/service.proto`):

```proto
rpc MintAnonBiscuit(MintAnonBiscuitRequest) returns (MintAnonBiscuitResponse);

message MintAnonBiscuitRequest {
  // Required only when WEFT_MINT_TURNSTILE_REQUIRED=true on the server.
  optional string turnstile_token = 1;
}

message MintAnonBiscuitResponse {
  bytes biscuit = 1;                           // raw bytes; tapestry b64-encodes for the cookie
  google.protobuf.Timestamp expires_at = 2;    // for setting cookie Max-Age without parsing the token
}
```

Shape derived from `weft/docs/auth/anon-biscuit-spike.md` §3 (subject + biscuit shape) + §7.1 / §7.2 (per-IP rate-limit + Turnstile break-glass).

## Version bump

- `crates/grpc/Cargo.toml`: `0.4.0` → `0.5.0` (MAJOR — Rust type surface change; proto3 added-field semantics keep the wire change non-breaking for old clients).
- `crates/cli/Cargo.toml`, `crates/client/Cargo.toml`, `crates/daemon/Cargo.toml`: heddle-grpc pin `0.4` → `0.5`.

`cargo tree --workspace -i heddle-grpc` confirms no `0.4`-pinned consumers remain.

## CHANGELOG

No `crates/grpc/CHANGELOG.md` exists in this repo (prior bump didn't create one either); matching prevailing convention.

## Auto-publish

Release ships automatically via the existing `.github/workflows/publish-crates.yml` on merge to main. Workflow not modified.

## Unblocks

- HeddleCo/weft#192 — server-side `MintAnonBiscuit` handler + browser-held biscuit substrate cutover.

## Test plan

- [x] `cargo build -p heddle-grpc` — green
- [x] `cargo test --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-no-silent-default-tree-load.sh` — clean
- [x] `cargo tree --workspace -i heddle-grpc` confirms only `0.5.0` consumers

Closes #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782174479&installation_id=132405951&pr_number=215&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F215&signature=34ab46ddefa4fae07f71455d3337f93e04d2c959af90efad528c231856d37faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->