### PR TITLE
heddle#211: witness-gated kernel_forget_inode on BrandedPending (fixes r11 #3)

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -540,6 +540,44 @@ impl<'brand> Pending<'brand> {
         self.state.iter().map(|(&id, &s)| (id, s))
     }
 
+    /// Witness-gated FUSE-forget discharge. The
+    /// `&KernelForgetWitness<'_, 'brand>` parameter is the type-level
+    /// proof that the caller has already gone through the discharge-
+    /// safety FSM check: the witness is constructed only inside
+    /// [`crate::pending::BrandedPending::kernel_forget_inode`], whose
+    /// body matches the same `None | Some(Live { open_count: 0 })`
+    /// pattern as [`crate::pending::BrandedPending::witness_kernel_forget`].
+    /// [`crate::pending::KernelForgetWitness::new`] is module-private
+    /// to [`crate::pending`], so the only callers that can name this
+    /// method's argument type are that one entry point (and code that
+    /// already held a witness — same brand-gating chain as
+    /// [`Self::apply_transition_to_orphan`]).
+    ///
+    /// Removes `hot[id]` (with its `hot_by_path` reverse-index
+    /// cleanup) and `state[id]`, then returns `true` iff `warm[id]`
+    /// is still populated — the caller in `MountInner::invalidate`
+    /// uses that bool to decide whether the inode-side `forget` is
+    /// safe to fire (warm is the durable pre-capture copy; if it's
+    /// there, capture still needs the NodeId → path chain).
+    ///
+    /// `warm` is intentionally preserved here per Codex r12 threads
+    /// 3293484634 / 3293510311 (P1): FUSE `forget` is a kernel-side
+    /// dcache eviction, not a close — dropping warm bytes silently
+    /// loses the user's committed-in-session data.
+    pub(crate) fn apply_kernel_forget(
+        &mut self,
+        w: &crate::pending::KernelForgetWitness<'_, 'brand>,
+    ) -> bool {
+        let id = w.id();
+        if let Some(buf) = self.hot.remove(&id)
+            && self.hot_by_path.get(&buf.path) == Some(&id)
+        {
+            self.hot_by_path.remove(&buf.path);
+        }
+        self.state.remove(&id);
+        self.warm.contains_key(&id)
+    }
+
     /// Apply the retention/clear pass of [`crate::pending::Pending::drain_for_capture`].
     /// `surviving` is the set of NodeIds whose `state` / `hot[id]` /
     /// `warm[id]` entries must outlive the capture — produced by the
