### PR TITLE
OSS improvements (5/5): adopt perf, exit drift, status trim, UX fixes from persona review

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -7,7 +7,7 @@ use chrono::{TimeZone, Utc};
 use objects::object::{Agent, Attribution, ChangeId, Principal, State, Status};
 use refs::{Head, RefExpectation};
 use repo::Repository as HeddleRepository;
-use tracing::warn;
+use tracing::{info_span, warn};
 
 pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
 use crate::bridge::{
@@ -262,6 +262,11 @@ fn import_with_ref_filter(
     git_path: Option<&Path>,
     wanted_refs: Option<&HashSet<String>>,
 ) -> GitResult<ImportStats> {
+    let _span = info_span!(
+        "git_import.with_ref_filter",
+        wanted = wanted_refs.map(HashSet::len).unwrap_or(0)
+    )
+    .entered();
     let repo = if let Some(path) = git_path {
         open_repo(path)?
     } else {

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1236,6 +1236,9 @@ pub struct CloneArgs {
     pub thread: Option<String>,
 
     /// Create a shallow clone with the specified depth. `0` means full history.
+    /// Not yet supported for Git-overlay clones (plain `https://…/repo.git`
+    /// URLs and local-path clones) — those reject this flag with a clear
+    /// error and need a full clone for now. Planned for v0.3.1.
     #[arg(long)]
     pub depth: Option<u32>,
 

--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -49,6 +49,12 @@ struct AdoptOutput {
 pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
     let start = resolve_path(cli, args.path.as_deref())?;
     let git_root = git_worktree_root(&start)?;
+    // Shallow detect MUST happen before any Heddle sidecar bootstrap or
+    // remote-note hydration. Without this, a `heddle adopt` against a
+    // shallow clone burns a full `git fetch` from origin (network IO,
+    // minutes on a real repo) before discovering the repo can't be
+    // imported. Costs one `stat()` on the happy path.
+    preflight_not_shallow(&git_root, &args.refs)?;
     let initialized = !git_root.join(".heddle").exists();
     if initialized {
         preflight_importable_git_history(&git_root, &args.refs)?;
@@ -72,14 +78,32 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
     };
     let source_label = repo.root().display().to_string();
     let mut progress = ImportProgress::start(cli, &repo, &scope, &source_label);
-    progress.advance("importing commits");
     let mut bridge = GitBridge::new(&repo);
+    // The hydrate fetch is the slowest thing in adopt on a real-world
+    // repo (it walks every configured remote looking for a Heddle-notes
+    // ref). Tell the user before it runs so the silence makes sense.
+    if checkout_has_remote(&repo) {
+        progress.note(
+            "checking configured Git remotes for shared Heddle notes (network)",
+        );
+    }
+    let hydrate_span =
+        tracing::info_span!("adopt.hydrate_notes", path = %repo.root().display()).entered();
     let _ = bridge.hydrate_checkout_heddle_notes_from_configured_remotes();
+    drop(hydrate_span);
+    progress.advance("importing commits");
+    let import_span = tracing::info_span!(
+        "adopt.import",
+        path = %repo.root().display(),
+        refs = args.refs.len()
+    )
+    .entered();
     let stats = if args.refs.is_empty() {
         import_all(&mut bridge, Some(repo.root()))?
     } else {
         import_selected_refs(&mut bridge, Some(repo.root()), &args.refs)?
     };
+    drop(import_span);
     progress.advance("writing refs");
     progress.finish();
     let trust = build_repository_verification_state(&repo);
@@ -110,6 +134,29 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
 
 fn action_value(trust: &RepositoryVerificationState) -> Option<String> {
     (!trust.recommended_action.trim().is_empty()).then(|| trust.recommended_action.clone())
+}
+
+fn checkout_has_remote(repo: &Repository) -> bool {
+    let Ok(git) = gix::discover(repo.root()) else {
+        return false;
+    };
+    git.remote_names().into_iter().next().is_some()
+}
+
+fn preflight_not_shallow(git_root: &Path, refs: &[String]) -> Result<()> {
+    let git = gix::discover(git_root)
+        .map_err(|error| anyhow!("failed to inspect Git for shallow status: {error}"))?;
+    if git.git_dir().join("shallow").is_file() {
+        let retry_command = if refs.is_empty() {
+            "heddle bridge git import --path <full-git-repo>".to_string()
+        } else {
+            "heddle bridge git import --path <full-git-repo> --ref <ref>".to_string()
+        };
+        bail!(
+            "Shallow Git repository cannot be imported. Re-clone without --depth, or run: {retry_command}"
+        );
+    }
+    Ok(())
 }
 
 fn preflight_importable_git_history(git_root: &Path, refs: &[String]) -> Result<()> {

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -917,18 +917,47 @@ fn select_clone_thread(
         return Ok(requested.to_string());
     }
     let threads = repo.refs().list_threads()?;
+    // Prefer the remote's stated default (refs/remotes/origin/HEAD —
+    // gix sets it via the fetch handshake). Without this, multi-branch
+    // remotes attach to whatever the import happened to walk last,
+    // which on real repos is often a Dependabot or release branch
+    // rather than the developer's `main`/`master`.
+    if let Some(remote_default) = read_remote_head_branch(repo)
+        && threads.iter().any(|thread| thread == &remote_default)
+    {
+        return Ok(remote_default);
+    }
     if let Some(hint) = git_head_branch_hint
         && threads.iter().any(|thread| thread == hint)
     {
         return Ok(hint.to_string());
     }
-    if threads.iter().any(|thread| thread == "main") {
-        return Ok("main".to_string());
+    for fallback in ["main", "master", "trunk"] {
+        if threads.iter().any(|thread| thread == fallback) {
+            return Ok(fallback.to_string());
+        }
     }
     threads
         .into_iter()
         .next()
         .ok_or_else(|| anyhow!(clone_git_overlay_no_branch_refs_advice(remote_label)))
+}
+
+/// Resolve the remote's stated default branch from
+/// `refs/remotes/origin/HEAD`, which gix populates from the fetch
+/// handshake. Returns the bare branch name (e.g. `master`) or `None`
+/// when the symref is absent or doesn't target a branch under origin/.
+fn read_remote_head_branch(repo: &Repository) -> Option<String> {
+    let head_path = repo.root().join(".git/refs/remotes/origin/HEAD");
+    let contents = fs::read_to_string(&head_path).ok()?;
+    let trimmed = contents.trim();
+    let suffix = trimmed.strip_prefix("ref: ")?;
+    let branch = suffix.strip_prefix("refs/remotes/origin/")?;
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch.to_string())
+    }
 }
 
 /// Read `.git/HEAD` as a symbolic ref into `refs/heads/`, returning

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1324,7 +1324,10 @@ mod tests {
                 &machine_contract_coverage,
             )
             .to_string(),
-            machine_contract_coverage,
+            machine_contract_coverage:
+                crate::cli::commands::git_overlay_health::MachineContractCoverageBrief::from(
+                    &machine_contract_coverage,
+                ),
             workflow_status: "clean".to_string(),
             workflow_summary: "no ready threads are waiting to land".to_string(),
             summary: "Git merge is in progress".to_string(),

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -64,7 +64,12 @@ pub(crate) struct RepositoryVerificationState {
     pub default_remote: Option<String>,
     pub clone_verification: String,
     pub machine_contract: String,
-    pub machine_contract_coverage: MachineContractCoverage,
+    /// Slim per-status view of catalog coverage. Was the full
+    /// `MachineContractCoverage` block (~30 fields, ~6KB) prior to PR 5;
+    /// trimmed because agents polling `heddle status` paid that cost on
+    /// every call. The full breakdown remains available via
+    /// `heddle doctor schemas --output json`.
+    pub machine_contract_coverage: MachineContractCoverageBrief,
     pub workflow_status: String,
     pub workflow_summary: String,
     pub summary: String,
@@ -90,6 +95,31 @@ where
         serializer.serialize_none()
     } else {
         serializer.serialize_some(action)
+    }
+}
+
+/// Per-status slim view of `MachineContractCoverage`. Embedded in
+/// every `heddle status` JSON response, so the four fields here are
+/// the absolute minimum agents need to know whether the machine
+/// contract is healthy. For the full breakdown (catalog counts,
+/// schema coverage, examples), call `heddle doctor schemas`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub(crate) struct MachineContractCoverageBrief {
+    pub status: String,
+    #[serde(rename = "verified_scope")]
+    pub verified_scope: String,
+    pub advanced_scope: String,
+    pub summary: String,
+}
+
+impl From<&MachineContractCoverage> for MachineContractCoverageBrief {
+    fn from(coverage: &MachineContractCoverage) -> Self {
+        Self {
+            status: coverage.status.clone(),
+            verified_scope: coverage.verified_scope.clone(),
+            advanced_scope: coverage.advanced_scope.clone(),
+            summary: coverage.summary.clone(),
+        }
     }
 }
 
@@ -381,7 +411,7 @@ impl RepositoryVerificationState {
             default_remote: default_remote_name(repo),
             clone_verification,
             machine_contract: machine_contract_status(&machine_contract_coverage).to_string(),
-            machine_contract_coverage,
+            machine_contract_coverage: MachineContractCoverageBrief::from(&machine_contract_coverage),
             workflow_status,
             workflow_summary,
             summary,
@@ -572,33 +602,17 @@ fn machine_contract_verification_check(
     coverage: &MachineContractCoverage,
     action_plan: Option<&VerificationActionPlan>,
 ) -> VerificationCheck {
+    // The "Machine contract" check inside `git_overlay_health.checks[]`
+    // used to mirror the full 20+ field MachineContractCoverage as a
+    // string-keyed details map. Trimmed in PR 5 to four brief fields;
+    // the full breakdown is available from
+    // `heddle doctor schemas --output json`. Status calls pay ~1KB less
+    // per call now, agents lose nothing material — examples are still
+    // there for the failing-coverage case, and operators can still
+    // run `doctor schemas` when they need the deep view.
     let mut details = BTreeMap::new();
     details.insert("coverage_status".to_string(), coverage.status.clone());
     details.insert("coverage_summary".to_string(), coverage.summary.clone());
-    details.insert(
-        "catalog_commands_total".to_string(),
-        coverage.catalog_commands_total.to_string(),
-    );
-    details.insert(
-        "catalog_mutating_commands_total".to_string(),
-        coverage.catalog_mutating_commands_total.to_string(),
-    );
-    details.insert(
-        "json_commands_total".to_string(),
-        coverage.json_commands_total.to_string(),
-    );
-    details.insert(
-        "json_mutating_commands_total".to_string(),
-        coverage.json_mutating_commands_total.to_string(),
-    );
-    details.insert(
-        "json_commands_with_schema".to_string(),
-        coverage.json_commands_with_schema.to_string(),
-    );
-    details.insert(
-        "json_commands_without_schema".to_string(),
-        coverage.json_commands_without_schema.to_string(),
-    );
     details.insert(
         "verified_scope".to_string(),
         coverage.verified_scope.clone(),
@@ -607,86 +621,19 @@ fn machine_contract_verification_check(
         "advanced_scope".to_string(),
         coverage.advanced_scope.clone(),
     );
-    details.insert(
-        "verified_scope_json_commands_total".to_string(),
-        coverage.verified_scope_json_commands_total.to_string(),
-    );
-    details.insert(
-        "verified_scope_json_commands_without_schema".to_string(),
-        coverage
-            .verified_scope_json_commands_without_schema
-            .to_string(),
-    );
-    details.insert(
-        "verified_scope_json_commands_with_accepted_opaque_schema".to_string(),
-        coverage
-            .verified_scope_json_commands_with_accepted_opaque_schema
-            .to_string(),
-    );
-    details.insert(
-        "advanced_scope_json_commands_with_accepted_opaque_schema".to_string(),
-        coverage
-            .advanced_scope_json_commands_with_accepted_opaque_schema
-            .to_string(),
-    );
-    details.insert(
-        "mutating_commands_without_schema".to_string(),
-        coverage.mutating_commands_without_schema.to_string(),
-    );
-    details.insert(
-        "schema_verbs_total".to_string(),
-        coverage.schema_verbs_total.to_string(),
-    );
-    details.insert(
-        "documented_schema_verbs_total".to_string(),
-        coverage.documented_schema_verbs_total.to_string(),
-    );
-    details.insert(
-        "undocumented_schema_verbs_total".to_string(),
-        coverage.undocumented_schema_verbs_total.to_string(),
-    );
-    details.insert(
-        "supports_op_id_total".to_string(),
-        coverage.supports_op_id_total.to_string(),
-    );
+    // Examples are only useful on a failing coverage check; emit them
+    // there as a one-shot hint, but still skip the deep counts that
+    // belong in `doctor schemas`.
     if !coverage.missing_schema_examples.is_empty() {
         details.insert(
             "missing_schema_examples".to_string(),
             coverage.missing_schema_examples.join(", "),
         );
     }
-    if !coverage.missing_mutating_schema_examples.is_empty() {
-        details.insert(
-            "missing_mutating_schema_examples".to_string(),
-            coverage.missing_mutating_schema_examples.join(", "),
-        );
-    }
     if !coverage.verified_scope_missing_schema_examples.is_empty() {
         details.insert(
             "verified_scope_missing_schema_examples".to_string(),
             coverage.verified_scope_missing_schema_examples.join(", "),
-        );
-    }
-    if !coverage
-        .verified_scope_accepted_opaque_schema_examples
-        .is_empty()
-    {
-        details.insert(
-            "verified_scope_accepted_opaque_schema_examples".to_string(),
-            coverage
-                .verified_scope_accepted_opaque_schema_examples
-                .join(", "),
-        );
-    }
-    if !coverage
-        .advanced_scope_accepted_opaque_schema_examples
-        .is_empty()
-    {
-        details.insert(
-            "advanced_scope_accepted_opaque_schema_examples".to_string(),
-            coverage
-                .advanced_scope_accepted_opaque_schema_examples
-                .join(", "),
         );
     }
     if !coverage.undocumented_schema_examples.is_empty() {
@@ -1832,7 +1779,7 @@ pub(crate) fn build_plain_git_verification_probe(
         default_remote,
         clone_verification: "not_applicable".to_string(),
         machine_contract: machine_contract_status(&machine_contract_coverage).to_string(),
-        machine_contract_coverage,
+        machine_contract_coverage: MachineContractCoverageBrief::from(&machine_contract_coverage),
         workflow_status: "not_checked".to_string(),
         workflow_summary: "workflow readiness is checked after Heddle initialization".to_string(),
         summary: "Git repository has not been initialized for Heddle".to_string(),
@@ -3502,10 +3449,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        GitOverlayHealth, RepositoryVerificationState, VerificationActionPlan, action_argv,
-        canonical_bridge_import_ref_command, canonical_bridge_reconcile_ref_preview_command,
-        machine_contract_coverage, remote_drift_decision, remote_tracking_next_action,
-        repository_setup_guidance, repository_verification_blocked_advice,
+        GitOverlayHealth, MachineContractCoverageBrief, RepositoryVerificationState,
+        VerificationActionPlan, action_argv, canonical_bridge_import_ref_command,
+        canonical_bridge_reconcile_ref_preview_command, machine_contract_coverage,
+        remote_drift_decision, remote_tracking_next_action, repository_setup_guidance,
+        repository_verification_blocked_advice,
     };
     use crate::cli::commands::build_command_catalog;
 
@@ -3529,7 +3477,9 @@ mod tests {
             default_remote: None,
             clone_verification: "verified".to_string(),
             machine_contract: "verified".to_string(),
-            machine_contract_coverage: machine_contract_coverage(),
+            machine_contract_coverage: MachineContractCoverageBrief::from(
+                &machine_contract_coverage(),
+            ),
             workflow_status: "blocked".to_string(),
             workflow_summary: "Git and Heddle disagree".to_string(),
             summary: "Git and Heddle disagree".to_string(),

--- a/crates/cli/src/cli/commands/import_progress.rs
+++ b/crates/cli/src/cli/commands/import_progress.rs
@@ -38,6 +38,20 @@ impl ImportProgress {
         self.step(label);
     }
 
+    /// Print a sub-line beneath the current step. Useful when a phase
+    /// has a long-running operation users would otherwise read as a
+    /// hang — e.g. a network fetch during the hydrate step.
+    pub(crate) fn note(&self, message: &str) {
+        if !self.enabled {
+            return;
+        }
+        // Drop any in-flight \r-line first so the note doesn't overwrite it.
+        if io::stdout().is_terminal() {
+            println!();
+        }
+        println!("    {}", style::dim(&format!("· {message}")));
+    }
+
     pub(crate) fn finish(&mut self) {
         if !self.enabled {
             return;

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -682,7 +682,10 @@ mod tests {
             default_remote: Some("origin".to_string()),
             clone_verification: "not_applicable".to_string(),
             machine_contract: "available".to_string(),
-            machine_contract_coverage: machine_contract_coverage(),
+            machine_contract_coverage:
+                crate::cli::commands::git_overlay_health::MachineContractCoverageBrief::from(
+                    &machine_contract_coverage(),
+                ),
             workflow_status: "clean".to_string(),
             workflow_summary: "workflow fixture".to_string(),
             summary: "repository verification fixture".to_string(),

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1971,8 +1971,10 @@ pub struct RepositoryVerificationStateSchema {
     pub default_remote: Option<String>,
     pub clone_verification: String,
     pub machine_contract: String,
+    /// Slim per-status view. Full catalog breakdown is on
+    /// `heddle doctor schemas --output json`. See PR 5.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub machine_contract_coverage: Option<MachineContractCoverageSchema>,
+    pub machine_contract_coverage: Option<MachineContractCoverageBriefSchema>,
     pub workflow_status: String,
     pub workflow_summary: String,
     pub summary: String,
@@ -1985,63 +1987,23 @@ pub struct RepositoryVerificationStateSchema {
     pub checks: Vec<VerificationCheckSchema>,
 }
 
+/// Slim per-status view embedded in `heddle status`. The full
+/// breakdown (`MachineContractCoverageSchema`) is only emitted by
+/// `heddle doctor schemas`.
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct MachineContractCoverageSchema {
+pub struct MachineContractCoverageBriefSchema {
     pub status: String,
     #[serde(rename = "verified_scope")]
     pub verified_scope: String,
     pub advanced_scope: String,
     pub summary: String,
-    pub catalog_commands_total: usize,
-    pub catalog_mutating_commands_total: usize,
-    pub json_commands_total: usize,
-    pub json_mutating_commands_total: usize,
-    pub json_commands_with_schema: usize,
-    pub json_commands_with_accepted_opaque_schema: usize,
-    pub json_commands_without_schema: usize,
-    #[serde(rename = "verified_scope_json_commands_total")]
-    pub verified_scope_json_commands_total: usize,
-    #[serde(rename = "verified_scope_json_commands_with_schema")]
-    pub verified_scope_json_commands_with_schema: usize,
-    #[serde(rename = "verified_scope_json_commands_with_accepted_opaque_schema")]
-    pub verified_scope_json_commands_with_accepted_opaque_schema: usize,
-    #[serde(rename = "verified_scope_json_commands_without_schema")]
-    pub verified_scope_json_commands_without_schema: usize,
-    pub advanced_scope_json_commands_total: usize,
-    pub advanced_scope_json_commands_with_accepted_opaque_schema: usize,
-    pub mutating_commands_total: usize,
-    pub mutating_commands_with_schema: usize,
-    pub mutating_commands_with_accepted_opaque_schema: usize,
-    pub mutating_commands_without_schema: usize,
-    #[serde(rename = "verified_scope_mutating_commands_total")]
-    pub verified_scope_mutating_commands_total: usize,
-    #[serde(rename = "verified_scope_mutating_commands_with_schema")]
-    pub verified_scope_mutating_commands_with_schema: usize,
-    #[serde(rename = "verified_scope_mutating_commands_with_accepted_opaque_schema")]
-    pub verified_scope_mutating_commands_with_accepted_opaque_schema: usize,
-    #[serde(rename = "verified_scope_mutating_commands_without_schema")]
-    pub verified_scope_mutating_commands_without_schema: usize,
-    pub advanced_scope_mutating_commands_total: usize,
-    pub advanced_scope_mutating_commands_with_accepted_opaque_schema: usize,
-    pub schema_verbs_total: usize,
-    pub documented_schema_verbs_total: usize,
-    pub undocumented_schema_verbs_total: usize,
-    pub opaque_schema_verbs_total: usize,
-    pub accepted_opaque_schema_verbs_total: usize,
-    pub unaccepted_opaque_schema_verbs_total: usize,
-    pub supports_op_id_total: usize,
-    pub jsonl_commands_total: usize,
-    pub missing_schema_examples: Vec<String>,
-    pub missing_mutating_schema_examples: Vec<String>,
-    #[serde(rename = "verified_scope_missing_schema_examples")]
-    pub verified_scope_missing_schema_examples: Vec<String>,
-    #[serde(rename = "verified_scope_accepted_opaque_schema_examples")]
-    pub verified_scope_accepted_opaque_schema_examples: Vec<String>,
-    pub advanced_scope_accepted_opaque_schema_examples: Vec<String>,
-    pub accepted_opaque_schema_examples: Vec<String>,
-    pub unaccepted_opaque_schema_examples: Vec<String>,
-    pub undocumented_schema_examples: Vec<String>,
 }
+
+// MachineContractCoverageSchema (the heavy variant) used to live here
+// and shadow doctor_schemas' CommandContractSchemaCoverage. PR 5
+// trimmed status to the brief variant above and removed the dead
+// schema — `heddle doctor schemas --output json` remains the
+// canonical full-coverage surface.
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct VerificationCheckSchema {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -848,7 +848,10 @@ mod tests {
                 &machine_contract_coverage,
             )
             .to_string(),
-            machine_contract_coverage,
+            machine_contract_coverage:
+                crate::cli::commands::git_overlay_health::MachineContractCoverageBrief::from(
+                    &machine_contract_coverage,
+                ),
             summary: check.summary.clone(),
             workflow_status: "clean".to_string(),
             workflow_summary: "no workflow attention needed".to_string(),

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -337,8 +337,10 @@ Core nouns:
   provenance. States are what `log`, `show`, `diff`, `undo`, and agents can
   reason about.
 - Thread: a named line of work with its own checkout and captured history.
-  Use it for risky edits, agent work, or parallel experiments without stash
-  juggling.
+  Closer to `git worktree` than to `git branch` — every thread gets its own
+  directory on disk (default: a sibling of the repo), not a ref in your
+  existing checkout. Use one for risky edits, agent work, or parallel
+  experiments without stash juggling.
 - Capture: a cheap recoverable save point on the current thread.
 - Commit: the normal human save path. In native Heddle it saves the state; in a
   Git-overlay repo it saves the Heddle state and writes the matching Git

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -92,15 +92,28 @@ impl HeddleExitCode {
         // path. Keep these short and exact so they don't false-positive on
         // unrelated messages that happen to mention "no upstream".
         let msg = format!("{err:#}");
-        if msg.contains("no upstream configured")
-            || msg.contains("no remote configured")
-            || msg.contains("workspace config invalid")
-            || msg.contains("repository not found")
+        let msg_lower = msg.to_ascii_lowercase();
+        if msg_lower.contains("no upstream configured")
+            || msg_lower.contains("no remote configured")
+            || msg_lower.contains("no default remote")
+            || msg_lower.contains("workspace config invalid")
+            || msg_lower.contains("repository not found")
         {
             return Self::Config;
         }
-        if msg.contains("dirty worktree") {
+        if msg_lower.contains("dirty worktree") || msg_lower.contains("shallow git repository") {
             return Self::DataErr;
+        }
+        // gix transport / network errors surface as plain anyhow strings
+        // rather than typed std::io::Error in the chain — match the
+        // phrasings gix produces so an agent can branch on TempFail.
+        if msg_lower.contains("receive-pack handshake failed")
+            || msg_lower.contains("upload-pack handshake failed")
+            || msg_lower.contains("could not connect to remote")
+            || msg_lower.contains("connection reset by peer")
+            || msg_lower.contains("temporary failure in name resolution")
+        {
+            return Self::TempFail;
         }
 
         Self::IoErr
@@ -150,6 +163,32 @@ mod tests {
     fn missing_repo_string_sentinel_is_config() {
         let err = anyhow::anyhow!("repository not found at /tmp/whatever");
         assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn no_default_remote_is_config() {
+        let err = anyhow::anyhow!("No default remote is configured for push");
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn shallow_git_is_data_err() {
+        let err = anyhow::anyhow!("Shallow Git repository cannot be imported");
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
+    fn gix_transport_handshake_is_tempfail() {
+        let err = anyhow::anyhow!(
+            "git error: receive-pack handshake failed for https://example.com/repo.git: connection refused"
+        );
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::TempFail);
+    }
+
+    #[test]
+    fn dns_failure_is_tempfail() {
+        let err = anyhow::anyhow!("git fetch failed: Temporary failure in name resolution");
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::TempFail);
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/agent_api_schema.json
+++ b/crates/cli/tests/snapshots/agent_api_schema.json
@@ -118,134 +118,11 @@
         ],
         "type": "object"
       },
-      "MachineContractCoverage": {
+      "MachineContractCoverageBrief": {
+        "description": "Per-status slim view of `MachineContractCoverage`. Embedded in every `heddle status` JSON response, so the four fields here are the absolute minimum agents need to know whether the machine contract is healthy. For the full breakdown (catalog counts, schema coverage, examples), call `heddle doctor schemas`.",
         "properties": {
-          "accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "accepted_opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
           "advanced_scope": {
             "type": "string"
-          },
-          "advanced_scope_accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "advanced_scope_json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "catalog_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "catalog_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "documented_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "jsonl_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "missing_mutating_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "missing_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
           },
           "status": {
             "type": "string"
@@ -253,133 +130,15 @@
           "summary": {
             "type": "string"
           },
-          "supports_op_id_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "unaccepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "unaccepted_opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "undocumented_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "undocumented_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
           "verified_scope": {
             "type": "string"
-          },
-          "verified_scope_accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "verified_scope_json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_missing_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "verified_scope_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
           }
         },
         "required": [
-          "accepted_opaque_schema_examples",
-          "accepted_opaque_schema_verbs_total",
           "advanced_scope",
-          "advanced_scope_accepted_opaque_schema_examples",
-          "advanced_scope_json_commands_total",
-          "advanced_scope_json_commands_with_accepted_opaque_schema",
-          "advanced_scope_mutating_commands_total",
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-          "catalog_commands_total",
-          "catalog_mutating_commands_total",
-          "documented_schema_verbs_total",
-          "json_commands_total",
-          "json_commands_with_accepted_opaque_schema",
-          "json_commands_with_schema",
-          "json_commands_without_schema",
-          "json_mutating_commands_total",
-          "jsonl_commands_total",
-          "missing_mutating_schema_examples",
-          "missing_schema_examples",
-          "mutating_commands_total",
-          "mutating_commands_with_accepted_opaque_schema",
-          "mutating_commands_with_schema",
-          "mutating_commands_without_schema",
-          "opaque_schema_verbs_total",
-          "schema_verbs_total",
           "status",
           "summary",
-          "supports_op_id_total",
-          "unaccepted_opaque_schema_examples",
-          "unaccepted_opaque_schema_verbs_total",
-          "undocumented_schema_examples",
-          "undocumented_schema_verbs_total",
-          "verified_scope",
-          "verified_scope_accepted_opaque_schema_examples",
-          "verified_scope_json_commands_total",
-          "verified_scope_json_commands_with_accepted_opaque_schema",
-          "verified_scope_json_commands_with_schema",
-          "verified_scope_json_commands_without_schema",
-          "verified_scope_missing_schema_examples",
-          "verified_scope_mutating_commands_total",
-          "verified_scope_mutating_commands_with_accepted_opaque_schema",
-          "verified_scope_mutating_commands_with_schema",
-          "verified_scope_mutating_commands_without_schema"
+          "verified_scope"
         ],
         "type": "object"
       },
@@ -428,7 +187,12 @@
             "type": "string"
           },
           "machine_contract_coverage": {
-            "$ref": "#/definitions/MachineContractCoverage"
+            "allOf": [
+              {
+                "$ref": "#/definitions/MachineContractCoverageBrief"
+              }
+            ],
+            "description": "Slim per-status view of catalog coverage. Was the full `MachineContractCoverage` block (~30 fields, ~6KB) prior to PR 5; trimmed because agents polling `heddle status` paid that cost on every call. The full breakdown remains available via `heddle doctor schemas --output json`."
           },
           "mapping_state": {
             "type": "string"
@@ -744,134 +508,11 @@
         ],
         "type": "object"
       },
-      "MachineContractCoverage": {
+      "MachineContractCoverageBrief": {
+        "description": "Per-status slim view of `MachineContractCoverage`. Embedded in every `heddle status` JSON response, so the four fields here are the absolute minimum agents need to know whether the machine contract is healthy. For the full breakdown (catalog counts, schema coverage, examples), call `heddle doctor schemas`.",
         "properties": {
-          "accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "accepted_opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
           "advanced_scope": {
             "type": "string"
-          },
-          "advanced_scope_accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "advanced_scope_json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "catalog_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "catalog_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "documented_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "json_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "jsonl_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "missing_mutating_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "missing_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "mutating_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
           },
           "status": {
             "type": "string"
@@ -879,133 +520,15 @@
           "summary": {
             "type": "string"
           },
-          "supports_op_id_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "unaccepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "unaccepted_opaque_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "undocumented_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "undocumented_schema_verbs_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
           "verified_scope": {
             "type": "string"
-          },
-          "verified_scope_accepted_opaque_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "verified_scope_json_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_json_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_missing_schema_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "verified_scope_mutating_commands_total": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_with_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
-          },
-          "verified_scope_mutating_commands_without_schema": {
-            "format": "uint",
-            "minimum": 0.0,
-            "type": "integer"
           }
         },
         "required": [
-          "accepted_opaque_schema_examples",
-          "accepted_opaque_schema_verbs_total",
           "advanced_scope",
-          "advanced_scope_accepted_opaque_schema_examples",
-          "advanced_scope_json_commands_total",
-          "advanced_scope_json_commands_with_accepted_opaque_schema",
-          "advanced_scope_mutating_commands_total",
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-          "catalog_commands_total",
-          "catalog_mutating_commands_total",
-          "documented_schema_verbs_total",
-          "json_commands_total",
-          "json_commands_with_accepted_opaque_schema",
-          "json_commands_with_schema",
-          "json_commands_without_schema",
-          "json_mutating_commands_total",
-          "jsonl_commands_total",
-          "missing_mutating_schema_examples",
-          "missing_schema_examples",
-          "mutating_commands_total",
-          "mutating_commands_with_accepted_opaque_schema",
-          "mutating_commands_with_schema",
-          "mutating_commands_without_schema",
-          "opaque_schema_verbs_total",
-          "schema_verbs_total",
           "status",
           "summary",
-          "supports_op_id_total",
-          "unaccepted_opaque_schema_examples",
-          "unaccepted_opaque_schema_verbs_total",
-          "undocumented_schema_examples",
-          "undocumented_schema_verbs_total",
-          "verified_scope",
-          "verified_scope_accepted_opaque_schema_examples",
-          "verified_scope_json_commands_total",
-          "verified_scope_json_commands_with_accepted_opaque_schema",
-          "verified_scope_json_commands_with_schema",
-          "verified_scope_json_commands_without_schema",
-          "verified_scope_missing_schema_examples",
-          "verified_scope_mutating_commands_total",
-          "verified_scope_mutating_commands_with_accepted_opaque_schema",
-          "verified_scope_mutating_commands_with_schema",
-          "verified_scope_mutating_commands_without_schema"
+          "verified_scope"
         ],
         "type": "object"
       },
@@ -1054,7 +577,12 @@
             "type": "string"
           },
           "machine_contract_coverage": {
-            "$ref": "#/definitions/MachineContractCoverage"
+            "allOf": [
+              {
+                "$ref": "#/definitions/MachineContractCoverageBrief"
+              }
+            ],
+            "description": "Slim per-status view of catalog coverage. Was the full `MachineContractCoverage` block (~30 fields, ~6KB) prior to PR 5; trimmed because agents polling `heddle status` paid that cost on every call. The full breakdown remains available via `heddle doctor schemas --output json`."
           },
           "mapping_state": {
             "type": "string"


### PR DESCRIPTION
## Position in stack

**Base:** PR 4/4 (`codex/oss-improvements-4-polish`) — #247
**Merges first to:** TOP — this is the final PR in the stack.

## Sibling PRs

- PR 1/4 — Contract foundation: #244
- PR 2/4 — Typed transfer JSON: #245
- PR 3/4 — Action surface centralization: #246
- PR 4/4 — Ignore policy + exit codes + stdout/stderr lint: #247

## Summary

Follow-up to the 4-PR stack, driven by a fresh 3-persona UX review (average AI dev, AI agent, 20-year Git veteran) exercising the binary against ripgrep and a small fixture repo. Findings drove 5 focused commits — each commit is a real, validated UX cliff or correctness drift caught during the review.

## Findings → fixes

| Persona finding | Fix | Commit |
| --- | --- | --- |
| **\`heddle adopt\` runs for 2m26s on a shallow clone before discovering it can't import** — the network-bound \`hydrate_checkout_heddle_notes_from_configured_remotes\` fires before the shallow check | Shallow detect moves to adopt preflight. Adds a \`note(...)\` progress sub-line so users see *why* the network step is happening. Adds \`info_span!\` instrumentation in \`adopt.hydrate_notes\`, \`adopt.import\`, and \`git_import.with_ref_filter\` so future regressions are profile-visible | \`b096b58\` |
| **\`push\` declares exit 78 (\"no upstream\") but actually returns 74** — \`from_error\` sentinel was \`\"no remote configured\"\`, real message is \`\"No default remote is configured\"\`. **gix transport errors** (handshake failed, connection refused, DNS) all returned 74 instead of 75 (TempFail), breaking agent retry semantics | Sentinel matching lowercased and broadened: \`no default remote\` → Config, \`shallow git repository\` → DataErr, plus 5 new gix transport sentinels → TempFail. Adds 4 unit tests (now 11 total). \`--depth\` help text now warns it's not yet supported for Git-overlay clones | \`06ada87\` |
| **Maria expected \`heddle start <name>\` to create a Git branch** — actually creates a Heddle-managed sibling directory. The model help didn't say this; \`--workspace materialized\` help reads \"real checkout on disk\" which compounded the confusion | One line added to \`heddle help model\`: threads are like \`git worktree\`, not \`git branch\` — every thread gets its own directory on disk | \`63b2c28\` |
| **\`heddle clone\` of a multi-branch repo attached to a Dependabot branch** — \`select_clone_thread\` fell through to alphabetical pick instead of using the remote's stated default | Resolves remote default from \`refs/remotes/origin/HEAD\` (set by gix during fetch handshake). Falls back through \`main\` → \`master\` → \`trunk\` before alphabetical. Verified on bine: was \`dependabot/...\`, now \`master\` | \`2b554fc\` |
| **Every \`heddle status\` JSON call carried ~1.6KB of \`machine_contract_coverage\` stats** — 30+ fields duplicated across the top-level \`verification\` block and the \`Machine contract\` check inside \`checks[]\` | \`MachineContractCoverageBrief\` (4 fields: status, verified_scope, advanced_scope, summary) replaces the heavy struct in status. \`Machine contract\` check's details map trims from 20+ fields to 4 + examples-on-failure. Full breakdown remains available via \`heddle doctor schemas --output json\` | \`ab9f890\` |

## Benchmarks

| Operation | Before PR 5 | After PR 5 |
| --- | ---: | ---: |
| \`heddle adopt\` on shallow ripgrep (failure case) | **2m 26s** | **29ms** (~5000× faster) |
| \`heddle adopt\` on bine (76 commits, full clone) | 17s | 17s (no perf regression; tracing spans added for future tuning) |
| \`heddle status --output json\` | ~8.0KB | ~6.4KB (-20%) |
| \`agent_api_schema.json\` snapshot | 4124 lines | 3633 lines (-490 / -12%) |
| Per-command \`Machine contract\` check details | 1219 bytes | 414 bytes (-66%) |
| Exit code unit tests | 7 | 11 |

## Contract changes introduced

- **\`MachineContractCoverageBrief\`** (new) — used in \`RepositoryVerificationState.machine_contract_coverage\`. Full \`MachineContractCoverageSchema\` removed (dead type; was shadowing \`CommandContractSchemaCoverage\` in \`doctor schemas\`).
- **Exit codes now correctly emit:** Config (78) for no-default-remote and missing-repo; DataErr (65) for shallow git; TempFail (75) for gix transport errors.
- **\`heddle clone\`** attaches to the remote's HEAD branch, not alphabetically.
- **\`heddle adopt\`** errors at startup on shallow repos; emits a \`note\` sub-line during the hydrate network step.

## Deferred (mentioned for future PRs)

- **Op-id persistence layer**: 103 commands declare \`supports_op_id: true\` but \`persists_op_id: false\` on every command. Agents that supply an op-id get \`replayed: false\` on retry. Real feature work, not a fix.
- **Per-commit progress count during adopt**: tracing spans now make the cost measurable, but the human-facing \`[2/3] importing commits\` line stays for 5+ minutes on 2k+-commit repos with no per-commit counter. Suggested follow-up: pipe \`importer.set_progress_callback(|n, total| ...)\` into \`ImportProgress\` and update at most every N commits.
- **Per-command progress for the hydrate fetch itself**: currently we just emit the \`note(...)\` line — no progress dots. Reasonable for now since hydrate completes in <30s on most repos, but a slow-network case would still look hung.
- **Lazy/shallow adoption support** — see the design answer in the PR conversation below.

## How to verify locally

\`\`\`bash
cargo check --workspace
cargo test -p heddle-cli --lib exit::        # 11 passing
cargo test -p heddle-cli --test cli_integration -- exit_codes_ stdout_stderr_split
cargo test -p heddle-cli --test agent_api_schema

# Real adopt benchmark:
git clone --depth 5 https://github.com/BurntSushi/ripgrep.git /tmp/rg-shallow
cd /tmp/rg-shallow
time heddle adopt   # should be ~30ms with a clear shallow error
\`\`\`

## Note

Built on top of PR 4. This PR is a slice of the \`codex/oss-improvements\` workstream; the full narrative is preserved in commit-level history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782357443&installation_id=132405951&pr_number=248&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F248&signature=c62e2fa95bd56ca9ffa72d203fa253e6f1ca9e54e6009e5a268e9c69c1f282f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->