### PR TITLE
heddle#25: `push --mirror` flag for ad-hoc dual-push

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1028,7 +1028,18 @@ pub struct PushArgs {
     /// to target a specific git remote. The mirror push is best-effort:
     /// if it fails, the primary push is still reported as successful
     /// and the mirror failure surfaces as a warning.
-    #[arg(long, value_name = "REMOTE", num_args = 0..=1, default_missing_value = "origin")]
+    ///
+    /// `require_equals` pairs with `default_missing_value` (clap
+    /// requires both, or the next token after `--mirror` would be
+    /// swallowed as the mirror's value — silently consuming the
+    /// positional primary remote).
+    #[arg(
+        long,
+        value_name = "REMOTE",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "origin",
+    )]
     pub mirror: Option<String>,
 }
 

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1021,6 +1021,15 @@ pub struct PushArgs {
     /// Force push.
     #[arg(short, long)]
     pub force: bool,
+
+    /// Ad-hoc dual-push: after the primary push to the heddle remote
+    /// succeeds, also push to the named git-bridge remote (default
+    /// `origin`). Use `--mirror` alone for `origin`, or `--mirror=<name>`
+    /// to target a specific git remote. The mirror push is best-effort:
+    /// if it fails, the primary push is still reported as successful
+    /// and the mirror failure surfaces as a warning.
+    #[arg(long, value_name = "REMOTE", num_args = 0..=1, default_missing_value = "origin")]
+    pub mirror: Option<String>,
 }
 
 /// Arguments for the `pull` command.

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -40,16 +40,25 @@ pub async fn cmd_push(
         let mut bridge = GitBridge::new(&repo);
         bridge.push(remote_name)?;
         if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{{\"pushed\":true,\"transport\":\"git\",\"remote\":{:?}}}",
-                remote_name
-            );
+            let record = serde_json::json!({
+                "pushed": true,
+                "transport": "git",
+                "remote": remote_name,
+            });
+            println!("{}", record);
         } else {
             println!(
                 "{} pushed Git-overlay refs to {}",
                 style::ok_marker(),
                 style::bold(remote_name)
             );
+        }
+        // Ad-hoc dual-push parity for the GitOverlay drop-in branch:
+        // `--mirror` must fire here too, with the same best-effort
+        // (warn-don't-abort) semantics as the hosted/native path.
+        if let Some(mirror_remote) = mirror.as_deref() {
+            let outcome = bridge.push(mirror_remote);
+            render_mirror_outcome(cli, &repo, mirror_remote, outcome);
         }
         return Ok(());
     }
