### PR TITLE
heddle#222: heddle-grpc 0.6 — redesign LinkOAuthIdentityRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 heddle-client = { path = "../client", version = "0.2", optional = true }
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -48,7 +48,7 @@ walkdir.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 fs2.workspace = true
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.5" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -1920,12 +1920,32 @@ message ThreadEvent {
 // ── OAuth identity linking ──────────────────────────────────────────────────
 
 message LinkOAuthIdentityRequest {
-  string provider = 1; // "github" | "gitlab"
-  string provider_user_id = 2; // numeric ID as string
-  string username = 3;
-  string email = 4;
-  string display_name = 5;
-  string avatar_url = 6;
+  // Which OAuth provider this proof is from. Used by the server to
+  // pick the correct ID-token verifier (JWKS for Google/Apple,
+  // /user + /user/emails API path for GitHub).
+  string provider = 1; // "google" | "apple" | "github"
+
+  // The provider's cryptographic proof of identity.
+  //   - Google / Apple: OIDC `id_token` (provider-signed JWT).
+  //   - GitHub: OAuth2 access token (server validates via /user +
+  //     /user/emails).
+  // Server validates this proof and extracts
+  // `(sub, email, email_verified)` from the verified result; the
+  // request itself carries NO user-identity claims the caller can
+  // forge. Closes the OAuth-link forge bypass surfaced on
+  // HeddleCo/weft#193 r2 (Codex cid 3294026240); design rationale
+  // in the HeddleCo/weft#195 spike amendment.
+  oneof oauth_proof {
+    string id_token = 2;
+    string access_token = 3;
+  }
+
+  // OPTIONAL: a fresh WebAuthn assertion proving ownership of the
+  // existing user account that this OAuth identity is being
+  // attached to. Required only when the OAuth-validated email
+  // collides with an existing user (per the email-collision passkey
+  // gate, weft spike §4.6); otherwise empty.
+  optional bytes webauthn_assertion = 4;
 }
 
 message StoreProviderTokenRequest {


### PR DESCRIPTION
## Summary

- Rewrites `LinkOAuthIdentityRequest` to carry a single provider-signed `oauth_proof` (`oneof { id_token, access_token }`) plus an optional `webauthn_assertion`, eliminating the forgeable identity fields (`provider_user_id`, `username`, `email`, `display_name`, `avatar_url`) the server had no way to verify.
- Closes the OAuth-link forge bypass surfaced on HeddleCo/weft#193 r2 (Codex cid 3294026240); design rationale in HeddleCo/weft#195's spike-doc amendment.
- Bumps `heddle-grpc` 0.5.0 → 0.6.0 (MAJOR — breaking Rust type surface) and updates the three workspace consumers (`cli`, `client`, `daemon`) to pin `0.6`.
- Pre-1.0, no external clients pin against the old shape — field numbers collapse to `1..4` with no `reserved` clauses.

Closes HeddleCo/heddle#222

## Red commit

N/A — DoD Type is release-ops / proto contract, not TDD-Rust. No behavioural logic in this repo changes; consumer logic lives in `weft`.

## Test evidence

```
$ cargo build -p heddle-grpc
    Compiling heddle-grpc v0.6.0 (/home/heddleco/dev/HeddleCo/workspace/issue-222/crates/grpc)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.18s

$ cargo test --workspace
Workspace: 2579 passed, 0 failed, 38 ignored across 70 test binaries

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 15s
    (no warnings)

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (500 file(s) scanned)
```

## Manual verification

N/A — proto + version bumps only; no UI surface and no functional Rust changes in this repo. The wire contract will be exercised end-to-end when HeddleCo/weft#195 lands the server side.

## Blocked by → resolved

- HeddleCo/weft#195 — this proto bump is the cross-repo prerequisite the weft cutover needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782224973&installation_id=132405951&pr_number=223&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F223&signature=a4105b2e30326a8b281ef4f0e2fd5015bd911c368acdc0d89c1a902defbbed57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->