### PR TITLE
OSS improvements (2/4): typed transfer JSON + recovery-advice centralization

### DIFF
--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -849,9 +849,154 @@ impl RecoveryAdvice {
         )
     }
 
+    pub(crate) fn from_git_bridge_error(
+        error: &crate::bridge::git_core::GitBridgeError,
+    ) -> Option<Self> {
+        use crate::bridge::git_core::GitBridgeError;
+        match error {
+            GitBridgeError::NonFastForwardRef { name, .. }
+                if name == crate::bridge::git_notes::NOTES_REF =>
+            {
+                Some(Self::git_overlay_note_ref_conflict())
+            }
+            GitBridgeError::NonFastForwardRef { name, .. } => name
+                .strip_prefix("refs/heads/")
+                .map(Self::git_overlay_remote_push_rejected),
+            GitBridgeError::Conflict(message) if is_git_overlay_mapping_conflict(message) => {
+                Some(Self::git_overlay_mapping_conflict())
+            }
+            GitBridgeError::GitHeddleThreadDiverged { thread, branch, .. } => {
+                Some(Self::git_heddle_thread_diverged(thread, branch))
+            }
+            GitBridgeError::RemoteDiverged {
+                branch, upstream, ..
+            } => Some(Self::git_overlay_remote_diverged(branch, upstream)),
+            GitBridgeError::ShallowClone {
+                repository,
+                retry_command,
+            } => Some(Self::git_overlay_shallow_clone(repository, retry_command)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn git_overlay_note_ref_conflict() -> Self {
+        Self::safety_refusal(
+            "git_overlay_note_ref_conflict",
+            "Remote Heddle notes do not fast-forward",
+            "Fetch the remote Heddle notes, then retry the push. If the conflict remains, create a fresh Heddle clone from the remote so Git-to-Heddle identity metadata stays authoritative.",
+            "updating refs/notes/heddle would replace remote Git-to-Heddle identity metadata instead of fast-forwarding it",
+            "pushing would remap commits that another Heddle checkout already identified",
+            "remote refs/notes/heddle was left unchanged",
+            "heddle fetch",
+            vec![
+                "heddle fetch".to_string(),
+                "heddle push".to_string(),
+                "heddle clone <remote> <fresh-path>".to_string(),
+            ],
+        )
+    }
+
+    pub(crate) fn git_overlay_mapping_conflict() -> Self {
+        Self::safety_refusal(
+            "git_overlay_mapping_conflict",
+            "Git-overlay mapping metadata disagrees with refs/notes/heddle",
+            "The local sidecar and refs/notes/heddle disagree about Git-to-Heddle identity. Use a fresh Heddle clone from the remote, or restore the notes ref from the checkout whose mapping is authoritative before retrying.",
+            "one Git commit maps to different Heddle change ids across the sidecar and refs/notes/heddle",
+            "continuing would corrupt or hide the Git/Heddle identity mapping",
+            "the command stopped before applying the requested ref or worktree update",
+            "heddle clone <remote> <fresh-path>",
+            vec!["heddle clone <remote> <fresh-path>".to_string()],
+        )
+    }
+
+    pub(crate) fn git_overlay_shallow_clone(
+        repository: &std::path::Path,
+        retry_command: &str,
+    ) -> Self {
+        let primary_command = "heddle clone <remote> <fresh-path>".to_string();
+        Self::safety_refusal(
+            "git_overlay_shallow_clone",
+            "Shallow Git repository cannot be imported",
+            format!(
+                "Import needs complete ancestry. Create or choose a complete checkout with `{primary_command}`, then retry with `{retry_command}`."
+            ),
+            format!(
+                "Git repository '{}' is shallow and does not contain the full commit ancestry Heddle needs to preserve stable change identity",
+                repository.display()
+            ),
+            "importing from this checkout would create an incomplete Git-to-Heddle history map",
+            "Heddle refs, Git refs, index, and worktree files were left unchanged",
+            primary_command.clone(),
+            vec![primary_command, retry_command.to_string()],
+        )
+    }
+
+    pub(crate) fn git_heddle_thread_diverged(thread: &str, branch: &str) -> Self {
+        let primary_command = format!("heddle bridge git reconcile --ref {branch} --preview");
+        let heddle_preview =
+            format!("heddle bridge git reconcile --prefer heddle --ref {branch} --preview");
+        let git_preview =
+            format!("heddle bridge git reconcile --prefer git --ref {branch} --preview");
+        Self::safety_refusal(
+            "git_heddle_thread_diverged",
+            "Git branch and Heddle thread have diverged",
+            format!(
+                "Inspect both local repair choices with `{primary_command}`. Preview mode does not move refs, update the index, change worktree files, push, or pull."
+            ),
+            format!(
+                "Heddle thread '{thread}' and Git branch '{branch}' both contain history the other side lacks"
+            ),
+            "importing or syncing now would need to choose whether the local Git branch or Heddle thread is authoritative",
+            "Heddle refs, Git refs, and worktree files were left unchanged",
+            primary_command.clone(),
+            vec![primary_command, heddle_preview, git_preview],
+        )
+    }
+
+    pub(crate) fn git_overlay_remote_push_rejected(branch: &str) -> Self {
+        let primary_command = "heddle fetch".to_string();
+        Self::safety_refusal(
+            "git_overlay_remote_diverged",
+            "Remote branch does not fast-forward the local Git checkpoint",
+            "Fetch first so Heddle can inspect the remote tip locally, then run `heddle verify` for the exact integration command.",
+            format!(
+                "pushing branch '{branch}' would rewrite the remote branch instead of fast-forwarding it"
+            ),
+            "pushing now would replace work that exists on the remote",
+            "the remote branch, local Git branch, Heddle refs, index, and worktree files were left unchanged",
+            primary_command.clone(),
+            vec![primary_command, "heddle verify".to_string()],
+        )
+    }
+
+    pub(crate) fn git_overlay_remote_diverged(branch: &str, upstream: &str) -> Self {
+        let import_command = format!("heddle bridge git import --ref {upstream}");
+        let merge_preview = format!("heddle merge {upstream} --preview");
+        Self::safety_refusal(
+            "git_overlay_remote_diverged",
+            "Remote branch does not fast-forward the local Git checkpoint",
+            format!(
+                "Import the fetched upstream tip with `{import_command}`, then preview integration with `{merge_preview}`."
+            ),
+            format!(
+                "local branch '{branch}' and upstream '{upstream}' both contain commits the other side lacks"
+            ),
+            "pulling now would need to integrate upstream work with local Heddle work before moving the branch",
+            "Heddle refs, the visible Git branch, and worktree files were left unchanged",
+            import_command.clone(),
+            vec![import_command, merge_preview],
+        )
+    }
+
     pub fn primary_hint(&self) -> &str {
         &self.hint
     }
+}
+
+fn is_git_overlay_mapping_conflict(message: &str) -> bool {
+    (message.starts_with("git oid ") || message.starts_with("change id "))
+        && message.contains(" mapped to ")
+        && message.contains(" (new ")
 }
 
 pub(crate) fn dirty_worktree_recovery_commands() -> Vec<String> {
@@ -892,3 +1037,53 @@ impl fmt::Display for RecoveryAdvice {
 }
 
 impl Error for RecoveryAdvice {}
+
+#[cfg(test)]
+mod tests {
+    use super::RecoveryAdvice;
+    use crate::bridge::git_core::GitBridgeError;
+
+    #[test]
+    fn git_bridge_mapping_conflict_returns_typed_advice() {
+        let error = GitBridgeError::Conflict(
+            "git oid abc mapped to old-change (new new-change)".to_string(),
+        );
+
+        let advice = RecoveryAdvice::from_git_bridge_error(&error)
+            .expect("mapping conflict should be classified");
+
+        assert_eq!(advice.kind, "git_overlay_mapping_conflict");
+        assert_eq!(advice.primary_command, "heddle clone <remote> <fresh-path>");
+        assert!(
+            advice
+                .unsafe_condition
+                .contains("one Git commit maps to different Heddle change ids")
+        );
+    }
+
+    #[test]
+    fn git_bridge_shallow_clone_returns_typed_advice() {
+        let retry_command = "heddle bridge git import --ref main";
+        let error = GitBridgeError::ShallowClone {
+            repository: std::path::PathBuf::from("/tmp/shallow"),
+            retry_command: retry_command.to_string(),
+        };
+
+        let advice = RecoveryAdvice::from_git_bridge_error(&error)
+            .expect("shallow clone should be classified");
+
+        assert_eq!(advice.kind, "git_overlay_shallow_clone");
+        assert_eq!(
+            advice.recovery_commands,
+            vec![
+                "heddle clone <remote> <fresh-path>".to_string(),
+                retry_command.to_string()
+            ]
+        );
+        assert!(
+            !advice.hint.contains("git fetch"),
+            "shallow recovery should stay no-git friendly: {}",
+            advice.hint
+        );
+    }
+}

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -988,6 +988,185 @@ impl RecoveryAdvice {
         )
     }
 
+    pub(crate) fn remote_transport_mismatch(action: &str, remote: &str) -> Self {
+        Self::safety_refusal(
+            "remote_transport_mismatch",
+            format!(
+                "Refusing to {action}: remote '{remote}' is a Git remote, not a Heddle-native remote"
+            ),
+            "Use a Heddle-native remote here, or clone/adopt that Git remote in a Git-overlay checkout.",
+            format!("remote '{remote}' resolves to Git storage"),
+            format!(
+                "{action} would route a Git repository through Heddle-native sync and fail after setup work"
+            ),
+            "remote configuration, Heddle refs, Git refs, and worktree files were left unchanged",
+            "heddle clone <remote> <fresh-path>",
+            vec![
+                "heddle clone <remote> <fresh-path>".to_string(),
+                "heddle remote add <name> <url>".to_string(),
+            ],
+        )
+    }
+
+    pub(crate) fn remote_not_configured(action: &str) -> Self {
+        Self::safety_refusal(
+            "remote_not_configured",
+            format!("No default remote is configured for {action}"),
+            "Add a remote with `heddle remote add <name> <url>`, inspect remotes with `heddle remote list`, or choose one with `heddle remote set-default <name>`.",
+            "the command did not receive a remote argument and no default remote is configured",
+            format!(
+                "{action} needs a concrete remote target before it can move remote refs or transfer objects"
+            ),
+            "repository state, refs, remote configuration, and worktree files were left unchanged",
+            "heddle remote add <name> <url>",
+            vec![
+                "heddle remote add <name> <url>".to_string(),
+                "heddle remote list".to_string(),
+                "heddle remote set-default <name>".to_string(),
+            ],
+        )
+    }
+
+    pub(crate) fn remote_not_found(name: &str) -> Self {
+        Self::safety_refusal(
+            "remote_not_found",
+            format!("Remote '{name}' not found"),
+            "Inspect configured remotes with `heddle remote list`, or add one with `heddle remote add <name> <url>`.",
+            format!("no configured Heddle or Git remote named '{name}' was found"),
+            "the command cannot inspect, fetch, pull, or push a remote until the remote name is resolved",
+            "remote configuration, refs, objects, and worktree files were left unchanged",
+            "heddle remote list",
+            vec![
+                "heddle remote list".to_string(),
+                "heddle remote add <name> <url>".to_string(),
+            ],
+        )
+    }
+
+    pub(crate) fn remote_name_required_for_fetch() -> Self {
+        Self::safety_refusal(
+            "remote_name_required",
+            "Refusing to fetch: remote name required unless --all is set",
+            "Run `heddle fetch <remote>` for one remote, or `heddle fetch --all` for every configured remote.",
+            "fetch was requested without a remote name and without --all",
+            "fetch updates remote refs and object storage, so the target remote set must be explicit",
+            "no remote refs or objects were written",
+            "heddle fetch --all",
+            vec![
+                "heddle fetch --all".to_string(),
+                "heddle remote list".to_string(),
+            ],
+        )
+    }
+
+    pub(crate) fn git_overlay_tracking_refresh_failed(
+        remote_name: &str,
+        full_ref: &str,
+        cause: Option<String>,
+    ) -> Self {
+        let fetch_command = format!("heddle fetch {remote_name}");
+        let error = match cause {
+            Some(cause) => format!(
+                "Pushed to {remote_name}, but could not refresh local tracking ref {full_ref}: {cause}"
+            ),
+            None => {
+                format!(
+                    "Pushed to {remote_name}, but could not refresh local tracking ref {full_ref}"
+                )
+            }
+        };
+        Self::safety_refusal(
+            "git_overlay_tracking_refresh_failed",
+            error,
+            format!(
+                "Run `{fetch_command}` if `heddle verify` still reports remote drift after the push."
+            ),
+            format!("remote push completed, but local Git tracking ref {full_ref} was not updated"),
+            format!(
+                "updating {full_ref} would record the pushed HEAD as the local tracking view of {remote_name}"
+            ),
+            "the remote push completed; the failed tracking-ref refresh did not make additional local tracking changes",
+            fetch_command.clone(),
+            vec![fetch_command, "heddle verify".to_string()],
+        )
+    }
+
+    pub(crate) fn local_lazy_pull_unsupported(source_path: &std::path::Path) -> Self {
+        let source = source_path.display().to_string();
+        let pull_without_lazy = format!("heddle pull {source}");
+        Self::safety_refusal(
+            "local_lazy_pull_unsupported",
+            "Refusing lazy pull from local remote: lazy materialization requires a hosted or network remote",
+            format!(
+                "Run `{pull_without_lazy}` without `--lazy`, or configure a hosted remote and retry lazy pull there."
+            ),
+            format!("selected remote resolves to local path file://{source}"),
+            "lazy pull would leave the worktree depending on on-demand object fetches that the local transport does not provide",
+            "repository state was left unchanged",
+            pull_without_lazy.clone(),
+            vec![pull_without_lazy, "heddle remote list".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub(crate) fn remote_push_failed(track_name: &str, error: &str) -> Self {
+        let primary_command = format!("heddle push {track_name}");
+        Self::safety_refusal(
+            "remote_push_failed",
+            format!("Push failed for {track_name}: {error}"),
+            format!(
+                "Inspect `heddle verify`, then retry with `{primary_command}` after fixing the remote."
+            ),
+            format!("remote push to {track_name} failed: {error}"),
+            "the remote branch was not confirmed updated",
+            "local Heddle state, Git refs, and worktree files were left unchanged by the failed push result",
+            primary_command.clone(),
+            vec![primary_command, "heddle verify".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub(crate) fn remote_pull_failed(
+        remote_thread: &str,
+        local_thread: Option<&str>,
+        error: &str,
+    ) -> Self {
+        let primary_command = if let Some(local_thread) = local_thread {
+            format!("heddle pull {remote_thread} {local_thread}")
+        } else {
+            format!("heddle pull {remote_thread}")
+        };
+        Self::safety_refusal(
+            "remote_pull_failed",
+            format!("Pull failed from {remote_thread}: {error}"),
+            format!(
+                "Inspect `heddle verify`, then retry with `{primary_command}` after fixing the remote."
+            ),
+            format!("remote pull from {remote_thread} failed: {error}"),
+            "the local thread was not confirmed updated from the remote",
+            "local Heddle state, Git refs, and worktree files were left unchanged by the failed pull result",
+            primary_command.clone(),
+            vec![primary_command, "heddle verify".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub(crate) fn network_clone_failed(error: &str, local_path: &std::path::Path) -> Self {
+        Self::safety_refusal(
+            "network_clone_failed",
+            format!("Clone failed: {error}"),
+            "Check the remote, credentials, and requested ref, then retry `heddle clone`.",
+            format!(
+                "network clone reported failure for '{}': {error}",
+                local_path.display()
+            ),
+            "clone cannot prove that all requested remote objects and refs were materialized",
+            "any created destination files or metadata were left for inspection",
+            "heddle clone <remote> <path>",
+            vec!["heddle clone <remote> <path>".to_string()],
+        )
+    }
+
     pub fn primary_hint(&self) -> &str {
         &self.hint
     }

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -46,9 +46,8 @@ use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
-    command_catalog::ActionTemplate,
+    command_catalog::{ActionFields, ActionTemplate},
     diff::compute_state_diff,
-    git_overlay_health::{action_argv, action_template},
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread::start_thread,
     thread_cmd::drop_thread_silent,
@@ -501,11 +500,8 @@ pub fn cmd_attempt(cli: &Cli, args: AttemptArgs) -> Result<()> {
     let next_action = recommended
         .as_deref()
         .map(|name| format!("heddle merge {name} --preview --with-diff"));
-    let next_action_argv = next_action.as_deref().and_then(action_argv);
-    let next_action_template = next_action.as_deref().and_then(action_template);
+    let next_action = ActionFields::from_optional_action(next_action);
     let recommended_action = next_action.clone();
-    let recommended_action_argv = recommended_action.as_deref().and_then(action_argv);
-    let recommended_action_template = recommended_action.as_deref().and_then(action_template);
 
     let message = match &recommended {
         Some(thread) if attempts_succeeded > 0 => format!(
@@ -534,12 +530,12 @@ pub fn cmd_attempt(cli: &Cli, args: AttemptArgs) -> Result<()> {
         attempts_dropped: dropped,
         attempts: all_results,
         recommended,
-        next_action,
-        next_action_argv,
-        next_action_template,
-        recommended_action,
-        recommended_action_argv,
-        recommended_action_template,
+        next_action: next_action.action,
+        next_action_argv: next_action.argv,
+        next_action_template: next_action.template,
+        recommended_action: recommended_action.action,
+        recommended_action_argv: recommended_action.argv,
+        recommended_action_template: recommended_action.template,
     };
 
     emit(cli, &repo, &output)

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -306,20 +306,24 @@ fn render_bridge_git_status(output: &BridgeGitStatusOutput, json: bool) {
     }
     match &output.git_overlay_import_hint {
         Some(hint) => {
-            println!(
-                "{}",
-                crate::cli::render::git_only_branch_summary(
-                    &hint.missing_branches,
-                    hint.missing_branch_count,
-                )
-            );
-            if hint
+            let current_branch_needs_import = hint
                 .missing_branches
                 .iter()
-                .any(|branch| branch == &hint.current_branch)
-            {
+                .any(|branch| branch == &hint.current_branch);
+            if current_branch_needs_import {
+                println!(
+                    "{}",
+                    git_import_required_summary(&hint.missing_branches, hint.missing_branch_count,)
+                );
                 println!("Next step: {}", style::bold(&hint.recommended_command));
             } else {
+                println!(
+                    "{}",
+                    crate::cli::render::git_only_branch_summary(
+                        &hint.missing_branches,
+                        hint.missing_branch_count,
+                    )
+                );
                 println!("Optional: {}", style::dim(&hint.recommended_command));
             }
         }
@@ -370,6 +374,14 @@ fn render_bridge_git_reconcile(
         }
     }
     Ok(())
+}
+
+fn git_import_required_summary(branches: &[String], total: usize) -> String {
+    let noun = if total == 1 { "branch" } else { "branches" };
+    format!(
+        "Git {noun} waiting for Heddle import: {}",
+        crate::cli::render::preview_list(branches, total)
+    )
 }
 
 /// Execute bridge subcommands.

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -46,6 +46,69 @@ impl ResolvedSource {
     }
 }
 
+#[derive(Serialize)]
+struct BridgeGitPushOutput {
+    output_kind: &'static str,
+    action: &'static str,
+    status: &'static str,
+    success: bool,
+    pushed: bool,
+    changed: bool,
+    transport: &'static str,
+    remote: String,
+    #[serde(rename = "verification")]
+    trust: RepositoryVerificationState,
+}
+
+#[derive(Serialize)]
+struct BridgeGitPullOutput {
+    output_kind: &'static str,
+    action: &'static str,
+    status: &'static str,
+    success: bool,
+    pulled: bool,
+    changed: bool,
+    transport: &'static str,
+    remote: String,
+    #[serde(rename = "verification")]
+    trust: RepositoryVerificationState,
+}
+
+fn bridge_git_push_output(
+    remote: String,
+    trust: RepositoryVerificationState,
+) -> BridgeGitPushOutput {
+    BridgeGitPushOutput {
+        output_kind: "bridge_git_push",
+        action: "bridge git push",
+        status: "pushed",
+        success: true,
+        pushed: true,
+        changed: true,
+        transport: "git",
+        remote,
+        trust,
+    }
+}
+
+fn bridge_git_pull_output(
+    remote: String,
+    changed: bool,
+    trust: RepositoryVerificationState,
+) -> BridgeGitPullOutput {
+    BridgeGitPullOutput {
+        output_kind: "bridge_git_pull",
+        action: "bridge git pull",
+        status: if changed { "updated" } else { "up_to_date" },
+        success: true,
+        pulled: changed,
+        changed,
+        transport: "git",
+        remote,
+        trust,
+    }
+}
+
 /// Owned scratch directory that removes itself on drop. Hand-rolled rather
 /// than pulling `tempfile` into the cli's runtime deps just for this.
 struct ScratchDir {
@@ -868,12 +931,9 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
             bridge.push(&remote_name)?;
 
             if should_output_json(cli, Some(repo.config())) {
-                let out = serde_json::json!({
-                    "pushed": true,
-                    "remote": remote_name,
-                    "verification": build_repository_verification_state(&repo),
-                });
-                println!("{out}");
+                let output =
+                    bridge_git_push_output(remote_name, build_repository_verification_state(&repo));
+                crate::cli::render::write_json_stdout(&output)?;
             } else {
                 println!(
                     "{} pushed to remote {}",
@@ -886,21 +946,14 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
         GitCommands::Pull { remote } => {
             let remote_name = resolve_default_remote_name(&repo, remote.as_deref())?;
             let outcome = bridge.pull(&remote_name)?;
-            let status = if outcome.changed {
-                "updated"
-            } else {
-                "up_to_date"
-            };
 
             if should_output_json(cli, Some(repo.config())) {
-                let out = serde_json::json!({
-                    "status": status,
-                    "pulled": outcome.changed,
-                    "changed": outcome.changed,
-                    "remote": remote_name,
-                    "verification": build_repository_verification_state(&repo),
-                });
-                println!("{out}");
+                let output = bridge_git_pull_output(
+                    remote_name,
+                    outcome.changed,
+                    build_repository_verification_state(&repo),
+                );
+                crate::cli::render::write_json_stdout(&output)?;
             } else {
                 if outcome.changed {
                     println!(

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -23,8 +23,8 @@ use super::{
     git_overlay_health::{
         RepositoryVerificationState, build_plain_git_verification_probe,
         build_repository_verification_state, detached_git_head_mutation_advice,
-        plain_git_mutation_advice, unimported_git_history_advice,
-        verification_blocking_mutation_advice,
+        plain_git_mutation_advice, repository_verification_blocked_advice,
+        unimported_git_history_advice, verification_blocking_mutation_advice,
     },
     snapshot::ensure_current_state,
     worktree_safety::dirty_worktree_advice,
@@ -236,17 +236,11 @@ fn git_checkpoint_preflight_advice(
                 trust.recommended_action.clone()
             }
         });
-    let recovery_commands = if primary_command != trust.recommended_action {
-        vec![primary_command.clone(), "heddle verify".to_string()]
-    } else if trust.recovery_commands.is_empty() {
-        vec![primary_command.clone()]
-    } else {
-        trust.recovery_commands.clone()
-    };
-    RecoveryAdvice::safety_refusal(
+    repository_verification_blocked_advice(
         "git_checkpoint_preflight_blocked",
         format!("Refusing to {action}: Git checkpoint preflight is blocked"),
-        format!("Run `{primary_command}` before retrying `heddle {action}`."),
+        format!("retrying `heddle {action}`"),
+        trust,
         format!(
             "repository verification status is {}; remote drift is {}: {}",
             trust.status, trust.remote_drift, trust.summary
@@ -255,8 +249,7 @@ fn git_checkpoint_preflight_advice(
             "{action} would capture Heddle state before the Git checkpoint ref update is known to be safe"
         ),
         "Git refs, Heddle refs, Git checkpoint metadata, and worktree files were left unchanged",
-        primary_command,
-        recovery_commands,
+        Some(primary_command),
     )
 }
 

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -18,8 +18,12 @@ use objects::{
 };
 use refs::Head;
 use repo::{BlobHydrator, Repository};
+use serde::Serialize;
 
-use super::{advice::RecoveryAdvice, git_overlay_health::build_repository_verification_state};
+use super::{
+    advice::RecoveryAdvice,
+    git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
+};
 #[cfg(feature = "client")]
 use crate::remote::credential_key_from_remote_url;
 use crate::{
@@ -39,6 +43,89 @@ struct CloneOptions {
     depth: Option<u32>,
     lazy: bool,
     filter: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CloneOutput {
+    output_kind: &'static str,
+    action: &'static str,
+    status: &'static str,
+    success: bool,
+    cloned: bool,
+    transport: &'static str,
+    remote: String,
+    local: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repository_capability: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commits_imported: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    states_created: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    objects: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<String>,
+    #[serde(rename = "verification")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trust: Option<RepositoryVerificationState>,
+}
+
+struct GitOverlayCloneOutputInput {
+    remote: String,
+    local: String,
+    branch: String,
+    commits_imported: usize,
+    states_created: usize,
+    trust: RepositoryVerificationState,
+}
+
+fn git_overlay_clone_output(input: GitOverlayCloneOutputInput) -> CloneOutput {
+    CloneOutput {
+        output_kind: "clone",
+        action: "clone",
+        status: "cloned",
+        success: true,
+        cloned: true,
+        transport: "git",
+        remote: input.remote,
+        local: input.local,
+        branch: Some(input.branch),
+        repository_capability: Some("git-overlay"),
+        commits_imported: Some(input.commits_imported),
+        states_created: Some(input.states_created),
+        objects: None,
+        state: None,
+        trust: Some(input.trust),
+    }
+}
+
+fn heddle_clone_output(
+    remote: String,
+    local: String,
+    branch: String,
+    objects: Option<usize>,
+    state: Option<String>,
+    trust: Option<RepositoryVerificationState>,
+) -> CloneOutput {
+    CloneOutput {
+        output_kind: "clone",
+        action: "clone",
+        status: "cloned",
+        success: true,
+        cloned: true,
+        transport: "heddle",
+        remote,
+        local,
+        branch: Some(branch),
+        repository_capability: Some("native"),
+        commits_imported: None,
+        states_created: None,
+        objects,
+        state,
+        trust,
+    }
 }
 
 pub async fn cmd_clone(
@@ -296,20 +383,15 @@ fn finish_git_overlay_clone(
 
     if should_output_json(cli, Some(repo.config())) {
         let trust = build_repository_verification_state(&repo);
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "clone",
-                "status": "cloned",
-                "transport": "git",
-                "remote": remote_label,
-                "local": local_path.display().to_string(),
-                "branch": track_name,
-                "commits_imported": stats.commits_imported,
-                "states_created": stats.states_created,
-                "verification": trust,
-            })
-        );
+        let output = git_overlay_clone_output(GitOverlayCloneOutputInput {
+            remote: remote_label,
+            local: local_path.display().to_string(),
+            branch: track_name,
+            commits_imported: stats.commits_imported,
+            states_created: stats.states_created,
+            trust,
+        });
+        crate::cli::render::write_json_stdout(&output)?;
     } else {
         let repo_name = clone_repo_name_from_label(&remote_label);
         for line in format_clone_completion_lines(repo_name, stats.commits_imported, &track_name) {
@@ -978,16 +1060,15 @@ async fn clone_local(
     let origin_url = configure_local_clone_origin(&local_repo, remote_path)?;
 
     if should_output_json(cli, Some(local_repo.config())) {
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "clone",
-                "status": "cloned",
-                "remote": origin_url,
-                "local": local_path.display().to_string(),
-                "objects": objects_copied,
-            })
+        let output = heddle_clone_output(
+            origin_url,
+            local_path.display().to_string(),
+            track_name.to_string(),
+            Some(objects_copied),
+            Some(state_id.to_string()),
+            Some(build_repository_verification_state(&local_repo)),
         );
+        crate::cli::render::write_json_stdout(&output)?;
     } else {
         let depth_info = depth.map(|d| format!(" (depth {})", d)).unwrap_or_default();
         println!(
@@ -1205,19 +1286,15 @@ async fn clone_network(
                 .context("failed to persist lazy-hydrator.toml")?;
         }
         if should_output_json(cli, Some(local_repo.config())) {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "clone",
-                    "status": "cloned",
-                    "remote": addr.to_string(),
-                    "local": local_path.display().to_string(),
-                    "state": result
-                        .final_state
-                        .map(|s| s.to_string())
-                        .unwrap_or_default(),
-                })
+            let output = heddle_clone_output(
+                addr.to_string(),
+                local_path.display().to_string(),
+                track_name.to_string(),
+                None,
+                result.final_state.map(|state| state.to_string()),
+                Some(build_repository_verification_state(&local_repo)),
             );
+            crate::cli::render::write_json_stdout(&output)?;
         } else {
             let depth_info = depth.map(|d| format!(" (depth {})", d)).unwrap_or_default();
             println!(

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -796,23 +796,6 @@ fn clone_git_overlay_no_branch_refs_advice(remote_label: &str) -> RecoveryAdvice
     )
 }
 
-#[cfg(feature = "client")]
-fn network_clone_failed_advice(error: &str, local_path: &Path) -> RecoveryAdvice {
-    RecoveryAdvice::safety_refusal(
-        "network_clone_failed",
-        format!("Clone failed: {error}"),
-        "Check the remote, credentials, and requested ref, then retry `heddle clone`.",
-        format!(
-            "network clone reported failure for '{}': {error}",
-            local_path.display()
-        ),
-        "clone cannot prove that all requested remote objects and refs were materialized",
-        "any created destination files or metadata were left for inspection",
-        "heddle clone <remote> <path>",
-        vec!["heddle clone <remote> <path>".to_string()],
-    )
-}
-
 #[cfg(not(feature = "client"))]
 fn network_clone_unavailable_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
@@ -1313,7 +1296,9 @@ async fn clone_network(
         }
     } else {
         let err = result.error.unwrap_or_else(|| "Unknown error".to_string());
-        return Err(anyhow!(network_clone_failed_advice(&err, local_path)));
+        return Err(anyhow!(RecoveryAdvice::network_clone_failed(
+            &err, local_path
+        )));
     }
 
     Ok(())

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -153,8 +153,12 @@ impl ActionFields {
         }
     }
 
+    pub(crate) fn from_optional_action_ref(action: Option<&str>) -> Self {
+        Self::from_optional_action(action.map(str::to_string))
+    }
+
     pub(crate) fn from_action(action: &str) -> Self {
-        Self::from_optional_action(Some(action.to_string()))
+        Self::from_optional_action_ref(Some(action))
     }
 
     pub(crate) fn none() -> Self {

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -134,6 +134,38 @@ pub struct ActionTemplate {
     pub agent_may_fill: bool,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ActionFields {
+    pub action: Option<String>,
+    pub argv: Option<Vec<String>>,
+    pub template: Option<ActionTemplate>,
+}
+
+impl ActionFields {
+    pub(crate) fn from_optional_action(action: Option<String>) -> Self {
+        let Some(action) = action.filter(|action| !action.trim().is_empty()) else {
+            return Self::none();
+        };
+        Self {
+            argv: recommended_action_argv(&action).ok().flatten(),
+            template: recommended_action_template(&action),
+            action: Some(action),
+        }
+    }
+
+    pub(crate) fn from_action(action: &str) -> Self {
+        Self::from_optional_action(Some(action.to_string()))
+    }
+
+    pub(crate) fn none() -> Self {
+        Self {
+            action: None,
+            argv: None,
+            template: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct CommandJsonDiscriminator {
     pub path: Vec<String>,

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -218,27 +218,6 @@ impl ErrorClassification {
         }
     }
 
-    fn known_with_error(
-        kind: &'static str,
-        human_error: impl Into<String>,
-        hint: impl Into<String>,
-        unsafe_condition: impl Into<String>,
-        would_change: impl Into<String>,
-        preserved: impl Into<String>,
-        primary_command: impl Into<String>,
-    ) -> Self {
-        let mut classification = Self::known(
-            kind,
-            hint,
-            unsafe_condition,
-            would_change,
-            preserved,
-            primary_command,
-        );
-        classification.human_error = Some(human_error.into());
-        classification
-    }
-
     fn runtime() -> Self {
         Self::known(
             "runtime_error",
@@ -297,43 +276,8 @@ fn classify_error(err: &anyhow::Error) -> ErrorClassification {
             };
         }
         if let Some(git_error) = cause.downcast_ref::<crate::bridge::git_core::GitBridgeError>() {
-            match git_error {
-                crate::bridge::git_core::GitBridgeError::NonFastForwardRef { name, .. }
-                    if name == crate::bridge::git_notes::NOTES_REF =>
-                {
-                    return git_overlay_note_ref_conflict_classification();
-                }
-                crate::bridge::git_core::GitBridgeError::NonFastForwardRef { name, .. } => {
-                    if let Some(branch) = name.strip_prefix("refs/heads/") {
-                        return git_overlay_remote_push_rejected_classification(branch);
-                    }
-                }
-                crate::bridge::git_core::GitBridgeError::Conflict(message)
-                    if is_git_overlay_mapping_conflict(message) =>
-                {
-                    return git_overlay_mapping_conflict_classification();
-                }
-                crate::bridge::git_core::GitBridgeError::GitHeddleThreadDiverged {
-                    thread,
-                    branch,
-                    ..
-                } => {
-                    return git_heddle_thread_diverged_classification(thread, branch);
-                }
-                crate::bridge::git_core::GitBridgeError::RemoteDiverged {
-                    branch,
-                    upstream,
-                    ..
-                } => {
-                    return git_overlay_remote_diverged_classification(branch, upstream);
-                }
-                crate::bridge::git_core::GitBridgeError::ShallowClone {
-                    repository,
-                    retry_command,
-                } => {
-                    return git_overlay_shallow_clone_classification(repository, retry_command);
-                }
-                _ => {}
+            if let Some(advice) = RecoveryAdvice::from_git_bridge_error(git_error) {
+                return ErrorClassification::from_advice(&advice);
             }
         }
         if let Some(heddle_err) = cause.downcast_ref::<HeddleError>() {
@@ -537,122 +481,4 @@ fn classify_error(err: &anyhow::Error) -> ErrorClassification {
         );
     }
     ErrorClassification::runtime()
-}
-
-fn is_git_overlay_mapping_conflict(message: &str) -> bool {
-    (message.starts_with("git oid ") || message.starts_with("change id "))
-        && message.contains(" mapped to ")
-        && message.contains(" (new ")
-}
-
-fn git_overlay_note_ref_conflict_classification() -> ErrorClassification {
-    let mut classification = ErrorClassification::known_with_error(
-        "git_overlay_note_ref_conflict",
-        "Remote Heddle notes do not fast-forward",
-        "Fetch the remote Heddle notes, then retry the push. If the conflict remains, create a fresh Heddle clone from the remote so Git-to-Heddle identity metadata stays authoritative.",
-        "updating refs/notes/heddle would replace remote Git-to-Heddle identity metadata instead of fast-forwarding it",
-        "pushing would remap commits that another Heddle checkout already identified",
-        "remote refs/notes/heddle was left unchanged",
-        "heddle fetch",
-    );
-    classification.recovery_commands = vec![
-        "heddle fetch".to_string(),
-        "heddle push".to_string(),
-        "heddle clone <remote> <fresh-path>".to_string(),
-    ];
-    classification
-}
-
-fn git_overlay_mapping_conflict_classification() -> ErrorClassification {
-    ErrorClassification::known_with_error(
-        "git_overlay_mapping_conflict",
-        "Git-overlay mapping metadata disagrees with refs/notes/heddle",
-        "The local sidecar and refs/notes/heddle disagree about Git-to-Heddle identity. Use a fresh Heddle clone from the remote, or restore the notes ref from the checkout whose mapping is authoritative before retrying.",
-        "one Git commit maps to different Heddle change ids across the sidecar and refs/notes/heddle",
-        "continuing would corrupt or hide the Git/Heddle identity mapping",
-        "the command stopped before applying the requested ref or worktree update",
-        "heddle clone <remote> <fresh-path>",
-    )
-}
-
-fn git_overlay_shallow_clone_classification(
-    repository: &std::path::Path,
-    retry_command: &str,
-) -> ErrorClassification {
-    let primary_command = "heddle clone <remote> <fresh-path>".to_string();
-    let mut classification = ErrorClassification::known_with_error(
-        "git_overlay_shallow_clone",
-        "Shallow Git repository cannot be imported",
-        format!(
-            "Import needs complete ancestry. Create or choose a complete checkout with `{primary_command}`, then retry with `{retry_command}`."
-        ),
-        format!(
-            "Git repository '{}' is shallow and does not contain the full commit ancestry Heddle needs to preserve stable change identity",
-            repository.display()
-        ),
-        "importing from this checkout would create an incomplete Git-to-Heddle history map",
-        "Heddle refs, Git refs, index, and worktree files were left unchanged",
-        primary_command.clone(),
-    );
-    classification.recovery_commands = vec![primary_command, retry_command.to_string()];
-    classification
-}
-
-fn git_heddle_thread_diverged_classification(thread: &str, branch: &str) -> ErrorClassification {
-    let primary_command = format!("heddle bridge git reconcile --ref {branch} --preview");
-    let heddle_preview =
-        format!("heddle bridge git reconcile --prefer heddle --ref {branch} --preview");
-    let git_preview = format!("heddle bridge git reconcile --prefer git --ref {branch} --preview");
-    let mut classification = ErrorClassification::known_with_error(
-        "git_heddle_thread_diverged",
-        "Git branch and Heddle thread have diverged",
-        format!(
-            "Inspect both local repair choices with `{primary_command}`. Preview mode does not move refs, update the index, change worktree files, push, or pull."
-        ),
-        format!(
-            "Heddle thread '{thread}' and Git branch '{branch}' both contain history the other side lacks"
-        ),
-        "importing or syncing now would need to choose whether the local Git branch or Heddle thread is authoritative",
-        "Heddle refs, Git refs, and worktree files were left unchanged",
-        primary_command.clone(),
-    );
-    classification.recovery_commands = vec![primary_command, heddle_preview, git_preview];
-    classification
-}
-
-fn git_overlay_remote_push_rejected_classification(branch: &str) -> ErrorClassification {
-    let primary_command = "heddle fetch".to_string();
-    let mut classification = ErrorClassification::known_with_error(
-        "git_overlay_remote_diverged",
-        "Remote branch does not fast-forward the local Git checkpoint",
-        "Fetch first so Heddle can inspect the remote tip locally, then run `heddle verify` for the exact integration command.",
-        format!(
-            "pushing branch '{branch}' would rewrite the remote branch instead of fast-forwarding it"
-        ),
-        "pushing now would replace work that exists on the remote",
-        "the remote branch, local Git branch, Heddle refs, index, and worktree files were left unchanged",
-        primary_command.clone(),
-    );
-    classification.recovery_commands = vec![primary_command, "heddle verify".to_string()];
-    classification
-}
-
-fn git_overlay_remote_diverged_classification(branch: &str, upstream: &str) -> ErrorClassification {
-    let import_command = format!("heddle bridge git import --ref {upstream}");
-    let merge_preview = format!("heddle merge {upstream} --preview");
-    let mut classification = ErrorClassification::known_with_error(
-        "git_overlay_remote_diverged",
-        "Remote branch does not fast-forward the local Git checkpoint",
-        format!(
-            "Import the fetched upstream tip with `{import_command}`, then preview integration with `{merge_preview}`."
-        ),
-        format!(
-            "local branch '{branch}' and upstream '{upstream}' both contain commits the other side lacks"
-        ),
-        "pulling now would need to integrate upstream work with local Heddle work before moving the branch",
-        "Heddle refs, the visible Git branch, and worktree files were left unchanged",
-        import_command.clone(),
-    );
-    classification.recovery_commands = vec![import_command, merge_preview];
-    classification
 }

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -58,7 +58,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
             } else if let Some(default) = resolved_default_remote_name(&repo)? {
                 default
             } else {
-                return Err(fetch_remote_required_advice().into());
+                return Err(RecoveryAdvice::remote_name_required_for_fetch().into());
             };
             vec![selected]
         };
@@ -109,7 +109,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
     } else if let Some(default) = resolved_default_remote_name(&repo)? {
         vec![default]
     } else {
-        return Err(fetch_remote_required_advice().into());
+        return Err(RecoveryAdvice::remote_name_required_for_fetch().into());
     };
 
     let mut total_refs = 0;
@@ -195,22 +195,6 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
     }
 
     Ok(())
-}
-
-fn fetch_remote_required_advice() -> RecoveryAdvice {
-    RecoveryAdvice::safety_refusal(
-        "remote_name_required",
-        "Refusing to fetch: remote name required unless --all is set",
-        "Run `heddle fetch <remote>` for one remote, or `heddle fetch --all` for every configured remote.",
-        "fetch was requested without a remote name and without --all",
-        "fetch updates remote refs and object storage, so the target remote set must be explicit",
-        "no remote refs or objects were written",
-        "heddle fetch --all",
-        vec![
-            "heddle fetch --all".to_string(),
-            "heddle remote list".to_string(),
-        ],
-    )
 }
 
 async fn fetch_local(

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -28,8 +28,8 @@ use super::{
         RepositoryVerificationState, action_argv, action_template,
         build_plain_git_verification_probe, build_repository_verification_state,
         detached_git_head_mutation_advice, plain_git_mutation_advice,
-        raw_git_operation_mutation_advice, unimported_git_history_advice,
-        verification_blocking_mutation_advice,
+        raw_git_operation_mutation_advice, repository_verification_blocked_advice,
+        unimported_git_history_advice, verification_blocking_mutation_advice,
     },
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
@@ -940,31 +940,21 @@ fn nothing_to_commit_advice() -> RecoveryAdvice {
 }
 
 fn commit_blocked_by_trust_advice(trust: &RepositoryVerificationState) -> RecoveryAdvice {
-    let primary_command = if trust.recommended_action.trim().is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let recovery_commands = if trust.recovery_commands.is_empty() {
-        vec![primary_command.clone()]
-    } else {
-        trust.recovery_commands.clone()
-    };
-    RecoveryAdvice::safety_refusal(
+    repository_verification_blocked_advice(
         "commit_blocked_by_verification",
         format!(
             "refusing to report nothing to commit: repository verification is blocked ({})",
             trust.status
         ),
-        format!("Run `{primary_command}` before retrying `heddle commit`."),
+        "retrying `heddle commit`",
+        trust,
         format!(
             "repository verification status is {}: {}",
             trust.status, trust.summary
         ),
         "claiming nothing to commit could hide a Git/Heddle/import/operation disagreement",
         "no capture, Git checkpoint, refs, or worktree files were changed",
-        primary_command,
-        recovery_commands,
+        None,
     )
 }
 

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -23,13 +23,13 @@ use super::{
         create_git_checkpoint, create_git_checkpoint_from_index_snapshot,
         preflight_git_checkpoint_ref_update,
     },
-    command_catalog::ActionTemplate,
+    command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{
-        RepositoryVerificationState, action_argv, action_template,
-        build_plain_git_verification_probe, build_repository_verification_state,
-        detached_git_head_mutation_advice, plain_git_mutation_advice,
-        raw_git_operation_mutation_advice, repository_verification_blocked_advice,
-        unimported_git_history_advice, verification_blocking_mutation_advice,
+        RepositoryVerificationState, build_plain_git_verification_probe,
+        build_repository_verification_state, detached_git_head_mutation_advice,
+        plain_git_mutation_advice, raw_git_operation_mutation_advice,
+        repository_verification_blocked_advice, unimported_git_history_advice,
+        verification_blocking_mutation_advice,
     },
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
@@ -916,13 +916,13 @@ fn pending_capture_before_commit(repo: &Repository) -> Result<Option<ChangeId>> 
 
 fn with_commit_action_metadata(mut output: CommitCompatOutput) -> CommitCompatOutput {
     output.recommended_action = output.next_action.clone();
-    output.next_action_argv = output.next_action.as_deref().and_then(action_argv);
-    output.next_action_template = output.next_action.as_deref().and_then(action_template);
-    output.recommended_action_argv = output.recommended_action.as_deref().and_then(action_argv);
-    output.recommended_action_template = output
-        .recommended_action
-        .as_deref()
-        .and_then(action_template);
+    let next_action = ActionFields::from_optional_action_ref(output.next_action.as_deref());
+    let recommended_action =
+        ActionFields::from_optional_action_ref(output.recommended_action.as_deref());
+    output.next_action_argv = next_action.argv;
+    output.next_action_template = next_action.template;
+    output.recommended_action_argv = recommended_action.argv;
+    output.recommended_action_template = recommended_action.template;
     output
 }
 

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -1125,32 +1125,70 @@ pub(crate) fn verification_blocking_mutation_advice(
     if trust.status != "needs_reconcile" {
         return None;
     }
-    let primary_command = if trust.recommended_action.trim().is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let recovery_commands = if trust.recovery_commands.is_empty() {
-        vec![primary_command.clone()]
-    } else {
-        trust.recovery_commands.clone()
-    };
-    Some(RecoveryAdvice::safety_refusal(
+    Some(repository_verification_blocked_advice(
         "repository_verification_blocked",
         format!(
             "Refusing to {action}: repository verification is blocked ({})",
             trust.status
         ),
-        format!("Run `{primary_command}` before retrying `heddle {action}`."),
+        format!("retrying `heddle {action}`"),
+        &trust,
         format!(
             "repository verification status is {}: {}",
             trust.status, trust.summary
         ),
         format!("{action} would write new Heddle or Git state while Git and Heddle disagree"),
         "Git refs, Heddle refs, Git checkpoint metadata, and worktree files were left unchanged",
+        None,
+    ))
+}
+
+pub(crate) fn repository_verification_blocked_advice(
+    kind: &'static str,
+    error: impl Into<String>,
+    retry_context: impl Into<String>,
+    trust: &RepositoryVerificationState,
+    unsafe_condition: impl Into<String>,
+    would_change: impl Into<String>,
+    preserved: impl Into<String>,
+    primary_override: Option<String>,
+) -> RecoveryAdvice {
+    let primary_command =
+        primary_override.unwrap_or_else(|| repository_verification_primary_command(trust));
+    let recovery_commands = repository_verification_recovery_commands(trust, &primary_command);
+    RecoveryAdvice::safety_refusal(
+        kind,
+        error,
+        format!("Run `{}` before {}.", primary_command, retry_context.into()),
+        unsafe_condition,
+        would_change,
+        preserved,
         primary_command,
         recovery_commands,
-    ))
+    )
+}
+
+pub(crate) fn repository_verification_primary_command(
+    trust: &RepositoryVerificationState,
+) -> String {
+    if trust.recommended_action.trim().is_empty() {
+        "heddle verify".to_string()
+    } else {
+        trust.recommended_action.clone()
+    }
+}
+
+pub(crate) fn repository_verification_recovery_commands(
+    trust: &RepositoryVerificationState,
+    primary_command: &str,
+) -> Vec<String> {
+    if primary_command != trust.recommended_action && !trust.recommended_action.trim().is_empty() {
+        vec![primary_command.to_string(), "heddle verify".to_string()]
+    } else if trust.recovery_commands.is_empty() {
+        vec![primary_command.to_string()]
+    } else {
+        trust.recovery_commands.clone()
+    }
 }
 
 pub(crate) fn plain_git_mutation_advice(
@@ -2997,8 +3035,121 @@ fn mapped_change_relation(
 
 #[cfg(test)]
 mod tests {
-    use super::machine_contract_coverage;
+    use super::{
+        RepositoryVerificationState, machine_contract_coverage,
+        repository_verification_blocked_advice,
+    };
     use crate::cli::commands::build_command_catalog;
+
+    fn verification_state(
+        recommended_action: impl Into<String>,
+        recovery_commands: Vec<String>,
+    ) -> RepositoryVerificationState {
+        RepositoryVerificationState {
+            verified: false,
+            status: "needs_reconcile".to_string(),
+            repository_mode: "git_overlay".to_string(),
+            heddle_initialized: true,
+            git_branch: Some("main".to_string()),
+            heddle_thread: Some("main".to_string()),
+            worktree_dirty: false,
+            worktree_state: "clean".to_string(),
+            import_state: "imported".to_string(),
+            mapping_state: "needs_reconcile".to_string(),
+            remote_drift: "none".to_string(),
+            active_operation: None,
+            default_remote: None,
+            clone_verification: "verified".to_string(),
+            machine_contract: "verified".to_string(),
+            machine_contract_coverage: machine_contract_coverage(),
+            workflow_status: "blocked".to_string(),
+            workflow_summary: "Git and Heddle disagree".to_string(),
+            summary: "Git and Heddle disagree".to_string(),
+            recommended_action: recommended_action.into(),
+            recommended_action_argv: None,
+            recommended_action_template: None,
+            recovery_commands,
+            recovery_command_argv: Vec::new(),
+            recovery_action_templates: Vec::new(),
+            checks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn repository_verification_blocked_advice_uses_verify_when_no_action_exists() {
+        let trust = verification_state("", Vec::new());
+
+        let advice = repository_verification_blocked_advice(
+            "repository_verification_blocked",
+            "blocked",
+            "retrying the operation",
+            &trust,
+            "unsafe",
+            "would change",
+            "nothing changed",
+            None,
+        );
+
+        assert_eq!(advice.primary_command, "heddle verify");
+        assert_eq!(advice.recovery_commands, vec!["heddle verify"]);
+        assert_eq!(
+            advice.hint,
+            "Run `heddle verify` before retrying the operation."
+        );
+    }
+
+    #[test]
+    fn repository_verification_blocked_advice_preserves_trust_recovery_commands() {
+        let trust = verification_state(
+            "heddle bridge git reconcile --ref main --preview",
+            vec![
+                "heddle bridge git reconcile --ref main --preview".to_string(),
+                "heddle verify".to_string(),
+            ],
+        );
+
+        let advice = repository_verification_blocked_advice(
+            "repository_verification_blocked",
+            "blocked",
+            "retrying the operation",
+            &trust,
+            "unsafe",
+            "would change",
+            "nothing changed",
+            None,
+        );
+
+        assert_eq!(
+            advice.primary_command,
+            "heddle bridge git reconcile --ref main --preview"
+        );
+        assert_eq!(advice.recovery_commands, trust.recovery_commands);
+    }
+
+    #[test]
+    fn repository_verification_blocked_advice_keeps_primary_override_first() {
+        let trust = verification_state(
+            "heddle bridge git import --ref origin/main",
+            vec!["heddle bridge git import --ref origin/main".to_string()],
+        );
+
+        let advice = repository_verification_blocked_advice(
+            "git_checkpoint_preflight_blocked",
+            "blocked",
+            "retrying `heddle commit`",
+            &trust,
+            "unsafe",
+            "would change",
+            "nothing changed",
+            Some("heddle pull origin main --preview".to_string()),
+        );
+
+        assert_eq!(advice.primary_command, "heddle pull origin main --preview");
+        assert_eq!(
+            advice.recovery_commands,
+            vec!["heddle pull origin main --preview", "heddle verify"]
+        );
+    }
 
     #[test]
     fn machine_contract_coverage_counts_the_same_rows_as_command_catalog() {

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -21,7 +21,8 @@ use serde::{Serialize, Serializer};
 use super::{
     advice::RecoveryAdvice,
     command_catalog::{
-        ActionTemplate, build_command_catalog, recommended_action_argv, recommended_action_template,
+        ActionFields, ActionTemplate, build_command_catalog, recommended_action_argv,
+        recommended_action_template,
     },
     schemas::opaque_schema_verbs,
 };
@@ -357,6 +358,7 @@ impl RepositoryVerificationState {
         } else {
             health.summary.clone()
         };
+        let recommended_action_fields = ActionFields::from_action(&recommended_action);
         Self {
             verified,
             status,
@@ -377,8 +379,8 @@ impl RepositoryVerificationState {
             workflow_status,
             workflow_summary,
             summary,
-            recommended_action_argv: action_argv(&recommended_action),
-            recommended_action_template: action_template(&recommended_action),
+            recommended_action_argv: recommended_action_fields.argv,
+            recommended_action_template: recommended_action_fields.template,
             recovery_command_argv: command_argvs(&recovery_commands),
             recovery_action_templates: action_templates(&recovery_commands),
             recommended_action,
@@ -393,16 +395,17 @@ pub(crate) fn override_trust_recommended_action(
     action: impl Into<String>,
 ) {
     let action = action.into();
-    trust.recommended_action_argv = action_argv(&action);
-    trust.recommended_action_template = action_template(&action);
+    let action_fields = ActionFields::from_action(&action);
+    trust.recommended_action_argv = action_fields.argv.clone();
+    trust.recommended_action_template = action_fields.template.clone();
     trust.recommended_action = action.clone();
     if let Some(check) = trust
         .checks
         .iter_mut()
         .find(|check| check.name == "Workflow")
     {
-        check.recommended_action_argv = action_argv(&action);
-        check.recommended_action_template = action_template(&action);
+        check.recommended_action_argv = action_fields.argv;
+        check.recommended_action_template = action_fields.template;
         check.recommended_action = Some(action);
     }
 }
@@ -1018,8 +1021,7 @@ fn verification_check(
     recommended_action: Option<String>,
     recovery_commands: Vec<String>,
 ) -> VerificationCheck {
-    let recommended_action_argv = recommended_action.as_deref().and_then(action_argv);
-    let recommended_action_template = recommended_action.as_deref().and_then(action_template);
+    let action = ActionFields::from_optional_action_ref(recommended_action.as_deref());
     let recovery_command_argv = command_argvs(&recovery_commands);
     let recovery_action_templates = action_templates(&recovery_commands);
     VerificationCheck {
@@ -1028,8 +1030,8 @@ fn verification_check(
         clean,
         summary: summary.to_string(),
         recommended_action,
-        recommended_action_argv,
-        recommended_action_template,
+        recommended_action_argv: action.argv,
+        recommended_action_template: action.template,
         recovery_commands,
         recovery_command_argv,
         recovery_action_templates,
@@ -1393,6 +1395,8 @@ pub(crate) fn build_plain_git_verification_probe(
         git_branches.len().to_string(),
     );
     details.insert("git_tag_count".to_string(), git_tags.len().to_string());
+    let setup_action_fields = ActionFields::from_action(&setup_action);
+    let import_action_fields = ActionFields::from_action(&import);
     let mut checks = vec![
         VerificationCheck {
             name: "Git".to_string(),
@@ -1413,8 +1417,8 @@ pub(crate) fn build_plain_git_verification_probe(
             clean: false,
             summary: "Heddle data is not initialized".to_string(),
             recommended_action: Some(setup_action.clone()),
-            recommended_action_argv: action_argv(&setup_action),
-            recommended_action_template: action_template(&setup_action),
+            recommended_action_argv: setup_action_fields.argv.clone(),
+            recommended_action_template: setup_action_fields.template.clone(),
             recovery_commands: setup_recovery_commands.clone(),
             recovery_command_argv: command_argvs(&setup_recovery_commands),
             recovery_action_templates: action_templates(&setup_recovery_commands),
@@ -1427,8 +1431,8 @@ pub(crate) fn build_plain_git_verification_probe(
                 clean: false,
                 summary: "Git history has not been imported into Heddle".to_string(),
                 recommended_action: Some(import.clone()),
-                recommended_action_argv: action_argv(&import),
-                recommended_action_template: action_template(&import),
+                recommended_action_argv: import_action_fields.argv,
+                recommended_action_template: import_action_fields.template,
                 recovery_commands: vec![import.clone()],
                 recovery_command_argv: command_argvs(std::slice::from_ref(&import)),
                 recovery_action_templates: action_templates(std::slice::from_ref(&import)),
@@ -1501,6 +1505,7 @@ pub(crate) fn build_plain_git_verification_probe(
         None,
         Vec::new(),
     ));
+    let setup_action_fields = ActionFields::from_action(&setup_action);
     let trust = RepositoryVerificationState {
         verified: false,
         status: "needs_init".to_string(),
@@ -1531,8 +1536,8 @@ pub(crate) fn build_plain_git_verification_probe(
         workflow_status: "not_checked".to_string(),
         workflow_summary: "workflow readiness is checked after Heddle initialization".to_string(),
         summary: "Git repository has not been initialized for Heddle".to_string(),
-        recommended_action_argv: action_argv(&setup_action),
-        recommended_action_template: action_template(&setup_action),
+        recommended_action_argv: setup_action_fields.argv,
+        recommended_action_template: setup_action_fields.template,
         recovery_command_argv: command_argvs(&setup_recovery_commands),
         recovery_action_templates: action_templates(&setup_recovery_commands),
         recommended_action: setup_action,

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -1180,6 +1180,15 @@ pub(crate) fn repository_verification_primary_command(
     }
 }
 
+pub(crate) fn repository_verification_blockers(trust: &RepositoryVerificationState) -> Vec<String> {
+    trust
+        .checks
+        .iter()
+        .filter(|check| !check.clean)
+        .map(|check| format!("{}: {}", check.name, check.summary))
+        .collect()
+}
+
 pub(crate) fn repository_verification_recovery_commands(
     trust: &RepositoryVerificationState,
     primary_command: &str,

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -23,6 +23,7 @@ use super::{
     git_overlay_health::{
         RepositoryVerificationState, action_argv, action_template,
         build_repository_verification_state, override_trust_recommended_action,
+        repository_verification_blocked_advice,
     },
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
     ready_cmd::{worktree_dirty, worktree_dirty_paths},
@@ -2414,10 +2415,22 @@ fn merge_preview_blocked_advice(output: &MergeOutput) -> RecoveryAdvice {
     } else {
         output.operator.blockers.join("; ")
     };
+    if let Some(trust) = output.trust.as_ref() {
+        return repository_verification_blocked_advice(
+            "merge_preview_blocked",
+            output.operator.message.clone(),
+            "retrying the merge preview",
+            trust,
+            blockers,
+            "the merge preview would otherwise describe a stale or unverifiable integration path",
+            "repository state, refs, and worktree files were left unchanged",
+            Some(primary_command.to_string()),
+        );
+    }
     RecoveryAdvice::safety_refusal(
         "merge_preview_blocked",
         output.operator.message.clone(),
-        format!("Run `{primary_command}`, then retry the merge preview."),
+        format!("Run `{primary_command}` before retrying the merge preview."),
         blockers,
         "the merge preview would otherwise describe a stale or unverifiable integration path",
         "repository state, refs, and worktree files were left unchanged",

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -2235,27 +2235,12 @@ fn merge_blocked_by_trust_output(
     preview_only: bool,
     semantic_result: Option<String>,
 ) -> MergeOutput {
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let blockers = trust
-        .checks
-        .iter()
-        .filter(|check| !check.clean)
-        .map(|check| format!("{}: {}", check.name, check.summary))
-        .collect::<Vec<_>>();
     MergeOutput {
-        operator: OperatorCommandOutput {
-            status: "blocked".to_string(),
-            action: "merge".to_string(),
-            message: trust_blocked_merge_message(&trust, preview_only),
-            blockers,
-            warnings: Vec::new(),
-            next_action: Some(recommended_action.clone()),
-            recommended_action: Some(recommended_action),
-        },
+        operator: OperatorCommandOutput::blocked_by_repository_verification(
+            "merge",
+            trust_blocked_merge_message(&trust, preview_only),
+            &trust,
+        ),
         would_merge: false,
         fast_forward: false,
         preview_only,

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -50,6 +50,7 @@ mod marker;
 mod merge;
 mod monitor;
 mod mount_lifecycle;
+mod next_action;
 mod operator_core;
 mod operator_loop;
 mod oss;

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared next-action selection for command surfaces.
+
+use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, RepositoryOperationStatus};
+
+use super::git_overlay_health::{RepositoryVerificationState, import_hint_includes_active_branch};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NextActionScope {
+    Default,
+    CurrentThread,
+    Ready,
+}
+
+pub(crate) struct NextActionInput<'a> {
+    pub operation: Option<&'a RepositoryOperationStatus>,
+    pub remote_tracking: Option<&'a GitRemoteTrackingStatus>,
+    pub import_hint: Option<&'a GitOverlayImportHint>,
+    pub fallback: Option<&'a str>,
+    pub thread_health: Option<&'a str>,
+    pub trust: Option<&'a RepositoryVerificationState>,
+    pub scope: NextActionScope,
+}
+
+impl<'a> NextActionInput<'a> {
+    pub(crate) fn default(
+        operation: Option<&'a RepositoryOperationStatus>,
+        remote_tracking: Option<&'a GitRemoteTrackingStatus>,
+        import_hint: Option<&'a GitOverlayImportHint>,
+        fallback: Option<&'a str>,
+    ) -> Self {
+        Self {
+            operation,
+            remote_tracking,
+            import_hint,
+            fallback,
+            thread_health: None,
+            trust: None,
+            scope: NextActionScope::Default,
+        }
+    }
+
+    pub(crate) fn with_verification(mut self, trust: &'a RepositoryVerificationState) -> Self {
+        self.trust = Some(trust);
+        self
+    }
+
+    pub(crate) fn current_thread(mut self, thread_health: Option<&'a str>) -> Self {
+        self.thread_health = thread_health;
+        self.scope = NextActionScope::CurrentThread;
+        self
+    }
+
+    pub(crate) fn ready(mut self) -> Self {
+        self.scope = NextActionScope::Ready;
+        self
+    }
+}
+
+pub(crate) fn effective_next_action(input: NextActionInput<'_>) -> String {
+    if let Some(trust) = input.trust
+        && !trust.verified
+    {
+        return trust.recommended_action.clone();
+    }
+
+    match input.scope {
+        NextActionScope::Ready => ready_next_action(input),
+        NextActionScope::CurrentThread => current_thread_next_action(input),
+        NextActionScope::Default => default_next_action(input),
+    }
+}
+
+fn ready_next_action(input: NextActionInput<'_>) -> String {
+    if let Some(operation) = input.operation {
+        return operation.next_action.clone();
+    }
+    if let Some(action) = non_empty_action(input.fallback) {
+        return action.to_string();
+    }
+    default_next_action(NextActionInput {
+        operation: None,
+        remote_tracking: input.remote_tracking,
+        import_hint: input.import_hint,
+        fallback: None,
+        thread_health: None,
+        trust: None,
+        scope: NextActionScope::Default,
+    })
+}
+
+fn current_thread_next_action(input: NextActionInput<'_>) -> String {
+    let thread_action = non_empty_action(input.fallback);
+    if input.operation.is_none()
+        && thread_recovery_precedes_publish(
+            input.remote_tracking,
+            input.thread_health,
+            thread_action,
+        )
+    {
+        return thread_action.unwrap_or_default().to_string();
+    }
+    default_next_action(NextActionInput {
+        operation: input.operation,
+        remote_tracking: input.remote_tracking,
+        import_hint: input.import_hint,
+        fallback: thread_action,
+        thread_health: None,
+        trust: None,
+        scope: NextActionScope::Default,
+    })
+}
+
+fn default_next_action(input: NextActionInput<'_>) -> String {
+    if let Some(operation) = input.operation {
+        return operation.next_action.clone();
+    }
+    if let Some(remote_tracking) = input.remote_tracking {
+        if remote_tracking.behind > 0 {
+            return if remote_tracking.ahead > 0 {
+                if remote_tracking.upstream.is_empty() {
+                    "heddle fetch".to_string()
+                } else {
+                    format!(
+                        "heddle bridge git import --ref {}",
+                        remote_tracking.upstream
+                    )
+                }
+            } else {
+                "heddle pull".to_string()
+            };
+        }
+        return "heddle push".to_string();
+    }
+    if let Some(action) = non_empty_action(input.fallback) {
+        return action.to_string();
+    }
+    if let Some(hint) = input.import_hint
+        && import_hint_includes_active_branch(hint)
+    {
+        return hint.recommended_command.clone();
+    }
+    String::new()
+}
+
+pub(crate) fn thread_recovery_precedes_publish(
+    remote_tracking: Option<&GitRemoteTrackingStatus>,
+    thread_health: Option<&str>,
+    thread_action: Option<&str>,
+) -> bool {
+    let Some(remote_tracking) = remote_tracking else {
+        return false;
+    };
+    if remote_tracking.ahead == 0 || remote_tracking.behind > 0 {
+        return false;
+    }
+    let Some(thread_action) = thread_action else {
+        return false;
+    };
+    thread_recovery_action_is_primary(thread_health, thread_action)
+}
+
+pub(crate) fn thread_recovery_action_is_primary(
+    thread_health: Option<&str>,
+    thread_action: &str,
+) -> bool {
+    matches!(
+        thread_health.unwrap_or_default(),
+        "blocked" | "dirty_worktree" | "uncaptured"
+    ) || thread_action == "heddle capture"
+        || thread_action.starts_with("heddle thread refresh ")
+        || thread_action.starts_with("heddle thread resolve ")
+        || thread_action.starts_with("heddle thread promote ")
+}
+
+fn non_empty_action(action: Option<&str>) -> Option<&str> {
+    action.filter(|action| !action.trim().is_empty())
+}

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -13,9 +13,9 @@ use super::{
     bisect::reset_bisect_state,
     git_overlay_health::{
         RepositoryVerificationState, action_argv, action_template,
-        import_hint_includes_active_branch, repository_verification_blockers,
-        repository_verification_primary_command,
+        repository_verification_blockers, repository_verification_primary_command,
     },
+    next_action::{NextActionInput, effective_next_action},
     rebase::{
         OperatorContinueStatus, cmd_rebase_silent, continue_rebase_for_operator,
         has_persisted_rebase_state,
@@ -391,36 +391,12 @@ pub(crate) fn recommend_next_action(
     import_hint: Option<&GitOverlayImportHint>,
     fallback: Option<&str>,
 ) -> String {
-    if let Some(operation) = operation {
-        return operation.next_action.clone();
-    }
-    if let Some(remote_tracking) = remote_tracking {
-        if remote_tracking.behind > 0 {
-            return if remote_tracking.ahead > 0 {
-                if remote_tracking.upstream.is_empty() {
-                    "heddle fetch".to_string()
-                } else {
-                    format!(
-                        "heddle bridge git import --ref {}",
-                        remote_tracking.upstream
-                    )
-                }
-            } else {
-                "heddle pull".to_string()
-            };
-        }
-        return "heddle push".to_string();
-    }
-    let fallback = fallback.unwrap_or_default();
-    if !fallback.is_empty() {
-        return fallback.to_string();
-    }
-    if let Some(hint) = import_hint {
-        if import_hint_includes_active_branch(hint) {
-            return hint.recommended_command.clone();
-        }
-    }
-    String::new()
+    effective_next_action(NextActionInput::default(
+        operation,
+        remote_tracking,
+        import_hint,
+        fallback,
+    ))
 }
 
 fn git_unmerged_paths(repo: &Repository) -> Result<Vec<String>> {

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -11,7 +11,11 @@ use serde::{Serialize, Serializer, ser::SerializeStruct};
 
 use super::{
     bisect::reset_bisect_state,
-    git_overlay_health::{action_argv, action_template, import_hint_includes_active_branch},
+    git_overlay_health::{
+        RepositoryVerificationState, action_argv, action_template,
+        import_hint_includes_active_branch, repository_verification_blockers,
+        repository_verification_primary_command,
+    },
     rebase::{
         OperatorContinueStatus, cmd_rebase_silent, continue_rebase_for_operator,
         has_persisted_rebase_state,
@@ -37,6 +41,25 @@ pub(crate) struct OperatorCommandOutput {
     pub warnings: Vec<String>,
     pub next_action: Option<String>,
     pub recommended_action: Option<String>,
+}
+
+impl OperatorCommandOutput {
+    pub(crate) fn blocked_by_repository_verification(
+        action: impl Into<String>,
+        message: impl Into<String>,
+        trust: &RepositoryVerificationState,
+    ) -> Self {
+        let recommended_action = repository_verification_primary_command(trust);
+        Self {
+            status: "blocked".to_string(),
+            action: action.into(),
+            message: message.into(),
+            blockers: repository_verification_blockers(trust),
+            warnings: Vec::new(),
+            next_action: Some(recommended_action.clone()),
+            recommended_action: Some(recommended_action),
+        }
+    }
 }
 
 pub(crate) fn blocked_operator_exit_code(status: &str) -> Option<i32> {

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -4,6 +4,7 @@ use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, RepositoryOperationSta
 
 use super::{
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
+    next_action::{NextActionInput, effective_next_action},
     operator_core::{
         OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
         open_operator_repo_from_path, recommend_next_action,
@@ -173,12 +174,12 @@ pub(crate) fn primary_next_action_with_verification(
     fallback: Option<&str>,
     trust: &RepositoryVerificationState,
 ) -> String {
-    if !trust.verified {
-        return trust.recommended_action.clone();
-    }
     let fallback = non_empty_action(fallback)
         .or_else(|| non_empty_action(Some(trust.recommended_action.as_str())));
-    recommend_next_action(operation, remote_tracking, import_hint, fallback)
+    effective_next_action(
+        NextActionInput::default(operation, remote_tracking, import_hint, fallback)
+            .with_verification(trust),
+    )
 }
 
 fn non_empty_action(action: Option<&str>) -> Option<&str> {

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -123,29 +123,14 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
 }
 
 fn sync_blocked_by_trust(trust: RepositoryVerificationState) -> OperatorCommandOutput {
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let blockers = trust
-        .checks
-        .iter()
-        .filter(|check| !check.clean)
-        .map(|check| format!("{}: {}", check.name, check.summary))
-        .collect::<Vec<_>>();
-    OperatorCommandOutput {
-        status: "blocked".to_string(),
-        action: "sync".to_string(),
-        message: format!(
+    OperatorCommandOutput::blocked_by_repository_verification(
+        "sync",
+        format!(
             "Sync changed the checkout, but repository verification is still blocked: {}",
             trust.summary
         ),
-        blockers,
-        warnings: Vec::new(),
-        next_action: Some(recommended_action.clone()),
-        recommended_action: Some(recommended_action),
-    }
+        &trust,
+    )
 }
 
 fn emit(cli: &Cli, output: OperatorCommandOutput) -> Result<()> {

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -17,8 +17,8 @@ use super::{
         build_repository_verification_state, override_trust_recommended_action,
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},
+    next_action::{NextActionInput, effective_next_action},
     operator_core::{OperatorCommandOutput, exit_if_blocked_operator_status},
-    operator_loop::primary_next_action,
     snapshot::{SnapshotAgentOverrides, create_snapshot, ensure_current_state},
     thread::contextual_thread_action,
     thread_cmd::{current_thread, load_thread, thread_manager, thread_not_found_advice},
@@ -352,13 +352,9 @@ fn ready_scoped_next_action(
     import_hint: Option<&GitOverlayImportHint>,
     thread_action: Option<&str>,
 ) -> String {
-    if let Some(operation) = operation {
-        return operation.next_action.clone();
-    }
-    if let Some(action) = thread_action.filter(|action| !action.trim().is_empty()) {
-        return action.to_string();
-    }
-    primary_next_action(None, remote_tracking, import_hint, None)
+    effective_next_action(
+        NextActionInput::default(operation, remote_tracking, import_hint, thread_action).ready(),
+    )
 }
 
 fn ready_verification_preflight_blocks(trust: &RepositoryVerificationState) -> bool {

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -448,31 +448,18 @@ fn trust_blocked_ready_output(
         .or_else(|| trust.heddle_thread.clone())
         .or_else(|| trust.git_branch.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let trust_blockers = trust
-        .checks
-        .iter()
-        .filter(|check| !check.clean)
-        .map(|check| format!("{}: {}", check.name, check.summary))
-        .collect::<Vec<_>>();
     let message = format!(
         "Thread '{thread}' cannot run readiness checks until repository verification is restored: {}",
         trust.summary
     );
+    let operator =
+        OperatorCommandOutput::blocked_by_repository_verification("ready", message, &trust);
+    let recommended_action = operator
+        .recommended_action
+        .clone()
+        .unwrap_or_else(|| "heddle verify".to_string());
     ReadyOutput {
-        operator: OperatorCommandOutput {
-            status: "blocked".to_string(),
-            action: "ready".to_string(),
-            message,
-            blockers: trust_blockers,
-            warnings: Vec::new(),
-            next_action: Some(recommended_action.clone()),
-            recommended_action: Some(recommended_action.clone()),
-        },
+        operator,
         captured: false,
         captured_state: None,
         thread_state: "blocked".to_string(),

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -13,6 +13,7 @@ use super::{
     ff_record::record_ff_advance,
     git_overlay_health::{
         RepositoryVerificationState, action_argv, build_repository_verification_state,
+        repository_verification_primary_command,
     },
     snapshot::ensure_current_state,
     worktree_safety::ensure_worktree_clean,
@@ -266,11 +267,7 @@ fn emit_up_to_date_blocked_by_trust(
     cli: &Cli,
     trust: RepositoryVerificationState,
 ) -> Result<()> {
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
+    let recommended_action = repository_verification_primary_command(&trust);
     if should_output_json(cli, Some(repo.config())) {
         println!(
             "{}",

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -14,10 +14,11 @@ use gix::{bstr::ByteSlice, refs::transaction::PreviousValue};
 use proto::AuthToken;
 use refs::Head;
 use repo::{Repository, RepositoryCapability};
+use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
-    command_catalog::{recommended_action_argv, recommended_action_template},
+    command_catalog::{ActionTemplate, recommended_action_argv, recommended_action_template},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     snapshot::ensure_current_state,
 };
@@ -84,6 +85,87 @@ pub(crate) struct GitOverlayConfiguredRemote {
     url: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct PushOutput {
+    output_kind: &'static str,
+    action: &'static str,
+    status: &'static str,
+    success: bool,
+    pushed: bool,
+    changed: bool,
+    transport: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    push_scope: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ref_scope: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_notes_ref: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_notes_visibility_warning: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_tracking_remote: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_remote_configured: Option<GitRemoteConfiguredOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_upstream_configured: Option<GitUpstreamConfiguredOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags_included: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    objects: Option<usize>,
+    next_action: Option<String>,
+    next_action_argv: Option<Vec<String>>,
+    next_action_template: Option<ActionTemplate>,
+    recommended_action: Option<String>,
+    recommended_action_argv: Option<Vec<String>>,
+    recommended_action_template: Option<ActionTemplate>,
+    #[serde(rename = "verification")]
+    trust: RepositoryVerificationState,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GitRemoteConfiguredOutput {
+    name: String,
+    url: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GitUpstreamConfiguredOutput {
+    branch: String,
+    remote: String,
+}
+
+#[derive(Debug, Clone)]
+struct PushActionFields {
+    action: Option<String>,
+    argv: Option<Vec<String>>,
+    template: Option<ActionTemplate>,
+}
+
+fn push_action_fields(trust: &RepositoryVerificationState) -> PushActionFields {
+    let recommended_action = trust.recommended_action.trim();
+    if recommended_action.is_empty() {
+        return PushActionFields {
+            action: None,
+            argv: None,
+            template: None,
+        };
+    }
+
+    PushActionFields {
+        action: Some(trust.recommended_action.clone()),
+        argv: recommended_action_argv(&trust.recommended_action)
+            .ok()
+            .flatten(),
+        template: recommended_action_template(&trust.recommended_action),
+    }
+}
+
 /// Execute push command.
 pub async fn cmd_push(
     cli: &Cli,
@@ -128,53 +210,14 @@ pub async fn cmd_push(
         let (remote_name, scope, current_thread, tracking_refresh, trust) =
             push_git_overlay_refs(&repo, remote.as_deref(), all_threads)?;
         if should_output_json(cli, Some(repo.config())) {
-            let action = action_value(&trust);
-            let configured_remote = tracking_refresh
-                .as_ref()
-                .and_then(|refresh| refresh.configured_remote.as_ref());
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "push",
-                    "status": "pushed",
-                    "success": true,
-                    "pushed": true,
-                    "changed": true,
-                    "transport": "git",
-                    "remote": remote_name,
-                    "push_scope": match scope {
-                        GitPushScope::CurrentThread => "current_thread",
-                        GitPushScope::AllThreads => "all_threads",
-                    },
-                    "ref_scope": match scope {
-                        GitPushScope::CurrentThread => "branch_and_heddle_notes",
-                        GitPushScope::AllThreads => "all_threads_tags_and_heddle_notes",
-                    },
-                    "git_notes_ref": "refs/notes/heddle",
-                    "git_notes_visibility_warning": "ordinary `git log --all` may show Heddle metadata commits from refs/notes/heddle",
-                    "git_tracking_remote": tracking_refresh.as_ref().map(|refresh| refresh.remote_name.as_str()),
-                    "git_remote_configured": configured_remote.map(|remote| serde_json::json!({
-                        "name": remote.name.as_str(),
-                        "url": remote.url.as_str(),
-                    })),
-                    "git_upstream_configured": tracking_refresh
-                        .as_ref()
-                        .and_then(|refresh| refresh.upstream_branch.as_ref())
-                        .map(|branch| serde_json::json!({
-                            "branch": branch,
-                            "remote": tracking_refresh.as_ref().map(|refresh| refresh.remote_name.as_str()).unwrap_or("origin"),
-                        })),
-                    "tags_included": matches!(scope, GitPushScope::AllThreads),
-                    "thread": current_thread,
-                    "next_action": action,
-                    "next_action_argv": action_argv_value(&trust),
-                    "next_action_template": action_template_value(&trust),
-                    "recommended_action": action_value(&trust),
-                    "recommended_action_argv": action_argv_value(&trust),
-                    "recommended_action_template": action_template_value(&trust),
-                    "verification": trust,
-                })
+            let output = git_overlay_push_output(
+                remote_name,
+                scope,
+                current_thread,
+                tracking_refresh,
+                trust,
             );
+            crate::cli::render::write_json_stdout(&output)?;
         } else {
             println!(
                 "{} pushed {} to {} ({})",
@@ -336,6 +379,107 @@ pub async fn cmd_push(
     }
 
     Ok(())
+}
+
+fn git_overlay_push_output(
+    remote_name: String,
+    scope: GitPushScope,
+    current_thread: Option<String>,
+    tracking_refresh: Option<GitOverlayTrackingRefresh>,
+    trust: RepositoryVerificationState,
+) -> PushOutput {
+    let action = push_action_fields(&trust);
+    let tracking_remote = tracking_refresh
+        .as_ref()
+        .map(|refresh| refresh.remote_name.clone());
+    let configured_remote = tracking_refresh
+        .as_ref()
+        .and_then(|refresh| refresh.configured_remote.as_ref())
+        .map(|remote| GitRemoteConfiguredOutput {
+            name: remote.name.clone(),
+            url: remote.url.clone(),
+        });
+    let upstream_configured = tracking_refresh
+        .as_ref()
+        .and_then(|refresh| refresh.upstream_branch.as_ref())
+        .map(|branch| GitUpstreamConfiguredOutput {
+            branch: branch.clone(),
+            remote: tracking_remote
+                .clone()
+                .unwrap_or_else(|| "origin".to_string()),
+        });
+    PushOutput {
+        output_kind: "push",
+        action: "push",
+        status: "pushed",
+        success: true,
+        pushed: true,
+        changed: true,
+        transport: "git",
+        remote: Some(remote_name),
+        push_scope: Some(match scope {
+            GitPushScope::CurrentThread => "current_thread",
+            GitPushScope::AllThreads => "all_threads",
+        }),
+        ref_scope: Some(match scope {
+            GitPushScope::CurrentThread => "branch_and_heddle_notes",
+            GitPushScope::AllThreads => "all_threads_tags_and_heddle_notes",
+        }),
+        git_notes_ref: Some("refs/notes/heddle"),
+        git_notes_visibility_warning: Some(
+            "ordinary `git log --all` may show Heddle metadata commits from refs/notes/heddle",
+        ),
+        git_tracking_remote: tracking_remote,
+        git_remote_configured: configured_remote,
+        git_upstream_configured: upstream_configured,
+        tags_included: Some(matches!(scope, GitPushScope::AllThreads)),
+        thread: current_thread,
+        state: None,
+        objects: None,
+        next_action: action.action.clone(),
+        next_action_argv: action.argv.clone(),
+        next_action_template: action.template.clone(),
+        recommended_action: action.action,
+        recommended_action_argv: action.argv,
+        recommended_action_template: action.template,
+        trust,
+    }
+}
+
+fn heddle_push_output(
+    state: Option<String>,
+    objects: Option<usize>,
+    trust: RepositoryVerificationState,
+) -> PushOutput {
+    let action = push_action_fields(&trust);
+    PushOutput {
+        output_kind: "push",
+        action: "push",
+        status: "pushed",
+        success: true,
+        pushed: true,
+        changed: true,
+        transport: "heddle",
+        remote: None,
+        push_scope: None,
+        ref_scope: None,
+        git_notes_ref: None,
+        git_notes_visibility_warning: None,
+        git_tracking_remote: None,
+        git_remote_configured: None,
+        git_upstream_configured: None,
+        tags_included: None,
+        thread: None,
+        state,
+        objects,
+        next_action: action.action.clone(),
+        next_action_argv: action.argv.clone(),
+        next_action_template: action.template.clone(),
+        recommended_action: action.action,
+        recommended_action_argv: action.argv,
+        recommended_action_template: action.template,
+        trust,
+    }
 }
 
 fn native_heddle_local_push_target(
@@ -896,27 +1040,8 @@ async fn push_local(
 
     if should_output_json(cli, Some(repo.config())) {
         let trust = build_repository_verification_state(repo);
-        let action = action_value(&trust);
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "push",
-                "status": "pushed",
-                "success": true,
-                "pushed": true,
-                "changed": true,
-                "transport": "heddle",
-                "state": state_id.to_string(),
-                "objects": objects_copied,
-                "next_action": action,
-                "next_action_argv": action_argv_value(&trust),
-                "next_action_template": action_template_value(&trust),
-                "recommended_action": action_value(&trust),
-                "recommended_action_argv": action_argv_value(&trust),
-                "recommended_action_template": action_template_value(&trust),
-                "verification": trust,
-            })
-        );
+        let output = heddle_push_output(Some(state_id.to_string()), Some(objects_copied), trust);
+        crate::cli::render::write_json_stdout(&output)?;
     } else {
         println!(
             "{} pushed {} to {} ({})",
@@ -969,26 +1094,8 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
     if result.success {
         if should_output_json(options.cli, Some(repo.config())) {
             let trust = build_repository_verification_state(repo);
-            let action = action_value(&trust);
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "push",
-                    "status": "pushed",
-                    "success": true,
-                    "pushed": true,
-                    "changed": true,
-                    "transport": "heddle",
-                    "state": result.new_state.map(|s| s.to_string()).unwrap_or_default(),
-                    "next_action": action,
-                    "next_action_argv": action_argv_value(&trust),
-                    "next_action_template": action_template_value(&trust),
-                    "recommended_action": action_value(&trust),
-                    "recommended_action_argv": action_argv_value(&trust),
-                    "recommended_action_template": action_template_value(&trust),
-                    "verification": trust,
-                })
-            );
+            let output = heddle_push_output(result.new_state.map(|s| s.to_string()), None, trust);
+            crate::cli::render::write_json_stdout(&output)?;
         } else {
             println!(
                 "{} pushed to {}",
@@ -1028,35 +1135,6 @@ fn network_push_failed_advice(track_name: &str, error: &str) -> RecoveryAdvice {
         primary_command.clone(),
         vec![primary_command, "heddle verify".to_string()],
     )
-}
-
-fn action_value(trust: &RepositoryVerificationState) -> serde_json::Value {
-    if trust.recommended_action.trim().is_empty() {
-        serde_json::Value::Null
-    } else {
-        serde_json::Value::String(trust.recommended_action.clone())
-    }
-}
-
-fn action_argv_value(trust: &RepositoryVerificationState) -> serde_json::Value {
-    trust
-        .recommended_action
-        .trim()
-        .is_empty()
-        .then_some(serde_json::Value::Null)
-        .unwrap_or_else(|| {
-            recommended_action_argv(&trust.recommended_action)
-                .ok()
-                .flatten()
-                .map(serde_json::Value::from)
-                .unwrap_or(serde_json::Value::Null)
-        })
-}
-
-fn action_template_value(trust: &RepositoryVerificationState) -> serde_json::Value {
-    recommended_action_template(&trust.recommended_action)
-        .and_then(|template| serde_json::to_value(template).ok())
-        .unwrap_or(serde_json::Value::Null)
 }
 
 #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
-    command_catalog::{ActionTemplate, recommended_action_argv, recommended_action_template},
+    command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     snapshot::ensure_current_state,
 };
@@ -138,32 +138,6 @@ struct GitRemoteConfiguredOutput {
 struct GitUpstreamConfiguredOutput {
     branch: String,
     remote: String,
-}
-
-#[derive(Debug, Clone)]
-struct PushActionFields {
-    action: Option<String>,
-    argv: Option<Vec<String>>,
-    template: Option<ActionTemplate>,
-}
-
-fn push_action_fields(trust: &RepositoryVerificationState) -> PushActionFields {
-    let recommended_action = trust.recommended_action.trim();
-    if recommended_action.is_empty() {
-        return PushActionFields {
-            action: None,
-            argv: None,
-            template: None,
-        };
-    }
-
-    PushActionFields {
-        action: Some(trust.recommended_action.clone()),
-        argv: recommended_action_argv(&trust.recommended_action)
-            .ok()
-            .flatten(),
-        template: recommended_action_template(&trust.recommended_action),
-    }
 }
 
 /// Execute push command.
@@ -388,7 +362,7 @@ fn git_overlay_push_output(
     tracking_refresh: Option<GitOverlayTrackingRefresh>,
     trust: RepositoryVerificationState,
 ) -> PushOutput {
-    let action = push_action_fields(&trust);
+    let action = ActionFields::from_action(&trust.recommended_action);
     let tracking_remote = tracking_refresh
         .as_ref()
         .map(|refresh| refresh.remote_name.clone());
@@ -451,7 +425,7 @@ fn heddle_push_output(
     objects: Option<usize>,
     trust: RepositoryVerificationState,
 ) -> PushOutput {
-    let action = push_action_fields(&trust);
+    let action = ActionFields::from_action(&trust.recommended_action);
     PushOutput {
         output_kind: "push",
         action: "push",

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -151,7 +151,7 @@ pub async fn cmd_push(
 ) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
-        return Err(anyhow!(remote_not_configured_advice("push")));
+        return Err(anyhow!(RecoveryAdvice::remote_not_configured("push")));
     }
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let default_remote_name = if remote.is_none() {
@@ -510,7 +510,7 @@ pub(super) fn preflight_native_remote_transport(
     }
     match classify_remote_spec(repo, remote_arg) {
         Some(RemoteTransportKind::LocalGit | RemoteTransportKind::GitUrl) => Err(anyhow!(
-            remote_transport_mismatch_advice(action, remote_arg.unwrap_or("<default>"))
+            RecoveryAdvice::remote_transport_mismatch(action, remote_arg.unwrap_or("<default>"))
         )),
         _ => Ok(()),
     }
@@ -582,45 +582,6 @@ fn looks_like_git_remote_url(value: &str) -> bool {
         || (value.contains('@') && value.contains(':'))
 }
 
-fn remote_transport_mismatch_advice(action: &str, remote: &str) -> RecoveryAdvice {
-    RecoveryAdvice::safety_refusal(
-        "remote_transport_mismatch",
-        format!(
-            "Refusing to {action}: remote '{remote}' is a Git remote, not a Heddle-native remote"
-        ),
-        "Use a Heddle-native remote here, or clone/adopt that Git remote in a Git-overlay checkout.",
-        format!("remote '{remote}' resolves to Git storage"),
-        format!(
-            "{action} would route a Git repository through Heddle-native sync and fail after setup work"
-        ),
-        "remote configuration, Heddle refs, Git refs, and worktree files were left unchanged",
-        "heddle clone <remote> <fresh-path>",
-        vec![
-            "heddle clone <remote> <fresh-path>".to_string(),
-            "heddle remote add <name> <url>".to_string(),
-        ],
-    )
-}
-
-fn remote_not_configured_advice(action: &str) -> RecoveryAdvice {
-    RecoveryAdvice::safety_refusal(
-        "remote_not_configured",
-        format!("No default remote is configured for {action}"),
-        "Add a remote with `heddle remote add <name> <url>`, inspect remotes with `heddle remote list`, or choose one with `heddle remote set-default <name>`.",
-        "the command did not receive a remote argument and no default remote is configured",
-        format!(
-            "{action} needs a concrete remote target before it can move remote refs or transfer objects"
-        ),
-        "repository state, refs, remote configuration, and worktree files were left unchanged",
-        "heddle remote add <name> <url>",
-        vec![
-            "heddle remote add <name> <url>".to_string(),
-            "heddle remote list".to_string(),
-            "heddle remote set-default <name>".to_string(),
-        ],
-    )
-}
-
 fn refresh_git_tracking_after_overlay_push(
     repo: &Repository,
     remote_name: &str,
@@ -676,11 +637,13 @@ fn refresh_git_tracking_after_overlay_push(
         PreviousValue::Any,
         &format!("heddle: push to {remote_name}"),
     ) {
-        return Err(anyhow!(git_tracking_refresh_failed_advice(
-            remote_name,
-            &full_ref,
-            Some(error.to_string()),
-        )));
+        return Err(anyhow!(
+            RecoveryAdvice::git_overlay_tracking_refresh_failed(
+                remote_name,
+                &full_ref,
+                Some(error.to_string()),
+            )
+        ));
     }
 
     write_git_overlay_branch_upstream(repo.root(), &branch, &tracking_remote.name)?;
@@ -690,36 +653,6 @@ fn refresh_git_tracking_after_overlay_push(
         configured_remote: tracking_remote.configured_remote,
         upstream_branch: Some(branch),
     }))
-}
-
-fn git_tracking_refresh_failed_advice(
-    remote_name: &str,
-    full_ref: &str,
-    cause: Option<String>,
-) -> RecoveryAdvice {
-    let fetch_command = format!("heddle fetch {remote_name}");
-    let error = match cause {
-        Some(cause) => format!(
-            "Pushed to {remote_name}, but could not refresh local tracking ref {full_ref}: {cause}"
-        ),
-        None => {
-            format!("Pushed to {remote_name}, but could not refresh local tracking ref {full_ref}")
-        }
-    };
-    RecoveryAdvice::safety_refusal(
-        "git_overlay_tracking_refresh_failed",
-        error,
-        format!(
-            "Run `{fetch_command}` if `heddle verify` still reports remote drift after the push."
-        ),
-        format!("remote push completed, but local Git tracking ref {full_ref} was not updated"),
-        format!(
-            "updating {full_ref} would record the pushed HEAD as the local tracking view of {remote_name}"
-        ),
-        "the remote push completed; the failed tracking-ref refresh did not make additional local tracking changes",
-        fetch_command.clone(),
-        vec![fetch_command, "heddle verify".to_string()],
-    )
 }
 
 #[derive(Debug, Clone)]
@@ -1085,30 +1018,13 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         }
     } else {
         let err = result.error.unwrap_or_else(|| "Unknown error".to_string());
-        return Err(anyhow::anyhow!(network_push_failed_advice(
+        return Err(anyhow::anyhow!(RecoveryAdvice::remote_push_failed(
             options.track_name,
             &err
         )));
     }
 
     Ok(())
-}
-
-#[cfg(feature = "client")]
-fn network_push_failed_advice(track_name: &str, error: &str) -> RecoveryAdvice {
-    let primary_command = format!("heddle push {track_name}");
-    RecoveryAdvice::safety_refusal(
-        "remote_push_failed",
-        format!("Push failed for {track_name}: {error}"),
-        format!(
-            "Inspect `heddle verify`, then retry with `{primary_command}` after fixing the remote."
-        ),
-        format!("remote push to {track_name} failed: {error}"),
-        "the remote branch was not confirmed updated",
-        "local Heddle state, Git refs, and worktree files were left unchanged by the failed push result",
-        primary_command.clone(),
-        vec![primary_command, "heddle verify".to_string()],
-    )
 }
 
 #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -29,7 +29,7 @@ use super::super::{
 #[cfg(feature = "client")]
 use crate::client::HostedGrpcClient;
 use crate::{
-    bridge::GitBridge,
+    bridge::{GitBridge, git_core::GitPullOutcome},
     cli::{Cli, RemoteCommands, should_output_json, style},
     client::LocalSync,
     config::UserConfig,
@@ -65,6 +65,127 @@ struct RemoteMutationOutput {
     trust: RepositoryVerificationState,
 }
 
+#[derive(Serialize)]
+struct PullOutput {
+    output_kind: &'static str,
+    action: &'static str,
+    status: &'static str,
+    success: bool,
+    pulled: bool,
+    changed: bool,
+    transport: &'static str,
+    remote: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_git_head: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_git_head: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    states_created: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commits_seen: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commits_seen_scope: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    materialized_checkout: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    changed_path_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    changed_paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    objects: Option<usize>,
+    #[serde(rename = "verification")]
+    trust: RepositoryVerificationState,
+}
+
+struct GitOverlayPullOutputInput {
+    remote: String,
+    branch: Option<String>,
+    old_git_head: Option<String>,
+    new_git_head: Option<String>,
+    old_state: Option<ChangeId>,
+    new_state: Option<ChangeId>,
+    changed_paths: Vec<String>,
+    outcome: GitPullOutcome,
+    trust: RepositoryVerificationState,
+}
+
+fn git_overlay_pull_output(input: GitOverlayPullOutputInput) -> PullOutput {
+    PullOutput {
+        output_kind: "pull",
+        action: "pull",
+        status: pull_status(input.outcome.changed),
+        success: true,
+        pulled: input.outcome.changed,
+        changed: input.outcome.changed,
+        transport: "git",
+        remote: input.remote,
+        branch: input.branch,
+        old_git_head: input.old_git_head,
+        new_git_head: input.new_git_head,
+        old_state: input.old_state.map(|state| state.to_string()),
+        new_state: input.new_state.map(|state| state.to_string()),
+        states_created: Some(input.outcome.states_created),
+        commits_seen: Some(input.outcome.commits_seen),
+        commits_seen_scope: Some("branches_and_heddle_notes"),
+        materialized_checkout: Some(input.outcome.materialized_checkout),
+        changed_path_count: Some(input.changed_paths.len()),
+        changed_paths: Some(input.changed_paths),
+        thread: None,
+        state: None,
+        objects: None,
+        trust: input.trust,
+    }
+}
+
+fn heddle_pull_output(
+    changed: bool,
+    remote: String,
+    thread: String,
+    state: Option<String>,
+    objects: Option<usize>,
+    trust: RepositoryVerificationState,
+) -> PullOutput {
+    PullOutput {
+        output_kind: "pull",
+        action: "pull",
+        status: pull_status(changed),
+        success: true,
+        pulled: changed,
+        changed,
+        transport: "heddle",
+        remote,
+        branch: None,
+        old_git_head: None,
+        new_git_head: None,
+        old_state: None,
+        new_state: None,
+        states_created: None,
+        commits_seen: None,
+        commits_seen_scope: None,
+        materialized_checkout: None,
+        changed_path_count: None,
+        changed_paths: None,
+        thread: Some(thread),
+        state,
+        objects,
+        trust,
+    }
+}
+
+fn pull_status(changed: bool) -> &'static str {
+    if changed { "updated" } else { "up_to_date" }
+}
+
 /// Execute pull command.
 pub async fn cmd_pull(
     cli: &Cli,
@@ -87,36 +208,19 @@ pub async fn cmd_pull(
         let changed_paths =
             changed_paths_between_states(&repo, old_state.as_ref(), new_state.as_ref())?;
         let verification = build_repository_verification_state(&repo);
-        let status = if outcome.changed {
-            "updated"
-        } else {
-            "up_to_date"
-        };
         if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "pull",
-                    "status": status,
-                    "success": true,
-                    "pulled": outcome.changed,
-                    "changed": outcome.changed,
-                    "transport": "git",
-                    "remote": remote_name,
-                    "branch": branch,
-                    "old_git_head": old_git_head,
-                    "new_git_head": new_git_head,
-                    "old_state": old_state.as_ref().map(ToString::to_string),
-                    "new_state": new_state.as_ref().map(ToString::to_string),
-                    "states_created": outcome.states_created,
-                    "commits_seen": outcome.commits_seen,
-                    "commits_seen_scope": "branches_and_heddle_notes",
-                    "materialized_checkout": outcome.materialized_checkout,
-                    "changed_path_count": changed_paths.len(),
-                    "changed_paths": changed_paths,
-                    "verification": verification,
-                })
-            );
+            let output = git_overlay_pull_output(GitOverlayPullOutputInput {
+                remote: remote_name,
+                branch,
+                old_git_head,
+                new_git_head,
+                old_state,
+                new_state,
+                changed_paths,
+                outcome,
+                trust: verification,
+            });
+            crate::cli::render::write_json_stdout(&output)?;
         } else {
             if outcome.changed {
                 println!(
@@ -320,22 +424,15 @@ async fn pull_local(
     }
 
     if should_output_json(cli, Some(repo.config())) {
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "pull",
-                "status": if changed { "updated" } else { "up_to_date" },
-                "success": true,
-                "pulled": changed,
-                "changed": changed,
-                "transport": "heddle",
-                "remote": source_path.display().to_string(),
-                "thread": track_to_update,
-                "state": state_id.to_string(),
-                "objects": objects_copied,
-                "verification": build_repository_verification_state(repo),
-            })
+        let output = heddle_pull_output(
+            changed,
+            source_path.display().to_string(),
+            track_to_update.to_string(),
+            Some(state_id.to_string()),
+            Some(objects_copied),
+            build_repository_verification_state(repo),
         );
+        crate::cli::render::write_json_stdout(&output)?;
     } else {
         println!(
             "{} pulled {} from {} ({})",
@@ -452,24 +549,18 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     if result.success {
         let changed = result.final_state.is_some();
         if should_output_json(options.cli, Some(repo.config())) {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "pull",
-                    "status": if changed { "updated" } else { "up_to_date" },
-                    "success": true,
-                    "pulled": changed,
-                    "changed": changed,
-                    "transport": "heddle",
-                    "remote": options.remote_thread,
-                    "thread": options.local_thread.unwrap_or(options.remote_thread),
-                    "state": result
-                        .final_state
-                        .map(|s| s.to_string())
-                        .unwrap_or_default(),
-                    "verification": build_repository_verification_state(repo),
-                })
+            let output = heddle_pull_output(
+                changed,
+                options.remote_thread.to_string(),
+                options
+                    .local_thread
+                    .unwrap_or(options.remote_thread)
+                    .to_string(),
+                result.final_state.map(|state| state.to_string()),
+                None,
+                build_repository_verification_state(repo),
             );
+            crate::cli::render::write_json_stdout(&output)?;
         } else {
             println!(
                 "{} pulled from {}",

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -360,7 +360,9 @@ async fn pull_local(
     lazy: bool,
 ) -> Result<()> {
     if lazy {
-        return Err(anyhow::anyhow!(local_lazy_pull_advice(source_path)));
+        return Err(anyhow::anyhow!(
+            RecoveryAdvice::local_lazy_pull_unsupported(source_path)
+        ));
     }
 
     if !should_output_json(cli, Some(repo.config())) {
@@ -488,24 +490,6 @@ fn changed_paths_between_states(
     Ok(paths)
 }
 
-fn local_lazy_pull_advice(source_path: &Path) -> RecoveryAdvice {
-    let source = source_path.display().to_string();
-    let pull_without_lazy = format!("heddle pull {source}");
-
-    RecoveryAdvice::safety_refusal(
-        "local_lazy_pull_unsupported",
-        "Refusing lazy pull from local remote: lazy materialization requires a hosted or network remote",
-        format!(
-            "Run `{pull_without_lazy}` without `--lazy`, or configure a hosted remote and retry lazy pull there."
-        ),
-        format!("selected remote resolves to local path file://{source}"),
-        "lazy pull would leave the worktree depending on on-demand object fetches that the local transport does not provide",
-        "repository state was left unchanged",
-        pull_without_lazy.clone(),
-        vec![pull_without_lazy, "heddle remote list".to_string()],
-    )
-}
-
 #[cfg(feature = "client")]
 async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Result<()> {
     let repo_path = options
@@ -576,7 +560,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
         }
     } else {
         let err = result.error.unwrap_or_else(|| "Unknown error".to_string());
-        return Err(anyhow::anyhow!(network_pull_failed_advice(
+        return Err(anyhow::anyhow!(RecoveryAdvice::remote_pull_failed(
             options.remote_thread,
             options.local_thread,
             &err,
@@ -584,31 +568,6 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     }
 
     Ok(())
-}
-
-#[cfg(feature = "client")]
-fn network_pull_failed_advice(
-    remote_thread: &str,
-    local_thread: Option<&str>,
-    error: &str,
-) -> RecoveryAdvice {
-    let primary_command = if let Some(local_thread) = local_thread {
-        format!("heddle pull {remote_thread} {local_thread}")
-    } else {
-        format!("heddle pull {remote_thread}")
-    };
-    RecoveryAdvice::safety_refusal(
-        "remote_pull_failed",
-        format!("Pull failed from {remote_thread}: {error}"),
-        format!(
-            "Inspect `heddle verify`, then retry with `{primary_command}` after fixing the remote."
-        ),
-        format!("remote pull from {remote_thread} failed: {error}"),
-        "the local thread was not confirmed updated from the remote",
-        "local Heddle state, Git refs, and worktree files were left unchanged by the failed pull result",
-        primary_command.clone(),
-        vec![primary_command, "heddle verify".to_string()],
-    )
 }
 
 /// Execute remote command.
@@ -647,7 +606,7 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
                 let url = items
                     .get(name)
                     .cloned()
-                    .ok_or_else(|| remote_not_found_advice(name))?;
+                    .ok_or_else(|| RecoveryAdvice::remote_not_found(name))?;
                 let output = RemoteInfoOutput {
                     output_kind: Some("remote_show"),
                     name: name.clone(),
@@ -765,7 +724,7 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
             let (url, source) = items
                 .get(&name)
                 .cloned()
-                .ok_or_else(|| remote_not_found_advice(&name))?;
+                .ok_or_else(|| RecoveryAdvice::remote_not_found(&name))?;
             let is_default = default.as_deref() == Some(name.as_str());
             let output = RemoteInfoOutput {
                 output_kind: Some("remote_show"),
@@ -778,22 +737,6 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
             Ok(())
         }
     }
-}
-
-fn remote_not_found_advice(name: &str) -> RecoveryAdvice {
-    RecoveryAdvice::safety_refusal(
-        "remote_not_found",
-        format!("Remote '{name}' not found"),
-        "Inspect configured remotes with `heddle remote list`, or add one with `heddle remote add <name> <url>`.",
-        format!("no configured Heddle or Git remote named '{name}' was found"),
-        "the command cannot inspect, fetch, pull, or push a remote until the remote name is resolved",
-        "remote configuration, refs, objects, and worktree files were left unchanged",
-        "heddle remote list",
-        vec![
-            "heddle remote list".to_string(),
-            "heddle remote add <name> <url>".to_string(),
-        ],
-    )
 }
 
 fn render_remote_mutation(output: RemoteMutationOutput, json: bool) -> Result<()> {

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1791,6 +1791,7 @@ pub struct PullSchema {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PushSchema {
     pub output_kind: Option<String>,
+    pub action: Option<String>,
     pub status: Option<String>,
     pub pushed: Option<bool>,
     pub changed: Option<bool>,
@@ -1801,6 +1802,16 @@ pub struct PushSchema {
     pub push_scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ref_scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_notes_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_notes_visibility_warning: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_tracking_remote: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_remote_configured: Option<GitRemoteConfiguredSchema>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_upstream_configured: Option<GitUpstreamConfiguredSchema>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags_included: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1815,6 +1826,18 @@ pub struct PushSchema {
     pub recommended_action_template: Option<ActionTemplateSchema>,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationStateSchema,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GitRemoteConfiguredSchema {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GitUpstreamConfiguredSchema {
+    pub branch: String,
+    pub remote: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2546,7 +2546,13 @@ pub struct BridgeGitReconcileSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct BridgePushSchema {
+    pub output_kind: Option<String>,
+    pub action: Option<String>,
+    pub status: Option<String>,
+    pub success: Option<bool>,
     pub pushed: bool,
+    pub changed: Option<bool>,
+    pub transport: Option<String>,
     pub remote: String,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationStateSchema,
@@ -2554,9 +2560,13 @@ pub struct BridgePushSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct BridgePullSchema {
+    pub output_kind: Option<String>,
+    pub action: Option<String>,
     pub status: Option<String>,
+    pub success: Option<bool>,
     pub pulled: bool,
     pub changed: Option<bool>,
+    pub transport: Option<String>,
     pub remote: String,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationStateSchema,

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1423,7 +1423,10 @@ pub struct ThreadSummarySchema {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct CloneSchema {
     pub output_kind: Option<String>,
+    pub action: Option<String>,
     pub status: Option<String>,
+    pub success: Option<bool>,
+    pub cloned: Option<bool>,
     pub transport: Option<String>,
     pub remote: Option<String>,
     pub local: Option<String>,
@@ -1431,6 +1434,8 @@ pub struct CloneSchema {
     pub repository_capability: Option<String>,
     pub commits_imported: Option<u64>,
     pub states_created: Option<u64>,
+    pub objects: Option<usize>,
+    pub state: Option<String>,
     #[serde(rename = "verification")]
     pub trust: Option<RepositoryVerificationStateSchema>,
 }

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1755,6 +1755,7 @@ pub struct FetchSchema {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PullSchema {
     pub output_kind: Option<String>,
+    pub action: Option<String>,
     pub status: Option<String>,
     pub pulled: Option<bool>,
     pub changed: Option<bool>,
@@ -1779,6 +1780,8 @@ pub struct PullSchema {
     pub objects: Option<usize>,
     pub states_created: Option<usize>,
     pub commits_seen: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commits_seen_scope: Option<String>,
     pub materialized_checkout: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changed_path_count: Option<usize>,

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -28,11 +28,12 @@ use tokio_tungstenite::{
 use tracing::debug;
 
 use super::{
+    command_catalog::ActionFields,
     git_compat::{GitIndexPlan, git_index_plan_for_root},
     git_overlay_health::{
-        GitOverlayHealth, RepositoryVerificationState, action_argv, action_template,
-        build_git_overlay_health, build_plain_git_verification_probe, command_argvs,
-        override_trust_recommended_action, serialize_empty_action_as_null,
+        GitOverlayHealth, RepositoryVerificationState, build_git_overlay_health,
+        build_plain_git_verification_probe, command_argvs, override_trust_recommended_action,
+        serialize_empty_action_as_null,
     },
     operator_loop::primary_next_action_with_verification,
     snapshot::resolve_principal,
@@ -501,6 +502,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             );
         }
         let presentation = crate::cli::render::repository_presentation(&repo, None, None);
+        let recommended_action_fields = ActionFields::from_action(&recommended_action);
         return Ok(StatusOutput {
             output_kind: "status",
             repository_capability: repo.capability_label().to_string(),
@@ -563,8 +565,8 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
                     .collect()
             },
             identity_notice: identity_notice.clone(),
-            recommended_action_argv: action_argv(&recommended_action),
-            recommended_action_template: action_template(&recommended_action),
+            recommended_action_argv: recommended_action_fields.argv,
+            recommended_action_template: recommended_action_fields.template,
             recommended_action,
             recovery_commands: trust.recovery_commands.clone(),
             recovery_command_argv: command_argvs(&trust.recovery_commands),
@@ -909,6 +911,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
     {
         override_trust_recommended_action(&mut trust, recommended_action.clone());
     }
+    let recommended_action_fields = ActionFields::from_action(&recommended_action);
     let thread_health = if trust.verified {
         advice
             .as_ref()
@@ -946,8 +949,8 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         },
         identity_notice: output.identity_notice,
         recommended_action: recommended_action.clone(),
-        recommended_action_argv: action_argv(&recommended_action),
-        recommended_action_template: action_template(&recommended_action),
+        recommended_action_argv: recommended_action_fields.argv,
+        recommended_action_template: recommended_action_fields.template,
         recovery_commands: trust.recovery_commands.clone(),
         recovery_command_argv: command_argvs(&trust.recovery_commands),
         recovery_action_templates: trust.recovery_action_templates.clone(),

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -33,6 +33,10 @@ use super::{
         serialize_empty_action_as_null,
     },
     mount_lifecycle,
+    next_action::{
+        NextActionInput, effective_next_action,
+        thread_recovery_action_is_primary as shared_thread_recovery_action_is_primary,
+    },
     operator_loop::{primary_next_action, primary_next_action_with_verification},
     snapshot::{ensure_current_state, summarize_confidence, summarize_verification},
     thread_cmd::{refresh_thread_freshness, thread_not_found_advice},
@@ -1051,17 +1055,12 @@ pub(crate) fn current_thread_next_action_with_verification(
     thread_action: Option<&str>,
     trust: &RepositoryVerificationState,
 ) -> String {
-    if !trust.verified {
-        return trust.recommended_action.clone();
-    }
     let fallback = non_empty_action_ref(thread_action)
         .or_else(|| non_empty_action_ref(Some(trust.recommended_action.as_str())));
-    current_thread_next_action(
-        operation,
-        remote_tracking,
-        import_hint,
-        thread_health,
-        fallback,
+    effective_next_action(
+        NextActionInput::default(operation, remote_tracking, import_hint, fallback)
+            .current_thread(thread_health)
+            .with_verification(trust),
     )
 }
 
@@ -1072,43 +1071,17 @@ pub(crate) fn current_thread_next_action(
     thread_health: Option<&str>,
     thread_action: Option<&str>,
 ) -> String {
-    let thread_action = non_empty_action_ref(thread_action);
-    if operation.is_none()
-        && thread_recovery_precedes_publish(remote_tracking, thread_health, thread_action)
-    {
-        return thread_action.unwrap_or_default().to_string();
-    }
-    primary_next_action(operation, remote_tracking, import_hint, thread_action)
-}
-
-pub(crate) fn thread_recovery_precedes_publish(
-    remote_tracking: Option<&GitRemoteTrackingStatus>,
-    thread_health: Option<&str>,
-    thread_action: Option<&str>,
-) -> bool {
-    let Some(remote_tracking) = remote_tracking else {
-        return false;
-    };
-    if remote_tracking.ahead == 0 || remote_tracking.behind > 0 {
-        return false;
-    }
-    let Some(thread_action) = thread_action else {
-        return false;
-    };
-    thread_recovery_action_is_primary(thread_health, thread_action)
+    effective_next_action(
+        NextActionInput::default(operation, remote_tracking, import_hint, thread_action)
+            .current_thread(thread_health),
+    )
 }
 
 pub(crate) fn thread_recovery_action_is_primary(
     thread_health: Option<&str>,
     thread_action: &str,
 ) -> bool {
-    matches!(
-        thread_health.unwrap_or_default(),
-        "blocked" | "dirty_worktree" | "uncaptured"
-    ) || thread_action == "heddle capture"
-        || thread_action.starts_with("heddle thread refresh ")
-        || thread_action.starts_with("heddle thread resolve ")
-        || thread_action.starts_with("heddle thread promote ")
+    shared_thread_recovery_action_is_primary(thread_health, thread_action)
 }
 
 fn non_empty_action_ref(action: Option<&str>) -> Option<&str> {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -462,29 +462,14 @@ fn thread_resolve_refresh_operator(
         };
     }
 
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    let blockers = trust
-        .checks
-        .iter()
-        .filter(|check| !check.clean)
-        .map(|check| format!("{}: {}", check.name, check.summary))
-        .collect::<Vec<_>>();
-    OperatorCommandOutput {
-        status: "blocked".to_string(),
-        action: "resolve".to_string(),
-        message: format!(
+    OperatorCommandOutput::blocked_by_repository_verification(
+        "resolve",
+        format!(
             "Thread refreshed cleanly, but repository verification is blocked: {}",
             trust.summary
         ),
-        blockers,
-        warnings: Vec::new(),
-        next_action: Some(recommended_action.clone()),
-        recommended_action: Some(recommended_action),
-    }
+        trust,
+    )
 }
 
 fn no_paths_matched_advice(

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -42,8 +42,8 @@ use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
-    command_catalog::ActionTemplate,
-    git_overlay_health::{action_argv, action_template, action_templates, command_argvs},
+    command_catalog::{ActionFields, ActionTemplate},
+    git_overlay_health::{action_templates, command_argvs},
     merge::merge_thread_into_current,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread::start_thread,
@@ -366,8 +366,8 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
         None
     };
     let recommended_action = next_action.clone();
-    let recommended_action_argv = recommended_action.as_deref().and_then(action_argv);
-    let recommended_action_template = recommended_action.as_deref().and_then(action_template);
+    let recommended_action_fields =
+        ActionFields::from_optional_action_ref(recommended_action.as_deref());
     let recovery_commands = if !args.auto_merge || !thread_dropped {
         vec![format!("heddle thread drop {thread_name}")]
     } else {
@@ -423,11 +423,11 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
         captured_state,
         merge_state,
         next_action,
-        next_action_argv: recommended_action_argv.clone(),
-        next_action_template: recommended_action_template.clone(),
+        next_action_argv: recommended_action_fields.argv.clone(),
+        next_action_template: recommended_action_fields.template.clone(),
         recommended_action,
-        recommended_action_argv,
-        recommended_action_template,
+        recommended_action_argv: recommended_action_fields.argv,
+        recommended_action_template: recommended_action_fields.template,
         recovery_commands,
         recovery_command_argv,
         recovery_action_templates,

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
-    command_catalog::{ActionTemplate, recommended_action_argv, recommended_action_template},
+    command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     undo_apply::{
         apply_redo_batch, apply_undo_batch, preflight_redo_batches, preflight_undo_batches,
@@ -157,7 +157,7 @@ pub fn cmd_undo(
 
     let post_undo_repo = Repository::open(repo.root())?;
     let post_undo_trust = build_repository_verification_state(&post_undo_repo);
-    let recommended_action = optional_action(&post_undo_trust.recommended_action);
+    let recommended_action = ActionFields::from_action(&post_undo_trust.recommended_action);
     let output = UndoRedoOutput {
         output_kind: "undo",
         status: "completed",
@@ -168,12 +168,12 @@ pub fn cmd_undo(
             if updated_batches.len() == 1 { "" } else { "es" }
         ),
         batches: updated_batches.iter().map(build_batch_output).collect(),
-        next_action: recommended_action.clone(),
-        next_action_argv: action_argv(&recommended_action),
-        next_action_template: action_template(&recommended_action),
-        recommended_action: recommended_action.clone(),
-        recommended_action_argv: action_argv(&recommended_action),
-        recommended_action_template: action_template(&recommended_action),
+        next_action: recommended_action.action.clone(),
+        next_action_argv: recommended_action.argv.clone(),
+        next_action_template: recommended_action.template.clone(),
+        recommended_action: recommended_action.action,
+        recommended_action_argv: recommended_action.argv,
+        recommended_action_template: recommended_action.template,
         trust: Some(post_undo_trust),
     };
 
@@ -262,7 +262,7 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     }
 
     let post_redo_trust = build_repository_verification_state(&repo);
-    let recommended_action = optional_action(&post_redo_trust.recommended_action);
+    let recommended_action = ActionFields::from_action(&post_redo_trust.recommended_action);
     let output = UndoRedoOutput {
         output_kind: "redo",
         status: "completed",
@@ -273,12 +273,12 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
             if updated_batches.len() == 1 { "" } else { "es" }
         ),
         batches: updated_batches.iter().map(build_batch_output).collect(),
-        next_action: recommended_action.clone(),
-        next_action_argv: action_argv(&recommended_action),
-        next_action_template: action_template(&recommended_action),
-        recommended_action: recommended_action.clone(),
-        recommended_action_argv: action_argv(&recommended_action),
-        recommended_action_template: action_template(&recommended_action),
+        next_action: recommended_action.action.clone(),
+        next_action_argv: recommended_action.argv.clone(),
+        next_action_template: recommended_action.template.clone(),
+        recommended_action: recommended_action.action,
+        recommended_action_argv: recommended_action.argv,
+        recommended_action_template: recommended_action.template,
         trust: Some(post_redo_trust),
     };
 
@@ -360,20 +360,6 @@ fn build_batch_output(batch: &OpBatch) -> OpBatchOutput {
             })
             .collect(),
     }
-}
-
-fn optional_action(action: &str) -> Option<String> {
-    (!action.trim().is_empty()).then(|| action.to_string())
-}
-
-fn action_argv(action: &Option<String>) -> Option<Vec<String>> {
-    action
-        .as_deref()
-        .and_then(|action| recommended_action_argv(action).ok().flatten())
-}
-
-fn action_template(action: &Option<String>) -> Option<ActionTemplate> {
-    action.as_deref().and_then(recommended_action_template)
 }
 
 fn batch_status(batch: &OpBatch) -> (bool, bool) {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -738,24 +738,15 @@ fn block_operator_claim_if_trust_blocked(
         return;
     }
 
-    operator.status = "blocked".to_string();
-    operator.message = format!(
-        "{} reached its local state checks, but repository verification is blocked: {}",
-        operator.action, trust.summary
+    let blocked = OperatorCommandOutput::blocked_by_repository_verification(
+        operator.action.clone(),
+        format!(
+            "{} reached its local state checks, but repository verification is blocked: {}",
+            operator.action, trust.summary
+        ),
+        trust,
     );
-    operator.blockers = trust
-        .checks
-        .iter()
-        .filter(|check| !check.clean)
-        .map(|check| format!("{}: {}", check.name, check.summary))
-        .collect();
-    let recommended_action = if trust.recommended_action.is_empty() {
-        "heddle verify".to_string()
-    } else {
-        trust.recommended_action.clone()
-    };
-    operator.next_action = Some(recommended_action.clone());
-    operator.recommended_action = Some(recommended_action);
+    *operator = blocked;
 }
 
 fn ship_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Option<RecoveryAdvice> {

--- a/crates/cli/src/cli/commands/workspace.rs
+++ b/crates/cli/src/cli/commands/workspace.rs
@@ -9,12 +9,11 @@ use serde::Serialize;
 use tokio::time::{Duration, sleep};
 
 use super::{
-    command_catalog::ActionTemplate,
+    command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{
-        RepositoryVerificationState, action_argv, action_template,
-        build_plain_git_verification_probe, build_repository_verification_state,
-        canonical_adopt_ref_command, override_trust_recommended_action,
-        serialize_empty_action_as_null,
+        RepositoryVerificationState, build_plain_git_verification_probe,
+        build_repository_verification_state, canonical_adopt_ref_command,
+        override_trust_recommended_action, serialize_empty_action_as_null,
     },
     thread::{
         AvailableGitRef, DEFAULT_AVAILABLE_GIT_REF_LIMIT, ThreadSummary, collect_thread_summaries,
@@ -264,6 +263,7 @@ pub(crate) fn build_workspace_output(cli: &Cli) -> Result<WorkspaceSummaryOutput
         current_summary.and_then(|summary| summary.target_thread.as_deref()),
         current_summary.and_then(|summary| summary.parent_thread.as_deref()),
     );
+    let recommended_action_fields = ActionFields::from_action(&recommended_action);
 
     Ok(WorkspaceSummaryOutput {
         output_kind: "workspace_summary",
@@ -285,8 +285,8 @@ pub(crate) fn build_workspace_output(cli: &Cli) -> Result<WorkspaceSummaryOutput
         remote_tracking: remote_tracking.clone(),
         trust,
         recommended_action: recommended_action.clone(),
-        recommended_action_argv: action_argv(&recommended_action),
-        recommended_action_template: action_template(&recommended_action),
+        recommended_action_argv: recommended_action_fields.argv,
+        recommended_action_template: recommended_action_fields.template,
         current_thread,
         groups,
         available_git_refs,

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -117,6 +117,34 @@ fn known_recovery_phrases_stay_in_typed_advice() {
     );
 }
 
+#[test]
+fn git_bridge_recovery_policy_stays_out_of_error_renderer() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let envelope = src_dir.join(ALLOWED_ENVELOPE_FILE);
+    let source = fs::read_to_string(&envelope)
+        .unwrap_or_else(|err| panic!("read {}: {err}", envelope.display()));
+
+    assert!(
+        source.contains("RecoveryAdvice::from_git_bridge_error"),
+        "{ALLOWED_ENVELOPE_FILE} should delegate GitBridgeError policy to typed advice"
+    );
+    for forbidden in [
+        "NonFastForwardRef",
+        "GitHeddleThreadDiverged",
+        "RemoteDiverged",
+        "ShallowClone",
+        "refs/notes/heddle",
+        "git_overlay_remote_diverged",
+        "git_overlay_mapping_conflict",
+        "git_overlay_shallow_clone",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "{ALLOWED_ENVELOPE_FILE} should render Git bridge recovery advice, not own policy `{forbidden}`"
+        );
+    }
+}
+
 fn recovery_phrase_allowed(rel: &Path, phrase: &str) -> bool {
     rel == Path::new(ALLOWED_ADVICE_FILE)
         || rel == Path::new(ALLOWED_ENVELOPE_FILE)

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -145,6 +145,54 @@ fn git_bridge_recovery_policy_stays_out_of_error_renderer() {
     }
 }
 
+#[test]
+fn remote_recovery_policy_uses_typed_advice_constructors() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut violations = Vec::new();
+    for (file, forbidden) in [
+        (
+            "cli/commands/remote/mod.rs",
+            &[
+                "remote_transport_mismatch_advice",
+                "remote_not_configured_advice",
+                "git_tracking_refresh_failed_advice",
+                "network_push_failed_advice",
+            ][..],
+        ),
+        (
+            "cli/commands/remote/remote_ops.rs",
+            &[
+                "local_lazy_pull_advice",
+                "network_pull_failed_advice",
+                "remote_not_found_advice",
+            ][..],
+        ),
+        (
+            "cli/commands/fetch.rs",
+            &["fetch_remote_required_advice"][..],
+        ),
+        (
+            "cli/commands/clone.rs",
+            &["network_clone_failed_advice"][..],
+        ),
+    ] {
+        let path = src_dir.join(file);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+        for symbol in forbidden {
+            if source.contains(symbol) {
+                violations.push(format!("{file} contains `{symbol}`"));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "remote recovery policy should live on RecoveryAdvice constructors:\n{}",
+        violations.join("\n")
+    );
+}
+
 fn recovery_phrase_allowed(rel: &Path, phrase: &str) -> bool {
     rel == Path::new(ALLOWED_ADVICE_FILE)
         || rel == Path::new(ALLOWED_ENVELOPE_FILE)

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -193,6 +193,35 @@ fn remote_recovery_policy_uses_typed_advice_constructors() {
     );
 }
 
+#[test]
+fn verification_blocked_outputs_use_shared_action_policy() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut violations = Vec::new();
+    for file in [
+        "cli/commands/operator_loop.rs",
+        "cli/commands/thread_shaping.rs",
+        "cli/commands/merge/mod.rs",
+        "cli/commands/ready_cmd.rs",
+        "cli/commands/workflow.rs",
+        "cli/commands/rebase/mod.rs",
+    ] {
+        let path = src_dir.join(file);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+        if source.contains("trust.recommended_action.is_empty()") {
+            violations.push(format!(
+                "{file} reimplements repository verification recommended-action fallback"
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "repository-verification blocked outputs should use repository_verification_primary_command or OperatorCommandOutput::blocked_by_repository_verification:\n{}",
+        violations.join("\n")
+    );
+}
+
 fn recovery_phrase_allowed(rel: &Path, phrase: &str) -> bool {
     rel == Path::new(ALLOWED_ADVICE_FILE)
         || rel == Path::new(ALLOWED_ENVELOPE_FILE)

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -13,6 +13,7 @@ use std::{
 const ALLOWED_ENVELOPE_FILE: &str = "cli/commands/error_envelope.rs";
 const ALLOWED_ADVICE_FILE: &str = "cli/commands/advice.rs";
 const ALLOWED_HISTORY_TARGET_FILE: &str = "cli/commands/history_target.rs";
+const ALLOWED_NEXT_ACTION_FILE: &str = "cli/commands/next_action.rs";
 
 const RAW_RECOVERY_PHRASES: &[&str] = &[
     "State not found:",
@@ -218,6 +219,42 @@ fn verification_blocked_outputs_use_shared_action_policy() {
     assert!(
         violations.is_empty(),
         "repository-verification blocked outputs should use repository_verification_primary_command or OperatorCommandOutput::blocked_by_repository_verification:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn next_action_priority_lives_in_shared_selector() {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut violations = Vec::new();
+    walk_rust_files(&src_dir, &mut |path| {
+        let rel = path.strip_prefix(&src_dir).unwrap_or(path);
+        if rel == Path::new(ALLOWED_NEXT_ACTION_FILE) {
+            return;
+        }
+        let Ok(source) = fs::read_to_string(path) else {
+            return;
+        };
+        for (line_index, line) in source.lines().enumerate() {
+            for fragment in [
+                "remote_tracking.behind > 0",
+                "heddle bridge git import --ref {}",
+                "thread_action.filter(|action| !action.trim().is_empty())",
+            ] {
+                if line.contains(fragment) {
+                    violations.push(format!(
+                        "{}:{} reimplements next-action priority fragment `{fragment}`",
+                        rel.display(),
+                        line_index + 1
+                    ));
+                }
+            }
+        }
+    });
+
+    assert!(
+        violations.is_empty(),
+        "next-action priority should be selected through {ALLOWED_NEXT_ACTION_FILE}; violations:\n{}",
         violations.join("\n")
     );
 }

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -327,14 +327,22 @@ fn test_cli_status_surfaces_git_import_hint_for_other_branches() {
     )
     .unwrap();
     let bridge: Value = serde_json::from_str(&bridge_output).unwrap();
-    assert_eq!(bridge["git_overlay_import_hint"]["missing_branch_count"], 1);
-    assert_eq!(
-        bridge["git_overlay_import_hint"]["missing_branches"][0],
-        "support/import-me"
+    assert_eq!(bridge["git_overlay_import_hint"]["missing_branch_count"], 2);
+    let missing = bridge["git_overlay_import_hint"]["missing_branches"]
+        .as_array()
+        .unwrap();
+    assert!(
+        missing
+            .iter()
+            .any(|branch| branch.as_str() == Some("feature/drop-in"))
+            && missing
+                .iter()
+                .any(|branch| branch.as_str() == Some("support/import-me")),
+        "first-run bridge import hint should include the active branch and the other local branch: {bridge}"
     );
     assert_eq!(
         bridge["git_overlay_import_hint"]["recommended_command"],
-        "heddle adopt --ref support/import-me"
+        "heddle adopt"
     );
 }
 
@@ -450,14 +458,22 @@ fn test_cli_status_surfaces_git_import_hint_for_many_branches() {
 
     assert_eq!(
         parsed["git_overlay_import_hint"]["missing_branch_count"],
-        12
+        13
     );
     assert_eq!(
         parsed["git_overlay_import_hint"]["missing_branches"]
             .as_array()
             .unwrap()
             .len(),
-        12
+        13
+    );
+    assert!(
+        parsed["git_overlay_import_hint"]["missing_branches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|branch| branch.as_str() == Some("feature/drop-in")),
+        "first-run bridge import hint should include the active branch: {parsed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -3454,7 +3454,9 @@ fn git_overlay_matrix_manual_git_commit_after_bootstrap_commands() {
     .unwrap();
     assert!(
         bridge_text.contains("Git branch 'feature/drop-in' advanced outside Heddle")
+            && bridge_text.contains("Git branch waiting for Heddle import: feature/drop-in")
             && bridge_text.contains("Recovery: heddle adopt --ref feature/drop-in")
+            && !bridge_text.contains("Optional Git-only branch available: feature/drop-in")
             && !bridge_text.contains("Setup needed"),
         "bridge git status text should identify mapping drift and exact recovery: {bridge_text}"
     );

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -3037,8 +3037,24 @@ fn git_overlay_matrix_top_level_push_closes_remote_verification_loop() {
 
     let push = json(temp.path(), &["--output", "json", "push"]);
     assert_eq!(push["output_kind"], "push");
+    assert_eq!(push["action"], "push");
     assert_eq!(push["success"], true);
     assert_eq!(push["pushed"], true);
+    assert_eq!(push["transport"], "git");
+    assert_eq!(push["push_scope"], "current_thread");
+    assert_eq!(push["ref_scope"], "branch_and_heddle_notes");
+    assert_eq!(push["git_notes_ref"], "refs/notes/heddle");
+    assert!(
+        push["git_notes_visibility_warning"]
+            .as_str()
+            .is_some_and(|warning| warning.contains("refs/notes/heddle")),
+        "push should disclose the Git-visible Heddle notes ref: {push}"
+    );
+    assert_eq!(push["git_tracking_remote"], "origin");
+    assert_eq!(push["git_remote_configured"], Value::Null);
+    assert_eq!(push["git_upstream_configured"]["branch"], "main");
+    assert_eq!(push["git_upstream_configured"]["remote"], "origin");
+    assert_eq!(push["tags_included"], false);
     assert_eq!(push["next_action"], Value::Null);
     assert_eq!(push["next_action_argv"], Value::Null);
     assert_eq!(push["next_action_template"], Value::Null);
@@ -3166,8 +3182,12 @@ fn git_overlay_matrix_push_defaults_to_branch_upstream_remote() {
 
     let push = json(temp.path(), &["--output", "json", "push"]);
     assert_eq!(push["output_kind"], "push");
+    assert_eq!(push["action"], "push");
     assert_eq!(push["pushed"], true);
     assert_eq!(push["remote"], "upstream");
+    assert_eq!(push["git_tracking_remote"], "upstream");
+    assert_eq!(push["git_upstream_configured"]["branch"], "main");
+    assert_eq!(push["git_upstream_configured"]["remote"], "upstream");
     assert_eq!(push["verification"]["verified"], true);
     assert_eq!(push["verification"]["status"], "clean");
 }
@@ -3201,6 +3221,10 @@ fn git_overlay_matrix_remote_without_upstream_is_not_verified_until_push_sets_tr
     let push = json(temp.path(), &["--output", "json", "push"]);
     assert_eq!(push["pushed"], true);
     assert_eq!(push["remote"], "upstream");
+    assert_eq!(push["action"], "push");
+    assert_eq!(push["git_tracking_remote"], "upstream");
+    assert_eq!(push["git_upstream_configured"]["branch"], "main");
+    assert_eq!(push["git_upstream_configured"]["remote"], "upstream");
     assert_eq!(push["verification"]["verified"], true);
     assert_eq!(push["verification"]["status"], "clean");
     assert_eq!(

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -2949,7 +2949,14 @@ fn git_overlay_matrix_bridge_push_pull_report_verification_state() {
         temp.path(),
         &["--output", "json", "bridge", "git", "push", origin_arg],
     );
+    assert_eq!(push["output_kind"], "bridge_git_push");
+    assert_eq!(push["action"], "bridge git push");
+    assert_eq!(push["status"], "pushed");
+    assert_eq!(push["success"], true);
     assert_eq!(push["pushed"], true);
+    assert_eq!(push["changed"], true);
+    assert_eq!(push["transport"], "git");
+    assert_eq!(push["remote"], origin_arg);
     assert_eq!(push["verification"]["verified"], true);
     assert_eq!(push["verification"]["status"], "clean");
     assert_verify_check_rows(&push["verification"]);
@@ -2958,9 +2965,14 @@ fn git_overlay_matrix_bridge_push_pull_report_verification_state() {
         temp.path(),
         &["--output", "json", "bridge", "git", "pull", origin_arg],
     );
+    assert_eq!(pull["output_kind"], "bridge_git_pull");
+    assert_eq!(pull["action"], "bridge git pull");
     assert_eq!(pull["status"], "up_to_date");
+    assert_eq!(pull["success"], true);
     assert_eq!(pull["pulled"], false);
     assert_eq!(pull["changed"], false);
+    assert_eq!(pull["transport"], "git");
+    assert_eq!(pull["remote"], origin_arg);
     assert_eq!(pull["verification"]["verified"], true);
     assert_eq!(pull["verification"]["status"], "clean");
     assert_verify_check_rows(&pull["verification"]);

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10670,9 +10670,13 @@ fn verify_after_git_overlay_clone_reports_clone_verified() {
     .expect("heddle clone");
     let clone_output: Value = serde_json::from_str(&clone_json).expect("clone JSON parses");
     assert_eq!(clone_output["output_kind"], "clone");
+    assert_eq!(clone_output["action"], "clone");
     assert_eq!(clone_output["status"], "cloned");
+    assert_eq!(clone_output["success"], true);
+    assert_eq!(clone_output["cloned"], true);
     assert_eq!(clone_output["transport"], "git");
     assert_eq!(clone_output["branch"], "master");
+    assert_eq!(clone_output["repository_capability"], "git-overlay");
     assert_eq!(clone_output["commits_imported"], 2);
     assert_eq!(clone_output["states_created"], 2);
     assert_eq!(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -3792,6 +3792,7 @@ fn assert_runtime_actions_parse(
     placeholders: &std::collections::BTreeSet<String>,
     source_args: &[&str],
 ) {
+    assert_action_sidecars_match(value, placeholders, source_args);
     let mut actions = Vec::new();
     collect_runtime_actions(value, &mut actions);
     assert!(
@@ -3819,6 +3820,109 @@ fn assert_runtime_actions_parse(
                 )
             });
     }
+}
+
+fn assert_action_sidecars_match(
+    value: &Value,
+    placeholders: &std::collections::BTreeSet<String>,
+    source_args: &[&str],
+) {
+    match value {
+        Value::Object(map) => {
+            for field in ["recommended_action", "next_action"] {
+                let argv_key = format!("{field}_argv");
+                let template_key = format!("{field}_template");
+                let action = map.get(field);
+                let argv = map.get(&argv_key);
+                let template = map.get(&template_key);
+                if action.is_none() && argv.is_none() && template.is_none() {
+                    continue;
+                }
+                match action {
+                    Some(Value::String(action)) if !action.trim().is_empty() => {
+                        if let Some(argv) = argv {
+                            assert_eq!(
+                                argv.clone(),
+                                expected_action_argv_json(action, placeholders, source_args),
+                                "{source_args:?} {argv_key} should match {field}: {action}; object={value}"
+                            );
+                        }
+                        if let Some(template) = template {
+                            let display_only = is_display_only_action(action)
+                                || placeholders.contains(action.trim());
+                            if display_only {
+                                assert!(
+                                    !template.is_null(),
+                                    "{source_args:?} {template_key} should describe display-only action `{action}`; object={value}"
+                                );
+                            }
+                        }
+                    }
+                    Some(Value::Null) | None => {
+                        if let Some(argv) = argv {
+                            assert!(
+                                argv.is_null(),
+                                "{source_args:?} {argv_key} must be null when {field} is null/missing: object={value}"
+                            );
+                        }
+                        if let Some(template) = template {
+                            assert!(
+                                template.is_null(),
+                                "{source_args:?} {template_key} must be null when {field} is null/missing: object={value}"
+                            );
+                        }
+                    }
+                    Some(other) => panic!(
+                        "{source_args:?} {field} should be string or null, got {other}: object={value}"
+                    ),
+                }
+            }
+            for child in map.values() {
+                assert_action_sidecars_match(child, placeholders, source_args);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                assert_action_sidecars_match(value, placeholders, source_args);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn expected_action_argv_json(
+    action: &str,
+    placeholders: &std::collections::BTreeSet<String>,
+    source_args: &[&str],
+) -> Value {
+    let trimmed = action.trim();
+    if trimmed.is_empty() || placeholders.contains(trimmed) || is_display_only_action(trimmed) {
+        return Value::Null;
+    }
+    let argv = split_recommended_action_for_test(trimmed)
+        .unwrap_or_else(|err| panic!("{source_args:?} action should split: {err}: {trimmed}"));
+    assert_eq!(
+        argv.first().map(String::as_str),
+        Some("heddle"),
+        "{source_args:?} action should use heddle or a registered placeholder: {trimmed}"
+    );
+    Cli::command()
+        .try_get_matches_from(argv.clone())
+        .unwrap_or_else(|err| {
+            panic!(
+                "{source_args:?} action should parse through clap: {err}: {}",
+                argv.join(" ")
+            )
+        });
+    serde_json::json!(
+        std::iter::once(env!("CARGO_BIN_EXE_heddle").to_string())
+            .chain(argv.into_iter().skip(1))
+            .collect::<Vec<_>>()
+    )
+}
+
+fn is_display_only_action(action: &str) -> bool {
+    action.contains("...") || action.contains('…') || (action.contains('<') && action.contains('>'))
 }
 
 fn collect_runtime_actions(value: &Value, out: &mut Vec<String>) {

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1727,6 +1727,40 @@ fn test_cli_git_overlay_explicit_path_push_discloses_configured_git_tracking_rem
 }
 
 #[test]
+fn test_cli_git_overlay_explicit_path_push_json_reports_configured_git_tracking_remote() {
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin.git");
+    let work = temp.path().join("work");
+    gix::init_bare(&origin).expect("init bare origin");
+    std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+    std::fs::create_dir_all(&work).unwrap();
+    git_ok(&["init", "-b", "main"], &work);
+    git_ok(&["config", "user.name", "Heddle Test"], &work);
+    git_ok(&["config", "user.email", "heddle@example.com"], &work);
+    std::fs::write(work.join("README.md"), "seed\n").unwrap();
+    git_ok(&["add", "README.md"], &work);
+    git_ok(&["commit", "-m", "seed"], &work);
+
+    heddle(&["adopt", "--ref", "main"], Some(&work)).expect("adopt seeded Git repo");
+    std::fs::write(work.join("README.md"), "seed\nlocal heddle\n").unwrap();
+    heddle(&["commit", "-m", "local heddle"], Some(&work)).expect("heddle commit succeeds");
+
+    let origin_arg = origin.to_str().expect("origin path utf8");
+    let push_json = heddle(&["--output", "json", "push", origin_arg], Some(&work))
+        .expect("explicit path JSON push succeeds");
+    let push: Value = serde_json::from_str(&push_json).expect("push JSON parses");
+    assert_eq!(push["action"], "push");
+    assert_eq!(push["remote"], origin_arg);
+    assert_eq!(push["git_tracking_remote"], "origin");
+    assert_eq!(push["git_remote_configured"]["name"], "origin");
+    assert_eq!(push["git_remote_configured"]["url"], origin_arg);
+    assert_eq!(push["git_upstream_configured"]["branch"], "main");
+    assert_eq!(push["git_upstream_configured"]["remote"], "origin");
+    assert_eq!(push["verification"]["status"], "clean");
+}
+
+#[test]
 fn test_cli_raw_git_clone_adopt_fetches_notes_before_import() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -292,9 +292,22 @@ fn test_cli_pull_local_updates_requested_track() {
         "pull --output json must emit exactly one JSON value: {output}"
     );
     let parsed: Value = serde_json::from_str(&output).expect("pull JSON should parse");
+    assert_eq!(parsed["output_kind"], "pull");
+    assert_eq!(parsed["action"], "pull");
     assert_eq!(
         parsed["success"], true,
         "pull should report success: {parsed}"
+    );
+    assert_eq!(parsed["status"], "updated");
+    assert_eq!(parsed["transport"], "heddle");
+    assert_eq!(parsed["thread"], "imported");
+    assert!(
+        parsed["state"].is_string(),
+        "pull should report state: {parsed}"
+    );
+    assert!(
+        parsed["objects"].is_number(),
+        "pull should report objects: {parsed}"
     );
     assert_eq!(parsed["verification"]["status"], "clean");
 
@@ -1218,6 +1231,10 @@ fn test_cli_clone_git_overlay_rewrites_origin_and_default_pull_keeps_git_clean()
     let pull_json =
         heddle(&["--output", "json", "pull"], Some(&work)).expect("default pull succeeds");
     let pull: Value = serde_json::from_str(&pull_json).expect("pull JSON parses");
+    assert_eq!(pull["output_kind"], "pull");
+    assert_eq!(pull["action"], "pull");
+    assert_eq!(pull["status"], "updated");
+    assert_eq!(pull["transport"], "git");
     assert_eq!(pull["remote"], "origin");
     assert_eq!(pull["branch"], "main");
     assert_eq!(pull["old_git_head"], first.to_string());
@@ -1225,6 +1242,7 @@ fn test_cli_clone_git_overlay_rewrites_origin_and_default_pull_keeps_git_clean()
     assert_eq!(pull["changed_path_count"], 1);
     assert_eq!(pull["changed_paths"], serde_json::json!(["tracked.txt"]));
     assert_eq!(pull["states_created"], 1);
+    assert_eq!(pull["commits_seen_scope"], "branches_and_heddle_notes");
     assert_eq!(pull["materialized_checkout"], true);
     assert_eq!(
         pull["verification"]["worktree_state"], "clean",

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -648,7 +648,23 @@ fn test_cli_clone_local_attaches_head_to_cloned_thread() {
 
     let source_path = source.path().to_string_lossy().to_string();
     let clone_path = clone_dir.to_string_lossy().to_string();
-    heddle(&["clone", &source_path, &clone_path], None).expect("local clone succeeds");
+    let clone_json = heddle(
+        &["--output", "json", "clone", &source_path, &clone_path],
+        None,
+    )
+    .expect("local clone succeeds");
+    let clone_output: Value = serde_json::from_str(&clone_json).expect("clone JSON parses");
+    assert_eq!(clone_output["output_kind"], "clone");
+    assert_eq!(clone_output["action"], "clone");
+    assert_eq!(clone_output["status"], "cloned");
+    assert_eq!(clone_output["success"], true);
+    assert_eq!(clone_output["cloned"], true);
+    assert_eq!(clone_output["transport"], "heddle");
+    assert_eq!(clone_output["branch"], "main");
+    assert_eq!(clone_output["repository_capability"], "native");
+    assert!(clone_output["objects"].is_number());
+    assert!(clone_output["state"].is_string());
+    assert_eq!(clone_output["verification"]["status"], "clean");
 
     let head = std::fs::read_to_string(clone_dir.join(".heddle").join("HEAD"))
         .expect("read cloned Heddle HEAD");

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1914,7 +1914,11 @@ the same ready envelope.
 
 ```json
 {
+  "output_kind": "pull",
+  "action": "pull",
+  "status": "updated",
   "pulled": true,
+  "changed": true,
   "success": true,
   "transport": "git",
   "remote": "origin",
@@ -1925,6 +1929,7 @@ the same ready envelope.
   "new_state": "hd-head456",
   "states_created": 1,
   "commits_seen": 1,
+  "commits_seen_scope": "branches_and_heddle_notes",
   "materialized_checkout": true,
   "changed_path_count": 1,
   "changed_paths": ["src/app.rs"],
@@ -2021,8 +2026,9 @@ the same ready envelope.
 | `name`, `url`, `source`, `is_default` | string/string/string/bool | required for `remote show` and remote entries | Remote identity and default marker. |
 | `refs_fetched`, `objects_fetched` | int | required for `fetch` | Fetch transfer counts. |
 | `pulled`, `pushed`, `success` | bool \| null | required when present | Transport result booleans. Pull reports `pulled`; push reports `pushed`. |
-| `action`, `status`, `transport` | string \| null | required for push | Stable action name, outcome status, and transport kind. Git-overlay pushes report `transport: "git"`; native Heddle pushes report `transport: "heddle"`. |
-| `state`, `objects` | string/int \| null | native Heddle push only | Resulting native Heddle state and transferred object count. Git-overlay pushes report Git ref publication details instead. |
+| `action`, `status`, `transport` | string \| null | required for pull/push | Stable action name, outcome status, and transport kind. Git-overlay transfers report `transport: "git"`; native Heddle transfers report `transport: "heddle"`. |
+| `branch`, `old_git_head`, `new_git_head`, `old_state`, `new_state`, `states_created`, `commits_seen`, `commits_seen_scope`, `materialized_checkout`, `changed_path_count`, `changed_paths` | mixed | Git-overlay pull only | Concrete Git/Heddle movement proof for a pull, including imported commit scope and materialized path changes. |
+| `state`, `objects` | string/int \| null | native Heddle pull/push only | Resulting native Heddle state and transferred object count. Git-overlay transfers report Git ref publication details instead. |
 | `push_scope`, `ref_scope`, `tags_included`, `thread` | string/bool \| null | Git-overlay push only | Whether the push published only the current thread or all threads, the concrete Git ref scope, whether tags were included, and the thread whose branch was pushed. |
 | `git_notes_ref`, `git_notes_visibility_warning` | string \| null | Git-overlay push only | Heddle metadata notes ref carried with the push and the human-visible Git disclosure for that ref. |
 | `git_tracking_remote`, `git_remote_configured`, `git_upstream_configured` | mixed | Git-overlay push only | Git config side effects when Heddle configures a remote or branch upstream during push. |

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2847,8 +2847,8 @@ key naming:
 | `export` | `{"states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
 | `import` | `{"commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "partial_mirror_refs": N}` |
 | `sync` | `{"states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
-| `push` | `{"pushed": true, "remote": "origin", "verification": {...}}` |
-| `pull` | `{"pulled": true, "remote": "origin", "verification": {...}}` |
+| `push` | `{"output_kind": "bridge_git_push", "action": "bridge git push", "status": "pushed", "success": true, "pushed": true, "changed": true, "transport": "git", "remote": "origin", "verification": {...}}` |
+| `pull` | `{"output_kind": "bridge_git_pull", "action": "bridge git pull", "status": "updated", "success": true, "pulled": true, "changed": true, "transport": "git", "remote": "origin", "verification": {...}}` |
 
 `heddle bridge git init --output json` emits:
 
@@ -2877,13 +2877,13 @@ key naming:
 `heddle bridge git push --output json` emits:
 
 ```json
-{"pushed": true, "remote": "origin", "verification": {}}
+{"output_kind": "bridge_git_push", "action": "bridge git push", "status": "pushed", "success": true, "pushed": true, "changed": true, "transport": "git", "remote": "origin", "verification": {}}
 ```
 
 `heddle bridge git pull --output json` emits:
 
 ```json
-{"pulled": true, "remote": "origin", "verification": {}}
+{"output_kind": "bridge_git_pull", "action": "bridge git pull", "status": "updated", "success": true, "pulled": true, "changed": true, "transport": "git", "remote": "origin", "verification": {}}
 ```
 
 ---

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1246,11 +1246,16 @@ verification.
 
 ```json
 {
+  "output_kind": "clone",
+  "action": "clone",
   "status": "cloned",
+  "success": true,
+  "cloned": true,
   "transport": "git",
   "remote": "file:///tmp/source.git",
   "local": "work",
   "branch": "main",
+  "repository_capability": "git-overlay",
   "commits_imported": 3,
   "states_created": 3,
   "verification": {
@@ -2019,8 +2024,9 @@ the same ready envelope.
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
-| `status`, `transport`, `remote`, `local`, `branch` | string \| null | required for Git-overlay `clone` | Clone outcome, transport, source, destination, and checked-out branch. |
+| `output_kind`, `action`, `status`, `success`, `cloned`, `transport`, `remote`, `local`, `branch`, `repository_capability` | mixed | required for successful `clone` | Stable clone envelope, transport, source, destination, checked-out branch, and initialized repository capability. |
 | `commits_imported`, `states_created` | int \| null | required for Git-overlay `clone` | Import counts reported after clone verification. |
+| `objects`, `state` | int/string \| null | native/hosted Heddle clone only | Transferred object count and resulting Heddle state when the transport is native Heddle rather than Git-overlay. |
 | `verification` | object \| null | required for Git-overlay `clone` | Post-clone repository verification proof; clean clones report `clone_verification: "verified"`. |
 | `remotes` | array<object> | required for `remote list` | Configured remotes. Empty if none. |
 | `name`, `url`, `source`, `is_default` | string/string/string/bool | required for `remote show` and remote entries | Remote identity and default marker. |

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1959,12 +1959,28 @@ the same ready envelope.
 ```json
 {
   "output_kind": "push",
+  "action": "push",
+  "status": "pushed",
   "pushed": true,
+  "changed": true,
   "success": true,
   "transport": "git",
   "remote": "origin",
-  "state": "hd-head456",
-  "objects": 2,
+  "push_scope": "current_thread",
+  "ref_scope": "branch_and_heddle_notes",
+  "git_notes_ref": "refs/notes/heddle",
+  "git_notes_visibility_warning": "ordinary `git log --all` may show Heddle metadata commits from refs/notes/heddle",
+  "git_tracking_remote": "origin",
+  "git_remote_configured": {
+    "name": "origin",
+    "url": "file:///tmp/example.git"
+  },
+  "git_upstream_configured": {
+    "branch": "main",
+    "remote": "origin"
+  },
+  "tags_included": false,
+  "thread": "main",
   "next_action": null,
   "next_action_argv": null,
   "next_action_template": null,
@@ -2005,7 +2021,11 @@ the same ready envelope.
 | `name`, `url`, `source`, `is_default` | string/string/string/bool | required for `remote show` and remote entries | Remote identity and default marker. |
 | `refs_fetched`, `objects_fetched` | int | required for `fetch` | Fetch transfer counts. |
 | `pulled`, `pushed`, `success` | bool \| null | required when present | Transport result booleans. Pull reports `pulled`; push reports `pushed`. |
-| `transport`, `state`, `objects` | string/int \| null | required for pull/push | Transport kind, resulting state, and transferred object count. |
+| `action`, `status`, `transport` | string \| null | required for push | Stable action name, outcome status, and transport kind. Git-overlay pushes report `transport: "git"`; native Heddle pushes report `transport: "heddle"`. |
+| `state`, `objects` | string/int \| null | native Heddle push only | Resulting native Heddle state and transferred object count. Git-overlay pushes report Git ref publication details instead. |
+| `push_scope`, `ref_scope`, `tags_included`, `thread` | string/bool \| null | Git-overlay push only | Whether the push published only the current thread or all threads, the concrete Git ref scope, whether tags were included, and the thread whose branch was pushed. |
+| `git_notes_ref`, `git_notes_visibility_warning` | string \| null | Git-overlay push only | Heddle metadata notes ref carried with the push and the human-visible Git disclosure for that ref. |
+| `git_tracking_remote`, `git_remote_configured`, `git_upstream_configured` | mixed | Git-overlay push only | Git config side effects when Heddle configures a remote or branch upstream during push. |
 | `next_action`, `recommended_action`, `next_action_argv`, `recommended_action_argv`, `next_action_template`, `recommended_action_template` | mixed | required for push | Post-push action metadata promoted from verification; all are `null` when the push closes the remote loop. |
 | `verification` | object | required for pull/push | Post-transfer verification proof. |
 


### PR DESCRIPTION
## Position in stack

**Base:** PR 1/4 (`codex/oss-improvements-1-foundation`) — #244
**Merges first to:** PR 3/4 — #246

## Sibling PRs

- PR 1/4 — Contract foundation: #244
- PR 3/4 — Action surface centralization: #246
- PR 4/4 — Ignore policy + exit codes + stdout/stderr lint: #247

## Summary

Types every transfer command's JSON output (`push`, `pull`, `clone`, `bridge git import/export/sync`) so agents stop pattern-matching free-form fields. Each command now emits a `*Output` struct with an `output_kind` discriminator that matches the catalog entry from PR 1.

Recovery-advice centralization continues in parallel: verification refusal text, emitted action metadata, remote recovery advice, and Git-bridge advice all move out of renderer code and into the catalog-driven advice layer.

13 commits in original order. Key inflection points:

- ` facbc1a` / ` 1ccd2a4` Align import hint tests + name required Git imports — hint contract finalized
- ` 61b4472` / ` 95d12aa` / ` 198658a` / ` 15df195` Typed JSON for `push`, `pull`, `bridge git transfer`, `clone` — every transfer surface
- ` cb69b1a` Centralize action field rendering — one renderer, all action lines
- ` df3da61` Centralize verification refusal advice
- ` e897051` Centralize emitted action metadata
- ` 50bc8dd` Move Git bridge advice out of renderer
- ` 2090f5f` Centralize remote recovery advice
- ` 0b035b2` Centralize verification blocked operator output
- ` 0270b53` Centralize next action selection

## Contract changes introduced

| Command | New `output_kind` |
| --- | --- |
| `push` | `push` |
| `pull` | `pull` |
| `clone` | `clone` |
| `bridge git push` | `bridge_git_push` |
| `bridge git pull` | `bridge_git_pull` |
| `bridge git sync` | `bridge_git_sync` |

## Note

This PR is a slice of the `codex/oss-improvements` branch, carved chronologically into 4 stacked PRs. The full narrative is preserved in commit-level history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)