@@ -181,10 +190,11 @@ fn render_mirror_outcome(
     match outcome {
         Ok(()) => {
             if json {
-                println!(
-                    "{{\"mirrored\":true,\"remote\":{:?}}}",
-                    mirror_remote
-                );
+                let record = serde_json::json!({
+                    "mirrored": true,
+                    "remote": mirror_remote,
+                });
+                println!("{}", record);
             } else {
                 println!(
                     "{} mirrored to {}",
@@ -195,11 +205,12 @@ fn render_mirror_outcome(
         }
         Err(err) => {
             if json {
-                println!(
-                    "{{\"mirrored\":false,\"remote\":{:?},\"error\":{:?}}}",
-                    mirror_remote,
-                    err.to_string()
-                );
+                let record = serde_json::json!({
+                    "mirrored": false,
+                    "remote": mirror_remote,
+                    "error": err.to_string(),
+                });
+                println!("{}", record);
             } else {
                 eprintln!(
                     "{} mirror push to {} failed: {}",

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -14,7 +14,7 @@ use super::snapshot::ensure_current_state;
 #[cfg(feature = "client")]
 use crate::client::HostedGrpcClient;
 use crate::{
-    bridge::GitBridge,
+    bridge::{GitBridge, GitResult},
     cli::{Cli, should_output_json, style},
     client::LocalSync,
     config::UserConfig,
@@ -32,6 +32,7 @@ pub async fn cmd_push(
     thread: Option<String>,
     state: Option<String>,
     force: bool,
+    mirror: Option<String>,
 ) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
@@ -144,6 +145,15 @@ pub async fn cmd_push(
         }
     }
 
+    // Ad-hoc dual-push: also push to the configured git mirror
+    // (default `origin`). Best-effort — mirror failure does not
+    // abort the primary push.
+    if let Some(mirror_remote) = mirror.as_deref() {
+        let mut bridge = GitBridge::new(&repo);
+        let outcome = bridge.push(mirror_remote);
+        render_mirror_outcome(cli, &repo, mirror_remote, outcome);
+    }
+
     // `post_push` JSON-protocol hook. Best-effort; fires after
     // a successful push.
     let post_push_payload = serde_json::json!({
@@ -159,6 +169,47 @@ pub async fn cmd_push(
     }
 
     Ok(())
+}
+
+fn render_mirror_outcome(
+    cli: &Cli,
+    repo: &Repository,
+    mirror_remote: &str,
+    outcome: GitResult<()>,
+) {
+    let json = should_output_json(cli, Some(repo.config()));
+    match outcome {
+        Ok(()) => {
+            if json {
+                println!(
+                    "{{\"mirrored\":true,\"remote\":{:?}}}",
+                    mirror_remote
+                );
+            } else {
+                println!(
+                    "{} mirrored to {}",
+                    style::ok_marker(),
+                    style::bold(mirror_remote)
+                );
+            }
+        }
+        Err(err) => {
+            if json {
+                println!(
+                    "{{\"mirrored\":false,\"remote\":{:?},\"error\":{:?}}}",
+                    mirror_remote,
+                    err.to_string()
+                );
+            } else {
+                eprintln!(
+                    "{} mirror push to {} failed: {}",
+                    style::warn_marker(),
+                    style::bold(mirror_remote),
+                    err
+                );
+            }
+        }
+    }
 }
 
 fn resolve_default_push_thread(repo: &Repository, requested: Option<&str>) -> Result<String> {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -372,6 +372,7 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
             None,
             merge_output.merge_state.clone(),
             false,
+            None,
         )
         .await?;
         pushed = true;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -525,6 +525,7 @@ async fn main() -> Result<()> {
                 args.remote_op.thread.clone(),
                 args.state.clone(),
                 args.force,
+                args.mirror.clone(),
             )
             .await
         }

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -116,20 +116,14 @@ fn test_cli_push_mirror_dual_push_to_weft_and_git_remote() {
 
     let weft_path = weft_target.path().to_string_lossy().to_string();
     let git_path = git_remote.path().to_string_lossy().to_string();
+    let mirror_arg = format!("--mirror={}", git_path);
     let result = heddle(
-        &[
-            "push",
-            &weft_path,
-            "--thread",
-            "main",
-            "--mirror",
-            &git_path,
-        ],
+        &["push", &weft_path, "--thread", "main", &mirror_arg],
         Some(source.path()),
     );
     assert!(
         result.is_ok(),
-        "dual push (--mirror) should succeed: {:?}",
+        "dual push (--mirror=<remote>) should succeed: {:?}",
         result.err()
     );
 
@@ -167,15 +161,9 @@ fn test_cli_push_mirror_failure_does_not_abort_primary_push() {
         .join("does-not-exist-mirror")
         .to_string_lossy()
         .to_string();
+    let mirror_arg = format!("--mirror={}", bogus_mirror);
     let result = heddle(
-        &[
-            "push",
-            &weft_path,
-            "--thread",
-            "main",
-            "--mirror",
-            &bogus_mirror,
-        ],
+        &["push", &weft_path, "--thread", "main", &mirror_arg],
         Some(source.path()),
     );
     assert!(
@@ -238,5 +226,131 @@ fn test_cli_push_mirror_requires_equals_does_not_swallow_positional() {
         threads.contains("main"),
         "primary push should land at the positional remote, not be swallowed by --mirror: {}",
         threads
+    );
+}
+
+/// `--mirror=<name>` parses the explicit value and `--mirror` alone
+/// takes the `default_missing_value`. Pins both forms in one test
+/// so the parse table is asserted from end to end.
+#[test]
+fn test_cli_push_mirror_explicit_equals_form_parses_value() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+    let git_remote = TempDir::new().unwrap();
+    let mirror_repo = gix::init_bare(git_remote.path()).unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "explicit eq").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    let git_path = git_remote.path().to_string_lossy().to_string();
+    let mirror_arg = format!("--mirror={}", git_path);
+    // Flag-before-positional ordering — the form Codex's finding said
+    // the original parse table mishandled.
+    let result = heddle(
+        &["push", &mirror_arg, "--thread", "main", &weft_path],
+        Some(source.path()),
+    );
+    assert!(
+        result.is_ok(),
+        "--mirror=<remote> followed by positional must parse cleanly: {:?}",
+        result.err()
+    );
+
+    let threads = heddle(&["thread", "list"], Some(weft_target.path())).unwrap();
+    assert!(threads.contains("main"));
+    assert!(
+        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        "mirror push should land at the explicit <git_path>"
+    );
+}
+
+/// JSON output path on mirror success: covers the `mirrored:true`
+/// branch of `render_mirror_outcome`.
+#[test]
+fn test_cli_push_mirror_json_success_emits_mirrored_true() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+    let git_remote = TempDir::new().unwrap();
+    gix::init_bare(git_remote.path()).unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "json ok").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    let git_path = git_remote.path().to_string_lossy().to_string();
+    let mirror_arg = format!("--mirror={}", git_path);
+    let stdout = heddle(
+        &[
+            "--output",
+            "json",
+            "push",
+            &weft_path,
+            "--thread",
+            "main",
+            &mirror_arg,
+        ],
+        Some(source.path()),
+    )
+    .expect("push --output json --mirror=<remote> must succeed");
+
+    assert!(
+        stdout.contains("\"mirrored\":true"),
+        "JSON success line missing: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&git_path),
+        "JSON output must echo the mirror remote: {}",
+        stdout
+    );
+}
+
+/// JSON output path on mirror failure: covers the `mirrored:false`
+/// + `error` branch of `render_mirror_outcome`.
+#[test]
+fn test_cli_push_mirror_json_failure_emits_mirrored_false_with_error() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "json err").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    let bogus = source
+        .path()
+        .join("nope-mirror")
+        .to_string_lossy()
+        .to_string();
+    let mirror_arg = format!("--mirror={}", bogus);
+    let stdout = heddle(
+        &[
+            "--output",
+            "json",
+            "push",
+            &weft_path,
+            "--thread",
+            "main",
+            &mirror_arg,
+        ],
+        Some(source.path()),
+    )
+    .expect("primary push must succeed even when mirror push fails");
+
+    assert!(
+        stdout.contains("\"mirrored\":false"),
+        "JSON failure line missing: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"error\""),
+        "JSON failure must include error field: {}",
+        stdout
     );
 }

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -192,3 +192,51 @@ fn test_cli_push_mirror_failure_does_not_abort_primary_push() {
         threads
     );
 }
+
+/// `--mirror` MUST require `=` to take an explicit value. Without
+/// `require_equals = true`, clap would consume the next token (the
+/// positional primary remote) as the mirror value, silently pushing
+/// the primary to the configured default and the mirror to the
+/// intended primary target.
+///
+/// Pins the behavior: `heddle push --mirror <PRIMARY>` parses
+/// `<PRIMARY>` as the positional remote, and `--mirror` takes its
+/// `default_missing_value` ("origin"). Since no `origin` git remote
+/// is configured here, the mirror push warns but does not abort.
+#[test]
+fn test_cli_push_mirror_requires_equals_does_not_swallow_positional() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "require equals").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    // Space form with the positional remote immediately after
+    // `--mirror`. Without `require_equals=true`, clap consumes
+    // `weft_path` as the mirror's value, leaving the primary remote
+    // unspecified — silently inverting the user's intent. With
+    // `require_equals=true`, `--mirror` takes its
+    // `default_missing_value` and `weft_path` parses as the
+    // positional primary remote.
+    let result = heddle(
+        &["push", "--mirror", &weft_path, "--thread", "main"],
+        Some(source.path()),
+    );
+    assert!(
+        result.is_ok(),
+        "push must succeed; primary should land at <PRIMARY> and mirror default (origin) is best-effort: {:?}",
+        result.err()
+    );
+
+    // Primary push landed at the heddle target — proving the
+    // positional was NOT swallowed by --mirror.
+    let threads = heddle(&["thread", "list"], Some(weft_target.path())).unwrap();
+    assert!(
+        threads.contains("main"),
+        "primary push should land at the positional remote, not be swallowed by --mirror: {}",
+        threads
+    );
+}

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -98,3 +98,97 @@ fn test_cli_bridge_git_push_to_local_bare_remote() {
 
     assert!(remote_repo.find_reference("refs/heads/main").is_ok());
 }
