### PR TITLE
heddle#252: reconcile swept-command exit codes with docs/exit-codes.md

### DIFF
--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -200,6 +200,9 @@ pub async fn cmd_pull(
     lazy: bool,
 ) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
+        return Err(anyhow::anyhow!(RecoveryAdvice::remote_not_configured("pull")));
+    }
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         ensure_worktree_clean(&repo, "pull")?;
         let remote_name = resolve_default_remote_name(&repo, remote.as_deref())?;

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -164,6 +164,63 @@ mod tests {
     }
 
     #[test]
+    fn no_default_remote_string_sentinel_is_config() {
+        // `heddle pull` against a repo with no default remote surfaces the
+        // raw `RemoteError::NotFound` display via `anyhow::Error::msg`, so it
+        // is only matchable as a string. The persona-flagged divergence
+        // (HeddleCo/heddle#252) was this returning the `IoErr` catch-all.
+        let err = anyhow::anyhow!("remote not found: (no default remote configured)");
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn remote_not_configured_advice_is_config() {
+        // `heddle push`/`heddle pull` with no default remote raise the typed
+        // `remote_not_configured` advice — a missing-precondition (Config),
+        // not the `IoErr` catch-all.
+        let err = anyhow::anyhow!(crate::cli::commands::RecoveryAdvice::remote_not_configured(
+            "push"
+        ));
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn nothing_to_commit_advice_is_data_err() {
+        // `heddle commit` with nothing staged is semantic rejection of
+        // well-formed input (DataErr), not an IO failure.
+        let advice = crate::cli::commands::RecoveryAdvice::safety_refusal(
+            "nothing_to_commit",
+            "nothing to commit",
+            "hint",
+            "unsafe",
+            "would change",
+            "preserved",
+            "heddle status",
+            vec!["heddle status".to_string()],
+        );
+        let err = anyhow::anyhow!(advice);
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
+    fn reconcile_direction_required_advice_is_data_err() {
+        // `heddle bridge git reconcile` without a `--prefer` side requires
+        // manual resolution — the reconcile contract's documented DataErr.
+        let advice = crate::cli::commands::RecoveryAdvice::safety_refusal(
+            "reconcile_direction_required",
+            "Refusing to reconcile 'main': choose a local side before applying",
+            "hint",
+            "unsafe",
+            "would change",
+            "preserved",
+            "heddle status",
+            vec!["heddle status".to_string()],
+        );
+        let err = anyhow::anyhow!(advice);
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
     fn missing_repo_string_sentinel_is_config() {
         let err = anyhow::anyhow!("repository not found at /tmp/whatever");
         assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -56,6 +56,22 @@ impl HeddleExitCode {
     /// get a code more informative than the bare `1` shell convention.
     pub fn from_error(err: &anyhow::Error) -> Self {
         for cause in err.chain() {
+            // Typed refusals carry a stable `kind` discriminator — route the
+            // ones whose documented code differs from the `IoErr` catch-all.
+            // Keyed on `kind` (not the user-visible message) so rewording the
+            // error text can't silently regress the contract.
+            if let Some(advice) = cause.downcast_ref::<crate::cli::commands::RecoveryAdvice>() {
+                match advice.kind {
+                    // No default remote configured (push/pull): a missing
+                    // precondition, not an IO failure.
+                    "remote_not_configured" => return Self::Config,
+                    // Nothing staged / no changes to capture, and a reconcile
+                    // that needs a `--prefer` side: well-formed input the
+                    // command semantically rejects.
+                    "nothing_to_commit" | "reconcile_direction_required" => return Self::DataErr,
+                    _ => {}
+                }
+            }
             if let Some(io) = cause.downcast_ref::<std::io::Error>() {
                 return match io.kind() {
                     IoErrorKind::PermissionDenied => Self::NoPerm,
@@ -94,6 +110,7 @@ impl HeddleExitCode {
         let msg = format!("{err:#}");
         if msg.contains("no upstream configured")
             || msg.contains("no remote configured")
+            || msg.contains("no default remote configured")
             || msg.contains("workspace config invalid")
             || msg.contains("repository not found")
         {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -31,6 +31,8 @@ mod context_recovery_advice;
 mod current_context_advice;
 #[path = "cli_integration/doctor_docs.rs"]
 mod doctor_docs;
+#[path = "cli_integration/error_envelope_lint.rs"]
+mod error_envelope_lint;
 #[path = "cli_integration/exit_codes.rs"]
 mod exit_codes;
 #[path = "cli_integration/fault_injection.rs"]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -31,6 +31,8 @@ mod context_recovery_advice;
 mod current_context_advice;
 #[path = "cli_integration/doctor_docs.rs"]
 mod doctor_docs;
+#[path = "cli_integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "cli_integration/fault_injection.rs"]
 mod fault_injection;
 #[path = "cli_integration/git_overlay_interop_matrix.rs"]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -307,6 +307,40 @@ fn status_json(path: &std::path::Path) -> Value {
     serde_json::from_str(&output).expect("status output should be JSON")
 }
 
+/// Run `git <args>` in `dir` under a fully isolated environment, asserting
+/// success. Hermetic by construction: global/system config, `$HOME`,
+/// init templates, and hooks are all neutralised so a developer's or CI's
+/// ambient Git setup can never leak into a temp-repo fixture and flake the
+/// tests. Identity is pinned via `-c` so commits don't depend on a global
+/// `user.name`/`user.email`. Shared by the exit-code and error-envelope
+/// fixtures (HeddleCo/heddle#252) so the isolation lives in one place.
+pub(crate) fn git_hermetic(args: &[&str], dir: &std::path::Path) {
+    let status = Command::new("git")
+        .args([
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("HOME", dir)
+        .env("GIT_TEMPLATE_DIR", "")
+        .env_remove("GIT_DIR")
+        .status()
+        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
 fn git_test_signature() -> gix::actor::Signature {
     gix::actor::Signature {
         name: "Heddle Test".into(),

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -308,14 +308,34 @@ fn status_json(path: &std::path::Path) -> Value {
 }
 
 /// Run `git <args>` in `dir` under a fully isolated environment, asserting
-/// success. Hermetic by construction: global/system config, `$HOME`,
-/// init templates, and hooks are all neutralised so a developer's or CI's
-/// ambient Git setup can never leak into a temp-repo fixture and flake the
-/// tests. Identity is pinned via `-c` so commits don't depend on a global
+/// success. Hermetic *by construction*: the child's environment is wiped with
+/// [`Command::env_clear`] and rebuilt from a minimal explicit allowlist, so no
+/// inherited variable — `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`,
+/// `GIT_OBJECT_DIRECTORY`, or any other `GIT_*` / ambient var — can leak in and
+/// flake the tests. A blocklist would only ever chase the next leaking var;
+/// clearing the slate and opting variables back in closes the whole class.
+/// Identity is pinned via `-c` so commits don't depend on a global
 /// `user.name`/`user.email`. Shared by the exit-code and error-envelope
 /// fixtures (HeddleCo/heddle#252) so the isolation lives in one place.
 pub(crate) fn git_hermetic(args: &[&str], dir: &std::path::Path) {
-    let status = Command::new("git")
+    let mut command = Command::new("git");
+    command.env_clear();
+    // Minimal allowlist — everything the child legitimately needs, nothing else.
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+    command
+        .env("HOME", dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("LANG", "C")
+        .env("LC_ALL", "C")
+        .env("TERM", "dumb")
         .args([
             "-c",
             "core.hooksPath=/dev/null",
@@ -329,13 +349,8 @@ pub(crate) fn git_hermetic(args: &[&str], dir: &std::path::Path) {
             "init.defaultBranch=main",
         ])
         .args(args)
-        .current_dir(dir)
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_CONFIG_SYSTEM", "/dev/null")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("HOME", dir)
-        .env("GIT_TEMPLATE_DIR", "")
-        .env_remove("GIT_DIR")
+        .current_dir(dir);
+    let status = command
         .status()
         .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
     assert!(status.success(), "git {args:?} failed in {}", dir.display());

--- a/crates/cli/tests/cli_integration/error_envelope_lint.rs
+++ b/crates/cli/tests/cli_integration/error_envelope_lint.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `Next:`-envelope invariant for command error paths.
+//!
+//! Every CLI failure must hand the caller an actionable next step: the
+//! agent-native contract (HeddleCo/heddle#252) is that a non-zero exit is
+//! never a dead end. Concretely, for a representative error case of each
+//! swept command this enforces, on the stderr envelope:
+//!
+//! 1. **Text mode** — a non-empty `Next: <command>` line.
+//! 2. **JSON mode** — a non-empty `primary_command` (the machine form of
+//!    `Next:`) AND a non-null *typed* action: either a concrete
+//!    `primary_command_argv` array the agent can exec directly, or a
+//!    `primary_command_template` object for actions with placeholders
+//!    (e.g. `heddle remote add <name> <url>`, whose argv is necessarily
+//!    null because the inputs aren't known yet).
+//!
+//! This is the error-path sibling of the `output_kind` invariant
+//! (cli_integration/output_kind_invariant.rs): like that test it drives a
+//! curated set of representative invocations rather than every verb, since
+//! most error conditions need a hand-built fixture. The swept set is the
+//! `init`/`status`/`verify`/`commit`/`merge`/`push`/`pull` + `bridge git`
+//! subset whose codes `docs/exit-codes.md` documents; `SWEPT_COVERAGE`
+//! guards that each is exercised here.
+
+use std::{path::Path, process::Command};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle_output;
+
+/// Swept commands whose error envelopes this lint exercises. Mirrors the
+/// `docs/exit-codes.md` Coverage list. A divergence between this and the
+/// `CASES` table fails `swept_commands_have_envelope_coverage`.
+const SWEPT_COVERAGE: &[&str] = &[
+    "init",
+    "status",
+    "verify",
+    "commit",
+    "merge",
+    "push",
+    "pull",
+    "bridge git import",
+    "bridge git sync",
+    "bridge git reconcile",
+];
+
+/// One representative error case: the swept command it covers, the argv
+/// (after the leading `--output` toggle) and a fixture builder.
+struct ErrorCase {
+    /// Swept command(s) this case exercises, for `SWEPT_COVERAGE`.
+    covers: &'static [&'static str],
+    label: &'static str,
+    argv: &'static [&'static str],
+    fixture: fn() -> TempDir,
+}
+
+fn git(args: &[&str], dir: &Path) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+/// A directory that is not a Heddle repo — commands that need one fail
+/// with the `repository_not_found` envelope.
+fn bare_dir() -> TempDir {
+    TempDir::new().expect("tempdir")
+}
+
+fn init_repo() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    heddle_output(
+        &[
+            "init",
+            "--principal-name",
+            "Heddle Test",
+            "--principal-email",
+            "heddle@test.example",
+        ],
+        Some(temp.path()),
+    )
+    .expect("heddle init");
+    temp
+}
+
+fn committed_repo() -> TempDir {
+    let temp = init_repo();
+    std::fs::write(temp.path().join("f.txt"), "base\n").expect("write f.txt");
+    heddle_output(&["commit", "-m", "base"], Some(temp.path())).expect("heddle commit");
+    temp
+}
+
+fn adopted_git_overlay() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    git(&["init", "-q", "-b", "main", "."], dir);
+    git(&["config", "user.email", "heddle@test.example"], dir);
+    git(&["config", "user.name", "Heddle Test"], dir);
+    std::fs::write(dir.join("a.txt"), "hello\n").expect("write a.txt");
+    git(&["add", "a.txt"], dir);
+    git(&["commit", "-qm", "init"], dir);
+    heddle_output(&["adopt"], Some(dir)).expect("heddle adopt");
+    heddle_output(&["bridge", "git", "import", "--ref", "main"], Some(dir))
+        .expect("heddle bridge git import");
+    temp
+}
+
+/// `init` / `status` / `verify` / `merge` / `bridge git import|sync` exit
+/// `0` on their documented happy paths, so this lint covers them through
+/// adjacent error conditions: an unparseable invocation (`init`), a
+/// missing-state lookup (`status`/`verify`/`merge` share the
+/// `state_not_found` / refusal envelopes), etc. The goal is envelope
+/// shape, not per-verb exhaustiveness.
+fn cases() -> Vec<ErrorCase> {
+    vec![
+        ErrorCase {
+            covers: &["init"],
+            label: "init into an existing repo",
+            argv: &[
+                "init",
+                "--principal-name",
+                "Heddle Test",
+                "--principal-email",
+                "heddle@test.example",
+            ],
+            fixture: init_repo,
+        },
+        ErrorCase {
+            covers: &["status", "verify"],
+            label: "verify outside a repository",
+            argv: &["verify"],
+            fixture: bare_dir,
+        },
+        ErrorCase {
+            covers: &["commit"],
+            label: "commit with nothing staged",
+            argv: &["commit", "-m", "again"],
+            fixture: committed_repo,
+        },
+        ErrorCase {
+            covers: &["merge"],
+            label: "merge a nonexistent thread",
+            argv: &["merge", "does-not-exist"],
+            fixture: committed_repo,
+        },
+        ErrorCase {
+            covers: &["push"],
+            label: "push with no remote configured",
+            argv: &["push"],
+            fixture: init_repo,
+        },
+        ErrorCase {
+            covers: &["pull"],
+            label: "pull with no remote configured",
+            argv: &["pull"],
+            fixture: init_repo,
+        },
+        ErrorCase {
+            covers: &["bridge git import"],
+            label: "bridge git import of a missing ref",
+            argv: &["bridge", "git", "import", "--ref", "no-such-branch"],
+            fixture: adopted_git_overlay,
+        },
+        ErrorCase {
+            covers: &["bridge git sync", "bridge git reconcile"],
+            label: "bridge git reconcile without a --prefer side",
+            argv: &["bridge", "git", "reconcile", "--ref", "main"],
+            fixture: adopted_git_overlay,
+        },
+    ]
+}
+
+/// The first non-empty line of `stderr` parsed as the JSON envelope.
+fn parse_json_envelope(stderr: &str, label: &str) -> Value {
+    let line = stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_else(|| panic!("[{label}] empty stderr; expected a JSON envelope"));
+    serde_json::from_str(line)
+        .unwrap_or_else(|err| panic!("[{label}] stderr is not a JSON envelope: {err}\n  line: {line}"))
+}
+
+#[test]
+fn error_envelopes_carry_actionable_next_step() {
+    let mut failures = Vec::new();
+
+    for case in cases() {
+        let fixture = (case.fixture)();
+        let dir = fixture.path();
+
+        // --- JSON mode -------------------------------------------------
+        let mut json_argv = vec!["--output", "json"];
+        json_argv.extend_from_slice(case.argv);
+        let json_out = heddle_output(&json_argv, Some(dir))
+            .unwrap_or_else(|err| panic!("[{}] spawn {json_argv:?}: {err}", case.label));
+        if json_out.status.success() {
+            failures.push(format!(
+                "[{}] expected a non-zero exit to exercise the error envelope, got success",
+                case.label
+            ));
+            continue;
+        }
+        let stderr = String::from_utf8_lossy(&json_out.stderr);
+        let envelope = parse_json_envelope(&stderr, case.label);
+
+        let primary_command = envelope.get("primary_command").and_then(Value::as_str);
+        if primary_command.is_none_or(|cmd| cmd.trim().is_empty()) {
+            failures.push(format!(
+                "[{}] JSON envelope has empty/missing `primary_command` (the `Next:` step): {envelope}",
+                case.label
+            ));
+        }
+
+        // A typed action is either a concrete argv array or, for actions
+        // with placeholders, a template object. Exactly one is non-null.
+        let argv_ok = envelope
+            .get("primary_command_argv")
+            .and_then(Value::as_array)
+            .is_some_and(|parts| !parts.is_empty());
+        let template_ok = envelope
+            .get("primary_command_template")
+            .is_some_and(Value::is_object);
+        if !argv_ok && !template_ok {
+            failures.push(format!(
+                "[{}] JSON envelope exposes no typed recommended action: \
+                 `primary_command_argv` must be a non-empty array OR \
+                 `primary_command_template` a non-null object: {envelope}",
+                case.label
+            ));
+        }
+
+        // --- Text mode -------------------------------------------------
+        let text_out = heddle_output(case.argv, Some(dir))
+            .unwrap_or_else(|err| panic!("[{}] spawn {:?}: {err}", case.label, case.argv));
+        let text_stderr = String::from_utf8_lossy(&text_out.stderr);
+        let next_line = text_stderr
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("Next:"))
+            .map(str::trim);
+        if next_line.is_none_or(|next| next.is_empty()) {
+            failures.push(format!(
+                "[{}] text-mode stderr is missing a non-empty `Next:` line:\n{text_stderr}",
+                case.label
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Error envelopes must surface an actionable next step (HeddleCo/heddle#252):\n  - {}",
+        failures.join("\n  - ")
+    );
+}
+
+#[test]
+fn swept_commands_have_envelope_coverage() {
+    let covered: std::collections::BTreeSet<&str> =
+        cases().iter().flat_map(|case| case.covers.iter().copied()).collect();
+    let missing: Vec<&str> = SWEPT_COVERAGE
+        .iter()
+        .copied()
+        .filter(|cmd| !covered.contains(cmd))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "Every swept command must have a representative error case in `CASES`; missing: {missing:?}"
+    );
+}

--- a/crates/cli/tests/cli_integration/error_envelope_lint.rs
+++ b/crates/cli/tests/cli_integration/error_envelope_lint.rs
@@ -22,12 +22,12 @@
 //! subset whose codes `docs/exit-codes.md` documents; `SWEPT_COVERAGE`
 //! guards that each is exercised here.
 
-use std::{path::Path, process::Command};
+use std::path::Path;
 
 use serde_json::Value;
 use tempfile::TempDir;
 
-use super::heddle_output;
+use super::{git_hermetic, heddle_output};
 
 /// Swept commands whose error envelopes this lint exercises. Mirrors the
 /// `docs/exit-codes.md` Coverage list. A divergence between this and the
@@ -56,12 +56,7 @@ struct ErrorCase {
 }
 
 fn git(args: &[&str], dir: &Path) {
-    let status = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .status()
-        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
-    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    git_hermetic(args, dir);
 }
 
 /// A directory that is not a Heddle repo — commands that need one fail
@@ -165,7 +160,18 @@ fn cases() -> Vec<ErrorCase> {
             fixture: adopted_git_overlay,
         },
         ErrorCase {
-            covers: &["bridge git sync", "bridge git reconcile"],
+            // `sync` has its own handler (bridge.rs `GitCommands::Sync`)
+            // that builds the error envelope independently of reconcile —
+            // exercise it directly so a regression that drops Sync's `Next:`
+            // fields fails the lint. A `--path` at a nonexistent source
+            // reaches the handler (export runs, then the import half fails).
+            covers: &["bridge git sync"],
+            label: "bridge git sync against a missing source",
+            argv: &["bridge", "git", "sync", "--path", "/heddle/no/such/source"],
+            fixture: adopted_git_overlay,
+        },
+        ErrorCase {
+            covers: &["bridge git reconcile"],
             label: "bridge git reconcile without a --prefer side",
             argv: &["bridge", "git", "reconcile", "--ref", "main"],
             fixture: adopted_git_overlay,

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Documented exit-code contract for the swept command subset.
+//!
+//! `docs/exit-codes.md` promises a sysexits-style taxonomy for the swept
+//! commands (`init`, `status`, `verify`, `commit`, `merge`, `push`,
+//! `pull`, and the three `bridge git` verbs). Agents branch on these
+//! codes without parsing stderr, so a divergence between the documented
+//! code and the runtime exit silently mis-handles a failure path.
+//!
+//! Persona round 3/5 (HeddleCo/heddle#252) caught two such divergences
+//! (`push`/`commit` returning the `IoErr` catch-all instead of the
+//! documented `Config`/`DataErr`) plus the `pull` and
+//! `bridge git reconcile` siblings. These tests pin the documented code
+//! for a reproducible documented condition of each swept command so the
+//! contract can't regress.
+
+use std::{path::Path, process::Command};
+
+use tempfile::TempDir;
+
+use super::heddle_output;
+
+/// Assert `heddle <args>` exits with `expected`, surfacing stderr on
+/// mismatch so a regression names the divergent code directly.
+fn assert_exit(args: &[&str], dir: &Path, expected: i32) {
+    let output =
+        heddle_output(args, Some(dir)).unwrap_or_else(|err| panic!("spawn {args:?}: {err}"));
+    let actual = output.status.code();
+    assert_eq!(
+        actual,
+        Some(expected),
+        "{args:?} should exit {expected} (documented in docs/exit-codes.md), got {actual:?}\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// A fresh, initialised native Heddle repo.
+fn init_repo() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    assert_exit(
+        &[
+            "init",
+            "--principal-name",
+            "Heddle Test",
+            "--principal-email",
+            "heddle@test.example",
+        ],
+        temp.path(),
+        0,
+    );
+    temp
+}
+
+/// Run `git <args>` in `dir`, asserting success.
+fn git(args: &[&str], dir: &Path) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+/// A git repo with one commit on `main`, adopted into a Heddle git overlay.
+fn adopted_git_overlay() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    git(&["init", "-q", "-b", "main", "."], dir);
+    git(&["config", "user.email", "heddle@test.example"], dir);
+    git(&["config", "user.name", "Heddle Test"], dir);
+    std::fs::write(dir.join("a.txt"), "hello\n").expect("write a.txt");
+    git(&["add", "a.txt"], dir);
+    git(&["commit", "-qm", "init"], dir);
+    assert_exit(&["adopt"], dir, 0);
+    temp
+}
+
+#[test]
+fn init_exits_zero_on_success() {
+    let temp = TempDir::new().expect("tempdir");
+    assert_exit(
+        &[
+            "init",
+            "--principal-name",
+            "Heddle Test",
+            "--principal-email",
+            "heddle@test.example",
+        ],
+        temp.path(),
+        0,
+    );
+}
+
+#[test]
+fn status_exits_zero_in_initialized_repo() {
+    let repo = init_repo();
+    assert_exit(&["status"], repo.path(), 0);
+}
+
+#[test]
+fn verify_exits_zero_when_clean() {
+    let repo = init_repo();
+    std::fs::write(repo.path().join("f.txt"), "base\n").expect("write f.txt");
+    assert_exit(&["commit", "-m", "base"], repo.path(), 0);
+    assert_exit(&["verify"], repo.path(), 0);
+}
+
+#[test]
+fn commit_with_nothing_staged_is_data_err() {
+    // Documented: `65 DataErr` — well-formed input, semantically rejected.
+    // Was the `74 IoErr` catch-all before HeddleCo/heddle#252.
+    let repo = init_repo();
+    std::fs::write(repo.path().join("f.txt"), "base\n").expect("write f.txt");
+    assert_exit(&["commit", "-m", "base"], repo.path(), 0);
+    // Second commit with a clean worktree: nothing to commit.
+    assert_exit(&["commit", "-m", "again"], repo.path(), 65);
+}
+
+#[test]
+fn push_without_remote_is_config() {
+    // Documented: `78 Config` — no remote configured. Was `74 IoErr`.
+    let repo = init_repo();
+    assert_exit(&["push"], repo.path(), 78);
+}
+
+#[test]
+fn pull_without_remote_is_config() {
+    // Documented: `78 Config` — no remote configured. Was `74 IoErr`.
+    let repo = init_repo();
+    assert_exit(&["pull"], repo.path(), 78);
+}
+
+#[test]
+fn merge_preview_exits_zero() {
+    // Documented: `0 ok`. A fast-forwardable thread previews cleanly.
+    let repo = init_repo();
+    std::fs::write(repo.path().join("f.txt"), "base\n").expect("write base");
+    assert_exit(&["commit", "-m", "base"], repo.path(), 0);
+    assert_exit(&["fork", "--name", "feature"], repo.path(), 0);
+    assert_exit(&["goto", "feature"], repo.path(), 0);
+    std::fs::write(repo.path().join("f.txt"), "base\nfeat\n").expect("write feat");
+    assert_exit(&["commit", "-m", "feat"], repo.path(), 0);
+    assert_exit(&["goto", "main"], repo.path(), 0);
+    assert_exit(&["merge", "feature", "--preview"], repo.path(), 0);
+}
+
+#[test]
+fn bridge_git_import_exits_zero() {
+    // Documented: `0 ok`.
+    let repo = adopted_git_overlay();
+    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+}
+
+#[test]
+fn bridge_git_sync_exits_zero() {
+    // Documented: `0 ok`.
+    let repo = adopted_git_overlay();
+    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+    assert_exit(&["bridge", "git", "sync"], repo.path(), 0);
+}
+
+#[test]
+fn bridge_git_reconcile_without_side_is_data_err() {
+    // Documented: `65 DataErr` — manual resolution required. The
+    // `reconcile_direction_required` refusal (no `--prefer` side) was the
+    // `74 IoErr` catch-all before HeddleCo/heddle#252.
+    let repo = adopted_git_overlay();
+    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "reconcile", "--ref", "main"],
+        repo.path(),
+        65,
+    );
+}
+
+#[test]
+fn unconfigured_remote_keeps_no_default_remote_phrasing() {
+    // Regression guard for the string sentinel `from_error` relies on for
+    // the raw `resolve_remote` path (HeddleCo/heddle#252). If the
+    // `RemoteError::NotFound` phrasing changes, the sentinel must follow.
+    let repo = init_repo();
+    let output = heddle_output(&["--output", "json", "pull"], Some(repo.path()))
+        .expect("spawn pull --output json");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let envelope: serde_json::Value = serde_json::from_str(stderr.trim().lines().next().unwrap())
+        .unwrap_or_else(|err| panic!("pull envelope not JSON: {err}\n  stderr: {stderr}"));
+    assert_eq!(
+        output.status.code(),
+        Some(78),
+        "pull without a remote should exit 78; envelope: {envelope}"
+    );
+}

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -14,11 +14,11 @@
 //! for a reproducible documented condition of each swept command so the
 //! contract can't regress.
 
-use std::{path::Path, process::Command};
+use std::path::Path;
 
 use tempfile::TempDir;
 
-use super::heddle_output;
+use super::{git_hermetic, heddle_output};
 
 /// Assert `heddle <args>` exits with `expected`, surfacing stderr on
 /// mismatch so a regression names the divergent code directly.
@@ -53,14 +53,9 @@ fn init_repo() -> TempDir {
     temp
 }
 
-/// Run `git <args>` in `dir`, asserting success.
+/// Run `git <args>` in `dir` under an isolated environment, asserting success.
 fn git(args: &[&str], dir: &Path) {
-    let status = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .status()
-        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
-    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    git_hermetic(args, dir);
 }
 
 /// A git repo with one commit on `main`, adopted into a Heddle git overlay.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -35,11 +35,13 @@ intentionally — let it surface naturally.
 - **`76` (Protocol) means the inputs are the problem, not the network.**
   Don't loop. Surface to the human or change strategy.
 - **`78` (Config) is the right code when a precondition is missing**
-  (no upstream, no remote configured, ambiguous identity). Agents should
-  print the missing setting rather than retry.
+  (no upstream, no remote configured, no default remote for `push`/`pull`,
+  ambiguous identity). Agents should print the missing setting rather than
+  retry.
 - **`65` (DataErr) covers semantic rejection of well-formed input**
-  (e.g. `commit` against a dirty worktree, `merge` with unresolvable
-  conflict). Agents must surface the condition; no retry will help.
+  (e.g. `commit` with nothing to capture, `merge` with unresolvable
+  conflict, `bridge git reconcile` that needs a `--prefer` side chosen).
+  Agents must surface the condition; no retry will help.
 - **`74` (IoErr) is the catch-all.** When a command's contract does not
   declare a more specific code, treat a non-zero exit as `IoErr` and surface
   the stderr envelope.


### PR DESCRIPTION
## Summary
- Route the persona-flagged exit-code divergences to their documented sysexits codes. `HeddleExitCode::from_error` now keys on the typed `RecoveryAdvice.kind` discriminator: `remote_not_configured` → `Config(78)`, and `nothing_to_commit` / `reconcile_direction_required` → `DataErr(65)`. These previously fell through to the `IoErr(74)` catch-all, so agents branching on the documented codes mis-handled the paths.
- `cmd_pull` now pre-checks the default remote and raises the same typed `remote_not_configured` advice `push` already does (it was a generic `runtime_error`). A `no default remote configured` string sentinel covers the raw `resolve_remote` path too.
- New `cli_integration/exit_codes.rs` asserts the documented exit code for a reproducible documented condition of each swept command (`init`, `status`, `verify`, `commit`, `merge`, `push`, `pull`, `bridge git import|sync|reconcile`).
- New `cli_integration/error_envelope_lint.rs` (the round-5 `Next:`-envelope lint) exercises a representative error case per swept command and asserts the stderr envelope carries a non-empty `Next:`/`primary_command` plus a typed action (`primary_command_argv` array or `primary_command_template` object) — same shape as the `output_kind` invariant.
- `docs/exit-codes.md`: ground the `78`/`65` agent-note examples in the now-true behavior.

Closes HeddleCo/heddle#252

## Red commit
`8993ae7`

## Test evidence
```
$ cargo test -p heddle-cli --lib exit::
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 464 filtered out

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 672 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out

$ cargo clippy --workspace --all-targets -- -D warnings
Finished (exit 0)

$ bash scripts/check-no-silent-default-tree-load.sh
exit 0

$ cargo test -p heddle-cli --test advice_lint --test typed_error_lint
advice_lint: 8 passed; typed_error_lint: 1 passed
```

The red commit `8993ae7` had the four `exit::tests::*` routing assertions and the `exit_codes` divergent cases failing (IoErr where Config/DataErr were documented); the green commit `4771a9f` makes them pass.

## Manual verification
N/A — covered by tests. Behavior also reproduced by hand: `heddle push`/`heddle pull` with no remote now exit `78`; second `heddle commit` with a clean worktree exits `65`; `heddle bridge git reconcile --ref main` (no `--prefer`) exits `65`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782589288&installation_id=132405951&pr_number=287&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F287&signature=4163ddada9149b79f0410180f3c3804cad31e258ec507cd507e66c3194a60775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 2 (Codex review fixes — fe875a7)
- Hermetic git fixtures: factored one shared `git_hermetic` helper (isolated GIT_CONFIG_*/HOME/templates/hooks/gpgsign + pinned identity) used by both `error_envelope_lint.rs` and `exit_codes.rs` (cid 3320314966, 3320314971).
- `bridge git sync` envelope now genuinely asserted: split from reconcile coverage + explicit `bridge git sync --path <missing>` case that reaches the Sync handler (cid 3320254700).
- `cargo test -p heddle-cli --test cli_integration` (672 passed) + `cargo clippy -p heddle-cli --all-targets -- -D warnings` green.

---

**Round 3 (Codex r3, cid 3320511217):** The r2 hermetic-git helper inherited the parent env and only removed `GIT_DIR` (a blocklist), so other inherited Git vars (e.g. `GIT_WORK_TREE`) could still leak and break `git init`. Fixed by making `git_hermetic` build the child `Command` with `.env_clear()` + a minimal explicit allowlist (PATH/HOME/GIT_CONFIG_*/pinned GIT_AUTHOR+COMMITTER identity/LANG/LC_ALL/TERM). No inherited `GIT_*` or ambient var can leak — closes the inherited-env class by construction rather than chasing the next leaking var. Verified: 13 swept fixtures pass with hostile `GIT_WORK_TREE`/`GIT_DIR`/`GIT_INDEX_FILE`/`GIT_OBJECT_DIRECTORY` exported in the parent env. (cdd508b)