### PR TITLE
heddle#208: type-state substrate for Pending (Lifecycle ZSTs + Witness/KernelForgetWitness)

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -420,7 +420,8 @@ pub(crate) enum NodeState {
 /// (Bug Class A in the spike doc §4) that produced every Codex
 /// finding r6 → r9 on PR #182.
 #[derive(Default)]
-pub(crate) struct Pending {
+#[doc(hidden)]
+pub struct Pending {
     /// Hot tier: per-`NodeId` open-file buffers.
     hot: BTreeMap<u64, HotBuffer>,
     /// Reverse-index for the hot tier: which NodeId currently owns a

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -579,12 +579,15 @@ pub(crate) struct MountInner {
     // Storage carries `Pending<'static>` as the long-lived shape;
     // every actual witness-minting access goes through
     // [`Pending::with_brand`], which re-borrows under a fresh
-    // invariant `'brand` introduced by HRTB. The `'static` slot is
-    // never exposed as a witness brand — `with_brand` is the only
-    // entry point that mints `Witness`/`KernelForgetWitness`, and
-    // its HRTB closure makes the inner brand opaque so witnesses
-    // from one access cannot leak to another (Codex PR #217 r2
-    // finding `3293832936`).
+    // invariant `'brand` introduced by HRTB and hands the closure a
+    // [`crate::pending::BrandedPending<'_, 'brand>`]. The `'static`
+    // slot can never be exposed as a witness brand because
+    // `Pending<'brand>` carries no witness constructors at all — the
+    // `witness_*` methods live on [`crate::pending::BrandedPending`],
+    // whose private field makes it unconstructible outside
+    // `with_brand`'s body. This closes the structural gap Codex
+    // flagged in r2 (`3293832936`) and the r3 follow-on
+    // (`3293898540`).
     pending: Mutex<Pending<'static>>,
     promotion: RwLock<PromotionPolicy>,
     mounted_at: SystemTime,

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -392,7 +392,7 @@ struct PendingEntry {
 /// pair with one map and forcing every callback that branches on
 /// lifecycle to `match`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum NodeState {
+pub(crate) enum NodeState {
     /// Live: the inode owns a binding in `inodes.by_path`. The
     /// refcount tracks how many FUSE `open` / `create` callbacks
     /// have minted handles to it; `release` drives it back down.
@@ -420,7 +420,7 @@ enum NodeState {
 /// (Bug Class A in the spike doc §4) that produced every Codex
 /// finding r6 → r9 on PR #182.
 #[derive(Default)]
-struct Pending {
+pub(crate) struct Pending {
     /// Hot tier: per-`NodeId` open-file buffers.
     hot: BTreeMap<u64, HotBuffer>,
     /// Reverse-index for the hot tier: which NodeId currently owns a
@@ -485,6 +485,26 @@ impl Pending {
             Some(NodeState::Live { open_count } | NodeState::Orphan { open_count }) => *open_count,
             None => 0,
         }
+    }
+
+    /// Read-only access to the per-NodeId lifecycle entry. Sole
+    /// reachable point for the [`crate::pending`] witness constructors
+    /// to query the FSM without taking a `pub(crate)` dependency on
+    /// the underlying `state` field. Returning `Option<NodeState>` by
+    /// value keeps the field private to this module — callers cannot
+    /// mutate state through this handle.
+    pub(crate) fn lookup_state(&self, id: u64) -> Option<NodeState> {
+        self.state.get(&id).copied()
+    }
+
+    /// Test-only: insert a per-NodeId lifecycle entry directly,
+    /// bypassing the FSM entry points. Used by the
+    /// [`crate::pending`] substrate tests to set up `Pending` states
+    /// without dragging in the full mount lifecycle. Gated behind
+    /// `cfg(test)` so it never reaches a release binary.
+    #[cfg(test)]
+    pub(crate) fn test_insert_state(&mut self, id: u64, state: NodeState) {
+        self.state.insert(id, state);
     }
 }
 

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -421,7 +421,7 @@ pub(crate) enum NodeState {
 /// finding r6 → r9 on PR #182.
 #[derive(Default)]
 #[doc(hidden)]
-pub struct Pending {
+pub struct Pending<'brand> {
     /// Hot tier: per-`NodeId` open-file buffers.
     hot: BTreeMap<u64, HotBuffer>,
     /// Reverse-index for the hot tier: which NodeId currently owns a
@@ -465,9 +465,18 @@ pub struct Pending {
     /// state (Released) — entries are removed on final `release`,
     /// `invalidate`, and `capture`.
     state: BTreeMap<u64, NodeState>,
+    /// Invariant phantom: ties this `Pending` to a unique `'brand`
+    /// introduced by [`Pending::with_brand`]. Witnesses minted under
+    /// one `'brand` cannot be passed to methods on a `Pending`
+    /// carrying a different `'brand` — closes Codex PR #217 r2
+    /// finding `3293832936`. The `fn(&'brand ()) -> &'brand ()`
+    /// shape makes `'brand` invariant (neither covariant nor
+    /// contravariant), so the borrow checker refuses to unify two
+    /// fresh brands handed out by separate `with_brand` calls.
+    _brand: std::marker::PhantomData<fn(&'brand ()) -> &'brand ()>,
 }
 
-impl Pending {
+impl<'brand> Pending<'brand> {
     /// True iff the NodeId is currently Orphan (directory entry gone
     /// but `open_count >= 0` fds still reference the inode). Every
     /// callback that branches on lifecycle goes through this helper
@@ -567,7 +576,16 @@ pub(crate) struct MountInner {
     thread: String,
     state: RwLock<MountState>,
     inodes: Mutex<Inodes>,
-    pending: Mutex<Pending>,
+    // Storage carries `Pending<'static>` as the long-lived shape;
+    // every actual witness-minting access goes through
+    // [`Pending::with_brand`], which re-borrows under a fresh
+    // invariant `'brand` introduced by HRTB. The `'static` slot is
+    // never exposed as a witness brand — `with_brand` is the only
+    // entry point that mints `Witness`/`KernelForgetWitness`, and
+    // its HRTB closure makes the inner brand opaque so witnesses
+    // from one access cannot leak to another (Codex PR #217 r2
+    // finding `3293832936`).
+    pending: Mutex<Pending<'static>>,
     promotion: RwLock<PromotionPolicy>,
     mounted_at: SystemTime,
     /// Write-side serialization. Acquired by structural-mutation

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -159,6 +159,7 @@ mod tests;
 pub mod __pending_substrate_for_doctest {
     pub use crate::core::Pending;
     pub use crate::pending::{
-        KernelForgetWitness, Lifecycle, LiveNonZero, LiveZero, Orphan, Released, Witness,
+        BrandedPending, KernelForgetWitness, Lifecycle, LiveNonZero, LiveZero, Orphan, Released,
+        Witness,
     };
 }

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod cache;
 pub mod core;
 pub mod error;
+mod pending;
 pub mod shell;
 
 #[cfg(all(target_os = "linux", feature = "fuse"))]

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -68,3 +68,52 @@ pub use crate::{
 
 #[cfg(test)]
 mod tests;
+
+/// NOT a stable public API. Re-exports the `pub(crate)` witness
+/// substrate so a `compile_fail` doctest can pin the brand-isolation
+/// invariant for Codex PR #217 r2 (`crates/mount/src/pending.rs`
+/// finding `3293832936`). Hidden from rendered docs; consumers must
+/// not depend on this module.
+///
+/// # Brand isolation (post heddle#208 r2)
+///
+/// The substrate brands `Pending`, `Witness`, and `KernelForgetWitness`
+/// with an invariant `'brand` lifetime that's introduced per call via
+/// [`core::Pending::with_brand`]. Witnesses minted under one `'brand`
+/// cannot be passed to methods on a `Pending` carrying a different
+/// `'brand` — the cross-instance bug Codex flagged on r1 stops
+/// type-checking.
+///
+/// The doctest below is the executable proof. It compiles against
+/// the pre-brand substrate (r1; cross-instance use is allowed —
+/// THE BUG) and fails to compile against the post-brand substrate
+/// (r2; brand mismatch — THE FIX).
+///
+/// ```compile_fail
+/// use mount::__pending_substrate_for_doctest::*;
+/// let mut p1 = Pending::default();
+/// let mut p2 = Pending::default();
+/// p1.with_brand(|p1_branded| {
+///     p2.with_brand(|p2_branded| {
+///         // `w` carries p1_branded's brand. Pre-fix it's
+///         // `Witness<'_, LiveNonZero>` (no brand); post-fix it's
+///         // `Witness<'_, 'brand_of_p1, LiveNonZero>`.
+///         let w = p1_branded
+///             .witness_live_nonzero(0)
+///             .expect("doctest never runs — compile_fail");
+///         // Pre-fix: `discharge_witness` accepts any `Witness<'_, S>`.
+///         //          Compiles → `compile_fail` assertion fails → RED.
+///         // Post-fix: `discharge_witness` on `Pending<'brand_of_p2>`
+///         //           wants `Witness<'_, 'brand_of_p2, S>`. Brand
+///         //           mismatch → fails to compile → assertion holds → GREEN.
+///         let _ = p2_branded.discharge_witness(w);
+///     });
+/// });
+/// ```
+#[doc(hidden)]
+pub mod __pending_substrate_for_doctest {
+    pub use crate::core::Pending;
+    pub use crate::pending::{
+        KernelForgetWitness, Lifecycle, LiveNonZero, LiveZero, Orphan, Released, Witness,
+    };
+}

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -116,6 +116,45 @@ mod tests;
 ///     });
 /// });
 /// ```
+///
+/// # Constructor bypass (post heddle#208 r3)
+///
+/// r2 brand-isolated `Witness` cross-instance use *inside* `with_brand`,
+/// but the `witness_*` constructors were still callable directly on
+/// `&mut Pending<'brand>`. Because `MountInner` stores
+/// `Pending<'static>`, an internal caller could mint
+/// `Witness<..., 'static, _>` without going through `with_brand` at all
+/// — and two distinct `Pending<'static>` values share the `'static`
+/// brand, so witnesses crossed between them (Codex PR #217 r2 finding
+/// `3293898540`).
+///
+/// r3 closes that hole by moving every `witness_*` (and `peek_witness`)
+/// onto a sealed `BrandedPending<'p, 'brand>` wrapper whose only
+/// constructor is `Pending::with_brand`. The doctest below is the
+/// executable proof. It compiles against r2 (constructors live on
+/// `Pending<'brand>`; direct mint succeeds → THE BUG) and fails to
+/// compile against r3 (constructors are unreachable outside
+/// `with_brand` → THE FIX).
+///
+/// ```compile_fail
+/// use mount::__pending_substrate_for_doctest::*;
+/// let mut p1 = Pending::default();
+/// let mut p2 = Pending::default();
+/// // Pre-r3: `Pending::witness_live_nonzero` exists on `Pending<'brand>`
+/// //         so this compiles; `w` ends up `Witness<'_, 'static, _>`.
+/// // Post-r3: `Pending` no longer has any `witness_*` method — this
+/// //         call refers to a non-existent name and fails to compile.
+/// let w = p1
+///     .witness_live_nonzero(0)
+///     .expect("doctest never runs — compile_fail");
+/// // Pre-r3: `Pending::peek_witness` accepts `&Witness<'_, 'static, _>`
+/// //         (both `p2` and `w` carry the `'static` brand). Compiles →
+/// //         the cross-instance bypass exists → `compile_fail`
+/// //         assertion fails → RED.
+/// // Post-r3: even if you somehow had a witness in scope, `peek_witness`
+/// //         is on `BrandedPending` now, so this also fails to compile.
+/// let _ = p2.peek_witness(&w);
+/// ```
 #[doc(hidden)]
 pub mod __pending_substrate_for_doctest {
     pub use crate::core::Pending;

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -101,12 +101,18 @@ mod tests;
 ///         let w = p1_branded
 ///             .witness_live_nonzero(0)
 ///             .expect("doctest never runs — compile_fail");
-///         // Pre-fix: `discharge_witness` accepts any `Witness<'_, S>`.
+///         // Pre-fix: `peek_witness` accepts any `&Witness<'_, S>`.
 ///         //          Compiles → `compile_fail` assertion fails → RED.
-///         // Post-fix: `discharge_witness` on `Pending<'brand_of_p2>`
-///         //           wants `Witness<'_, 'brand_of_p2, S>`. Brand
+///         // Post-fix: `peek_witness` on `Pending<'brand_of_p2>`
+///         //           wants `&Witness<'_, 'brand_of_p2, S>`. Brand
 ///         //           mismatch → fails to compile → assertion holds → GREEN.
-///         let _ = p2_branded.discharge_witness(w);
+///         //
+///         // `peek_witness` takes `&self` + `&Witness` (not consuming)
+///         // so the proof stays orthogonal to the borrow-checker
+///         // constraint introduced by `_borrow: PhantomData<&'p mut ()>`
+///         // on the witness — that's a separate spike-doc question
+///         // the retrofit issues will address, not this PR.
+///         let _ = p2_branded.peek_witness(&w);
 ///     });
 /// });
 /// ```

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Type-state substrate for the [`crate::core::Pending`] write-overlay
+//! FSM (heddle#208 — sub 1 of the heddle#206 retrofit chain).
+//!
+//! Substrate-only — the types and witness constructors land here; the
+//! callsite retrofits that replace the per-method runtime preconditions
+//! with witness-gated signatures land in heddle#209 / #210 / #211 / #212.
+//!
+//! See [`docs/design/mount-pending-api-contracts.md`][doc] §2 for the
+//! design and §3 for how each r11 finding becomes a compile-time error
+//! once the retrofits land.
+//!
+//! [doc]: ../../../../docs/design/mount-pending-api-contracts.md
+
+// Red-commit stub. The substrate types and `Pending::witness_*`
+// constructors land in the green commit; the tests below name the
+// expected API surface so the compile failure pins the contract.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{NodeState, Pending};
+
+    #[test]
+    fn witness_live_nonzero_some_for_live_with_open() {
+        let mut p = Pending::default();
+        p.test_insert_state(7, NodeState::Live { open_count: 1 });
+        let w = p.witness_live_nonzero(7).expect("LiveNonZero witness");
+        assert_eq!(w.id(), 7);
+    }
+
+    #[test]
+    fn witness_live_nonzero_none_for_live_zero() {
+        let mut p = Pending::default();
+        p.test_insert_state(7, NodeState::Live { open_count: 0 });
+        assert!(p.witness_live_nonzero(7).is_none());
+    }
+}

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -62,7 +62,8 @@ mod sealed {
 /// The per-NodeId lifecycle the FSM tracks. Sealed — only the four
 /// ZSTs in this module implement it, and only this module can ever
 /// add more.
-pub(crate) trait Lifecycle: sealed::Sealed {}
+#[doc(hidden)]
+pub trait Lifecycle: sealed::Sealed {}
 
 /// Marker: `Live { open_count >= 1 }`.
 ///
@@ -70,7 +71,8 @@ pub(crate) trait Lifecycle: sealed::Sealed {}
 /// which `transition_to_orphan` is sound (closing the r11 #1 bug
 /// once the retrofit lands).
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct LiveNonZero;
+#[doc(hidden)]
+pub struct LiveNonZero;
 
 /// Marker: `Live { open_count == 0 }`.
 ///
@@ -78,7 +80,8 @@ pub(crate) struct LiveNonZero;
 /// from [`LiveNonZero`] so a method that requires the "has open fds"
 /// invariant can name it at the type level.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct LiveZero;
+#[doc(hidden)]
+pub struct LiveZero;
 
 /// Marker: `Orphan { open_count >= 0 }`.
 ///
@@ -87,7 +90,8 @@ pub(crate) struct LiveZero;
 /// `transition_to_orphan`, the only state from which the open-unlinked
 /// last-close-wins flow runs.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Orphan;
+#[doc(hidden)]
+pub struct Orphan;
 
 /// Marker: entry absent from the `state` map.
 ///
@@ -96,7 +100,8 @@ pub(crate) struct Orphan;
 /// Never stored in the map; the marker exists purely so a
 /// [`Witness<'_, Released>`] can prove the absence at the call site.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Released;
+#[doc(hidden)]
+pub struct Released;
 
 impl sealed::Sealed for LiveNonZero {}
 impl sealed::Sealed for LiveZero {}
@@ -130,7 +135,8 @@ impl Lifecycle for Released {}
 ///
 /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
 #[derive(Debug)]
-pub(crate) struct Witness<'p, S: Lifecycle> {
+#[doc(hidden)]
+pub struct Witness<'p, S: Lifecycle> {
     id: u64,
     _state: PhantomData<S>,
     // Invariance over `'p` + ties the witness to a `&mut Pending`
@@ -160,8 +166,39 @@ impl<'p, S: Lifecycle> Witness<'p, S> {
 
     /// The NodeId the witness is bound to. Retrofitted method bodies
     /// will read this to know which entry of `Pending` to act on.
-    pub(crate) fn id(&self) -> u64 {
+    #[doc(hidden)]
+    pub fn id(&self) -> u64 {
         self.id
+    }
+}
+
+impl Pending {
+    /// Re-borrow `self` for a callback that wants to mint witnesses.
+    ///
+    /// In the red-commit shape this is an identity no-op — it hands
+    /// the caller the same `&mut Pending`. The green commit
+    /// introduces a brand-lifetime parameter on `Pending` and uses
+    /// the HRTB on `f` to issue a fresh, invariant brand per call;
+    /// that's what makes witnesses minted inside non-fungible with
+    /// witnesses from a different `Pending` (the Codex PR #217 r2
+    /// finding). Keeping the shape here in the red commit lets the
+    /// `compile_fail` doctest reference the same call pattern across
+    /// red and green.
+    #[doc(hidden)]
+    pub fn with_brand<R>(&mut self, f: impl FnOnce(&mut Pending) -> R) -> R {
+        f(self)
+    }
+
+    /// Substrate hook for the brand-isolation doctest: takes a
+    /// witness and returns its NodeId without doing anything else.
+    /// Retrofit issues (heddle#209/#210/#211/#212) will replace
+    /// this no-op with the real witness-gated transitions; for the
+    /// substrate PR it exists so the `compile_fail` proof in
+    /// [`crate::__pending_substrate_for_doctest`] can demonstrate
+    /// brand-mismatch rejection.
+    #[doc(hidden)]
+    pub fn discharge_witness<S: Lifecycle>(&mut self, w: Witness<'_, S>) -> u64 {
+        w.id()
     }
 }
 
@@ -182,7 +219,8 @@ impl<'p, S: Lifecycle> Witness<'p, S> {
 ///
 /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
 #[derive(Debug)]
-pub(crate) struct KernelForgetWitness<'p> {
+#[doc(hidden)]
+pub struct KernelForgetWitness<'p> {
     id: u64,
     _borrow: PhantomData<&'p mut ()>,
     _not_send: PhantomData<*const ()>,
@@ -199,7 +237,8 @@ impl<'p> KernelForgetWitness<'p> {
     }
 
     /// The NodeId the witness is bound to.
-    pub(crate) fn id(&self) -> u64 {
+    #[doc(hidden)]
+    pub fn id(&self) -> u64 {
         self.id
     }
 }
@@ -215,7 +254,8 @@ impl Pending {
     /// orphaned by construction.
     ///
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
-    pub(crate) fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, LiveNonZero>> {
+    #[doc(hidden)]
+    pub fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, LiveNonZero>> {
         match self.lookup_state(id) {
             Some(NodeState::Live { open_count }) if open_count >= 1 => Some(Witness::new(id)),
             _ => None,
@@ -225,7 +265,8 @@ impl Pending {
     /// Witness that `id` is in `Live { open_count == 0 }`. Returns
     /// `None` for `Live` with any non-zero refcount, for any `Orphan`,
     /// and for `Released`.
-    pub(crate) fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, LiveZero>> {
+    #[doc(hidden)]
+    pub fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, LiveZero>> {
         match self.lookup_state(id) {
             Some(NodeState::Live { open_count: 0 }) => Some(Witness::new(id)),
             _ => None,
@@ -234,7 +275,8 @@ impl Pending {
 
     /// Witness that `id` is in `Orphan { .. }` (any refcount).
     /// Returns `None` for `Live` (any refcount) and `Released`.
-    pub(crate) fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, Orphan>> {
+    #[doc(hidden)]
+    pub fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, Orphan>> {
         match self.lookup_state(id) {
             Some(NodeState::Orphan { .. }) => Some(Witness::new(id)),
             _ => None,
@@ -246,7 +288,8 @@ impl Pending {
     /// variants. Useful for the "first open" path of the lifecycle
     /// (`record_open` minting a `LiveZero -> LiveNonZero` transition
     /// when there is no prior entry).
-    pub(crate) fn witness_released(&mut self, id: u64) -> Option<Witness<'_, Released>> {
+    #[doc(hidden)]
+    pub fn witness_released(&mut self, id: u64) -> Option<Witness<'_, Released>> {
         match self.lookup_state(id) {
             None => Some(Witness::new(id)),
             _ => None,
@@ -270,7 +313,8 @@ impl Pending {
     /// the retrofit).
     ///
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
-    pub(crate) fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_>> {
+    #[doc(hidden)]
+    pub fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_>> {
         match self.lookup_state(id) {
             None => Some(KernelForgetWitness::new(id)),
             Some(NodeState::Live { open_count: 0 }) => Some(KernelForgetWitness::new(id)),

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -114,7 +114,7 @@ impl Lifecycle for Orphan {}
 impl Lifecycle for Released {}
 
 /// Type-level proof that `id` was in lifecycle state `S` under the
-/// `&mut Pending` borrow `'p` that minted it.
+/// `&mut Pending<'brand>` borrow `'p` that minted it.
 ///
 /// # Invariants
 ///
@@ -128,6 +128,12 @@ impl Lifecycle for Released {}
 ///   exists — closing the "stale witness across a mutation" hole
 ///   spelled out in
 ///   [`docs/design/mount-pending-api-contracts.md`][doc] §2.2.1.
+/// * The lifetime parameter `'brand` ties the witness to the specific
+///   `Pending` instance that minted it. Two `Pending<'brand>` values
+///   handed out by separate [`Pending::with_brand`] calls carry
+///   distinct, invariant brands; a witness from one cannot be passed
+///   to methods on the other (closes Codex PR #217 r2 finding
+///   `3293832936`).
 /// * `S` is invariant via the [`PhantomData<&'p mut ()>`] field — the
 ///   compiler will not silently widen or narrow the state parameter.
 /// * `!Send` and `!Sync` via the raw-pointer marker — the witness is
@@ -136,22 +142,29 @@ impl Lifecycle for Released {}
 /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
 #[derive(Debug)]
 #[doc(hidden)]
-pub struct Witness<'p, S: Lifecycle> {
+pub struct Witness<'p, 'brand, S: Lifecycle> {
     id: u64,
     _state: PhantomData<S>,
     // Invariance over `'p` + ties the witness to a `&mut Pending`
     // borrow. The `&'p mut ()` is for the lifetime relationship; the
-    // borrow extension on `&'p mut Pending -> Witness<'p, _>` is what
-    // makes the borrow checker refuse a concurrent mutable borrow of
-    // `Pending` while the witness is alive.
+    // borrow extension on `&'p mut Pending -> Witness<'p, _, _>` is
+    // what makes the borrow checker refuse a concurrent mutable
+    // borrow of `Pending` while the witness is alive.
     _borrow: PhantomData<&'p mut ()>,
+    // Invariant brand binding the witness to its originating
+    // `Pending<'brand>` instance. `fn(&'brand ()) -> &'brand ()` is
+    // the canonical invariant carrier — neither covariant nor
+    // contravariant. Witnesses minted under one `with_brand` HRTB
+    // closure cannot be passed to a `Pending` with a different
+    // brand, even when both carry the same lifecycle state `S`.
+    _brand: PhantomData<fn(&'brand ()) -> &'brand ()>,
     // `!Send` + `!Sync` marker. The witness is short-lived and tied
     // to one thread of execution by design; cross-thread transfer is
     // never sound.
     _not_send: PhantomData<*const ()>,
 }
 
-impl<'p, S: Lifecycle> Witness<'p, S> {
+impl<'p, 'brand, S: Lifecycle> Witness<'p, 'brand, S> {
     /// Mint a witness. Visible only inside this module — every
     /// witness must come from a `Pending::witness_*` constructor that
     /// performed the FSM check.
@@ -160,6 +173,7 @@ impl<'p, S: Lifecycle> Witness<'p, S> {
             id,
             _state: PhantomData,
             _borrow: PhantomData,
+            _brand: PhantomData,
             _not_send: PhantomData,
         }
     }
@@ -172,32 +186,68 @@ impl<'p, S: Lifecycle> Witness<'p, S> {
     }
 }
 
-impl Pending {
-    /// Re-borrow `self` for a callback that wants to mint witnesses.
+impl<'a> Pending<'a> {
+    /// Re-borrow `self` under a freshly-minted, invariant `'brand`
+    /// lifetime that's unique to this call.
     ///
-    /// In the red-commit shape this is an identity no-op — it hands
-    /// the caller the same `&mut Pending`. The green commit
-    /// introduces a brand-lifetime parameter on `Pending` and uses
-    /// the HRTB on `f` to issue a fresh, invariant brand per call;
-    /// that's what makes witnesses minted inside non-fungible with
-    /// witnesses from a different `Pending` (the Codex PR #217 r2
-    /// finding). Keeping the shape here in the red commit lets the
-    /// `compile_fail` doctest reference the same call pattern across
-    /// red and green.
+    /// The HRTB on `f` (`for<'brand>`) forces the compiler to treat
+    /// the brand as opaque inside the closure. Each call to
+    /// `with_brand` issues a brand that can't unify with any other
+    /// call's brand, even if both originate from the same physical
+    /// `Pending`. Witnesses minted on the inner `&mut Pending<'brand>`
+    /// carry that closure's `'brand` and cannot be passed to a
+    /// `Pending` borrowed under a different `with_brand` invocation
+    /// — closing Codex PR #217 r2 finding `3293832936`.
+    ///
+    /// # Soundness
+    ///
+    /// The transmute changes only the phantom brand lifetime, which
+    /// has no representation in the type's layout (`PhantomData<fn(..)>`
+    /// is zero-sized). All other lifetime + ownership invariants
+    /// transfer verbatim through `mem::transmute_mut`. The HRTB
+    /// bound on `f` prevents the inner brand from escaping the
+    /// closure: any value returned by `f` cannot mention `'brand`
+    /// because there's no fixed `'brand` to mention from outside.
     #[doc(hidden)]
-    pub fn with_brand<R>(&mut self, f: impl FnOnce(&mut Pending) -> R) -> R {
-        f(self)
+    pub fn with_brand<R>(
+        &mut self,
+        f: impl for<'brand> FnOnce(&mut Pending<'brand>) -> R,
+    ) -> R {
+        // SAFETY: `Pending<'a>` and `Pending<'brand>` have identical
+        // layout — `_brand` is `PhantomData<fn(&_ ()) -> &_ ()>`,
+        // which is zero-sized regardless of the brand lifetime, so
+        // only the phantom-only lifetime parameter changes. The
+        // HRTB on `f` ensures the freshly-introduced `'brand`
+        // cannot leak via the return type.
+        let branded: &mut Pending<'_> =
+            unsafe { std::mem::transmute::<&mut Pending<'a>, &mut Pending<'_>>(self) };
+        f(branded)
     }
 
     /// Substrate hook for the brand-isolation doctest: takes a
-    /// witness and returns its NodeId without doing anything else.
-    /// Retrofit issues (heddle#209/#210/#211/#212) will replace
-    /// this no-op with the real witness-gated transitions; for the
-    /// substrate PR it exists so the `compile_fail` proof in
-    /// [`crate::__pending_substrate_for_doctest`] can demonstrate
-    /// brand-mismatch rejection.
+    /// borrowed witness branded to `self`'s `'a` and returns its
+    /// NodeId without doing anything else.
+    ///
+    /// Retrofit issues (heddle#209/#210/#211/#212) will introduce
+    /// the real witness-gated transitions, which need to mutate
+    /// `self` and consume the witness; those signatures live there,
+    /// not here. For the substrate PR we only need a non-consuming
+    /// brand-matching method so the [`crate::__pending_substrate_for_doctest`]
+    /// `compile_fail` proof can demonstrate that a witness minted
+    /// under a different `with_brand` closure fails to type-check
+    /// (the brand lifetimes are invariant and don't unify).
+    ///
+    /// `&self` (not `&mut self`) plus `&Witness` (not `Witness`)
+    /// keeps the proof orthogonal to the separate borrow-checker
+    /// constraint introduced by the witness's `_borrow:
+    /// PhantomData<&'p mut ()>` field — the consume pattern
+    /// `p.transition_to_orphan(w)` that retrofit issues will need
+    /// is a pre-existing substrate design question (the `'p` field
+    /// makes it not compile today; see the spike doc §2.2.1) and
+    /// isn't this PR's scope.
     #[doc(hidden)]
-    pub fn discharge_witness<S: Lifecycle>(&mut self, w: Witness<'_, S>) -> u64 {
+    pub fn peek_witness<S: Lifecycle>(&self, w: &Witness<'_, 'a, S>) -> u64 {
+        let _ = self;
         w.id()
     }
 }
@@ -220,18 +270,24 @@ impl Pending {
 /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
 #[derive(Debug)]
 #[doc(hidden)]
-pub struct KernelForgetWitness<'p> {
+pub struct KernelForgetWitness<'p, 'brand> {
     id: u64,
     _borrow: PhantomData<&'p mut ()>,
+    // Same invariant brand carrier as [`Witness`]. Binds the witness
+    // to the originating `Pending<'brand>` instance so a forget
+    // witness from one mount cannot be discharged against another's
+    // hot-tier buffer (Codex PR #217 r2 finding `3293832936`).
+    _brand: PhantomData<fn(&'brand ()) -> &'brand ()>,
     _not_send: PhantomData<*const ()>,
 }
 
-impl<'p> KernelForgetWitness<'p> {
+impl<'p, 'brand> KernelForgetWitness<'p, 'brand> {
     /// Mint a kernel-forget witness. Visible only inside this module.
     fn new(id: u64) -> Self {
         Self {
             id,
             _borrow: PhantomData,
+            _brand: PhantomData,
             _not_send: PhantomData,
         }
     }
@@ -243,7 +299,7 @@ impl<'p> KernelForgetWitness<'p> {
     }
 }
 
-impl Pending {
+impl<'brand> Pending<'brand> {
     /// Witness that `id` is in `Live { open_count >= 1 }`. Returns
     /// `None` for any other state, including `Live { open_count == 0 }`,
     /// any `Orphan`, and `Released` (no entry). This is the
@@ -255,7 +311,7 @@ impl Pending {
     ///
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
     #[doc(hidden)]
-    pub fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, LiveNonZero>> {
+    pub fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, 'brand, LiveNonZero>> {
         match self.lookup_state(id) {
             Some(NodeState::Live { open_count }) if open_count >= 1 => Some(Witness::new(id)),
             _ => None,
@@ -266,7 +322,7 @@ impl Pending {
     /// `None` for `Live` with any non-zero refcount, for any `Orphan`,
     /// and for `Released`.
     #[doc(hidden)]
-    pub fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, LiveZero>> {
+    pub fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, 'brand, LiveZero>> {
         match self.lookup_state(id) {
             Some(NodeState::Live { open_count: 0 }) => Some(Witness::new(id)),
             _ => None,
@@ -276,7 +332,7 @@ impl Pending {
     /// Witness that `id` is in `Orphan { .. }` (any refcount).
     /// Returns `None` for `Live` (any refcount) and `Released`.
     #[doc(hidden)]
-    pub fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, Orphan>> {
+    pub fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, 'brand, Orphan>> {
         match self.lookup_state(id) {
             Some(NodeState::Orphan { .. }) => Some(Witness::new(id)),
             _ => None,
@@ -289,7 +345,7 @@ impl Pending {
     /// (`record_open` minting a `LiveZero -> LiveNonZero` transition
     /// when there is no prior entry).
     #[doc(hidden)]
-    pub fn witness_released(&mut self, id: u64) -> Option<Witness<'_, Released>> {
+    pub fn witness_released(&mut self, id: u64) -> Option<Witness<'_, 'brand, Released>> {
         match self.lookup_state(id) {
             None => Some(Witness::new(id)),
             _ => None,
@@ -314,7 +370,7 @@ impl Pending {
     ///
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
     #[doc(hidden)]
-    pub fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_>> {
+    pub fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_, 'brand>> {
         match self.lookup_state(id) {
             None => Some(KernelForgetWitness::new(id)),
             Some(NodeState::Live { open_count: 0 }) => Some(KernelForgetWitness::new(id)),
@@ -537,11 +593,11 @@ mod tests {
         struct Invalid;
         impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
 
-        let _ = <Witness<'static, LiveNonZero> as AmbiguousIfSend<_>>::some;
-        let _ = <Witness<'static, LiveZero> as AmbiguousIfSend<_>>::some;
-        let _ = <Witness<'static, Orphan> as AmbiguousIfSend<_>>::some;
-        let _ = <Witness<'static, Released> as AmbiguousIfSend<_>>::some;
-        let _ = <KernelForgetWitness<'static> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, 'static, LiveNonZero> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, 'static, LiveZero> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, 'static, Orphan> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, 'static, Released> as AmbiguousIfSend<_>>::some;
+        let _ = <KernelForgetWitness<'static, 'static> as AmbiguousIfSend<_>>::some;
     };
 
     const _ASSERT_NOT_SYNC: () = {
@@ -553,10 +609,91 @@ mod tests {
         struct Invalid;
         impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
 
-        let _ = <Witness<'static, LiveNonZero> as AmbiguousIfSync<_>>::some;
-        let _ = <Witness<'static, LiveZero> as AmbiguousIfSync<_>>::some;
-        let _ = <Witness<'static, Orphan> as AmbiguousIfSync<_>>::some;
-        let _ = <Witness<'static, Released> as AmbiguousIfSync<_>>::some;
-        let _ = <KernelForgetWitness<'static> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, 'static, LiveNonZero> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, 'static, LiveZero> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, 'static, Orphan> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, 'static, Released> as AmbiguousIfSync<_>>::some;
+        let _ = <KernelForgetWitness<'static, 'static> as AmbiguousIfSync<_>>::some;
     };
+
+    // ------- brand isolation (Codex PR #217 r2) ------------------------------
+
+    /// `with_brand` is the only way to mint a brand-bound witness;
+    /// each invocation introduces a freshly-typed, invariant
+    /// `'brand` lifetime via HRTB. Verify it threads through
+    /// witness construction at the type level — and that
+    /// brand-free data (a `u64` NodeId) can escape the closure
+    /// while a `Witness<'_, 'brand, S>` (carrying `'brand`) cannot.
+    /// The cross-instance brand-rejection invariant itself is
+    /// pinned by the `compile_fail` doctest at
+    /// `crates/mount/src/lib.rs::__pending_substrate_for_doctest`.
+    #[test]
+    fn with_brand_threads_a_fresh_brand_through_witness_construction() {
+        let mut p = Pending::default();
+        p.test_insert_state(7, NodeState::Live { open_count: 1 });
+        let id = p
+            .with_brand(|p| {
+                // `w` is `Witness<'_, 'brand, LiveNonZero>` for the
+                // closure's fresh `'brand`. We extract the brand-free
+                // NodeId and drop `w` — the witness itself cannot
+                // escape because it carries `'brand`.
+                p.witness_live_nonzero(7).map(|w| w.id())
+            })
+            .expect("LiveNonZero witness");
+        assert_eq!(id, 7);
+    }
+
+    /// Two `Pending` values, each accessed under its own
+    /// `with_brand` closure, mint witnesses with brands that don't
+    /// unify. Verify the positive side — each closure round-trips
+    /// its own NodeIds independently — so a future regression that
+    /// accidentally collapses the brand into a shared one (e.g., by
+    /// removing the `PhantomData<fn(&'brand ()) -> &'brand ()>`
+    /// invariance marker) is visible in the lib test output rather
+    /// than only in the doctest.
+    #[test]
+    fn brand_round_trips_independently_across_two_pendings() {
+        let mut p1 = Pending::default();
+        let mut p2 = Pending::default();
+        p1.test_insert_state(11, NodeState::Live { open_count: 2 });
+        p2.test_insert_state(13, NodeState::Live { open_count: 0 });
+
+        let id1 = p1
+            .with_brand(|p| p.witness_live_nonzero(11).map(|w| w.id()))
+            .expect("p1 LiveNonZero witness");
+        let id2 = p2
+            .with_brand(|p| p.witness_live_zero(13).map(|w| w.id()))
+            .expect("p2 LiveZero witness");
+
+        assert_eq!(id1, 11);
+        assert_eq!(id2, 13);
+    }
+
+    /// `peek_witness` is the cross-instance brand-check entry
+    /// point used by the `compile_fail` doctest in
+    /// [`crate::__pending_substrate_for_doctest`]. Cross-instance
+    /// is the *only* shape the substrate proves compile-rejects
+    /// here; the same-instance consume pattern
+    /// (`p.transition_to_orphan(w)`) that retrofit issues
+    /// (heddle#209-#212) want is a separate spike-doc question
+    /// — the witness's `_borrow: PhantomData<&'p mut ()>` field
+    /// already prevents it independent of brand. Verify the
+    /// cross-instance positive path: `peek_witness` on a *third*
+    /// `Pending` (`p_observer`) with a witness from `p_subject`
+    /// type-checks when both share the same `with_brand`-induced
+    /// brand (they don't here, so it can't — the negative shape is
+    /// in the doctest). Use a witness already-discharged via
+    /// `w.id()` to keep the test focused on `with_brand` ergonomics
+    /// rather than the borrow-pattern.
+    #[test]
+    fn with_brand_can_return_unbranded_node_id() {
+        let mut p = Pending::default();
+        p.test_insert_state(17, NodeState::Orphan { open_count: 3 });
+        let extracted: u64 = p.with_brand(|p| {
+            // `u64` is brand-free, so it escapes the closure.
+            // A `Witness<'_, 'brand, Orphan>` could not.
+            p.witness_orphan(17).map(|w| w.id()).unwrap_or(0)
+        });
+        assert_eq!(extracted, 17);
+    }
 }

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -2,24 +2,288 @@
 //! Type-state substrate for the [`crate::core::Pending`] write-overlay
 //! FSM (heddle#208 — sub 1 of the heddle#206 retrofit chain).
 //!
-//! Substrate-only — the types and witness constructors land here; the
-//! callsite retrofits that replace the per-method runtime preconditions
-//! with witness-gated signatures land in heddle#209 / #210 / #211 / #212.
+//! # What this module is
 //!
-//! See [`docs/design/mount-pending-api-contracts.md`][doc] §2 for the
-//! design and §3 for how each r11 finding becomes a compile-time error
-//! once the retrofits land.
+//! A set of zero-sized marker types — one per per-NodeId lifecycle
+//! state — plus two witness structs that, once owned, are proof at the
+//! type level that `Pending` saw that NodeId in that state under the
+//! current `&mut` borrow.
 //!
-//! [doc]: ../../../../docs/design/mount-pending-api-contracts.md
+//! The four lifecycle states match
+//! [`docs/design/mount-posix-semantics.md`][posix] §1:
+//!
+//! * [`LiveNonZero`] — `Live { open_count >= 1 }`. Inode has an active
+//!   binding in the inode map and at least one kernel fd open.
+//! * [`LiveZero`] — `Live { open_count == 0 }`. Inode is still
+//!   resolvable; no open fds.
+//! * [`Orphan`] — directory entry gone (post-unlink / post-rename-over),
+//!   bytes outlive the entry for as long as a kernel fd holds the
+//!   NodeId.
+//! * [`Released`] — entry retired; absence from
+//!   [`crate::core::Pending`]'s `state` map. Never stored in the map —
+//!   the marker exists so a witness can prove "no entry at this id"
+//!   for the `Pending::witness_*` constructors that need it.
+//!
+//! # What this module is **not**
+//!
+//! Substrate-only — the witness-gated method signatures and the
+//! callsite retrofits that fix the four r11 P1 bugs land in the
+//! follow-up issues (heddle#209/#210/#211/#212). Nothing in
+//! [`crate::core`] consumes the substrate in this PR; every existing
+//! method keeps its current signature. The substrate is `pub(crate)`-
+//! visible from `core.rs` but unused there.
+//!
+//! See [`docs/design/mount-pending-api-contracts.md`][doc] §2.2.1 for
+//! the witness-type idiom rationale and §3 for the bug-by-bug
+//! impossibility analysis the retrofits will realise.
+//!
+//! [doc]: ../../../docs/design/mount-pending-api-contracts.md
+//! [posix]: ../../../docs/design/mount-posix-semantics.md
 
-// Red-commit stub. The substrate types and `Pending::witness_*`
-// constructors land in the green commit; the tests below name the
-// expected API surface so the compile failure pins the contract.
+// The substrate is intentionally unused by `core.rs` in this PR — the
+// callsite retrofits that consume it land in heddle#209 / #210 / #211
+// / #212. Test coverage exercises every witness constructor, so the
+// types are not dead, but lints don't see through `#[cfg(test)]`-only
+// use sites.
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+use crate::core::{NodeState, Pending};
+
+/// Crate-private "sealed" trait. Lives in a private inner module so
+/// only this file can implement it for new types; the
+/// [`Lifecycle`] supertrait bound therefore restricts the set of
+/// types that can ever be a lifecycle state to the four named below.
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// The per-NodeId lifecycle the FSM tracks. Sealed — only the four
+/// ZSTs in this module implement it, and only this module can ever
+/// add more.
+pub(crate) trait Lifecycle: sealed::Sealed {}
+
+/// Marker: `Live { open_count >= 1 }`.
+///
+/// At least one kernel fd holds this NodeId. The only state from
+/// which `transition_to_orphan` is sound (closing the r11 #1 bug
+/// once the retrofit lands).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LiveNonZero;
+
+/// Marker: `Live { open_count == 0 }`.
+///
+/// The inode is still resolvable but has no open kernel fds. Distinct
+/// from [`LiveNonZero`] so a method that requires the "has open fds"
+/// invariant can name it at the type level.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LiveZero;
+
+/// Marker: `Orphan { open_count >= 0 }`.
+///
+/// Directory entry gone; bytes outlive it. The reverse of
+/// [`LiveNonZero`] in the transition diagram — the destination of
+/// `transition_to_orphan`, the only state from which the open-unlinked
+/// last-close-wins flow runs.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Orphan;
+
+/// Marker: entry absent from the `state` map.
+///
+/// `Released` is the lifecycle's "no entry here" state — distinct
+/// from [`LiveZero`] (which has an entry with `open_count == 0`).
+/// Never stored in the map; the marker exists purely so a
+/// [`Witness<'_, Released>`] can prove the absence at the call site.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Released;
+
+impl sealed::Sealed for LiveNonZero {}
+impl sealed::Sealed for LiveZero {}
+impl sealed::Sealed for Orphan {}
+impl sealed::Sealed for Released {}
+
+impl Lifecycle for LiveNonZero {}
+impl Lifecycle for LiveZero {}
+impl Lifecycle for Orphan {}
+impl Lifecycle for Released {}
+
+/// Type-level proof that `id` was in lifecycle state `S` under the
+/// `&mut Pending` borrow `'p` that minted it.
+///
+/// # Invariants
+///
+/// * Constructed only by [`Pending::witness_live_nonzero`] /
+///   [`Pending::witness_live_zero`] / [`Pending::witness_orphan`] /
+///   [`Pending::witness_released`], each of which performs the
+///   matching FSM check and returns `Some` iff it holds.
+/// * The lifetime parameter `'p` is the lifetime of the `&mut Pending`
+///   borrow that produced the witness. The borrow checker therefore
+///   forbids any other code from mutating `Pending` while the witness
+///   exists — closing the "stale witness across a mutation" hole
+///   spelled out in
+///   [`docs/design/mount-pending-api-contracts.md`][doc] §2.2.1.
+/// * `S` is invariant via the [`PhantomData<&'p mut ()>`] field — the
+///   compiler will not silently widen or narrow the state parameter.
+/// * `!Send` and `!Sync` via the raw-pointer marker — the witness is
+///   a single-thread, single-borrow token by design.
+///
+/// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+#[derive(Debug)]
+pub(crate) struct Witness<'p, S: Lifecycle> {
+    id: u64,
+    _state: PhantomData<S>,
+    // Invariance over `'p` + ties the witness to a `&mut Pending`
+    // borrow. The `&'p mut ()` is for the lifetime relationship; the
+    // borrow extension on `&'p mut Pending -> Witness<'p, _>` is what
+    // makes the borrow checker refuse a concurrent mutable borrow of
+    // `Pending` while the witness is alive.
+    _borrow: PhantomData<&'p mut ()>,
+    // `!Send` + `!Sync` marker. The witness is short-lived and tied
+    // to one thread of execution by design; cross-thread transfer is
+    // never sound.
+    _not_send: PhantomData<*const ()>,
+}
+
+impl<'p, S: Lifecycle> Witness<'p, S> {
+    /// Mint a witness. Visible only inside this module — every
+    /// witness must come from a `Pending::witness_*` constructor that
+    /// performed the FSM check.
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            _state: PhantomData,
+            _borrow: PhantomData,
+            _not_send: PhantomData,
+        }
+    }
+
+    /// The NodeId the witness is bound to. Retrofitted method bodies
+    /// will read this to know which entry of `Pending` to act on.
+    pub(crate) fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+/// Type-level proof that `id` is in a state where the FUSE forget
+/// callback may safely drop the hot-tier buffer.
+///
+/// Distinct from [`Witness`] because the FUSE forget check has a
+/// different shape than the per-state lifecycle checks — it asserts
+/// "no open kernel handles AND no orphan-pending bytes," not "matches
+/// exactly one of the four [`Lifecycle`] states." See
+/// [`docs/design/mount-pending-api-contracts.md`][doc] §2.3.
+///
+/// # Invariants
+///
+/// * Constructed only by [`Pending::witness_kernel_forget`], whose
+///   body IS the discharge-safety check.
+/// * Lifetime + `!Send` / `!Sync` semantics identical to [`Witness`].
+///
+/// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+#[derive(Debug)]
+pub(crate) struct KernelForgetWitness<'p> {
+    id: u64,
+    _borrow: PhantomData<&'p mut ()>,
+    _not_send: PhantomData<*const ()>,
+}
+
+impl<'p> KernelForgetWitness<'p> {
+    /// Mint a kernel-forget witness. Visible only inside this module.
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            _borrow: PhantomData,
+            _not_send: PhantomData,
+        }
+    }
+
+    /// The NodeId the witness is bound to.
+    pub(crate) fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+impl Pending {
+    /// Witness that `id` is in `Live { open_count >= 1 }`. Returns
+    /// `None` for any other state, including `Live { open_count == 0 }`,
+    /// any `Orphan`, and `Released` (no entry). This is the
+    /// constructor that closes
+    /// [r11 #1][doc] — the
+    /// `transition_to_orphan` retrofit will accept only
+    /// [`Witness<LiveNonZero>`], so a `LiveZero` node cannot be
+    /// orphaned by construction.
+    ///
+    /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+    pub(crate) fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, LiveNonZero>> {
+        match self.lookup_state(id) {
+            Some(NodeState::Live { open_count }) if open_count >= 1 => Some(Witness::new(id)),
+            _ => None,
+        }
+    }
+
+    /// Witness that `id` is in `Live { open_count == 0 }`. Returns
+    /// `None` for `Live` with any non-zero refcount, for any `Orphan`,
+    /// and for `Released`.
+    pub(crate) fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, LiveZero>> {
+        match self.lookup_state(id) {
+            Some(NodeState::Live { open_count: 0 }) => Some(Witness::new(id)),
+            _ => None,
+        }
+    }
+
+    /// Witness that `id` is in `Orphan { .. }` (any refcount).
+    /// Returns `None` for `Live` (any refcount) and `Released`.
+    pub(crate) fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, Orphan>> {
+        match self.lookup_state(id) {
+            Some(NodeState::Orphan { .. }) => Some(Witness::new(id)),
+            _ => None,
+        }
+    }
+
+    /// Witness that `id` is `Released` — i.e. has no entry in the
+    /// `state` map. Returns `None` for any of the three resident
+    /// variants. Useful for the "first open" path of the lifecycle
+    /// (`record_open` minting a `LiveZero -> LiveNonZero` transition
+    /// when there is no prior entry).
+    pub(crate) fn witness_released(&mut self, id: u64) -> Option<Witness<'_, Released>> {
+        match self.lookup_state(id) {
+            None => Some(Witness::new(id)),
+            _ => None,
+        }
+    }
+
+    /// Witness that the kernel `forget` callback may safely drop
+    /// `hot[id]` for this NodeId. Returns `Some` iff one of:
+    ///
+    /// * `Released` (no entry in the `state` map) — nothing referencing
+    ///   the bytes.
+    /// * `Live { open_count == 0 }` — the entry is still resolvable,
+    ///   but no kernel fd holds the bytes; the forget can drop them
+    ///   without racing an open handle.
+    ///
+    /// Returns `None` for `Live { open_count >= 1 }` (open fds still
+    /// hold the bytes) and for any `Orphan` (the open-unlinked POSIX
+    /// flow needs the bytes to live as long as any fd references the
+    /// NodeId — closing
+    /// [r11 #3][doc] under
+    /// the retrofit).
+    ///
+    /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+    pub(crate) fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_>> {
+        match self.lookup_state(id) {
+            None => Some(KernelForgetWitness::new(id)),
+            Some(NodeState::Live { open_count: 0 }) => Some(KernelForgetWitness::new(id)),
+            _ => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{NodeState, Pending};
+
+    // ------- witness_live_nonzero --------------------------------------------
 
     #[test]
     fn witness_live_nonzero_some_for_live_with_open() {
@@ -30,9 +294,225 @@ mod tests {
     }
 
     #[test]
+    fn witness_live_nonzero_some_for_high_refcount() {
+        let mut p = Pending::default();
+        p.test_insert_state(11, NodeState::Live { open_count: u32::MAX });
+        let w = p.witness_live_nonzero(11).expect("LiveNonZero witness");
+        assert_eq!(w.id(), 11);
+    }
+
+    #[test]
     fn witness_live_nonzero_none_for_live_zero() {
         let mut p = Pending::default();
         p.test_insert_state(7, NodeState::Live { open_count: 0 });
         assert!(p.witness_live_nonzero(7).is_none());
     }
+
+    #[test]
+    fn witness_live_nonzero_none_for_orphan() {
+        let mut p = Pending::default();
+        p.test_insert_state(7, NodeState::Orphan { open_count: 3 });
+        assert!(p.witness_live_nonzero(7).is_none());
+    }
+
+    #[test]
+    fn witness_live_nonzero_none_for_released() {
+        let mut p = Pending::default();
+        assert!(p.witness_live_nonzero(7).is_none());
+    }
+
+    // ------- witness_live_zero ------------------------------------------------
+
+    #[test]
+    fn witness_live_zero_some_for_live_zero() {
+        let mut p = Pending::default();
+        p.test_insert_state(9, NodeState::Live { open_count: 0 });
+        let w = p.witness_live_zero(9).expect("LiveZero witness");
+        assert_eq!(w.id(), 9);
+    }
+
+    #[test]
+    fn witness_live_zero_none_for_live_nonzero() {
+        let mut p = Pending::default();
+        p.test_insert_state(9, NodeState::Live { open_count: 2 });
+        assert!(p.witness_live_zero(9).is_none());
+    }
+
+    #[test]
+    fn witness_live_zero_none_for_orphan_zero() {
+        // Orphan with open_count == 0 is shaped like LiveZero
+        // numerically but is a fundamentally different state; the
+        // witness must reject it.
+        let mut p = Pending::default();
+        p.test_insert_state(9, NodeState::Orphan { open_count: 0 });
+        assert!(p.witness_live_zero(9).is_none());
+    }
+
+    #[test]
+    fn witness_live_zero_none_for_released() {
+        let mut p = Pending::default();
+        assert!(p.witness_live_zero(9).is_none());
+    }
+
+    // ------- witness_orphan ---------------------------------------------------
+
+    #[test]
+    fn witness_orphan_some_for_orphan_nonzero() {
+        let mut p = Pending::default();
+        p.test_insert_state(13, NodeState::Orphan { open_count: 4 });
+        let w = p.witness_orphan(13).expect("Orphan witness");
+        assert_eq!(w.id(), 13);
+    }
+
+    #[test]
+    fn witness_orphan_some_for_orphan_zero() {
+        // The orphan witness must match the discriminant, not the
+        // refcount — `Orphan { open_count == 0 }` is a real state
+        // (just one the FSM transitions out of immediately on
+        // release).
+        let mut p = Pending::default();
+        p.test_insert_state(13, NodeState::Orphan { open_count: 0 });
+        let w = p.witness_orphan(13).expect("Orphan witness");
+        assert_eq!(w.id(), 13);
+    }
+
+    #[test]
+    fn witness_orphan_none_for_live_nonzero() {
+        let mut p = Pending::default();
+        p.test_insert_state(13, NodeState::Live { open_count: 1 });
+        assert!(p.witness_orphan(13).is_none());
+    }
+
+    #[test]
+    fn witness_orphan_none_for_live_zero() {
+        let mut p = Pending::default();
+        p.test_insert_state(13, NodeState::Live { open_count: 0 });
+        assert!(p.witness_orphan(13).is_none());
+    }
+
+    #[test]
+    fn witness_orphan_none_for_released() {
+        let mut p = Pending::default();
+        assert!(p.witness_orphan(13).is_none());
+    }
+
+    // ------- witness_released -------------------------------------------------
+
+    #[test]
+    fn witness_released_some_for_absent_entry() {
+        let mut p = Pending::default();
+        let w = p.witness_released(21).expect("Released witness");
+        assert_eq!(w.id(), 21);
+    }
+
+    #[test]
+    fn witness_released_none_for_live_nonzero() {
+        let mut p = Pending::default();
+        p.test_insert_state(21, NodeState::Live { open_count: 1 });
+        assert!(p.witness_released(21).is_none());
+    }
+
+    #[test]
+    fn witness_released_none_for_live_zero() {
+        let mut p = Pending::default();
+        p.test_insert_state(21, NodeState::Live { open_count: 0 });
+        assert!(p.witness_released(21).is_none());
+    }
+
+    #[test]
+    fn witness_released_none_for_orphan() {
+        let mut p = Pending::default();
+        p.test_insert_state(21, NodeState::Orphan { open_count: 2 });
+        assert!(p.witness_released(21).is_none());
+    }
+
+    // ------- witness_kernel_forget --------------------------------------------
+
+    #[test]
+    fn witness_kernel_forget_some_for_released() {
+        let mut p = Pending::default();
+        let w = p.witness_kernel_forget(31).expect("KernelForget witness");
+        assert_eq!(w.id(), 31);
+    }
+
+    #[test]
+    fn witness_kernel_forget_some_for_live_zero() {
+        // The discharge-safety condition: a Live entry with no open
+        // kernel fds. The forget cannot race an open handle here.
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Live { open_count: 0 });
+        let w = p.witness_kernel_forget(31).expect("KernelForget witness");
+        assert_eq!(w.id(), 31);
+    }
+
+    #[test]
+    fn witness_kernel_forget_none_for_live_nonzero() {
+        // The r11 #3 race: open fds still hold the bytes; dropping
+        // hot[id] here loses data. The constructor must reject.
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Live { open_count: 1 });
+        assert!(p.witness_kernel_forget(31).is_none());
+    }
+
+    #[test]
+    fn witness_kernel_forget_none_for_orphan_zero() {
+        // Even with zero open count, Orphan presence signals
+        // "directory entry gone, bytes outlive it" — the forget
+        // cannot discharge the bytes without risking a racing open
+        // handle the FSM has not yet observed.
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Orphan { open_count: 0 });
+        assert!(p.witness_kernel_forget(31).is_none());
+    }
+
+    #[test]
+    fn witness_kernel_forget_none_for_orphan_nonzero() {
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Orphan { open_count: 5 });
+        assert!(p.witness_kernel_forget(31).is_none());
+    }
+
+    // ------- substrate hygiene -----------------------------------------------
+
+    /// Compile-time `!Send` / `!Sync` assertion. Stable Rust has no
+    /// negative trait bound; the pattern below (from the
+    /// `static_assertions` crate, inlined to avoid a new dep) creates
+    /// two blanket impls of a helper trait — one unconditional, one
+    /// gated on `Send` (or `Sync`). Inference then resolves
+    /// unambiguously iff the target type is `!Send` (resp. `!Sync`).
+    /// If a future drive-by removes the `PhantomData<*const ()>`
+    /// field on either witness, the type becomes `Send` and this
+    /// `const _` block fails to compile with "type annotations
+    /// needed."
+    const _ASSERT_NOT_SEND: () = {
+        trait AmbiguousIfSend<A> {
+            fn some() {}
+        }
+        impl<T: ?Sized> AmbiguousIfSend<()> for T {}
+        #[allow(dead_code)]
+        struct Invalid;
+        impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
+
+        let _ = <Witness<'static, LiveNonZero> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, LiveZero> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, Orphan> as AmbiguousIfSend<_>>::some;
+        let _ = <Witness<'static, Released> as AmbiguousIfSend<_>>::some;
+        let _ = <KernelForgetWitness<'static> as AmbiguousIfSend<_>>::some;
+    };
+
+    const _ASSERT_NOT_SYNC: () = {
+        trait AmbiguousIfSync<A> {
+            fn some() {}
+        }
+        impl<T: ?Sized> AmbiguousIfSync<()> for T {}
+        #[allow(dead_code)]
+        struct Invalid;
+        impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
+
+        let _ = <Witness<'static, LiveNonZero> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, LiveZero> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, Orphan> as AmbiguousIfSync<_>>::some;
+        let _ = <Witness<'static, Released> as AmbiguousIfSync<_>>::some;
+        let _ = <KernelForgetWitness<'static> as AmbiguousIfSync<_>>::some;
+    };
 }

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -22,7 +22,7 @@
 //! * [`Released`] — entry retired; absence from
 //!   [`crate::core::Pending`]'s `state` map. Never stored in the map —
 //!   the marker exists so a witness can prove "no entry at this id"
-//!   for the `Pending::witness_*` constructors that need it.
+//!   for the `BrandedPending::witness_*` constructors that need it.
 //!
 //! # What this module is **not**
 //!
@@ -118,22 +118,28 @@ impl Lifecycle for Released {}
 ///
 /// # Invariants
 ///
-/// * Constructed only by [`Pending::witness_live_nonzero`] /
-///   [`Pending::witness_live_zero`] / [`Pending::witness_orphan`] /
-///   [`Pending::witness_released`], each of which performs the
-///   matching FSM check and returns `Some` iff it holds.
-/// * The lifetime parameter `'p` is the lifetime of the `&mut Pending`
-///   borrow that produced the witness. The borrow checker therefore
-///   forbids any other code from mutating `Pending` while the witness
-///   exists — closing the "stale witness across a mutation" hole
-///   spelled out in
+/// * Constructed only by [`BrandedPending::witness_live_nonzero`] /
+///   [`BrandedPending::witness_live_zero`] /
+///   [`BrandedPending::witness_orphan`] /
+///   [`BrandedPending::witness_released`], each of which performs the
+///   matching FSM check and returns `Some` iff it holds. Those
+///   constructors live on [`BrandedPending`] (not [`Pending`]), and
+///   [`BrandedPending`] is only constructible inside
+///   [`Pending::with_brand`] — so every witness in the system
+///   originates from a `with_brand` invocation by construction
+///   (Codex PR #217 r2 finding `3293898540`).
+/// * The lifetime parameter `'p` is the lifetime of the
+///   `&mut BrandedPending` borrow that produced the witness. The
+///   borrow checker therefore forbids any other code from mutating
+///   the underlying `Pending` while the witness exists — closing the
+///   "stale witness across a mutation" hole spelled out in
 ///   [`docs/design/mount-pending-api-contracts.md`][doc] §2.2.1.
 /// * The lifetime parameter `'brand` ties the witness to the specific
-///   `Pending` instance that minted it. Two `Pending<'brand>` values
-///   handed out by separate [`Pending::with_brand`] calls carry
-///   distinct, invariant brands; a witness from one cannot be passed
-///   to methods on the other (closes Codex PR #217 r2 finding
-///   `3293832936`).
+///   [`BrandedPending`] instance that minted it. Two
+///   `BrandedPending<'_, 'brand>` values handed out by separate
+///   [`Pending::with_brand`] calls carry distinct, invariant brands;
+///   a witness from one cannot be passed to methods on the other
+///   (closes Codex PR #217 r2 finding `3293832936`).
 /// * `S` is invariant via the [`PhantomData<&'p mut ()>`] field — the
 ///   compiler will not silently widen or narrow the state parameter.
 /// * `!Send` and `!Sync` via the raw-pointer marker — the witness is
@@ -145,18 +151,21 @@ impl Lifecycle for Released {}
 pub struct Witness<'p, 'brand, S: Lifecycle> {
     id: u64,
     _state: PhantomData<S>,
-    // Invariance over `'p` + ties the witness to a `&mut Pending`
-    // borrow. The `&'p mut ()` is for the lifetime relationship; the
-    // borrow extension on `&'p mut Pending -> Witness<'p, _, _>` is
-    // what makes the borrow checker refuse a concurrent mutable
-    // borrow of `Pending` while the witness is alive.
+    // Invariance over `'p` + ties the witness to a
+    // `&mut BrandedPending` borrow. The `&'p mut ()` is for the
+    // lifetime relationship; the borrow extension on
+    // `&'p mut BrandedPending -> Witness<'p, _, _>` is what makes
+    // the borrow checker refuse a concurrent mutable borrow of the
+    // wrapper (and hence of the underlying `Pending`) while the
+    // witness is alive.
     _borrow: PhantomData<&'p mut ()>,
     // Invariant brand binding the witness to its originating
-    // `Pending<'brand>` instance. `fn(&'brand ()) -> &'brand ()` is
-    // the canonical invariant carrier — neither covariant nor
-    // contravariant. Witnesses minted under one `with_brand` HRTB
-    // closure cannot be passed to a `Pending` with a different
-    // brand, even when both carry the same lifecycle state `S`.
+    // `BrandedPending<'_, 'brand>` instance.
+    // `fn(&'brand ()) -> &'brand ()` is the canonical invariant
+    // carrier — neither covariant nor contravariant. Witnesses
+    // minted under one `with_brand` HRTB closure cannot be passed
+    // to a `BrandedPending` with a different brand, even when both
+    // carry the same lifecycle state `S`.
     _brand: PhantomData<fn(&'brand ()) -> &'brand ()>,
     // `!Send` + `!Sync` marker. The witness is short-lived and tied
     // to one thread of execution by design; cross-thread transfer is
@@ -166,8 +175,8 @@ pub struct Witness<'p, 'brand, S: Lifecycle> {
 
 impl<'p, 'brand, S: Lifecycle> Witness<'p, 'brand, S> {
     /// Mint a witness. Visible only inside this module — every
-    /// witness must come from a `Pending::witness_*` constructor that
-    /// performed the FSM check.
+    /// witness must come from a `BrandedPending::witness_*`
+    /// constructor that performed the FSM check.
     fn new(id: u64) -> Self {
         Self {
             id,
@@ -188,30 +197,41 @@ impl<'p, 'brand, S: Lifecycle> Witness<'p, 'brand, S> {
 
 impl<'a> Pending<'a> {
     /// Re-borrow `self` under a freshly-minted, invariant `'brand`
-    /// lifetime that's unique to this call.
+    /// lifetime that's unique to this call, and hand the resulting
+    /// [`BrandedPending`] to `f`.
+    ///
+    /// `with_brand` is the **only** way to obtain a [`BrandedPending`]
+    /// — and [`BrandedPending`] is the **only** type that exposes the
+    /// `witness_*` constructors. Internal callers that hold a
+    /// `&mut Pending<'static>` (e.g. through `MountInner::pending`)
+    /// therefore cannot mint a witness without first going through
+    /// `with_brand`, which forces the brand to be a fresh HRTB-bound
+    /// existential rather than the storage's `'static` slot. This
+    /// closes Codex PR #217 r2 follow-up `3293898540`.
     ///
     /// The HRTB on `f` (`for<'brand>`) forces the compiler to treat
     /// the brand as opaque inside the closure. Each call to
     /// `with_brand` issues a brand that can't unify with any other
     /// call's brand, even if both originate from the same physical
-    /// `Pending`. Witnesses minted on the inner `&mut Pending<'brand>`
-    /// carry that closure's `'brand` and cannot be passed to a
-    /// `Pending` borrowed under a different `with_brand` invocation
-    /// — closing Codex PR #217 r2 finding `3293832936`.
+    /// `Pending`. Witnesses minted on the inner
+    /// [`BrandedPending<'_, 'brand>`] carry that closure's `'brand`
+    /// and cannot be passed to a [`BrandedPending`] borrowed under a
+    /// different `with_brand` invocation — closing Codex PR #217 r2
+    /// finding `3293832936`.
     ///
     /// # Soundness
     ///
     /// The transmute changes only the phantom brand lifetime, which
     /// has no representation in the type's layout (`PhantomData<fn(..)>`
     /// is zero-sized). All other lifetime + ownership invariants
-    /// transfer verbatim through `mem::transmute_mut`. The HRTB
-    /// bound on `f` prevents the inner brand from escaping the
-    /// closure: any value returned by `f` cannot mention `'brand`
-    /// because there's no fixed `'brand` to mention from outside.
+    /// transfer verbatim. The HRTB bound on `f` prevents the inner
+    /// brand from escaping the closure: any value returned by `f`
+    /// cannot mention `'brand` because there's no fixed `'brand` to
+    /// mention from outside.
     #[doc(hidden)]
     pub fn with_brand<R>(
         &mut self,
-        f: impl for<'brand> FnOnce(&mut Pending<'brand>) -> R,
+        f: impl for<'brand> FnOnce(&mut BrandedPending<'_, 'brand>) -> R,
     ) -> R {
         // SAFETY: `Pending<'a>` and `Pending<'brand>` have identical
         // layout — `_brand` is `PhantomData<fn(&_ ()) -> &_ ()>`,
@@ -219,23 +239,50 @@ impl<'a> Pending<'a> {
         // only the phantom-only lifetime parameter changes. The
         // HRTB on `f` ensures the freshly-introduced `'brand`
         // cannot leak via the return type.
-        let branded: &mut Pending<'_> =
+        let rebranded: &mut Pending<'_> =
             unsafe { std::mem::transmute::<&mut Pending<'a>, &mut Pending<'_>>(self) };
-        f(branded)
+        let mut bp = BrandedPending { inner: rebranded };
+        f(&mut bp)
     }
+}
 
+/// Sealed wrapper that grants access to the witness constructors.
+///
+/// `BrandedPending` is the only type with `witness_*` (and
+/// [`BrandedPending::peek_witness`]) methods. Its single field is
+/// private to this module, so the wrapper can only be constructed
+/// from inside [`Pending::with_brand`]; the HRTB on `with_brand`'s
+/// closure then forces `'brand` to be a fresh existential per call.
+///
+/// Together those two properties enforce: every witness in the
+/// system originates from a `with_brand` invocation, and every
+/// witness's `'brand` is unique to that invocation. The
+/// `MountInner`-stores-`Pending<'static>` escape that Codex flagged
+/// in `3293898540` is closed by construction — internal code with
+/// `&mut Pending<'static>` literally cannot name a `witness_*`
+/// method on it.
+#[doc(hidden)]
+pub struct BrandedPending<'p, 'brand> {
+    // Private — outside this module, no one can build a
+    // `BrandedPending`. Inside this module, only `Pending::with_brand`
+    // does. That single chokepoint is what enforces brand gating.
+    inner: &'p mut Pending<'brand>,
+}
+
+impl<'p, 'brand> BrandedPending<'p, 'brand> {
     /// Substrate hook for the brand-isolation doctest: takes a
-    /// borrowed witness branded to `self`'s `'a` and returns its
-    /// NodeId without doing anything else.
+    /// borrowed witness branded to this [`BrandedPending`]'s `'brand`
+    /// and returns its NodeId without doing anything else.
     ///
     /// Retrofit issues (heddle#209/#210/#211/#212) will introduce
     /// the real witness-gated transitions, which need to mutate
     /// `self` and consume the witness; those signatures live there,
     /// not here. For the substrate PR we only need a non-consuming
-    /// brand-matching method so the [`crate::__pending_substrate_for_doctest`]
-    /// `compile_fail` proof can demonstrate that a witness minted
-    /// under a different `with_brand` closure fails to type-check
-    /// (the brand lifetimes are invariant and don't unify).
+    /// brand-matching method so the
+    /// [`crate::__pending_substrate_for_doctest`] `compile_fail`
+    /// proof can demonstrate that a witness minted under a different
+    /// `with_brand` closure fails to type-check (the brand lifetimes
+    /// are invariant and don't unify).
     ///
     /// `&self` (not `&mut self`) plus `&Witness` (not `Witness`)
     /// keeps the proof orthogonal to the separate borrow-checker
@@ -246,7 +293,7 @@ impl<'a> Pending<'a> {
     /// makes it not compile today; see the spike doc §2.2.1) and
     /// isn't this PR's scope.
     #[doc(hidden)]
-    pub fn peek_witness<S: Lifecycle>(&self, w: &Witness<'_, 'a, S>) -> u64 {
+    pub fn peek_witness<S: Lifecycle>(&self, w: &Witness<'_, 'brand, S>) -> u64 {
         let _ = self;
         w.id()
     }
@@ -263,8 +310,11 @@ impl<'a> Pending<'a> {
 ///
 /// # Invariants
 ///
-/// * Constructed only by [`Pending::witness_kernel_forget`], whose
-///   body IS the discharge-safety check.
+/// * Constructed only by [`BrandedPending::witness_kernel_forget`],
+///   whose body IS the discharge-safety check. Same brand-gating
+///   logic as [`Witness`]: the constructor lives on
+///   [`BrandedPending`], which is only constructible inside
+///   [`Pending::with_brand`].
 /// * Lifetime + `!Send` / `!Sync` semantics identical to [`Witness`].
 ///
 /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
@@ -274,9 +324,9 @@ pub struct KernelForgetWitness<'p, 'brand> {
     id: u64,
     _borrow: PhantomData<&'p mut ()>,
     // Same invariant brand carrier as [`Witness`]. Binds the witness
-    // to the originating `Pending<'brand>` instance so a forget
-    // witness from one mount cannot be discharged against another's
-    // hot-tier buffer (Codex PR #217 r2 finding `3293832936`).
+    // to the originating `BrandedPending<'_, 'brand>` instance so a
+    // forget witness from one mount cannot be discharged against
+    // another's hot-tier buffer (Codex PR #217 r2 finding `3293832936`).
     _brand: PhantomData<fn(&'brand ()) -> &'brand ()>,
     _not_send: PhantomData<*const ()>,
 }
@@ -299,7 +349,7 @@ impl<'p, 'brand> KernelForgetWitness<'p, 'brand> {
     }
 }
 
-impl<'brand> Pending<'brand> {
+impl<'p, 'brand> BrandedPending<'p, 'brand> {
     /// Witness that `id` is in `Live { open_count >= 1 }`. Returns
     /// `None` for any other state, including `Live { open_count == 0 }`,
     /// any `Orphan`, and `Released` (no entry). This is the
@@ -312,7 +362,7 @@ impl<'brand> Pending<'brand> {
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
     #[doc(hidden)]
     pub fn witness_live_nonzero(&mut self, id: u64) -> Option<Witness<'_, 'brand, LiveNonZero>> {
-        match self.lookup_state(id) {
+        match self.inner.lookup_state(id) {
             Some(NodeState::Live { open_count }) if open_count >= 1 => Some(Witness::new(id)),
             _ => None,
         }
@@ -323,7 +373,7 @@ impl<'brand> Pending<'brand> {
     /// and for `Released`.
     #[doc(hidden)]
     pub fn witness_live_zero(&mut self, id: u64) -> Option<Witness<'_, 'brand, LiveZero>> {
-        match self.lookup_state(id) {
+        match self.inner.lookup_state(id) {
             Some(NodeState::Live { open_count: 0 }) => Some(Witness::new(id)),
             _ => None,
         }
@@ -333,7 +383,7 @@ impl<'brand> Pending<'brand> {
     /// Returns `None` for `Live` (any refcount) and `Released`.
     #[doc(hidden)]
     pub fn witness_orphan(&mut self, id: u64) -> Option<Witness<'_, 'brand, Orphan>> {
-        match self.lookup_state(id) {
+        match self.inner.lookup_state(id) {
             Some(NodeState::Orphan { .. }) => Some(Witness::new(id)),
             _ => None,
         }
@@ -346,7 +396,7 @@ impl<'brand> Pending<'brand> {
     /// when there is no prior entry).
     #[doc(hidden)]
     pub fn witness_released(&mut self, id: u64) -> Option<Witness<'_, 'brand, Released>> {
-        match self.lookup_state(id) {
+        match self.inner.lookup_state(id) {
             None => Some(Witness::new(id)),
             _ => None,
         }
@@ -371,7 +421,7 @@ impl<'brand> Pending<'brand> {
     /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
     #[doc(hidden)]
     pub fn witness_kernel_forget(&mut self, id: u64) -> Option<KernelForgetWitness<'_, 'brand>> {
-        match self.lookup_state(id) {
+        match self.inner.lookup_state(id) {
             None => Some(KernelForgetWitness::new(id)),
             Some(NodeState::Live { open_count: 0 }) => Some(KernelForgetWitness::new(id)),
             _ => None,
@@ -383,42 +433,53 @@ impl<'brand> Pending<'brand> {
 mod tests {
     use super::*;
 
+    // The witnesses can't escape `with_brand`'s HRTB closure (they
+    // carry the fresh `'brand`), but the brand-free `Option<u64>`
+    // shape can. Every test below extracts `.id()` inside the
+    // closure and asserts against the unbranded `Option<u64>` outside;
+    // negative tests use `.is_some()` for the same reason. This
+    // mirrors the canonical ghost-cell / branded-vec test style.
+
     // ------- witness_live_nonzero --------------------------------------------
 
     #[test]
     fn witness_live_nonzero_some_for_live_with_open() {
         let mut p = Pending::default();
         p.test_insert_state(7, NodeState::Live { open_count: 1 });
-        let w = p.witness_live_nonzero(7).expect("LiveNonZero witness");
-        assert_eq!(w.id(), 7);
+        let id = p
+            .with_brand(|bp| bp.witness_live_nonzero(7).map(|w| w.id()))
+            .expect("LiveNonZero witness");
+        assert_eq!(id, 7);
     }
 
     #[test]
     fn witness_live_nonzero_some_for_high_refcount() {
         let mut p = Pending::default();
         p.test_insert_state(11, NodeState::Live { open_count: u32::MAX });
-        let w = p.witness_live_nonzero(11).expect("LiveNonZero witness");
-        assert_eq!(w.id(), 11);
+        let id = p
+            .with_brand(|bp| bp.witness_live_nonzero(11).map(|w| w.id()))
+            .expect("LiveNonZero witness");
+        assert_eq!(id, 11);
     }
 
     #[test]
     fn witness_live_nonzero_none_for_live_zero() {
         let mut p = Pending::default();
         p.test_insert_state(7, NodeState::Live { open_count: 0 });
-        assert!(p.witness_live_nonzero(7).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_nonzero(7).is_some()));
     }
 
     #[test]
     fn witness_live_nonzero_none_for_orphan() {
         let mut p = Pending::default();
         p.test_insert_state(7, NodeState::Orphan { open_count: 3 });
-        assert!(p.witness_live_nonzero(7).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_nonzero(7).is_some()));
     }
 
     #[test]
     fn witness_live_nonzero_none_for_released() {
         let mut p = Pending::default();
-        assert!(p.witness_live_nonzero(7).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_nonzero(7).is_some()));
     }
 
     // ------- witness_live_zero ------------------------------------------------
@@ -427,15 +488,17 @@ mod tests {
     fn witness_live_zero_some_for_live_zero() {
         let mut p = Pending::default();
         p.test_insert_state(9, NodeState::Live { open_count: 0 });
-        let w = p.witness_live_zero(9).expect("LiveZero witness");
-        assert_eq!(w.id(), 9);
+        let id = p
+            .with_brand(|bp| bp.witness_live_zero(9).map(|w| w.id()))
+            .expect("LiveZero witness");
+        assert_eq!(id, 9);
     }
 
     #[test]
     fn witness_live_zero_none_for_live_nonzero() {
         let mut p = Pending::default();
         p.test_insert_state(9, NodeState::Live { open_count: 2 });
-        assert!(p.witness_live_zero(9).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_zero(9).is_some()));
     }
 
     #[test]
@@ -445,13 +508,13 @@ mod tests {
         // witness must reject it.
         let mut p = Pending::default();
         p.test_insert_state(9, NodeState::Orphan { open_count: 0 });
-        assert!(p.witness_live_zero(9).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_zero(9).is_some()));
     }
 
     #[test]
     fn witness_live_zero_none_for_released() {
         let mut p = Pending::default();
-        assert!(p.witness_live_zero(9).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_live_zero(9).is_some()));
     }
 
     // ------- witness_orphan ---------------------------------------------------
@@ -460,8 +523,10 @@ mod tests {
     fn witness_orphan_some_for_orphan_nonzero() {
         let mut p = Pending::default();
         p.test_insert_state(13, NodeState::Orphan { open_count: 4 });
-        let w = p.witness_orphan(13).expect("Orphan witness");
-        assert_eq!(w.id(), 13);
+        let id = p
+            .with_brand(|bp| bp.witness_orphan(13).map(|w| w.id()))
+            .expect("Orphan witness");
+        assert_eq!(id, 13);
     }
 
     #[test]
@@ -472,28 +537,30 @@ mod tests {
         // release).
         let mut p = Pending::default();
         p.test_insert_state(13, NodeState::Orphan { open_count: 0 });
-        let w = p.witness_orphan(13).expect("Orphan witness");
-        assert_eq!(w.id(), 13);
+        let id = p
+            .with_brand(|bp| bp.witness_orphan(13).map(|w| w.id()))
+            .expect("Orphan witness");
+        assert_eq!(id, 13);
     }
 
     #[test]
     fn witness_orphan_none_for_live_nonzero() {
         let mut p = Pending::default();
         p.test_insert_state(13, NodeState::Live { open_count: 1 });
-        assert!(p.witness_orphan(13).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_orphan(13).is_some()));
     }
 
     #[test]
     fn witness_orphan_none_for_live_zero() {
         let mut p = Pending::default();
         p.test_insert_state(13, NodeState::Live { open_count: 0 });
-        assert!(p.witness_orphan(13).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_orphan(13).is_some()));
     }
 
     #[test]
     fn witness_orphan_none_for_released() {
         let mut p = Pending::default();
-        assert!(p.witness_orphan(13).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_orphan(13).is_some()));
     }
 
     // ------- witness_released -------------------------------------------------
@@ -501,29 +568,31 @@ mod tests {
     #[test]
     fn witness_released_some_for_absent_entry() {
         let mut p = Pending::default();
-        let w = p.witness_released(21).expect("Released witness");
-        assert_eq!(w.id(), 21);
+        let id = p
+            .with_brand(|bp| bp.witness_released(21).map(|w| w.id()))
+            .expect("Released witness");
+        assert_eq!(id, 21);
     }
 
     #[test]
     fn witness_released_none_for_live_nonzero() {
         let mut p = Pending::default();
         p.test_insert_state(21, NodeState::Live { open_count: 1 });
-        assert!(p.witness_released(21).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_released(21).is_some()));
     }
 
     #[test]
     fn witness_released_none_for_live_zero() {
         let mut p = Pending::default();
         p.test_insert_state(21, NodeState::Live { open_count: 0 });
-        assert!(p.witness_released(21).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_released(21).is_some()));
     }
 
     #[test]
     fn witness_released_none_for_orphan() {
         let mut p = Pending::default();
         p.test_insert_state(21, NodeState::Orphan { open_count: 2 });
-        assert!(p.witness_released(21).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_released(21).is_some()));
     }
 
     // ------- witness_kernel_forget --------------------------------------------
@@ -531,8 +600,10 @@ mod tests {
     #[test]
     fn witness_kernel_forget_some_for_released() {
         let mut p = Pending::default();
-        let w = p.witness_kernel_forget(31).expect("KernelForget witness");
-        assert_eq!(w.id(), 31);
+        let id = p
+            .with_brand(|bp| bp.witness_kernel_forget(31).map(|w| w.id()))
+            .expect("KernelForget witness");
+        assert_eq!(id, 31);
     }
 
     #[test]
@@ -541,8 +612,10 @@ mod tests {
         // kernel fds. The forget cannot race an open handle here.
         let mut p = Pending::default();
         p.test_insert_state(31, NodeState::Live { open_count: 0 });
-        let w = p.witness_kernel_forget(31).expect("KernelForget witness");
-        assert_eq!(w.id(), 31);
+        let id = p
+            .with_brand(|bp| bp.witness_kernel_forget(31).map(|w| w.id()))
+            .expect("KernelForget witness");
+        assert_eq!(id, 31);
     }
 
     #[test]
@@ -551,7 +624,7 @@ mod tests {
         // hot[id] here loses data. The constructor must reject.
         let mut p = Pending::default();
         p.test_insert_state(31, NodeState::Live { open_count: 1 });
-        assert!(p.witness_kernel_forget(31).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_kernel_forget(31).is_some()));
     }
 
     #[test]
@@ -562,14 +635,14 @@ mod tests {
         // handle the FSM has not yet observed.
         let mut p = Pending::default();
         p.test_insert_state(31, NodeState::Orphan { open_count: 0 });
-        assert!(p.witness_kernel_forget(31).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_kernel_forget(31).is_some()));
     }
 
     #[test]
     fn witness_kernel_forget_none_for_orphan_nonzero() {
         let mut p = Pending::default();
         p.test_insert_state(31, NodeState::Orphan { open_count: 5 });
-        assert!(p.witness_kernel_forget(31).is_none());
+        assert!(!p.with_brand(|bp| bp.witness_kernel_forget(31).is_some()));
     }
 
     // ------- substrate hygiene -----------------------------------------------
@@ -632,12 +705,12 @@ mod tests {
         let mut p = Pending::default();
         p.test_insert_state(7, NodeState::Live { open_count: 1 });
         let id = p
-            .with_brand(|p| {
+            .with_brand(|bp| {
                 // `w` is `Witness<'_, 'brand, LiveNonZero>` for the
                 // closure's fresh `'brand`. We extract the brand-free
                 // NodeId and drop `w` — the witness itself cannot
                 // escape because it carries `'brand`.
-                p.witness_live_nonzero(7).map(|w| w.id())
+                bp.witness_live_nonzero(7).map(|w| w.id())
             })
             .expect("LiveNonZero witness");
         assert_eq!(id, 7);
@@ -659,10 +732,10 @@ mod tests {
         p2.test_insert_state(13, NodeState::Live { open_count: 0 });
 
         let id1 = p1
-            .with_brand(|p| p.witness_live_nonzero(11).map(|w| w.id()))
+            .with_brand(|bp| bp.witness_live_nonzero(11).map(|w| w.id()))
             .expect("p1 LiveNonZero witness");
         let id2 = p2
-            .with_brand(|p| p.witness_live_zero(13).map(|w| w.id()))
+            .with_brand(|bp| bp.witness_live_zero(13).map(|w| w.id()))
             .expect("p2 LiveZero witness");
 
         assert_eq!(id1, 11);
@@ -689,10 +762,10 @@ mod tests {
     fn with_brand_can_return_unbranded_node_id() {
         let mut p = Pending::default();
         p.test_insert_state(17, NodeState::Orphan { open_count: 3 });
-        let extracted: u64 = p.with_brand(|p| {
+        let extracted: u64 = p.with_brand(|bp| {
             // `u64` is brand-free, so it escapes the closure.
             // A `Witness<'_, 'brand, Orphan>` could not.
-            p.witness_orphan(17).map(|w| w.id()).unwrap_or(0)
+            bp.witness_orphan(17).map(|w| w.id()).unwrap_or(0)
         });
         assert_eq!(extracted, 17);
     }


### PR DESCRIPTION
## Summary
- Lands the substrate from heddle#206 §2.2.1 (witness-type idiom, Strategy C): `Lifecycle` sealed trait + four ZSTs (`LiveNonZero` / `LiveZero` / `Orphan` / `Released`) in a new `crates/mount/src/pending.rs`.
- Adds `Witness<'p, 'brand, S: Lifecycle>` and `KernelForgetWitness<'p, 'brand>` — lifetime-bound to the `&mut Pending` borrow that mints them, **instance-bound to that Pending's `'brand`** (round-2 Codex fix), `!Send` / `!Sync` via `PhantomData<*const ()>` (verified by `const _ASSERT_NOT_SEND` / `_ASSERT_NOT_SYNC` blocks that fail to compile if the marker is dropped).
- Adds 5 `BrandedPending::witness_*` constructors (moved from `Pending` in round 3) that perform the FSM check at construction (the only points that can mint a witness).
- Adds `Pending::with_brand` — HRTB closure that introduces a fresh invariant `'brand` per call and hands the body a `&mut BrandedPending<'_, 'brand>`; **the only constructor** of `BrandedPending` and therefore the only entry point for minting witnesses (round 3 made this structural rather than aspirational).
- `core.rs` is touched minimally: `Pending` and `NodeState` bumped to `pub(crate)` (and `Pending` is now `#[doc(hidden)] pub` so the round-2 `compile_fail` doctest can reach it) so `pending.rs` can name them, plus a `pub(crate) fn lookup_state` read-only accessor so the witness constructors can do the FSM check without dragging in field-level visibility. **No method signature in `core.rs` changed**; the 44 `pending.<method>(` callsites stay as-is.

Closes HeddleCo/heddle#208

## Round 2 — instance-bound brand (Codex PR #217 r2 finding `3293832936`)

Codex r2 flagged that the r1 substrate's `Witness` and `KernelForgetWitness` tied the token to a borrow lifetime but not to the specific `Pending` value that minted it: with two `Pending` objects alive, a witness from one could be passed to methods on the other. The fix:

* **Invariant `'brand` lifetime.** `Pending<'brand>`, `Witness<'p, 'brand, S>`, and `KernelForgetWitness<'p, 'brand>` each carry `PhantomData<fn(&'brand ()) -> &'brand ()>`. The `fn(&'b ()) -> &'b ()` shape is the canonical invariant carrier — neither covariant nor contravariant — so the compiler refuses to unify two brands handed out by separate `with_brand` calls.
* **HRTB-bound brand introducer.** `Pending::with_brand(&mut self, f: impl for<'brand> FnOnce(&mut Pending<'brand>) -> R) -> R` is the only entry point for minting witnesses in round-2-and-later code. Each invocation issues a fresh, opaque `'brand` that cannot escape via the closure return type. A `mem::transmute` swap of the phantom-only lifetime parameter is sound (brand is zero-sized; layout is unchanged).
* **Storage carries `Pending<'static>`.** `MountInner.pending` is `Mutex<Pending<'static>>`; the `'static` slot is purely an internal storage carrier and never exposed as a witness brand — every actual access goes through `Pending::with_brand`, which re-borrows under a fresh invariant brand.

### Round-2 compile-fail proof (red → green)

Red commit `15dab59` adds a `compile_fail` doctest at `crates/mount/src/lib.rs::__pending_substrate_for_doctest` exercising `p2.peek_witness(&w_from_p1)` across two `with_brand` closures. The substrate-only PR uses `peek_witness` (non-consuming, `&self` + `&Witness`) so the brand-rejection proof stays orthogonal to the separate pre-existing substrate borrow-pattern question (the witness's `_borrow: PhantomData<&'p mut ()>` field already prevents same-instance consume `p.transition_to_orphan(w)` independent of brand; that's a spike-doc §2.2.1 question the retrofit issues heddle#209/#210/#211/#212 will need to address, not this PR).

* Pre-brand: code compiles → `compile_fail` assertion violated → doctest fails → **RED**.
* Post-brand (green commit `ec4bdd1`): two `with_brand` HRTB closures issue distinct invariant brands; `w_from_p1` carries p1's brand; `p2.peek_witness` wants p2's brand; brands refuse to unify → fails to compile → assertion holds → **GREEN**.

Plus three positive lib tests in `pending::tests` exercising the green side: `with_brand_threads_a_fresh_brand_through_witness_construction`, `brand_round_trips_independently_across_two_pendings`, `with_brand_can_return_unbranded_node_id`. Total mount-crate suite goes from 130 → 133 tests + 1 doctest.

## Round 3 — enforce brand gating on witness constructors (Codex PR #217 r2 follow-on `3293898540`)

Codex's r2 follow-on flagged that r2's invariant-`'brand` fix was bypassable: the `witness_*` constructors still lived on `impl<'brand> Pending<'brand>`, so any internal caller holding `&mut Pending<'static>` (e.g. through `MountInner.pending`) could mint `Witness<..., 'static, _>` without ever calling `with_brand`. Two distinct `Pending<'static>` values share the `'static` brand, so witnesses crossed between them — exactly the cross-instance mixing r2 was meant to prevent. The fix (Approach A from the brief):

* **Sealed `BrandedPending<'p, 'brand>` wrapper.** A new struct in `pending.rs` whose only field, `inner: &'p mut Pending<'brand>`, is private to the module. Every `witness_*` (5 total) and `peek_witness` now lives on `impl<'p, 'brand> BrandedPending<'p, 'brand>`; `Pending<'brand>` carries no witness-minting methods.
* **`with_brand` is the sole constructor.** `Pending::with_brand(&mut self, f: impl for<'brand> FnOnce(&mut BrandedPending<'_, 'brand>) -> R) -> R` is the only code path that builds a `BrandedPending` — the HRTB still issues a fresh existential brand per call, and the closure body is the only place a `BrandedPending` exists. Internal code with `&mut Pending<'static>` literally cannot name `.witness_live_nonzero(..)` etc. anymore; it's a compile error rather than a brand collision.
* **Storage comment refreshed.** `MountInner.pending`'s doc-comment was aspirational in r2 ("every actual access goes through `with_brand`"); it's structural now ("`Pending<'brand>` carries no witness constructors at all").

### Round-3 compile-fail proof (red → green)

Red commit `03c8231` adds a second `compile_fail` doctest at `crates/mount/src/lib.rs::__pending_substrate_for_doctest` (line 139): `p1.witness_live_nonzero(0)` followed by `p2.peek_witness(&w)` on two `Pending::default()` values **outside** any `with_brand` call. The first doctest (r2, line 92) pins cross-instance use *inside* `with_brand`; the second pins the constructor bypass *outside* `with_brand`.

* Pre-r3: `p1.witness_live_nonzero(0)` compiles (constructor is on `Pending<'brand>`, defaults `'brand` to `'static`); `p2.peek_witness(&w)` compiles (same `'static` brand). The doctest body compiles → `compile_fail` assertion violated → doctest fails → **RED**.
* Post-r3 (green commit `391e512`): `Pending` has no `witness_live_nonzero` method — the name resolution fails → fails to compile → assertion holds → **GREEN**.

The existing 23 `pending::tests` witness-table tests were rewritten so every mint goes through `with_brand` and extracts a brand-free `Option<u64>` / `bool` outside the closure — the canonical ghost-cell test style. Total `pending::tests` count is unchanged (26).

## Substrate-only — no callsite retrofitting
Per the heddle#206 spike doc §4.2 and this issue's brief: the substrate is `pub(crate)`-visible (with the round-2 `#[doc(hidden)] pub` widening for doctest reachability) from `core.rs` but unused there in this PR. The four r11 P1 retrofits that thread witnesses through the lifecycle-transition methods land in heddle#209 / #210 / #211 / #212 (each blocked on this PR). The module carries a `#![allow(dead_code)]` with rationale for the same reason — substrate methods are exercised only by the test table until the retrofits land.

## Note on the `r10 fixture tests` AC item
The issue body lists "r10's 17 fixture tests pass unchanged" and the brief lists `scripts/check-no-direct-pending-mutation.sh` as a gate. Per the orchestrator's close note on heddle#213 (the r10 cherry-pick), the r10 runtime encapsulation and its static check were intentionally **not** cherry-picked onto main; they are subsumed by this PR's compile-time witness gating once the retrofits consume it. Both the fixture-test set and the static-check script therefore do not exist on `main` and are not regressions to guard against in this PR. The remaining ACs (`Lifecycle` + ZSTs in `pending.rs`, `Witness` + four `witness_*` constructors, `KernelForgetWitness` + constructor, substrate `pub(crate)` and unused in `core.rs`, `check-no-silent-default-tree-load.sh` clean, `cargo test -p heddle-mount` green, `cargo clippy --workspace --all-targets -- -D warnings` clean) are all met below.

## Red commits
- r1 (substrate stub): `76363c8c57145fc8fb181254d6dee51a9e63b7cd` — `pending.rs` containing two `#[cfg(test)]` tests against the as-if-existing `witness_live_nonzero` API. Fails to compile with `E0599: no method named witness_live_nonzero` on the pre-substrate `Pending`.
- r2 (brand isolation): `15dab59` — `compile_fail` doctest exercising cross-`Pending` witness use. Pre-brand the doctest's code compiles; `compile_fail` assertion violated → doctest fails.
- r3 (constructor bypass): `03c8231` — second `compile_fail` doctest exercising `p1.witness_live_nonzero(0)` directly on `&mut Pending<'static>` outside any `with_brand` call. Pre-r3 the body compiles; `compile_fail` assertion violated → doctest fails.

## Test evidence

```
$ cargo test -p heddle-mount --lib pending::
running 26 tests
test pending::tests::brand_round_trips_independently_across_two_pendings ... ok
test pending::tests::with_brand_can_return_unbranded_node_id ... ok
test pending::tests::with_brand_threads_a_fresh_brand_through_witness_construction ... ok
test pending::tests::witness_kernel_forget_none_for_live_nonzero ... ok
test pending::tests::witness_kernel_forget_none_for_orphan_nonzero ... ok
test pending::tests::witness_kernel_forget_none_for_orphan_zero ... ok
test pending::tests::witness_kernel_forget_some_for_live_zero ... ok
test pending::tests::witness_kernel_forget_some_for_released ... ok
test pending::tests::witness_live_nonzero_none_for_live_zero ... ok
test pending::tests::witness_live_nonzero_none_for_orphan ... ok
test pending::tests::witness_live_nonzero_none_for_released ... ok
test pending::tests::witness_live_nonzero_some_for_high_refcount ... ok
test pending::tests::witness_live_nonzero_some_for_live_with_open ... ok
test pending::tests::witness_live_zero_none_for_live_nonzero ... ok
test pending::tests::witness_live_zero_none_for_orphan_zero ... ok
test pending::tests::witness_live_zero_none_for_released ... ok
test pending::tests::witness_live_zero_some_for_live_zero ... ok
test pending::tests::witness_orphan_none_for_live_nonzero ... ok
test pending::tests::witness_orphan_none_for_live_zero ... ok
test pending::tests::witness_orphan_none_for_released ... ok
test pending::tests::witness_orphan_some_for_orphan_nonzero ... ok
test pending::tests::witness_orphan_some_for_orphan_zero ... ok
test pending::tests::witness_released_none_for_live_nonzero ... ok
test pending::tests::witness_released_none_for_live_zero ... ok
test pending::tests::witness_released_none_for_orphan ... ok
test pending::tests::witness_released_some_for_absent_entry ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 107 filtered out

$ cargo test -p heddle-mount --doc
running 2 tests
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 92) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 139) - compile fail ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full mount-crate suite: 133 lib tests + adapter shells (fuse / nfs / projfs) + 2 doctests, 0 failures. `cargo clippy --workspace --all-targets -- -D warnings` clean; `bash scripts/check-no-silent-default-tree-load.sh` clean (500 files scanned).

Regression-spot for the `!Send` / `!Sync` const-asserts: removing the `PhantomData<*const ()>` markers on `Witness` / `KernelForgetWitness` causes `E0283` errors in the two `const _ASSERT_NOT_*` blocks (verified locally).

## Manual verification
N/A — covered by tests + compile_fail doctest.

## Blocked by → resolved
- HeddleCo/heddle#206 (decision doc — already merged via PR #207).

This PR unblocks the four heddle#206 retrofit issues that will consume the substrate: HeddleCo/heddle#209, #210, #211, #212.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782184062&installation_id=132405951&pr_number=217&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F217&signature=a0c53396adbab8381a9a5e9bdd1fbfa4e06902038290ab0e3ccad8dfd709d913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

