### PR TITLE
heddle#257: document clone default-thread resolution & depth semantics

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1247,7 +1247,7 @@ pub struct PullArgs {
 #[command(after_help = "\
 Behavior:
   Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
-  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N materializes the tip plus N generations of ancestry; history older than that is not fetched up front but is hydrated on demand the first time you reach it, so `heddle log` initially stops at the depth boundary. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
+  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N fetches only the tip plus N generations of ancestry, so `heddle log` stops at the depth boundary; history older than that is not present locally — re-clone at a greater --depth (or --depth 0) to obtain it. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
   Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
 
   See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1246,16 +1246,16 @@ pub struct PullArgs {
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Behavior:
-  Default thread: with --thread omitted, the clone checks out the remote's advertised default branch (its Git HEAD). If the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. It never prompts.
-  Depth: --depth 0 (the default) clones full history. --depth N keeps roughly N generations of ancestry — a shallow clone — and marks states beyond that boundary as grafted, so `heddle log` stops at the shallow edge.
+  Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
+  Depth (Heddle remotes only — Git-overlay clones reject --depth): --depth 0 (the default) clones full history. --depth N keeps roughly N generations of ancestry — a shallow clone. States beyond that boundary are not fetched, so `heddle log` stops at the shallow edge.
   Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
 
-  See `heddle help threads` for the thread model.
+  See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.
 
 Examples:
-  heddle clone ./repo ./clone                # full clone; lands on the remote's default thread
-  heddle clone ./repo ./clone --thread main  # check out a named thread after cloning
-  heddle clone ./repo ./clone --depth 1      # shallow clone: keep the tip, graft older ancestry
+  heddle clone https://example.com/repo.git ./clone   # Git repo: lands on the remote's default branch
+  heddle clone ./repo ./clone --thread main           # check out a named thread after cloning
+  heddle clone heddle://host/repo ./clone --depth 1   # shallow Heddle clone: keep the tip, drop older ancestry
 ")]
 pub struct CloneArgs {
     /// Remote repository path.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1248,7 +1248,7 @@ pub struct PullArgs {
 Behavior:
   Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
   Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N fetches only the tip plus N generations of ancestry, so `heddle log` stops at the depth boundary; history older than that is not present locally — re-clone at a greater --depth (or --depth 0) to obtain it. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
-  Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
+  Depth controls history extent only — how many states the clone fetches — and says nothing about object contents. Whether a state's blobs are present locally or fetched lazily is a separate, independent concern that --depth never governs.
 
   See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.
 

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1244,6 +1244,19 @@ pub struct PullArgs {
 
 /// Arguments for the `clone` command.
 #[derive(Clone, Debug, clap::Args)]
+#[command(after_help = "\
+Behavior:
+  Default thread: with --thread omitted, the clone checks out the remote's advertised default branch (its Git HEAD). If the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. It never prompts.
+  Depth: --depth 0 (the default) clones full history. --depth N keeps roughly N generations of ancestry — a shallow clone — and marks states beyond that boundary as grafted, so `heddle log` stops at the shallow edge.
+  Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
+
+  See `heddle help threads` for the thread model.
+
+Examples:
+  heddle clone ./repo ./clone                # full clone; lands on the remote's default thread
+  heddle clone ./repo ./clone --thread main  # check out a named thread after cloning
+  heddle clone ./repo ./clone --depth 1      # shallow clone: keep the tip, graft older ancestry
+")]
 pub struct CloneArgs {
     /// Remote repository path.
     pub remote: String,

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1247,7 +1247,7 @@ pub struct PullArgs {
 #[command(after_help = "\
 Behavior:
   Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
-  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth 1 materializes the tip plus its immediate parents, then marks the next generation shallow; more generally --depth N keeps the tip plus N generations of ancestry materialized. The first generation past that boundary is grafted (marked shallow) and not fetched, so `heddle log` stops at the shallow edge. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
+  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N materializes the tip plus N generations of ancestry; history older than that is not fetched up front but is hydrated on demand the first time you reach it, so `heddle log` initially stops at the depth boundary. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
   Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
 
   See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1247,7 +1247,7 @@ pub struct PullArgs {
 #[command(after_help = "\
 Behavior:
   Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
-  Depth (Heddle remotes only — Git-overlay clones reject --depth): --depth 0 (the default) clones full history. --depth N keeps roughly N generations of ancestry — a shallow clone. States beyond that boundary are not fetched, so `heddle log` stops at the shallow edge.
+  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth 1 materializes the tip plus its immediate parents, then marks the next generation shallow; more generally --depth N keeps the tip plus N generations of ancestry materialized. The first generation past that boundary is grafted (marked shallow) and not fetched, so `heddle log` stops at the shallow edge. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
   Depth bounds history, not file content: every state the clone keeps is fully materialized. A shallow clone is smaller because it holds fewer states, not because their blobs are absent.
 
   See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.
@@ -1255,7 +1255,7 @@ Behavior:
 Examples:
   heddle clone https://example.com/repo.git ./clone   # Git repo: lands on the remote's default branch
   heddle clone ./repo ./clone --thread main           # check out a named thread after cloning
-  heddle clone heddle://host/repo ./clone --depth 1   # shallow Heddle clone: keep the tip, drop older ancestry
+  heddle clone heddle://host/repo ./clone --depth 1   # shallow Heddle clone: keep the tip plus its immediate parents
 ")]
 pub struct CloneArgs {
     /// Remote repository path.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1246,7 +1246,7 @@ pub struct PullArgs {
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Behavior:
-  Default thread (no --thread): cloning a Git repository lands on the remote's advertised default branch (its Git HEAD); if the remote advertises none, it falls back to a thread named `main`, then to the alphabetically first imported thread. Cloning a Heddle remote (local path or hosted) lands on `main`. It never prompts.
+  Default thread (no --thread): Git-overlay clones (cloning a Git repository) land on the remote's advertised default branch (its Git HEAD); if the remote advertises none, they fall back to a thread named `main`, then to the alphabetically first imported thread. Native-local and hosted Heddle clones instead target `main` directly with no fallback chain; if the remote has no `main` thread, the clone fails — pass `--thread <name>` to select one. It never prompts.
   Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N fetches only the tip plus N generations of ancestry, so `heddle log` stops at the depth boundary; history older than that is not present locally — re-clone at a greater --depth (or --depth 0) to obtain it. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
   Depth controls history extent only — how many states the clone fetches — and says nothing about object contents. Whether a state's blobs are present locally or fetched lazily is a separate, independent concern that --depth never governs.
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -23,6 +23,8 @@ mod attempt;
 mod basics;
 #[path = "cli_integration/bridge.rs"]
 mod bridge;
+#[path = "cli_integration/cli_help_consistency.rs"]
+mod cli_help_consistency;
 #[path = "cli_integration/cli_premium_output.rs"]
 mod cli_premium_output;
 #[path = "cli_integration/context_recovery_advice.rs"]

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -16,16 +16,22 @@ fn clone_help_pins_behavior_stanza() {
         help.contains("Behavior:"),
         "clone help should include a Behavior stanza: {help}"
     );
-    // Default-thread resolution: omitting --thread lands on the remote's
-    // advertised default branch.
+    // Default-thread resolution for Git-overlay clones: lands on the
+    // remote's advertised default branch (its Git HEAD).
     assert!(
-        help.contains("--thread omitted") && help.contains("default branch"),
+        help.contains("no --thread") && help.contains("default branch"),
         "clone help should explain where an unhinted clone lands: {help}"
     );
-    // The documented fallback chain (main, then first imported thread).
+    // The Git-overlay fallback chain (main, then first imported thread).
     assert!(
         help.contains("`main`") && help.contains("alphabetically first"),
         "clone help should name the default-thread fallback chain: {help}"
+    );
+    // The transport distinction: native Heddle remotes default to `main`,
+    // not the Git-HEAD chain — the inaccuracy this stanza must not regress.
+    assert!(
+        help.contains("Heddle remote") && help.contains("lands on `main`"),
+        "clone help should distinguish the Heddle-remote default from the Git-overlay chain: {help}"
     );
     // Depth semantics: 0 means full history, N is shallow.
     assert!(
@@ -33,8 +39,13 @@ fn clone_help_pins_behavior_stanza() {
         "clone help should explain that --depth 0 is full history: {help}"
     );
     assert!(
-        help.contains("shallow") && help.contains("grafted"),
-        "clone help should explain shallow/grafted depth semantics: {help}"
+        help.contains("shallow") && help.contains("shallow edge"),
+        "clone help should explain shallow depth semantics: {help}"
+    );
+    // Depth is a Heddle-remote-only flag; Git-overlay clones reject it.
+    assert!(
+        help.contains("Git-overlay clones reject --depth"),
+        "clone help should note that Git-overlay clones reject --depth: {help}"
     );
     // Cross-reference to the thread model topic.
     assert!(

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -39,8 +39,8 @@ fn clone_help_pins_behavior_stanza() {
         "clone help should explain that --depth 0 is full history: {help}"
     );
     assert!(
-        help.contains("hydrated on demand") && help.contains("depth boundary"),
-        "clone help should explain that history past the depth boundary is hydrated on demand: {help}"
+        help.contains("depth boundary") && help.contains("re-clone at a greater --depth"),
+        "clone help should explain that history past the depth boundary is absent and recovered by re-cloning at a greater depth: {help}"
     );
     // Depth on Git-overlay clones: nonzero is rejected, --depth 0 is accepted
     // (= the full-clone default, since cmd_clone normalizes 0 to None before

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Snapshot-style pins on curated `--help` prose so that edits to the
+//! clap doc comments don't silently regress the behavior stanzas users
+//! rely on.
+
+use super::*;
+
+/// `heddle clone --help` must keep its Behavior stanza: the prose that
+/// answers Priya's "wait, where am I?" — default-thread resolution and
+/// what `--depth` actually materializes (heddle#257).
+#[test]
+fn clone_help_pins_behavior_stanza() {
+    let help = heddle(&["clone", "--help"], None).expect("clone help should render");
+
+    assert!(
+        help.contains("Behavior:"),
+        "clone help should include a Behavior stanza: {help}"
+    );
+    // Default-thread resolution: omitting --thread lands on the remote's
+    // advertised default branch.
+    assert!(
+        help.contains("--thread omitted") && help.contains("default branch"),
+        "clone help should explain where an unhinted clone lands: {help}"
+    );
+    // The documented fallback chain (main, then first imported thread).
+    assert!(
+        help.contains("`main`") && help.contains("alphabetically first"),
+        "clone help should name the default-thread fallback chain: {help}"
+    );
+    // Depth semantics: 0 means full history, N is shallow.
+    assert!(
+        help.contains("--depth 0") && help.contains("full history"),
+        "clone help should explain that --depth 0 is full history: {help}"
+    );
+    assert!(
+        help.contains("shallow") && help.contains("grafted"),
+        "clone help should explain shallow/grafted depth semantics: {help}"
+    );
+    // Cross-reference to the thread model topic.
+    assert!(
+        help.contains("heddle help threads"),
+        "clone help should point at the threads topic: {help}"
+    );
+}

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -33,14 +33,14 @@ fn clone_help_pins_behavior_stanza() {
         help.contains("Heddle remote") && help.contains("lands on `main`"),
         "clone help should distinguish the Heddle-remote default from the Git-overlay chain: {help}"
     );
-    // Depth semantics: 0 means full history, N is shallow.
+    // Depth semantics: 0 means full history, N keeps the tip plus N ancestry levels.
     assert!(
         help.contains("--depth 0") && help.contains("full history"),
         "clone help should explain that --depth 0 is full history: {help}"
     );
     assert!(
-        help.contains("shallow") && help.contains("shallow edge"),
-        "clone help should explain shallow depth semantics: {help}"
+        help.contains("hydrated on demand") && help.contains("depth boundary"),
+        "clone help should explain that history past the depth boundary is hydrated on demand: {help}"
     );
     // Depth on Git-overlay clones: nonzero is rejected, --depth 0 is accepted
     // (= the full-clone default, since cmd_clone normalizes 0 to None before

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -27,11 +27,19 @@ fn clone_help_pins_behavior_stanza() {
         help.contains("`main`") && help.contains("alphabetically first"),
         "clone help should name the default-thread fallback chain: {help}"
     );
-    // The transport distinction: native Heddle remotes default to `main`,
-    // not the Git-HEAD chain — the inaccuracy this stanza must not regress.
+    // The transport distinction: native-local and hosted Heddle clones target
+    // `main` directly (no Git-HEAD fallback chain) — the inaccuracy this stanza
+    // must not regress.
     assert!(
-        help.contains("Heddle remote") && help.contains("lands on `main`"),
+        help.contains("Native-local and hosted Heddle clones")
+            && help.contains("target `main` directly"),
         "clone help should distinguish the Heddle-remote default from the Git-overlay chain: {help}"
+    );
+    // The failure mode: an unhinted native/hosted clone fails when the remote
+    // has no `main` thread, and the user must pass `--thread <name>`.
+    assert!(
+        help.contains("the clone fails") && help.contains("--thread <name>"),
+        "clone help should document that an unhinted native/hosted clone fails when the remote has no `main` thread: {help}"
     );
     // Depth semantics: 0 means full history, N keeps the tip plus N ancestry levels.
     assert!(

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -42,10 +42,18 @@ fn clone_help_pins_behavior_stanza() {
         help.contains("shallow") && help.contains("shallow edge"),
         "clone help should explain shallow depth semantics: {help}"
     );
-    // Depth is a Heddle-remote-only flag; Git-overlay clones reject it.
+    // Depth on Git-overlay clones: nonzero is rejected, --depth 0 is accepted
+    // (= the full-clone default, since cmd_clone normalizes 0 to None before
+    // the rejection check).
     assert!(
-        help.contains("Git-overlay clones reject --depth"),
-        "clone help should note that Git-overlay clones reject --depth: {help}"
+        help.contains("Git-overlay clones reject a nonzero --depth")
+            && help.contains("--depth 0 is accepted"),
+        "clone help should distinguish nonzero --depth (rejected) from --depth 0 (accepted) for Git-overlay clones: {help}"
+    );
+    // Depth-1 materializes the tip plus its immediate parents, not just the tip.
+    assert!(
+        help.contains("tip plus its immediate parents"),
+        "clone help should explain that --depth 1 keeps the tip plus immediate parents: {help}"
     );
     // Cross-reference to the thread model topic.
     assert!(


### PR DESCRIPTION
## Summary
- Add a "Behavior" stanza to `heddle clone --help` (`CloneArgs` `after_help` in `crates/cli/src/cli/cli_args/commands_args.rs`) that answers Priya's "wait, where am I?": per-transport default-thread resolution and `--depth` semantics.
- Pin the prose with a snapshot test (`cli_help_consistency::clone_help_pins_behavior_stanza`) so future edits can't silently regress the load-bearing accuracy facts.
- Self-audit (AGENTS.md Rule 6a) corrected three ungrounded claims from the first draft — see "Documentation grounding".

Closes HeddleCo/heddle#257

## Red commit
`88b7f1e` (pins the Behavior stanza; failed before the help text existed)

## Documentation grounding
Self-audit caught that the first draft described the default-thread chain and `--depth` as uniform across transports — they are not. Corrected, every claim is grounded:
- **Git-overlay default thread** = Git HEAD → `main` → alphabetically first imported thread — `select_clone_thread` (`crates/cli/src/cli/commands/clone.rs:911`).
- **Native (local/hosted) default thread** = `main` — `clone.rs` `thread.as_deref().unwrap_or("main")` (clone_local + clone_network).
- **`--depth` is Heddle-remote-only**; Git-overlay clones reject it — `reject_unsupported_for_git_overlay` (`clone.rs:275`).
- **`--depth 0` = full history** — `depth.filter(|d| *d > 0)` in `cmd_clone` collapses 0 → full.
- **Shallow edge** — `fetch_state_with_depth` stops fetching parents past the boundary and marks the tip via `set_shallow` (`crates/cli/src/client/local_sync.rs:138`, `crates/repo/src/repository.rs:1854`); `heddle log` stops there because those states aren't local (no graft check).
- **`heddle help threads` / `heddle help advanced`** are real topics — `crates/cli/src/cli/help.rs:288,292`.

## Test evidence
```
test cli_help_consistency::clone_help_pins_behavior_stanza ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 674 filtered out; finished in 0.03s
```
Also clean: `scripts/check-no-silent-default-tree-load.sh` (513 files, no silent-default sites) and `cargo clippy -p heddle-cli --all-targets`. Branch is merged up to current `origin/main`.

## Manual verification
N/A — covered by the snapshot test.

## Round 2 (codex)
- **depth-1 semantics (cid 3320227921, 3320287942):** `--depth 1` now documented as tip + immediate parents (was "keep the tip"); stanza generalizes to N generations of ancestry per `fetch_state_with_depth` (local_sync.rs:138-147).
- **Git-overlay depth refusal (cid 3320287947):** qualified — nonzero `--depth` rejected, `--depth 0` accepted (= full clone) since `cmd_clone` normalizes 0 → None before the rejection check.
- Updated `cli_help_consistency` assertions to pin the corrected text. Green: snapshot/help test, full `heddle-cli` suite, clippy -D warnings, silent-default static check.
- Fixed in a39ed14.

**Round 3 (codex cid 3320425718):** depth help asserted the wrong state was `set_shallow`. Rather than make a third precise mechanical claim, rewrote the stanza to describe user-observable behavior — `--depth N` materializes the tip plus N ancestry levels; older history is hydrated on demand on first access; `--depth 0` = full history. No falsifiable internal-mechanics claim remains. Help-consistency assertion + comment updated; `heddle-cli` tests + clippy green. (c50c846)

## Round 4
Dropped the r3 "hydrated on demand" claim for history past `--depth` — it was false (the lazy hydrator only materializes blobs; `is_shallow` never triggers a history fetch and there is no unshallow/deepen verb). The depth help now asserts only observable, durable behavior: `--depth N` fetches tip + N ancestry generations, `heddle log` stops at the boundary, older history is absent, and the only recovery is re-cloning at a greater `--depth`. No lazy/shallow internals remain in the help.

## Round 5 (codex)
- cid 3321013829 (P2): depth help conflated history extent with blob materialization — the "fully materialized" claim was false under hosted lazy clones (`--lazy`/`--filter blob:none` → `PullMaterialization::Lazy`, clone.rs:1243). Rewrote the depth help to describe **history extent only** and call out materialization as a separate, independent axis that `--depth` never governs. Wording avoids naming the hidden flags so first-run clone-help gates stay green. Fixed in 7c841a4.


## Round 6 (codex)
- cid 3320158592 (P2): the default-thread Behavior promise applied to `heddle clone` in general, but the advertised-default → `main` → alphabetically-first fallback chain is only used by **Git-overlay clones** via `select_clone_thread` (clone.rs:923). Native-local (clone.rs:1005) and hosted (clone.rs:1242) clones use `thread.as_deref().unwrap_or("main")` with no fallback, and **fail** when the remote has no `main` thread (clone.rs:1010 / `network_clone_failed` at clone.rs:1302). Scoped each claim to its clone context: Git-overlay keeps the fallback chain; native-local + hosted documented as targeting `main` directly and requiring `--thread <name>` otherwise. Mirrors r5's two-axis split — the default-thread help is now true regardless of clone context. Pinned-stanza test updated. Fixed in c4d5040.
