### PR TITLE
heddle#284: gate --features postgres in CI (silent-rot prevention)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -96,6 +96,20 @@ jobs:
       - name: Bench-compare script unit tests
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 
+      # 3c. Compile gate for the `postgres` (server / weft) feature. This is
+      #     the silent-rot guard: `--features postgres` is NOT exercised by
+      #     the default-feature build above, so a server-path regression
+      #     (e.g. a backend that wasn't updated after a newtype migration)
+      #     compiles fine on the OSS build and lands undetected. heddle#259
+      #     hit exactly this — `PgRefBackend` rotted after the
+      #     `ThreadName`/`MarkerName` migration. Build + clippy need no DB;
+      #     the integration tests live in the separate `postgres-tests` job.
+      - name: Build (postgres feature)
+        run: cargo build --locked --workspace --tests --features postgres
+
+      - name: Clippy (postgres feature)
+        run: cargo clippy --locked --workspace --all-targets --features postgres -- -D warnings
+
       # 4. Verify the OSS build flavors compile. `cargo check` is fast on
       #    a warm cache; the feature-delta from defaults is small.
       - name: Check git-overlay-only
@@ -111,6 +125,66 @@ jobs:
       # (heddle#190 r5 / Codex PR #225 P2).
       - name: Default install ships heddle-fuse-worker
         run: bash scripts/check-default-install-ships-worker.sh
+
+      - name: sccache stats
+        run: sccache --show-stats
+
+  # Postgres integration tests. The `postgres` feature is the server /
+  # weft code path (`PgRefBackend`, `PgOpLogBackend`); its `#[ignore]`-gated
+  # tests (`crates/refs/.../pg_refs.rs`, `crates/oplog/.../pg_oplog.rs`) need
+  # a reachable database. A `postgres:16` service container provides one and
+  # `DATABASE_URL` points the test setup at it — without that env var the
+  # tests fall back to an unreachable placeholder (port 1), so a plain
+  # `cargo test` stays hermetic and DB-free. The compile-rot class is
+  # already caught by the build+clippy steps in `check-and-test`; this job
+  # additionally exercises the runtime bridge against a live server.
+  postgres-tests:
+    name: Postgres integration tests
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: heddle_test
+          POSTGRES_PASSWORD: heddle_test
+          POSTGRES_DB: heddle_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: postgres-tests-${{ runner.os }}
+          cache-on-failure: true
+
+      # Scope to the two crates that own the postgres backends: a
+      # workspace-wide `--ignored` run would also pull in unrelated
+      # `#[ignore]`-gated suites (FUSE/NFS smoke, perf, real-git) that need
+      # environments this runner doesn't have. `-p heddle-refs -p
+      # heddle-oplog` compiles only the pg backends, and `--ignored` then
+      # selects exactly their two integration tests (they're `#[ignore]`-gated
+      # so a default `cargo test --features postgres` skips them).
+      # `--test-threads=1` keeps the shared service DB deterministic;
+      # `--nocapture` surfaces the live round-trip in the log so it's clear
+      # the tests actually ran against the container and were not no-op'd by
+      # the unreachable-placeholder fallback.
+      - name: Postgres integration tests
+        env:
+          DATABASE_URL: postgres://heddle_test:heddle_test@localhost:5432/heddle_test
+        run: |
+          cargo test --locked -p heddle-refs -p heddle-oplog --features postgres \
+            -- --ignored --test-threads=1 --nocapture
 
       - name: sccache stats
         run: sccache --show-stats

--- a/crates/oplog/src/oplog/pg_oplog.rs
+++ b/crates/oplog/src/oplog/pg_oplog.rs
@@ -372,24 +372,36 @@ mod current_thread_runtime_tests {
 
     use super::*;
 
+    /// Connection URL for the integration test: the CI `postgres-tests`
+    /// job sets `DATABASE_URL` to the service container; everywhere else it
+    /// is unset and we fall back to a deliberately-unreachable endpoint
+    /// (port 1) so the call still round-trips through the runtime bridge
+    /// without depending on a real database.
+    fn test_database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://heddle-test@127.0.0.1:1/heddle_test".to_string())
+    }
+
     /// Issue #62: `PgOpLogBackend`'s sync methods must not panic when the
     /// caller is on a `current_thread` Tokio runtime. The pre-fix
     /// `tokio::task::block_in_place(...)` path is only valid on a
     /// `multi_thread` runtime; on `current_thread` it panics with
     /// `"can call blocking only when running on the multi-threaded runtime"`.
     ///
