### PR TITLE
heddle#210: retrofit drain_for_capture to typed Live/Orphan split (fixes r11 #2)

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -528,6 +528,43 @@ impl<'brand> Pending<'brand> {
         self.state.insert(id, NodeState::Orphan { open_count });
     }
 
+    /// Read-only iterator over the per-NodeId lifecycle map. Sole
+    /// enumeration point for [`crate::pending::Pending::drain_for_capture`]'s
+    /// typed-match classification pass — keeps the underlying `state`
+    /// field private to this module while letting the retrofitted drain
+    /// classify every resident entry by [`crate::pending::ResidentLifecycle`].
+    /// Returns owned `(u64, NodeState)` pairs (both are `Copy`) so the
+    /// iterator does not borrow `self` past the classify pass; the drain
+    /// then takes its own `&mut self` borrow to apply the retention.
+    pub(crate) fn lifecycle_iter(&self) -> impl Iterator<Item = (u64, NodeState)> + '_ {
+        self.state.iter().map(|(&id, &s)| (id, s))
+    }
+
+    /// Apply the retention/clear pass of [`crate::pending::Pending::drain_for_capture`].
+    /// `surviving` is the set of NodeIds whose `state` / `hot[id]` /
+    /// `warm[id]` entries must outlive the capture — produced by the
+    /// typed-match classifier in [`crate::pending`]; every NodeId in
+    /// the set was classified as [`crate::pending::ResidentLifecycle::LiveNonZero`]
+    /// (open fds still hold the bytes — POSIX last-close-wins) or
+    /// [`crate::pending::ResidentLifecycle::Orphan`] (directory entry
+    /// gone but the bytes outlive it).
+    ///
+    /// The path-keyed overlays are unconditionally cleared: every path
+    /// they covered is now folded into the new captured tree, and the
+    /// unlink/rename T1/T3 transitions already removed `hot_by_path` /
+    /// `symlinks` / `inodes.by_path` bindings for any orphan branch,
+    /// so nothing here references a surviving NodeId by path.
+    pub(crate) fn apply_drain_for_capture(&mut self, surviving: &BTreeSet<u64>) {
+        self.hot.retain(|id, _| surviving.contains(id));
+        self.warm.retain(|id, _| surviving.contains(id));
+        self.state.retain(|id, _| surviving.contains(id));
+        self.hot_by_path.clear();
+        self.tombstones.clear();
+        self.dir_tombstones.clear();
+        self.explicit_dirs.clear();
+        self.symlinks.clear();
+    }
+
     /// Test-only: insert a per-NodeId lifecycle entry directly,
     /// bypassing the FSM entry points. Used by the
     /// [`crate::pending`] substrate tests to set up `Pending` states
@@ -536,6 +573,31 @@ impl<'brand> Pending<'brand> {
     #[cfg(test)]
     pub(crate) fn test_insert_state(&mut self, id: u64, state: NodeState) {
         self.state.insert(id, state);
+    }
+
+    /// Test-only: insert a hot-tier buffer for `id` with the given
+    /// `path` and `bytes`. Used by the [`crate::pending`] tests to set
+    /// up scenarios where `drain_for_capture` must preserve the
+    /// per-NodeId byte storage alongside the lifecycle entry.
+    #[cfg(test)]
+    pub(crate) fn test_insert_hot(&mut self, id: u64, path: PathBuf, bytes: Vec<u8>) {
+        self.hot.insert(
+            id,
+            HotBuffer {
+                path,
+                mode: FileMode::Normal,
+                bytes,
+                last_touched: Instant::now(),
+            },
+        );
+    }
+
+    /// Test-only: true iff `hot[id]` is currently populated. Mirror
+    /// of [`Self::test_insert_hot`] for assertion in
+    /// `drain_for_capture` tests.
+    #[cfg(test)]
+    pub(crate) fn test_has_hot(&self, id: u64) -> bool {
+        self.hot.contains_key(&id)
     }
 }
 
@@ -3935,46 +3997,16 @@ impl ContentAddressedMount {
             warn!(?err, "thread metadata refresh from mount capture failed");
         }
 
