### PR TITLE
OSS improvements (7): pack-batch blob+tree writes during adopt (-31-43%)

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -565,6 +565,10 @@ fn import_with_ref_filter(
                 &mut stats,
             )?;
         }
+        // Flush the importer's pending blob writes as a single
+        // packfile. Buffering them turns N per-blob fsyncs into
+        // one — measured ~900ms saved on a 76-commit import (bine).
+        tree_importer.flush_pending_writes()?;
         Ok(())
     })();
     drop(_ancestry_span);

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -15,6 +15,12 @@ pub struct GitTreeImporter<'a> {
     repo: &'a gix::Repository,
     tree_cache: HashMap<gix::hash::ObjectId, ContentHash>,
     blob_cache: HashMap<gix::hash::ObjectId, ContentHash>,
+    /// Blobs and trees to write at flush time. Buffering them turns
+    /// N `put_blob` / `put_tree` syscalls (one fsync each, ~3.6ms on
+    /// Linux ext4) into one `put_*_packed` pack file each (one fsync
+    /// per pack). Empty unless `flush_pending_writes` has yet to run.
+    pending_blobs: Vec<(ContentHash, Vec<u8>)>,
+    pending_trees: Vec<(ContentHash, Vec<u8>)>,
 }
 
 impl<'a> GitTreeImporter<'a> {
@@ -24,7 +30,30 @@ impl<'a> GitTreeImporter<'a> {
             repo,
             tree_cache: HashMap::new(),
             blob_cache: HashMap::new(),
+            pending_blobs: Vec::new(),
+            pending_trees: Vec::new(),
         }
+    }
+
+    /// Persist any buffered blob/tree writes as packs. MUST be called
+    /// before the importer is dropped, otherwise objects referenced
+    /// by imported states won't actually exist in the store.
+    pub fn flush_pending_writes(&mut self) -> GitResult<()> {
+        if !self.pending_blobs.is_empty() {
+            let batch = std::mem::take(&mut self.pending_blobs);
+            self.heddle_repo
+                .store()
+                .put_blobs_packed(batch)
+                .map_err(|e| GitBridgeError::Git(format!("flush packed blobs: {e}")))?;
+        }
+        if !self.pending_trees.is_empty() {
+            let batch = std::mem::take(&mut self.pending_trees);
+            self.heddle_repo
+                .store()
+                .put_trees_packed(batch)
+                .map_err(|e| GitBridgeError::Git(format!("flush packed trees: {e}")))?;
+        }
+        Ok(())
     }
 
     pub fn import_tree(&mut self, tree_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
@@ -101,7 +130,14 @@ impl<'a> GitTreeImporter<'a> {
         }
 
         let tree = Tree::from_entries(entries);
-        let hash = self.heddle_repo.store().put_tree(&tree)?;
+        let hash = tree.hash();
+        // Defer the disk write. `Tree::hash` is a pure function of
+        // entries, so the hash is stable now; callers needing the
+        // tree to actually be on disk must invoke
+        // `flush_pending_writes`.
+        let serialized = rmp_serde::to_vec(&tree)
+            .map_err(|e| GitBridgeError::Git(format!("rmp encode tree: {e}")))?;
+        self.pending_trees.push((hash, serialized));
         self.tree_cache.insert(tree_oid, hash);
         Ok(hash)
     }
@@ -116,8 +152,14 @@ impl<'a> GitTreeImporter<'a> {
             .find_blob(blob_oid)
             .map_err(|err| GitBridgeError::Git(err.to_string()))?;
 
-        let heddle_blob = Blob::new(blob.take_data());
-        let hash = self.heddle_repo.store().put_blob(&heddle_blob)?;
+        let data = blob.take_data();
+        let heddle_blob = Blob::from_slice(&data);
+        let hash = heddle_blob.hash();
+        // Defer the actual disk write — caller MUST call
+        // `flush_pending_writes` before relying on the blob being
+        // present. The hash is stable now because Blob's hash is a
+        // pure function of bytes.
+        self.pending_blobs.push((hash, data));
         self.blob_cache.insert(blob_oid, hash);
         Ok(hash)
     }