+
+/// `heddle push --mirror=<git-remote>` performs the primary push to the
+/// heddle remote AND a git-bridge push to the configured mirror, in one
+/// invocation.
+#[test]
+fn test_cli_push_mirror_dual_push_to_weft_and_git_remote() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+    let git_remote = TempDir::new().unwrap();
+    let mirror_repo = gix::init_bare(git_remote.path()).unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "dual push").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    let git_path = git_remote.path().to_string_lossy().to_string();
+    let result = heddle(
+        &[
+            "push",
+            &weft_path,
+            "--thread",
+            "main",
+            "--mirror",
+            &git_path,
+        ],
+        Some(source.path()),
+    );
+    assert!(
+        result.is_ok(),
+        "dual push (--mirror) should succeed: {:?}",
+        result.err()
+    );
+
+    // Primary push landed at the heddle target.
+    let threads = heddle(&["thread", "list"], Some(weft_target.path())).unwrap();
+    assert!(
+        threads.contains("main"),
+        "weft target should have main thread after primary push: {}",
+        threads
+    );
+
+    // Mirror push landed at the bare git remote.
+    assert!(
+        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        "git mirror remote should have refs/heads/main after mirror push"
+    );
+}
+
+/// Mirror push failure is reported as a warning but does NOT cause the
+/// primary push to fail. The user still sees the primary push succeed.
+#[test]
+fn test_cli_push_mirror_failure_does_not_abort_primary_push() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "warn on mirror fail").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    // Pointing the mirror at a nonexistent path is a failure.
+    let bogus_mirror = source
+        .path()
+        .join("does-not-exist-mirror")
+        .to_string_lossy()
+        .to_string();
+    let result = heddle(
+        &[
+            "push",
+            &weft_path,
+            "--thread",
+            "main",
+            "--mirror",
+            &bogus_mirror,
+        ],
+        Some(source.path()),
+    );
+    assert!(
+        result.is_ok(),
+        "primary push must still succeed even when mirror push fails: {:?}",
+        result.err()
+    );
+
+    // Primary push still landed.
+    let threads = heddle(&["thread", "list"], Some(weft_target.path())).unwrap();
+    assert!(
+        threads.contains("main"),
+        "primary push should land even if mirror push fails: {}",
+        threads
+    );
+}

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -326,6 +326,149 @@ fn test_cli_push_mirror_json_success_emits_mirrored_true() {
     );
 }
 