-        // Step 4: drain the pending tier. Codex r12 thread 3293484633
-        // (P1): the prior wholesale `state.clear()` here dropped
-        // Orphan entries for inodes with still-open fds; the next
-        // write through those fds would then take the Live branch
-        // (`is_orphan` returns false → republish path / clear
-        // tombstone / coalesce hot_by_path), republishing a pathname
-        // that POSIX says must remain detached until final close.
-        // It also dropped `hot[id]` / `warm[id]` for those Orphan
-        // entries, losing the surviving fd's own bytes.
-        //
-        // The correct drain retires only Live entries plus all of
-        // the path-keyed bookkeeping (the new tree owns those paths
-        // now). Orphan entries — and their per-NodeId `hot[id]` /
-        // `warm[id]` bytes — survive so the orphan branches in
-        // `read` / `write` / `attrs` / `apply_truncate` keep serving
-        // the surviving fd, and `unlink_entry` / `rename`'s T1/T3
-        // transition stays in effect across capture.
+        // Step 4: drain the pending tier. See
+        // [`crate::pending::Pending::drain_for_capture`] for the
+        // contract: `LiveZero` retires; `LiveNonZero` (open fds still
+        // hold bytes — POSIX last-close-wins) and `Orphan`
+        // (open-but-unlinked) survive with their `hot[id]`/`warm[id]`
+        // bytes; the path-keyed overlays clear because every path they
+        // covered is now folded into the new tree.
         {
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            let orphan_ids: BTreeSet<u64> = pending
-                .state
-                .iter()
-                .filter_map(|(id, s)| match s {
-                    NodeState::Orphan { .. } => Some(*id),
-                    NodeState::Live { .. } => None,
-                })
-                .collect();
-            pending.hot.retain(|id, _| orphan_ids.contains(id));
-            pending.warm.retain(|id, _| orphan_ids.contains(id));
-            pending.state.retain(|id, _| orphan_ids.contains(id));
-            // Path-keyed bookkeeping is for the Live tree, which is
-            // now folded into the captured state; the orphan path
-            // overlays are gone by definition (T1/T3 already removed
-            // their `hot_by_path` / `symlinks` / `inodes.by_path`
-            // bindings) so wholesale clear is safe.
-            pending.hot_by_path.clear();
-            pending.tombstones.clear();
-            pending.dir_tombstones.clear();
-            pending.explicit_dirs.clear();
-            pending.symlinks.clear();
+            pending.drain_for_capture();
         }
         let mut state_lock = self.inner.state.write().expect("mount state lock");
         *state_lock = MountState {

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -244,6 +244,29 @@ impl<'a> Pending<'a> {
         let mut bp = BrandedPending { inner: rebranded };
         f(&mut bp)
     }
+
+    /// Retire per-NodeId entries that the just-completed capture has
+    /// folded into the new state, and clear all path-keyed overlays.
+    ///
+    /// **NOTE — heddle#210 in progress.** This commit extracts the
+    /// previously-inline drain in `core::ContentAddressedMount::capture_with_attribution`
+    /// into a method but **preserves the pre-retrofit (buggy) behaviour**:
+    /// every `Live` entry is dropped, including `Live { open_count >= 1 }`.
+    /// That's r11 #2 — POSIX last-close-wins is broken across capture
+    /// because the open fd's lifecycle entry + hot/warm bytes disappear.
+    /// The green commit replaces this body with a [`ResidentLifecycle`]-
+    /// typed exhaustive match so the "drop `LiveNonZero`" line cannot be
+    /// written without naming the discriminant explicitly.
+    pub(crate) fn drain_for_capture(&mut self) {
+        let surviving: std::collections::BTreeSet<u64> = self
+            .lifecycle_iter()
+            .filter_map(|(id, s)| match s {
+                NodeState::Orphan { .. } => Some(id),
+                NodeState::Live { .. } => None,
+            })
+            .collect();
+        self.apply_drain_for_capture(&surviving);
+    }
 }
 
 /// Sealed wrapper that grants access to the witness constructors.
@@ -839,5 +862,162 @@ mod tests {
             bp.witness_orphan(17).map(|w| w.id()).unwrap_or(0)
         });
         assert_eq!(extracted, 17);