@@ -127,18 +169,27 @@ impl<'a> GitTreeImporter<'a> {
             return Ok(*hash);
         }
 
-        let blob = Blob::new(format!("{} {}", SUBMODULE_PREFIX, oid).into_bytes());
-        let hash = self.heddle_repo.store().put_blob(&blob)?;
+        let data = format!("{} {}", SUBMODULE_PREFIX, oid).into_bytes();
+        let blob = Blob::from_slice(&data);
+        let hash = blob.hash();
+        self.pending_blobs.push((hash, data));
         self.blob_cache.insert(oid, hash);
         Ok(hash)
     }
 }
 
-/// Import a Git tree as a Heddle tree.
+/// Import a Git tree as a Heddle tree. Convenience wrapper: persists
+/// blobs and trees before returning. Long-running callers should
+/// instead instantiate [`GitTreeImporter`] directly and call
+/// [`GitTreeImporter::flush_pending_writes`] once at the end of the
+/// import to batch the writes into a single packfile.
 pub fn import_git_tree(
     heddle_repo: &HeddleRepository,
     repo: &gix::Repository,
     tree_oid: gix::hash::ObjectId,
 ) -> GitResult<ContentHash> {
-    GitTreeImporter::new(heddle_repo, repo).import_tree(tree_oid)
+    let mut importer = GitTreeImporter::new(heddle_repo, repo);
+    let hash = importer.import_tree(tree_oid)?;
+    importer.flush_pending_writes()?;
+    Ok(hash)
 }

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -880,6 +880,11 @@ impl ObjectStore for FsStore {
         self.put_blobs_packed_impl(blobs)
     }
 
