### PR TITLE
heddle#209: witness-gated transition_to_orphan + thread at unlink/rename

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -507,6 +507,27 @@ impl<'brand> Pending<'brand> {
         self.state.get(&id).copied()
     }
 
+    /// Witness-gated LiveNonZero → Orphan state transition. The
+    /// `&Witness<'_, 'brand, Orphan>` parameter is the type-level
+    /// proof that the caller has already gone through the FSM check —
+    /// `Witness::new` is module-private to [`crate::pending`], so the
+    /// only callers that can name this method's argument type are the
+    /// [`crate::pending::BrandedPending::transition_to_orphan`] body
+    /// (which constructs the witness after consuming a matching
+    /// `Witness<LiveNonZero>`) and code that already held a
+    /// `Witness<Orphan>` (in which case the state was already Orphan,
+    /// and re-inserting is a no-op on the discriminant). Direct
+    /// callers in this module have no way to mint a `Witness<Orphan>`,
+    /// so they cannot bypass the witness discipline.
+    pub(crate) fn apply_transition_to_orphan(
+        &mut self,
+        w: &crate::pending::Witness<'_, 'brand, crate::pending::Orphan>,
+    ) {
+        let id = w.id();
+        let open_count = self.open_count(id);
+        self.state.insert(id, NodeState::Orphan { open_count });
+    }
+
     /// Test-only: insert a per-NodeId lifecycle entry directly,
     /// bypassing the FSM entry points. Used by the
     /// [`crate::pending`] substrate tests to set up `Pending` states
@@ -1480,26 +1501,24 @@ impl ContentAddressedMount {
             // (r9 fix: pre-spike code called `pending.hot.remove(&node_id)`
             // here and the unflushed bytes vanished.)
             pending.hot_by_path.remove(&child_path);
-            // Transition T1: Live → Orphan { open_count: N }. Carry
-            // the current open count over so the final `release`
-            // fires correctly. N == 0 is permitted; the inode stays
-            // tracked until `release` / `invalidate` / `capture`
-            // drops it (matching pre-spike orphan-set semantics for
-            // tests that skip the explicit `on_open`).
+            // Transition T1: Live{open_count >= 1} → Orphan{open_count}.
+            // The witness-gated retrofit (heddle#209) makes the FSM
+            // check the gate: `bp.transition_to_orphan(node_id)`
+            // returns `None` (without touching `state`) for any
+            // non-`LiveNonZero` state, and the missing
+            // `Witness<Orphan>` IS the short-circuit at this call
+            // site.
             //
-            // Codex r12 thread 3293510317 (P3): symlinks have no
-            // `open`/`release` lifecycle (they're not openable for
-            // IO), so we MUST NOT orphan them — no event would ever
-            // clear the state entry, and `pending.state` would grow
-            // under symlink churn until capture/invalidate. Files
-            // (regular + executable) do receive open/release events
-            // and take the Orphan branch.
-            if entry.kind != NodeKind::Symlink {
-                let open_count = pending.open_count(node_id);
-                pending
-                    .state
-                    .insert(node_id, NodeState::Orphan { open_count });
-            }
+            // That subsumes two earlier defensive checks: Codex r12
+            // thread 3293510317 (symlinks have no `open`/`release`
+            // lifecycle, so they never enter `state` and the
+            // transition never fires for them), and r11 finding
+            // 3293575534 (orphaning a `Live { open_count: 0 }` node
+            // creates a record nothing will ever reap — same shape,
+            // same fix).
+            pending.with_brand(|bp| {
+                let _ = bp.transition_to_orphan(node_id);
+            });
             // Symlinks are path-keyed; their overlay goes when the
             // directory entry goes.
             pending.symlinks.remove(&child_path);
@@ -1756,14 +1775,26 @@ impl ContentAddressedMount {
                 buf.path = new_path.clone();
             }
             if let Some(dest_id) = displaced_dest {
-                // T3: the displaced destination transitions to Orphan.
-                // Bytes (hot[dest_id], warm[dest_id]) stay put so the
+                // T3: the displaced destination transitions to Orphan
+                // iff it's currently `Live { open_count >= 1 }`. Bytes
+                // (hot[dest_id], warm[dest_id]) stay put so the
                 // surviving fd keeps reading the inode's own data
                 // (spike doc §1.2 T3).
-                let open_count = pending.open_count(dest_id);
-                pending
-                    .state
-                    .insert(dest_id, NodeState::Orphan { open_count });
+                //
+                // Closes Codex PR #182 r11 finding 3293575541 (heddle
+                // #209): `bp.transition_to_orphan(dest_id)` returns
+                // `None` (without touching `state`) for any
+                // non-`LiveNonZero` displaced destination, and the
+                // missing `Witness<Orphan>` IS the short-circuit at
+                // this call site. Pre-retrofit this branch
+                // unconditionally inserted `Orphan { open_count: 0 }`
+                // for non-`Live` destinations — including symlinks,
+                // which have no `open`/`release` lifecycle and would
+                // never reap the entry, growing `state` under symlink
+                // churn until capture / invalidate.
+                pending.with_brand(|bp| {
+                    let _ = bp.transition_to_orphan(dest_id);
+                });
             }
         }
         Ok(())

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -155,6 +155,33 @@ mod tests;
 /// //         is on `BrandedPending` now, so this also fails to compile.
 /// let _ = p2.peek_witness(&w);
 /// ```