+    }
+
+    // ------- drain_for_capture (heddle#210 — r11 #2 retrofit) ----------------
+    //
+    // Pin the per-lifecycle contract of [`Pending::drain_for_capture`]:
+    //
+    // * `LiveZero` retires — the entry has no open fds, so its byte
+    //   storage and lifecycle row are safe to drop once the capture
+    //   folds the path into the new tree.
+    // * `LiveNonZero` survives — open fds still hold the NodeId; POSIX
+    //   last-close-wins says the fd's view outlives the path-level
+    //   capture. Dropping this entry strands the kernel fd and loses
+    //   the writes it accumulated (r11 #2).
+    // * `Orphan` survives — directory entry already gone (T1/T3); the
+    //   open-but-unlinked POSIX flow needs the bytes to live until the
+    //   last close.
+    //
+    // Pre-retrofit (the buggy body this commit extracts) drops every
+    // `Live` entry indiscriminately, so the `LiveNonZero` tests below
+    // fail until the green commit lands the typed-match fix.
+
+    #[test]
+    fn drain_for_capture_preserves_live_nonzero_state() {
+        let mut p = Pending::default();
+        p.test_insert_state(7, NodeState::Live { open_count: 1 });
+        p.drain_for_capture();
+        assert_eq!(
+            p.lookup_state(7),
+            Some(NodeState::Live { open_count: 1 }),
+            "LiveNonZero must survive capture (POSIX last-close-wins; r11 #2)"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_preserves_live_nonzero_with_high_refcount() {
+        let mut p = Pending::default();
+        p.test_insert_state(11, NodeState::Live { open_count: u32::MAX });
+        p.drain_for_capture();
+        assert_eq!(
+            p.lookup_state(11),
+            Some(NodeState::Live {
+                open_count: u32::MAX
+            }),
+            "LiveNonZero entries must carry their open_count across capture"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_preserves_live_nonzero_hot_bytes() {
+        let mut p = Pending::default();
+        p.test_insert_state(13, NodeState::Live { open_count: 2 });
+        p.test_insert_hot(13, std::path::PathBuf::from("file.txt"), b"BYTES".to_vec());
+        p.drain_for_capture();
+        assert!(
+            p.test_has_hot(13),
+            "hot[id] for a LiveNonZero entry must survive capture so reads via the open fd serve the buffered bytes"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_drops_live_zero_state() {
+        let mut p = Pending::default();
+        p.test_insert_state(9, NodeState::Live { open_count: 0 });
+        p.drain_for_capture();
+        assert!(
+            p.lookup_state(9).is_none(),
+            "LiveZero entries (no open fds) must be retired by capture; the new tree owns their data"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_drops_live_zero_hot_bytes() {
+        let mut p = Pending::default();
+        p.test_insert_state(9, NodeState::Live { open_count: 0 });
+        p.test_insert_hot(9, std::path::PathBuf::from("x.txt"), b"X".to_vec());
+        p.drain_for_capture();
+        assert!(
+            !p.test_has_hot(9),
+            "hot[id] for a LiveZero entry should be dropped alongside its state row"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_preserves_orphan_state() {
+        let mut p = Pending::default();
+        p.test_insert_state(21, NodeState::Orphan { open_count: 3 });
+        p.drain_for_capture();
+        assert_eq!(
+            p.lookup_state(21),
+            Some(NodeState::Orphan { open_count: 3 }),
+            "Orphan entries must survive capture (open-but-unlinked POSIX)"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_preserves_orphan_with_zero_refcount() {
+        // Orphan { open_count: 0 } is a transient state the FSM
+        // releases on the next `release_node` — it must NOT be
+        // collapsed with `LiveZero` and dropped, because the
+        // path-side handler that retires it relies on observing the
+        // discriminant.
+        let mut p = Pending::default();
+        p.test_insert_state(23, NodeState::Orphan { open_count: 0 });
+        p.drain_for_capture();
+        assert_eq!(
+            p.lookup_state(23),
+            Some(NodeState::Orphan { open_count: 0 }),
+            "Orphan with zero refcount must survive capture; the discriminant — not the count — is what matters"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_preserves_orphan_hot_bytes() {
+        let mut p = Pending::default();
+        p.test_insert_state(25, NodeState::Orphan { open_count: 1 });
+        p.test_insert_hot(
+            25,
+            std::path::PathBuf::from("gone.txt"),
+            b"SURVIVES".to_vec(),
+        );
+        p.drain_for_capture();
+        assert!(
+            p.test_has_hot(25),
+            "hot[id] for an Orphan entry must survive capture so the surviving fd serves the inode's own bytes"
+        );
+    }
+
+    #[test]
+    fn drain_for_capture_mixed_state_map() {
+        // One of each resident lifecycle — the typed match must
+        // handle them simultaneously without collapsing distinctions.
+        let mut p = Pending::default();
+        p.test_insert_state(100, NodeState::Live { open_count: 1 }); // preserve
+        p.test_insert_state(101, NodeState::Live { open_count: 0 }); // drop
+        p.test_insert_state(102, NodeState::Orphan { open_count: 2 }); // preserve
+        p.test_insert_state(103, NodeState::Orphan { open_count: 0 }); // preserve
+        p.test_insert_state(104, NodeState::Live { open_count: 7 }); // preserve
+
+        p.drain_for_capture();
+
+        assert_eq!(
+            p.lookup_state(100),
+            Some(NodeState::Live { open_count: 1 })
+        );
+        assert!(p.lookup_state(101).is_none(), "LiveZero must retire");
+        assert_eq!(
+            p.lookup_state(102),
+            Some(NodeState::Orphan { open_count: 2 })
+        );
+        assert_eq!(
+            p.lookup_state(103),
+            Some(NodeState::Orphan { open_count: 0 })
+        );
+        assert_eq!(
+            p.lookup_state(104),
+            Some(NodeState::Live { open_count: 7 })
+        );
     }
 }

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -113,6 +113,67 @@ impl Lifecycle for LiveZero {}
 impl Lifecycle for Orphan {}
 impl Lifecycle for Released {}
 
+/// Runtime discriminator for the three *resident* [`Lifecycle`]
+/// markers — the ones that can ever appear in [`crate::core::Pending`]'s
+/// `state` map. [`Released`] is the absence-of-entry state and is
+/// never returned: the classifier runs only after a successful
+/// [`crate::core::Pending::lookup_state`] (the `Option<NodeState>`
+/// has already been unwrapped to a `NodeState`), so a `Released` arm
+/// would be unreachable. The doc-comment on
+/// [`Pending::drain_for_capture`] documents why the match has no
+/// fourth arm.
+///
+/// The variants intentionally mirror the substrate's [`LiveNonZero`]
+/// / [`LiveZero`] / [`Orphan`] type-state ZSTs at the value layer.
+/// Code that wants to drop `LiveNonZero` (the r11 #2 bug) cannot
+/// collapse the discriminant by accident: the variant must be named
+/// explicitly in any match against `ResidentLifecycle`, which makes
+/// the bug unwritable without an obvious diff
+/// ([`docs/design/mount-pending-api-contracts.md`][doc] §3 row 2).
+///
+/// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub(crate) enum ResidentLifecycle {
+    /// `Live { open_count >= 1 }`. POSIX last-close-wins applies — at
+    /// least one kernel fd holds the NodeId, so the lifecycle row and
+    /// per-NodeId byte storage must outlive any path-level operation,
+    /// including capture, until the final close.
+    LiveNonZero,
+    /// `Live { open_count == 0 }`. The path is still resolvable but
+    /// no fd references the inode; the per-NodeId byte storage can be
+    /// retired alongside the lifecycle row on capture without
+    /// breaking POSIX.
+    LiveZero,
+    /// `Orphan { open_count >= 0 }`. Directory entry already retired
+    /// (post-unlink / post-rename-over T1/T3); the per-NodeId bytes
+    /// must outlive the entry as long as any fd holds the NodeId.
+    /// Refcount-irrelevant — the discriminant is what gates the
+    /// drain decision, mirroring the substrate's [`BrandedPending::witness_orphan`]
+    /// constructor.
+    Orphan,
+}
+
+impl ResidentLifecycle {
+    /// Project a runtime [`NodeState`] onto its [`ResidentLifecycle`]
+    /// discriminator. The match is exhaustive over [`NodeState`]'s
+    /// two variants (`Live` / `Orphan`) by language rule, and
+    /// exhaustive over the three resident [`Lifecycle`] markers by
+    /// codomain.
+    pub(crate) fn classify(s: &NodeState) -> Self {
+        match s {
+            // `LiveZero` is split out from `LiveNonZero` so the drain
+            // contract can name the two discriminants separately.
+            // Without this split, "drop every Live entry" would be
+            // one line; with it, the diff has to say `LiveNonZero`
+            // explicitly — the r11 #2 type-system rejection.
+            NodeState::Live { open_count: 0 } => Self::LiveZero,
+            NodeState::Live { .. } => Self::LiveNonZero,
+            NodeState::Orphan { .. } => Self::Orphan,
+        }
+    }
+}
+
 /// Type-level proof that `id` was in lifecycle state `S` under the
 /// `&mut Pending<'brand>` borrow `'p` that minted it.
 ///
@@ -248,21 +309,59 @@ impl<'a> Pending<'a> {
     /// Retire per-NodeId entries that the just-completed capture has
     /// folded into the new state, and clear all path-keyed overlays.
     ///
-    /// **NOTE — heddle#210 in progress.** This commit extracts the
-    /// previously-inline drain in `core::ContentAddressedMount::capture_with_attribution`
-    /// into a method but **preserves the pre-retrofit (buggy) behaviour**:
-    /// every `Live` entry is dropped, including `Live { open_count >= 1 }`.
-    /// That's r11 #2 — POSIX last-close-wins is broken across capture
-    /// because the open fd's lifecycle entry + hot/warm bytes disappear.
-    /// The green commit replaces this body with a [`ResidentLifecycle`]-
-    /// typed exhaustive match so the "drop `LiveNonZero`" line cannot be
-    /// written without naming the discriminant explicitly.
+    /// The classifier match is exhaustive over the three *resident*
+    /// [`Lifecycle`] markers — [`LiveNonZero`], [`LiveZero`], [`Orphan`]:
+    ///
+    /// * [`ResidentLifecycle::LiveNonZero`] — survives. At least one
+    ///   kernel fd holds the NodeId; POSIX last-close-wins says the
+    ///   fd's view of the inode must outlive any path-level operation
+    ///   until the final close. The lifecycle row, `hot[id]`, and
+    ///   `warm[id]` are all preserved so the open fd keeps seeing its
+    ///   own bytes after the capture folds the path into the new tree.
+    /// * [`ResidentLifecycle::LiveZero`] — retires. The path is now
+    ///   in the captured tree and no fd references the inode, so the
+    ///   lifecycle row + per-NodeId bytes are safe to drop.
+    /// * [`ResidentLifecycle::Orphan`] — survives. The directory
+    ///   entry is already gone (post T1/T3); the bytes must outlive
+    ///   the entry as long as any fd holds the NodeId. Refcount-
+    ///   irrelevant — `Orphan { open_count: 0 }` is a transient state
+    ///   the FSM clears on the next `release_node`, not here.
+    ///
+    /// [`Released`] is intentionally absent from the match.
+    /// [`crate::core::Pending::lifecycle_iter`] only yields entries
+    /// that exist in `state`, and the `state` map never stores the
+    /// absence-of-entry state by construction — adding a `Released`
+    /// arm would be unreachable (and incorrect). See
+    /// [`docs/design/mount-pending-api-contracts.md`][doc] §3 row 2
+    /// for the bug-by-bug analysis.
+    ///
+    /// The path-keyed overlays (`hot_by_path`, `tombstones`,
+    /// `dir_tombstones`, `explicit_dirs`, `symlinks`) clear
+    /// unconditionally: every path they covered is now folded into
+    /// the new tree, and the orphan branches in
+    /// `unlink_entry` / `rename_entry`'s T1/T3 already retired their
+    /// path-side bindings, so no surviving NodeId is reachable through
+    /// them.
+    ///
+    /// # Why the match makes r11 #2 unwritable
+    ///
+    /// The pre-retrofit drain matched directly on `NodeState`'s
+    /// `Live` / `Orphan` discriminants, so collapsing both Live
+    /// refcount states into one `=> None` arm was one line. The
+    /// retrofitted match goes through [`ResidentLifecycle`], which
+    /// splits `LiveZero` and `LiveNonZero` into separate variants —
+    /// a future drive-by that wanted to drop Live-with-fds (the r11
+    /// #2 bug) has to write `ResidentLifecycle::LiveNonZero => None`
+    /// explicitly, which is loud in code review.
+    ///
+    /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
     pub(crate) fn drain_for_capture(&mut self) {
         let surviving: std::collections::BTreeSet<u64> = self
             .lifecycle_iter()
-            .filter_map(|(id, s)| match s {
-                NodeState::Orphan { .. } => Some(id),
-                NodeState::Live { .. } => None,
+            .filter_map(|(id, s)| match ResidentLifecycle::classify(&s) {
+                ResidentLifecycle::LiveNonZero => Some(id), // POSIX last-close-wins
+                ResidentLifecycle::Orphan => Some(id),      // open-but-unlinked
+                ResidentLifecycle::LiveZero => None,        // safe to retire
             })
             .collect();
         self.apply_drain_for_capture(&surviving);
@@ -1019,5 +1118,109 @@ mod tests {
             p.lookup_state(104),
             Some(NodeState::Live { open_count: 7 })
         );
+    }
+
+    // ------- ResidentLifecycle classifier ------------------------------------
+
+    #[test]
+    fn resident_lifecycle_classify_live_zero() {
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Live { open_count: 0 }),
+            ResidentLifecycle::LiveZero,
+        );
+    }
+
+    #[test]
+    fn resident_lifecycle_classify_live_nonzero_at_one() {
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Live { open_count: 1 }),
+            ResidentLifecycle::LiveNonZero,
+        );
+    }
+
+    #[test]
+    fn resident_lifecycle_classify_live_nonzero_at_max() {
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Live {
+                open_count: u32::MAX
+            }),
+            ResidentLifecycle::LiveNonZero,
+        );
+    }
+
+    #[test]
+    fn resident_lifecycle_classify_orphan_any_refcount() {
+        // The classifier collapses both `Orphan { 0 }` and
+        // `Orphan { n }` onto the same discriminant — the substrate
+        // contract is "discriminant gates the drain decision", not
+        // refcount.
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Orphan { open_count: 0 }),
+            ResidentLifecycle::Orphan,
+        );
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Orphan { open_count: 5 }),
+            ResidentLifecycle::Orphan,
+        );
+        assert_eq!(
+            ResidentLifecycle::classify(&NodeState::Orphan {
+                open_count: u32::MAX
+            }),
+            ResidentLifecycle::Orphan,
+        );
+    }
+
+    // ------- proptest: FSM-trace-ending-in-capture -----------------------------
+    //
+    // Generates a random sequence of `(NodeId, NodeState)` writes
+    // (last-write-wins per id), replays them into a fresh `Pending`,
+    // runs `drain_for_capture`, and asserts the post-capture map is
+    // exactly the input collapse minus the `LiveZero` entries — i.e.
+    // every `LiveNonZero` / `Orphan` survivor carries its `open_count`
+    // intact, and every `LiveZero` retires. The NodeId range is kept
+    // small (0..16) to maximise collisions, and the trace length is
+    // capped at 32 to keep shrunken counterexamples readable. Covers
+    // the heddle#210 AC: "random FSM trace ending in a capture
+    // preserves all open-fd refcounts".
+
+    use proptest::prelude::*;
+
+    proptest::proptest! {
+        #[test]
+        fn drain_for_capture_proptest_preserves_open_counts(
+            entries in proptest::collection::vec(
+                (
+                    0u64..16,
+                    proptest::prop_oneof![
+                        proptest::num::u32::ANY
+                            .prop_map(|n| NodeState::Live { open_count: n }),
+                        proptest::num::u32::ANY
+                            .prop_map(|n| NodeState::Orphan { open_count: n }),
+                    ],
+                ),
+                0..32usize,
+            ),
+        ) {
+            // Replay the trace; last write wins per NodeId. Build the
+            // expected post-drain map alongside.
+            let mut p = Pending::default();
+            let mut expected: std::collections::BTreeMap<u64, NodeState> =
+                std::collections::BTreeMap::new();
+            for (id, state) in &entries {
+                p.test_insert_state(*id, *state);
+                expected.insert(*id, *state);
+            }
+            // LiveZero retires by contract.
+            expected.retain(|_, s| !matches!(s, NodeState::Live { open_count: 0 }));
+
+            p.drain_for_capture();
+
+            // Post-drain state must equal the expected map exactly:
+            // every `LiveNonZero` / `Orphan` entry (with its
+            // `open_count` intact) is present, and nothing else is.
+            let after: std::collections::BTreeMap<u64, NodeState> =
+                p.lifecycle_iter().collect();
+            proptest::prop_assert_eq!(after, expected);
+        }
     }
 }

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -3037,6 +3037,58 @@ mod write_ops {
         );
     }
 
+    /// Codex thread 3293484633 cont. (r11 #2, P1) — heddle#210
+    /// retrofit. `drain_for_capture` used to drop every `Live` entry,
+    /// including `Live { open_count >= 1 }`. The open fd's lifecycle
+    /// row + hot/warm bytes disappeared, so a subsequent write through
+    /// that fd took the `Released` branch (no `state[node]`) and
+    /// republished the file under its original path with empty
+    /// content — breaking POSIX last-close-wins for live-and-open
+    /// files across capture. The fix preserves `LiveNonZero` entries
+    /// + their per-NodeId byte storage so reads/writes via the open
+    /// fd keep serving the buffered content.
+    #[test]
+    fn capture_preserves_live_state_for_open_inodes() {
+        let (_temp, mount) = open_mount();
+        // Create a fresh file, open it (refcount = 1), write through
+        // the fd. NO unlink — the directory entry remains, so the
+        // inode stays `Live { open_count: 1 }`.
+        let entry = mount
+            .create_file(
+                NodeId::ROOT,
+                OsStr::new("live-and-open"),
+                FileMode::Normal,
+                false,
+            )
+            .expect("create");
+        mount.on_open(entry.node).expect("on_open");
+        mount.write(entry.node, 0, b"BEFORE").expect("write");
+
+        // Capture. Pre-fix this wipes `state` for the Live entry
+        // (and its `hot[id]` / `warm[id]`), stranding the kernel fd.
+        mount
+            .capture(Some("capture with live-and-open fd".into()))
+            .expect("capture");
+
+        // Through the surviving fd: write replaces bytes, read serves
+        // them. Pre-fix: the post-capture write republishes the path
+        // under the (now-captured) name, and the read returns whatever
+        // the captured state held. Post-fix: the fd's view of the
+        // inode is independent of the capture's path-level fold-in.
+        mount
+            .write(entry.node, 0, b"AFTER")
+            .expect("write through live fd survives capture");
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(entry.node, 0, &mut buf)
+            .expect("read via live fd after capture");
+        assert_eq!(
+            &buf[..n],
+            b"AFTER",
+            "live hot bytes must survive capture so subsequent writes via the open fd are readable (POSIX last-close-wins; r11 #2)"
+        );
+    }
+
     /// Codex threads 3293484634 + 3293510311 (P1). `invalidate` (FUSE
     /// `forget`) drops `pending.warm[node]` unconditionally, but `forget`
     /// only signals that the kernel released its cached inode reference —

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -3037,16 +3037,13 @@ mod write_ops {
         );
     }
 
-    /// Codex thread 3293484633 cont. (r11 #2, P1) — heddle#210
-    /// retrofit. `drain_for_capture` used to drop every `Live` entry,
-    /// including `Live { open_count >= 1 }`. The open fd's lifecycle
-    /// row + hot/warm bytes disappeared, so a subsequent write through
-    /// that fd took the `Released` branch (no `state[node]`) and
-    /// republished the file under its original path with empty
-    /// content — breaking POSIX last-close-wins for live-and-open
-    /// files across capture. The fix preserves `LiveNonZero` entries
-    /// + their per-NodeId byte storage so reads/writes via the open
-    /// fd keep serving the buffered content.
+    /// Codex thread 3293484633 cont. (r11 #2, P1) — heddle#210 retrofit.
+    /// `drain_for_capture` used to drop every `Live` entry, including
+    /// `Live { open_count >= 1 }`. The open fd's lifecycle row + hot/warm
+    /// bytes disappeared, so a subsequent write through that fd
+    /// recreated an empty hot buffer — POSIX last-close-wins requires
+    /// the fd to keep seeing the bytes it already buffered. The fix
+    /// preserves `LiveNonZero` entries + their per-NodeId byte storage.
     #[test]
     fn capture_preserves_live_state_for_open_inodes() {
         let (_temp, mount) = open_mount();
@@ -3070,11 +3067,14 @@ mod write_ops {
             .capture(Some("capture with live-and-open fd".into()))
             .expect("capture");
 
-        // Through the surviving fd: write replaces bytes, read serves
-        // them. Pre-fix: the post-capture write republishes the path
-        // under the (now-captured) name, and the read returns whatever
-        // the captured state held. Post-fix: the fd's view of the
-        // inode is independent of the capture's path-level fold-in.
+        // Through the surviving fd: a 5-byte overwrite at offset 0
+        // must lay over the 6-byte "BEFORE" buffer, NOT a fresh
+        // empty one. Pre-fix the drain dropped `hot[node]`, so the
+        // post-capture write recreated an empty buffer and the read
+        // returned just "AFTER" (5 bytes) — losing the trailing 'E'
+        // that POSIX last-close-wins requires the fd to still see.
+        // Post-fix the hot buffer survives, the 5-byte overwrite
+        // leaves the 6th byte alone, and the read returns "AFTERE".
         mount
             .write(entry.node, 0, b"AFTER")
             .expect("write through live fd survives capture");
@@ -3084,8 +3084,8 @@ mod write_ops {
             .expect("read via live fd after capture");
         assert_eq!(
             &buf[..n],
-            b"AFTER",
-            "live hot bytes must survive capture so subsequent writes via the open fd are readable (POSIX last-close-wins; r11 #2)"
+            b"AFTERE",
+            "live hot bytes must survive capture so a partial overwrite via the open fd preserves the trailing pre-capture byte (POSIX last-close-wins; r11 #2)"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds `ResidentLifecycle` enum (`LiveNonZero` / `LiveZero` / `Orphan`) in `crates/mount/src/pending.rs` — a runtime discriminator for the three resident `Lifecycle` markers; mirrors the substrate's type-state ZSTs at the value layer. `Released` is intentionally absent because the classifier only runs on already-unwrapped `NodeState` values and `state` never stores absence-of-entry.
- Rewrites `Pending::drain_for_capture` to filter through `ResidentLifecycle::classify`: `LiveNonZero` survives (POSIX last-close-wins), `Orphan` survives (open-but-unlinked), `LiveZero` retires. Path-keyed overlays (`hot_by_path` / `tombstones` / `dir_tombstones` / `explicit_dirs` / `symlinks`) still clear unconditionally because every path they covered is folded into the new tree.
- Closes Codex PR #182 r11 #2 (P1): `drain_for_capture` used to drop every `Live` entry, including `Live { open_count >= 1 }` — the open fd's lifecycle row + hot/warm bytes disappeared, breaking POSIX last-close-wins across capture. The retrofit makes the bug unwritable: the `LiveZero` / `LiveNonZero` split forces any "drop Live with open fds" change to name `LiveNonZero` explicitly in a match.
- Extracts the previously-inline drain in `core::ContentAddressedMount::capture_with_attribution` into `Pending::drain_for_capture`, plumbed through two narrow `pub(crate)` accessors on `Pending` (`lifecycle_iter` for the classify pass + `apply_drain_for_capture` for the retention/clear pass) — mirrors the `lookup_state` / `apply_transition_to_orphan` split heddle#219 established.

Closes HeddleCo/heddle#210.

## Red commit
`fd3008b5cc7e37589f1fd07f07ec845c3f23d9e0` — failing tests at the red SHA:
- `pending::tests::drain_for_capture_preserves_live_nonzero_state`
- `pending::tests::drain_for_capture_preserves_live_nonzero_with_high_refcount`
- `pending::tests::drain_for_capture_preserves_live_nonzero_hot_bytes`
- `pending::tests::drain_for_capture_mixed_state_map`

## Approach: method on `Pending`, not `BrandedPending`

heddle#219 placed `transition_to_orphan` on `BrandedPending<'p, 'brand>` because that method consumes a `Witness<LiveNonZero>` and produces a `Witness<Orphan>` — the brand-gated wrapper is what makes the witness API sound across a `Pending`'s lifetime. `drain_for_capture` neither consumes nor produces a witness; the brief notes this explicitly (\"the signature gains no parameters (capture-drain is whole-map by construction)\"). The witness pattern is not relevant here, so the method lives on `Pending<'a>` directly, matching the issue title's `Pending::drain_for_capture` naming.

The type-system rejection that fixes r11 #2 comes from the `ResidentLifecycle` split — not from a witness gate. Splitting `LiveZero` and `LiveNonZero` into two enum variants forces any code that wants to drop Live-with-fds to name the discriminant explicitly:

```rust
self.lifecycle_iter()
    .filter_map(|(id, s)| match ResidentLifecycle::classify(&s) {
        ResidentLifecycle::LiveNonZero => Some(id), // POSIX last-close-wins
        ResidentLifecycle::Orphan      => Some(id), // open-but-unlinked
        ResidentLifecycle::LiveZero    => None,     // safe to retire
    })
```

A drive-by that wanted to short-circuit "drop every Live entry" has to write `ResidentLifecycle::LiveNonZero => None` — loud in code review, and the diff explicitly names the discriminant POSIX requires to survive.

## Why no `Released` arm

`Released` (absence-of-entry) is one of the four `Lifecycle` markers in the substrate, but it can never appear in `Pending::state` by construction. The `lifecycle_iter` accessor walks `state.iter()`, which only yields entries that exist. Adding a `ResidentLifecycle::Released` variant + arm would be unreachable (and conceptually wrong — `Released` is not a *resident* state). The enum's variant docs + the `drain_for_capture` doc-comment both call this out so future readers don't add a fourth arm.

## Test evidence

```
$ cargo test -p heddle-mount --lib
...
test pending::tests::drain_for_capture_preserves_live_nonzero_state ... ok
test pending::tests::drain_for_capture_preserves_live_nonzero_with_high_refcount ... ok
test pending::tests::drain_for_capture_preserves_live_nonzero_hot_bytes ... ok
test pending::tests::drain_for_capture_drops_live_zero_state ... ok
test pending::tests::drain_for_capture_drops_live_zero_hot_bytes ... ok
test pending::tests::drain_for_capture_preserves_orphan_state ... ok
test pending::tests::drain_for_capture_preserves_orphan_with_zero_refcount ... ok
test pending::tests::drain_for_capture_preserves_orphan_hot_bytes ... ok
test pending::tests::drain_for_capture_mixed_state_map ... ok
test pending::tests::resident_lifecycle_classify_live_zero ... ok
test pending::tests::resident_lifecycle_classify_live_nonzero_at_one ... ok
test pending::tests::resident_lifecycle_classify_live_nonzero_at_max ... ok
test pending::tests::resident_lifecycle_classify_orphan_any_refcount ... ok
test pending::tests::drain_for_capture_proptest_preserves_open_counts ... ok
test tests::write_ops::capture_preserves_live_state_for_open_inodes ... ok
test tests::write_ops::capture_preserves_orphan_state_for_open_inodes ... ok
...
test result: ok. 149 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 37.10s

$ cargo test -p heddle-mount --doc
running 3 tests
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 92) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 139) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 176) - compile fail ... ok
test result: ok. 3 passed; 0 failed

$ cargo clippy --workspace --all-targets -- -D warnings
... Finished `dev` profile [unoptimized + debuginfo] target(s)

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (500 file(s) scanned)
```

## Acceptance criteria

- [x] Inner `match` is exhaustive over the three *resident* `Lifecycle` types — `LiveNonZero`, `LiveZero`, `Orphan`. `Released` is the absence-of-entry state and is never stored in the map; the `ResidentLifecycle` enum's doc + the `drain_for_capture` doc-comment both call this out so future readers don't add a `Released` arm.
- [x] `LiveNonZero` entries are preserved across capture (POSIX last-close-wins regression test — `drain_for_capture_preserves_live_nonzero_state` + `_with_high_refcount` + `_hot_bytes` + the integration test `capture_preserves_live_state_for_open_inodes`).
- [x] r10 fixture tests still pass (`capture_preserves_orphan_state_for_open_inodes` + the rest of `tests::write_ops::*` continue to pass).
- [x] New proptest fixture: `drain_for_capture_proptest_preserves_open_counts` — random FSM trace (0..16 NodeIds × 0..32 events) ending in capture preserves all open-fd refcounts.
- [x] Local CI parity gates green (`cargo test -p heddle-mount`, `cargo clippy --workspace --all-targets -- -D warnings`, `bash scripts/check-no-silent-default-tree-load.sh`).

## Manual verification
N/A — covered by tests + proptest.

## Blocked by → resolved
- HeddleCo/heddle#208 (substrate — already merged via PR #217).

This unblocks heddle#212 (the property-test harness sub-issue, per `docs/design/mount-pending-api-contracts.md` §6 sub-issue 5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782210481&installation_id=132405951&pr_number=220&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F220&signature=706e4069ddad32adf36b7e30af8baa20abb4d2f7d93c3e59e53c2a23d533938b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->