+    #[instrument(skip(self, trees), fields(count = trees.len()))]
+    fn put_trees_packed(&self, trees: Vec<(crate::object::ContentHash, Vec<u8>)>) -> Result<()> {
+        self.put_trees_packed_impl(trees)
+    }
+
     #[instrument(skip(self))]
     fn install_pack_streaming(
         &self,

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -75,6 +75,44 @@ impl FsStore {
         Ok(())
     }
 
+    /// Trees analogue of [`put_blobs_packed_impl`]. Each tree is
+    /// supplied as its pre-serialized rmp bytes (the caller is
+    /// expected to have built it via `rmp_serde::to_vec(&tree)` and
+    /// computed its hash via `Tree::hash()`). Used by the git-import
+    /// hot path to coalesce N tree writes into one pack install.
+    pub(super) fn put_trees_packed_impl(
+        &self,
+        trees: Vec<(ContentHash, Vec<u8>)>,
+    ) -> Result<()> {
+        if trees.is_empty() {
+            return Ok(());
+        }
+        let mut compression = self.compression;
+        compression.max_delta_size = 0;
+        let mut builder = PackBuilder::new(compression);
+        let mut staged: Vec<(ContentHash, Vec<u8>)> = Vec::with_capacity(trees.len());
+        for (hash, data) in trees {
+            if ObjectStore::has_tree(self, &hash)? {
+                continue;
+            }
+            staged.push((hash, data.clone()));
+            builder.add(hash, PackObjectType::Tree, data);
+        }
+        if staged.is_empty() {
+            return Ok(());
+        }
+        let (pack_data, index_data, _stats) = builder.build()?;
+        self.install_pack_files(&pack_data, &index_data)?;
+        if let Ok(mut cache) = self.recent_trees.write() {
+            for (hash, data) in staged {
+                let tree: crate::object::Tree = rmp_serde::from_slice(&data)
+                    .map_err(|e| HeddleError::Config(format!("rmp decode tree: {e}")))?;
+                cache.insert(hash, tree);
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn pack_objects_impl(&self, _aggressive: bool) -> Result<(u64, u64)> {
         let blobs = list_hashes_from_dir(&blobs_dir(&self.root))?;
         let trees = list_hashes_from_dir(&trees_dir(&self.root))?;

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -127,6 +127,9 @@ impl ObjectStore for SharedStore {
     fn put_blobs_packed(&self, blobs: Vec<(ContentHash, Vec<u8>)>) -> Result<()> {
         self.0.put_blobs_packed(blobs)
     }
+    fn put_trees_packed(&self, trees: Vec<(ContentHash, Vec<u8>)>) -> Result<()> {
+        self.0.put_trees_packed(trees)
+    }
     fn begin_snapshot_write_batch(&self) -> Result<()> {
         self.0.begin_snapshot_write_batch()
     }
@@ -370,6 +373,25 @@ pub trait ObjectStore: Send + Sync {
         for (hash, data) in blobs {
             if !self.has_blob(&hash)? {
                 self.put_blob_bytes_with_hash(&data, hash)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Trees analogue of [`put_blobs_packed`]. Backends with native
+    /// pack support coalesce N tree writes into one fsync-pair (one
+    /// for `.pack`, one for `.idx`). Default impl falls through to
+    /// per-tree writes via `put_tree_serialized` so backends without
+    /// pack support still satisfy the contract.
+    ///
+    /// Trees are supplied as pre-serialized rmp bytes plus the
+    /// pre-computed `Tree::hash()`. The caller is responsible for the
+    /// (hash, bytes) round-trip — backends will validate corruption
+    /// the same way `put_tree_serialized` does.
+    fn put_trees_packed(&self, trees: Vec<(ContentHash, Vec<u8>)>) -> Result<()> {
+        for (hash, data) in trees {
+            if !self.has_tree(&hash)? {
+                self.put_tree_serialized(&data, hash)?;
             }
         }
         Ok(())


### PR DESCRIPTION
## Position in stack

**Base:** PR 6 (`codex/oss-improvements-6-clone-head-and-adopt-perf`) — #249
**Merges first to:** TOP — this is the latest PR in the stack.

## Sibling PRs

- PR 1/4 — Contract foundation: #244
- PR 2/4 — Typed transfer JSON: #245
- PR 3/4 — Action surface centralization: #246
- PR 4/4 — Ignore policy + exit codes + stdout/stderr lint: #247
- PR 5 — Persona-review follow-up: #248
- PR 6 — Clone HEAD detection + adopt perf (4-100x): #249

## Summary

Drives Heddle's per-commit import cost from **25ms → ~14ms** by collapsing N per-blob and N per-tree fsyncs into two pack-file installs (one fsync pair each).

## How we got here

PR 6 pulled adopt down from 14.2s to 3.95s on bine (and from 5+min-killed to 56s on ripgrep) by attacking the network + bulk-copy paths. After PR 6, the remaining cost was \"the actual Heddle-side conversion\" — 25ms per commit on ripgrep, 30ms on bine.

Per-commit profile (bine, before this PR):

| Stage | avg | total | % |
|---|---:|---:|---:|
| `meta` (gix commit + author parse) | 251µs | 18ms | 0.8% |
| `identity` (mapping/note/trailer) | 458µs | 33ms | 1.5% |
| **`tree` (import_tree recursion)** | **27,479µs** | **2,006ms** | **91.5%** |
| `put_state` | 1,833µs | 134ms | 6.1% |

Drilling into the `tree` bucket:

| Sub-step | total | n | per-call |
|---|---:|---:|---:|
| tree_cache hits | — | 355 | (cache works) |
| tree_cache misses | — | 246 | full walk |
| blob_cache hits | — | 606 | (cache works) |
| blob_cache misses | — | 274 | full read |
| `find_tree` | 11ms | 246 | 45µs |
| `find_blob` | 510ms | 274 | 1.9ms |
| **`put_blob`** | **982ms** | **274** | **3.6ms** ← fsync-per-blob |
| **`put_tree`** | **463ms** | **246** | **1.9ms** ← fsync-per-tree |
| `iter` (walk + recursive payload) | 4,562ms | — | — |

The hot path was not the walk itself — it was the **fsync-per-object** in `write_loose_object_atomic`. `BatchDirectorySync` mode (already in use during snapshot batches) defers the *directory* sync but still calls `file.sync_data()` per write — and a 3.6ms fsync × 274 blobs is just \"slow disk lights up.\"

Heddle already had the right primitive for blobs (`put_blobs_packed` — installs one `.pack`+`.idx` pair with one fsync pair regardless of object count, used by the snapshot hot path). Just nobody was calling it from import.

## What this PR does

- **`ObjectStore::put_trees_packed`** — trees analogue, defaults to per-tree writes for backends without native pack support so the trait stays backend-portable.
- **`FsStore::put_trees_packed_impl`** — real implementation in `crates/objects/src/store/fs/fs_pack.rs`, mirrors `put_blobs_packed_impl` exactly (skips already-present trees, builds a single `PackBuilder` with `PackObjectType::Tree`, installs once).
- **`GitTreeImporter` buffers `(hash, bytes)` for both blobs and trees** instead of writing them immediately. `Tree::hash()` is a pure function of entries and `Blob::hash()` is a pure function of bytes, so the hashes returned to callers are stable even before disk persistence.
- **`GitTreeImporter::flush_pending_writes()`** — new method that does the two pack installs. `import_with_ref_filter` calls it after the ancestry walk completes, before the mapping write. The standalone `import_git_tree` helper flushes internally so its single-shot contract is unchanged (one regression test relied on that).

## Benchmarks

| Repo | Commits | Before PR 6 | After PR 6 | **After PR 7** |
|---|---:|---:|---:|---:|
| Tiny 3-commit repo | 3 | <1s | 123ms | **~120ms** (no change; fsync amortization doesn't help here) |
| `cretz/bine` (full clone) | 76 | 14.21s | 3.95s | **2.71s** (-31%) |
| `BurntSushi/ripgrep` (full clone) | 2,209 | >5 min killed | 56s | **31.8s** (-43%) |
| Implied per-commit on ripgrep | — | — | 25ms | **14ms** |

## What's left

The remaining 14ms/commit on a large repo is:

- gix tree iteration + entry construction + the recursive descent (the ~2.6s \"intrinsic\" iter time on bine after subtracting recursive payloads). To push this further we'd need either bulk tree decoding (gix doesn't expose this today) or a smarter cache strategy that recognises unchanged subtrees from the parent commit's structure without descending — a real refactor of `GitTreeImporter`, not a one-PR fix.
- `put_state` is still per-commit (~1.8ms × N). The state objects are tiny but pay one fsync each. A `put_states_packed` would buy another 0-15% depending on disk; smaller win than blobs/trees.

## Verification

```bash
cargo check --workspace
cargo test -p heddle-cli --lib
cargo test -p heddle-objects --lib

# End-to-end on bine:
git clone https://github.com/cretz/bine.git /tmp/bine-perf
cd /tmp/bine-perf
heddle init && time heddle adopt
heddle verify  # should print 'Workspace verified'
heddle log     # should show all 76 commits

# Profile:
HEDDLE_LOG_SPANS=1 RUST_LOG=cli=info heddle adopt 2>&1 | grep time.busy
```

## Note

This PR is a slice of the `codex/oss-improvements` workstream. Stack: PR 1 → PR 2 → PR 3 → PR 4 → PR 5 → PR 6 → PR 7. The full narrative is preserved in commit-level history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782361147&installation_id=132405951&pr_number=250&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F250&signature=77d1897c816edd6a1dac9624c1e59cd3e484c79172c61b23f16f50a5764c0537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->