+///
+/// # Witness-gated transitions (heddle#209)
+///
+/// The retrofit issues that consume the substrate (heddle#209 / #210 /
+/// #211 / #212) add FSM-transition methods on
+/// [`crate::pending::BrandedPending`] whose entry-point gating mirrors
+/// the [`crate::pending::BrandedPending::witness_*`] constructors:
+/// they live on `BrandedPending`, which can only be obtained via
+/// [`core::Pending::with_brand`]. Direct callers in `core.rs` (or
+/// future external callers) cannot reach the transitions on
+/// [`core::Pending`] itself.
+///
+/// The doctest below pins that entry-point discipline for the first
+/// retrofitted transition (`transition_to_orphan`, heddle#209). It
+/// compiles only if `Pending::transition_to_orphan` exists as a
+/// directly-callable method — and it doesn't, so the doctest fails
+/// to compile and the `compile_fail` assertion holds (GREEN).
+///
+/// ```compile_fail
+/// use mount::__pending_substrate_for_doctest::*;
+/// let mut p = Pending::default();
+/// // `transition_to_orphan` lives on `BrandedPending`, not on
+/// // `Pending`. A direct call on `Pending` is the bypass shape:
+/// // post-retrofit it fails to compile (the method doesn't exist on
+/// // `Pending`), so the `compile_fail` assertion holds → GREEN.
+/// let _ = p.transition_to_orphan(0);
+/// ```
 #[doc(hidden)]
 pub mod __pending_substrate_for_doctest {
     pub use crate::core::Pending;

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -402,6 +402,77 @@ impl<'p, 'brand> BrandedPending<'p, 'brand> {
         }
     }
 
