### PR TITLE
heddle#272: output_kind invariant lint + sweep on named-by-persona verbs

### DIFF
--- a/crates/cli/src/cli/commands/bisect.rs
+++ b/crates/cli/src/cli/commands/bisect.rs
@@ -56,7 +56,11 @@ pub fn cmd_bisect(cli: &Cli, command: BisectCommands) -> Result<()> {
             fs::write(&state_path, "{}\n")?;
 
             if should_output_json(cli, Some(repo.config())) {
-                println!("{{\"status\": \"started\"}}");
+                let envelope = serde_json::json!({
+                    "output_kind": "bisect_start",
+                    "status": "started",
+                });
+                println!("{}", serde_json::to_string(&envelope)?);
             } else {
                 println!("Bisect started");
             }
@@ -68,10 +72,12 @@ pub fn cmd_bisect(cli: &Cli, command: BisectCommands) -> Result<()> {
 
             let resolved = resolve_commit(&repo, commit.as_deref())?;
             if should_output_json(cli, Some(repo.config())) {
-                println!(
-                    "{{\"status\": \"marked_good\", \"commit\": \"{}\"}}",
-                    resolved
-                );
+                let envelope = serde_json::json!({
+                    "output_kind": "bisect_good",
+                    "status": "marked_good",
+                    "commit": resolved,
+                });
+                println!("{}", serde_json::to_string(&envelope)?);
             } else {
                 println!("Marked {} as good", resolved);
             }
@@ -83,10 +89,12 @@ pub fn cmd_bisect(cli: &Cli, command: BisectCommands) -> Result<()> {
 
             let resolved = resolve_commit(&repo, commit.as_deref())?;
             if should_output_json(cli, Some(repo.config())) {
-                println!(
-                    "{{\"status\": \"marked_bad\", \"commit\": \"{}\"}}",
-                    resolved
-                );
+                let envelope = serde_json::json!({
+                    "output_kind": "bisect_bad",
+                    "status": "marked_bad",
+                    "commit": resolved,
+                });
+                println!("{}", serde_json::to_string(&envelope)?);
             } else {
                 println!("Marked {} as bad", resolved);
             }
@@ -95,7 +103,11 @@ pub fn cmd_bisect(cli: &Cli, command: BisectCommands) -> Result<()> {
             reset_bisect_state(&repo)?;
 
             if should_output_json(cli, Some(repo.config())) {
-                println!("{{\"status\": \"reset\"}}");
+                let envelope = serde_json::json!({
+                    "output_kind": "bisect_reset",
+                    "status": "reset",
+                });
+                println!("{}", serde_json::to_string(&envelope)?);
             } else {
                 println!("Bisect reset");
             }

--- a/crates/cli/src/cli/commands/cherry_pick.rs
+++ b/crates/cli/src/cli/commands/cherry_pick.rs
@@ -42,10 +42,13 @@ pub fn cmd_cherry_pick(
 
     if no_commit {
         if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{{\"status\": \"applied\", \"commit\": \"{}\", \"no_commit\": true}}",
-                commit
-            );
+            let envelope = serde_json::json!({
+                "output_kind": "cherry_pick",
+                "status": "applied",
+                "commit": commit,
+                "no_commit": true,
+            });
+            println!("{}", serde_json::to_string(&envelope)?);
         } else {
             println!("Applied {} (not committed)", commit);
         }
@@ -56,11 +59,13 @@ pub fn cmd_cherry_pick(
         let new_state = repo.snapshot_with_attribution(Some(cherry_message), None, attribution)?;
 
         if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{{\"status\": \"committed\", \"commit\": \"{}\", \"new_commit\": \"{}\"}}",
-                commit,
-                new_state.change_id.short()
-            );
+            let envelope = serde_json::json!({
+                "output_kind": "cherry_pick",
+                "status": "committed",
+                "commit": commit,
+                "new_commit": new_state.change_id.short(),
+            });
+            println!("{}", serde_json::to_string(&envelope)?);
         } else {
             println!(
                 "Cherry-picked {} as {}",

--- a/crates/cli/src/cli/commands/clean.rs
+++ b/crates/cli/src/cli/commands/clean.rs
@@ -13,6 +13,7 @@ use crate::cli::{Cli, should_output_json, worktree_status_options};
 
 #[derive(Serialize)]
 struct CleanOutput {
+    output_kind: &'static str,
     removed: Vec<String>,
     dry_run: bool,
 }
@@ -112,6 +113,7 @@ fn output_result(cli: &Cli, repo: &Repository, removed: &[String], dry_run: bool
         println!(
             "{}",
             serde_json::to_string(&CleanOutput {
+                output_kind: "clean",
                 removed: removed.to_vec(),
                 dry_run
             })?

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -40,6 +40,18 @@ use crate::{
     remote::{Remote, RemoteConfig, RemoteTarget},
 };
 
+/// `output_kind` value carried by the final `heddle clone --output json`
+/// payload. Referenced by the command catalog and the catalog/runtime
+/// invariant test to keep the runtime emission and the advertised
+/// discriminator from drifting apart.
+pub const CLONE_OUTPUT_KIND: &str = "clone";
+
+/// `output_kind` value carried by the *preliminary* JSON record emitted
+/// by `clone_network` before the final clone payload. Hosted clones
+/// emit two JSON objects on one invocation (connection envelope, then
+/// the clone result), so the catalog advertises both discriminators.
+pub const CLONE_CONNECTION_OUTPUT_KIND: &str = "clone_connection";
+
 /// Pull/materialization options shared by local and network clone paths.
 struct CloneOptions {
     thread: Option<String>,
@@ -86,7 +98,7 @@ struct GitOverlayCloneOutputInput {
 
 fn git_overlay_clone_output(input: GitOverlayCloneOutputInput) -> CloneOutput {
     CloneOutput {
-        output_kind: "clone",
+        output_kind: CLONE_OUTPUT_KIND,
         action: "clone",
         status: "cloned",
         success: true,
@@ -113,7 +125,7 @@ fn heddle_clone_output(
     trust: Option<RepositoryVerificationState>,
 ) -> CloneOutput {
     CloneOutput {
-        output_kind: "clone",
+        output_kind: CLONE_OUTPUT_KIND,
         action: "clone",
         status: "cloned",
         success: true,
@@ -1218,7 +1230,7 @@ async fn clone_network(
         println!(
             "{}",
             serde_json::json!({
-                "output_kind": "clone_connection",
+                "output_kind": CLONE_CONNECTION_OUTPUT_KIND,
                 "status": "connected",
                 "address": addr.to_string(),
             })

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -916,6 +916,25 @@ const fn json_discriminator(
     }
 }
 
+/// Helper for advertising a JSON discriminator value that is *not*
+/// backed by a documented schema verb — used for preliminary /
+/// transport-envelope records emitted alongside the primary payload
+/// (e.g. `clone_connection` ahead of the final `clone` object on
+/// hosted clones). The `reason` is required by the metadata invariant
+/// test so the catalog can't carry orphan discriminators.
+const fn json_discriminator_no_schema(
+    reason: &'static str,
+    field: &'static str,
+    value: &'static str,
+) -> CommandJsonDiscriminatorSpec {
+    CommandJsonDiscriminatorSpec {
+        schema_verb: None,
+        field,
+        value,
+        no_schema_reason: Some(reason),
+    }
+}
+
 const fn front_door(contract: CommandContract, help_rank: u16) -> CommandContract {
     CommandContract {
         help_visibility: "everyday",
@@ -1383,7 +1402,25 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     },
                     &["clone"],
                 ),
-                &[json_discriminator(Some("clone"), "output_kind", "clone")],
+                &[
+                    json_discriminator(Some("clone"), "output_kind", "clone"),
+                    // `clone --output json` on a hosted/network remote
+                    // emits a preliminary connection envelope before the
+                    // final clone payload. Both records carry
+                    // `output_kind` so agents that route on the
+                    // discriminator (per heddle#272) can classify each
+                    // line without falling back to text parsing. The
+                    // envelope has no separate schema verb — it's a
+                    // small inline object, not a Serialize struct in
+                    // `schemas`. Source-of-truth value:
+                    // `cli::cli::commands::CLONE_CONNECTION_OUTPUT_KIND`.
+                    json_discriminator_no_schema(
+                        "preliminary connection envelope emitted by hosted clones \
+                         before the final clone payload (no separate schema)",
+                        "output_kind",
+                        "clone_connection",
+                    ),
+                ],
             ),
             220,
         ),
@@ -5105,6 +5142,12 @@ mod tests {
         // revert, purge, redact, stash, clean, discuss, context, review,
         // cherry-pick, bisect). Any further sweep MUST extend this list
         // and document the addition.
+        //
+        // `clone` appears twice because hosted `clone --output json`
+        // emits two JSON records per invocation (a preliminary
+        // `clone_connection` envelope followed by the final `clone`
+        // payload); both discriminator values are advertised so agents
+        // can route on either record. See heddle#272 (PR #281 r3).
         let displays = raw_json_discriminator_specs()
             .iter()
             .map(|(path, _)| path.join(" "))
@@ -5124,6 +5167,7 @@ mod tests {
                 "checkpoint",
                 "cherry-pick",
                 "clean",
+                "clone",
                 "clone",
                 "commit",
                 "commands",
@@ -5181,14 +5225,21 @@ mod tests {
     #[test]
     fn json_discriminator_metadata_is_internally_consistent() {
         let raw_discriminators = raw_json_discriminator_specs();
-        let raw_paths = raw_discriminators
+        // A single command path MAY advertise more than one
+        // discriminator (e.g. `clone` carries both `clone` and
+        // `clone_connection` because hosted `clone --output json`
+        // emits a preliminary connection envelope before the final
+        // payload — see heddle#272). But each (path, value) pair must
+        // still be unique, otherwise two entries would advertise the
+        // same wire-format token and agents couldn't tell them apart.
+        let path_value_pairs = raw_discriminators
             .iter()
-            .map(|(path, _)| path.to_vec())
+            .map(|(path, d)| (path.to_vec(), d.value))
             .collect::<BTreeSet<_>>();
         assert_eq!(
-            raw_paths.len(),
+            path_value_pairs.len(),
             raw_discriminators.len(),
-            "JSON discriminator table contains duplicate command paths"
+            "JSON discriminator table contains duplicate (path, value) pairs"
         );
 
         let mut schema_verbs = BTreeSet::new();

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -1119,19 +1119,47 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["bisect"], GROUP),
     entry(
         &["bisect", "start"],
-        opaque_schemas(WORKTREE_MUTATION, &["bisect start"]),
+        json_discriminators(
+            opaque_schemas(WORKTREE_MUTATION, &["bisect start"]),
+            &[json_discriminator(
+                Some("bisect start"),
+                "output_kind",
+                "bisect_start",
+            )],
+        ),
     ),
     entry(
         &["bisect", "good"],
-        opaque_schemas(WORKTREE_MUTATION, &["bisect good"]),
+        json_discriminators(
+            opaque_schemas(WORKTREE_MUTATION, &["bisect good"]),
+            &[json_discriminator(
+                Some("bisect good"),
+                "output_kind",
+                "bisect_good",
+            )],
+        ),
     ),
     entry(
         &["bisect", "bad"],
-        opaque_schemas(WORKTREE_MUTATION, &["bisect bad"]),
+        json_discriminators(
+            opaque_schemas(WORKTREE_MUTATION, &["bisect bad"]),
+            &[json_discriminator(
+                Some("bisect bad"),
+                "output_kind",
+                "bisect_bad",
+            )],
+        ),
     ),
     entry(
         &["bisect", "reset"],
-        opaque_schemas(WORKTREE_MUTATION, &["bisect reset"]),
+        json_discriminators(
+            opaque_schemas(WORKTREE_MUTATION, &["bisect reset"]),
+            &[json_discriminator(
+                Some("bisect reset"),
+                "output_kind",
+                "bisect_reset",
+            )],
+        ),
     ),
     entry(&["blame"], documented_schemas(READ_JSON, &["blame"])),
     entry(
@@ -1324,25 +1352,38 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["cherry-pick"],
-        opaque_schemas(WORKTREE_MUTATION, &["cherry-pick"]),
+        json_discriminators(
+            opaque_schemas(WORKTREE_MUTATION, &["cherry-pick"]),
+            &[json_discriminator(
+                Some("cherry-pick"),
+                "output_kind",
+                "cherry_pick",
+            )],
+        ),
     ),
     entry(
         &["clean"],
-        documented_schemas(DESTRUCTIVE_WORKTREE_ONLY_MUTATION, &["clean"]),
+        json_discriminators(
+            documented_schemas(DESTRUCTIVE_WORKTREE_ONLY_MUTATION, &["clean"]),
+            &[json_discriminator(Some("clean"), "output_kind", "clean")],
+        ),
     ),
     entry(
         &["clone"],
         front_door(
-            documented_schemas(
-                CommandContract {
-                    may_initialize: true,
-                    may_write_worktree: true,
-                    may_move_ref: true,
-                    writes_worktree: true,
-                    network_io: true,
-                    ..MUTATING
-                },
-                &["clone"],
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        may_initialize: true,
+                        may_write_worktree: true,
+                        may_move_ref: true,
+                        writes_worktree: true,
+                        network_io: true,
+                        ..MUTATING
+                    },
+                    &["clone"],
+                ),
+                &[json_discriminator(Some("clone"), "output_kind", "clone")],
             ),
             220,
         ),
@@ -1407,43 +1448,113 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["context"], GROUP),
     entry(
         &["context", "set"],
-        opaque_schemas(MUTATING, &["context set"]),
+        json_discriminators(
+            opaque_schemas(MUTATING, &["context set"]),
+            &[json_discriminator(
+                Some("context set"),
+                "output_kind",
+                "context_set",
+            )],
+        ),
     ),
     entry(
         &["context", "get"],
-        opaque_schemas(READ_JSON, &["context get"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context get"]),
+            &[json_discriminator(
+                Some("context get"),
+                "output_kind",
+                "context_get",
+            )],
+        ),
     ),
     entry(
         &["context", "list"],
-        opaque_schemas(READ_JSON, &["context list"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context list"]),
+            &[json_discriminator(
+                Some("context list"),
+                "output_kind",
+                "context_list",
+            )],
+        ),
     ),
     entry(
         &["context", "history"],
-        opaque_schemas(READ_JSON, &["context history"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context history"]),
+            &[json_discriminator(
+                Some("context history"),
+                "output_kind",
+                "context_history",
+            )],
+        ),
     ),
     entry(
         &["context", "edit"],
-        opaque_schemas(MUTATING, &["context edit"]),
+        json_discriminators(
+            opaque_schemas(MUTATING, &["context edit"]),
+            &[json_discriminator(
+                Some("context edit"),
+                "output_kind",
+                "context_edit",
+            )],
+        ),
     ),
     entry(
         &["context", "supersede"],
-        opaque_schemas(MUTATING, &["context supersede"]),
+        json_discriminators(
+            opaque_schemas(MUTATING, &["context supersede"]),
+            &[json_discriminator(
+                Some("context supersede"),
+                "output_kind",
+                "context_supersede",
+            )],
+        ),
     ),
     entry(
         &["context", "rm"],
-        opaque_schemas(MUTATING, &["context rm"]),
+        json_discriminators(
+            opaque_schemas(MUTATING, &["context rm"]),
+            &[json_discriminator(
+                Some("context rm"),
+                "output_kind",
+                "context_rm",
+            )],
+        ),
     ),
     entry(
         &["context", "check"],
-        opaque_schemas(READ_JSON, &["context check"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context check"]),
+            &[json_discriminator(
+                Some("context check"),
+                "output_kind",
+                "context_check",
+            )],
+        ),
     ),
     entry(
         &["context", "suggest"],
-        opaque_schemas(READ_JSON, &["context suggest"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context suggest"]),
+            &[json_discriminator(
+                Some("context suggest"),
+                "output_kind",
+                "context_suggest",
+            )],
+        ),
     ),
     entry(
         &["context", "audit"],
-        opaque_schemas(READ_JSON, &["context audit"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["context audit"]),
+            &[json_discriminator(
+                Some("context audit"),
+                "output_kind",
+                "context_audit",
+            )],
+        ),
     ),
     entry(&["daemon"], surface(GROUP, "admin")),
     entry(
@@ -1476,23 +1587,58 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["discuss"], GROUP),
     entry(
         &["discuss", "open"],
-        documented_schemas(MUTATING, &["discuss open"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["discuss open"]),
+            &[json_discriminator(
+                Some("discuss open"),
+                "output_kind",
+                "discuss_open",
+            )],
+        ),
     ),
     entry(
         &["discuss", "append"],
-        documented_schemas(MUTATING, &["discuss append"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["discuss append"]),
+            &[json_discriminator(
+                Some("discuss append"),
+                "output_kind",
+                "discuss_append",
+            )],
+        ),
     ),
     entry(
         &["discuss", "resolve"],
-        documented_schemas(MUTATING, &["discuss resolve"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["discuss resolve"]),
+            &[json_discriminator(
+                Some("discuss resolve"),
+                "output_kind",
+                "discuss_resolve",
+            )],
+        ),
     ),
     entry(
         &["discuss", "list"],
-        documented_schemas(READ_JSON, &["discuss list"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["discuss list"]),
+            &[json_discriminator(
+                Some("discuss list"),
+                "output_kind",
+                "discuss_list",
+            )],
+        ),
     ),
     entry(
         &["discuss", "show"],
-        documented_schemas(READ_JSON, &["discuss show"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["discuss show"]),
+            &[json_discriminator(
+                Some("discuss show"),
+                "output_kind",
+                "discuss_show",
+            )],
+        ),
     ),
     entry(
         &["doctor"],
@@ -1536,14 +1682,26 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "Use pull for the normal remote update workflow; inspect verification output before materializing changes.",
         ),
     ),
-    entry(&["fork"], opaque_schemas(MUTATING, &["fork"])),
+    entry(
+        &["fork"],
+        json_discriminators(
+            opaque_schemas(MUTATING, &["fork"]),
+            &[json_discriminator(Some("fork"), "output_kind", "fork")],
+        ),
+    ),
     entry(&["fsck"], documented_schemas(MUTATING, &["fsck"])),
     entry(&["gc"], hidden(opaque_schemas(GC_MUTATION, &["gc"]))),
     entry(
         &["git-overlay"],
         documented_schemas(READ_JSON, &["git-overlay"]),
     ),
-    entry(&["goto"], documented_schemas(WORKTREE_MUTATION, &["goto"])),
+    entry(
+        &["goto"],
+        json_discriminators(
+            documented_schemas(WORKTREE_MUTATION, &["goto"]),
+            &[json_discriminator(Some("goto"), "output_kind", "goto")],
+        ),
+    ),
     entry(
         &["harness-bridge"],
         hidden(opaque_schemas(READ_JSONL, &["harness-bridge"])),
@@ -1579,7 +1737,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["init"],
         exits(
-            front_door(documented_schemas(INIT, &["init"]), 200),
+            front_door(
+                json_discriminators(
+                    documented_schemas(INIT, &["init"]),
+                    &[json_discriminator(Some("init"), "output_kind", "init")],
+                ),
+                200,
+            ),
             &[
                 (0, "ok"),
                 (73, "cannot create state directory"),
@@ -1685,14 +1849,34 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["stack"], opaque_schemas(READ_JSON, &["stack"])),
+    entry(
+        &["stack"],
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["stack"]),
+            &[json_discriminator(Some("stack"), "output_kind", "stack")],
+        ),
+    ),
     entry(
         &["stack", "ready"],
-        opaque_schemas(READ_JSON, &["stack ready"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["stack ready"]),
+            &[json_discriminator(
+                Some("stack ready"),
+                "output_kind",
+                "stack_ready",
+            )],
+        ),
     ),
     entry(
         &["stack", "snapshot"],
-        opaque_schemas(READ_JSON, &["stack snapshot"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["stack snapshot"]),
+            &[json_discriminator(
+                Some("stack snapshot"),
+                "output_kind",
+                "stack_snapshot",
+            )],
+        ),
     ),
     entry(
         &["monitor"],
@@ -1725,17 +1909,31 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["purge"], GROUP),
     entry(
         &["purge", "apply"],
-        opaque_schemas(
-            CommandContract {
-                destructive_requires_force: true,
-                ..DESTRUCTIVE_DATA_MUTATION
-            },
-            &["purge apply"],
+        json_discriminators(
+            opaque_schemas(
+                CommandContract {
+                    destructive_requires_force: true,
+                    ..DESTRUCTIVE_DATA_MUTATION
+                },
+                &["purge apply"],
+            ),
+            &[json_discriminator(
+                Some("purge apply"),
+                "output_kind",
+                "purge_apply",
+            )],
         ),
     ),
     entry(
         &["purge", "list"],
-        opaque_schemas(READ_JSON, &["purge list"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["purge list"]),
+            &[json_discriminator(
+                Some("purge list"),
+                "output_kind",
+                "purge_list",
+            )],
+        ),
     ),
     entry(
         &["push"],
@@ -1778,28 +1976,70 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["redact"], GROUP),
     entry(
         &["redact", "apply"],
-        opaque_schemas(DATA_MUTATION, &["redact apply"]),
+        json_discriminators(
+            opaque_schemas(DATA_MUTATION, &["redact apply"]),
+            &[json_discriminator(
+                Some("redact apply"),
+                "output_kind",
+                "redact_apply",
+            )],
+        ),
     ),
     entry(
         &["redact", "list"],
-        opaque_schemas(READ_JSON, &["redact list"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["redact list"]),
+            &[json_discriminator(
+                Some("redact list"),
+                "output_kind",
+                "redact_list",
+            )],
+        ),
     ),
     entry(
         &["redact", "show"],
-        opaque_schemas(READ_JSON, &["redact show"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["redact show"]),
+            &[json_discriminator(
+                Some("redact show"),
+                "output_kind",
+                "redact_show",
+            )],
+        ),
     ),
     entry(&["redact", "trust"], GROUP),
     entry(
         &["redact", "trust", "add"],
-        opaque_schemas(DATA_MUTATION, &["redact trust add"]),
+        json_discriminators(
+            opaque_schemas(DATA_MUTATION, &["redact trust add"]),
+            &[json_discriminator(
+                Some("redact trust add"),
+                "output_kind",
+                "redact_trust_add",
+            )],
+        ),
     ),
     entry(
         &["redact", "trust", "list"],
-        opaque_schemas(READ_JSON, &["redact trust list"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["redact trust list"]),
+            &[json_discriminator(
+                Some("redact trust list"),
+                "output_kind",
+                "redact_trust_list",
+            )],
+        ),
     ),
     entry(
         &["redact", "trust", "remove"],
-        opaque_schemas(DATA_MUTATION, &["redact trust remove"]),
+        json_discriminators(
+            opaque_schemas(DATA_MUTATION, &["redact trust remove"]),
+            &[json_discriminator(
+                Some("redact trust remove"),
+                "output_kind",
+                "redact_trust_remove",
+            )],
+        ),
     ),
     entry(
         &["redo"],
@@ -1836,24 +2076,55 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["retro"], documented_schemas(READ_JSON, &["retro"])),
     entry(
         &["revert"],
-        documented_schemas(WORKTREE_MUTATION, &["revert"]),
+        json_discriminators(
+            documented_schemas(WORKTREE_MUTATION, &["revert"]),
+            &[json_discriminator(Some("revert"), "output_kind", "revert")],
+        ),
     ),
     entry(&["review"], GROUP),
     entry(
         &["review", "show"],
-        documented_schemas(READ_JSON, &["review show"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["review show"]),
+            &[json_discriminator(
+                Some("review show"),
+                "output_kind",
+                "review_show",
+            )],
+        ),
     ),
     entry(
         &["review", "sign"],
-        documented_schemas(MUTATING, &["review sign"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["review sign"]),
+            &[json_discriminator(
+                Some("review sign"),
+                "output_kind",
+                "review_sign",
+            )],
+        ),
     ),
     entry(
         &["review", "next"],
-        documented_schemas(READ_JSON, &["review next"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["review next"]),
+            &[json_discriminator(
+                Some("review next"),
+                "output_kind",
+                "review_next",
+            )],
+        ),
     ),
     entry(
         &["review", "health"],
-        documented_schemas(READ_JSON, &["review health"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["review health"]),
+            &[json_discriminator(
+                Some("review health"),
+                "output_kind",
+                "review_health",
+            )],
+        ),
     ),
     entry(&["run"], surface(EXTERNAL_WORKTREE_COMMAND, "automation")),
     entry(
@@ -1953,7 +2224,14 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["stash", "list"],
         git_adapter_action(
-            documented_schemas(READ_JSON, &["stash list"]),
+            json_discriminators(
+                documented_schemas(READ_JSON, &["stash list"]),
+                &[json_discriminator(
+                    Some("stash list"),
+                    "output_kind",
+                    "stash_list",
+                )],
+            ),
             "thread captures",
             "conceptual_home",
             "Use thread captures to inspect durable Heddle save points.",
@@ -2003,7 +2281,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["stash", "show"],
-        git_adapter_alias(documented_schemas(READ_JSON, &["stash show"]), "show"),
+        git_adapter_alias(
+            json_discriminators(
+                documented_schemas(READ_JSON, &["stash show"]),
+                &[json_discriminator(
+                    Some("stash show"),
+                    "output_kind",
+                    "stash_show",
+                )],
+            ),
+            "show",
+        ),
     ),
     entry(
         &["status"],
@@ -2149,7 +2437,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["verify"],
         exits(
-            front_door(documented_schemas(READ_JSON, &["verify"]), 110),
+            front_door(
+                json_discriminators(
+                    documented_schemas(READ_JSON, &["verify"]),
+                    &[json_discriminator(Some("verify"), "output_kind", "verify")],
+                ),
+                110,
+            ),
             &[
                 (0, "verified clean"),
                 (65, "verification reports blocked state"),
@@ -4806,6 +5100,11 @@ mod tests {
 
     #[test]
     fn json_discriminator_table_starts_with_bounded_command_slice() {
+        // Wire-format-stable list. PR #251 instrumented the initial set;
+        // heddle#272 swept the named-by-persona verbs (stack, goto, fork,
+        // revert, purge, redact, stash, clean, discuss, context, review,
+        // cherry-pick, bisect). Any further sweep MUST extend this list
+        // and document the addition.
         let displays = raw_json_discriminator_specs()
             .iter()
             .map(|(path, _)| path.join(" "))
@@ -4813,22 +5112,66 @@ mod tests {
         assert_eq!(
             displays,
             vec![
+                "bisect start",
+                "bisect good",
+                "bisect bad",
+                "bisect reset",
                 "bridge git status",
                 "bridge git import",
                 "bridge git sync",
                 "bridge git reconcile",
                 "capture",
                 "checkpoint",
+                "cherry-pick",
+                "clean",
+                "clone",
                 "commit",
                 "commands",
+                "context set",
+                "context get",
+                "context list",
+                "context history",
+                "context edit",
+                "context supersede",
+                "context rm",
+                "context check",
+                "context suggest",
+                "context audit",
                 "diff",
+                "discuss open",
+                "discuss append",
+                "discuss resolve",
+                "discuss list",
+                "discuss show",
                 "doctor docs",
                 "doctor schemas",
+                "fork",
+                "goto",
+                "init",
+                "stack",
+                "stack ready",
+                "stack snapshot",
+                "purge apply",
+                "purge list",
+                "redact apply",
+                "redact list",
+                "redact show",
+                "redact trust add",
+                "redact trust list",
+                "redact trust remove",
                 "redo",
+                "revert",
+                "review show",
+                "review sign",
+                "review next",
+                "review health",
                 "schemas",
+                "stash list",
+                "stash show",
                 "status",
                 "thread list",
                 "thread show",
+                "verify",
                 "undo",
                 "workspace show",
             ]

--- a/crates/cli/src/cli/commands/context/context_mutate.rs
+++ b/crates/cli/src/cli/commands/context/context_mutate.rs
@@ -83,6 +83,7 @@ pub async fn cmd_context_set(
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_set",
                 "target": label,
                 "annotations": blob.annotations.len(),
                 "state": new_state.change_id.short(),
@@ -168,6 +169,7 @@ pub async fn cmd_context_edit(
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_edit",
                 "annotation_id": annotation_id,
                 "state": new_state.change_id.short(),
                 "revision_count": revision_count,
@@ -261,6 +263,7 @@ pub async fn cmd_context_supersede(
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_supersede",
                 "annotation_id": annotation_id,
                 "replacement_target": label,
                 "rewrite_pct": rewrite_pct,
@@ -326,6 +329,7 @@ pub async fn cmd_context_rm(
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_rm",
                 "target": label,
                 "removed": true,
                 "state": new_state.change_id.short(),

--- a/crates/cli/src/cli/commands/context/context_query.rs
+++ b/crates/cli/src/cli/commands/context/context_query.rs
@@ -15,8 +15,8 @@ use repo::{
 use serde::Serialize;
 
 use super::{
-    AnnotationHistoryOutput, AnnotationOutput, ContextGetOutput, RevisionOutput,
-    filter_annotations, print_context_get, resolve_state, resolve_state_id, target_label,
+    AnnotationHistoryOutput, AnnotationOutput, ContextListRow, RevisionOutput, filter_annotations,
+    print_context_get, resolve_state, resolve_state_id, target_label,
 };
 use crate::cli::{Cli, commands::RecoveryAdvice, should_output_json};
 
@@ -89,7 +89,7 @@ pub async fn cmd_context_list(
     let entries = repo.list_context_entries(context_root, prefix.as_deref().map(Path::new))?;
 
     if should_output_json(cli, None) {
-        let items: Vec<ContextGetOutput> = entries
+        let items: Vec<ContextListRow> = entries
             .iter()
             .filter_map(|entry| {
                 let annotations = filter_annotations(
@@ -103,13 +103,7 @@ pub async fn cmd_context_list(
                     return None;
                 }
                 let (target_kind, target_label) = target_label(&entry.target);
-                Some(ContextGetOutput {
-                    // `context_list` envelopes ContextGetOutput rows, so
-                    // the inner `output_kind` field is suppressed via
-                    // serialization to avoid leaking a misleading
-                    // per-row discriminator. The outer envelope owns
-                    // the discriminator.
-                    output_kind: "context_get",
+                Some(ContextListRow {
                     target_kind,
                     target: target_label,
                     annotations: annotations

--- a/crates/cli/src/cli/commands/context/context_query.rs
+++ b/crates/cli/src/cli/commands/context/context_query.rs
@@ -76,7 +76,10 @@ pub async fn cmd_context_list(
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let Some(context_root) = &state_obj.context else {
         if should_output_json(cli, None) {
-            println!("[]");
+            println!(
+                "{}",
+                serde_json::json!({"output_kind": "context_list", "items": []})
+            );
         } else {
             println!("No context annotations.");
         }
@@ -86,7 +89,7 @@ pub async fn cmd_context_list(
     let entries = repo.list_context_entries(context_root, prefix.as_deref().map(Path::new))?;
 
     if should_output_json(cli, None) {
-        let output: Vec<ContextGetOutput> = entries
+        let items: Vec<ContextGetOutput> = entries
             .iter()
             .filter_map(|entry| {
                 let annotations = filter_annotations(
@@ -101,6 +104,12 @@ pub async fn cmd_context_list(
                 }
                 let (target_kind, target_label) = target_label(&entry.target);
                 Some(ContextGetOutput {
+                    // `context_list` envelopes ContextGetOutput rows, so
+                    // the inner `output_kind` field is suppressed via
+                    // serialization to avoid leaking a misleading
+                    // per-row discriminator. The outer envelope owns
+                    // the discriminator.
+                    output_kind: "context_get",
                     target_kind,
                     target: target_label,
                     annotations: annotations
@@ -110,7 +119,11 @@ pub async fn cmd_context_list(
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string(&output)?);
+        let envelope = serde_json::json!({
+            "output_kind": "context_list",
+            "items": items,
+        });
+        println!("{}", serde_json::to_string(&envelope)?);
     } else if entries.is_empty() {
         println!("No context annotations.");
     } else {
@@ -156,6 +169,7 @@ pub async fn cmd_context_history(
     let annotation = &blob.annotations[index];
     let (target_kind, target_label) = target_label(&target);
     let output = AnnotationHistoryOutput {
+        output_kind: "context_history",
         annotation_id: annotation.annotation_id.clone(),
         target_kind,
         target: target_label,
@@ -242,7 +256,14 @@ pub async fn cmd_context_check(
 
     if filtered_entries.is_empty() {
         if should_output_json(cli, None) {
-            println!("{}", serde_json::json!({ "annotations": 0, "stale": 0 }));
+            println!(
+                "{}",
+                serde_json::json!({
+                    "output_kind": "context_check",
+                    "annotations": 0,
+                    "stale": 0,
+                })
+            );
         } else {
             println!("No annotations found.");
         }
@@ -310,6 +331,7 @@ pub async fn cmd_context_check(
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_check",
                 "annotations": total,
                 "fresh": fresh,
                 "stale": stale,
@@ -341,7 +363,7 @@ pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize)
     let suggestions = repo.suggest_context_targets(&state_obj, limit)?;
 
     if should_output_json(cli, None) {
-        let output: Vec<SuggestionOutput> = suggestions
+        let items: Vec<SuggestionOutput> = suggestions
             .into_iter()
             .map(|suggestion| SuggestionOutput {
                 path: suggestion.path,
@@ -358,7 +380,11 @@ pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize)
                 stale_annotations: suggestion.stale_annotations,
             })
             .collect();
-        println!("{}", serde_json::to_string(&output)?);
+        let envelope = serde_json::json!({
+            "output_kind": "context_suggest",
+            "items": items,
+        });
+        println!("{}", serde_json::to_string(&envelope)?);
     } else if suggestions.is_empty() {
         println!("No low-noise context suggestions right now.");
     } else {
@@ -384,7 +410,13 @@ pub async fn cmd_context_audit(cli: &Cli, r#ref: Option<String>) -> Result<()> {
         if should_output_json(cli, None) {
             println!(
                 "{}",
-                serde_json::json!({"annotations": 0, "superseded": 0, "duplicates": 0, "stale": 0})
+                serde_json::json!({
+                    "output_kind": "context_audit",
+                    "annotations": 0,
+                    "superseded": 0,
+                    "duplicates": 0,
+                    "stale": 0,
+                })
             );
         } else {
             println!("No context annotations.");
@@ -444,6 +476,7 @@ pub async fn cmd_context_audit(cli: &Cli, r#ref: Option<String>) -> Result<()> {
         println!(
             "{}",
             serde_json::json!({
+                "output_kind": "context_audit",
                 "annotations": total,
                 "superseded": superseded,
                 "duplicates": duplicates,

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -73,6 +73,7 @@ impl AnnotationOutput {
 
 #[derive(Serialize)]
 pub(crate) struct ContextGetOutput {
+    pub(crate) output_kind: &'static str,
     pub(crate) target_kind: String,
     pub(crate) target: String,
     pub(crate) annotations: Vec<AnnotationOutput>,
@@ -80,6 +81,7 @@ pub(crate) struct ContextGetOutput {
 
 #[derive(Serialize)]
 pub(crate) struct AnnotationHistoryOutput {
+    pub(crate) output_kind: &'static str,
     pub(crate) annotation_id: String,
     pub(crate) target_kind: String,
     pub(crate) target: String,
@@ -370,6 +372,7 @@ pub(crate) fn print_context_get(
     let (target_kind, target_label) = target_label(target);
     if should_output_json(cli, None) {
         let output = ContextGetOutput {
+            output_kind: "context_get",
             target_kind,
             target: target_label,
             annotations: annotations

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -79,6 +79,18 @@ pub(crate) struct ContextGetOutput {
     pub(crate) annotations: Vec<AnnotationOutput>,
 }
 
+/// A single `context list` row. Identical to [`ContextGetOutput`] minus
+/// the per-row `output_kind`: the `context_list` envelope owns the
+/// discriminator, so list rows must not repeat it (consumers that route
+/// recursively on `output_kind` would otherwise misclassify a list row
+/// as a standalone `context get` payload).
+#[derive(Serialize)]
+pub(crate) struct ContextListRow {
+    pub(crate) target_kind: String,
+    pub(crate) target: String,
+    pub(crate) annotations: Vec<AnnotationOutput>,
+}
+
 #[derive(Serialize)]
 pub(crate) struct AnnotationHistoryOutput {
     pub(crate) output_kind: &'static str,

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -71,7 +71,19 @@ struct TurnView {
 
 #[derive(Serialize)]
 struct DiscussionListOutput {
+    output_kind: &'static str,
     discussions: Vec<DiscussionOutput>,
+}
+
+/// Envelope used by per-discussion verbs (`open`/`append`/`resolve`/`show`).
+/// The verb's `output_kind` rides on top of the discussion payload; the
+/// inner fields stay flat for wire compat with PR #251's discussion
+/// schema.
+#[derive(Serialize)]
+struct DiscussionEnvelope<'a> {
+    output_kind: &'static str,
+    #[serde(flatten)]
+    discussion: &'a DiscussionOutput,
 }
 
 fn open_service() -> Result<LocalDiscussionService> {
@@ -100,7 +112,7 @@ async fn run_open(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussOpenArg
         .open_discussion(tonic::Request::new(req))
         .await
         .map_err(status_to_anyhow)?;
-    emit_discussion(cli, &to_view(&resp.into_inner()))
+    emit_discussion(cli, "discuss_open", &to_view(&resp.into_inner()))
 }
 
 async fn run_append(
@@ -118,7 +130,7 @@ async fn run_append(
         .append_turn(tonic::Request::new(req))
         .await
         .map_err(status_to_anyhow)?;
-    emit_discussion(cli, &to_view(&resp.into_inner()))
+    emit_discussion(cli, "discuss_append", &to_view(&resp.into_inner()))
 }
 
 async fn run_resolve(
@@ -174,7 +186,7 @@ async fn run_resolve(
         .resolve_discussion(tonic::Request::new(req))
         .await
         .map_err(status_to_anyhow)?;
-    emit_discussion(cli, &to_view(&resp.into_inner()))
+    emit_discussion(cli, "discuss_resolve", &to_view(&resp.into_inner()))
 }
 
 async fn run_list(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussListArgs) -> Result<()> {
@@ -206,6 +218,7 @@ async fn run_list(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussListArg
         resp.into_inner().discussions
     };
     let output = DiscussionListOutput {
+        output_kind: "discuss_list",
         discussions: discussions.iter().map(to_view).collect(),
     };
     if should_output_json(cli, None) {
@@ -242,14 +255,18 @@ async fn run_show(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussShowArg
         .get_discussion(tonic::Request::new(req))
         .await
         .map_err(status_to_anyhow)?;
-    emit_discussion(cli, &to_view(&resp.into_inner()))
+    emit_discussion(cli, "discuss_show", &to_view(&resp.into_inner()))
 }
 
-fn emit_discussion(cli: &Cli, view: &DiscussionOutput) -> Result<()> {
+fn emit_discussion(cli: &Cli, output_kind: &'static str, view: &DiscussionOutput) -> Result<()> {
     if should_output_json(cli, None) {
+        let envelope = DiscussionEnvelope {
+            output_kind,
+            discussion: view,
+        };
         println!(
             "{}",
-            serde_json::to_string(view).context("serialize discussion")?
+            serde_json::to_string(&envelope).context("serialize discussion")?
         );
     } else {
         println!("discussion {}", view.id);

--- a/crates/cli/src/cli/commands/doctor_schemas.rs
+++ b/crates/cli/src/cli/commands/doctor_schemas.rs
@@ -790,6 +790,34 @@ fn extract_samples(doc: &str) -> Vec<DocSample> {
     samples
 }
 
+/// Every `docs/json-schemas.md` ```json sample that binds to at least one
+/// verb in `verbs`, paired with the subset of `verbs` it binds to (via
+/// section heading or inline `heddle <verb>` hint), in document order.
+///
+/// This is the same heading/inline binding `heddle doctor schemas`
+/// validates samples with, exposed so the `output_kind` discriminator
+/// invariant can assert — sample-by-sample — that every documented sample
+/// for a catalog-advertised discriminator verb carries the right
+/// discriminator. Returning the full bound-verb set (not one verb at a
+/// time) lets the invariant accept a grouped sample, e.g. the single
+/// `heddle undo|redo` sample binds to both `undo` and `redo` and may
+/// legitimately show either variant's discriminator. Sharing the binding
+/// keeps the invariant and the production drift gate agreeing on which
+/// sample documents which verb.
+pub fn documented_samples_with_bound_verbs(doc: &str, verbs: &[&str]) -> Vec<(Value, Vec<String>)> {
+    extract_samples(doc)
+        .into_iter()
+        .filter_map(|sample| {
+            let bound: Vec<String> = verbs
+                .iter()
+                .filter(|verb| sample_matches_verb_with_hints(&sample, verb))
+                .map(|verb| (*verb).to_string())
+                .collect();
+            (!bound.is_empty()).then_some((sample.json, bound))
+        })
+        .collect()
+}
+
 /// Bind a sample to a verb using inline hints first, then heading
 /// fallback.
 fn sample_matches_verb_with_hints(sample: &DocSample, verb: &str) -> bool {

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -18,6 +18,7 @@ use crate::{
 
 #[derive(Serialize)]
 struct ForkOutput {
+    output_kind: &'static str,
     change_id: String,
     content_hash: String,
     thread: Option<String>,
@@ -93,6 +94,7 @@ pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result
         .record_fork(&new_state.change_id, &source_state.change_id)?;
 
     let output = ForkOutput {
+        output_kind: "fork",
         change_id: new_state.change_id.short(),
         content_hash: new_state.compute_hash().short(),
         thread: name.clone(),

--- a/crates/cli/src/cli/commands/goto.rs
+++ b/crates/cli/src/cli/commands/goto.rs
@@ -20,6 +20,7 @@ use crate::{
 
 #[derive(Serialize)]
 struct GotoOutput {
+    output_kind: &'static str,
     target: String,
     intent: Option<String>,
     message: String,
@@ -71,6 +72,7 @@ pub fn cmd_goto(cli: &Cli, target: String, force: bool) -> Result<()> {
     }
 
     let output = GotoOutput {
+        output_kind: "goto",
         target: target_id.short(),
         intent: target_state.intent.clone(),
         message: format!("Now at: {}", target_id.short()),

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -21,6 +21,7 @@ use crate::{
 
 #[derive(Serialize)]
 struct InitOutput {
+    output_kind: &'static str,
     status: String,
     action: String,
     path: PathBuf,
@@ -124,6 +125,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         (!trust.recommended_action.is_empty()).then(|| trust.recommended_action.clone());
     let principal_status = init_principal_status(&repo, &user_config)?;
     let output = InitOutput {
+        output_kind: "init",
         status: "initialized".to_string(),
         action: "init".to_string(),
         path: repo.heddle_dir().to_path_buf(),

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -121,7 +121,10 @@ pub use bridge::cmd_bridge_git;
 pub use checkpoint::run as cmd_checkpoint;
 pub use cherry_pick::cmd_cherry_pick;
 pub use clean::cmd_clean;
-pub use clone::{GitOverlayBlobHydrator, cmd_clone, register_git_overlay_factory};
+pub use clone::{
+    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, GitOverlayBlobHydrator, cmd_clone,
+    register_git_overlay_factory,
+};
 pub use collapse::cmd_collapse;
 pub use command_catalog::{
     CommandCatalogOutput, build_command_catalog, cmd_commands, command_canonical_command,

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -148,7 +148,7 @@ pub use diagnose::cmd_diagnose;
 pub use diff::cmd_diff;
 pub use discuss::run as cmd_discuss;
 pub use doctor_docs::cmd_doctor_docs;
-pub use doctor_schemas::cmd_doctor_schemas;
+pub use doctor_schemas::{cmd_doctor_schemas, documented_samples_with_bound_verbs};
 pub use error_envelope::{print_error_with_hint, print_parse_error_json_envelope};
 pub use fetch::cmd_fetch;
 pub use fork::cmd_fork;

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -28,6 +28,7 @@ pub fn cmd_purge(cli: &Cli, command: PurgeCommands) -> Result<()> {
 
 #[derive(Serialize)]
 struct PurgeApplyOutput {
+    output_kind: &'static str,
     redaction_id: Option<String>,
     blob: String,
     state: String,
@@ -103,6 +104,7 @@ fn cmd_purge_apply(cli: &Cli, repo: &Repository, args: PurgeApplyArgs) -> Result
     let ignore_hint = super::redact::ignore_hint_for_path(repo, &args.path)?;
 
     let output = PurgeApplyOutput {
+        output_kind: "purge_apply",
         redaction_id: outcome.redaction_id.map(|h| h.short()),
         blob: blob.short(),
         state: state.short(),
@@ -143,6 +145,7 @@ fn cmd_purge_list(cli: &Cli, repo: &Repository, _args: PurgeListArgs) -> Result<
     }
     #[derive(Serialize)]
     struct Listing {
+        output_kind: &'static str,
         purges: Vec<Row>,
         count: usize,
     }
@@ -165,6 +168,7 @@ fn cmd_purge_list(cli: &Cli, repo: &Repository, _args: PurgeListArgs) -> Result<
     }
     let count = rows.len();
     let payload = Listing {
+        output_kind: "purge_list",
         purges: rows,
         count,
     };

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -49,6 +49,7 @@ pub fn cmd_redact(cli: &Cli, command: RedactCommands) -> Result<()> {
 
 #[derive(Serialize)]
 struct RedactApplyOutput {
+    output_kind: &'static str,
     redaction_id: String,
     blob: String,
     state: String,
@@ -170,6 +171,7 @@ fn cmd_redact_apply(cli: &Cli, repo: &Repository, args: RedactApplyArgs) -> Resu
     let ignore_hint = ignore_hint_for_path(repo, &args.path)?;
 
     let output = RedactApplyOutput {
+        output_kind: "redact_apply",
         redaction_id: primary_id.short(),
         blob: blob.short(),
         state: state.short(),
@@ -296,6 +298,7 @@ fn cmd_redact_list(cli: &Cli, repo: &Repository, _args: RedactListArgs) -> Resul
     }
     #[derive(Serialize)]
     struct Listing {
+        output_kind: &'static str,
         redactions: Vec<Row>,
         count: usize,
     }
@@ -320,6 +323,7 @@ fn cmd_redact_list(cli: &Cli, repo: &Repository, _args: RedactListArgs) -> Resul
 
     let count = rows.len();
     let payload = Listing {
+        output_kind: "redact_list",
         redactions: rows,
         count,
     };
@@ -369,6 +373,7 @@ fn cmd_redact_show(cli: &Cli, repo: &Repository, args: RedactShowArgs) -> Result
 
     #[derive(Serialize)]
     struct ShowOutput<'a> {
+        output_kind: &'static str,
         redaction_id: String,
         blob: String,
         state: String,
@@ -385,6 +390,7 @@ fn cmd_redact_show(cli: &Cli, repo: &Repository, args: RedactShowArgs) -> Result
         stub_preview: String,
     }
     let output = ShowOutput {
+        output_kind: "redact_show",
         redaction_id: id.short(),
         blob: blob.short(),
         state: redaction.state.short(),
@@ -603,9 +609,23 @@ struct TrustEntryOutput {
 }
 
 #[derive(Serialize)]
+struct TrustAddOutput {
+    output_kind: &'static str,
+    #[serde(flatten)]
+    entry: TrustEntryOutput,
+}
+
+#[derive(Serialize)]
 struct TrustListOutput {
+    output_kind: &'static str,
     trusted_keys: Vec<TrustEntryOutput>,
     count: usize,
+}
+
+#[derive(Serialize)]
+struct TrustRemoveOutput {
+    output_kind: &'static str,
+    removed: usize,
 }
 
 fn cmd_redact_trust(cli: &Cli, repo: &Repository, command: RedactTrustCommands) -> Result<()> {
@@ -708,19 +728,23 @@ fn cmd_redact_trust_add(cli: &Cli, repo: &Repository, args: RedactTrustAddArgs) 
     std::fs::write(&config_path, serialized)
         .with_context(|| format!("write '{}'", config_path.display()))?;
 
-    let output = TrustEntryOutput {
+    let entry = TrustEntryOutput {
         algorithm,
         public_key,
         label: args.label,
+    };
+    let output = TrustAddOutput {
+        output_kind: "redact_trust_add",
+        entry,
     };
     if should_output_json(cli, None) {
         println!("{}", serde_json::to_string(&output)?);
     } else {
         println!(
             "trusted {} key {} ({})",
-            output.algorithm,
-            short_key(&output.public_key),
-            output.label.as_deref().unwrap_or("unlabeled"),
+            output.entry.algorithm,
+            short_key(&output.entry.public_key),
+            output.entry.label.as_deref().unwrap_or("unlabeled"),
         );
     }
     Ok(())
@@ -740,6 +764,7 @@ fn cmd_redact_trust_list(cli: &Cli, repo: &Repository, _args: RedactTrustListArg
         .collect();
     let count = keys.len();
     let output = TrustListOutput {
+        output_kind: "redact_trust_list",
         trusted_keys: keys,
         count,
     };
@@ -816,7 +841,11 @@ fn cmd_redact_trust_remove(
         .with_context(|| format!("write '{}'", config_path.display()))?;
 
     if should_output_json(cli, None) {
-        println!("{{\"removed\":{removed}}}");
+        let output = TrustRemoveOutput {
+            output_kind: "redact_trust_remove",
+            removed,
+        };
+        println!("{}", serde_json::to_string(&output)?);
     } else {
         println!(
             "removed {removed} trust entry/entries matching {}",

--- a/crates/cli/src/cli/commands/revert.rs
+++ b/crates/cli/src/cli/commands/revert.rs
@@ -17,6 +17,7 @@ use crate::cli::{Cli, should_output_json};
 
 #[derive(Serialize)]
 struct RevertOutput {
+    output_kind: &'static str,
     change_id: Option<String>,
     reverted_state: String,
     files_affected: Vec<String>,
@@ -72,6 +73,7 @@ pub fn cmd_revert(
             println!(
                 "{}",
                 serde_json::to_string(&RevertOutput {
+                    output_kind: "revert",
                     change_id: None,
                     reverted_state: target_id.short(),
                     files_affected,
@@ -96,6 +98,7 @@ pub fn cmd_revert(
         println!(
             "{}",
             serde_json::to_string(&RevertOutput {
+                output_kind: "revert",
                 change_id: Some(new_state.change_id.short()),
                 reverted_state: target_id.short(),
                 files_affected,

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -38,6 +38,7 @@ pub async fn run(cli: &Cli, command: &ReviewCommands) -> Result<()> {
 
 #[derive(Serialize)]
 struct ReviewShowOutput {
+    output_kind: &'static str,
     change_id: String,
     headline: String,
     agent_narrative: Option<String>,
@@ -138,6 +139,7 @@ async fn run_show(cli: &Cli, args: &ReviewShowArgs) -> Result<()> {
         .collect();
 
     let output = ReviewShowOutput {
+        output_kind: "review_show",
         change_id: bytes_to_change_id_string(&payload_resp.state_id),
         headline: summary.headline,
         agent_narrative: opt_string(payload_resp.agent_narrative),
@@ -296,6 +298,7 @@ async fn run_sign(cli: &Cli, args: &ReviewSignArgs) -> Result<()> {
     if should_output_json(cli, None) {
         let state_str = bytes_to_change_id_string(&resp.state_id);
         let out = serde_json::json!({
+            "output_kind": "review_sign",
             "signature_id": resp.signature_id,
             "change_id": state_str,
         });
@@ -376,13 +379,28 @@ async fn run_next(cli: &Cli, args: &ReviewNextArgs) -> Result<()> {
     }
 
     if should_output_json(cli, None) {
-        match &next_state {
-            Some(view) => println!(
-                "{}",
-                serde_json::to_string(view).context("serialize next pending review")?
-            ),
-            None => println!("null"),
-        }
+        // `review next` returns either the pending state's view flattened
+        // alongside `output_kind`, or `next: null` when the window holds
+        // none. Keeping a single envelope shape lets agents key off
+        // `output_kind` without branching on payload shape.
+        let envelope = match &next_state {
+            Some(view) => serde_json::json!({
+                "output_kind": "review_next",
+                "change_id": view.change_id,
+                "headline": view.headline,
+                "existing_signatures": view.existing_signatures,
+                "next": view,
+            }),
+            None => serde_json::json!({
+                "output_kind": "review_next",
+                "next": serde_json::Value::Null,
+            }),
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&envelope)
+                .context("serialize review next envelope")?
+        );
     } else {
         match &next_state {
             Some(view) => {
@@ -432,6 +450,7 @@ async fn run_health(cli: &Cli, args: &ReviewHealthArgs) -> Result<()> {
             })
             .collect();
         let out = serde_json::json!({
+            "output_kind": "review_health",
             "entries": entries,
             "window_states": resp.window_states,
         });

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -116,7 +116,7 @@ schema_registry! {
     (&["review health"], ReviewHealthSchema),
     (&["inspect"], InspectSchema),
     (&["retro"], RetroSchema),
-    (&["discuss open", "discuss append", "discuss resolve", "discuss show"], DiscussionSchema),
+    (&["discuss open", "discuss append", "discuss resolve", "discuss show"], DiscussionEnvelopeSchema),
     (&["discuss list"], DiscussionListSchema),
     (&["query"], QuerySchema),
     (&["transaction commit"], TransactionCommitSchema),
@@ -755,6 +755,20 @@ pub struct DiscussionSchema {
     pub resolved_annotation_id: Option<String>,
 }
 
+/// Per-discussion verbs (`open`/`append`/`resolve`/`show`) emit the
+/// discussion payload flattened beneath an `output_kind` discriminator,
+/// mirroring `DiscussionEnvelope` in `discuss.rs`. `discuss list` reuses
+/// the bare [`DiscussionSchema`] for its inner items — those carry no
+/// per-item discriminator (the list envelope owns it), so the
+/// discriminator lives on this wrapper rather than on the shared inner
+/// struct.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiscussionEnvelopeSchema {
+    pub output_kind: String,
+    #[serde(flatten)]
+    pub discussion: DiscussionSchema,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct DiscussionResolutionSchema {
     pub kind: String,
@@ -773,6 +787,7 @@ pub struct DiscussionTurnSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct DiscussionListSchema {
+    pub output_kind: String,
     pub discussions: Vec<DiscussionSchema>,
 }
 
@@ -807,6 +822,7 @@ pub struct OperationRecordSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct InitSchema {
+    pub output_kind: String,
     pub status: String,
     pub action: String,
     pub path: String,
@@ -949,6 +965,7 @@ pub struct UndoSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct CleanSchema {
+    pub output_kind: String,
     pub removed: Vec<String>,
     pub dry_run: bool,
 }
@@ -978,6 +995,7 @@ pub struct DiffStatsSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct GotoSchema {
+    pub output_kind: String,
     pub target: String,
     pub intent: Option<String>,
     pub message: String,
@@ -2237,6 +2255,7 @@ pub struct WorkspaceGroupSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ReviewShowSchema {
+    pub output_kind: String,
     pub change_id: String,
     pub headline: String,
     pub agent_narrative: Option<String>,
@@ -2250,6 +2269,7 @@ pub struct ReviewShowSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ReviewSignSchema {
+    pub output_kind: String,
     pub signature_id: String,
     pub change_id: String,
 }
@@ -2280,6 +2300,7 @@ pub struct ReviewNextStateSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ReviewHealthSchema {
+    pub output_kind: String,
     pub entries: Vec<ReviewHealthEntrySchema>,
     pub window_states: usize,
 }
@@ -2569,6 +2590,7 @@ pub struct StashMutationSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct StashListSchema {
+    pub output_kind: String,
     pub stashes: Vec<StashListEntrySchema>,
 }
 
@@ -2581,6 +2603,7 @@ pub struct StashListEntrySchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct StashShowSchema {
+    pub output_kind: String,
     pub modified: Vec<String>,
     pub added: Vec<String>,
     pub deleted: Vec<String>,
@@ -2588,6 +2611,7 @@ pub struct StashShowSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct RevertSchema {
+    pub output_kind: String,
     pub change_id: Option<String>,
     pub reverted_state: String,
     pub files_affected: Vec<String>,

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2287,7 +2287,28 @@ pub struct ReviewNextSchema {
     pub change_id: Option<String>,
     pub headline: Option<String>,
     pub existing_signatures: Option<u32>,
-    pub next: Option<ReviewNextStateSchema>,
+    pub next: RequiredNullableNextState,
+}
+
+/// `next` is ALWAYS present in the runtime envelope — either the pending
+/// review state or an explicit JSON `null`. Modeling it as
+/// `Option<ReviewNextStateSchema>` directly would let schemars drop the
+/// field from the schema's `required` set, advertising a shape the command
+/// never emits. This wrapper keeps the value nullable (its schema delegates
+/// to `Option`'s nullable form) while reporting `_schemars_private_is_option
+/// == false`, so the derive marks `next` required (heddle#272 Codex r7).
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct RequiredNullableNextState(pub Option<ReviewNextStateSchema>);
+
+impl JsonSchema for RequiredNullableNextState {
+    fn schema_name() -> String {
+        "RequiredNullableNextState".to_owned()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <Option<ReviewNextStateSchema> as JsonSchema>::json_schema(generator)
+    }
 }
 
 /// The pending review state echoed under `review next`'s `next` field.

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2254,14 +2254,28 @@ pub struct ReviewSignSchema {
     pub change_id: String,
 }
 
-/// `heddle review next --output json` emits either a populated object or the
-/// literal `null`. We model the populated shape; the `null` case is
-/// allowed by the doc and isn't covered here.
+/// `heddle review next --output json` emits a stable envelope keyed by
+/// `output_kind: "review_next"`. When the scan window holds a pending
+/// review, the pending state's view is flattened alongside `output_kind`
+/// (`change_id`, `headline`, `existing_signatures`) and the same view is
+/// echoed under `next`. When no pending review is found, only
+/// `output_kind` and `next: null` are emitted — there is no top-level
+/// `null`. Mirrors the envelope built in `review::run_next`.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ReviewNextSchema {
+    pub output_kind: String,
+    pub change_id: Option<String>,
+    pub headline: Option<String>,
+    pub existing_signatures: Option<u32>,
+    pub next: Option<ReviewNextStateSchema>,
+}
+
+/// The pending review state echoed under `review next`'s `next` field.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReviewNextStateSchema {
     pub change_id: String,
     pub headline: String,
-    pub existing_signatures: Vec<Value>,
+    pub existing_signatures: u32,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2806,6 +2806,61 @@ mod tests {
         }
     }
 
+    /// Every documented (non-opaque) verb whose catalog advertises an
+    /// `output_kind` discriminator must declare the `output_kind`
+    /// property on its *registered schema struct*, not merely rely on the
+    /// runtime injection in [`schema_for_verb`].
+    ///
+    /// heddle#272 r6 (Codex P2): `schema_for_verb` injects the
+    /// discriminator from the catalog after deriving the struct schema,
+    /// so `heddle schemas <verb>` already surfaces `output_kind`. That
+    /// injection masks the fact that the Rust mirror struct (e.g.
+    /// `CleanSchema`, `GotoSchema`) never declares the field. The mirror
+    /// is the source of truth a reader greps; it must be honest about the
+    /// discriminator the runtime always emits. This check reads the
+    /// *pre-injection* struct schema so a missing field fails CI rather
+    /// than being papered over by the catalog.
+    #[test]
+    fn documented_swept_schema_structs_declare_output_kind() {
+        let mut missing = Vec::new();
+        for verb in documented_schema_verbs() {
+            // Opaque verbs expose a generic object schema; their
+            // discriminator is genuinely catalog-only (there is no
+            // Serialize mirror struct to declare it on).
+            if opaque_schema_verbs().contains(verb) {
+                continue;
+            }
+            let Some(discriminator) =
+                command_catalog::command_json_discriminator_for_schema_verb(verb)
+            else {
+                continue;
+            };
+            if discriminator.field != "output_kind" {
+                continue;
+            }
+            let bare = schema_for_registered_verb(verb)
+                .unwrap_or_else(|| panic!("documented verb `{verb}` has no registered schema"));
+            let declares = bare
+                .get("properties")
+                .and_then(|properties| properties.get("output_kind"))
+                .is_some();
+            if !declares {
+                missing.push(format!(
+                    "{verb}: catalog advertises output_kind=`{}` but the schema struct declares no `output_kind` property",
+                    discriminator.value
+                ));
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "Documented swept schema structs missing the `output_kind` property. Add \
+             `pub output_kind: String` to each mirror struct so it matches the runtime \
+             emission (the catalog injection masks this at the `heddle schemas` layer, \
+             but the struct must be honest):\n  - {}",
+            missing.join("\n  - ")
+        );
+    }
+
     #[test]
     fn implementation_registry_matches_command_contract_registry() {
         let advertised = schema_verbs();

--- a/crates/cli/src/cli/commands/stack.rs
+++ b/crates/cli/src/cli/commands/stack.rs
@@ -45,6 +45,7 @@ fn resolve_target_thread(repo: &Repository, explicit: Option<String>) -> Result<
 
 #[derive(Serialize)]
 struct StackDescribeOutput {
+    output_kind: &'static str,
     /// The thread whose stack we scoped to. `None` when HEAD is detached
     /// and no `--thread` was given — then `stacks` lists every stack in
     /// the repo.
@@ -126,6 +127,7 @@ fn cmd_stack_describe(cli: &Cli, repo: &Repository, thread: Option<String>) -> R
 
     let stack_entries: Vec<StackEntry> = stacks.iter().map(stack_to_entry).collect();
     let output = StackDescribeOutput {
+        output_kind: "stack",
         thread: target.clone(),
         stack: scoped_stack.as_ref().map(stack_to_entry),
         stacks: stack_entries,
@@ -178,6 +180,7 @@ fn print_tree(node: &StackNode, depth: usize) {
 
 #[derive(Serialize)]
 struct StackReadyOutput {
+    output_kind: &'static str,
     thread: String,
     next_action: StackNextAction,
 }
@@ -189,6 +192,7 @@ fn cmd_stack_ready(cli: &Cli, repo: &Repository, thread: Option<String>) -> Resu
 
     if should_output_json(cli, Some(repo.config())) {
         let out = StackReadyOutput {
+            output_kind: "stack_ready",
             thread: target,
             next_action: action,
         };
@@ -234,14 +238,25 @@ fn cmd_stack_snapshot(cli: &Cli, repo: &Repository, thread: Option<String>) -> R
         None => full,
     };
 
+    let envelope = StackSnapshotOutput {
+        output_kind: "stack_snapshot",
+        snapshot: &snapshot,
+    };
     if should_output_json(cli, Some(repo.config())) {
-        println!("{}", serde_json::to_string(&snapshot)?);
+        println!("{}", serde_json::to_string(&envelope)?);
     } else {
         // Text mode still emits JSON — the snapshot is structured data
         // by definition. Pretty-print it so terminal output is readable.
-        println!("{}", serde_json::to_string_pretty(&snapshot)?);
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
     }
     Ok(())
+}
+
+#[derive(Serialize)]
+struct StackSnapshotOutput<'a> {
+    output_kind: &'static str,
+    #[serde(flatten)]
+    snapshot: &'a RepositorySnapshot,
 }
 
 #[cfg(test)]

--- a/crates/cli/src/cli/commands/stash.rs
+++ b/crates/cli/src/cli/commands/stash.rs
@@ -27,11 +27,13 @@ struct StashListEntry {
 
 #[derive(Serialize)]
 struct StashListOutput {
+    output_kind: &'static str,
     stashes: Vec<StashListEntry>,
 }
 
 #[derive(Serialize)]
 struct StashShowOutput {
+    output_kind: &'static str,
     modified: Vec<String>,
     added: Vec<String>,
     deleted: Vec<String>,
@@ -110,7 +112,10 @@ fn cmd_stash_list(cli: &Cli, repo: &Repository) -> Result<()> {
             .collect();
         println!(
             "{}",
-            serde_json::to_string(&StashListOutput { stashes: entries })?
+            serde_json::to_string(&StashListOutput {
+                output_kind: "stash_list",
+                stashes: entries
+            })?
         );
     } else if stashes.is_empty() {
         println!("No stashes.");
@@ -253,6 +258,7 @@ fn cmd_stash_show(cli: &Cli, repo: &Repository) -> Result<()> {
         println!(
             "{}",
             serde_json::to_string(&StashShowOutput {
+                output_kind: "stash_show",
                 modified,
                 added,
                 deleted,

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -49,6 +49,8 @@ mod hooks;
 mod misc;
 #[path = "cli_integration/oss_cli_polish.rs"]
 mod oss_cli_polish;
+#[path = "cli_integration/output_kind_invariant.rs"]
+mod output_kind_invariant;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
 #[path = "cli_integration/realworld_git.rs"]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -51,6 +51,8 @@ mod misc;
 mod oss_cli_polish;
 #[path = "cli_integration/output_kind_invariant.rs"]
 mod output_kind_invariant;
+#[path = "cli_integration/output_kind_runtime.rs"]
+mod output_kind_runtime;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
 #[path = "cli_integration/realworld_git.rs"]

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -2902,6 +2902,30 @@ fn core_loop_schemas_are_discoverable() {
 }
 
 #[test]
+fn review_next_envelope_top_level_keys_match_registered_schema() {
+    // The output_kind sweep wrapped `review next --output json` in a
+    // stable envelope (`output_kind` + the flattened pending view +
+    // `next`), replacing the old bare `NextStateView`/top-level-`null`
+    // shape. Pin the wire contract against the registered schema mirror
+    // so the doc/schema can't drift back. A fresh capture carries no
+    // signatures, so it surfaces as the pending state — exercising the
+    // richer flattened envelope (all five top-level keys), a superset of
+    // the empty `{output_kind, next: null}` case.
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("review.txt"), "needs review\n").unwrap();
+    heddle(&["capture", "-m", "seed review"], Some(temp.path())).unwrap();
+
+    let value = json_value(temp.path(), &["review", "next"]);
+    assert_eq!(value["output_kind"], "review_next");
+    assert!(
+        value.get("next").is_some(),
+        "review next must always emit a `next` field (object or null): {value}"
+    );
+    assert_schema_declares_runtime_top_level(&["review", "next"], &value);
+}
+
+#[test]
 fn isolated_thread_json_outputs_match_registered_schemas() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -493,6 +493,68 @@ fn unswept_verbs_have_no_output_kind_declaration() {
     );
 }
 
+#[test]
+fn swept_verb_doc_samples_show_output_kind() {
+    // heddle#272 r5 (Codex P1): the `docs/json-schemas.md` sample for
+    // each #272-swept verb must show the `output_kind` field so the
+    // documented machine contract matches the runtime emission. The
+    // `doctor schemas` gate only checks that a sample's keys are a
+    // subset of the schema's properties (it does not enforce
+    // required-field presence), so it would NOT catch a sample that
+    // silently drops `output_kind`; this test does.
+    //
+    // Verbs documented with one representative sample for a pipe-listed
+    // group (e.g. `bisect start|good|bad|reset`) show the first
+    // variant's value; the per-variant value is mechanically
+    // `display.replace(['-', ' '], "_")`.
+    let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .join("docs/json-schemas.md");
+    let doc = std::fs::read_to_string(&doc_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()));
+
+    const REQUIRED: &[&str] = &[
+        "goto",
+        "clean",
+        "revert",
+        "fork",
+        "cherry_pick",
+        "stack",
+        "stack_ready",
+        "stack_snapshot",
+        "stash_list",
+        "stash_show",
+        "review_show",
+        "review_sign",
+        "review_next",
+        "review_health",
+        "bisect_start",
+        "purge_apply",
+        "redact_apply",
+        "redact_trust_add",
+        "discuss_open",
+        "discuss_list",
+        "context_set",
+        "context_list",
+    ];
+
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|value| !doc.contains(&format!("\"output_kind\": \"{value}\"")))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "docs/json-schemas.md is missing `output_kind` in the sample(s) for \
+         these heddle#272-swept verbs: {missing:?}. Add `\"output_kind\": \
+         \"<value>\"` to each sample so the documented contract matches the \
+         runtime discriminator."
+    );
+}
+
 // ---------------------------------------------------------------------
 // Runtime contract: invoke a representative subset of swept verbs and
 // confirm the emitted JSON carries `output_kind` matching the catalog

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -31,7 +31,7 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 use cli::cli::commands::{
-    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog,
+    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog, schema_for_verb,
 };
 
 use super::{heddle, heddle_output};
@@ -699,18 +699,236 @@ fn doc_sample_top_level_keys(doc: &str, output_kind_value: &str) -> Option<BTree
     None
 }
 
+/// The heddle#272 named-by-persona sweep group (mirrors the second block of
+/// [`SWEPT`]). The doc-sample-vs-runtime invariant is EXHAUSTIVE over every
+/// one of these verbs that carries a documented `output_kind` sample — there
+/// is no hand-picked subset. Verbs whose specific `output_kind` is not
+/// individually documented (they ride a grouped sample under a representative
+/// sibling, e.g. `purge list` under `purge_apply`) are skipped automatically
+/// because no sample with their discriminator exists.
+const SWEPT_272: &[&str] = &[
+    "stack",
+    "stack ready",
+    "stack snapshot",
+    "goto",
+    "fork",
+    "revert",
+    "purge apply",
+    "purge list",
+    "redact apply",
+    "redact list",
+    "redact show",
+    "redact trust add",
+    "redact trust list",
+    "redact trust remove",
+    "stash list",
+    "stash show",
+    "clean",
+    "discuss open",
+    "discuss append",
+    "discuss resolve",
+    "discuss list",
+    "discuss show",
+    "context set",
+    "context get",
+    "context list",
+    "context history",
+    "context edit",
+    "context supersede",
+    "context rm",
+    "context check",
+    "context suggest",
+    "context audit",
+    "review show",
+    "review sign",
+    "review next",
+    "review health",
+    "cherry-pick",
+    "bisect start",
+    "bisect good",
+    "bisect bad",
+    "bisect reset",
+];
+
+fn sv(args: &[&str]) -> Vec<String> {
+    args.iter().map(|s| s.to_string()).collect()
+}
+
+/// `change_id` of the current HEAD state in `dir` (first `log` record).
+fn head_change_id(dir: &std::path::Path) -> String {
+    let stdout = heddle(&["--output", "json", "log"], Some(dir)).expect("heddle log");
+    let first = stdout.lines().next().unwrap_or("");
+    let parsed: Value = serde_json::from_str(first).expect("log stdout is JSON");
+    parsed["states"][0]["change_id"]
+        .as_str()
+        .expect("log states[0].change_id")
+        .to_string()
+}
+
+/// Build a fixture repo carrying exactly the state `output_kind`'s verb needs,
+/// plus the argv (after `--output json`) that drives it. `None` means the verb
+/// has no synthetic-fixture invocation here — the caller then requires the
+/// verb's registered schema to pin every documented key instead.
+///
+/// Returning a value here is the structural anti-subset guarantee: a #272 verb
+/// with a documented sample and a *generic* schema (one that pins none of the
+/// real fields, as the inline `serde_json::json!` verbs do) MUST appear in this
+/// match or the invariant test fails demanding it.
+fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
+    let case = match output_kind {
+        "bisect_start" => (init_fixture(), sv(&["bisect", "start"])),
+        "clean" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("untracked.txt"), "junk").unwrap();
+            (t, sv(&["clean", "--dry-run"]))
+        }
+        "fork" => (init_fixture(), sv(&["fork"])),
+        "goto" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            (t, sv(&["goto", "main"]))
+        }
+        "revert" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit base");
+            std::fs::write(t.path().join("a.txt"), "base\nmore").unwrap();
+            heddle(&["commit", "-m", "second"], Some(t.path())).expect("commit second");
+            (t, sv(&["revert", "HEAD"]))
+        }
+        "stack" => (init_fixture(), sv(&["stack"])),
+        "stack_ready" => (init_fixture(), sv(&["stack", "ready"])),
+        "stack_snapshot" => {
+            let t = init_fixture();
+            heddle(&["start", "feature-x", "--workspace", "solid"], Some(t.path()))
+                .expect("start feature-x");
+            (t, sv(&["stack", "snapshot", "--thread", "feature-x"]))
+        }
+        "stash_list" => (init_fixture(), sv(&["stash", "list"])),
+        "stash_show" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            std::fs::write(t.path().join("a.txt"), "base\nwip").unwrap();
+            heddle(&["stash", "push", "-m", "wip"], Some(t.path())).expect("stash push");
+            (t, sv(&["stash", "show"]))
+        }
+        "cherry_pick" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("f.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit base");
+            heddle(&["fork", "--name", "feature"], Some(t.path())).expect("fork feature");
+            heddle(&["goto", "feature"], Some(t.path())).expect("goto feature");
+            std::fs::write(t.path().join("g.txt"), "feat").unwrap();
+            heddle(&["commit", "-m", "feature work"], Some(t.path())).expect("commit feature");
+            let src = head_change_id(t.path());
+            heddle(&["goto", "main"], Some(t.path())).expect("goto main");
+            (t, vec!["cherry-pick".to_string(), src])
+        }
+        "redact_apply" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("secrets.env"), "TOKEN=abc").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            (
+                t,
+                sv(&["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"]),
+            )
+        }
+        "purge_apply" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("secrets.env"), "TOKEN=abc").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            heddle(
+                &["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"],
+                Some(t.path()),
+            )
+            .expect("redact apply");
+            (
+                t,
+                sv(&["purge", "apply", "HEAD", "--path", "secrets.env", "--force"]),
+            )
+        }
+        "redact_trust_add" => (
+            init_fixture(),
+            sv(&[
+                "redact", "trust", "add", "--public-key", "abc123def456", "--algorithm", "ed25519",
+                "--label", "security",
+            ]),
+        ),
+        "discuss_open" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "fn verify(){}").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            (t, sv(&["discuss", "open", "a.txt", "verify", "check edge case"]))
+        }
+        "discuss_list" => (init_fixture(), sv(&["discuss", "list"])),
+        "context_set" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "code").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            (
+                t,
+                sv(&["context", "set", "--path", "a.txt", "--scope", "file", "-m", "owner note"]),
+            )
+        }
+        "context_list" => (init_fixture(), sv(&["context", "list"])),
+        "review_show" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "fn verify(){}").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            let cid = head_change_id(t.path());
+            (t, vec!["review".to_string(), "show".to_string(), cid])
+        }
+        "review_next" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            heddle(&["fork"], Some(t.path())).expect("fork");
+            (t, sv(&["review", "next"]))
+        }
+        "review_health" => (init_fixture(), sv(&["review", "health"])),
+        _ => return None,
+    };
+    Some(case)
+}
+
+/// Top-level property names declared by the registered schema for `verb`, or
+/// an empty set when the verb has no schema or only a generic envelope.
+fn schema_property_names(verb: &str) -> BTreeSet<String> {
+    let Some(schema) = schema_for_verb(verb) else {
+        return BTreeSet::new();
+    };
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|props| props.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
 #[test]
-fn swept_doc_samples_match_runtime_keys() {
-    // heddle#272 r6 (Codex P2 x2): `doctor schemas` only checks that a
-    // documented sample's keys are a SUBSET of the schema's properties —
-    // it never checks the sample against the actual `--output json`
-    // payload. So a sample can describe a stale shape (the old
-    // key/value-style context payload; the `thread`/`snapshot` stack
-    // wrapper) and pass. This test closes that gap: for verbs we can
-    // invoke in a fixture, the documented sample's top-level keys must be
-    // a subset of the real runtime keys, and `output_kind` must be
-    // present in both. Doc drift now turns CI red until the sample is
-    // corrected.
+fn doc_samples_match_runtime_for_every_swept_272_verb() {
+    // heddle#272 r7 (Codex P2 x7): the r6 doc-sample-vs-runtime check ran a
+    // hand-picked list of three verbs, so seven more stale samples
+    // (cherry-pick, purge apply, bisect start, fork, redact apply, redact
+    // trust add, review next) sailed through and Codex had to find them by
+    // hand. This invariant closes the loophole: it is EXHAUSTIVE over the
+    // entire #272 sweep group. Every #272 verb that carries a documented
+    // `output_kind` sample must either
+    //
+    //   (a) be invoked here against a fixture, with the documented sample's
+    //       top-level key set asserted EXACTLY equal to the live payload's,
+    //       or
+    //   (b) have a registered schema that pins every documented key
+    //       (doc-keys ⊆ schema-properties), so `doctor schemas` guards it.
+    //
+    // (b) is required because a few verbs can't be exercised with a synthetic
+    // fixture (`review sign` cryptographically validates its `--signature`).
+    // Crucially, the inline `serde_json::json!` verbs resolve to a GENERIC
+    // operation-record schema (`additionalProperties: true`) that pins NONE
+    // of their real fields, so (b) fails for them and they are forced down
+    // path (a). A new generic-schema verb added to the doc without a runtime
+    // case here fails this test rather than deferring to an r8.
     let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(2)
@@ -719,74 +937,85 @@ fn swept_doc_samples_match_runtime_keys() {
     let doc = std::fs::read_to_string(&doc_path)
         .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()));
 
-    let fixture = init_fixture();
-    // Build a stack so `stack snapshot` has a member to scope to (an
-    // empty repo's `main` is not part of any stack).
-    heddle(
-        &["start", "feature-x", "--workspace", "solid"],
-        Some(fixture.path()),
-    )
-    .expect("heddle start feature-x");
-    std::fs::write(fixture.path().join("annotated.txt"), "content")
-        .expect("write annotated fixture file");
-
-    // (output_kind value, runtime argv) — each invocation must succeed in
-    // the fixture and the documented sample must mirror its key set.
-    let cases: &[(&str, &[&str])] = &[
-        (
-            "stack_snapshot",
-            &["--output", "json", "stack", "snapshot", "--thread", "feature-x"],
-        ),
-        (
-            "context_set",
-            &[
-                "--output",
-                "json",
-                "context",
-                "set",
-                "--path",
-                "annotated.txt",
-                "--scope",
-                "file",
-                "-m",
-                "owner note",
-            ],
-        ),
-        ("context_list", &["--output", "json", "context", "list"]),
-    ];
-
     let mut failures = Vec::new();
-    for (output_kind, argv) in cases {
-        let runtime_keys = runtime_top_level_keys(argv, fixture.path());
-        let Some(doc_keys) = doc_sample_top_level_keys(&doc, output_kind) else {
-            failures.push(format!(
-                "{output_kind}: no documented `{output_kind}` sample found in docs/json-schemas.md"
-            ));
+    let mut covered_by_runtime = 0usize;
+    let mut covered_by_schema = 0usize;
+
+    for &verb in SWEPT_272 {
+        let output_kind = expected_output_kind(verb);
+        let Some(doc_keys) = doc_sample_top_level_keys(&doc, &output_kind) else {
+            // This verb's discriminator is not individually documented
+            // (grouped under a representative sibling) — nothing to check.
             continue;
         };
+
         if !doc_keys.contains("output_kind") {
             failures.push(format!(
-                "{output_kind}: documented sample is missing the `output_kind` key"
+                "{output_kind} ({verb}): documented sample is missing the `output_kind` key"
             ));
+            continue;
         }
-        if !runtime_keys.contains("output_kind") {
-            failures.push(format!(
-                "{output_kind}: runtime payload is missing the `output_kind` key (keys: {runtime_keys:?})"
-            ));
+
+        if let Some((fixture, argv)) = runtime_doc_case(&output_kind) {
+            let argv_refs: Vec<&str> = std::iter::once("--output")
+                .chain(std::iter::once("json"))
+                .chain(argv.iter().map(String::as_str))
+                .collect();
+            let runtime_keys = runtime_top_level_keys(&argv_refs, fixture.path());
+            if !runtime_keys.contains("output_kind") {
+                failures.push(format!(
+                    "{output_kind} ({verb}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
+                ));
+            }
+            if doc_keys != runtime_keys {
+                let doc_only: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
+                let runtime_only: Vec<&String> = runtime_keys.difference(&doc_keys).collect();
+                failures.push(format!(
+                    "{output_kind} ({verb}): documented sample does not match the live \
+                     `--output json` payload.\n      in doc only:     {doc_only:?}\n      \
+                     in runtime only: {runtime_only:?}\n      doc keys:     {doc_keys:?}\n      \
+                     runtime keys: {runtime_keys:?}"
+                ));
+            }
+            covered_by_runtime += 1;
+            continue;
         }
-        let extra: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
-        if !extra.is_empty() {
+
+        // No runtime case: the registered schema MUST pin every documented
+        // key, otherwise the sample is unguarded and could drift freely.
+        let schema_props = schema_property_names(verb);
+        let unpinned: Vec<&String> = doc_keys
+            .iter()
+            .filter(|k| k.as_str() != "output_kind")
+            .filter(|k| !schema_props.contains(*k))
+            .collect();
+        if unpinned.is_empty() {
+            covered_by_schema += 1;
+        } else {
             failures.push(format!(
-                "{output_kind}: documented sample has keys absent from the real `--output json` \
-                 payload: {extra:?}\n      doc keys:     {doc_keys:?}\n      runtime keys: {runtime_keys:?}"
+                "{output_kind} ({verb}): no runtime case AND its registered schema does not pin \
+                 documented keys {unpinned:?} (schema is generic). Add a `runtime_doc_case` arm \
+                 so the sample is checked against the live payload."
             ));
         }
     }
 
     assert!(
         failures.is_empty(),
-        "Documented samples drifted from the real runtime payloads:\n  - {}",
+        "Documented #272 samples drifted from runtime / are unguarded:\n  - {}",
         failures.join("\n  - ")
+    );
+
+    // Sanity floor: the seven Codex r7 findings are all runtime-checked, and
+    // at least one verb leans on the schema path (`review sign`). If these
+    // collapse to zero the harness silently stopped covering anything.
+    assert!(
+        covered_by_runtime >= 18,
+        "expected the #272 sweep to runtime-check most documented verbs; only {covered_by_runtime} ran"
+    );
+    assert!(
+        covered_by_schema >= 1,
+        "expected at least one schema-guarded #272 verb (review sign); got {covered_by_schema}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -604,6 +604,193 @@ fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bo
 }
 
 #[test]
+fn runtime_init_emits_output_kind() {
+    // heddle#272 r6 (Codex P2): `init` is in SWEPT and the catalog
+    // advertises `output_kind: "init"`, but the previous runtime sweep
+    // never invoked `init` (it needs a fresh, un-init'd directory, so it
+    // wasn't in `runtime_invocation_args`). That left an
+    // advertise-without-emit gap the catalog injection in
+    // `heddle schemas` could not catch. Pin it here: a clean directory
+    // initialised with `--output json` must carry `output_kind: "init"`.
+    let temp = TempDir::new().expect("tempdir");
+    let output = heddle_output(
+        &[
+            "--output",
+            "json",
+            "init",
+            "--principal-name",
+            "Heddle Test",
+            "--principal-email",
+            "heddle@test.example",
+        ],
+        Some(temp.path()),
+    )
+    .expect("heddle init --output json");
+
+    assert!(
+        output.status.success(),
+        "init exited non-zero: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next().unwrap_or("").trim();
+    let parsed: Value =
+        serde_json::from_str(first_line).expect("init stdout is parseable JSON");
+    assert_eq!(
+        parsed.get("output_kind").and_then(|v| v.as_str()),
+        Some("init"),
+        "`heddle init --output json` must emit `output_kind: \"init\"`; payload: {first_line}"
+    );
+}
+
+/// Top-level key set of the first JSON object emitted by `argv` in
+/// `dir`. Panics with the captured output on failure so doc-vs-runtime
+/// mismatches surface a readable diff.
+fn runtime_top_level_keys(argv: &[&str], dir: &std::path::Path) -> BTreeSet<String> {
+    let output = heddle_output(argv, Some(dir))
+        .unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
+    assert!(
+        output.status.success(),
+        "{argv:?} exited non-zero: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next().unwrap_or("").trim();
+    let parsed: Value = serde_json::from_str(first_line)
+        .unwrap_or_else(|err| panic!("{argv:?} stdout not JSON: {err}\n  line: {first_line}"));
+    parsed
+        .as_object()
+        .unwrap_or_else(|| panic!("{argv:?} top-level JSON is not an object: {first_line}"))
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// First fenced ```json block in `doc` whose top-level `output_kind`
+/// equals `value`, returned as its top-level key set. `None` if no such
+/// documented sample exists.
+fn doc_sample_top_level_keys(doc: &str, output_kind_value: &str) -> Option<BTreeSet<String>> {
+    let mut in_block = false;
+    let mut buf = String::new();
+    for line in doc.lines() {
+        let trimmed = line.trim();
+        if !in_block {
+            if trimmed == "```json" {
+                in_block = true;
+                buf.clear();
+            }
+            continue;
+        }
+        if trimmed == "```" {
+            in_block = false;
+            if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&buf) {
+                if map.get("output_kind").and_then(|v| v.as_str()) == Some(output_kind_value) {
+                    return Some(map.keys().cloned().collect());
+                }
+            }
+            buf.clear();
+            continue;
+        }
+        buf.push_str(line);
+        buf.push('\n');
+    }
+    None
+}
+
+#[test]
+fn swept_doc_samples_match_runtime_keys() {
+    // heddle#272 r6 (Codex P2 x2): `doctor schemas` only checks that a
+    // documented sample's keys are a SUBSET of the schema's properties —
+    // it never checks the sample against the actual `--output json`
+    // payload. So a sample can describe a stale shape (the old
+    // key/value-style context payload; the `thread`/`snapshot` stack
+    // wrapper) and pass. This test closes that gap: for verbs we can
+    // invoke in a fixture, the documented sample's top-level keys must be
+    // a subset of the real runtime keys, and `output_kind` must be
+    // present in both. Doc drift now turns CI red until the sample is
+    // corrected.
+    let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .join("docs/json-schemas.md");
+    let doc = std::fs::read_to_string(&doc_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()));
+
+    let fixture = init_fixture();
+    // Build a stack so `stack snapshot` has a member to scope to (an
+    // empty repo's `main` is not part of any stack).
+    heddle(
+        &["start", "feature-x", "--workspace", "solid"],
+        Some(fixture.path()),
+    )
+    .expect("heddle start feature-x");
+    std::fs::write(fixture.path().join("annotated.txt"), "content")
+        .expect("write annotated fixture file");
+
+    // (output_kind value, runtime argv) — each invocation must succeed in
+    // the fixture and the documented sample must mirror its key set.
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "stack_snapshot",
+            &["--output", "json", "stack", "snapshot", "--thread", "feature-x"],
+        ),
+        (
+            "context_set",
+            &[
+                "--output",
+                "json",
+                "context",
+                "set",
+                "--path",
+                "annotated.txt",
+                "--scope",
+                "file",
+                "-m",
+                "owner note",
+            ],
+        ),
+        ("context_list", &["--output", "json", "context", "list"]),
+    ];
+
+    let mut failures = Vec::new();
+    for (output_kind, argv) in cases {
+        let runtime_keys = runtime_top_level_keys(argv, fixture.path());
+        let Some(doc_keys) = doc_sample_top_level_keys(&doc, output_kind) else {
+            failures.push(format!(
+                "{output_kind}: no documented `{output_kind}` sample found in docs/json-schemas.md"
+            ));
+            continue;
+        };
+        if !doc_keys.contains("output_kind") {
+            failures.push(format!(
+                "{output_kind}: documented sample is missing the `output_kind` key"
+            ));
+        }
+        if !runtime_keys.contains("output_kind") {
+            failures.push(format!(
+                "{output_kind}: runtime payload is missing the `output_kind` key (keys: {runtime_keys:?})"
+            ));
+        }
+        let extra: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
+        if !extra.is_empty() {
+            failures.push(format!(
+                "{output_kind}: documented sample has keys absent from the real `--output json` \
+                 payload: {extra:?}\n      doc keys:     {doc_keys:?}\n      runtime keys: {runtime_keys:?}"
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Documented samples drifted from the real runtime payloads:\n  - {}",
+        failures.join("\n  - ")
+    );
+}
+
+#[test]
 fn runtime_emits_output_kind_for_invokable_swept_verbs() {
     let fixture = init_fixture();
     let mut failures = Vec::new();

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -30,7 +30,9 @@ use std::collections::BTreeSet;
 use serde_json::Value;
 use tempfile::TempDir;
 
-use cli::cli::commands::build_command_catalog;
+use cli::cli::commands::{
+    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog,
+};
 
 use super::{heddle, heddle_output};
 
@@ -362,6 +364,105 @@ fn kind_field_exceptions_use_kind_intentionally() {
             "`{display}` is documented as a `kind`-rather-than-output_kind exception but the catalog declares no `kind` discriminator. Update the catalog or drop the exception."
         );
     }
+}
+
+#[test]
+fn clone_catalog_entry_advertises_both_clone_and_clone_connection() {
+    // Hosted `heddle clone --output json` emits TWO JSON records on
+    // one invocation: a preliminary connection envelope
+    // (`output_kind: "clone_connection"`) followed by the final clone
+    // payload (`output_kind: "clone"`). Agents that consume
+    // `commands` / `json_discriminators` only see legitimate
+    // routes for the final record unless the catalog advertises both
+    // discriminators (heddle#272 Codex r3 finding, PR #281).
+    //
+    // This test pins both discriminators against the constants used
+    // by the runtime emission sites in `crates/cli/src/cli/commands/clone.rs`,
+    // so a future rename of either value updates the catalog and the
+    // runtime in lockstep — divergence fails CI.
+    let catalog = build_command_catalog();
+    let clone = catalog
+        .commands
+        .iter()
+        .find(|c| c.display == "clone")
+        .expect("clone should be cataloged");
+
+    let output_kind_values: Vec<&str> = clone
+        .json_discriminators
+        .iter()
+        .filter(|d| d.field == "output_kind")
+        .map(|d| d.value.as_str())
+        .collect();
+
+    assert!(
+        output_kind_values.contains(&CLONE_OUTPUT_KIND),
+        "clone catalog entry must advertise `output_kind = {CLONE_OUTPUT_KIND}` \
+         (the final clone payload); actually advertises {output_kind_values:?}"
+    );
+    assert!(
+        output_kind_values.contains(&CLONE_CONNECTION_OUTPUT_KIND),
+        "clone catalog entry must advertise `output_kind = {CLONE_CONNECTION_OUTPUT_KIND}` \
+         alongside `{CLONE_OUTPUT_KIND}` so agents can route the hosted \
+         preliminary connection envelope; actually advertises {output_kind_values:?}"
+    );
+
+    // The preliminary envelope is not backed by a documented schema
+    // verb (it's a small inline object); the metadata invariant test
+    // requires `no_schema_reason` to be set in that case. Pin the
+    // shape here so a future refactor of the catalog helper doesn't
+    // silently drop the documentation.
+    let envelope = clone
+        .json_discriminators
+        .iter()
+        .find(|d| d.value == CLONE_CONNECTION_OUTPUT_KIND)
+        .expect("clone_connection discriminator must be present");
+    assert!(
+        envelope.schema_verb.is_none(),
+        "clone_connection envelope has no schema verb (it is not a Serialize struct); \
+         got schema_verb={:?}",
+        envelope.schema_verb
+    );
+    assert!(
+        envelope
+            .no_schema_reason
+            .as_deref()
+            .is_some_and(|reason| !reason.is_empty()),
+        "clone_connection envelope must document why it has no schema verb"
+    );
+}
+
+#[test]
+#[ignore = "requires a live hosted gRPC fixture; runtime equality is enforced \
+            statically via CLONE_CONNECTION_OUTPUT_KIND (see \
+            clone_catalog_entry_advertises_both_clone_and_clone_connection). \
+            When a hosted-clone fixture lands, drop the #[ignore] and parse \
+            both stdout records here."]
+fn hosted_clone_emits_both_discriminator_values() {
+    // Placeholder for the live-network assertion: spawn `heddle
+    // clone --output json <hosted-remote> <path>` against a fixture
+    // server, then assert the first stdout line carries
+    // `output_kind: "clone_connection"` and the final line carries
+    // `output_kind: "clone"`. Both values must match the catalog.
+    //
+    // Until the fixture exists, the constants used by clone.rs at
+    // the actual emit sites (CLONE_OUTPUT_KIND and
+    // CLONE_CONNECTION_OUTPUT_KIND) are pinned to the catalog by the
+    // sibling test, so a rename can't silently desync runtime from
+    // catalog.
+    let catalog = build_command_catalog();
+    let clone = catalog
+        .commands
+        .iter()
+        .find(|c| c.display == "clone")
+        .expect("clone should be cataloged");
+    let advertised: Vec<&str> = clone
+        .json_discriminators
+        .iter()
+        .filter(|d| d.field == "output_kind")
+        .map(|d| d.value.as_str())
+        .collect();
+    assert!(advertised.contains(&CLONE_OUTPUT_KIND));
+    assert!(advertised.contains(&CLONE_CONNECTION_OUTPUT_KIND));
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -685,10 +685,10 @@ fn doc_sample_top_level_keys(doc: &str, output_kind_value: &str) -> Option<BTree
         }
         if trimmed == "```" {
             in_block = false;
-            if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&buf) {
-                if map.get("output_kind").and_then(|v| v.as_str()) == Some(output_kind_value) {
-                    return Some(map.keys().cloned().collect());
-                }
+            if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&buf)
+                && map.get("output_kind").and_then(|v| v.as_str()) == Some(output_kind_value)
+            {
+                return Some(map.keys().cloned().collect());
             }
             buf.clear();
             continue;

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `output_kind` JSON discriminator invariant.
+//!
+//! Every CLI verb that emits JSON output must carry a top-level
+//! `output_kind` (or `kind`, for the catalog itself) field. Agents that
+//! route on the discriminator otherwise fall back to fragile text
+//! parsing.
+//!
+//! This module enforces the invariant in two layers:
+//!
+//! 1. **Catalog completeness (static).** Walks the
+//!    `build_command_catalog()` table and asserts that every verb with
+//!    `supports_json: true` either declares a `json_discriminator` with
+//!    field `"output_kind"` (matching the snake-cased verb path) OR is
+//!    listed in `UNSWEPT_TODO` as a known gap. Adding a new
+//!    JSON-emitting verb without classifying it fails CI.
+//!
+//! 2. **Runtime contract (dynamic).** Spawns the built `heddle` binary
+//!    against representative fixtures and asserts the emitted JSON
+//!    actually carries the `output_kind` field with the catalog-declared
+//!    value. Without this, a struct could ship without the field while
+//!    the catalog claimed it was present.
+//!
+//! Issue-of-record: HeddleCo/heddle#272. The unswept allowlist is the
+//! TODO list for follow-up sweeps; do not grow it for newly-added
+//! verbs.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use cli::cli::commands::build_command_catalog;
+
+use super::{heddle, heddle_output};
+
+/// Verbs whose `output_kind` invariant is enforced — both the catalog
+/// declaration and (where invocable) the runtime emission.
+///
+/// Sourced from PR #251 (the initial sweep) plus heddle#272 (which
+/// closes the gap on the named-by-persona verbs from round 4 finding
+/// S1).
+const SWEPT: &[&str] = &[
+    // PR #251 — initial discriminator coverage.
+    "status",
+    "verify",
+    "init",
+    "capture",
+    "checkpoint",
+    "commit",
+    "clone",
+    "diff",
+    "undo",
+    "redo",
+    "thread list",
+    "thread show",
+    "workspace show",
+    "doctor docs",
+    "doctor schemas",
+    "schemas",
+    "bridge git status",
+    "bridge git import",
+    "bridge git sync",
+    "bridge git reconcile",
+    // heddle#272 — output_kind sweep on the named-by-persona verbs.
+    "stack",
+    "stack ready",
+    "stack snapshot",
+    "goto",
+    "fork",
+    "revert",
+    "purge apply",
+    "purge list",
+    "redact apply",
+    "redact list",
+    "redact show",
+    "redact trust add",
+    "redact trust list",
+    "redact trust remove",
+    "stash list",
+    "stash show",
+    "clean",
+    "discuss open",
+    "discuss append",
+    "discuss resolve",
+    "discuss list",
+    "discuss show",
+    "context set",
+    "context get",
+    "context list",
+    "context history",
+    "context edit",
+    "context supersede",
+    "context rm",
+    "context check",
+    "context suggest",
+    "context audit",
+    "review show",
+    "review sign",
+    "review next",
+    "review health",
+    "cherry-pick",
+    "bisect start",
+    "bisect good",
+    "bisect bad",
+    "bisect reset",
+];
+
+/// The catalog itself advertises its container kind as `"kind":
+/// "command_catalog"` rather than `output_kind`. Single intentional
+/// exception, baked into the schema and the catalog discoverability
+/// contract that agents already rely on.
+const KIND_FIELD_EXCEPTIONS: &[&str] = &["commands"];
+
+/// JSON-emitting verbs that have NOT yet had `output_kind` wired
+/// through their Serialize structs. Do NOT add new verbs here — pick
+/// up the sweep instead. This list is the rolldown surface for
+/// follow-up work tracked separately from #272.
+const UNSWEPT_TODO: &[&str] = &[
+    "abort",
+    "adopt",
+    "actor done",
+    "actor explain",
+    "actor list",
+    "actor show",
+    "actor spawn",
+    "agent capture",
+    "agent heartbeat",
+    "agent list",
+    "agent ready",
+    "agent release",
+    "agent reserve",
+    "agent serve",
+    "agent status",
+    "agent stop",
+    "attempt",
+    "blame",
+    "branch",
+    "bridge git export",
+    "bridge git ingest",
+    "bridge git init",
+    "bridge git pull",
+    "bridge git push",
+    "bridge git reason",
+    "checkout",
+    "collapse",
+    "compare",
+    "conflict list",
+    "conflict show",
+    "continue",
+    "daemon serve",
+    "daemon status",
+    "daemon stop",
+    "delegate",
+    "diagnose",
+    "doctor",
+    "fetch",
+    "fsck",
+    "gc",
+    "git-overlay",
+    "harness-bridge",
+    "hook events",
+    "hook install",
+    "hook list",
+    "hook uninstall",
+    "index",
+    "inspect",
+    "integration doctor",
+    "integration install",
+    "integration list",
+    "integration relay",
+    "integration uninstall",
+    "integration upgrade",
+    "log",
+    "maintenance gc",
+    "maintenance index",
+    "maintenance inspect",
+    "maintenance monitor",
+    "maintenance run",
+    "marker create",
+    "marker delete",
+    "marker list",
+    "marker show",
+    "merge",
+    "monitor",
+    "pull",
+    "push",
+    "query",
+    "rebase",
+    "ready",
+    "remote add",
+    "remote list",
+    "remote remove",
+    "remote set-default",
+    "remote show",
+    "resolve",
+    "retro",
+    "semantic hot",
+    "session end",
+    "session list",
+    "session segment",
+    "session show",
+    "session start",
+    "ship",
+    "show",
+    "stash apply",
+    "stash clear",
+    "stash drop",
+    "stash pop",
+    "stash push",
+    "start",
+    "store warm",
+    "switch",
+    "sync",
+    "thread absorb",
+    "thread approvals",
+    "thread approve",
+    "thread captures",
+    "thread check-merge",
+    "thread cleanup",
+    "thread create",
+    "thread current",
+    "thread drop",
+    "thread move",
+    "thread promote",
+    "thread refresh",
+    "thread rename",
+    "thread resolve",
+    "thread revoke-approval",
+    "thread switch",
+    "transaction abort",
+    "transaction begin",
+    "transaction commit",
+    "transaction status",
+    "try",
+    "version",
+    "watch",
+    "workspace",
+];
+
+/// Snake-cased value an `output_kind` discriminator should carry for a
+/// given display path. Mirrors `display.replace(['-', ' '], "_")` for
+/// most verbs; wire-format-stable overrides set in PR #251 stay as-is.
+fn expected_output_kind(display: &str) -> String {
+    if let Some(stable) = output_kind_override(display) {
+        return stable.to_string();
+    }
+    display.replace(['-', ' '], "_")
+}
+
+/// Pre-existing `output_kind` values that don't follow the snake-cased
+/// path rule. Frozen wire format — agents already key off these.
+fn output_kind_override(display: &str) -> Option<&'static str> {
+    match display {
+        // `workspace show` was instrumented in PR #251 as
+        // `workspace_summary` (the underlying struct's semantic name)
+        // rather than the snake-cased path. Wire-format-stable.
+        "workspace show" => Some("workspace_summary"),
+        _ => None,
+    }
+}
+
+#[test]
+fn every_json_emitting_verb_is_classified() {
+    let catalog = build_command_catalog();
+    let known: BTreeSet<&str> = SWEPT
+        .iter()
+        .copied()
+        .chain(UNSWEPT_TODO.iter().copied())
+        .chain(KIND_FIELD_EXCEPTIONS.iter().copied())
+        .collect();
+
+    let mut unclassified = Vec::new();
+    for entry in &catalog.commands {
+        if !entry.supports_json {
+            continue;
+        }
+        if entry.json_kind == "none" {
+            continue;
+        }
+        if !known.contains(entry.display.as_str()) {
+            unclassified.push(entry.display.clone());
+        }
+    }
+
+    assert!(
+        unclassified.is_empty(),
+        "New JSON-emitting verbs lack an `output_kind` classification. \
+         Either add `output_kind` to the verb's Serialize struct AND add the \
+         entry to `SWEPT` (with a `json_discriminator(... \"output_kind\", \
+         ...)` declaration in `command_catalog.rs`), or — as a documented \
+         gap — add the entry to `UNSWEPT_TODO`. New verbs MUST take the \
+         first path; the second is the rolldown surface for pre-existing \
+         unswept verbs.\n\nUnclassified:\n  - {}",
+        unclassified.join("\n  - ")
+    );
+}
+
+#[test]
+fn swept_verbs_declare_output_kind_in_catalog() {
+    let catalog = build_command_catalog();
+    let mut missing = Vec::new();
+    let mut wrong_value = Vec::new();
+
+    for &display in SWEPT {
+        let Some(entry) = catalog.commands.iter().find(|c| c.display == display) else {
+            missing.push(format!("{display}: not present in command catalog"));
+            continue;
+        };
+        let expected = expected_output_kind(display);
+        let discriminator = entry
+            .json_discriminators
+            .iter()
+            .find(|d| d.field == "output_kind");
+        match discriminator {
+            None => missing.push(format!(
+                "{display}: catalog entry has no `output_kind` discriminator (expected value `{expected}`)"
+            )),
+            Some(d) if d.value != expected => wrong_value.push(format!(
+                "{display}: declared output_kind=`{}` but expected `{expected}`",
+                d.value
+            )),
+            Some(_) => {}
+        }
+    }
+
+    if !missing.is_empty() || !wrong_value.is_empty() {
+        let mut msg = String::new();
+        if !missing.is_empty() {
+            msg.push_str("Verbs in SWEPT missing the `output_kind` catalog declaration:\n  - ");
+            msg.push_str(&missing.join("\n  - "));
+            msg.push('\n');
+        }
+        if !wrong_value.is_empty() {
+            msg.push_str("Verbs in SWEPT with the wrong `output_kind` value:\n  - ");
+            msg.push_str(&wrong_value.join("\n  - "));
+            msg.push('\n');
+        }
+        panic!(
+            "Catalog/SWEPT contract violations. The catalog discriminator is the \
+             wire-format promise agents read; it must match the verb's display \
+             path (snake-cased).\n\n{msg}"
+        );
+    }
+}
+
+#[test]
+fn kind_field_exceptions_use_kind_intentionally() {
+    let catalog = build_command_catalog();
+    for &display in KIND_FIELD_EXCEPTIONS {
+        let entry = catalog
+            .commands
+            .iter()
+            .find(|c| c.display == display)
+            .unwrap_or_else(|| panic!("`{display}` listed in KIND_FIELD_EXCEPTIONS is not in the catalog"));
+        let has_kind = entry
+            .json_discriminators
+            .iter()
+            .any(|d| d.field == "kind");
+        assert!(
+            has_kind,
+            "`{display}` is documented as a `kind`-rather-than-output_kind exception but the catalog declares no `kind` discriminator. Update the catalog or drop the exception."
+        );
+    }
+}
+
+#[test]
+fn unswept_verbs_have_no_output_kind_declaration() {
+    // Defensive: if a verb is on the TODO list but the catalog already
+    // declares output_kind for it, the TODO entry is stale — move it to
+    // SWEPT.
+    let catalog = build_command_catalog();
+    let mut stale = Vec::new();
+    for &display in UNSWEPT_TODO {
+        let Some(entry) = catalog.commands.iter().find(|c| c.display == display) else {
+            continue;
+        };
+        let has_output_kind = entry
+            .json_discriminators
+            .iter()
+            .any(|d| d.field == "output_kind");
+        if has_output_kind {
+            stale.push(display.to_string());
+        }
+    }
+    assert!(
+        stale.is_empty(),
+        "Verbs listed in UNSWEPT_TODO already declare `output_kind` in the \
+         catalog. Move them to SWEPT (and add a runtime invocation if \
+         feasible):\n  - {}",
+        stale.join("\n  - ")
+    );
+}
+
+// ---------------------------------------------------------------------
+// Runtime contract: invoke a representative subset of swept verbs and
+// confirm the emitted JSON carries `output_kind` matching the catalog
+// declaration. The set covers the heddle#272 named-by-persona verbs
+// that run safely in an empty/init'd repo without elaborate fixtures.
+// ---------------------------------------------------------------------
+
+fn init_fixture() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    heddle(
+        &[
+            "init",
+            "--principal-name",
+            "Heddle Test",
+            "--principal-email",
+            "heddle@test.example",
+        ],
+        Some(temp.path()),
+    )
+    .expect("heddle init");
+    temp
+}
+
+/// Invocations for swept verbs we exercise at runtime. Per-verb argv +
+/// whether the verb is expected to exit zero. Some named verbs need a
+/// non-trivial fixture (e.g. `revert` requires a state to revert); we
+/// skip those here and rely on dedicated tests elsewhere.
+fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bool /* expect_ok */)> {
+    match display {
+        "stack" => Some((&["stack"], true)),
+        "stack ready" => Some((&["stack", "ready"], true)),
+        "purge list" => Some((&["purge", "list"], true)),
+        "redact list" => Some((&["redact", "list"], true)),
+        "redact trust list" => Some((&["redact", "trust", "list"], true)),
+        "stash list" => Some((&["stash", "list"], true)),
+        "discuss list" => Some((&["discuss", "list"], true)),
+        "context list" => Some((&["context", "list"], true)),
+        "review next" => Some((&["review", "next"], true)),
+        "review health" => Some((&["review", "health"], true)),
+        // `fork` succeeds in an init'd repo (forks the empty initial state).
+        "fork" => Some((&["fork"], true)),
+        // `bisect start` accepts a no-state init and emits its session.
+        "bisect start" => Some((&["bisect", "start"], true)),
+        "bisect reset" => Some((&["bisect", "reset"], true)),
+        _ => None,
+    }
+}
+
+#[test]
+fn runtime_emits_output_kind_for_invokable_swept_verbs() {
+    let fixture = init_fixture();
+    let mut failures = Vec::new();
+
+    for &display in SWEPT {
+        let Some((argv, expect_ok)) = runtime_invocation_args(display) else {
+            continue;
+        };
+        let expected = expected_output_kind(display);
+        let mut full_argv: Vec<&str> = vec!["--output", "json"];
+        full_argv.extend(argv.iter().copied());
+        let output = match heddle_output(&full_argv, Some(fixture.path())) {
+            Ok(out) => out,
+            Err(err) => {
+                failures.push(format!("{display}: spawn failed: {err}"));
+                continue;
+            }
+        };
+
+        if expect_ok && !output.status.success() {
+            failures.push(format!(
+                "{display}: exited non-zero (status {:?})\nstdout: {}\nstderr: {}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            ));
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Pick the JSON payload from stdout: jsonl emitters print one
+        // object per line; the discriminator must surface on the first
+        // record. For verbs whose output root is a JSON array (e.g.
+        // `context list`), the catalog mandates envelope-wrapping into
+        // `{"output_kind": ..., "items": [...]}` (per heddle#272 brief
+        // option (a)).
+        let first_line = stdout.lines().next().unwrap_or("").trim();
+        let parsed: Value = match serde_json::from_str(first_line) {
+            Ok(v) => v,
+            Err(err) => {
+                failures.push(format!(
+                    "{display}: stdout is not parseable JSON: {err}\n  first_line: {first_line}"
+                ));
+                continue;
+            }
+        };
+
+        let actual = parsed.get("output_kind").and_then(|v| v.as_str());
+        match actual {
+            Some(value) if value == expected => {}
+            Some(other) => failures.push(format!(
+                "{display}: runtime JSON has output_kind=`{other}` but catalog declares `{expected}`"
+            )),
+            None => failures.push(format!(
+                "{display}: runtime JSON missing `output_kind` field (expected `{expected}`); payload: {first_line}"
+            )),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Runtime JSON output is missing or mismatches `output_kind`:\n  - {}",
+        failures.join("\n  - ")
+    );
+}

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -31,7 +31,8 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 use cli::cli::commands::{
-    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog, schema_for_verb,
+    CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog,
+    documented_samples_with_bound_verbs, schema_for_verb,
 };
 
 use super::{heddle, heddle_output};
@@ -260,6 +261,40 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         "workspace show" => Some("workspace_summary"),
         _ => None,
     }
+}
+
+/// Read `docs/json-schemas.md` from the workspace root.
+fn read_json_schemas_doc() -> String {
+    let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .join("docs/json-schemas.md");
+    std::fs::read_to_string(&doc_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()))
+}
+
+/// The single source of truth for the doc-vs-runtime sweep: every catalog
+/// discriminator whose field is `output_kind`, as `(display, value,
+/// has_schema_verb)`. Driving the doc invariants from this set — rather
+/// than a hand-maintained `SWEPT_272`-style subset — is what makes a stale
+/// sample for ANY swept verb (the early PR #251 verbs included) fail CI
+/// mechanically. `has_schema_verb` is false only for transport-envelope
+/// discriminators with no backing schema (e.g. `clone_connection`), which
+/// carry no documented sample and are pinned separately.
+fn catalog_output_kind_discriminators() -> Vec<(String, String, bool)> {
+    build_command_catalog()
+        .json_discriminators
+        .into_iter()
+        .filter(|discriminator| discriminator.field == "output_kind")
+        .map(|discriminator| {
+            (
+                discriminator.display,
+                discriminator.value,
+                discriminator.schema_verb.is_some(),
+            )
+        })
+        .collect()
 }
 
 #[test]
@@ -494,64 +529,72 @@ fn unswept_verbs_have_no_output_kind_declaration() {
 }
 
 #[test]
-fn swept_verb_doc_samples_show_output_kind() {
-    // heddle#272 r5 (Codex P1): the `docs/json-schemas.md` sample for
-    // each #272-swept verb must show the `output_kind` field so the
-    // documented machine contract matches the runtime emission. The
-    // `doctor schemas` gate only checks that a sample's keys are a
-    // subset of the schema's properties (it does not enforce
-    // required-field presence), so it would NOT catch a sample that
-    // silently drops `output_kind`; this test does.
+fn doc_samples_carry_catalog_output_kind_for_every_discriminated_verb() {
+    // heddle#272 r5/r8 (Codex P1, cid 3318094405): every documented sample
+    // for a verb whose catalog advertises an `output_kind` discriminator
+    // must show that discriminator with a catalog-advertised value. The
+    // `doctor schemas` gate only checks that a sample's keys are a subset
+    // of the schema's properties (it does not enforce required-field
+    // presence), so it would NOT catch a sample that silently drops or
+    // misnames `output_kind`; this test does.
     //
-    // Verbs documented with one representative sample for a pipe-listed
-    // group (e.g. `bisect start|good|bad|reset`) show the first
-    // variant's value; the per-variant value is mechanically
-    // `display.replace(['-', ' '], "_")`.
-    let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("workspace root")
-        .join("docs/json-schemas.md");
-    let doc = std::fs::read_to_string(&doc_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()));
+    // This drives from the FULL catalog discriminator set and binds each
+    // sample to its verb the same way `doctor schemas` does (heading +
+    // inline hint), so it is exhaustive over every documented sample — not
+    // a hand-maintained subset. A grouped sample bound to several verbs
+    // (e.g. the single `heddle undo|redo` sample) is accepted when its
+    // `output_kind` matches ANY of the verbs it binds to.
+    let doc = read_json_schemas_doc();
 
-    const REQUIRED: &[&str] = &[
-        "goto",
-        "clean",
-        "revert",
-        "fork",
-        "cherry_pick",
-        "stack",
-        "stack_ready",
-        "stack_snapshot",
-        "stash_list",
-        "stash_show",
-        "review_show",
-        "review_sign",
-        "review_next",
-        "review_health",
-        "bisect_start",
-        "purge_apply",
-        "redact_apply",
-        "redact_trust_add",
-        "discuss_open",
-        "discuss_list",
-        "context_set",
-        "context_list",
-    ];
+    // display -> set of advertised output_kind values (clone advertises
+    // both `clone` and `clone_connection`).
+    let mut advertised: std::collections::BTreeMap<String, BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+    for (display, value, _) in catalog_output_kind_discriminators() {
+        advertised.entry(display).or_default().insert(value);
+    }
+    let verbs: Vec<&str> = advertised.keys().map(String::as_str).collect();
 
-    let missing: Vec<&str> = REQUIRED
-        .iter()
-        .copied()
-        .filter(|value| !doc.contains(&format!("\"output_kind\": \"{value}\"")))
-        .collect();
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+    for (sample, bound) in documented_samples_with_bound_verbs(&doc, &verbs) {
+        let allowed: BTreeSet<&str> = bound
+            .iter()
+            .filter_map(|verb| advertised.get(verb))
+            .flat_map(|values| values.iter().map(String::as_str))
+            .collect();
+        let Some(object) = sample.as_object() else {
+            failures.push(format!(
+                "sample bound to {bound:?} is not a JSON object, so it cannot carry the \
+                 required `output_kind` discriminator (catalog advertises {allowed:?})"
+            ));
+            continue;
+        };
+        checked += 1;
+        match object.get("output_kind").and_then(Value::as_str) {
+            None => failures.push(format!(
+                "sample bound to {bound:?} omits the `output_kind` discriminator \
+                 (catalog advertises {allowed:?})"
+            )),
+            Some(found) if !allowed.contains(found) => failures.push(format!(
+                "sample bound to {bound:?} declares output_kind=`{found}`, which is not a \
+                 catalog-advertised value for those verbs ({allowed:?})"
+            )),
+            Some(_) => {}
+        }
+    }
 
     assert!(
-        missing.is_empty(),
-        "docs/json-schemas.md is missing `output_kind` in the sample(s) for \
-         these heddle#272-swept verbs: {missing:?}. Add `\"output_kind\": \
-         \"<value>\"` to each sample so the documented contract matches the \
-         runtime discriminator."
+        failures.is_empty(),
+        "Documented samples drift from the catalog `output_kind` contract. The catalog is the \
+         source of truth; every sample bound to a discriminator verb must carry a catalog \
+         value:\n  - {}",
+        failures.join("\n  - ")
+    );
+    assert!(
+        checked >= 30,
+        "expected the catalog-driven doc sweep to inspect many discriminator samples; only \
+         {checked} were bound — the heading/inline binding likely regressed"
     );
 }
 
@@ -698,57 +741,6 @@ fn doc_sample_top_level_keys(doc: &str, output_kind_value: &str) -> Option<BTree
     }
     None
 }
-
-/// The heddle#272 named-by-persona sweep group (mirrors the second block of
-/// [`SWEPT`]). The doc-sample-vs-runtime invariant is EXHAUSTIVE over every
-/// one of these verbs that carries a documented `output_kind` sample — there
-/// is no hand-picked subset. Verbs whose specific `output_kind` is not
-/// individually documented (they ride a grouped sample under a representative
-/// sibling, e.g. `purge list` under `purge_apply`) are skipped automatically
-/// because no sample with their discriminator exists.
-const SWEPT_272: &[&str] = &[
-    "stack",
-    "stack ready",
-    "stack snapshot",
-    "goto",
-    "fork",
-    "revert",
-    "purge apply",
-    "purge list",
-    "redact apply",
-    "redact list",
-    "redact show",
-    "redact trust add",
-    "redact trust list",
-    "redact trust remove",
-    "stash list",
-    "stash show",
-    "clean",
-    "discuss open",
-    "discuss append",
-    "discuss resolve",
-    "discuss list",
-    "discuss show",
-    "context set",
-    "context get",
-    "context list",
-    "context history",
-    "context edit",
-    "context supersede",
-    "context rm",
-    "context check",
-    "context suggest",
-    "context audit",
-    "review show",
-    "review sign",
-    "review next",
-    "review health",
-    "cherry-pick",
-    "bisect start",
-    "bisect good",
-    "bisect bad",
-    "bisect reset",
-];
 
 fn sv(args: &[&str]) -> Vec<String> {
     args.iter().map(|s| s.to_string()).collect()
@@ -907,56 +899,62 @@ fn schema_property_names(verb: &str) -> BTreeSet<String> {
 }
 
 #[test]
-fn doc_samples_match_runtime_for_every_swept_272_verb() {
-    // heddle#272 r7 (Codex P2 x7): the r6 doc-sample-vs-runtime check ran a
-    // hand-picked list of three verbs, so seven more stale samples
-    // (cherry-pick, purge apply, bisect start, fork, redact apply, redact
-    // trust add, review next) sailed through and Codex had to find them by
-    // hand. This invariant closes the loophole: it is EXHAUSTIVE over the
-    // entire #272 sweep group. Every #272 verb that carries a documented
-    // `output_kind` sample must either
+fn doc_samples_match_runtime_for_every_catalog_discriminator() {
+    // heddle#272 r7/r8 (Codex P2, cid 3319783461): the r7 doc-sample-vs-runtime
+    // check iterated a hand-maintained `SWEPT_272` subset, so documented
+    // samples for earlier-swept verbs (`init`, `status`, `verify`, `clone`,
+    // `thread list/show`, the bridge/doctor commands, ...) were never compared
+    // against live payloads and could drift silently. This invariant re-roots
+    // the loop on the FULL catalog discriminator set, so every verb the catalog
+    // advertises an `output_kind` for is checked.
+    //
+    // For each catalog `output_kind` value with a documented sample, the sample
+    // must either
     //
     //   (a) be invoked here against a fixture, with the documented sample's
-    //       top-level key set asserted EXACTLY equal to the live payload's,
-    //       or
+    //       top-level key set asserted EXACTLY equal to the live payload's, or
     //   (b) have a registered schema that pins every documented key
     //       (doc-keys ⊆ schema-properties), so `doctor schemas` guards it.
     //
-    // (b) is required because a few verbs can't be exercised with a synthetic
-    // fixture (`review sign` cryptographically validates its `--signature`).
-    // Crucially, the inline `serde_json::json!` verbs resolve to a GENERIC
-    // operation-record schema (`additionalProperties: true`) that pins NONE
-    // of their real fields, so (b) fails for them and they are forced down
-    // path (a). A new generic-schema verb added to the doc without a runtime
-    // case here fails this test rather than deferring to an r8.
-    let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
-        .expect("workspace root")
-        .join("docs/json-schemas.md");
-    let doc = std::fs::read_to_string(&doc_path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", doc_path.display()));
+    // (b) covers verbs that can't be exercised with a synthetic fixture
+    // (`review sign` cryptographically validates its `--signature`; `verify`/
+    // `status` need elaborate verification fixtures). Crucially, the inline
+    // `serde_json::json!` opaque verbs resolve to a GENERIC schema
+    // (`additionalProperties: true`) that pins NONE of their real fields, so
+    // (b) fails for them and they are forced down path (a). A new generic-schema
+    // verb documented without a runtime case here fails this test rather than
+    // deferring to a later round.
+    let doc = read_json_schemas_doc();
 
     let mut failures = Vec::new();
     let mut covered_by_runtime = 0usize;
     let mut covered_by_schema = 0usize;
 
-    for &verb in SWEPT_272 {
-        let output_kind = expected_output_kind(verb);
-        let Some(doc_keys) = doc_sample_top_level_keys(&doc, &output_kind) else {
-            // This verb's discriminator is not individually documented
-            // (grouped under a representative sibling) — nothing to check.
+    for (display, value, has_schema_verb) in catalog_output_kind_discriminators() {
+        // Transport-envelope discriminators (e.g. `clone_connection`) have no
+        // schema verb and no documented sample; they are pinned separately.
+        if !has_schema_verb {
+            continue;
+        }
+        let Some(doc_keys) = doc_sample_top_level_keys(&doc, &value) else {
+            // This value is not individually documented (it rides a grouped
+            // sample under a representative sibling, e.g. `redo` under `undo`,
+            // `purge list` under `purge_apply`) — nothing to compare here.
+            // `doc_samples_carry_catalog_output_kind_for_every_discriminated_verb`
+            // still guards the grouped sample's discriminator.
             continue;
         };
 
+        // `doc_sample_top_level_keys` matched on the `output_kind` value, so
+        // the key is present by construction; assert it defensively.
         if !doc_keys.contains("output_kind") {
             failures.push(format!(
-                "{output_kind} ({verb}): documented sample is missing the `output_kind` key"
+                "{value} ({display}): documented sample is missing the `output_kind` key"
             ));
             continue;
         }
 
-        if let Some((fixture, argv)) = runtime_doc_case(&output_kind) {
+        if let Some((fixture, argv)) = runtime_doc_case(&value) {
             let argv_refs: Vec<&str> = std::iter::once("--output")
                 .chain(std::iter::once("json"))
                 .chain(argv.iter().map(String::as_str))
@@ -964,14 +962,14 @@ fn doc_samples_match_runtime_for_every_swept_272_verb() {
             let runtime_keys = runtime_top_level_keys(&argv_refs, fixture.path());
             if !runtime_keys.contains("output_kind") {
                 failures.push(format!(
-                    "{output_kind} ({verb}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
+                    "{value} ({display}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
                 ));
             }
             if doc_keys != runtime_keys {
                 let doc_only: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
                 let runtime_only: Vec<&String> = runtime_keys.difference(&doc_keys).collect();
                 failures.push(format!(
-                    "{output_kind} ({verb}): documented sample does not match the live \
+                    "{value} ({display}): documented sample does not match the live \
                      `--output json` payload.\n      in doc only:     {doc_only:?}\n      \
                      in runtime only: {runtime_only:?}\n      doc keys:     {doc_keys:?}\n      \
                      runtime keys: {runtime_keys:?}"
@@ -983,7 +981,7 @@ fn doc_samples_match_runtime_for_every_swept_272_verb() {
 
         // No runtime case: the registered schema MUST pin every documented
         // key, otherwise the sample is unguarded and could drift freely.
-        let schema_props = schema_property_names(verb);
+        let schema_props = schema_property_names(&display);
         let unpinned: Vec<&String> = doc_keys
             .iter()
             .filter(|k| k.as_str() != "output_kind")
@@ -993,7 +991,7 @@ fn doc_samples_match_runtime_for_every_swept_272_verb() {
             covered_by_schema += 1;
         } else {
             failures.push(format!(
-                "{output_kind} ({verb}): no runtime case AND its registered schema does not pin \
+                "{value} ({display}): no runtime case AND its registered schema does not pin \
                  documented keys {unpinned:?} (schema is generic). Add a `runtime_doc_case` arm \
                  so the sample is checked against the live payload."
             ));
@@ -1002,20 +1000,20 @@ fn doc_samples_match_runtime_for_every_swept_272_verb() {
 
     assert!(
         failures.is_empty(),
-        "Documented #272 samples drifted from runtime / are unguarded:\n  - {}",
+        "Documented samples drifted from runtime / are unguarded:\n  - {}",
         failures.join("\n  - ")
     );
 
-    // Sanity floor: the seven Codex r7 findings are all runtime-checked, and
-    // at least one verb leans on the schema path (`review sign`). If these
-    // collapse to zero the harness silently stopped covering anything.
+    // Sanity floor: the #272 persona verbs are runtime-checked, and the
+    // earlier-swept verbs lean on the schema path. If either collapses the
+    // harness silently stopped covering anything.
     assert!(
         covered_by_runtime >= 18,
-        "expected the #272 sweep to runtime-check most documented verbs; only {covered_by_runtime} ran"
+        "expected the sweep to runtime-check most documented persona verbs; only {covered_by_runtime} ran"
     );
     assert!(
-        covered_by_schema >= 1,
-        "expected at least one schema-guarded #272 verb (review sign); got {covered_by_schema}"
+        covered_by_schema >= 5,
+        "expected several schema-guarded earlier-swept verbs (clone, status, verify, ...); got {covered_by_schema}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Runtime `output_kind` coverage for verbs the catalog lint can't
+//! invoke generically. The lint at [`super::output_kind_invariant`]
+//! walks every swept verb that runs against a vanilla `heddle init`
+//! fixture and asserts the emitted JSON carries the expected
+//! discriminator. Several heddle#272 verbs need richer fixtures —
+//! captured states, redactions, stashes, annotations, bisect sessions
+//! — and live here.
+//!
+//! Each test asserts the catalog's wire contract: the JSON payload
+//! parses, carries `output_kind` set to the snake-cased verb path,
+//! and (where the sweep introduced an envelope shape) preserves the
+//! pre-existing fields agents already key off.
+
+use std::fs;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{heddle, heddle_output};
+
+/// Init a repo, write a tracked file, capture one state.
+fn init_and_capture() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    heddle(&["init"], Some(temp.path())).expect("heddle init");
+    fs::write(temp.path().join("main.rs"), "fn main() {}\n").expect("seed main.rs");
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).expect("seed capture");
+    temp
+}
+
+/// Capture a second state on top of the seeded one so `HEAD~1` resolves.
+fn capture_second(temp: &TempDir) {
+    fs::write(temp.path().join("main.rs"), "fn main() { println!(\"hi\"); }\n")
+        .expect("modify main.rs");
+    heddle(&["capture", "-m", "second"], Some(temp.path())).expect("second capture");
+}
+
+/// Run heddle with `--output json` and parse the first stdout line as JSON.
+fn heddle_json(args: &[&str], temp: &TempDir) -> Value {
+    let mut argv: Vec<&str> = vec!["--output", "json"];
+    argv.extend(args.iter().copied());
+    let stdout = heddle(&argv, Some(temp.path())).unwrap_or_else(|err| {
+        panic!("heddle {argv:?} failed: {err}");
+    });
+    let line = stdout
+        .lines()
+        .next()
+        .unwrap_or_else(|| panic!("heddle {argv:?} produced no stdout"));
+    serde_json::from_str(line)
+        .unwrap_or_else(|err| panic!("heddle {argv:?} stdout not JSON: {err}\n  line: {line}"))
+}
+
+fn assert_output_kind(value: &Value, expected: &str) {
+    assert_eq!(
+        value.get("output_kind").and_then(|v| v.as_str()),
+        Some(expected),
+        "expected output_kind={expected}, got payload: {value}"
+    );
+}
+
+/// Detach HEAD onto the current state so `stack snapshot` follows the
+/// detached-HEAD branch (`for_stack(None)`) and yields the full repo
+/// projection. Without this, a fresh `heddle init` leaves HEAD attached
+/// to `main`, but `main` has no thread record — `for_stack("main")`
+/// returns `None` and the snapshot bails out instead of emitting JSON.
+fn detach_head(temp: &TempDir) {
+    let log = heddle_json(&["log", "--limit", "1"], temp);
+    let state = log["states"][0]["change_id"]
+        .as_str()
+        .expect("log JSON change_id")
+        .to_string();
+    heddle(&["goto", &state], Some(temp.path())).expect("goto state detaches HEAD");
+}
+
+#[test]
+fn stack_snapshot_emits_output_kind_alongside_flattened_snapshot() {
+    let temp = init_and_capture();
+    detach_head(&temp);
+    let value = heddle_json(&["stack", "snapshot"], &temp);
+    assert_output_kind(&value, "stack_snapshot");
+    // `#[serde(flatten)]` injects `output_kind` alongside the
+    // pre-existing `RepositorySnapshot` fields. Agents that already
+    // key off `version` / `stacks` / `threads` must keep seeing them
+    // at the top level — not nested under `snapshot`.
+    assert!(
+        value.get("version").is_some(),
+        "stack snapshot must keep `version` at the flat top level: {value}"
+    );
+    assert!(
+        value.get("stacks").and_then(|v| v.as_array()).is_some(),
+        "stack snapshot must keep `stacks` at the flat top level: {value}"
+    );
+    assert!(
+        value.get("threads").and_then(|v| v.as_array()).is_some(),
+        "stack snapshot must keep `threads` at the flat top level: {value}"
+    );
+    assert!(
+        value.get("snapshot").is_none(),
+        "stack snapshot must not wrap the snapshot under a `snapshot` field: {value}"
+    );
+}
+
+#[test]
+fn goto_emits_output_kind_with_target_metadata() {
+    let temp = init_and_capture();
+    capture_second(&temp);
+    let value = heddle_json(&["goto", "HEAD~1"], &temp);
+    assert_output_kind(&value, "goto");
+    assert!(
+        value.get("target").and_then(|v| v.as_str()).is_some(),
+        "goto JSON must carry `target` state id: {value}"
+    );
+    assert!(
+        value
+            .get("message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.starts_with("Now at: ")),
+        "goto JSON must carry the `message` field: {value}"
+    );
+}
+
+#[test]
+fn revert_no_commit_emits_output_kind_without_change_id() {
+    let temp = init_and_capture();
+    capture_second(&temp);
+    let value = heddle_json(&["revert", "HEAD", "--no-commit"], &temp);
+    assert_output_kind(&value, "revert");
+    assert!(
+        value["change_id"].is_null(),
+        "revert --no-commit must leave change_id null: {value}"
+    );
+    assert!(
+        value
+            .get("files_affected")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| !arr.is_empty()),
+        "revert must report files_affected: {value}"
+    );
+}
+
+#[test]
+fn revert_commit_emits_output_kind_with_new_change_id() {
+    let temp = init_and_capture();
+    capture_second(&temp);
+    let value = heddle_json(&["revert", "HEAD"], &temp);
+    assert_output_kind(&value, "revert");
+    assert!(
+        value
+            .get("change_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "revert (committed) must carry the new state's change_id: {value}"
+    );
+}
+
+#[test]
+fn clean_dry_run_emits_output_kind() {
+    let temp = init_and_capture();
+    // Add an untracked file so the removed list is non-trivial.
+    fs::write(temp.path().join("stray.txt"), "junk\n").expect("write stray");
+    let value = heddle_json(&["clean", "--dry-run"], &temp);
+    assert_output_kind(&value, "clean");
+    assert_eq!(
+        value.get("dry_run").and_then(|v| v.as_bool()),
+        Some(true),
+        "clean --dry-run must report dry_run=true: {value}"
+    );
+    assert!(
+        value
+            .get("removed")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| arr.iter().any(|entry| entry
+                .as_str()
+                .is_some_and(|s| s.contains("stray.txt")))),
+        "clean --dry-run must list the would-remove paths: {value}"
+    );
+}
+
+#[test]
+fn cherry_pick_no_commit_emits_output_kind() {
+    let temp = init_and_capture();
+    fs::write(temp.path().join("feature.txt"), "added\n").expect("write feature");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+
+    // Resolve the feature state's id (HEAD), then move back to the seed.
+    let head = heddle_json(&["log", "--limit", "1"], &temp);
+    let feature_id = head["states"][0]["change_id"]
+        .as_str()
+        .expect("log --output json must expose change_id")
+        .to_string();
+    heddle(&["goto", "HEAD~1"], Some(temp.path())).expect("goto back to seed");
+
+    let value = heddle_json(&["cherry-pick", &feature_id, "--no-commit"], &temp);
+    assert_output_kind(&value, "cherry_pick");
+    assert_eq!(value["status"].as_str(), Some("applied"));
+    assert_eq!(value["no_commit"].as_bool(), Some(true));
+    assert_eq!(
+        value["commit"].as_str(),
+        Some(feature_id.as_str()),
+        "cherry-pick must echo the source commit id: {value}"
+    );
+}
+
+#[test]
+fn cherry_pick_commit_emits_output_kind_with_new_commit() {
+    let temp = init_and_capture();
+    fs::write(temp.path().join("feature.txt"), "added\n").expect("write feature");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+    let head = heddle_json(&["log", "--limit", "1"], &temp);
+    let feature_id = head["states"][0]["change_id"]
+        .as_str()
+        .expect("log JSON change_id")
+        .to_string();
+    heddle(&["goto", "HEAD~1"], Some(temp.path())).expect("goto back to seed");
+
+    let value = heddle_json(&["cherry-pick", &feature_id], &temp);
+    assert_output_kind(&value, "cherry_pick");
+    assert_eq!(value["status"].as_str(), Some("committed"));
+    assert_eq!(value["commit"].as_str(), Some(feature_id.as_str()));
+    assert!(
+        value
+            .get("new_commit")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "cherry-pick (committed) must report new_commit: {value}"
+    );
+}
+
+#[test]
+fn bisect_good_bad_emit_output_kind() {
+    let temp = init_and_capture();
+    capture_second(&temp);
+    // Start the session — covered by the lint test, but we need an
+    // active session before good/bad will accept marks.
+    let started = heddle_json(&["bisect", "start"], &temp);
+    assert_output_kind(&started, "bisect_start");
+
+    let log = heddle_json(&["log", "--limit", "2"], &temp);
+    let head_id = log["states"][0]["change_id"]
+        .as_str()
+        .expect("log JSON head id")
+        .to_string();
+    let parent_id = log["states"][1]["change_id"]
+        .as_str()
+        .expect("log JSON parent id")
+        .to_string();
+
+    let good = heddle_json(&["bisect", "good", &parent_id], &temp);
+    assert_output_kind(&good, "bisect_good");
+    assert_eq!(good["status"].as_str(), Some("marked_good"));
+    assert!(
+        good.get("commit")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "bisect good must echo resolved commit: {good}"
+    );
+
+    let bad = heddle_json(&["bisect", "bad", &head_id], &temp);
+    assert_output_kind(&bad, "bisect_bad");
+    assert_eq!(bad["status"].as_str(), Some("marked_bad"));
+    assert!(
+        bad.get("commit")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "bisect bad must echo resolved commit: {bad}"
+    );
+
+    // `bisect reset` is exercised by the lint test, but rerunning it
+    // here keeps the test self-contained (leaves no dangling session
+    // for the harness to clean up).
+    let reset = heddle_json(&["bisect", "reset"], &temp);
+    assert_output_kind(&reset, "bisect_reset");
+    assert_eq!(reset["status"].as_str(), Some("reset"));
+}
+
+#[test]
+fn stash_show_emits_output_kind() {
+    let temp = init_and_capture();
+    // Dirty the worktree so stash push has something to capture.
+    fs::write(temp.path().join("main.rs"), "fn main() { /* tweak */ }\n").expect("modify main.rs");
+    heddle(&["stash", "push", "-m", "wip"], Some(temp.path())).expect("stash push");
+
+    let value = heddle_json(&["stash", "show"], &temp);
+    assert_output_kind(&value, "stash_show");
+    // The stash modified `main.rs`; the diff against the stash parent
+    // must surface it as a modified path. Catches the case where the
+    // sweep wired `output_kind` but broke the diff fields underneath.
+    assert!(
+        value
+            .get("modified")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| arr.iter().any(|p| p.as_str() == Some("main.rs"))),
+        "stash show must list main.rs as modified: {value}"
+    );
+}
+
+#[test]
+fn redact_apply_show_emit_output_kind() {
+    let temp = init_and_capture();
+    // Reuse main.rs as the redaction target; redact apply doesn't
+    // care that the content isn't a "real" secret.
+    let log = heddle_json(&["log", "--limit", "1"], &temp);
+    let state = log["states"][0]["change_id"]
+        .as_str()
+        .expect("log JSON change_id")
+        .to_string();
+
+    let apply = heddle_json(
+        &[
+            "redact", "apply", &state, "--path", "main.rs", "--reason", "test",
+        ],
+        &temp,
+    );
+    assert_output_kind(&apply, "redact_apply");
+    let redaction_id = apply["redaction_id"]
+        .as_str()
+        .expect("redact apply must carry redaction_id")
+        .to_string();
+
+    let show = heddle_json(&["redact", "show", &redaction_id], &temp);
+    assert_output_kind(&show, "redact_show");
+    assert_eq!(show["redaction_id"].as_str(), Some(redaction_id.as_str()));
+}
+
+#[test]
+fn redact_trust_add_and_remove_emit_output_kind() {
+    let temp = init_and_capture();
+    // Ed25519 public keys are 32 bytes / 64 hex chars; the trust
+    // store accepts any well-formed hex without contacting a key
+    // server. Using a deterministic test key keeps add+remove tied.
+    let pubkey = "11".repeat(32);
+
+    let add = heddle_json(
+        &[
+            "redact",
+            "trust",
+            "add",
+            "--algorithm",
+            "ed25519",
+            "--public-key",
+            &pubkey,
+            "--label",
+            "test-key",
+        ],
+        &temp,
+    );
+    assert_output_kind(&add, "redact_trust_add");
+    // The envelope flattens TrustEntryOutput so the wire shape stays
+    // compatible with PR #251's `trusted_keys` row format.
+    assert_eq!(add["algorithm"].as_str(), Some("ed25519"));
+    assert_eq!(add["public_key"].as_str(), Some(pubkey.as_str()));
+    assert_eq!(add["label"].as_str(), Some("test-key"));
+
+    let remove = heddle_json(&["redact", "trust", "remove", &pubkey], &temp);
+    assert_output_kind(&remove, "redact_trust_remove");
+    assert_eq!(remove["removed"].as_u64(), Some(1));
+}
+
+#[test]
+fn purge_apply_emits_output_kind() {
+    let temp = init_and_capture();
+    let log = heddle_json(&["log", "--limit", "1"], &temp);
+    let state = log["states"][0]["change_id"]
+        .as_str()
+        .expect("log JSON change_id")
+        .to_string();
+    heddle(
+        &[
+            "redact", "apply", &state, "--path", "main.rs", "--reason", "test",
+        ],
+        Some(temp.path()),
+    )
+    .expect("redact apply");
+
+    let value = heddle_json(
+        &[
+            "purge", "apply", &state, "--path", "main.rs", "--force",
+        ],
+        &temp,
+    );
+    assert_output_kind(&value, "purge_apply");
+    assert!(
+        value.get("blob").and_then(|v| v.as_str()).is_some(),
+        "purge apply must echo blob id: {value}"
+    );
+}
+
+#[test]
+fn context_set_get_history_audit_check_emit_output_kind() {
+    let temp = init_and_capture();
+
+    let set = heddle_json(
+        &[
+            "context",
+            "set",
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "rationale",
+            "-m",
+            "entry point",
+        ],
+        &temp,
+    );
+    assert_output_kind(&set, "context_set");
+    assert_eq!(set["target"].as_str(), Some("main.rs"));
+
+    let get = heddle_json(&["context", "get", "--path", "main.rs"], &temp);
+    assert_output_kind(&get, "context_get");
+    let annotation_id = get["annotations"][0]["annotation_id"]
+        .as_str()
+        .expect("context get must surface annotation_id")
+        .to_string();
+
+    let history = heddle_json(&["context", "history", &annotation_id], &temp);
+    assert_output_kind(&history, "context_history");
+    assert_eq!(
+        history["annotation_id"].as_str(),
+        Some(annotation_id.as_str())
+    );
+
+    let edit = heddle_json(
+        &[
+            "context",
+            "edit",
+            &annotation_id,
+            "-m",
+            "refined entry point",
+        ],
+        &temp,
+    );
+    assert_output_kind(&edit, "context_edit");
+    assert_eq!(edit["annotation_id"].as_str(), Some(annotation_id.as_str()));
+    assert_eq!(edit["revision_count"].as_u64(), Some(2));
+
+    let supersede = heddle_json(
+        &[
+            "context",
+            "supersede",
+            &annotation_id,
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "rationale",
+            "-m",
+            "fully rewritten guidance",
+        ],
+        &temp,
+    );
+    assert_output_kind(&supersede, "context_supersede");
+    assert_eq!(supersede["replacement_target"].as_str(), Some("main.rs"));
+
+    let check = heddle_json(&["context", "check"], &temp);
+    assert_output_kind(&check, "context_check");
+
+    let audit = heddle_json(&["context", "audit"], &temp);
+    assert_output_kind(&audit, "context_audit");
+    // After set→edit→supersede there's exactly one logical
+    // annotation but two active+superseded rows; the audit
+    // counter must reflect both.
+    assert!(
+        audit["annotations"].as_u64().is_some_and(|n| n >= 2),
+        "context audit must count active+superseded rows: {audit}"
+    );
+
+    let suggest = heddle_json(&["context", "suggest"], &temp);
+    assert_output_kind(&suggest, "context_suggest");
+    assert!(
+        suggest.get("items").and_then(|v| v.as_array()).is_some(),
+        "context suggest envelope must carry an `items` array: {suggest}"
+    );
+
+    let rm = heddle_json(
+        &["context", "rm", "--path", "main.rs", "--all"],
+        &temp,
+    );
+    assert_output_kind(&rm, "context_rm");
+    assert_eq!(rm["removed"].as_bool(), Some(true));
+}
+
+#[test]
+fn context_list_envelope_wraps_items_for_empty_and_populated() {
+    // Empty list — the `context_root.is_none()` early return path
+    // (already covered by the lint test) emits the envelope shape.
+    let empty_temp = init_and_capture();
+    let empty = heddle_json(&["context", "list"], &empty_temp);
+    assert_output_kind(&empty, "context_list");
+    assert_eq!(
+        empty["items"].as_array().map(|arr| arr.len()),
+        Some(0),
+        "empty context list must wrap as {{output_kind, items:[]}}: {empty}"
+    );
+
+    // Populated list — exercises the entry-collection branch in
+    // `cmd_context_list` that builds the `items` Vec.
+    let populated_temp = init_and_capture();
+    heddle(
+        &[
+            "context", "set", "--path", "main.rs", "--scope", "file", "--kind",
+            "rationale", "-m", "entry point",
+        ],
+        Some(populated_temp.path()),
+    )
+    .expect("context set");
+    let populated = heddle_json(&["context", "list"], &populated_temp);
+    assert_output_kind(&populated, "context_list");
+    let items = populated["items"]
+        .as_array()
+        .expect("populated context list items array");
+    assert!(
+        !items.is_empty(),
+        "populated context list must surface items: {populated}"
+    );
+    // Per-row `output_kind` rides as `context_get` (the envelope
+    // discriminator owns the outer one). Locking the inner value
+    // catches accidental row-discriminator changes.
+    assert_eq!(items[0]["output_kind"].as_str(), Some("context_get"));
+}
+
+#[test]
+fn discuss_open_show_append_emit_output_kind() {
+    let temp = init_and_capture();
+
+    let open = heddle_json(
+        &[
+            "discuss",
+            "open",
+            "main.rs",
+            "main",
+            "first turn",
+        ],
+        &temp,
+    );
+    assert_output_kind(&open, "discuss_open");
+    let discussion_id = open["id"]
+        .as_str()
+        .expect("discuss open envelope must flatten the discussion `id`")
+        .to_string();
+
+    let append = heddle_json(
+        &["discuss", "append", &discussion_id, "follow-up turn"],
+        &temp,
+    );
+    assert_output_kind(&append, "discuss_append");
+    assert_eq!(append["id"].as_str(), Some(discussion_id.as_str()));
+
+    let show = heddle_json(&["discuss", "show", &discussion_id], &temp);
+    assert_output_kind(&show, "discuss_show");
+    assert_eq!(show["id"].as_str(), Some(discussion_id.as_str()));
+    // Flattened `turns` field must surface both turns at the top
+    // level — the envelope must not nest the discussion payload.
+    assert_eq!(
+        show["turns"]
+            .as_array()
+            .map(|arr| arr.len())
+            .unwrap_or(0),
+        2,
+        "discuss show must flatten `turns` at the top level: {show}"
+    );
+
+    let resolve = heddle_json(
+        &[
+            "discuss",
+            "resolve",
+            &discussion_id,
+            "--mode",
+            "dismiss",
+            "--reason",
+            "not relevant",
+        ],
+        &temp,
+    );
+    assert_output_kind(&resolve, "discuss_resolve");
+    assert_eq!(resolve["id"].as_str(), Some(discussion_id.as_str()));
+}
+
+#[test]
+fn review_show_emits_output_kind() {
+    let temp = init_and_capture();
+    let value = heddle_json(&["review", "show", "HEAD"], &temp);
+    assert_output_kind(&value, "review_show");
+    assert!(
+        value
+            .get("change_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "review show must surface change_id: {value}"
+    );
+}
+
+#[test]
+fn review_next_envelope_is_emitted_when_window_empty() {
+    // Smoke test: `review next` against a fresh repo with no
+    // pending review work hits the `None`-branch of the envelope —
+    // that path is the one the lint test exercises generally, but
+    // asserting the explicit `next: null` shape here pins the wire
+    // contract that agents key off when there's nothing to review.
+    let temp = init_and_capture();
+    let value = heddle_json(&["review", "next"], &temp);
+    assert_output_kind(&value, "review_next");
+    assert!(
+        value.get("next").is_some(),
+        "review next must always emit a `next` field (null or object): {value}"
+    );
+}
+
+#[test]
+fn purge_list_envelope_includes_recent_apply() {
+    let temp = init_and_capture();
+    let log = heddle_json(&["log", "--limit", "1"], &temp);
+    let state = log["states"][0]["change_id"].as_str().unwrap().to_string();
+    heddle(
+        &[
+            "redact", "apply", &state, "--path", "main.rs", "--reason", "test",
+        ],
+        Some(temp.path()),
+    )
+    .expect("redact apply");
+    heddle(
+        &[
+            "purge", "apply", &state, "--path", "main.rs", "--force",
+        ],
+        Some(temp.path()),
+    )
+    .expect("purge apply");
+
+    let value = heddle_json(&["purge", "list"], &temp);
+    assert_output_kind(&value, "purge_list");
+    assert!(
+        value["count"].as_u64().is_some_and(|n| n >= 1),
+        "purge list after purge apply must show at least one entry: {value}"
+    );
+}
+
+#[test]
+fn stack_snapshot_text_mode_still_emits_envelope_with_output_kind() {
+    // Text mode pretty-prints the envelope (the snapshot is
+    // structured data by definition). The discriminator must still
+    // ride on top so agents that read text output during interactive
+    // sessions can still route on it.
+    let temp = init_and_capture();
+    detach_head(&temp);
+    let output = heddle_output(&["--output", "text", "stack", "snapshot"], Some(temp.path()))
+        .expect("invoke stack snapshot text");
+    assert!(
+        output.status.success(),
+        "stack snapshot text must succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|err| panic!("text stack snapshot must be valid JSON: {err}\n{stdout}"));
+    assert_output_kind(&value, "stack_snapshot");
+}

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -515,10 +515,24 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
         !items.is_empty(),
         "populated context list must surface items: {populated}"
     );
-    // Per-row `output_kind` rides as `context_get` (the envelope
-    // discriminator owns the outer one). Locking the inner value
-    // catches accidental row-discriminator changes.
-    assert_eq!(items[0]["output_kind"].as_str(), Some("context_get"));
+    // List rows MUST NOT repeat a per-row `output_kind`: the
+    // `context_list` envelope owns the discriminator. A row that carried
+    // its own `output_kind: "context_get"` would make consumers that
+    // route recursively on the discriminator misclassify the list row as
+    // a standalone `context get` payload (heddle#272 Codex r5 finding).
+    assert!(
+        items[0].get("output_kind").is_none(),
+        "context list rows must not carry a nested output_kind: {populated}"
+    );
+    // The row still carries its substantive fields.
+    assert!(
+        items[0].get("target").and_then(|v| v.as_str()).is_some(),
+        "context list row must keep its `target`: {populated}"
+    );
+    assert!(
+        items[0].get("annotations").and_then(|v| v.as_array()).is_some(),
+        "context list row must keep its `annotations` array: {populated}"
+    );
 }
 
 #[test]

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2168,6 +2168,7 @@ Hosted-review payload for a single state.
 
 ```json
 {
+  "output_kind": "review_show",
   "change_id": "hd-def456",
   "headline": "Tighten parser recovery",
   "agent_narrative": null,
@@ -2183,7 +2184,7 @@ Hosted-review payload for a single state.
 `heddle review sign --output json` emits:
 
 ```json
-{"signature_id": "...", "change_id": "..."}
+{"output_kind": "review_sign", "signature_id": "...", "change_id": "..."}
 ```
 
 `heddle review next --output json` emits a stable envelope keyed by
@@ -2201,7 +2202,7 @@ top-level `null`.
 `heddle review health --output json` emits:
 
 ```json
-{"entries": [{"module_id": "...", "fire_rate": 0.42, "warn": false}], "window_states": 12}
+{"output_kind": "review_health", "entries": [{"module_id": "...", "fire_rate": 0.42, "warn": false}], "window_states": 12}
 ```
 
 ---
@@ -2712,6 +2713,7 @@ Move the active checkout to a resolved state.
 
 ```json
 {
+  "output_kind": "goto",
   "target": "hd-sqr398dvx9ay",
   "intent": "capture parser fix",
   "message": "Now at: hd-sqr398dvx9ay"
@@ -2726,6 +2728,7 @@ List or remove untracked worktree paths.
 
 ```json
 {
+  "output_kind": "clean",
   "removed": ["tmp/output.txt"],
   "dry_run": true
 }
@@ -2854,19 +2857,19 @@ Preview or apply a ref reconciliation between Git and Heddle.
 `heddle stack` emits:
 
 ```json
-{"thread": "main", "stack": null, "stacks": []}
+{"output_kind": "stack", "thread": "main", "stack": null, "stacks": []}
 ```
 
 `heddle stack ready` emits:
 
 ```json
-{"thread": "main", "next_action": {"kind": "unknown"}}
+{"output_kind": "stack_ready", "thread": "main", "next_action": {"kind": "unknown"}}
 ```
 
 `heddle stack snapshot` emits:
 
 ```json
-{"thread": "main", "snapshot": null}
+{"output_kind": "stack_snapshot", "thread": "main", "snapshot": null}
 ```
 
 ---
@@ -2890,6 +2893,7 @@ List saved stash entries.
 
 ```json
 {
+  "output_kind": "stash_list",
   "stashes": [
     {
       "index": 0,
@@ -2908,6 +2912,7 @@ Show the top stash as path buckets.
 
 ```json
 {
+  "output_kind": "stash_show",
   "modified": ["src/parser.rs"],
   "added": ["tests/parser.rs"],
   "deleted": []
@@ -2923,6 +2928,7 @@ Apply the inverse of a state. With `--no-commit`, `change_id` is
 
 ```json
 {
+  "output_kind": "revert",
   "change_id": null,
   "reverted_state": "hd-sqr398dvx9ay",
   "files_affected": ["M src/parser.rs"],
@@ -2977,10 +2983,12 @@ Every verified everyday/agent runtime schema is a concrete machine-contract
 mirror. Advanced/internal/admin opaque entries are counted separately
 outside clean verification coverage.
 
-`heddle bisect start|good|bad|reset --output json` emit:
+`heddle bisect start|good|bad|reset --output json` emit (each carries
+`output_kind` set to the snake-cased subcommand, e.g. `bisect_start`,
+`bisect_good`):
 
 ```json
-{"status": "started", "current": "hd-sqr398dvx9ay", "remaining": 5, "good": "hd-good123", "bad": "hd-bad456"}
+{"output_kind": "bisect_start", "status": "started", "current": "hd-sqr398dvx9ay", "remaining": 5, "good": "hd-good123", "bad": "hd-bad456"}
 ```
 
 `heddle blame --output json` emits:
@@ -2998,7 +3006,7 @@ outside clean verification coverage.
 `heddle cherry-pick --output json` emits:
 
 ```json
-{"cherry_picked": true, "source_change_id": "hd-source123", "change_id": "hd-result456", "conflicts": []}
+{"output_kind": "cherry_pick", "cherry_picked": true, "source_change_id": "hd-source123", "change_id": "hd-result456", "conflicts": []}
 ```
 
 `heddle collapse --output json` emits:
@@ -3019,10 +3027,12 @@ outside clean verification coverage.
 {"conflicts": [{"id": "conflict-1", "kind": "content", "path": "src/lib.rs", "candidate_resolutions": []}]}
 ```
 
-`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit:
+`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`):
+
+`context list` wraps its rows in an `{"output_kind": "context_list", "items": [...]}` envelope; the rows themselves carry no per-row discriminator (the envelope owns it).
 
 ```json
-{"path": "src/lib.rs", "key": "owner", "value": "platform", "entries": [{"path": "src/lib.rs", "key": "owner", "value": "platform"}], "suggestions": [], "issues": []}
+{"output_kind": "context_set", "path": "src/lib.rs", "key": "owner", "value": "platform", "entries": [{"path": "src/lib.rs", "key": "owner", "value": "platform"}], "suggestions": [], "issues": []}
 ```
 
 `heddle daemon serve|status|stop --output json` emit:
@@ -3031,22 +3041,24 @@ outside clean verification coverage.
 {"running": true, "pid": 4242, "endpoint": "/work/project/.heddle/daemon.sock", "mounts": 1, "stopped": false}
 ```
 
-`heddle discuss open|append|resolve|show --output json` emit:
+`heddle discuss open|append|resolve|show --output json` emit (each carries
+`output_kind` set to the snake-cased subcommand, e.g. `discuss_open`,
+`discuss_append`):
 
 ```json
-{"id": "disc-123", "file": "src/lib.rs", "symbol": "verify", "opened_against_state": "hd-sqr398dvx9ay", "opened_at_secs": 1767225600, "visibility": "team", "body_changed_since_open": false, "orphaned": false, "resolution": {"kind": "open", "annotation_id": null, "state_id": null, "reason": null}, "turns": [{"author_name": "A. Engineer", "author_email": "a@example.com", "body": "Please check this edge case.", "posted_at_secs": 1767225600}], "resolved_annotation_id": null}
+{"output_kind": "discuss_open", "id": "disc-123", "file": "src/lib.rs", "symbol": "verify", "opened_against_state": "hd-sqr398dvx9ay", "opened_at_secs": 1767225600, "visibility": "team", "body_changed_since_open": false, "orphaned": false, "resolution": {"kind": "open", "annotation_id": null, "state_id": null, "reason": null}, "turns": [{"author_name": "A. Engineer", "author_email": "a@example.com", "body": "Please check this edge case.", "posted_at_secs": 1767225600}], "resolved_annotation_id": null}
 ```
 
 `heddle discuss list --output json` emits:
 
 ```json
-{"discussions": [{"id": "disc-123", "file": "src/lib.rs", "symbol": "verify", "opened_against_state": "hd-sqr398dvx9ay", "opened_at_secs": 1767225600, "visibility": "team", "body_changed_since_open": false, "orphaned": false, "resolution": {"kind": "open", "annotation_id": null, "state_id": null, "reason": null}, "turns": [{"author_name": "A. Engineer", "author_email": "a@example.com", "body": "Please check this edge case.", "posted_at_secs": 1767225600}], "resolved_annotation_id": null}]}
+{"output_kind": "discuss_list", "discussions": [{"id": "disc-123", "file": "src/lib.rs", "symbol": "verify", "opened_against_state": "hd-sqr398dvx9ay", "opened_at_secs": 1767225600, "visibility": "team", "body_changed_since_open": false, "orphaned": false, "resolution": {"kind": "open", "annotation_id": null, "state_id": null, "reason": null}, "turns": [{"author_name": "A. Engineer", "author_email": "a@example.com", "body": "Please check this edge case.", "posted_at_secs": 1767225600}], "resolved_annotation_id": null}]}
 ```
 
 `heddle fork --output json` emits:
 
 ```json
-{"thread": "review/fix-parser", "from": "main", "base_change_id": "hd-sqr398dvx9ay", "message": "forked review/fix-parser from main"}
+{"output_kind": "fork", "thread": "review/fix-parser", "from": "main", "base_change_id": "hd-sqr398dvx9ay", "message": "forked review/fix-parser from main"}
 ```
 
 `heddle fsck --output json` emits:
@@ -3079,10 +3091,11 @@ outside clean verification coverage.
 {"ok": true, "tasks": [{"name": "gc", "status": "skipped"}], "objects_removed": 0, "index_updated": true, "monitoring": false}
 ```
 
-`heddle purge apply|list --output json` emit:
+`heddle purge apply|list --output json` emit (each carries `output_kind`
+set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`):
 
 ```json
-{"purged": true, "redaction_id": "redact-123", "bytes_removed": 2048, "redactions": [{"redaction_id": "redact-123", "purged": true}]}
+{"output_kind": "purge_apply", "purged": true, "redaction_id": "redact-123", "bytes_removed": 2048, "redactions": [{"redaction_id": "redact-123", "purged": true}]}
 ```
 
 `heddle query --output json` emits:
@@ -3097,16 +3110,20 @@ outside clean verification coverage.
 {"rebased": true, "old_base": "hd-old123", "new_base": "hd-new456", "change_id": "hd-result789", "conflicts": []}
 ```
 
-`heddle redact apply|list|show --output json` emit:
+`heddle redact apply|list|show --output json` emit (each carries
+`output_kind` set to the snake-cased subcommand, e.g. `redact_apply`,
+`redact_list`):
 
 ```json
-{"redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "purged": false}
+{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "purged": false}
 ```
 
-`heddle redact trust add|list|remove --output json` emit:
+`heddle redact trust add|list|remove --output json` emit (each carries
+`output_kind` set to the snake-cased subcommand, e.g. `redact_trust_add`,
+`redact_trust_list`):
 
 ```json
-{"trusted_keys": [{"algorithm": "ed25519", "label": "security", "public_key": "abc123"}], "added": true, "removed": false}
+{"output_kind": "redact_trust_add", "trusted_keys": [{"algorithm": "ed25519", "label": "security", "public_key": "abc123"}], "added": true, "removed": false}
 ```
 
 `heddle resolve --output json` emits:

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2186,12 +2186,16 @@ Hosted-review payload for a single state.
 {"signature_id": "...", "change_id": "..."}
 ```
 
-`heddle review next --output json` emits either a `NextStateView`
-(`{change_id, headline, existing_signatures}`) or the literal `null`
-when there are no pending reviews in the scan window.
+`heddle review next --output json` emits a stable envelope keyed by
+`output_kind: "review_next"`. When the scan window holds a pending
+review, the pending state's view is flattened alongside `output_kind`
+(`change_id`, `headline`, `existing_signatures`) and the same view is
+echoed under `next`. When the scan window holds no pending review, the
+payload carries only `output_kind` and `next: null` — never a
+top-level `null`.
 
 ```json
-{"change_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": []}
+{"output_kind": "review_next", "change_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0, "next": {"change_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0}}
 ```
 
 `heddle review health --output json` emits:

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2866,10 +2866,10 @@ Preview or apply a ref reconciliation between Git and Heddle.
 {"output_kind": "stack_ready", "thread": "main", "next_action": {"kind": "unknown"}}
 ```
 
-`heddle stack snapshot` emits:
+`heddle stack snapshot` emits a `RepositorySnapshot` flattened beneath the discriminator, so the root carries `output_kind` alongside `version`, `captured_at`, `stacks`, and `threads` — there is no `thread`/`snapshot` wrapper:
 
 ```json
-{"output_kind": "stack_snapshot", "thread": "main", "snapshot": null}
+{"output_kind": "stack_snapshot", "version": 1, "captured_at": "2026-05-28T15:43:36Z", "stacks": [{"root": {"name": "feature-x", "children": []}}], "threads": [{"thread": "feature-x", "parent_thread": null, "base_state": "hd-sqr398dvx9ay", "current_state": "hd-sqr398dvx9ay", "state": "active", "freshness": "current"}]}
 ```
 
 ---
@@ -3027,12 +3027,16 @@ outside clean verification coverage.
 {"conflicts": [{"id": "conflict-1", "kind": "content", "path": "src/lib.rs", "candidate_resolutions": []}]}
 ```
 
-`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`):
-
-`context list` wraps its rows in an `{"output_kind": "context_list", "items": [...]}` envelope; the rows themselves carry no per-row discriminator (the envelope owns it).
+`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
 
 ```json
-{"output_kind": "context_set", "path": "src/lib.rs", "key": "owner", "value": "platform", "entries": [{"path": "src/lib.rs", "key": "owner", "value": "platform"}], "suggestions": [], "issues": []}
+{"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hd-k6a0wfrbgcg7"}
+```
+
+`heddle context list --output json` wraps its rows in an `items` envelope; the rows themselves carry no per-row discriminator (the envelope owns it). Each row is `{"target_kind": ..., "target": ..., "annotations": [...]}` — it emits:
+
+```json
+{"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hd-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
 ```
 
 `heddle daemon serve|status|stop --output json` emit:

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2985,10 +2985,11 @@ outside clean verification coverage.
 
 `heddle bisect start|good|bad|reset --output json` emit (each carries
 `output_kind` set to the snake-cased subcommand, e.g. `bisect_start`,
-`bisect_good`):
+`bisect_good`). The `start` payload is just the discriminator and status;
+`good`/`bad` also carry a `commit` field for the marked state:
 
 ```json
-{"output_kind": "bisect_start", "status": "started", "current": "hd-sqr398dvx9ay", "remaining": 5, "good": "hd-good123", "bad": "hd-bad456"}
+{"output_kind": "bisect_start", "status": "started"}
 ```
 
 `heddle blame --output json` emits:
@@ -3003,10 +3004,12 @@ outside clean verification coverage.
 {"ingested": true, "commits_imported": 2, "states_created": 2, "reason": "mirror update", "remote": "origin"}
 ```
 
-`heddle cherry-pick --output json` emits:
+`heddle cherry-pick --output json` emits the committed shape by default;
+with `--no-commit` the `new_commit` field is replaced by `"no_commit":
+true` and `status` is `"applied"`:
 
 ```json
-{"output_kind": "cherry_pick", "cherry_picked": true, "source_change_id": "hd-source123", "change_id": "hd-result456", "conflicts": []}
+{"output_kind": "cherry_pick", "status": "committed", "commit": "hd-source123", "new_commit": "hd-result456"}
 ```
 
 `heddle collapse --output json` emits:
@@ -3059,10 +3062,11 @@ outside clean verification coverage.
 {"output_kind": "discuss_list", "discussions": [{"id": "disc-123", "file": "src/lib.rs", "symbol": "verify", "opened_against_state": "hd-sqr398dvx9ay", "opened_at_secs": 1767225600, "visibility": "team", "body_changed_since_open": false, "orphaned": false, "resolution": {"kind": "open", "annotation_id": null, "state_id": null, "reason": null}, "turns": [{"author_name": "A. Engineer", "author_email": "a@example.com", "body": "Please check this edge case.", "posted_at_secs": 1767225600}], "resolved_annotation_id": null}]}
 ```
 
-`heddle fork --output json` emits:
+`heddle fork --output json` emits (`thread` is `null` unless `--name`
+names a new thread for the fork):
 
 ```json
-{"output_kind": "fork", "thread": "review/fix-parser", "from": "main", "base_change_id": "hd-sqr398dvx9ay", "message": "forked review/fix-parser from main"}
+{"output_kind": "fork", "change_id": "hd-result456", "content_hash": "b9c34842", "thread": "review/fix-parser", "from_state": "hd-sqr398dvx9ay", "message": "Created fork hd-result456 from hd-sqr398dvx9ay"}
 ```
 
 `heddle fsck --output json` emits:
@@ -3096,10 +3100,12 @@ outside clean verification coverage.
 ```
 
 `heddle purge apply|list --output json` emit (each carries `output_kind`
-set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`):
+set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`).
+`ignore_hint` is present only when the purged path is not yet covered by a
+`.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "purge_apply", "purged": true, "redaction_id": "redact-123", "bytes_removed": 2048, "redactions": [{"redaction_id": "redact-123", "purged": true}]}
+{"output_kind": "purge_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "redactions_marked": 1, "blob_bytes_removed": false, "blob_remains_in_pack": false, "purger": "A. Engineer <a@example.com>", "message": "purged blob sha256:abc123 at secrets.env in hd-sqr398dvx9ay (1 redaction(s) marked)", "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle query --output json` emits:
@@ -3116,18 +3122,23 @@ set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`):
 
 `heddle redact apply|list|show --output json` emit (each carries
 `output_kind` set to the snake-cased subcommand, e.g. `redact_apply`,
-`redact_list`):
+`redact_list`). `signature_algorithm` is present only when the redaction
+is signed (`--sign-with`); `ignore_hint` only when the path is not yet
+covered by a `.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "purged": false}
+{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "redactor": "A. Engineer <a@example.com>", "redacted_at": "2026-01-01T00:00:00Z", "all_states": false, "states_redacted": 1, "signed": false, "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle redact trust add|list|remove --output json` emit (each carries
 `output_kind` set to the snake-cased subcommand, e.g. `redact_trust_add`,
-`redact_trust_list`):
+`redact_trust_list`). The `add` payload flattens the added entry alongside
+`output_kind` (`label` present only when `--label` is supplied); `list`
+returns a `trusted_keys` array plus `count`; `remove` returns a `removed`
+count:
 
 ```json
-{"output_kind": "redact_trust_add", "trusted_keys": [{"algorithm": "ed25519", "label": "security", "public_key": "abc123"}], "added": true, "removed": false}
+{"output_kind": "redact_trust_add", "algorithm": "ed25519", "public_key": "abc123def456", "label": "security"}
 ```
 
 `heddle resolve --output json` emits:

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -108,6 +108,7 @@ metadata only; it does not import Git history or write Git-tracked files.
 
 ```json
 {
+  "output_kind": "init",
   "status": "initialized",
   "action": "init",
   "path": "/repo/.heddle",
@@ -155,6 +156,7 @@ in-progress operation.
 
 ```json
 {
+  "output_kind": "status",
   "repository_capability": "git-overlay",
   "repository_label": "Git + Heddle",
   "storage_model": "git+heddle-sidecar",
@@ -323,7 +325,7 @@ blocked verification state on stdout.
 
 ```json
 {
-  "output_kind": "verification",
+  "output_kind": "verify",
   "clean": true,
   "repository_label": "Git + Heddle",
   "verified": true,
@@ -370,7 +372,7 @@ blocked verification state on stdout.
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
-| `output_kind` | string | required | Always `verification`; lets agents identify the proof payload without a wrapper object. |
+| `output_kind` | string | required | Always `verify`; lets agents identify the proof payload without a wrapper object. |
 | `repository_label` | string | required | Human-facing repository identity; managed Git-overlay child checkouts use `"Git + Heddle isolated checkout"`. |
 | `repository_context` | object | optional | Present for managed child checkouts; includes `kind`, `parent_repository`, and any recorded `target_thread` / `parent_thread`. |
 | `verified` | bool | required | `true` only when all verification checks are clean or not applicable. |
@@ -421,7 +423,6 @@ standard recovery fields plus nested verification proof:
     }
   ],
   "verification": {
-    "output_kind": "verification",
     "clean": false,
     "verified": false,
     "status": "dirty_worktree",
@@ -447,6 +448,7 @@ surface; the native first-run loop should prefer `commit`.
 
 ```json
 {
+  "output_kind": "capture",
   "status": "captured",
   "action": "capture",
   "change_id": "hd-capture123",
@@ -468,6 +470,7 @@ surface; the native first-run loop should prefer `commit`.
 
 ```json
 {
+  "output_kind": "checkpoint",
   "status": "checkpointed",
   "action": "checkpoint",
   "change_id": "hd-capture123",
@@ -483,6 +486,7 @@ surface; the native first-run loop should prefer `commit`.
 
 ```json
 {
+  "output_kind": "commit",
   "status": "committed",
   "action": "commit",
   "change_id": "hd-capture123",
@@ -602,6 +606,7 @@ state and worktree/default comparison target.
 
 ```json
 {
+  "output_kind": "diff",
   "from_state": "hd-base123",
   "to_state": "hd-head456",
   "changes": []
@@ -1615,6 +1620,7 @@ carries `git_overlay_import_hint`.
 
 ```json
 {
+  "output_kind": "bridge_git_status",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
   "mirror_path": "/repo/.heddle/git",
@@ -1811,6 +1817,7 @@ State detail view, pretty-printed.
 
 ```json
 {
+  "output_kind": "thread_list",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
   "hosted_enabled": false,
@@ -1901,6 +1908,7 @@ Control-tower view across every active thread.
 
 ```json
 {
+  "output_kind": "workspace_summary",
   "repository": "/work/project",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
@@ -2327,8 +2335,8 @@ key naming:
 |------|-------|
 | `init` | `{"initialized": true, "path": "..."}` |
 | `export` | `{"states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
-| `import` | `{"commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "partial_mirror_refs": N}` |
-| `sync` | `{"states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
+| `import` | `{"output_kind": "bridge_git_import", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "partial_mirror_refs": N}` |
+| `sync` | `{"output_kind": "bridge_git_sync", "states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
 | `push` | `{"output_kind": "bridge_git_push", "action": "bridge git push", "status": "pushed", "success": true, "pushed": true, "changed": true, "transport": "git", "remote": "origin"}` |
 | `pull` | `{"output_kind": "bridge_git_pull", "action": "bridge git pull", "status": "updated", "success": true, "pulled": true, "changed": true, "transport": "git", "remote": "origin"}` |
 
@@ -2347,13 +2355,13 @@ key naming:
 `heddle bridge git import --output json` emits:
 
 ```json
-{"commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "partial_mirror_refs": 0, "already_in_sync": false}
+{"output_kind": "bridge_git_import", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "partial_mirror_refs": 0, "already_in_sync": false}
 ```
 
 `heddle bridge git sync --output json` emits:
 
 ```json
-{"states_exported": 3, "commits_imported": 4, "threads_synced": 1, "markers_synced": 2}
+{"output_kind": "bridge_git_sync", "states_exported": 3, "commits_imported": 4, "threads_synced": 1, "markers_synced": 2}
 ```
 
 `heddle bridge git push --output json` emits:
@@ -2377,8 +2385,9 @@ List every runtime schema verb and the subset enforced by
 
 ```json
 {
-  "schema_verbs": ["status", "verification", "try"],
-  "documented_schema_verbs": ["status", "verification", "try"]
+  "output_kind": "schemas",
+  "schema_verbs": ["status", "verify", "try"],
+  "documented_schema_verbs": ["status", "verify", "try"]
 }
 ```
 
@@ -2838,6 +2847,7 @@ Preview or apply a ref reconciliation between Git and Heddle.
 
 ```json
 {
+  "output_kind": "bridge_git_reconcile",
   "status": "preview",
   "prefer": null,
   "ref_name": "main",


### PR DESCRIPTION
## Summary

- Adds a catalog-walking + runtime-invoking lint that fails CI when a JSON-emitting verb lacks an `output_kind` discriminator (Issue #272 finding S1, generalizes Round-3 #255).
- Sweeps `output_kind` onto every Serialize struct for the named-by-persona verbs: `stack`, `goto`, `fork`, `revert`, `purge`, `redact`, `stash`, `clean`, `discuss`, `context/*`, `review`, `cherry-pick`, `bisect`. Also closes catalog-only gaps PR #251 left behind (`init`, `clone`, `verify`).
- New verbs added without a discriminator default to FAIL — they must be declared in `SWEPT` or in `UNSWEPT_TODO` (the documented rolldown surface for follow-up sweeps).

Closes HeddleCo/heddle#272 — closes #255 as a special case.

## Red commit

`44083e6` — failing tests: `output_kind_invariant::swept_verbs_declare_output_kind_in_catalog` (43 verbs missing catalog declaration), `output_kind_invariant::runtime_emits_output_kind_for_invokable_swept_verbs` (13 verbs missing runtime field).

## Test evidence

\`\`\`
$ cargo test -p heddle-cli --test cli_integration output_kind_invariant -- --test-threads=1
running 7 tests
test output_kind_invariant::clone_catalog_entry_advertises_both_clone_and_clone_connection ... ok
test output_kind_invariant::every_json_emitting_verb_is_classified ... ok
test output_kind_invariant::hosted_clone_emits_both_discriminator_values ... ignored, requires a live hosted gRPC fixture
test output_kind_invariant::kind_field_exceptions_use_kind_intentionally ... ok
test output_kind_invariant::runtime_emits_output_kind_for_invokable_swept_verbs ... ok
test output_kind_invariant::swept_verbs_declare_output_kind_in_catalog ... ok
test output_kind_invariant::unswept_verbs_have_no_output_kind_declaration ... ok

test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 653 filtered out
\`\`\`

\`cargo test --workspace\` + \`cargo clippy --workspace --all-targets -- -D warnings\` + the two `bash scripts/check-*.sh` parity gates all green.

## Manual verification

N/A — covered by tests. Runtime emission is verified by the `runtime_emits_output_kind_for_invokable_swept_verbs` test, which spawns the built `heddle` binary against an init'd repo and parses the JSON for each invokable swept verb.

## Notes

- `workspace show` keeps its wire-format-stable `output_kind: workspace_summary` value (PR #251 set this; the brief forbids changing existing instrumented verbs). Modeled as a per-verb override in `output_kind_override`.
- `commands` retains its `kind: command_catalog` discriminator (catalog itself; documented exception via `KIND_FIELD_EXCEPTIONS`).
- `context list` / `context suggest` JSON roots become `{"output_kind": ..., "items": [...]}` envelopes per the brief's option (a) recommendation. Other context subverbs inject the field directly into their existing object root.
- `stack snapshot` uses `#[serde(flatten)]` to inject `output_kind` while preserving the existing top-level shape consumed by agentic tooling.
- `UNSWEPT_TODO` documents the remaining ~110 JSON-emitting verbs whose Rust structs don't yet emit `output_kind`. The lint forces future verbs into `SWEPT` (must declare) rather than letting them slip silently into the unswept set.

## Round 3 — Codex review fixes

- **P2 ([cid 3313127560](https://github.com/HeddleCo/heddle/pull/281#discussion_r3313127560)):** Hosted `heddle clone --output json` emits two JSON records per invocation — a preliminary connection envelope (`output_kind: "clone_connection"`) and the final clone payload (`output_kind: "clone"`). The r1/r2 catalog advertised only the final discriminator, so agents that route on `commands` / `json_discriminators` had to fall back to text parsing on the first record.
  - Fixed in `8b7b3ce`. New catalog helper `json_discriminator_no_schema` lets a verb advertise a discriminator value that isn't backed by its own Serialize struct (documented reason required). The `clone` entry now carries both `clone` and `clone_connection` discriminators.
  - Both wire-format values are lifted into named `pub const`s (`CLONE_OUTPUT_KIND`, `CLONE_CONNECTION_OUTPUT_KIND`) in `commands/clone.rs`; the runtime emission sites and the new lint test reference the same constants, so a rename can't silently desync runtime from catalog.
  - New lint test `clone_catalog_entry_advertises_both_clone_and_clone_connection` pins both discriminator values to the constants and asserts the envelope's `schema_verb` is `None` with a non-empty `no_schema_reason`. A sibling `#[ignore]`d test `hosted_clone_emits_both_discriminator_values` documents the future live-fixture path.
  - The metadata invariant (`json_discriminator_metadata_is_internally_consistent`) is relaxed from "no duplicate paths" to "no duplicate (path, value) pairs" — a single verb may legitimately carry more than one discriminator when it emits multiple records per invocation.

## Round 4 — Codex review fixes

- **P2 ([cid 3315306070](https://github.com/HeddleCo/heddle/pull/281#discussion_r3315306070)):** The r1 sweep wrapped `review next --output json` in a stable envelope (`{output_kind: "review_next", change_id, headline, existing_signatures, next}`, with no top-level `null`), but the schema mirror and generated doc still described a bare `NextStateView` or literal `null`. Agents validating/generating against `heddle schemas review next` / `doctor schemas` saw the wrong top-level shape for both the pending and no-pending cases.
  - Fixed in `9737cb1`. `ReviewNextSchema` now models the real envelope: `output_kind` + the flattened pending view (`change_id`/`headline`/`existing_signatures`) + a nested `next` (new `ReviewNextStateSchema`) that is `null` when the scan window holds no pending review. `existing_signatures` corrected from `Vec<Value>` to `u32` (the emitted signature count).
  - `docs/json-schemas.md` updated: the sample is now the full envelope and the prose describes both the pending (flattened + echoed under `next`) and empty (`next: null`) cases. The stale "bare `NextStateView` or `null`" wording is gone.
  - New runtime test `review_next_envelope_top_level_keys_match_registered_schema` asserts a real `review next --output json` invocation's top-level keys are all declared by the registered schema (an init+capture fixture surfaces the pending/flattened case — a superset of the empty case). The existing `doctor_schemas_reports_runtime_and_documented_coverage` test (asserts zero drift against the repo doc) now validates the full envelope's keys against the schema.
  - Code output shape unchanged — only the doc/schema and a test were touched.

## Round 5 — Codex review fixes

- **P1 ([cid 3318094405](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318094405)):** The `docs/json-schemas.md` samples for the #272-swept documented verbs still omitted `output_kind`, so the documented machine contract didn't match the runtime emission.
  - Fixed in `4b0aa94`. Added `output_kind` to the sample(s) for every #272-swept verb: `clean`, `goto`, `revert`, `fork`, `cherry-pick`, `stack` / `stack ready` / `stack snapshot`, `stash list` / `stash show`, `review show` / `review sign` / `review health`, `bisect`, `purge`, `redact` (+ `redact trust`), `discuss` (+ `discuss list`), and the `context` group. Pipe-listed group samples show the first variant's value and note that `output_kind` is the snake-cased subcommand.
  - Mechanism correction: `heddle doctor schemas` checks that a sample's keys are a *subset* of the schema's properties — it does **not** enforce required-field *presence* (`cmd_doctor_schemas` only flags keys absent from the schema). So registering the discriminator did not make the gate report drift; `doctor schemas --output json` was `verified: true, issues: []` before and after. The samples were inaccurate vs runtime regardless — that's the real fix.
  - New test `swept_verb_doc_samples_show_output_kind` asserts each swept verb's `output_kind` literal is present in the doc, since the existing gate can't catch a missing-but-not-required field.
- **P2 ([cid 3318041027](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318041027)):** `heddle context list --output json` rows reused `ContextGetOutput` and so carried a nested `output_kind: "context_get"` *inside* the `{output_kind: "context_list", items: [...]}` envelope — consumers routing recursively on `output_kind` could misclassify a list row as a standalone `context get` payload.
  - Fixed in `4b0aa94`. List rows now serialize through a dedicated `ContextListRow` struct (`target_kind` / `target` / `annotations`, no discriminator) — the envelope owns the only `output_kind`. The stale comment claiming the field was already suppressed is removed. Standalone `heddle context get --output json` is unchanged and still emits `output_kind: "context_get"`.
  - The runtime test `context_list_envelope_wraps_items_for_empty_and_populated` now asserts list rows have no `output_kind` (and still carry `target` / `annotations`); `context_set_get_history_audit_check_emit_output_kind` guards the standalone case.

## Round 6 — Codex review fixes

Strengthened the invariant so all four findings fail CI rather than slipping past the existing gates (the drip-ender).

- **P2 ([cid 3318853686](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318853686)) — `init` advertised `output_kind` but never emitted it.** Fixed in `a02a44a`: added `output_kind: "init"` to `InitOutput` and `output_kind: String` to `InitSchema`. New `runtime_init_emits_output_kind` invokes `heddle init --output json` in a clean dir and asserts the discriminator — closing the runtime skip.
- **P2 ([cid 3318853676](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318853676)) — documented schema structs lacked the `output_kind` property.** Fixed in `a02a44a`: added it to `CleanSchema`, `GotoSchema`, `RevertSchema`, `ReviewShow/Sign/HealthSchema`, `StashList/ShowSchema`, `InitSchema`. For discuss, split the mirror to match the runtime — new `DiscussionEnvelopeSchema` (output_kind flattened over the discussion) backs `open`/`append`/`resolve`/`show`, while `discuss list` keeps the bare `DiscussionSchema` for inner rows and `DiscussionListSchema` gains its own top-level `output_kind`. New `documented_swept_schema_structs_declare_output_kind` reads the *pre-injection* struct schema, so a missing field fails CI instead of being masked by the `schema_for_verb` catalog injection.
- **P2 ([cid 3318853691](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318853691)) — context doc sample was the old key/value shape.** Fixed in `a02a44a`: rewrote the `context_set` sample to `{output_kind, target, annotations, state}` and added a `context list` `items`-envelope sample with the real per-row shape (verified against live `--output json` runs).
- **P2 ([cid 3318853698](https://github.com/HeddleCo/heddle/pull/281#discussion_r3318853698)) — stack snapshot doc sample used a `thread`/`snapshot` wrapper.** Fixed in `a02a44a`: rewrote it to the flattened `RepositorySnapshot` shape (`output_kind` + `version`/`captured_at`/`stacks`/`threads`).
- **Invariant strengthening:** new `swept_doc_samples_match_runtime_keys` asserts each documented sample's top-level keys are a subset of the real `--output json` payload keys (stack_snapshot, context_set, context_list) — converting "Codex finds the next stale sample" into "CI is red until docs match runtime". Red commit `255ee12`; green `a02a44a`.

## Round 7 (Codex r7 — 7 P2 findings, all `ea2af2b`)

All seven findings were stale machine-contracts that the runtime never emits. Root cause: the r6 doc-vs-runtime check ran a hand-picked list of three verbs, and the inline `serde_json::json!` verbs resolve to a generic operation-record schema (`additionalProperties: true`) that `doctor schemas` can't validate — so the rest drifted unchecked.

- **[cid 3319350338] cherry-pick** — sample now `{output_kind, status, commit, new_commit}` (committed shape; prose notes the `--no-commit` variant). Matches `cmd_cherry_pick`.
- **[cid 3319350346] purge apply** — sample now mirrors `PurgeApplyOutput` (`redaction_id, blob, state, path, redactions_marked, blob_bytes_removed, blob_remains_in_pack, purger, message, ignore_hint`); dropped `purged`/`bytes_removed`/`redactions`.
- **[cid 3319350353] bisect start** — sample reduced to `{output_kind, status}`; removed `current`/`remaining`/`good`/`bad`.
- **[cid 3319350358] fork** — sample now matches `ForkOutput` (`output_kind, change_id, content_hash, thread, from_state, message`); removed `from`/`base_change_id`.
- **[cid 3319350364] redact apply** — sample now matches `RedactApplyOutput` (adds `redactor, redacted_at, all_states, states_redacted, signed` + optional `signature_algorithm`/`ignore_hint`); removed `purged`.
- **[cid 3319350371] redact trust add** — sample now shows the flattened `TrustEntryOutput` (`algorithm, public_key`, optional `label`) next to `output_kind`; removed `trusted_keys`/`added`/`removed`.
- **[cid 3319350376] review next schema** — `next` is now required-but-nullable. `RequiredNullableNextState` wraps `Option<ReviewNextStateSchema>`; its `json_schema` delegates to Option's nullable form while leaving `_schemars_private_is_option == false`, so schemars adds `next` to `required`. Verified `schemas review next` now requires `next` with value `anyOf: [ReviewNextStateSchema, null]`.

**Invariant closed (the actual fix).** Replaced the 3-verb subset check with `doc_samples_match_runtime_for_every_swept_272_verb`: EXHAUSTIVE over the whole #272 sweep group. Every #272 verb that carries a documented `output_kind` sample is either invoked against a fixture (exact top-level-key-set equality with the live `--output json` payload) or has a registered schema that pins every documented key (so `doctor schemas` guards it — `review sign`, which cryptographically validates its `--signature`, is the only such verb). Generic-schema verbs are *forced* down the runtime path: a new stale sample fails CI immediately instead of deferring to an r8. Verified the invariant fails on injected drift before shipping.

## Round 8 — `output_kind` gets one source of truth

r7 claimed the doc-vs-runtime invariant was "exhaustive," but it still iterated only the `SWEPT_272` subset, so Codex hand-found drift in earlier-swept verbs. r8 makes the **catalog discriminator set the single source of truth** and re-roots everything on it, so the whole class fails CI mechanically.

- **Root fix (P2 cid 3319783461).** Dropped `SWEPT_272` entirely. Both doc invariants now drive from `catalog_output_kind_discriminators()` (every catalog discriminator with field `output_kind`). `doc_samples_match_runtime_for_every_catalog_discriminator` compares each documented sample against the live `--output json` payload (runtime case) or the registered schema (schema-pin) across the FULL set — `init`, `status`, `verify`, `clone`, `thread list/show`, bridge/doctor included.
- **Sample-centric correctness (P1 cid 3318094405).** New `doc_samples_carry_catalog_output_kind_for_every_discriminated_verb`: every `​```json` sample bound to a discriminator verb (bound via the same heading/inline rule `doctor schemas` uses — new public `documented_samples_with_bound_verbs`) must carry a catalog-advertised `output_kind`. This catches a sample that *drops* or *misnames* the discriminator — which `doctor schemas` (keys-only, no required-field check) cannot. Proven locally: reintroducing the `verify`→`verification` typo and a dropped `status` key both fail.
- **Stale docs fixed (the drift the broadened sweep surfaced).** Runtime already emitted the right value everywhere; the docs were stale. Added/fixed `output_kind` for `init`, `status`, `verify` (was `verification`), `capture`, `checkpoint`, `commit`, `diff`, `thread list`, `workspace show`, `schemas`, and `bridge git status/import/sync/reconcile`; removed a spurious `output_kind` from verify's nested verification proof.
- **`init` contradiction (P2 cid 3318853686) — resolved via option (a).** `init` is a real documented JSON verb, so it stays swept: catalog + `InitOutput` runtime + `InitSchema` struct + doc sample all carry `output_kind: "init"`, and the runtime is pinned by `runtime_init_emits_output_kind` (not skipped).
- **Schema structs (P2 cid 3318853676) and review-next envelope (P2 cid 3315306070)** were already correct at r7 and remain guarded — `documented_swept_schema_structs_declare_output_kind` exhaustively checks the pre-injection mirror struct, and `ReviewNextSchema` is the `{output_kind, next: required-but-nullable}` envelope.

### Test evidence

```
output_kind_invariant: 28 passed (incl. doc_samples_carry_catalog_output_kind_for_every_discriminated_verb
  + doc_samples_match_runtime_for_every_catalog_discriminator); proven to fail on injected drift
doctor_schemas / doctor_docs integration gates: green (no doc/schema drift)
cargo build --locked --workspace --tests: ok
cargo clippy --locked --workspace --all-targets -- -D warnings: ok
scripts/check-no-silent-default-tree-load.sh: clean
```

### ⚠️ Pre-existing blocker from main (#282), not from this PR

After merging `origin/main` (#282, the Repository-backend generics + native-async Pg refactor), `scripts/check-default-install-ships-worker.sh` (CI `cargo build --locked -p heddle-cli`) fails to compile `heddle-ingest`: `crates/ingest/src/ref_emit.rs:110` `.await`s `get_marker`, which is **sync** under the `default-features = false` ingest build that `-p heddle-cli` selects, and `crates/ingest/src/importer.rs:531` builds `Importer<dyn RefBackend>` (unsized). This is in #282's async backend split (`refs`/`repo`/`ingest`), is **byte-identical to `origin/main`** on this branch, compiles before `heddle-cli` so it is independent of #272's cli/doc changes, and passes under the broad `--workspace` feature unification (hence the workspace build/clippy/test gates are green). It is outside #272's scope; flagging for a separate fix to #282's sync/async ref-backend gating rather than touching it here.

## Blocked by → resolved

`#255` (round-3 special case for the named verbs).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782494694&installation_id=132405951&pr_number=281&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F281&signature=2c11e5858d23bf62cb9d316148591beb3f4077dd79b37e117b5d892056795f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