-    /// The pool is built with `connect_lazy` — no real database is required.
-    /// Method calls return an `Err` when the bridged future fails to
-    /// connect, which is fine: this test only asserts that the call returns
-    /// a `Result` instead of panicking.
+    /// `#[ignore]`: the postgres integration suite only runs under the CI
+    /// `postgres-tests` job (`cargo test --features postgres -- --ignored`)
+    /// which provides a real `DATABASE_URL`. Without it the pool points at an
+    /// unreachable endpoint, so the method returns `Err` rather than `Ok` —
+    /// either way the contract under test is the *absence of a panic*.
     #[tokio::test(flavor = "current_thread")]
+    #[ignore = "postgres integration: needs DATABASE_URL (CI postgres-tests job)"]
     async fn pg_oplog_methods_do_not_panic_on_current_thread_runtime() {
-        // Short `acquire_timeout` keeps the test snappy: the future will
-        // resolve to `Err(PoolTimedOut)` instead of waiting for sqlx's
-        // 30 s default against the unreachable endpoint.
+        // Short `acquire_timeout` keeps the test snappy when the endpoint is
+        // unreachable: the future resolves to `Err(PoolTimedOut)` instead of
+        // waiting for sqlx's 30 s default.
         let pool = PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(200))
-            .connect_lazy("postgres://heddle-test@127.0.0.1:1/heddle_test")
+            .connect_lazy(&test_database_url())
             .expect("connect_lazy accepts the URL");
         let backend = PgOpLogBackend::new(Arc::new(pool), Uuid::new_v4());
         // `last()` is the cheapest read; the panic surfaces inside

--- a/crates/refs/src/refs/pg_refs.rs
+++ b/crates/refs/src/refs/pg_refs.rs
@@ -383,24 +383,36 @@ mod current_thread_runtime_tests {
 
     use super::*;
 
+    /// Connection URL for the integration test: the CI `postgres-tests`
+    /// job sets `DATABASE_URL` to the service container; everywhere else it
+    /// is unset and we fall back to a deliberately-unreachable endpoint
+    /// (port 1) so the call still round-trips through the runtime bridge
+    /// without depending on a real database.
+    fn test_database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://heddle-test@127.0.0.1:1/heddle_test".to_string())
+    }
+
     /// Issue #62: `PgRefBackend`'s sync methods must not panic when the
     /// caller is on a `current_thread` Tokio runtime. The pre-fix
     /// `tokio::task::block_in_place(...)` path is only valid on a
     /// `multi_thread` runtime; on `current_thread` it panics with
     /// `"can call blocking only when running on the multi-threaded runtime"`.
     ///
-    /// The pool is built with `connect_lazy` — no real database is required.
-    /// Method calls return an `Err` when the bridged future fails to
-    /// connect, which is fine: this test only asserts that the call returns
-    /// a `Result` instead of panicking.
+    /// `#[ignore]`: the postgres integration suite only runs under the CI
+    /// `postgres-tests` job (`cargo test --features postgres -- --ignored`)
+    /// which provides a real `DATABASE_URL`. Without it the pool points at an
+    /// unreachable endpoint, so the method returns `Err` rather than `Ok` —
+    /// either way the contract under test is the *absence of a panic*.
     #[tokio::test(flavor = "current_thread")]
