### PR TITLE
heddle#226: heddle-grpc 0.7 — add VerifySignupEmail RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 heddle-client = { path = "../client", version = "0.2", optional = true }
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -48,7 +48,7 @@ walkdir.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
 fs2.workspace = true
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.6" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -89,6 +89,13 @@ service AuthService {
   rpc ListScopeCapabilities(ListScopeCapabilitiesRequest) returns (ListScopeCapabilitiesResponse);
   rpc LinkOAuthIdentity(LinkOAuthIdentityRequest) returns (AccessTokenResponse);
   rpc StoreProviderToken(StoreProviderTokenRequest) returns (StoreProviderTokenResponse);
+  // Verify the single-use token emailed to a signup address. On success
+  // the server marks the signup_email_verification challenge satisfied
+  // and returns a bootstrap-scope Biscuit the client presents on the
+  // subsequent `BeginWebAuthnRegistration` call. Closes the latent
+  // duplicate-username takeover surface named in HeddleCo/weft#120 §1
+  // and tracked by HeddleCo/weft#181.
+  rpc VerifySignupEmail(VerifySignupEmailRequest) returns (VerifySignupEmailResponse);
   rpc AnalyzeExternalDiff(AnalyzeExternalDiffRequest) returns (AnalyzeExternalDiffResponse);
 
   // Public lookup of an invitation's shape (namespace path + role) by id.
@@ -1957,6 +1964,25 @@ message StoreProviderTokenRequest {
 }
 
 message StoreProviderTokenResponse {}
+
+// ── Signup-email verification ───────────────────────────────────────────────
+
+message VerifySignupEmailRequest {
+  // The single-use token emailed to the signup address (opaque to
+  // clients — the server validates this against the pending
+  // signup_email_verification challenge row).
+  string verification_token = 1;
+}
+
+message VerifySignupEmailResponse {
+  // Opaque bootstrap-scope Biscuit the client presents on the
+  // subsequent `BeginWebAuthnRegistration` call. Empty on rejection
+  // (the RPC returns a non-OK status in that case; this field is
+  // populated only on success). Carrying the token as raw bytes lets
+  // future fields (expiry, refresh window) extend the response
+  // additively without breaking the wire format.
+  bytes bootstrap_token = 1;
+}
 
 // ── External diff analysis (for PR review packets) ──────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `VerifySignupEmail` RPC + `VerifySignupEmailRequest`/`VerifySignupEmailResponse` messages to `AuthService` so HeddleCo/weft#181 can gate signup behind email verification before the WebAuthn registration step.
- Response carries an opaque `bytes bootstrap_token` (additive — future fields like `expires_at` extend the message without breaking the wire format).
- Bumps `heddle-grpc` 0.6.0 → 0.7.0 (following the prevailing minor-bump-per-proto-addition pattern, e.g. heddle#222's 0.5→0.6).
- Updates the three workspace consumers (`cli`, `client`, `daemon`) to pin `0.7`.
- Pre-1.0, no external clients pin the old shape — no `reserved` clauses.

Audit note (matches the issue body's discipline): no proto-level challenge-kind enum exists in `service.proto` today. Existing ceremonies — WebAuthn reg/auth, OAuth link — distinguish kinds by RPC name, not by an enum variant on `AuthChallengeResponse`. The `signup_email_verification` kind named in weft#181's AC lives as a substrate-level Rust enum on the weft side; nothing new on the wire here.

Closes HeddleCo/heddle#226

## Red commit

N/A — DoD Type is release-ops / proto contract, not TDD-Rust. No behavioural logic in this repo changes; consumer logic lives in `weft`.

## Test evidence

\`\`\`
$ cargo build -p heddle-grpc
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 5m 07s

$ cargo test --workspace
Workspace: 2587 passed, 0 failed, 38 ignored across 71 test binaries

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished \`dev\` profile [unoptimized + debuginfo] target(s)
    (no warnings)

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (500 file(s) scanned)
\`\`\`

## Manual verification

N/A — proto + version bumps only; no UI surface and no functional Rust changes in this repo. The wire contract will be exercised end-to-end when HeddleCo/weft#181 lands the server side.

## Blocked by → resolved

- HeddleCo/weft#181 — this proto bump is the cross-repo prerequisite the weft signup-verification + duplicate-username rejection work needs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782313370&installation_id=132405951&pr_number=228&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F228&signature=b192c2fa8c857d5aee09ffdb4ccb962c273bb080e3587271272566d6e8cc1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->