+/// `heddle push --mirror=<git-remote>` in a Git-overlay (non-hosted)
+/// repo must push to BOTH the primary and the mirror. The cmd_push
+/// early-return for the `GitOverlay && !hosted_enabled` branch
+/// previously skipped the mirror block entirely, silently ignoring
+/// `--mirror` for the overlay drop-in case.
+#[test]
+fn test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes() {
+    let source = TempDir::new().unwrap();
+    let primary_remote = TempDir::new().unwrap();
+    let mirror_remote = TempDir::new().unwrap();
+    let primary_repo = gix::init_bare(primary_remote.path()).unwrap();
+    let mirror_repo = gix::init_bare(mirror_remote.path()).unwrap();
+
+    // Plain `git init` → RepositoryCapability::GitOverlay,
+    // hosted_enabled() == false. This is the drop-in case the
+    // early-return in cmd_push handles.
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .current_dir(source.path())
+            .status()
+            .unwrap()
+            .success()
+    );
+    for (k, v) in [
+        ("user.name", "Heddle Test"),
+        ("user.email", "heddle@example.com"),
+        ("init.defaultBranch", "main"),
+    ] {
+        Command::new("git")
+            .args(["config", k, v])
+            .current_dir(source.path())
+            .status()
+            .unwrap();
+    }
+    Command::new("git")
+        .args(["checkout", "-B", "main"])
+        .current_dir(source.path())
+        .status()
+        .unwrap();
+    std::fs::write(source.path().join("file.txt"), "overlay dual push").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(source.path())
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(source.path())
+        .status()
+        .unwrap();
+
+    // Bootstrap the heddle overlay sidecar so the bridge has content
+    // to push. Without an imported state, `bridge.push` silently
+    // succeeds but copies nothing — masking the real --mirror bug.
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(source.path()),
+    )
+    .expect("bridge git import should bootstrap the overlay sidecar");
+
+    let primary_path = primary_remote.path().to_string_lossy().to_string();
+    let mirror_path = mirror_remote.path().to_string_lossy().to_string();
+    let mirror_arg = format!("--mirror={}", mirror_path);
+    heddle(
+        &["push", &primary_path, &mirror_arg],
+        Some(source.path()),
+    )
+    .expect("push --mirror in GitOverlay repo should succeed");
+
+    assert!(
+        primary_repo.find_reference("refs/heads/main").is_ok(),
+        "primary remote should have refs/heads/main after overlay push"
+    );
+    assert!(
+        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        "mirror remote MUST ALSO have refs/heads/main — the GitOverlay early-return previously bypassed --mirror"
+    );
+}
+
+/// `render_mirror_outcome` JSON must use RFC 8259 escaping — not
+/// Rust's `Debug` format. A remote name containing U+2028
+/// (LINE SEPARATOR) round-trips through `{:?}` as `"\u{2028}"`
+/// (Rust syntax), which is NOT valid JSON. With proper serde
+/// serialization the output parses and the field round-trips.
+#[test]
+fn test_cli_push_mirror_json_uses_rfc8259_escaping_for_unicode() {
+    let source = TempDir::new().unwrap();
+    let weft_target = TempDir::new().unwrap();
+    let mirror_parent = TempDir::new().unwrap();
+    // A real bare git repo at a path containing U+2028, so the mirror
+    // push succeeds and the `"remote"` field carries the bad codepoint.
+    let mirror_dir = mirror_parent.path().join("mirror\u{2028}suffix");
+    std::fs::create_dir_all(&mirror_dir).unwrap();
+    let mirror_repo = gix::init_bare(&mirror_dir).unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    heddle(&["init"], Some(weft_target.path())).unwrap();
+    std::fs::write(source.path().join("file.txt"), "u+2028").unwrap();
+    heddle(&["capture", "-m", "Initial"], Some(source.path())).unwrap();
+
+    let weft_path = weft_target.path().to_string_lossy().to_string();
+    let mirror_path = mirror_dir.to_string_lossy().to_string();
+    let mirror_arg = format!("--mirror={}", mirror_path);
+    let stdout = heddle(
+        &[
+            "--output",
+            "json",
+            "push",
+            &weft_path,
+            "--thread",
+            "main",
+            &mirror_arg,
+        ],
+        Some(source.path()),
+    )
+    .expect("push --output json --mirror=<U+2028> must succeed");
+
+    let mirror_line = stdout
+        .lines()
+        .find(|line| line.contains("\"mirrored\""))
+        .unwrap_or_else(|| panic!("mirror outcome JSON line missing in stdout: {}", stdout));
+
+    // The Debug-format bug emits `"\u{2028}"` (literal braces), which
+    // is not valid JSON — `serde_json::from_str` rejects it.
+    let parsed: serde_json::Value = serde_json::from_str(mirror_line).unwrap_or_else(|err| {
+        panic!(
+            "mirror outcome must be RFC 8259 JSON, got {}: {:?}",
+            err, mirror_line
+        )
+    });
+    assert_eq!(
+        parsed["remote"].as_str(),
+        Some(mirror_path.as_str()),
+        "remote field must round-trip the U+2028 codepoint exactly"
+    );
+    // Sanity: mirror push landed too.
+    assert!(
+        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        "mirror push should have landed at the U+2028 path"
+    );
+}
+
 /// JSON output path on mirror failure: covers the `mirrored:false`
 /// + `error` branch of `render_mirror_outcome`.
 #[test]

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -117,14 +117,23 @@ fn test_cli_push_mirror_dual_push_to_weft_and_git_remote() {
     let weft_path = weft_target.path().to_string_lossy().to_string();
     let git_path = git_remote.path().to_string_lossy().to_string();
     let mirror_arg = format!("--mirror={}", git_path);
-    let result = heddle(
-        &["push", &weft_path, "--thread", "main", &mirror_arg],
+    // `--output text` forces the text branch of `render_mirror_outcome`.
+    // Default `auto` resolves to JSON when stdout is piped (which it is
+    // under `cargo test`), so without this flag the text-success path
+    // would never execute and codecov/patch would miss it.
+    let stdout = heddle(
+        &[
+            "--output", "text", "push", &weft_path, "--thread", "main", &mirror_arg,
+        ],
         Some(source.path()),
-    );
+    )
+    .expect("dual push (--mirror=<remote>) should succeed");
+
+    // Text branch on success emits a "mirrored to <remote>" line.
     assert!(
-        result.is_ok(),
-        "dual push (--mirror=<remote>) should succeed: {:?}",
-        result.err()
+        stdout.contains("mirrored to") && stdout.contains(&git_path),
+        "text-mode success line missing: {}",
+        stdout
     );
 
     // Primary push landed at the heddle target.
@@ -162,8 +171,15 @@ fn test_cli_push_mirror_failure_does_not_abort_primary_push() {
         .to_string_lossy()
         .to_string();
     let mirror_arg = format!("--mirror={}", bogus_mirror);
+    // `--output text` forces the text branch of `render_mirror_outcome`
+    // on the failure path. The warning lands on stderr, so this test
+    // proves the primary push still succeeds and leaves separate
+    // stderr-checking to the JSON variant (which captures the structured
+    // failure on stdout).
     let result = heddle(
-        &["push", &weft_path, "--thread", "main", &mirror_arg],
+        &[
+            "--output", "text", "push", &weft_path, "--thread", "main", &mirror_arg,
+        ],
         Some(source.path()),
     );
     assert!(


### PR DESCRIPTION
## Summary
- Adds `--mirror[=<REMOTE>]` flag to `heddle push`. When set, after the primary heddle push succeeds, also pushes to the named git-bridge remote (default `origin`).
- Mirror push is best-effort: failure surfaces as a warning (or `{"mirrored":false,...}` JSON) and does NOT abort the primary push.
- Reuses existing `GitBridge::push` plumbing; no new mirror-config concept introduced. The "configured GitHub mirror" is whatever git remote the embedded `.heddle/git` mirror (or the working tree's `.git`) has by that name.
- Documentation lives in the `--help` text on the flag — heddle has no separate CLI reference doc, so `--help` is the de-facto reference.

Closes HeddleCo/heddle#25

## Red commit
`1152079`

## Test evidence
```
running 2 tests
test bridge::test_cli_push_mirror_failure_does_not_abort_primary_push ... ok
test bridge::test_cli_push_mirror_dual_push_to_weft_and_git_remote ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 304 filtered out
```

Full workspace `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` both green. `check-no-silent-default-tree-load.sh` clean (500 files scanned).

## Manual verification
N/A — covered by integration tests using a temp bare git remote + a temp local heddle target.

## Blocked by → resolved
None.



## Round 2

**P1 — `--mirror` swallowed positional primary remote** (Codex finding 3298803256)

`--mirror` was defined with `default_missing_value = "origin"` but no `require_equals = true`. clap pairs the two: without the pairing, `heddle push --mirror <REMOTE>` consumed `<REMOTE>` as the mirror's value, leaving the primary remote unspecified.

Fix: added `require_equals = true`. Users now write `--mirror` alone (mirror defaults to `origin`) or `--mirror=<name>` (explicit value). Existing dual-push tests migrated from space form to equals form.

Pinned by:
- `test_cli_push_mirror_requires_equals_does_not_swallow_positional` — `heddle push --mirror <PRIMARY>` → primary parses as positional, mirror defaults to "origin".
- `test_cli_push_mirror_explicit_equals_form_parses_value` — `--mirror=<custom> <primary>` → primary=primary, mirror=custom.

**codecov/patch gap**

Added `test_cli_push_mirror_json_success_emits_mirrored_true` and `test_cli_push_mirror_json_failure_emits_mirrored_false_with_error` covering both JSON branches of `render_mirror_outcome`.

### Round 2 red commit
`c362613`

### Round 2 test evidence
```
test bridge::test_cli_push_mirror_requires_equals_does_not_swallow_positional ... ok
test bridge::test_cli_push_mirror_explicit_equals_form_parses_value ... ok
test bridge::test_cli_push_mirror_json_success_emits_mirrored_true ... ok
test bridge::test_cli_push_mirror_json_failure_emits_mirrored_false_with_error ... ok
test bridge::test_cli_push_mirror_dual_push_to_weft_and_git_remote ... ok
test bridge::test_cli_push_mirror_failure_does_not_abort_primary_push ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 300 filtered out
```

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `check-no-silent-default-tree-load.sh` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782312524&installation_id=132405951&pr_number=227&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F227&signature=0462de9a091434cb560dd88735862032680c8cbaf824c7f8f78a5dee9f795ff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


## Round 4 — Codex review pass

**P2 — `--mirror` silently ignored in Git-overlay drop-in repos** (Codex finding 3299019975)

`cmd_push` short-circuits with an early `return Ok(())` in the `RepositoryCapability::GitOverlay && !hosted_enabled()` branch (drop-in overlay over a plain git repo). The mirror block lived after the early return, so `heddle push --mirror=<remote>` in such a repo silently pushed only the primary.

Fix: in the overlay branch, after the primary `bridge.push(remote_name)`, call `bridge.push(mirror_remote)` if `--mirror` was supplied and route the outcome through the same `render_mirror_outcome` helper. Same best-effort (warn-don't-abort) semantics as the hosted/native path.

Pinned by `test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes`: a plain-git source with the bridge sidecar imported, then `heddle push <primary_path> --mirror=<mirror_path>` — both bare remotes must end up with `refs/heads/main`.

**P3 — mirror JSON output used Rust Debug instead of RFC 8259** (Codex finding 3299019980)

`render_mirror_outcome` hand-built JSON with `format!("…{:?}…", remote)` for the `"remote"` and `"error"` fields. `{:?}` is Rust's Debug formatter — for a string containing `U+2028` (LINE SEPARATOR) it emits `"\u{2028}"` (literal braces), which is not valid JSON. Downstream parsers reject.

Fix: rewrote both JSON branches via `serde_json::json!`, which guarantees RFC 8259 escaping. Same treatment applied to the overlay branch's `"pushed":true` line for consistency.

Pinned by `test_cli_push_mirror_json_uses_rfc8259_escaping_for_unicode`: mirror bare repo at a path containing `U+2028`, then `heddle --output json push … --mirror=<path>` — the `"mirrored"` line must parse with `serde_json::from_str` and round-trip the codepoint via `parsed["remote"]`.

### Round 4 red commit
`01d6934`

### Round 4 test evidence
```
test bridge::test_cli_push_mirror_dual_push_to_weft_and_git_remote ... ok
test bridge::test_cli_push_mirror_explicit_equals_form_parses_value ... ok
test bridge::test_cli_push_mirror_failure_does_not_abort_primary_push ... ok
test bridge::test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes ... ok
test bridge::test_cli_push_mirror_json_failure_emits_mirrored_false_with_error ... ok
test bridge::test_cli_push_mirror_json_success_emits_mirrored_true ... ok
test bridge::test_cli_push_mirror_json_uses_rfc8259_escaping_for_unicode ... ok
test bridge::test_cli_push_mirror_requires_equals_does_not_swallow_positional ... ok

test result: ok. 8 passed; 0 failed
```

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `check-no-silent-default-tree-load.sh` all green.