+    /// Witness-gated FSM transition: `LiveNonZero` → `Orphan`,
+    /// carrying the current `open_count` over to the orphan record.
+    /// Returns `Some(Witness<Orphan>)` iff `id` was in
+    /// `Live { open_count >= 1 }` at the moment of the call; returns
+    /// `None` (without touching `state`) for any other lifecycle
+    /// state, including `Live { open_count == 0 }`, any `Orphan`, and
+    /// `Released` (no entry).
+    ///
+    /// # Why `id` and not a [`Witness<LiveNonZero>`] input?
+    ///
+    /// The spike doc ([§2.2.1][doc]) sketched the API as
+    /// `transition_to_orphan(&mut self, w: Witness<LiveNonZero>) -> Witness<Orphan>`,
+    /// with the caller pre-minting `w` via
+    /// [`Self::witness_live_nonzero`] and threading it in. The
+    /// heddle#208 r3 self-audit flagged — and an attempted retrofit at
+    /// this issue confirmed — that the literal shape does not compile
+    /// against the substrate: [`Witness`]'s
+    /// `_borrow: PhantomData<&'p mut ()>` field is invariant over
+    /// `'p`, so the prior `&mut BrandedPending` reborrow that minted
+    /// `w` cannot shrink to admit the second `&mut self` call that
+    /// would consume `w` (rustc `E0499`). The fix the brief proposed
+    /// in [Option B][option-b] — relax `'p`'s variance — would weaken
+    /// the substrate's stale-witness protection and is out of scope
+    /// for this retrofit.
+    ///
+    /// Folding the FSM check and the mutation into one call preserves
+    /// the spike doc's invariant — *the transition can only fire on
+    /// a [`LiveNonZero`] state* — by construction:
+    ///
+    /// * The body's `match` IS the
+    ///   [`Self::witness_live_nonzero`] FSM check; both refer to the
+    ///   same `Live { open_count >= 1 }` discriminant.
+    /// * Any non-`LiveNonZero` state path returns `None` before
+    ///   touching [`crate::core::Pending::apply_transition_to_orphan`].
+    ///   Callers in `core.rs` propagate the `None` with `if let
+    ///   Some(_) = bp.transition_to_orphan(id) { … }` — the missing
+    ///   witness IS the short-circuit at the call site.
+    /// * The returned `Witness<Orphan>` is the only path to evidence
+    ///   that the transition fired; [`Witness::new`] is
+    ///   module-private to this file and the
+    ///   [`crate::core::Pending::apply_transition_to_orphan`]
+    ///   accessor takes `&Witness<Orphan>` as proof — together they
+    ///   keep the discipline that no code outside this module's
+    ///   `BrandedPending` impl can synthesize an orphan witness or
+    ///   record a transition.
+    ///
+    /// Closes [r11 #1][doc] (`transition_to_orphan` records
+    /// `Orphan { open_count: 0 }` for nodes with no live fds — now
+    /// impossible because the `Live { open_count: 0 }` branch returns
+    /// `None`) and [r11 #4][doc] (`rename_entry_with_options` calls
+    /// the transition for symlinks/dirs that have no `open`/`release`
+    /// lifecycle — symlinks never enter `state`, so the lookup
+    /// returns `None` and the transition never fires).
+    ///
+    /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+    /// [option-b]: ../../../docs/design/mount-pending-api-contracts.md
+    #[doc(hidden)]
+    pub(crate) fn transition_to_orphan<'a>(
+        &'a mut self,
+        id: u64,
+    ) -> Option<Witness<'a, 'brand, Orphan>> {
+        match self.inner.lookup_state(id) {
+            Some(NodeState::Live { open_count }) if open_count >= 1 => {
+                let w = Witness::<'a, 'brand, Orphan>::new(id);
+                self.inner.apply_transition_to_orphan(&w);
+                Some(w)
+            }
+            _ => None,
+        }
+    }
+
     /// Witness that the kernel `forget` callback may safely drop
     /// `hot[id]` for this NodeId. Returns `Some` iff one of:
     ///

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -1754,6 +1754,12 @@ mod write_ops {
         let entry = mount
             .create_file(NodeId::ROOT, OsStr::new("temp"), FileMode::Normal, false)
             .expect("create");
+        // The `O_CREAT|O_RDWR` open above bumps `open_count` to 1 —
+        // without this the witness-gated unlink (heddle#209) sees the
+        // node as `Released` (no entry) and skips the orphan
+        // transition, breaking the open-unlinked POSIX flow this test
+        // exercises.
+        mount.on_open(entry.node).expect("on_open");
         mount.write(entry.node, 0, b"v1").expect("first write");
         // `unlink("temp")` while the handle is still in use.
         mount
@@ -2362,6 +2368,11 @@ mod write_ops {
         let (_temp, mount) = open_mount();
         // `fd = open("hello.txt")` — captured file, no overlay yet.
         let node = mount.lookup_path("hello.txt").unwrap();
+        // The `open` above bumps `open_count` to 1 — without this the
+        // witness-gated unlink (heddle#209) skips the orphan
+        // transition for `Released` (no entry) nodes and the test's
+        // open-unlinked POSIX flow doesn't engage.
+        mount.on_open(node).expect("on_open");
         // `unlink("hello.txt")` while the handle is still in use.
         mount
             .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
@@ -2461,6 +2472,11 @@ mod write_ops {
         let (_temp, mount) = open_mount();
         // `fd = open("hello.txt")` — captured file, no overlay.
         let dest_id = mount.lookup_path("hello.txt").unwrap();
+        // The `open` above bumps `open_count` to 1 — without this the
+        // witness-gated rename-over (heddle#209) skips the orphan
+        // transition for `Released` destinations and the
+        // captured-bytes-via-old-fd flow doesn't engage.
+        mount.on_open(dest_id).expect("on_open");
         // Source file with replacement payload; flush so move_file's
         // flush_node returns immediately.
         let src = mount
@@ -2508,6 +2524,11 @@ mod write_ops {
         let (_temp, mount) = open_mount();
         // `fd = open("hello.txt")` — captured Normal-mode file.
         let orphan_id = mount.lookup_path("hello.txt").unwrap();
+        // The `open` above bumps `open_count` to 1 — without this the
+        // witness-gated unlink (heddle#209) skips the orphan
+        // transition for `Released` (no entry) nodes and the
+        // open-unlinked POSIX flow this test exercises doesn't engage.
+        mount.on_open(orphan_id).expect("on_open");
         // `unlink("hello.txt")` while the fd lives on.
         mount
             .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
@@ -2584,6 +2605,10 @@ mod write_ops {
         // so the bytes are at `pending.warm["hello.txt"]`, not in any
         // hot buffer.
         let node = mount.lookup_path("hello.txt").unwrap();
+        // The `open` above bumps `open_count` to 1 — without this the
+        // witness-gated unlink (heddle#209) sees the node as
+        // `Released` (no entry) and skips the orphan transition.
+        mount.on_open(node).expect("on_open");
         mount.write(node, 0, b"WARM-BYTES").expect("write");
         mount.flush(node).expect("flush — promote to warm");
         // Sanity: warm tier holds the bytes.
@@ -2632,6 +2657,11 @@ mod write_ops {
         let entry = mount
             .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
             .expect("create");
+        // The `create` (`O_CREAT|O_RDWR`) above bumps `open_count` to
+        // 1 — without this the witness-gated unlink (heddle#209) sees
+        // the node as `Released` (no entry) and skips the orphan
+        // transition, breaking the open-unlinked POSIX flow.
+        mount.on_open(entry.node).expect("on_open");
         mount.write(entry.node, 0, b"hello-world").expect("write");
         mount.flush(entry.node).expect("flush — promote to warm");
         assert!(
@@ -2685,6 +2715,11 @@ mod write_ops {
         // not hot. r7's existing rename-over preservation fix is for
         // hot buffers; this one exercises the warm-tier preservation.
         let dest_id = mount.lookup_path("hello.txt").unwrap();
+        // The `open` above bumps `open_count` to 1 — without this the
+        // witness-gated rename-over (heddle#209) skips the orphan
+        // transition for `Released` destinations and the
+        // warm-preservation path doesn't engage.
+        mount.on_open(dest_id).expect("on_open");
         mount.write(dest_id, 0, b"DEST-WARM-BYTES").expect("write dest");
         mount.flush(dest_id).expect("flush dest — promote to warm");
         assert!(

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -2087,6 +2087,47 @@ mod write_ops {
         assert_eq!(target.as_os_str(), OsStr::new("hello.txt"));
     }
 
+    /// r11 #4 regression: renaming a regular file over a symlink must
+    /// not push an `Orphan { open_count: 0 }` state entry for the
+    /// displaced symlink's NodeId. Symlinks have no `open`/`release`
+    /// lifecycle, so a state entry there is dead bookkeeping that
+    /// nothing will ever reap — it just grows under symlink churn.
+    ///
+    /// Pre-retrofit (heddle#209) `rename_entry_with_options`'s displaced-
+    /// destination branch unconditionally did
+    /// `pending.state.insert(displaced_dest, Orphan{ open_count })` even
+    /// for non-`Live` nodes (Codex PR #182 r11 finding 3293575541). The
+    /// witness-gated retrofit replaces that with a
+    /// `BrandedPending::witness_live_nonzero` check whose `None` result
+    /// IS the short-circuit — a symlink never enters `state`, so the
+    /// witness constructor returns `None` and no transition fires.
+    #[test]
+    fn rename_over_symlink_does_not_orphan_state() {
+        let (_temp, mount) = open_mount();
+        let link = mount
+            .create_symlink(NodeId::ROOT, OsStr::new("link"), Path::new("hello.txt"))
+            .expect("create symlink");
+        assert!(
+            !mount.orphans_contains(link.node),
+            "newly-created symlink must have no Pending state entry",
+        );
+        mount
+            .create_file(NodeId::ROOT, OsStr::new("source"), FileMode::Normal, false)
+            .expect("create source file");
+        mount
+            .rename_entry(
+                NodeId::ROOT,
+                OsStr::new("source"),
+                NodeId::ROOT,
+                OsStr::new("link"),
+            )
+            .expect("rename file over symlink");
+        assert!(
+            !mount.orphans_contains(link.node),
+            "displaced symlink must not acquire a Pending state entry (r11 #4)",
+        );
+    }
+
     /// Cross-tree directory rename — i.e. renaming a captured-tree
     /// directory — is intentionally refused by `move_overlay_dir`;
     /// the overlay would otherwise need to rewrite every descendant


### PR DESCRIPTION
## Summary
- Adds `BrandedPending::transition_to_orphan(id) -> Option<Witness<Orphan>>` (the witness-gated FSM transition consuming heddle#208's substrate) and a `pub(crate) Pending::apply_transition_to_orphan(&Witness<Orphan>)` mutation hook whose `&Witness<Orphan>` parameter is the type-level discipline (`Witness::new` is module-private, so callers in `core.rs` cannot synthesize one).
- Threads the witness at both `core.rs` lifecycle-mutation sites — `unlink_entry` and `rename_entry_with_options`'s displaced-destination branch — replacing the previous direct `pending.state.insert(_, Orphan { open_count })` mutations.
- Closes Codex PR #182 r11 #4 (`rename_entry_with_options` orphaning the displaced destination regardless of state — including symlinks, which have no `open`/`release` lifecycle): the missing `Witness<Orphan>` from `bp.transition_to_orphan(dest_id)` IS the short-circuit at the call site. Pins this with a new regression test and subsumes the previous defensive `entry.kind != NodeKind::Symlink` gate in `unlink_entry` (the witness handles it by construction).
- Adds a `compile_fail` doctest pinning the entry-point discipline (`Pending::transition_to_orphan(0)` directly on `&mut Pending` fails to compile — the method lives on `BrandedPending`, which only `Pending::with_brand` can build).

Closes HeddleCo/heddle#209.

## Approach chosen + why

The brief sketched three candidate shapes (Approach A: `bp.transition_to_orphan(w)`; Option B: relax `Witness::_borrow` variance; Option C: CPS / closure). It noted A would be mechanical *if* the substrate's witness `'p` already matched `BrandedPending::'p`.

**This PR confirmed A is not mechanical**, then folded the FSM check and mutation into one call as a substrate-preserving variant:

* Literal Approach A — `bp.witness_live_nonzero(id).map(|w| bp.transition_to_orphan(w))` — fails to compile with `E0499`. The substrate's `Witness::_borrow: PhantomData<&'p mut ()>` is *invariant* over `'p`, so the prior `&mut BrandedPending` reborrow that minted `w` cannot shrink to admit the second `&mut self` call that would consume `w`. (The heddle#208 r3 self-audit explicitly flagged this as a known retrofit-time question.)
* Option B (relax `_borrow` variance) would weaken the substrate's stale-witness protection — the property that holding a `Witness` reborrow-locks the originating `BrandedPending` against intra-closure mutations. That's a substrate change for a separately-load-bearing invariant and is out of scope.
* Option C (CPS / closure pattern) preserves the most type discipline but adds an extra closure layer at every call site.

The fold preserves the spike doc's stated invariant — *the transition can only fire on a `LiveNonZero` state* — by construction:
* The body's `match` IS the `BrandedPending::witness_live_nonzero` FSM check; both refer to the same `Live { open_count >= 1 }` discriminant.
* Any non-`LiveNonZero` path returns `None` before touching `Pending::apply_transition_to_orphan`. Both call sites in `core.rs` propagate the `None` via `let _ = bp.transition_to_orphan(id)` — the missing witness IS the short-circuit (matching the brief's framing for r11 #4).
* The returned `Witness<Orphan>` is the only path to evidence that the transition fired — `Witness::new` is module-private and `Pending::apply_transition_to_orphan` takes `&Witness<Orphan>` as proof, so no code outside `pending.rs`'s `BrandedPending` impl can synthesize an orphan witness or record a transition.

The doc-comment on `BrandedPending::transition_to_orphan` cites this trade-off in full so future readers see why the spike doc's literal two-step shape isn't here.

## Red commit
\`$RED_SHA\` — `tests::write_ops::rename_over_symlink_does_not_orphan_state`. Creates a symlink, renames a regular file over it, asserts the displaced symlink's NodeId has no `Pending` state entry. Pre-retrofit it failed on the second `orphans_contains` assertion (`Orphan { open_count: 0 }` was inserted unconditionally).

## Test evidence

\`\`\`
\$ cargo test -p heddle-mount
...
test tests::write_ops::rename_over_symlink_does_not_orphan_state ... ok
test tests::write_ops::rename_over_preserves_warm_for_open_fd ... ok
test tests::write_ops::rename_over_destination_data_via_old_fd ... ok
test tests::write_ops::truncate_unlinked_open_doesnt_resurrect_path ... ok
test tests::write_ops::truncate_unlinked_open_keeps_warm_bytes ... ok
test tests::write_ops::unlink_then_read_warm_via_open_fd ... ok
test tests::write_ops::write_to_unlinked_open_inode_does_not_resurrect_path ... ok
test tests::write_ops::fchmod_on_unlinked_open_doesnt_leak_to_recreated ... ok
...
test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

\$ cargo test -p heddle-mount --doc
running 3 tests
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 92) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 139) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 176) - compile fail ... ok
test result: ok. 3 passed; 0 failed

\$ cargo clippy --workspace --all-targets -- -D warnings
... Finished \`dev\` profile [unoptimized + debuginfo] target(s)

\$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (500 file(s) scanned)
\`\`\`

## Note on the 7 amended pre-existing tests

Seven `mod write_ops` tests exercised "open fd → unlink/rename → read" flows but skipped the explicit `mount.on_open(node)` call, so the test harness left `state[node]` as `Released` (no entry). The pre-retrofit unconditional orphan transition masked the missing `on_open` — that's precisely the r11 #1 bug (`Records Orphan { open_count: 0 } for nodes with no live fds`). With the retrofit in place, `Released` nodes no longer transition to Orphan, and the seven tests must drive the FSM the same way production FUSE callbacks do. Each is amended with one `mount.on_open(node).expect("on_open")` call right after the implicit \`open\` event their test comments already named (\`fd = open(...)\` / \`O_CREAT|O_RDWR\`). The amended tests now match production semantics; none of their pre-existing assertions changed.

## Manual verification
N/A — covered by tests + compile-fail doctest.

## Blocked by → resolved
- HeddleCo/heddle#208 (substrate — already merged via PR #217).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782195141&installation_id=132405951&pr_number=219&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F219&signature=f3003233d172db367a4d3a3fee5fc6b6fd6ff6746049c23d600f3b8f080e1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->