### PR TITLE
heddle#271: remove OutputMode::Auto — eliminate JSON-when-piped surprise

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -289,7 +289,7 @@ impl UserConfig {
             let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
             objects::error::HeddleError::ConfigParse {
                 path: resolved,
-                message: err.to_string(),
+                source: err,
             }
             .into()
         })

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -278,7 +278,14 @@ impl UserConfig {
         let mut file = fs::File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        Ok(toml::from_str(&contents)?)
+        // Route TOML parse failures through `HeddleError::Config` so the
+        // CLI error envelope (see `print_error_with_hint`) can classify
+        // them by substring — same path the repo-config loader uses.
+        // Without this wrap, a global `output.format = "auto"` (the
+        // exact regression #271 closed for repo configs) would surface
+        // as a raw `toml::de::Error` and bypass the typed `Next:` envelope.
+        toml::from_str::<Self>(&contents)
+            .map_err(|err| objects::error::HeddleError::Config(err.to_string()).into())
     }
 
     pub fn load_default() -> anyhow::Result<Self> {

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -278,14 +278,21 @@ impl UserConfig {
         let mut file = fs::File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        // Route TOML parse failures through `HeddleError::Config` so the
-        // CLI error envelope (see `print_error_with_hint`) can classify
-        // them by substring — same path the repo-config loader uses.
-        // Without this wrap, a global `output.format = "auto"` (the
-        // exact regression #271 closed for repo configs) would surface
-        // as a raw `toml::de::Error` and bypass the typed `Next:` envelope.
-        toml::from_str::<Self>(&contents)
-            .map_err(|err| objects::error::HeddleError::Config(err.to_string()).into())
+        // Route TOML parse failures through `HeddleError::ConfigParse` so
+        // the CLI error envelope (see `print_error_with_hint`) can
+        // classify them and render the *actual* source file in the
+        // recovery advice — not a hard-coded `.heddle/config.toml`
+        // (Codex R3 cid 3313132711 on #271). The path is canonicalized
+        // so the rendered hint is copy/paste-safe even when the caller
+        // passed a relative or env-derived path.
+        toml::from_str::<Self>(&contents).map_err(|err| {
+            let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            objects::error::HeddleError::ConfigParse {
+                path: resolved,
+                message: err.to_string(),
+            }
+            .into()
+        })
     }
 
     pub fn load_default() -> anyhow::Result<Self> {

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -108,6 +108,21 @@ pub fn print_error_with_hint(cli: &Cli, err: &anyhow::Error) {
     }
 }
 
+/// Pull the `invalid output.format: '<value>' — ...` sentence out of a
+/// multi-line toml-parser error so the user-facing envelope stays
+/// focused on the field name, the bad value, and the valid set. The
+/// surrounding `TOML parse error at line ...` framing is dropped because
+/// the `Next:` line names the recovery step and the JSON envelope
+/// carries the structured fields.
+fn extract_invalid_output_format_message(raw: &str) -> String {
+    raw.lines()
+        .rev()
+        .map(|line| line.trim())
+        .find(|line| line.starts_with("invalid output.format"))
+        .map(|line| line.to_string())
+        .unwrap_or_else(|| raw.to_string())
+}
+
 fn compact_dirty_worktree_condition(condition: &str) -> String {
     const PREFIX: &str = "unsaved worktree path(s): ";
     let Some(paths) = condition.strip_prefix(PREFIX) else {
@@ -395,6 +410,34 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
                 return ErrorClassification::from_advice(&advice);
             }
         if let Some(heddle_err) = cause.downcast_ref::<HeddleError>() {
+            // `output.format = "auto"` is rejected at config-parse time by
+            // the hand-rolled `OutputFormat` deserializer (see
+            // `crates/repo/src/repo_config.rs`). The error string carries
+            // the field-and-value contract; we match on it here so the
+            // user gets a typed `Next:` envelope instead of a generic
+            // runtime fallback.
+            if let HeddleError::Config(message) = heddle_err
+                && message.contains("invalid output.format")
+            {
+                return ErrorClassification {
+                    kind: "invalid_repo_config_output_format".to_string(),
+                    human_error: Some(extract_invalid_output_format_message(message)),
+                    hint: "Edit `.heddle/config.toml` and set `output.format` to `text` or `json`."
+                        .to_string(),
+                    unsafe_condition:
+                        "repository configuration declares an unknown output.format value"
+                            .to_string(),
+                    would_change:
+                        "the requested command did not run because Heddle could not load the repository config"
+                            .to_string(),
+                    preserved:
+                        "no repository objects, refs, metadata, or worktree files were changed"
+                            .to_string(),
+                    primary_command: "heddle status".to_string(),
+                    recovery_commands: vec!["heddle status".to_string()],
+                    extra_json_fields: serde_json::Map::new(),
+                };
+            }
             match heddle_err {
                 HeddleError::RepositoryNotFound(path) => {
                     let command =

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -420,15 +420,16 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
             // `$HOME/.config/heddle/config.toml`, or the repo's
             // `.heddle/config.toml`) — not a hard-coded path that may
             // not be the one that produced the failure (Codex R3 on #271).
-            if let HeddleError::ConfigParse { path, message } = heddle_err
-                && message.contains("invalid output.format")
+            if let HeddleError::ConfigParse { path, source } = heddle_err
+                && source.to_string().contains("invalid output.format")
             {
+                let message = source.to_string();
                 let path_display = path.display().to_string();
                 return ErrorClassification {
                     kind: "invalid_repo_config_output_format".to_string(),
                     human_error: Some(format!(
                         "{} (in {})",
-                        extract_invalid_output_format_message(message),
+                        extract_invalid_output_format_message(&message),
                         path_display
                     )),
                     hint: format!(

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -415,20 +415,30 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
             // `crates/repo/src/repo_config.rs`). The error string carries
             // the field-and-value contract; we match on it here so the
             // user gets a typed `Next:` envelope instead of a generic
-            // runtime fallback.
-            if let HeddleError::Config(message) = heddle_err
+            // runtime fallback. The path comes from `ConfigParse` so the
+            // hint cites the *actual* file (`HEDDLE_CONFIG`, the resolved
+            // `$HOME/.config/heddle/config.toml`, or the repo's
+            // `.heddle/config.toml`) — not a hard-coded path that may
+            // not be the one that produced the failure (Codex R3 on #271).
+            if let HeddleError::ConfigParse { path, message } = heddle_err
                 && message.contains("invalid output.format")
             {
+                let path_display = path.display().to_string();
                 return ErrorClassification {
                     kind: "invalid_repo_config_output_format".to_string(),
-                    human_error: Some(extract_invalid_output_format_message(message)),
-                    hint: "Edit `.heddle/config.toml` and set `output.format` to `text` or `json`."
-                        .to_string(),
-                    unsafe_condition:
-                        "repository configuration declares an unknown output.format value"
-                            .to_string(),
+                    human_error: Some(format!(
+                        "{} (in {})",
+                        extract_invalid_output_format_message(message),
+                        path_display
+                    )),
+                    hint: format!(
+                        "Edit {path_display} and set output.format to 'text' or 'json'."
+                    ),
+                    unsafe_condition: format!(
+                        "configuration at {path_display} declares an unknown output.format value"
+                    ),
                     would_change:
-                        "the requested command did not run because Heddle could not load the repository config"
+                        "the requested command did not run because Heddle could not load the configuration"
                             .to_string(),
                     preserved:
                         "no repository objects, refs, metadata, or worktree files were changed"

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -122,8 +122,9 @@ pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> 
             writeln!(out)?;
             writeln!(
                 out,
-                "Output: `--output auto` renders text on a TTY and JSON when piped; \
-                 use `--output text` or `--output json` to force a mode."
+                "Output: text is the default; pass `--output json` for the \
+                 machine contract (stable `output_kind`, exit codes, recovery \
+                 templates). No TTY/pipe auto-detection."
             )?;
             writeln!(out)?;
             writeln!(

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -48,10 +48,15 @@ pub fn is_tty() -> bool {
 pub fn user_config_or_exit() -> &'static UserConfig {
     static USER_CONFIG: OnceLock<UserConfig> = OnceLock::new();
     USER_CONFIG.get_or_init(|| {
-        UserConfig::load_default().unwrap_or_else(|err| {
-            eprintln!("failed to load Heddle user config: {err}");
-            std::process::exit(2);
-        })
+        // Failure here MUST NOT short-circuit with a raw `eprintln` +
+        // exit(2) — that path bypassed the typed `Next:` envelope when
+        // the global user config carried `output.format = "auto"`
+        // (Codex R2 on #271). The early-load in `main` already routes
+        // that failure through `print_error_with_hint`; this fallback
+        // exists only so re-entrant callers (e.g. `should_output_json`
+        // invoked from inside the error printer itself) get a usable
+        // default instead of a recursive load failure.
+        UserConfig::load_default().unwrap_or_default()
     })
 }
 

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -135,6 +135,21 @@ mod tests {
     }
 
     #[test]
+    fn config_parse_preserves_toml_source_as_data_err() {
+        // Regression for Codex R4 (cid 3315305484): `ConfigParse` must keep
+        // the `toml::de::Error` as its source so the chain-walk still
+        // classifies it, rather than flattening to a String and falling
+        // through to `IoErr`.
+        let toml_err = toml::from_str::<toml::Value>("= nope").unwrap_err();
+        let err: anyhow::Error = objects::error::HeddleError::ConfigParse {
+            path: std::path::PathBuf::from("/tmp/config.toml"),
+            source: toml_err,
+        }
+        .into();
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
     fn serde_json_is_data_err() {
         let err: anyhow::Error = serde_json::from_str::<serde_json::Value>("{")
             .unwrap_err()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -182,7 +182,20 @@ async fn async_main() -> Result<()> {
     let command_name = command_contract.display.clone();
     let command_supports_op_id = command_contract.supports_op_id;
     let config_start = Instant::now();
-    let user_config = UserConfig::load_default()?;
+    // Route early UserConfig load failures through the same typed
+    // envelope as command-body errors. Without this, a legacy
+    // `output.format = "auto"` in the global user config (or via
+    // `HEDDLE_CONFIG`) exits with a raw TOML parse error and bypasses
+    // the `Next:` / JSON-envelope contract #271 promised — `?` here
+    // would propagate to `main` and print via anyhow's Debug impl.
+    let user_config = match UserConfig::load_default() {
+        Ok(config) => config,
+        Err(err) => {
+            let code = HeddleExitCode::from_error(&err);
+            print_error_with_hint(&cli, &err);
+            std::process::exit(code.into());
+        }
+    };
     let config_load_ms = config_start.elapsed().as_millis();
     let logging_start = Instant::now();
     // Foreground CLI commands default to WARN-level logs so the human-facing

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -49,6 +49,8 @@ mod hooks;
 mod misc;
 #[path = "cli_integration/oss_cli_polish.rs"]
 mod oss_cli_polish;
+#[path = "cli_integration/output_mode_no_auto.rs"]
+mod output_mode_no_auto;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
 #[path = "cli_integration/realworld_git.rs"]

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `--output auto` and `output.format = "auto"` are gone — regression cover.
+//!
+//! Background: PR #251 fixed the *default* surface (no flag → text regardless
+//! of pipe state) but left the `--output auto` value and its
+//! TTY-detect-then-pick behaviour in place. Round 5 of the persona eval
+//! confirmed that under a config with `output.format = "auto"`,
+//! `heddle status > file` still emitted JSON — the exact ergonomic surprise
+//! we tried to delete. Heddle #271 deletes `auto` entirely from both the
+//! CLI surface and the repo/user config; this file pins the contract.
+//!
+//! No backcompat alias. Pre-1.0; legacy configs error loudly with a typed
+//! `Next:` envelope rather than silently mapping to text.
+
+use std::str;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{assert_json_recovery_advice_fields, heddle, heddle_output};
+
+#[test]
+fn piped_status_with_no_output_flag_renders_text() {
+    // Post-PR251 default — re-asserted here because the failure mode this
+    // regression-protects (silent JSON on a pipe) was the entire reason
+    // #271 exists. `Command::output()` always pipes stdout/stderr, so
+    // `heddle_output` is already the "piped" shape.
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init should succeed");
+
+    let output =
+        heddle_output(&["status"], Some(temp.path())).expect("status with no --output flag");
+    assert!(
+        output.status.success(),
+        "default status under a pipe should succeed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = str::from_utf8(&output.stdout).expect("stdout utf8");
+    let trimmed = stdout.trim_start();
+    assert!(
+        !trimmed.starts_with('{') && !trimmed.starts_with('['),
+        "piped default status must stay text, not JSON: {stdout}"
+    );
+    assert!(
+        serde_json::from_str::<Value>(stdout).is_err(),
+        "piped default status must not parse as JSON: {stdout}"
+    );
+}
+
+#[test]
+fn piped_status_with_explicit_json_flag_emits_json() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init should succeed");
+
+    let stdout = heddle(&["status", "--output", "json"], Some(temp.path()))
+        .expect("status --output json should succeed under a pipe");
+    let parsed: Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|err| panic!("JSON parse failed: {err}: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "status --output json should emit a JSON object: {stdout}"
+    );
+}
+
+#[test]
+fn output_auto_flag_errors_at_parse_with_helpful_message() {
+    // `--output auto` is gone. clap should reject it at parse time with a
+    // value-list hint that names the remaining valid values.
+    let output = heddle_output(&["--output", "auto", "status"], None)
+        .expect("heddle should run even when args reject");
+    assert!(
+        !output.status.success(),
+        "--output auto should fail at parse: stdout={}; stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr_lower = stderr.to_ascii_lowercase();
+    assert!(
+        stderr_lower.contains("auto"),
+        "parse error should name the rejected value 'auto': {stderr}"
+    );
+    assert!(
+        stderr_lower.contains("text") && stderr_lower.contains("json"),
+        "parse error should list the remaining valid values 'text' and 'json': {stderr}"
+    );
+}
+
+#[test]
+fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
+    // Loud error, typed envelope. The repo config file is the place a
+    // legacy `auto` value can still appear in the wild (anyone who copied
+    // the example config from before the rip will have it). We refuse to
+    // silently map it to text — that's the bug class #271 closes.
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init should succeed");
+
+    let config_path = temp.path().join(".heddle").join("config.toml");
+    let existing = std::fs::read_to_string(&config_path).expect("repo config exists after init");
+    assert!(
+        !existing.contains("[output]"),
+        "init shouldn't write an [output] section by default: {existing}"
+    );
+    let mutated = format!("{existing}\n[output]\nformat = \"auto\"\n");
+    std::fs::write(&config_path, &mutated).expect("write mutated config");
+
+    // Any command that loads the repo config exercises the parse path.
+    // Use `status` because it's the one R5/A1 personas hit on the JSON-pipe
+    // bug.
+    let text_out =
+        heddle_output(&["status"], Some(temp.path())).expect("status should run with bad config");
+    assert!(
+        !text_out.status.success(),
+        "status with output.format='auto' must fail loudly: stdout={}; stderr={}",
+        String::from_utf8_lossy(&text_out.stdout),
+        String::from_utf8_lossy(&text_out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&text_out.stderr);
+    assert!(
+        stderr.contains("output.format") && stderr.contains("'auto'"),
+        "text envelope should name the field and the rejected value: {stderr}"
+    );
+    assert!(
+        stderr.contains("'text'") && stderr.contains("'json'"),
+        "text envelope should list the valid values: {stderr}"
+    );
+    assert!(
+        stderr.contains("Next:"),
+        "text envelope should carry a typed Next: line: {stderr}"
+    );
+
+    // JSON envelope path. Same failure must surface a structured body
+    // with the recovery-advice fields the rest of the CLI envelope
+    // contract requires.
+    let json_out = heddle_output(&["--output", "json", "status"], Some(temp.path()))
+        .expect("status --output json should run with bad config");
+    assert!(
+        !json_out.status.success(),
+        "status with output.format='auto' must fail under --output json too"
+    );
+    let stderr_json_text = String::from_utf8_lossy(&json_out.stderr);
+    let last_line = stderr_json_text
+        .lines()
+        .filter(|line| line.trim_start().starts_with('{'))
+        .next_back()
+        .unwrap_or_else(|| panic!("expected a JSON envelope on stderr; got: {stderr_json_text}"));
+    let envelope: Value = serde_json::from_str(last_line.trim()).unwrap_or_else(|err| {
+        panic!("stderr JSON envelope should parse: {err}: {last_line}")
+    });
+    assert_eq!(
+        envelope["kind"], "invalid_repo_config_output_format",
+        "JSON envelope kind should classify the field-specific failure: {envelope}"
+    );
+    assert!(
+        envelope["error"]
+            .as_str()
+            .is_some_and(|err| err.contains("output.format") && err.contains("'auto'")),
+        "JSON envelope error message should name field and value: {envelope}"
+    );
+    assert_json_recovery_advice_fields(&envelope, "repo config output.format=auto");
+}
+
+#[test]
+fn output_mode_auto_variant_is_absent_from_source() {
+    // Belt-and-braces grep: if anyone re-adds `OutputMode::Auto` or
+    // `OutputFormat::Auto`, this test fails before runtime behaviour does.
+    // We scan the cli + repo source trees relative to CARGO_MANIFEST_DIR.
+    let cli_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let repo_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates dir")
+        .join("repo")
+        .join("src");
+    for root in [cli_src, repo_src] {
+        for entry in walkdir(&root) {
+            if entry.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            let contents = std::fs::read_to_string(&entry).expect("read rs file");
+            assert!(
+                !contents.contains("OutputMode::Auto"),
+                "{} still references OutputMode::Auto",
+                entry.display()
+            );
+            assert!(
+                !contents.contains("OutputFormat::Auto"),
+                "{} still references OutputFormat::Auto",
+                entry.display()
+            );
+        }
+    }
+}
+
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = match std::fs::read_dir(&dir) {
+            Ok(read) => read,
+            Err(_) => continue,
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -19,6 +19,11 @@ use tempfile::TempDir;
 
 use super::{assert_json_recovery_advice_fields, heddle, heddle_output};
 
+/// `EX_DATAERR` from BSD `sysexits.h` — the exit code Heddle assigns to a
+/// `toml::de::Error` in the error chain (see `HeddleExitCode::from_error`).
+/// A config-parse failure is well-formed-but-rejected input, not an IO error.
+const EX_DATAERR: i32 = 65;
+
 #[test]
 fn piped_status_with_no_output_flag_renders_text() {
     // Post-PR251 default — re-asserted here because the failure mode this
@@ -320,6 +325,110 @@ fn user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope(
     assert!(
         !hint.contains(".heddle/config.toml"),
         "hint must not point at the repo config when the bad value is in the HOME user config: hint={hint}"
+    );
+}
+
+#[test]
+fn repo_config_output_format_auto_exits_data_err() {
+    // Codex R4 (cid 3315305484): the r3 `ConfigParse` wrapping stored only
+    // `err.to_string()`, flattening the source `toml::de::Error` out of the
+    // chain. `HeddleExitCode::from_error` classifies config-parse failures by
+    // downcasting to `toml::de::Error`; with the source gone it fell through
+    // to `EX_IOERR` (74). The exit code must stay `EX_DATAERR` (65) so retry
+    // agents and the JSON envelope's `exit_code` report the failure class
+    // correctly.
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init should succeed");
+    let config_path = temp.path().join(".heddle").join("config.toml");
+    let existing = std::fs::read_to_string(&config_path).expect("repo config exists after init");
+    let mutated = existing.replace("[output]\n", "[output]\nformat = \"auto\"\n");
+    std::fs::write(&config_path, &mutated).expect("write mutated config");
+
+    let out = heddle_output(&["status"], Some(temp.path())).expect("status runs with bad config");
+    assert_eq!(
+        out.status.code(),
+        Some(EX_DATAERR),
+        "repo config output.format='auto' must exit EX_DATAERR (65), not EX_IOERR (74): stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json_out = heddle_output(&["--output", "json", "status"], Some(temp.path()))
+        .expect("status --output json runs with bad config");
+    assert_eq!(
+        json_out.status.code(),
+        Some(EX_DATAERR),
+        "JSON-mode exit code must also be EX_DATAERR (65): stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let envelope = parse_envelope(&json_out.stderr);
+    assert_eq!(
+        envelope["exit_code"].as_u64(),
+        Some(EX_DATAERR as u64),
+        "JSON envelope exit_code must report EX_DATAERR (65): {envelope}"
+    );
+}
+
+#[test]
+fn user_config_heddle_config_output_format_auto_exits_data_err() {
+    // Mirror of the repo-config case for the `HEDDLE_CONFIG` source.
+    let temp = TempDir::new().unwrap();
+    let bad_user_config = temp.path().join("user-config.toml");
+    std::fs::write(&bad_user_config, "[output]\nformat = \"auto\"\n")
+        .expect("write bad user config");
+
+    let out = run_with_bad_user_config(&bad_user_config, None, &["status"]);
+    assert_eq!(
+        out.status.code(),
+        Some(EX_DATAERR),
+        "HEDDLE_CONFIG output.format='auto' must exit EX_DATAERR (65), not EX_IOERR (74): stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json_out =
+        run_with_bad_user_config(&bad_user_config, None, &["--output", "json", "status"]);
+    assert_eq!(
+        json_out.status.code(),
+        Some(EX_DATAERR),
+        "JSON-mode exit code must also be EX_DATAERR (65): stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let envelope = parse_envelope(&json_out.stderr);
+    assert_eq!(
+        envelope["exit_code"].as_u64(),
+        Some(EX_DATAERR as u64),
+        "JSON envelope exit_code must report EX_DATAERR (65): {envelope}"
+    );
+}
+
+#[test]
+fn user_config_home_output_format_auto_exits_data_err() {
+    // Mirror of the repo-config case for the `$HOME/.config` source.
+    let temp = TempDir::new().unwrap();
+    let fake_home = temp.path();
+    let config_path = fake_home.join(".config").join("heddle").join("config.toml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).expect("mkdir config parent");
+    std::fs::write(&config_path, "[output]\nformat = \"auto\"\n").expect("write bad home config");
+
+    let out = run_with_home_user_config(fake_home, None, &["status"]);
+    assert_eq!(
+        out.status.code(),
+        Some(EX_DATAERR),
+        "HOME user output.format='auto' must exit EX_DATAERR (65), not EX_IOERR (74): stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json_out = run_with_home_user_config(fake_home, None, &["--output", "json", "status"]);
+    assert_eq!(
+        json_out.status.code(),
+        Some(EX_DATAERR),
+        "JSON-mode exit code must also be EX_DATAERR (65): stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let envelope = parse_envelope(&json_out.stderr);
+    assert_eq!(
+        envelope["exit_code"].as_u64(),
+        Some(EX_DATAERR as u64),
+        "JSON envelope exit_code must report EX_DATAERR (65): {envelope}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -99,11 +99,13 @@ fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
 
     let config_path = temp.path().join(".heddle").join("config.toml");
     let existing = std::fs::read_to_string(&config_path).expect("repo config exists after init");
-    assert!(
-        !existing.contains("[output]"),
-        "init shouldn't write an [output] section by default: {existing}"
+    // `init` writes an empty `[output]` section. Inject `format = "auto"`
+    // into it so the toml parser hits the rejection path.
+    let mutated = existing.replace("[output]\n", "[output]\nformat = \"auto\"\n");
+    assert_ne!(
+        mutated, existing,
+        "test fixture should mutate the [output] section: {existing}"
     );
-    let mutated = format!("{existing}\n[output]\nformat = \"auto\"\n");
     std::fs::write(&config_path, &mutated).expect("write mutated config");
 
     // Any command that loads the repo config exercises the parse path.
@@ -143,8 +145,7 @@ fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
     let stderr_json_text = String::from_utf8_lossy(&json_out.stderr);
     let last_line = stderr_json_text
         .lines()
-        .filter(|line| line.trim_start().starts_with('{'))
-        .next_back()
+        .rfind(|line| line.trim_start().starts_with('{'))
         .unwrap_or_else(|| panic!("expected a JSON envelope on stderr; got: {stderr_json_text}"));
     let envelope: Value = serde_json::from_str(last_line.trim()).unwrap_or_else(|err| {
         panic!("stderr JSON envelope should parse: {err}: {last_line}")

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -161,6 +161,36 @@ fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
         "JSON envelope error message should name field and value: {envelope}"
     );
     assert_json_recovery_advice_fields(&envelope, "repo config output.format=auto");
+
+    // Codex R3 (cid 3313132711): the recovery hint must cite the actual
+    // file that produced the parse failure — not a hard-coded
+    // `.heddle/config.toml`. Resolve the repo config path to its
+    // absolute form (mirrors the `canonicalize()` in `RepoConfig::load`)
+    // and assert it appears verbatim in the hint.
+    let expected_path = config_path
+        .canonicalize()
+        .expect("repo config path canonicalizes");
+    let expected_path = expected_path.display().to_string();
+    let hint = envelope["hint"]
+        .as_str()
+        .expect("envelope.hint should be a string");
+    assert!(
+        hint.contains(&expected_path),
+        "hint should cite the actual repo config path {expected_path}: hint={hint}"
+    );
+    assert!(
+        hint.contains("output.format"),
+        "hint should name the field: {hint}"
+    );
+    assert!(
+        hint.contains("'text'") && hint.contains("'json'"),
+        "hint should list the valid values: {hint}"
+    );
+    let stderr_text_after = String::from_utf8_lossy(&text_out.stderr);
+    assert!(
+        stderr_text_after.contains(&expected_path),
+        "text envelope should also surface the path so the user knows which file to edit: stderr={stderr_text_after}"
+    );
 }
 
 #[test]
@@ -206,6 +236,32 @@ fn user_config_with_output_format_auto_via_heddle_config_env_errors_with_typed_e
         "JSON envelope error message should name field and value: {envelope}"
     );
     assert_json_recovery_advice_fields(&envelope, "user config HEDDLE_CONFIG output.format=auto");
+
+    // Codex R3 (cid 3313132711): when the bad value lives in the user
+    // config reached via `HEDDLE_CONFIG`, the hint must cite that exact
+    // file — not a hard-coded `.heddle/config.toml` the user does not
+    // even have. Use the canonical form so the rendered hint is
+    // copy/paste-safe across symlinks.
+    let expected_path = bad_user_config
+        .canonicalize()
+        .expect("HEDDLE_CONFIG path canonicalizes");
+    let expected_path = expected_path.display().to_string();
+    let hint = envelope["hint"]
+        .as_str()
+        .expect("envelope.hint should be a string");
+    assert!(
+        hint.contains(&expected_path),
+        "hint should cite the HEDDLE_CONFIG path {expected_path}: hint={hint}"
+    );
+    assert!(
+        !hint.contains(".heddle/config.toml"),
+        "hint must not point at the repo config when the bad value is in the user config: hint={hint}"
+    );
+    let stderr_text_after = String::from_utf8_lossy(&text_out.stderr);
+    assert!(
+        stderr_text_after.contains(&expected_path),
+        "text envelope should also surface the HEDDLE_CONFIG path so the user knows which file to edit: stderr={stderr_text_after}"
+    );
 }
 
 #[test]
@@ -232,6 +288,39 @@ fn user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope(
     );
     let stderr = String::from_utf8_lossy(&text_out.stderr);
     assert_typed_output_format_envelope(&stderr, "HOME-based user config");
+
+    // Codex R3 (cid 3313132711): the recovery hint must cite the actual
+    // discovered file — `$HOME/.config/heddle/config.toml` in this case
+    // — so the user does not have to guess which of `HEDDLE_CONFIG`,
+    // `XDG_CONFIG_HOME`-derived, HOME-derived, or repo config holds the
+    // bad value. Mirrors `UserConfig::load`'s `canonicalize()`.
+    let expected_path = config_path
+        .canonicalize()
+        .expect("HOME-based user config path canonicalizes");
+    let expected_path = expected_path.display().to_string();
+    assert!(
+        stderr.contains(&expected_path),
+        "text envelope should cite the HOME-based config path {expected_path}: stderr={stderr}"
+    );
+
+    let json_out = run_with_home_user_config(fake_home, None, &["--output", "json", "status"]);
+    assert!(
+        !json_out.status.success(),
+        "status --output json with HOME user output.format='auto' must fail too: stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let envelope = parse_envelope(&json_out.stderr);
+    let hint = envelope["hint"]
+        .as_str()
+        .expect("envelope.hint should be a string");
+    assert!(
+        hint.contains(&expected_path),
+        "JSON envelope hint should cite the HOME-based config path {expected_path}: hint={hint}"
+    );
+    assert!(
+        !hint.contains(".heddle/config.toml"),
+        "hint must not point at the repo config when the bad value is in the HOME user config: hint={hint}"
+    );
 }
 
 fn run_with_bad_user_config(

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -12,7 +12,7 @@
 //! No backcompat alias. Pre-1.0; legacy configs error loudly with a typed
 //! `Next:` envelope rather than silently mapping to text.
 
-use std::str;
+use std::{process::Command, str};
 
 use serde_json::Value;
 use tempfile::TempDir;
@@ -161,6 +161,150 @@ fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
         "JSON envelope error message should name field and value: {envelope}"
     );
     assert_json_recovery_advice_fields(&envelope, "repo config output.format=auto");
+}
+
+#[test]
+fn user_config_with_output_format_auto_via_heddle_config_env_errors_with_typed_envelope() {
+    // Codex R2: the deserializer rejection only produced a typed envelope
+    // when `output.format = "auto"` lived in `.heddle/config.toml`. The
+    // same value in the GLOBAL user config (`HEDDLE_CONFIG` / `~/.config`)
+    // hit a parse failure during `UserConfig::load_default` in `main`
+    // before the error printer was wired, so every command exited with
+    // a raw TOML parse error instead of the promised `Next:` envelope.
+    // This test pins the contract for the `HEDDLE_CONFIG` route.
+    let temp = TempDir::new().unwrap();
+    let bad_user_config = temp.path().join("user-config.toml");
+    std::fs::write(&bad_user_config, "[output]\nformat = \"auto\"\n")
+        .expect("write bad user config");
+
+    let text_out = run_with_bad_user_config(&bad_user_config, None, &["status"]);
+    assert!(
+        !text_out.status.success(),
+        "status with user output.format='auto' must fail loudly: stdout={}; stderr={}",
+        String::from_utf8_lossy(&text_out.stdout),
+        String::from_utf8_lossy(&text_out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&text_out.stderr);
+    assert_typed_output_format_envelope(&stderr, "HEDDLE_CONFIG user config");
+
+    let json_out =
+        run_with_bad_user_config(&bad_user_config, None, &["--output", "json", "status"]);
+    assert!(
+        !json_out.status.success(),
+        "status --output json with user output.format='auto' must fail too: stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let envelope = parse_envelope(&json_out.stderr);
+    assert_eq!(
+        envelope["kind"], "invalid_repo_config_output_format",
+        "JSON envelope kind should classify the field-specific failure: {envelope}"
+    );
+    assert!(
+        envelope["error"]
+            .as_str()
+            .is_some_and(|err| err.contains("output.format") && err.contains("'auto'")),
+        "JSON envelope error message should name field and value: {envelope}"
+    );
+    assert_json_recovery_advice_fields(&envelope, "user config HEDDLE_CONFIG output.format=auto");
+}
+
+#[test]
+fn user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope() {
+    // Mirror case: the same failure must surface a typed envelope when
+    // the user config is discovered via `$HOME/.config/heddle/config.toml`
+    // (the no-env-var fallback). Without `HEDDLE_CONFIG` and
+    // `XDG_CONFIG_HOME` overrides, `UserConfig::default_path` walks down
+    // to the HOME-based path; we set HOME explicitly so the test does
+    // not depend on the developer's real `~/.config/heddle/`.
+    let temp = TempDir::new().unwrap();
+    let fake_home = temp.path();
+    let config_path = fake_home.join(".config").join("heddle").join("config.toml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).expect("mkdir config parent");
+    std::fs::write(&config_path, "[output]\nformat = \"auto\"\n")
+        .expect("write bad home config");
+
+    let text_out = run_with_home_user_config(fake_home, None, &["status"]);
+    assert!(
+        !text_out.status.success(),
+        "status with HOME user output.format='auto' must fail loudly: stdout={}; stderr={}",
+        String::from_utf8_lossy(&text_out.stdout),
+        String::from_utf8_lossy(&text_out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&text_out.stderr);
+    assert_typed_output_format_envelope(&stderr, "HOME-based user config");
+}
+
+fn run_with_bad_user_config(
+    config_path: &std::path::Path,
+    cwd: Option<&std::path::Path>,
+    args: &[&str],
+) -> std::process::Output {
+    let temp;
+    let dir = match cwd {
+        Some(dir) => dir.to_path_buf(),
+        None => {
+            temp = TempDir::new().expect("tempdir for cwd");
+            temp.path().to_path_buf()
+        }
+    };
+    Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .current_dir(&dir)
+        .env("HEDDLE_CONFIG", config_path)
+        .output()
+        .expect("spawn heddle")
+}
+
+fn run_with_home_user_config(
+    home: &std::path::Path,
+    cwd: Option<&std::path::Path>,
+    args: &[&str],
+) -> std::process::Output {
+    let temp;
+    let dir = match cwd {
+        Some(dir) => dir.to_path_buf(),
+        None => {
+            temp = TempDir::new().expect("tempdir for cwd");
+            temp.path().to_path_buf()
+        }
+    };
+    Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .current_dir(&dir)
+        .env_remove("HEDDLE_CONFIG")
+        .env_remove("XDG_CONFIG_HOME")
+        .env("HOME", home)
+        .output()
+        .expect("spawn heddle")
+}
+
+fn assert_typed_output_format_envelope(stderr: &str, context: &str) {
+    assert!(
+        stderr.contains("output.format") && stderr.contains("'auto'"),
+        "{context}: text envelope should name the field and the rejected value: {stderr}"
+    );
+    assert!(
+        stderr.contains("'text'") && stderr.contains("'json'"),
+        "{context}: text envelope should list the valid values: {stderr}"
+    );
+    assert!(
+        stderr.contains("Next:"),
+        "{context}: text envelope should carry a typed Next: line: {stderr}"
+    );
+    assert!(
+        !stderr.contains("TOML parse error"),
+        "{context}: raw TOML parse error must not leak past the typed envelope: {stderr}"
+    );
+}
+
+fn parse_envelope(stderr_bytes: &[u8]) -> Value {
+    let stderr = String::from_utf8_lossy(stderr_bytes);
+    let line = stderr
+        .lines()
+        .rfind(|line| line.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("expected JSON envelope on stderr; got: {stderr}"));
+    serde_json::from_str(line.trim())
+        .unwrap_or_else(|err| panic!("stderr JSON envelope should parse: {err}: {line}"))
 }
 
 #[test]

--- a/crates/objects/src/error.rs
+++ b/crates/objects/src/error.rs
@@ -22,6 +22,11 @@ pub enum HeddleError {
     Serialization(String),
     #[error("configuration error: {0}")]
     Config(String),
+    #[error("configuration parse error at {path}: {message}")]
+    ConfigParse {
+        path: std::path::PathBuf,
+        message: String,
+    },
     #[error("conflict: {0}")]
     Conflict(String),
     #[error("compression error: {0}")]

--- a/crates/objects/src/error.rs
+++ b/crates/objects/src/error.rs
@@ -22,10 +22,15 @@ pub enum HeddleError {
     Serialization(String),
     #[error("configuration error: {0}")]
     Config(String),
-    #[error("configuration parse error at {path}: {message}")]
+    #[error("configuration parse error at {path}: {source}")]
     ConfigParse {
         path: std::path::PathBuf,
-        message: String,
+        // Keep the original `toml::de::Error` as the error source — not a
+        // flattened string — so `HeddleExitCode::from_error` can still
+        // downcast through the chain and classify config-parse failures as
+        // EX_DATAERR (65) rather than falling through to EX_IOERR (74).
+        #[source]
+        source: toml::de::Error,
     },
     #[error("conflict: {0}")]
     Conflict(String),

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -276,16 +276,48 @@ impl Default for DefaultsConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
     Json,
-    // `auto` is the historical name for the default; accept it as an
-    // alias so user configs from before the TTY-detection rip survive
-    // an upgrade without a hard error. New writes use `text`.
-    #[serde(alias = "auto")]
     #[default]
     Text,
+}
+
+// Hand-written Deserialize so a legacy `output.format = "auto"` fails
+// with a field-named, value-named message instead of the default serde
+// "unknown variant" wording. The bug class #271 closes is the silent
+// JSON-when-piped surprise the old `auto` mode produced; rather than
+// keeping an alias that would re-route it to `text`, pre-1.0 we error
+// loudly so the operator updates the config. The error string is the
+// load-bearing contract — the CLI's error envelope (see
+// `print_error_with_hint`) classifies it by substring match.
+impl<'de> Deserialize<'de> for OutputFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct OutputFormatVisitor;
+        impl<'de> serde::de::Visitor<'de> for OutputFormatVisitor {
+            type Value = OutputFormat;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("'text' or 'json'")
+            }
+            fn visit_str<E>(self, value: &str) -> std::result::Result<OutputFormat, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "text" => Ok(OutputFormat::Text),
+                    "json" => Ok(OutputFormat::Json),
+                    other => Err(E::custom(format!(
+                        "invalid output.format: '{other}' — valid values are 'text' or 'json'"
+                    ))),
+                }
+            }
+        }
+        deserializer.deserialize_str(OutputFormatVisitor)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -447,6 +447,56 @@ version = 1
     }
 
     #[test]
+    fn output_format_text_and_json_parse_normally() {
+        let toml_text = r#"
+[repository]
+version = 1
+[output]
+format = "text"
+"#;
+        let config: RepoConfig = toml::from_str(toml_text).expect("text should parse");
+        assert_eq!(config.output.format, Some(OutputFormat::Text));
+
+        let toml_json = r#"
+[repository]
+version = 1
+[output]
+format = "json"
+"#;
+        let config: RepoConfig = toml::from_str(toml_json).expect("json should parse");
+        assert_eq!(config.output.format, Some(OutputFormat::Json));
+    }
+
+    #[test]
+    fn output_format_auto_is_rejected_with_field_specific_message() {
+        // Pre-1.0: no silent alias. A repo config with `output.format =
+        // "auto"` must fail loudly so the operator updates it to `text`
+        // or `json` rather than silently inheriting the
+        // JSON-when-piped surprise that motivated #271.
+        let toml_auto = r#"
+[repository]
+version = 1
+[output]
+format = "auto"
+"#;
+        let err = toml::from_str::<RepoConfig>(toml_auto)
+            .expect_err("output.format='auto' must reject");
+        let message = err.to_string();
+        assert!(
+            message.contains("output.format"),
+            "error should name the field: {message}"
+        );
+        assert!(
+            message.contains("'auto'"),
+            "error should name the rejected value: {message}"
+        );
+        assert!(
+            message.contains("'text'") && message.contains("'json'"),
+            "error should list the valid values: {message}"
+        );
+    }
+
+    #[test]
     fn test_save_overwrites_atomically() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("config.toml");

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -437,7 +437,7 @@ impl RepoConfig {
             let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
             objects::error::HeddleError::ConfigParse {
                 path: resolved,
-                message: err.to_string(),
+                source: err,
             }
         })
     }

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -428,7 +428,18 @@ impl RepoConfig {
         let mut file = std::fs::File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        Ok(toml::from_str(&contents)?)
+        // Wrap parse failures in `HeddleError::ConfigParse` so the CLI
+        // error envelope can render the actual config file in the
+        // recovery hint (Codex R3 cid 3313132711 on #271). The implicit
+        // `From<toml::de::Error>` would lose the path; we attach it
+        // here where we still know which file produced the failure.
+        toml::from_str::<Self>(&contents).map_err(|err| {
+            let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            objects::error::HeddleError::ConfigParse {
+                path: resolved,
+                message: err.to_string(),
+            }
+        })
     }
 
     /// Save configuration to a file.


### PR DESCRIPTION
## Summary

- Hand-rolled `Deserialize` for `OutputFormat` rejects any value other than `text`/`json`, with a field-named, value-named message (`invalid output.format: 'auto' — valid values are 'text' or 'json'`). The legacy `#[serde(alias = "auto")]` shim that silently mapped to text is gone.
- `print_error_with_hint` classifies the new error as `kind: "invalid_repo_config_output_format"` with a typed `Next:` line in text mode and structured recovery fields under `--output json`.
- Help text drops the stale `--output auto renders text on a TTY and JSON when piped` line — there is no `--output auto` any more.
- Five regression tests pin the contract: piped default stays text, `--output json` still emits JSON, `--output auto` errors at clap parse with the remaining values listed, repo config `output.format = "auto"` errors with the typed envelope, and a grep-style scan asserts neither `OutputMode::Auto` nor `OutputFormat::Auto` re-enters the source tree.

Closes HeddleCo/heddle#271. Re-closes #256 — round 5 of the persona eval confirmed that PR was wrongly assumed to be closed: PR #251 fixed the *default* surface, but `Auto` mode (and `output.format = "auto"` in a repo config) still emitted JSON when piped.

## Round 2 (Codex P2 cid 3312334066)

Codex flagged a gap: r1 only routed the typed envelope when `output.format = "auto"` lived in `.heddle/config.toml`. The same value in the **global** user config (`HEDDLE_CONFIG` or `~/.config/heddle/config.toml`) hit the deserializer rejection during `UserConfig::load_default` in `main` *before* the error printer was wired, so every command exited with a raw TOML parse error and bypassed the `Next:` / JSON-envelope contract.

Three fixes, smallest diff that closes the gap:

- `UserConfig::load` wraps `toml::de::Error` in `HeddleError::Config` so the existing `invalid_repo_config_output_format` classifier catches the global-config case via the same substring match.
- `main` catches `UserConfig::load_default()` failures and routes them through `print_error_with_hint` + a typed `HeddleExitCode` before exiting, instead of letting `?` propagate to Rust's default anyhow-Debug surface.
- `user_config_or_exit` no longer `eprintln!`s + `exit(2)` on load failure (which was the exact raw-error path Codex saw) and falls back to `UserConfig::default()` so re-entrant callers — `should_output_json` invoked from inside the error printer itself — get a usable default instead of triggering a second load failure with the old path.

Two new integration tests cover the `HEDDLE_CONFIG` env-var path and the `$HOME/.config/heddle/config.toml` fallback path; both assert the text envelope carries `Next:` and names the field + valid values; the HEDDLE_CONFIG case also asserts the JSON envelope kind is `invalid_repo_config_output_format` and that no raw TOML parse error leaks past the typed envelope.

## Round 3 (Codex P2 cid 3313132711)

Codex flagged that r2 closed the *envelope-shape* gap but not the *content* gap: regardless of where the bad `output.format` lived, the JSON envelope's `hint` text was hard-coded to `Edit `.heddle/config.toml`…`. When the value was in `HEDDLE_CONFIG` or `~/.config/heddle/config.toml`, that hint pointed the user at a file unrelated to the failure, so following it left every command failing the same way.

Fix: thread the actual source path through the error type so the classifier renders the real file in the recovery advice.

- New `HeddleError::ConfigParse { path, message }` variant carries the file alongside the parse message. `HeddleError::Config(String)` is unchanged — it stays for runtime/non-parse config errors so existing call sites keep working.
- `UserConfig::load` and `RepoConfig::load` `.canonicalize()` the path at the wrap site (the file is already open, so the canonicalization succeeds) and construct `ConfigParse` directly; the resolved-absolute form is what the hint renders.
- The CLI error envelope classifier matches `ConfigParse` first. The `hint` is now `Edit /abs/path/config.toml and set output.format to 'text' or 'json'.`; the human_error suffixes ` (in /abs/path/config.toml)` so text mode also surfaces the path; `unsafe_condition` cites the path too. The old hard-coded `Edit `.heddle/config.toml`` branch is removed.

Three integration tests (one per source — repo / `HEDDLE_CONFIG` / `$HOME/.config/heddle/config.toml`) assert the canonicalized path appears in both the JSON envelope's `hint` field and the text-mode stderr. The two user-config cases also assert `.heddle/config.toml` is *not* mentioned, so a regression that reintroduces the hard-coded path fails loudly.

## Round 4 (Codex P2 cid 3315305484)

Codex flagged an exit-code regression introduced by r3's wrapping: `ConfigParse { path, message }` stored `err.to_string()`, flattening the source `toml::de::Error` out of the error chain. `HeddleExitCode::from_error` classifies config-parse failures by downcasting to `toml::de::Error`; with the source gone, the downcast failed and the classifier fell through to `EX_IOERR` (74). So `output.format = "auto"` started exiting 74 instead of `EX_DATAERR` (65) — the wrong failure class for retry agents and for the JSON envelope's `exit_code` field.

Fix (purely about restoring the exit code; r3's path-aware hint is untouched):

- `HeddleError::ConfigParse` now holds `#[source] source: toml::de::Error` instead of a flattened `message: String`. The chain-walk in `from_error` can downcast through it again, so config-parse failures classify as `EX_DATAERR` (65).
- `UserConfig::load` and `RepoConfig::load` move the parse error straight into the variant (the path is still canonicalized at the wrap site).
- The envelope classifier reads the message via `source.to_string()`; the r3 path-aware recovery advice (real config file in `hint` / `human_error` / `unsafe_condition`) is unchanged.

A router unit test (`config_parse_preserves_toml_source_as_data_err`) pins `ConfigParse → DataErr` without spawning the binary, and three integration tests (one per source — repo / `HEDDLE_CONFIG` / `$HOME/.config/heddle/config.toml`) assert both the process exit code and the JSON envelope's `exit_code` field are `EX_DATAERR` (65).

### Round 4 red commit

`3b1327dccc` (red — the three exit-code integration tests fail at 74).

### Round 4 test evidence

```
$ cargo test -p heddle-cli --lib exit::
running 8 tests
test exit::tests::config_parse_preserves_toml_source_as_data_err ... ok
test exit::tests::io_permission_denied_maps_to_noperm ... ok
test exit::tests::io_timed_out_is_retry_safe ... ok
test exit::tests::missing_repo_string_sentinel_is_config ... ok
test exit::tests::no_upstream_string_sentinel_is_config ... ok
test exit::tests::serde_json_is_data_err ... ok
test exit::tests::u8_repr_matches_sysexits ... ok
test exit::tests::unknown_falls_back_to_io_err ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out

$ cargo test -p heddle-cli --test cli_integration output_format_auto
running 6 tests
test output_mode_no_auto::repo_config_output_format_auto_exits_data_err ... ok
test output_mode_no_auto::user_config_heddle_config_output_format_auto_exits_data_err ... ok
test output_mode_no_auto::user_config_home_output_format_auto_exits_data_err ... ok
test output_mode_no_auto::repo_config_with_output_format_auto_errors_with_typed_envelope ... ok
test output_mode_no_auto::user_config_with_output_format_auto_via_heddle_config_env_errors_with_typed_envelope ... ok
test output_mode_no_auto::user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 638 filtered out
```

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `scripts/check-no-silent-default-tree-load.sh`, and `scripts/check-default-install-ships-worker.sh` are all green.


## Red commit

`df567fc862d8beadfe1e6645dadbcdf2c1477f51`

## Test evidence

```
$ cargo test -p heddle-repo --lib output_format
running 2 tests
test repository::repo_config::tests::output_format_text_and_json_parse_normally ... ok
test repository::repo_config::tests::output_format_auto_is_rejected_with_field_specific_message ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 319 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --test cli_integration output_mode_no_auto
running 7 tests
test output_mode_no_auto::output_auto_flag_errors_at_parse_with_helpful_message ... ok
test output_mode_no_auto::output_mode_auto_variant_is_absent_from_source ... ok
test output_mode_no_auto::piped_status_with_no_output_flag_renders_text ... ok
test output_mode_no_auto::piped_status_with_explicit_json_flag_emits_json ... ok
test output_mode_no_auto::repo_config_with_output_format_auto_errors_with_typed_envelope ... ok
test output_mode_no_auto::user_config_with_output_format_auto_via_heddle_config_env_errors_with_typed_envelope ... ok
test output_mode_no_auto::user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 634 filtered out; finished in 0.33s
```

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` are green; `scripts/check-no-silent-default-tree-load.sh` and `scripts/check-default-install-ships-worker.sh` both pass.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782489312&installation_id=132405951&pr_number=280&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F280&signature=826bdac3b69d4a35321540738e8705408ac2d3f95c08925ae405020c541fb5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