+    #[ignore = "postgres integration: needs DATABASE_URL (CI postgres-tests job)"]
     async fn pg_refs_methods_do_not_panic_on_current_thread_runtime() {
-        // Short `acquire_timeout` keeps the test snappy: the future will
-        // resolve to `Err(PoolTimedOut)` instead of waiting for sqlx's
-        // 30 s default against the unreachable endpoint.
+        // Short `acquire_timeout` keeps the test snappy when the endpoint is
+        // unreachable: the future resolves to `Err(PoolTimedOut)` instead of
+        // waiting for sqlx's 30 s default.
         let pool = PgPoolOptions::new()
             .acquire_timeout(std::time::Duration::from_millis(200))
-            .connect_lazy("postgres://heddle-test@127.0.0.1:1/heddle_test")
+            .connect_lazy(&test_database_url())
             .expect("connect_lazy accepts the URL");
         let backend = PgRefBackend::new(Arc::new(pool), Uuid::new_v4());
         // `read_head()` is the cheapest read; the panic surfaces inside


### PR DESCRIPTION
## Summary

- **Compile gate** (`check-and-test` job): adds `cargo build --features postgres` + `cargo clippy --features postgres -- -D warnings`. This directly closes the gap that let `PgRefBackend` rot undetected in #259 — `--features postgres` was never built in CI, so a server-path regression compiled fine on the OSS build and landed on `main`.
- **Integration gate** (new `postgres-tests` job): a `postgres:16` service container + `DATABASE_URL` wired to it, running the pg backends' `#[ignore]`-gated tests against a live DB. Scoped to `-p heddle-refs -p heddle-oplog` so a workspace-wide `--ignored` run doesn't pull in unrelated ignored suites (FUSE/NFS smoke, perf, real-git) that this runner can't satisfy.
- **Test wiring**: the pg test setup now reads `DATABASE_URL` from env, falling back to the deliberately-unreachable placeholder (`port :1`) only when unset — so a default `cargo test` stays hermetic and DB-free. The two tests are now `#[ignore]`-gated so only the CI job (`-- --ignored`) runs them.

Closes HeddleCo/heddle#284

## Red commit

N/A — this is a CI/infra task (DoD Type ≠ TDD-Rust). The test-file changes are env-wiring + `#[ignore]` on existing regression tests, not new behavior tests.

## Test evidence

Local bar (the integration tests themselves run on CI against the service container — no Postgres in the sandbox):

\`\`\`
$ cargo build --locked --workspace --tests --features postgres
    Finished `dev` profile [unoptimized + debuginfo] target(s)   # exit 0

$ cargo clippy --locked --workspace --all-targets --features postgres -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s   # exit 0

$ cargo test --locked --workspace            # default features: green + hermetic
    ... test result: ok (all crates)   # exit 0

# The CI postgres job's exact selection — confirms it is NOT a no-op:
$ cargo test --locked -p heddle-refs -p heddle-oplog --features postgres -- --ignored --list
oplog::pg_oplog::current_thread_runtime_tests::pg_oplog_methods_do_not_panic_on_current_thread_runtime: test
refs::pg_refs::current_thread_runtime_tests::pg_refs_methods_do_not_panic_on_current_thread_runtime: test
\`\`\`

## Manual verification

N/A — covered by the CI gates.

### How to verify the integration gate actually runs the pg tests (not no-op'd by port-1)

The old setup hardcoded `connect_lazy("postgres://heddle-test@127.0.0.1:1/...")` — port `:1` is unreachable, so the tests never touched a real DB. Now:

- The `postgres-tests` job sets `DATABASE_URL=postgres://heddle_test:heddle_test@localhost:5432/heddle_test`, so the pool connects to the live `postgres:16` service container and the runtime bridge round-trips against a real server.
- `--nocapture` + `--test-threads=1` mean the job log shows both tests executing (`running 2 tests` … `2 passed`). If `--ignored` selected zero tests, the log would say `0 filtered out; running 0 tests` — that's the no-op signal to watch for.
- The fallback keeps local/default runs hermetic: with `DATABASE_URL` unset, `cargo test --features postgres -- --ignored` still passes against the unreachable placeholder (no-panic contract), and a plain `cargo test` skips them entirely.

### Scope note

heddle has no migration system for the pg schema (no `migrations/` dir, no `sqlx::migrate!`) — that schema lives in the weft server, not this repo. So the integration gate proves: (a) `--features postgres` compiles + is clippy-clean, and (b) the sync→async runtime bridge round-trips against a live Postgres rather than short-circuiting on a dead port. Asserting actual read/write *data* results would require the weft-owned schema and is a reasonable follow-up; I did not fabricate a schema here.

## Blocked by → resolved

N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782587151&installation_id=132405951&pr_number=285&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F285&signature=e96e08de3f75bc79268f6bbcbad0b98c758db888bab23d6957c68d25328de5ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->