@@ -3742,41 +3780,45 @@ impl PlatformShell for ContentAddressedMount {
     }
 
     fn invalidate(&self, node: NodeId) -> Result<()> {
-        // Drop any hot buffer attached to this NodeId — the kernel
-        // is telling us our cached identity is no longer valid, and
-        // we don't want a stale buffer surviving the inode flip.
-        // Only retract the path → inode mapping if it still points
-        // at us; an unlink-then-recreate sequence may have moved
-        // the live mapping to a fresh inode at the same name, and
-        // a blind `remove` would yank that fresh inode's entry.
+        // Witness-gated discharge: `bp.kernel_forget_inode(node.0)`
+        // returns:
         //
-        // Codex r12 threads 3293484634 / 3293510311 (P1): FUSE
-        // `forget` only signals that the kernel released its cached
-        // identity for this inode — it does NOT say the file's
-        // pending overlay data is stale. Warm is the only durable
-        // pre-capture copy of flushed writes; dropping it silently
-        // loses the user's committed-in-session data. Preserve
-        // `warm[node]` here, and only retire the inode record when
-        // nothing in the overlay still references the NodeId —
-        // otherwise capture loses the NodeId → path chain it needs
-        // to plant the warm bytes back into the new tree.
-        let still_referenced = {
+        // * `Some(warm_still_references)` — the FSM check passed
+        //   (state is `Released` or `Live { open_count == 0 }`);
+        //   `hot[node]` (with its `hot_by_path` reverse-index
+        //   cleanup) and `state[node]` have been dropped, and the
+        //   bool tells us whether `warm[node]` is still populated.
+        //   Retire the inode-side record iff warm doesn't reference
+        //   — otherwise capture still needs the NodeId → path chain
+        //   to plant the warm bytes back into the new tree.
+        // * `None` — the FSM check failed (state is
+        //   `Live { open_count >= 1 }` or any `Orphan`); the bytes
+        //   are still referenced. The witness-gated retrofit
+        //   (heddle#211) makes the entire forget path short-circuit
+        //   here: `hot[node]` / `state[node]` are preserved and the
+        //   inode-side `forget` is skipped. The kernel will re-issue
+        //   `forget` once the surviving fd closes (or never, and the
+        //   next `release_node` retires the record). Closes Codex
+        //   r11 finding #3 — the pre-retrofit path removed
+        //   `hot[node]` before any FSM check, stranding an open
+        //   Orphan fd with no readable bytes.
+        //
+        // Warm preservation (Codex r12 threads 3293484634 /
+        // 3293510311, P1): `apply_kernel_forget` intentionally
+        // leaves `warm[node]` alone — warm is the only durable
+        // pre-capture copy of flushed writes, and FUSE `forget` is
+        // a kernel-side dcache eviction (not a close), so dropping
+        // warm would silently lose the user's committed-in-session
+        // data.
+        let retire_inode_record = {
             let mut pending = self.inner.pending.lock().expect("pending lock");
-            if let Some(buf) = pending.hot.remove(&node.0)
-                && pending.hot_by_path.get(&buf.path) == Some(&node.0)
-            {
-                pending.hot_by_path.remove(&buf.path);
-            }
-            // State tracks the per-inode open-handle refcount; FUSE
-            // `forget` is a kernel-side cache eviction (not a close),
-            // so the refcount is already at 0 by the time we see it.
-            // Drop the state entry so a long-running mount doesn't
-            // accumulate dead lifecycle records. Warm preservation
-            // (above) is the load-bearing change here.
-            pending.state.remove(&node.0);
-            pending.warm.contains_key(&node.0)
+            pending.with_brand(|bp| {
+                bp.kernel_forget_inode(node.0)
+                    .map(|warm_still_references| !warm_still_references)
+                    .unwrap_or(false)
+            })
         };
-        if !still_referenced {
+        if retire_inode_record {
             self.inner.inodes.lock().expect("inode lock").forget(node);
         }
         Ok(())

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -182,6 +182,29 @@ mod tests;
 /// // `Pending`), so the `compile_fail` assertion holds → GREEN.
 /// let _ = p.transition_to_orphan(0);
 /// ```
+///
+/// The same entry-point discipline applies to the witness-gated
+/// kernel-forget retrofit (heddle#211): `kernel_forget_inode` lives
+/// on [`crate::pending::BrandedPending`], not on [`core::Pending`].
+/// A direct call on `Pending` is the bypass shape — pre-retrofit
+/// the forget logic was inlined in `MountInner::invalidate` with no
+/// FSM gate, and the natural drive-by "add a method on `Pending`"
+/// would re-open the same r11 #3 race. The doctest below pins the
+/// post-retrofit discipline: `Pending::kernel_forget_inode` does not
+/// exist as a directly-callable method, so this fails to compile
+/// and the `compile_fail` assertion holds (GREEN).
+///
+/// ```compile_fail
+/// use mount::__pending_substrate_for_doctest::*;
+/// let mut p = Pending::default();
+/// // `kernel_forget_inode` lives on `BrandedPending`, not on
+/// // `Pending`. A direct un-witnessed call on `Pending` is the
+/// // bypass shape that would re-introduce r11 #3 (drop hot[id]
+/// // without first checking the FSM). Post-retrofit the method
+/// // doesn't exist on `Pending`, so the call fails to compile and
+/// // the `compile_fail` assertion holds → GREEN.
+/// let _ = p.kernel_forget_inode(0);
+/// ```
 #[doc(hidden)]
 pub mod __pending_substrate_for_doctest {
     pub use crate::core::Pending;

--- a/crates/mount/src/pending.rs
+++ b/crates/mount/src/pending.rs
@@ -620,6 +620,77 @@ impl<'p, 'brand> BrandedPending<'p, 'brand> {
             _ => None,
         }
     }
+
+    /// Witness-gated FUSE-forget discharge. Returns:
+    ///
+    /// * `Some(warm_still_references)` — the lifecycle check passed
+    ///   (`Released` or `Live { open_count == 0 }`); `hot[id]` and
+    ///   `state[id]` have been dropped, and the bool tells the caller
+    ///   whether `warm[id]` is still populated (i.e., whether the
+    ///   inode record is still load-bearing for capture's
+    ///   NodeId → path chain). `MountInner::invalidate` retires the
+    ///   inode-side record iff this bool is `false`.
+    /// * `None` — the lifecycle check failed (`Live { open_count >= 1 }`
+    ///   or any `Orphan`); the bytes are still referenced. **The
+    ///   entire forget path short-circuits** at the call site:
+    ///   `hot[id]` / `state[id]` are preserved and the inode-side
+    ///   `forget` is skipped. The kernel will re-issue `forget` once
+    ///   the surviving fd closes (or never — the next `release_node`
+    ///   retires the record).
+    ///
+    /// # Why `id` and not a [`KernelForgetWitness`] input?
+    ///
+    /// The spike doc ([§2.3][doc]) sketched the API as
+    /// `kernel_forget_inode(&mut self, w: KernelForgetWitness<'_, 'brand>) -> ...`,
+    /// with the caller pre-minting `w` via
+    /// [`Self::witness_kernel_forget`] and threading it in. heddle#209
+    /// (the analogous `transition_to_orphan` retrofit) found — and
+    /// this issue confirms — that the two-step shape does not compile
+    /// against the substrate: [`KernelForgetWitness`]'s
+    /// `_borrow: PhantomData<&'p mut ()>` field is invariant over
+    /// `'p`, so the prior `&mut BrandedPending` reborrow that minted
+    /// `w` cannot shrink to admit the second `&mut self` call that
+    /// would consume `w` (rustc `E0499`). Relaxing the substrate's
+    /// `'p` variance to admit the two-step shape would weaken its
+    /// stale-witness protection and is out of scope.
+    ///
+    /// Folding the FSM check and the mutation into one call preserves
+    /// the spike doc's invariant — *the discharge can only fire on a
+    /// state where it's safe to drop `hot[id]`* — by construction:
+    ///
+    /// * The body's `match` IS the [`Self::witness_kernel_forget`]
+    ///   FSM check; both refer to the same
+    ///   `None | Some(Live { open_count: 0 })` pattern.
+    /// * Any non-discharge-safe path returns `None` before touching
+    ///   [`crate::core::Pending::apply_kernel_forget`]. The call site
+    ///   in `core.rs`'s `MountInner::invalidate` propagates the
+    ///   `None` through to the inode-side decision — the missing
+    ///   witness IS the short-circuit at the call site.
+    /// * The mutation hook
+    ///   [`crate::core::Pending::apply_kernel_forget`] takes
+    ///   `&KernelForgetWitness` as proof; [`KernelForgetWitness::new`]
+    ///   is module-private to this file, so no code outside this
+    ///   module's `BrandedPending` impl can synthesize a witness or
+    ///   bypass the discharge-safety check.
+    ///
+    /// Closes [r11 #3][doc] — the pre-retrofit `MountInner::invalidate`
+    /// inlined `pending.hot.remove(&node.0)` before any FSM check, so
+    /// a kernel `forget` racing an open Orphan fd lost the bytes the
+    /// surviving fd needed. Now impossible by construction: the
+    /// `Orphan { .. }` branch returns `None`, the call site
+    /// short-circuits, and `hot[node.0]` survives.
+    ///
+    /// [doc]: ../../../docs/design/mount-pending-api-contracts.md
+    #[doc(hidden)]
+    pub(crate) fn kernel_forget_inode(&mut self, id: u64) -> Option<bool> {
+        match self.inner.lookup_state(id) {
+            None | Some(NodeState::Live { open_count: 0 }) => {
+                let w = KernelForgetWitness::<'_, 'brand>::new(id);
+                Some(self.inner.apply_kernel_forget(&w))
+            }
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1118,6 +1189,157 @@ mod tests {
             p.lookup_state(104),
             Some(NodeState::Live { open_count: 7 })
         );
+    }
+
+    // ------- kernel_forget_inode (heddle#211 — r11 #3 retrofit) ---------------
+    //
+    // Pin the witness-gated contract of
+    // [`BrandedPending::kernel_forget_inode`]:
+    //
+    // * `Released` (no entry) → `Some(false)` — discharge ran, warm
+    //   doesn't reference, caller retires the inode record.
+    // * `Live { open_count == 0 }` → `Some(false)` — discharge ran,
+    //   state row + hot bytes dropped, warm doesn't reference, caller
+    //   retires the inode record.
+    // * `Live { open_count == 0 }` with warm populated →
+    //   `Some(true)` — discharge ran but warm still references; the
+    //   inode record must outlive the kernel-side forget so capture
+    //   can plant the warm bytes.
+    // * `Live { open_count >= 1 }` → `None` — discharge rejected;
+    //   `hot[id]`, `state[id]` preserved, caller skips the
+    //   inode-side forget.
+    // * `Orphan { .. }` (any refcount) → `None` — discharge rejected
+    //   (open-but-unlinked POSIX needs the bytes to live as long as
+    //   any fd holds the NodeId, which the dentry-side forget
+    //   doesn't track).
+    //
+    // Pre-retrofit the discharge ran unconditionally inline in
+    // `MountInner::invalidate`; the `Orphan` tests below would have
+    // failed (hot[id] dropped, state[id] dropped) — that's the
+    // exact r11 #3 race the retrofit closes.
+
+    #[test]
+    fn kernel_forget_inode_some_for_released_no_warm() {
+        let mut p = Pending::default();
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(
+            outcome,
+            Some(false),
+            "Released + no warm → discharge ran, inode record retires"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_some_for_live_zero_no_warm() {
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Live { open_count: 0 });
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(
+            outcome,
+            Some(false),
+            "LiveZero + no warm → discharge ran, inode record retires"
+        );
+        assert!(
+            p.lookup_state(31).is_none(),
+            "discharge must drop state[id] for LiveZero"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_drops_hot_bytes_for_live_zero() {
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Live { open_count: 0 });
+        p.test_insert_hot(31, std::path::PathBuf::from("x.txt"), b"X".to_vec());
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(outcome, Some(false));
+        assert!(
+            !p.test_has_hot(31),
+            "hot[id] for a LiveZero entry must be dropped by the discharge"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_none_for_live_nonzero() {
+        // The r11 #3 race shape: open fds still hold the NodeId. The
+        // pre-retrofit inline path removed hot[id] regardless; the
+        // retrofit rejects the discharge.
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Live { open_count: 1 });
+        p.test_insert_hot(31, std::path::PathBuf::from("x.txt"), b"X".to_vec());
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(outcome, None, "LiveNonZero must reject the discharge");
+        assert_eq!(
+            p.lookup_state(31),
+            Some(NodeState::Live { open_count: 1 }),
+            "state[id] must be preserved when the witness rejects"
+        );
+        assert!(
+            p.test_has_hot(31),
+            "hot[id] must be preserved when the witness rejects \
+             (otherwise the open fd loses its bytes)"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_none_for_orphan_nonzero() {
+        // The headline r11 #3 case: kernel forget racing an open
+        // Orphan fd. Pre-retrofit hot[id] was dropped — the surviving
+        // fd then had no readable bytes. Post-retrofit the discharge
+        // is rejected and hot[id] survives.
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Orphan { open_count: 1 });
+        p.test_insert_hot(31, std::path::PathBuf::from("gone.txt"), b"BYTES".to_vec());
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(outcome, None, "Orphan with open fds must reject");
+        assert_eq!(
+            p.lookup_state(31),
+            Some(NodeState::Orphan { open_count: 1 }),
+            "Orphan state must be preserved when the witness rejects"
+        );
+        assert!(
+            p.test_has_hot(31),
+            "hot[id] for an Orphan with open fds must outlive a kernel \
+             forget — the surviving fd needs the bytes (r11 #3)"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_none_for_orphan_zero() {
+        // Even with zero open count, `Orphan` signals "directory entry
+        // gone, bytes outlive it" — the discharge must reject because
+        // the FSM may not have observed a racing open handle yet
+        // (matches the substrate's `witness_kernel_forget` contract).
+        let mut p = Pending::default();
+        p.test_insert_state(31, NodeState::Orphan { open_count: 0 });
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(31));
+        assert_eq!(
+            outcome, None,
+            "Orphan with zero refcount must still reject the discharge"
+        );
+        assert_eq!(
+            p.lookup_state(31),
+            Some(NodeState::Orphan { open_count: 0 }),
+            "Orphan state must be preserved when the witness rejects"
+        );
+    }
+
+    #[test]
+    fn kernel_forget_inode_short_circuits_state_and_hot_when_none() {
+        // Composite assertion: when the witness rejects, NONE of
+        // state[id], hot[id], or hot_by_path is touched. This is the
+        // "entire forget path short-circuits" contract from the
+        // doc-comment.
+        let mut p = Pending::default();
+        p.test_insert_state(42, NodeState::Live { open_count: 3 });
+        p.test_insert_hot(42, std::path::PathBuf::from("live.txt"), b"L".to_vec());
+        let outcome = p.with_brand(|bp| bp.kernel_forget_inode(42));
+        assert_eq!(outcome, None);
+        assert_eq!(
+            p.lookup_state(42),
+            Some(NodeState::Live { open_count: 3 }),
+            "state[id] untouched on short-circuit"
+        );
+        assert!(p.test_has_hot(42), "hot[id] untouched on short-circuit");
     }
 
     // ------- ResidentLifecycle classifier ------------------------------------

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -3125,6 +3125,66 @@ mod write_ops {
         );
     }
 
+    /// Codex PR #182 r11 finding #3 (P1; heddle#211). `invalidate`
+    /// (FUSE `forget`) drops `pending.hot[node]` unconditionally,
+    /// without first checking whether the inode is still referenced.
+    /// For an `Orphan { open_count >= 1 }` node (open-unlinked POSIX
+    /// flow), the kernel can issue `forget` for the dentry-side
+    /// reference while a userspace fd still holds the inode; dropping
+    /// `hot[node]` strands the surviving fd with no readable bytes.
+    /// Post-retrofit (heddle#211) the witness-gated
+    /// `BrandedPending::kernel_forget_inode` rejects any `Orphan`
+    /// state, and the missing witness short-circuits the entire
+    /// forget path in `MountInner::invalidate` — leaving `hot[node]`,
+    /// `state[node]`, and the inode record intact until the final
+    /// `release` retires them.
+    #[test]
+    fn invalidate_preserves_hot_bytes_for_orphan_with_open_fd() {
+        let (_temp, mount) = open_mount();
+        // Create + open a fresh file, write through the fd. Bytes
+        // stay in `hot[node]` — no flush, so warm is untouched.
+        let entry = mount
+            .create_file(NodeId::ROOT, OsStr::new("scratch"), FileMode::Normal, false)
+            .expect("create");
+        mount.on_open(entry.node).expect("on_open");
+        mount
+            .write(entry.node, 0, b"HOT-BYTES")
+            .expect("write through live fd populates hot");
+        // Unlink while the fd lives on. POSIX: dentry gone, inode
+        // survives behind the fd; FSM transitions to
+        // `Orphan { open_count: 1 }`.
+        mount
+            .unlink_entry(NodeId::ROOT, OsStr::new("scratch"))
+            .expect("unlink");
+        assert!(
+            mount.orphans_contains(entry.node),
+            "pre-invalidate sanity: unlink-while-open must orphan the inode"
+        );
+
+        // Kernel forget arrives for the dentry-side reference while
+        // the fd is still in userspace's hands. Pre-retrofit
+        // `invalidate` blindly removed `hot[node]`; post-retrofit
+        // the witness rejects `Orphan` and the forget path
+        // short-circuits.
+        mount
+            .invalidate(entry.node)
+            .expect("invalidate (kernel forget) on orphan with open fd");
+
+        // Read via the surviving fd. The hot-tier bytes must still
+        // be served — the open-unlinked POSIX contract demands that
+        // the fd's view of the inode outlives the dentry.
+        let mut buf = vec![0u8; 32];
+        let n = mount
+            .read(entry.node, 0, &mut buf)
+            .expect("read via orphan fd after kernel forget");
+        assert_eq!(
+            &buf[..n],
+            b"HOT-BYTES",
+            "kernel forget racing an open Orphan fd must not drop \
+             hot[node] — the surviving fd needs the bytes (r11 #3)"
+        );
+    }
+
     /// Codex thread 3293510310 (P1). `rmdir_entry` plants a
     /// `dir_tombstones` entry but leaves `inodes.by_path[child_path]`
     /// intact. A subsequent `create_file` / `make_dir` at the same path


### PR DESCRIPTION
## Summary

- Adds `BrandedPending::kernel_forget_inode(id) -> Option<bool>` (witness-gated FUSE-forget discharge consuming heddle#208's substrate) and a `pub(crate) Pending::apply_kernel_forget(&KernelForgetWitness)` mutation hook whose `&KernelForgetWitness` parameter is the type-level discipline (`KernelForgetWitness::new` is module-private to `pending.rs`, so callers in `core.rs` cannot synthesize one).
- Rewrites `MountInner::invalidate` to thread the witness via `pending.with_brand(|bp| bp.kernel_forget_inode(node.0))`, replacing the previous inline `pending.hot.remove(&node.0)` + `pending.state.remove(&node.0)` mutations. The `None` branch — for `Live { open_count >= 1 }` or any `Orphan` — short-circuits the entire forget path (hot/state preserved AND the inode-side `forget` skipped); matches the brief's framing.
- Closes Codex PR #182 r11 #3 (P1): the pre-retrofit `invalidate` removed `hot[node]` unconditionally before any FSM check. For an `Orphan { open_count >= 1 }` node (open-unlinked POSIX), the kernel can issue `forget` for the dentry while a userspace fd still holds the inode — the unconditional remove stranded the surviving fd with no readable bytes. The retrofit makes the bug unwritable: the discharge runs only on `Released` / `Live { open_count == 0 }`, and the witness-as-proof shape (`apply_kernel_forget(&KernelForgetWitness)`) means no code outside the `BrandedPending` impl in `pending.rs` can bypass the FSM check.
- Adds a `compile_fail` doctest pinning the entry-point discipline (`Pending::kernel_forget_inode(0)` directly on `&mut Pending` fails to compile — the method lives on `BrandedPending`, which only `Pending::with_brand` can build). Mirrors heddle#209's pattern for `transition_to_orphan`.

Closes HeddleCo/heddle#211.

## Approach chosen + why (mirrors heddle#209 / #210)

The brief named "Approach A: method on `BrandedPending<'p, 'brand>` that takes `KernelForgetWitness<'_, 'brand>`". heddle#209 found — and this PR confirms — that the literal two-step shape does not compile against the substrate:

* Literal Approach A — `bp.witness_kernel_forget(id).map(|w| bp.kernel_forget_inode(w))` — fails with `E0499`. `KernelForgetWitness::_borrow: PhantomData<&'p mut ()>` is *invariant* over `'p`, so the `&mut BrandedPending` reborrow that minted `w` cannot shrink to admit the second `&mut self` call that would consume `w`. (The heddle#208 r3 self-audit and heddle#209's PR body both flag this as a known retrofit-time question.)
* Option B (relax `_borrow` variance) would weaken the substrate's stale-witness protection and is out of scope.

The fold preserves the spike doc's stated invariant — *the discharge can only fire on a state where it's safe to drop `hot[id]`* — by construction:
* The body's `match` IS the `BrandedPending::witness_kernel_forget` FSM check; both refer to the same `None | Some(Live { open_count: 0 })` pattern.
* Any non-discharge-safe path returns `None` before touching `Pending::apply_kernel_forget`. The call site in `MountInner::invalidate` propagates the `None` via `.unwrap_or(false)` — the missing witness IS the short-circuit at the call site.
* The mutation hook `Pending::apply_kernel_forget` takes `&KernelForgetWitness` as proof — `KernelForgetWitness::new` is module-private to `pending.rs`, so no code outside `BrandedPending::kernel_forget_inode` can synthesize a witness or record a discharge.

The doc-comment on `BrandedPending::kernel_forget_inode` cites this trade-off in full so future readers see why the brief's literal two-step shape isn't here.

## Why the `None` branch short-circuits the inode-side `forget` too

The pre-retrofit `invalidate` always called `inodes.forget(node)` when `warm[node]` was empty. Post-retrofit, when the witness rejects (Orphan or LiveNonZero), the entire path skips: state preserved, hot preserved, **and** `inodes.forget` skipped. Rationale: a kernel `forget` for a dentry-side reference while an open fd still holds the inode does not retire the inode — the fd pins it. The next FUSE `release` (driving `open_count` to 0) is what should retire the lifecycle row and the inode record. Retiring eagerly here would invalidate the surviving fd's NodeId binding. This matches the brief's "the `None` branch short-circuits the entire forget path" framing.

## Red commit

`5a6b360` — `tests::write_ops::invalidate_preserves_hot_bytes_for_orphan_with_open_fd`. Create + open a fresh file, write through the fd (hot tier populated), unlink (state → Orphan{1}), `invalidate(node)`, read via the surviving fd. Pre-retrofit failed with `Stale(\"node 2\")` because `invalidate` dropped `hot[node]`; post-retrofit serves `HOT-BYTES` from the preserved hot buffer.

## Test evidence

```
$ cargo test -p heddle-mount
test pending::tests::kernel_forget_inode_some_for_released_no_warm ... ok
test pending::tests::kernel_forget_inode_some_for_live_zero_no_warm ... ok
test pending::tests::kernel_forget_inode_drops_hot_bytes_for_live_zero ... ok
test pending::tests::kernel_forget_inode_none_for_live_nonzero ... ok
test pending::tests::kernel_forget_inode_none_for_orphan_nonzero ... ok
test pending::tests::kernel_forget_inode_none_for_orphan_zero ... ok
test pending::tests::kernel_forget_inode_short_circuits_state_and_hot_when_none ... ok
test tests::write_ops::invalidate_preserves_hot_bytes_for_orphan_with_open_fd ... ok
test tests::write_ops::invalidate_preserves_warm_bytes_for_live_inode ... ok
test tests::write_ops::invalidate_clears_orphan_tracking_for_forgotten_inode ... ok
test tests::write_ops::forget_after_unlink_recreate_preserves_new_path_binding ... ok
...
test result: ok. 157 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 45.88s

$ cargo test -p heddle-mount --doc
running 4 tests
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 92) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 139) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 176) - compile fail ... ok
test crates/mount/src/lib.rs - __pending_substrate_for_doctest (line 197) - compile fail ... ok
test result: ok. 4 passed; 0 failed

$ cargo clippy --workspace --all-targets -- -D warnings
... Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 26s

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (500 file(s) scanned)
```

## Acceptance criteria

- [x] `kernel_forget_inode` signature changed; old signature removed. Pre-retrofit there was no `Pending::kernel_forget_inode` method — the discharge was inlined in `MountInner::invalidate`. Post-retrofit the method lives on `BrandedPending` (via `Pending::with_brand`), and the inline mutations are gone.
- [x] `MountInner::invalidate` call site updated to construct the witness; the `None` branch short-circuits the entire forget path (state/hot preserved AND `inodes.forget` skipped) — matches the brief's framing.
- [x] Regression test: kernel forget racing an open Orphan fd does not drop the bytes (`tests::write_ops::invalidate_preserves_hot_bytes_for_orphan_with_open_fd`). Plus 7 substrate-level unit tests in `pending::tests::kernel_forget_inode_*` covering every FSM state.
- [x] r10 fixture tests still pass — `invalidate_preserves_warm_bytes_for_live_inode`, `invalidate_clears_orphan_tracking_for_forgotten_inode`, `forget_after_unlink_recreate_preserves_new_path_binding` all green.
- [x] Compile-fail doctest pinning the entry-point discipline (`Pending::kernel_forget_inode(0)` direct call fails to compile) — `crates/mount/src/lib.rs` line 197.
- [x] Local CI parity gates green (`cargo test -p heddle-mount`, `cargo clippy --workspace --all-targets -- -D warnings`, `bash scripts/check-no-silent-default-tree-load.sh`).

## Manual verification

N/A — covered by tests + compile-fail doctest.

## Blocked by → resolved

- HeddleCo/heddle#208 (substrate — already merged via PR #217).

This is the third of three retrofit sub-issues (#209 / #210 / #211) that consume the heddle#208 substrate; only heddle#212 (proptest harness) remains in the chain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782213126&installation_id=132405951&pr_number=221&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F221&signature=22ffc25cc13a56b378479c5b147d541e6a0415b5cdb50276e02f56837a533694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->