### PR TITLE
heddle#262: parse .git/config remotes via gix_config, not by hand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "fs2",
  "futures",
  "gix",
+ "gix-config",
  "gix-index",
  "gix-pack",
  "gix-protocol",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ clap_complete.workspace = true
 ed25519-dalek.workspace = true
 fs2.workspace = true
 futures.workspace = true
+gix-config = "0.53"
 gix-index = "0.48"
 gix-pack = "0.67"
 gix-protocol = { version = "0.58", features = ["blocking-client"] }

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -1043,6 +1043,24 @@ impl RecoveryAdvice {
         )
     }
 
+    pub(crate) fn git_remote_in_included_config(name: &str, path: &std::path::Path) -> Self {
+        let path = path.display();
+        Self::safety_refusal(
+            "git_remote_in_included_config",
+            format!(
+                "Remote '{name}' is defined in an included Git config that heddle won't edit: {path}"
+            ),
+            "Edit the included config file directly, or move the `[remote]` section into the repository's own `.git/config`.",
+            format!(
+                "remote '{name}' resolves to a `[remote]` section in '{path}', reached through an include.path/includeIf directive outside the repository's Git directory"
+            ),
+            "editing that file would mutate config the user pulled in via an include directive rather than the repository's own config",
+            "remote configuration, refs, objects, and worktree files were left unchanged",
+            "heddle remote list",
+            vec!["heddle remote list".to_string()],
+        )
+    }
+
     pub(crate) fn remote_name_required_for_fetch() -> Self {
         Self::safety_refusal(
             "remote_name_required",

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1209,3 +1209,121 @@ struct PullNetworkOptions<'a> {
     lazy: bool,
     cli: &'a Cli,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_git(root: &Path) {
+        gix::init(root).expect("init git repo");
+    }
+
+    #[test]
+    fn parses_quoted_url_with_equals_and_strips_quotes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        fs::write(
+            tmp.path().join(".git").join("config"),
+            "[remote \"origin\"]\n\turl = \"https://example.com/repo?ref=main&a=b\"\n",
+        )
+        .unwrap();
+
+        let remotes = plain_git_remote_items(tmp.path());
+
+        assert_eq!(
+            remotes.get("origin").map(String::as_str),
+            Some("https://example.com/repo?ref=main&a=b"),
+        );
+    }
+
+    #[test]
+    fn strips_inline_comments_from_url() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        fs::write(
+            tmp.path().join(".git").join("config"),
+            "[remote \"origin\"]\n\turl = https://example.com/repo ; trailing comment\n",
+        )
+        .unwrap();
+
+        let remotes = plain_git_remote_items(tmp.path());
+
+        assert_eq!(
+            remotes.get("origin").map(String::as_str),
+            Some("https://example.com/repo"),
+        );
+    }
+
+    #[test]
+    fn follows_include_directives() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("extra.config"),
+            "[remote \"upstream\"]\n\turl = https://example.com/upstream\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[include]\n\tpath = extra.config\n",
+        )
+        .unwrap();
+
+        let remotes = plain_git_remote_items(tmp.path());
+
+        assert_eq!(
+            remotes.get("upstream").map(String::as_str),
+            Some("https://example.com/upstream"),
+        );
+    }
+
+    #[test]
+    fn worktree_config_overrides_local_when_extension_enabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[extensions]\n\tworktreeConfig = true\n\
+             [remote \"origin\"]\n\turl = https://example.com/local\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config.worktree"),
+            "[remote \"origin\"]\n\turl = https://example.com/worktree\n",
+        )
+        .unwrap();
+
+        let remotes = plain_git_remote_items(tmp.path());
+
+        assert_eq!(
+            remotes.get("origin").map(String::as_str),
+            Some("https://example.com/worktree"),
+        );
+    }
+
+    #[test]
+    fn ignores_worktree_config_when_extension_disabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = https://example.com/local\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config.worktree"),
+            "[remote \"origin\"]\n\turl = https://example.com/worktree\n",
+        )
+        .unwrap();
+
+        let remotes = plain_git_remote_items(tmp.path());
+
+        assert_eq!(
+            remotes.get("origin").map(String::as_str),
+            Some("https://example.com/local"),
+        );
+    }
+}

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -3,9 +3,10 @@
 
 #[cfg(feature = "client")]
 use std::net::SocketAddr;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
 
 use anyhow::{Context, Result};
+use gix::bstr::{BStr, BString};
 #[cfg(feature = "client")]
 use heddle_client::grpc_hosted::PullMaterialization;
 use objects::{
@@ -695,12 +696,17 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
             if !merged_remote_items(&repo)?.contains_key(&name) {
                 return Err(RecoveryAdvice::remote_not_found(&name).into());
             }
+            // Remove the git-overlay side FIRST so its uneditable-include
+            // refusal (raised before any file is touched) leaves the Heddle
+            // config unmutated. Persisting the Heddle removal ahead of this
+            // fallible step stranded the repo in partial state: the Heddle
+            // remote gone, the Git remote still present.
+            sync_git_overlay_remote_remove(&repo, &name)?;
             let mut cfg = RemoteConfig::open(&repo).map_err(anyhow::Error::msg)?;
             match cfg.remove(&name) {
                 Ok(()) | Err(RemoteError::NotFound(_)) => {}
                 Err(err) => return Err(anyhow::Error::msg(err)),
             }
-            sync_git_overlay_remote_remove(&repo, &name)?;
             render_remote_mutation(
                 RemoteMutationOutput {
                     output_kind: "remote_remove",
@@ -1181,115 +1187,78 @@ fn validate_git_overlay_remote_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Add or replace the `[remote "<name>"]` section in a single physical config
+/// file via `gix_config`'s structured editing, so the writer resolves the same
+/// section the reader does regardless of the surface header form (quoted
+/// `[remote "x"]`, legacy dotted `[remote.x]`, or comment-suffixed). Every
+/// existing definition of the remote is dropped before a fresh canonical
+/// section is appended, so an upsert replaces rather than appends a duplicate
+/// that the first-seen (stale) section would win over on the next read.
 fn upsert_git_remote_config(config_path: &Path, name: &str, url: &str) -> Result<()> {
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let original = fs::read_to_string(config_path).unwrap_or_default();
-    let mut rewritten = String::new();
-    let mut skipping_remote = false;
-    for line in original.lines() {
-        if let Some(section_name) = parse_git_remote_section_name(line) {
-            skipping_remote = section_name == name;
-            if skipping_remote {
-                continue;
-            }
-        } else if line.trim_start().starts_with('[') && line.trim_end().ends_with(']') {
-            skipping_remote = false;
-        }
-        if !skipping_remote {
-            rewritten.push_str(line);
-            rewritten.push('\n');
-        }
-    }
-    if !rewritten.is_empty() && !rewritten.ends_with("\n\n") {
-        rewritten.push('\n');
-    }
-    rewritten.push_str(&format!(
-        "[remote \"{}\"]\n\turl = {}\n\tfetch = {}\n",
-        git_config_quoted_section(name),
-        git_config_quoted_value(url),
-        git_config_quoted_value(&format!("+refs/heads/*:refs/remotes/{name}/*"))
-    ));
-    write_file_atomic(config_path, rewritten.as_bytes())?;
+    let mut file = load_config_file_for_edit(config_path)?;
+    remove_remote_sections(&mut file, name);
+    let mut section = file
+        .new_section("remote", Some(Cow::Owned(BString::from(name))))
+        .with_context(|| format!("invalid git remote section name '{name}'"))?;
+    section.push(git_config_key("url")?, Some(BStr::new(url)));
+    let fetch = format!("+refs/heads/*:refs/remotes/{name}/*");
+    section.push(git_config_key("fetch")?, Some(BStr::new(fetch.as_str())));
+    let serialized = file.to_bstring();
+    write_file_atomic(config_path, &serialized)?;
     Ok(())
 }
 
+/// Remove every `[remote "<name>"]` section from a single physical config file
+/// via `gix_config`, matching whatever header form the reader resolves the
+/// remote through. No-ops (no write) when the file is absent or defines no such
+/// remote.
 fn remove_git_remote_config(config_path: &Path, name: &str) -> Result<()> {
-    let Ok(original) = fs::read_to_string(config_path) else {
-        return Ok(());
-    };
-    let mut rewritten = String::new();
-    let mut skipping_remote = false;
-    let mut removed = false;
-    for line in original.lines() {
-        if let Some(section_name) = parse_git_remote_section_name(line) {
-            skipping_remote = section_name == name;
-            if skipping_remote {
-                removed = true;
-                continue;
-            }
-        } else if line.trim_start().starts_with('[') && line.trim_end().ends_with(']') {
-            skipping_remote = false;
-        }
-        if !skipping_remote {
-            rewritten.push_str(line);
-            rewritten.push('\n');
-        }
-    }
-    if !removed {
+    if !config_path.exists() {
         return Ok(());
     }
-    write_file_atomic(config_path, rewritten.as_bytes())?;
+    let mut file = load_config_file_for_edit(config_path)?;
+    if !remove_remote_sections(&mut file, name) {
+        return Ok(());
+    }
+    let serialized = file.to_bstring();
+    write_file_atomic(config_path, &serialized)?;
     Ok(())
 }
 
-fn parse_git_remote_section_name(line: &str) -> Option<String> {
-    let trimmed = line.trim();
-    let inner = trimmed.strip_prefix("[remote \"")?.strip_suffix("\"]")?;
-    unescape_git_config_string(inner)
-}
-
-fn unescape_git_config_string(value: &str) -> Option<String> {
-    let mut out = String::new();
-    let mut chars = value.chars();
-    while let Some(ch) = chars.next() {
-        if ch != '\\' {
-            out.push(ch);
-            continue;
-        }
-        match chars.next()? {
-            '\\' => out.push('\\'),
-            '"' => out.push('"'),
-            'n' => out.push('\n'),
-            't' => out.push('\t'),
-            'r' => out.push('\r'),
-            'b' => out.push('\u{0008}'),
-            escaped => out.push(escaped),
-        }
+/// Drop every `[remote "<name>"]` section from `file`, returning whether any
+/// was removed. `gix_config` keys sections by parsed name + subsection, so this
+/// matches the remote regardless of its surface header syntax. `remove_section`
+/// removes only the last match, so loop until none remain.
+fn remove_remote_sections(file: &mut gix_config::File<'static>, name: &str) -> bool {
+    let mut removed = false;
+    while file
+        .remove_section("remote", Some(BStr::new(name)))
+        .is_some()
+    {
+        removed = true;
     }
-    Some(out)
+    removed
 }
 
-fn git_config_quoted_section(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn git_config_quoted_value(value: &str) -> String {
-    let mut quoted = String::from("\"");
-    for ch in value.chars() {
-        match ch {
-            '\\' => quoted.push_str("\\\\"),
-            '"' => quoted.push_str("\\\""),
-            '\n' => quoted.push_str("\\n"),
-            '\t' => quoted.push_str("\\t"),
-            '\r' => quoted.push_str("\\r"),
-            '\u{0008}' => quoted.push_str("\\b"),
-            ch => quoted.push(ch),
-        }
+/// Load a single physical config file for in-place editing. Includes are NOT
+/// followed: the caller already resolved the physical file that defines the
+/// remote (see `defining_files_for`), and a write must round-trip that file
+/// alone rather than inline the content of any files it includes. A missing
+/// file yields an empty document so a brand-new remote can be appended.
+fn load_config_file_for_edit(config_path: &Path) -> Result<gix_config::File<'static>> {
+    if !config_path.exists() {
+        return Ok(gix_config::File::default());
     }
-    quoted.push('"');
-    quoted
+    gix_config::File::from_path_no_includes(config_path.to_path_buf(), gix_config::Source::Local)
+        .with_context(|| format!("reading git config at {}", config_path.display()))
+}
+
+fn git_config_key(key: &'static str) -> Result<gix_config::parse::section::ValueName<'static>> {
+    gix_config::parse::section::ValueName::try_from(key)
+        .with_context(|| format!("invalid git config key '{key}'"))
 }
 
 #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1582,4 +1582,108 @@ mod tests {
             Some("https://example.com/new"),
         );
     }
+
+    #[test]
+    fn remove_clears_comment_suffixed_remote_header() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        // A valid Git header gix accepts but the hand-rolled writer didn't:
+        // an inline comment trails the `[remote "origin"]` header.
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"] # primary mirror\n\turl = https://example.com/repo\n",
+        )
+        .unwrap();
+
+        // The reader resolves it, so it shows up in `remote list`...
+        assert!(plain_git_remote_items(tmp.path()).contains_key("origin"));
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        for path in ctx.remove_files_for("origin").unwrap() {
+            remove_git_remote_config(&path, "origin").unwrap();
+        }
+
+        // ...so a remove must actually clear it, not silently no-op against a
+        // header form the writer can't parse.
+        assert!(!plain_git_remote_items(tmp.path()).contains_key("origin"));
+    }
+
+    #[test]
+    fn remove_clears_dotted_remote_header() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        // The legacy dotted subsection form, equally valid to gix.
+        fs::write(
+            git_dir.join("config"),
+            "[remote.origin]\n\turl = https://example.com/repo\n",
+        )
+        .unwrap();
+
+        assert!(plain_git_remote_items(tmp.path()).contains_key("origin"));
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        for path in ctx.remove_files_for("origin").unwrap() {
+            remove_git_remote_config(&path, "origin").unwrap();
+        }
+
+        assert!(!plain_git_remote_items(tmp.path()).contains_key("origin"));
+    }
+
+    #[test]
+    fn upsert_replaces_comment_suffixed_remote_header_without_duplicating() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"] # primary mirror\n\turl = https://example.com/old\n",
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        upsert_git_remote_config(
+            &ctx.write_file_for("origin").unwrap(),
+            "origin",
+            "https://example.com/new",
+        )
+        .unwrap();
+
+        // The upsert must update the existing section, not append a second
+        // `[remote "origin"]` the first-seen (stale) section wins over on read.
+        assert_eq!(
+            plain_git_remote_items(tmp.path())
+                .get("origin")
+                .map(String::as_str),
+            Some("https://example.com/new"),
+        );
+    }
+
+    #[test]
+    fn upsert_replaces_dotted_remote_header() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[remote.origin]\n\turl = https://example.com/old\n",
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        upsert_git_remote_config(
+            &ctx.write_file_for("origin").unwrap(),
+            "origin",
+            "https://example.com/new",
+        )
+        .unwrap();
+
+        assert_eq!(
+            plain_git_remote_items(tmp.path())
+                .get("origin")
+                .map(String::as_str),
+            Some("https://example.com/new"),
+        );
+    }
 }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1012,31 +1012,87 @@ impl GitConfigContext {
             .unwrap_or(false)
     }
 
-    /// The config layer a write to remote `name` must target so the next
-    /// `remote list` read resolves the value we just wrote. Returns the
-    /// highest-precedence layer that already defines the remote (matching
-    /// `layered_paths` read precedence); when no layer defines it, the
+    /// The file a write to remote `name` must target so the next
+    /// `remote list` read resolves the value we just wrote. The
+    /// highest-precedence file that already defines the remote, resolved
+    /// through `include.path`/`includeIf` indirection — not merely the
+    /// top-level layer that *follows* the include, whose physical text has
+    /// no `[remote]` section to edit. When no file defines the remote, the
     /// common config — git's default target for a brand-new remote.
-    fn write_layer_for(&self, name: &str) -> std::path::PathBuf {
-        self.layered_paths()
-            .into_iter()
-            .find(|path| self.layer_defines_remote(path, name))
-            .unwrap_or_else(|| self.common_dir.join("config"))
+    ///
+    /// Errors when the defining file lies outside the repository's Git
+    /// directory (reached via an include), so a reported-successful write is
+    /// never a silent no-op against a file heddle won't edit.
+    fn write_file_for(&self, name: &str) -> Result<std::path::PathBuf> {
+        match self.defining_files_for(name).into_iter().next() {
+            Some(path) => {
+                if !self.owns_config_file(&path) {
+                    anyhow::bail!(RecoveryAdvice::git_remote_in_included_config(name, &path));
+                }
+                Ok(path)
+            }
+            None => Ok(self.common_dir.join("config")),
+        }
     }
 
-    /// Every config layer that currently defines remote `name`. A remove
-    /// must clear all of them, otherwise a lower-precedence definition
-    /// resurfaces — or a higher-precedence one keeps winning — on the next
-    /// read, leaving the "successful" removal silently divergent.
-    fn remove_layers_for(&self, name: &str) -> Vec<std::path::PathBuf> {
-        self.layered_paths()
-            .into_iter()
-            .filter(|path| self.layer_defines_remote(path, name))
-            .collect()
+    /// Every file that currently defines remote `name`, resolved through
+    /// includes. A remove must clear all of them, otherwise a
+    /// lower-precedence definition resurfaces — or a higher-precedence one
+    /// keeps winning — on the next read, leaving the "successful" removal
+    /// silently divergent. Errors when any defining file lies outside the
+    /// repository's Git directory rather than no-op'ing against it.
+    fn remove_files_for(&self, name: &str) -> Result<Vec<std::path::PathBuf>> {
+        let files = self.defining_files_for(name);
+        for path in &files {
+            if !self.owns_config_file(path) {
+                anyhow::bail!(RecoveryAdvice::git_remote_in_included_config(name, path));
+            }
+        }
+        Ok(files)
     }
 
-    fn layer_defines_remote(&self, path: &Path, name: &str) -> bool {
-        self.remotes(vec![path.to_path_buf()]).contains_key(name)
+    /// The file(s) whose `[remote "<name>"]` section the reader resolves,
+    /// following `include.path`/`includeIf`. Returned highest-precedence
+    /// first, matching `remotes` read precedence (first-seen wins). The
+    /// section metadata records the file each section physically lives in,
+    /// so an include-defined remote resolves to the included file — the one
+    /// a write must edit — not the including config.
+    fn defining_files_for(&self, name: &str) -> Vec<std::path::PathBuf> {
+        let Some(file) = self.load(self.layered_paths()) else {
+            return Vec::new();
+        };
+        let Some(sections) = file.sections_by_name("remote") else {
+            return Vec::new();
+        };
+        let mut files = Vec::new();
+        for section in sections {
+            let matches = section
+                .header()
+                .subsection_name()
+                .map(|subsection| subsection.to_string());
+            if matches.as_deref() != Some(name) {
+                continue;
+            }
+            let Some(path) = section.meta().path.clone() else {
+                continue;
+            };
+            if !files.contains(&path) {
+                files.push(path);
+            }
+        }
+        files
+    }
+
+    /// Whether heddle may rewrite `path`: only config files within the
+    /// repository's own Git directory tree (git-dir / common-dir). A section
+    /// pulled in from a file outside that tree via `include.path`/`includeIf`
+    /// (e.g. a user-global config) is not ours to edit.
+    fn owns_config_file(&self, path: &Path) -> bool {
+        let target = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        [&self.git_dir, &self.common_dir].into_iter().any(|root| {
+            let root = root.canonicalize().unwrap_or_else(|_| root.clone());
+            target.starts_with(&root)
+        })
     }
 
     fn remotes(&self, paths: Vec<std::path::PathBuf>) -> BTreeMap<String, String> {
@@ -1090,7 +1146,7 @@ fn sync_git_overlay_remote_add(repo: &Repository, name: &str, url: &str) -> Resu
     validate_git_overlay_remote_name(name)?;
     let ctx = GitConfigContext::discover(repo.root())
         .context("Git-overlay remote add requires a writable Git config")?;
-    upsert_git_remote_config(&ctx.write_layer_for(name), name, url)
+    upsert_git_remote_config(&ctx.write_file_for(name)?, name, url)
 }
 
 fn sync_git_overlay_remote_remove(repo: &Repository, name: &str) -> Result<()> {
@@ -1100,7 +1156,7 @@ fn sync_git_overlay_remote_remove(repo: &Repository, name: &str) -> Result<()> {
     let Some(ctx) = GitConfigContext::discover(repo.root()) else {
         return Ok(());
     };
-    for config_path in ctx.remove_layers_for(name) {
+    for config_path in ctx.remove_files_for(name)? {
         remove_git_remote_config(&config_path, name)?;
     }
     Ok(())

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1385,7 +1385,7 @@ mod tests {
         .unwrap();
 
         let ctx = GitConfigContext::discover(tmp.path()).unwrap();
-        for path in ctx.remove_layers_for("origin") {
+        for path in ctx.remove_files_for("origin").unwrap() {
             remove_git_remote_config(&path, "origin").unwrap();
         }
 
@@ -1411,8 +1411,12 @@ mod tests {
         .unwrap();
 
         let ctx = GitConfigContext::discover(tmp.path()).unwrap();
-        upsert_git_remote_config(&ctx.write_layer_for("origin"), "origin", "https://example.com/new")
-            .unwrap();
+        upsert_git_remote_config(
+            &ctx.write_file_for("origin").unwrap(),
+            "origin",
+            "https://example.com/new",
+        )
+        .unwrap();
 
         // The upsert must hit the per-worktree layer (where the remote
         // lives and wins on read); writing to common would leave the
@@ -1421,6 +1425,79 @@ mod tests {
             plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
             Some("https://example.com/new"),
         );
+    }
+
+    #[test]
+    fn remove_clears_remote_defined_via_include_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("extra.config"),
+            "[remote \"upstream\"]\n\turl = https://example.com/upstream\n",
+        )
+        .unwrap();
+        fs::write(git_dir.join("config"), "[include]\n\tpath = extra.config\n").unwrap();
+
+        // The reader follows the include, so the remote is visible...
+        assert!(plain_git_remote_items(tmp.path()).contains_key("upstream"));
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        for path in ctx.remove_files_for("upstream").unwrap() {
+            remove_git_remote_config(&path, "upstream").unwrap();
+        }
+
+        // ...and a remove must clear the section from the *included* file
+        // it actually lives in, not no-op against the including config.
+        assert!(!plain_git_remote_items(tmp.path()).contains_key("upstream"));
+    }
+
+    #[test]
+    fn write_to_included_remote_targets_the_defining_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("extra.config"),
+            "[remote \"origin\"]\n\turl = https://example.com/old\n",
+        )
+        .unwrap();
+        fs::write(git_dir.join("config"), "[include]\n\tpath = extra.config\n").unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        let target = ctx.write_file_for("origin").unwrap();
+        assert_eq!(target, git_dir.join("extra.config"));
+        upsert_git_remote_config(&target, "origin", "https://example.com/new").unwrap();
+
+        assert_eq!(
+            plain_git_remote_items(tmp.path())
+                .get("origin")
+                .map(String::as_str),
+            Some("https://example.com/new"),
+        );
+    }
+
+    #[test]
+    fn write_to_remote_in_external_include_errors_rather_than_no_ops() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        // An included config that lives *outside* the repository's Git tree.
+        let external = tmp.path().join("external.config");
+        fs::write(
+            &external,
+            "[remote \"origin\"]\n\turl = https://example.com/external\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config"),
+            format!("[include]\n\tpath = {}\n", external.display()),
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        assert!(ctx.write_file_for("origin").is_err());
+        assert!(ctx.remove_files_for("origin").is_err());
     }
 
     #[test]
@@ -1437,9 +1514,13 @@ mod tests {
         let ctx = GitConfigContext::discover(tmp.path()).unwrap();
         // A brand-new remote (no layer defines it yet) follows git's
         // default: the common config.
-        assert_eq!(ctx.write_layer_for("origin"), git_dir.join("config"));
-        upsert_git_remote_config(&ctx.write_layer_for("origin"), "origin", "https://example.com/new")
-            .unwrap();
+        assert_eq!(ctx.write_file_for("origin").unwrap(), git_dir.join("config"));
+        upsert_git_remote_config(
+            &ctx.write_file_for("origin").unwrap(),
+            "origin",
+            "https://example.com/new",
+        )
+        .unwrap();
         assert_eq!(
             plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
             Some("https://example.com/new"),

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1015,8 +1015,10 @@ impl GitConfigContext {
     /// `layered_paths` read precedence); when no layer defines it, the
     /// common config — git's default target for a brand-new remote.
     fn write_layer_for(&self, name: &str) -> std::path::PathBuf {
-        let _ = name;
-        self.common_dir.join("config")
+        self.layered_paths()
+            .into_iter()
+            .find(|path| self.layer_defines_remote(path, name))
+            .unwrap_or_else(|| self.common_dir.join("config"))
     }
 
     /// Every config layer that currently defines remote `name`. A remove
@@ -1024,8 +1026,10 @@ impl GitConfigContext {
     /// resurfaces — or a higher-precedence one keeps winning — on the next
     /// read, leaving the "successful" removal silently divergent.
     fn remove_layers_for(&self, name: &str) -> Vec<std::path::PathBuf> {
-        let _ = name;
-        vec![self.common_dir.join("config")]
+        self.layered_paths()
+            .into_iter()
+            .filter(|path| self.layer_defines_remote(path, name))
+            .collect()
     }
 
     fn layer_defines_remote(&self, path: &Path, name: &str) -> bool {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -933,24 +933,10 @@ fn is_local_git_repository(path: &Path) -> bool {
 }
 
 fn plain_git_remote_items(root: &Path) -> BTreeMap<String, String> {
-    let mut remotes = BTreeMap::new();
-    for config_path in plain_git_config_paths(root) {
-        parse_git_config_remotes(&config_path, &mut remotes);
-    }
-    remotes
-}
-
-fn plain_git_config_paths(root: &Path) -> Vec<std::path::PathBuf> {
-    let mut paths = Vec::new();
-    let dot_git = root.join(".git");
-    paths.push(dot_git.join("config"));
-    if let Some(git_dir) = pointed_git_dir(&dot_git) {
-        paths.push(git_dir.join("config"));
-        if let Some(common_dir) = common_git_dir(&git_dir) {
-            paths.push(common_dir.join("config"));
-        }
-    }
-    paths
+    let Some(ctx) = GitConfigContext::discover(root) else {
+        return BTreeMap::new();
+    };
+    ctx.remotes(ctx.layered_paths())
 }
 
 fn default_remote_from_items(items: &BTreeMap<String, String>) -> Option<String> {
@@ -964,76 +950,106 @@ fn default_remote_from_items(items: &BTreeMap<String, String>) -> Option<String>
 }
 
 fn git_overlay_config_remotes(repo: &Repository) -> BTreeMap<String, String> {
-    let mut remotes = BTreeMap::new();
-    for config_path in git_overlay_config_paths(repo) {
-        parse_git_config_remotes(&config_path, &mut remotes);
-    }
-    remotes
-}
-
-fn git_overlay_config_paths(repo: &Repository) -> Vec<std::path::PathBuf> {
-    let mut paths = Vec::new();
-    paths.push(repo.root().join(".git").join("config"));
-    if let Some(git_dir) = pointed_git_dir(&repo.root().join(".git")) {
-        paths.push(git_dir.join("config"));
-        if let Some(common_dir) = common_git_dir(&git_dir) {
-            paths.push(common_dir.join("config"));
-        }
-    }
-    paths.push(repo.heddle_dir().join("git").join("config"));
-    paths
-}
-
-fn pointed_git_dir(dot_git: &Path) -> Option<std::path::PathBuf> {
-    if dot_git.is_dir() {
-        return Some(dot_git.to_path_buf());
-    }
-    let contents = fs::read_to_string(dot_git).ok()?;
-    let target = contents.trim().strip_prefix("gitdir:")?.trim();
-    let path = Path::new(target);
-    Some(if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        dot_git.parent()?.join(path)
-    })
-}
-
-fn common_git_dir(git_dir: &Path) -> Option<std::path::PathBuf> {
-    let contents = fs::read_to_string(git_dir.join("commondir")).ok()?;
-    let target = contents.trim();
-    let path = Path::new(target);
-    Some(if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        git_dir.join(path)
-    })
-}
-
-fn parse_git_config_remotes(path: &Path, remotes: &mut BTreeMap<String, String>) {
-    let Ok(contents) = fs::read_to_string(path) else {
-        return;
+    let Some(ctx) = GitConfigContext::discover(repo.root()) else {
+        return BTreeMap::new();
     };
-    let mut current_remote: Option<String> = None;
-    for raw in contents.lines() {
-        let line = raw.trim();
-        if line.starts_with('[') && line.ends_with(']') {
-            current_remote = line
-                .strip_prefix("[remote \"")
-                .and_then(|rest| rest.strip_suffix("\"]"))
-                .map(str::to_string);
-            continue;
+    let mut paths = ctx.layered_paths();
+    paths.push(repo.heddle_dir().join("git").join("config"));
+    ctx.remotes(paths)
+}
+
+/// The resolved Git directory layout for a repository, used to read remote
+/// definitions from `.git/config` (and its layered companions) through
+/// `gix_config`, which correctly handles quoting, inline comments, include
+/// directives, and conditional `includeIf` directives.
+struct GitConfigContext {
+    git_dir: std::path::PathBuf,
+    common_dir: std::path::PathBuf,
+    branch: Option<gix::refs::FullName>,
+}
+
+impl GitConfigContext {
+    fn discover(root: &Path) -> Option<Self> {
+        let git = gix::discover(root).ok()?;
+        Some(Self {
+            git_dir: git.git_dir().to_path_buf(),
+            common_dir: git.common_dir().to_path_buf(),
+            branch: git.head_name().ok().flatten(),
+        })
+    }
+
+    fn branch_ref(&self) -> Option<&gix::refs::FullNameRef> {
+        self.branch.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The standard repository config files, ordered highest-precedence first:
+    /// the per-worktree `config.worktree` (only when `extensions.worktreeConfig`
+    /// is enabled), then the git-dir `config`, then the shared common-dir
+    /// `config` for linked worktrees.
+    fn layered_paths(&self) -> Vec<std::path::PathBuf> {
+        let mut paths = Vec::new();
+        if self.worktree_config_enabled() {
+            paths.push(self.git_dir.join("config.worktree"));
         }
-        let Some(name) = current_remote.as_ref() else {
-            continue;
+        paths.push(self.git_dir.join("config"));
+        if self.common_dir != self.git_dir {
+            paths.push(self.common_dir.join("config"));
+        }
+        paths
+    }
+
+    fn worktree_config_enabled(&self) -> bool {
+        let mut paths = vec![self.git_dir.join("config")];
+        if self.common_dir != self.git_dir {
+            paths.push(self.common_dir.join("config"));
+        }
+        self.load(paths)
+            .and_then(|file| file.boolean("extensions.worktreeConfig"))
+            .and_then(Result::ok)
+            .unwrap_or(false)
+    }
+
+    fn remotes(&self, paths: Vec<std::path::PathBuf>) -> BTreeMap<String, String> {
+        let mut remotes = BTreeMap::new();
+        let Some(file) = self.load(paths) else {
+            return remotes;
         };
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
+        let Some(sections) = file.sections_by_name("remote") else {
+            return remotes;
         };
-        if key.trim() == "url" {
+        for section in sections {
+            let Some(name) = section.header().subsection_name() else {
+                continue;
+            };
+            let Some(url) = section.value("url") else {
+                continue;
+            };
             remotes
-                .entry(name.clone())
-                .or_insert_with(|| value.trim().to_string());
+                .entry(name.to_string())
+                .or_insert_with(|| url.to_string());
         }
+        remotes
+    }
+
+    fn load(&self, paths: Vec<std::path::PathBuf>) -> Option<gix_config::File<'static>> {
+        let options = gix_config::file::init::Options {
+            includes: gix_config::file::includes::Options::follow(
+                gix_config::path::interpolate::Context::default(),
+                gix_config::file::includes::conditional::Context {
+                    git_dir: Some(&self.git_dir),
+                    branch_name: self.branch_ref(),
+                },
+            ),
+            lossy: true,
+            ignore_io_errors: true,
+        };
+        let mut metadata = paths
+            .into_iter()
+            .map(|path| gix_config::file::Metadata::from(gix_config::Source::Local).at(path));
+        let mut buf = Vec::new();
+        gix_config::File::from_paths_metadata_buf(&mut metadata, &mut buf, false, options)
+            .ok()
+            .flatten()
     }
 }
 
@@ -1058,12 +1074,8 @@ fn sync_git_overlay_remote_remove(repo: &Repository, name: &str) -> Result<()> {
 }
 
 fn git_overlay_config_path_for_write(repo: &Repository) -> Option<std::path::PathBuf> {
-    let dot_git = repo.root().join(".git");
-    if dot_git.is_dir() {
-        return Some(dot_git.join("config"));
-    }
-    let git_dir = pointed_git_dir(&dot_git)?;
-    Some(common_git_dir(&git_dir).unwrap_or(git_dir).join("config"))
+    let git = gix::discover(repo.root()).ok()?;
+    Some(git.common_dir().join("config"))
 }
 
 fn validate_git_overlay_remote_name(name: &str) -> Result<()> {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1009,6 +1009,29 @@ impl GitConfigContext {
             .unwrap_or(false)
     }
 
+    /// The config layer a write to remote `name` must target so the next
+    /// `remote list` read resolves the value we just wrote. Returns the
+    /// highest-precedence layer that already defines the remote (matching
+    /// `layered_paths` read precedence); when no layer defines it, the
+    /// common config — git's default target for a brand-new remote.
+    fn write_layer_for(&self, name: &str) -> std::path::PathBuf {
+        let _ = name;
+        self.common_dir.join("config")
+    }
+
+    /// Every config layer that currently defines remote `name`. A remove
+    /// must clear all of them, otherwise a lower-precedence definition
+    /// resurfaces — or a higher-precedence one keeps winning — on the next
+    /// read, leaving the "successful" removal silently divergent.
+    fn remove_layers_for(&self, name: &str) -> Vec<std::path::PathBuf> {
+        let _ = name;
+        vec![self.common_dir.join("config")]
+    }
+
+    fn layer_defines_remote(&self, path: &Path, name: &str) -> bool {
+        self.remotes(vec![path.to_path_buf()]).contains_key(name)
+    }
+
     fn remotes(&self, paths: Vec<std::path::PathBuf>) -> BTreeMap<String, String> {
         let mut remotes = BTreeMap::new();
         let Some(file) = self.load(paths) else {
@@ -1058,24 +1081,22 @@ fn sync_git_overlay_remote_add(repo: &Repository, name: &str, url: &str) -> Resu
         return Ok(());
     }
     validate_git_overlay_remote_name(name)?;
-    let config_path = git_overlay_config_path_for_write(repo)
+    let ctx = GitConfigContext::discover(repo.root())
         .context("Git-overlay remote add requires a writable Git config")?;
-    upsert_git_remote_config(&config_path, name, url)
+    upsert_git_remote_config(&ctx.write_layer_for(name), name, url)
 }
 
 fn sync_git_overlay_remote_remove(repo: &Repository, name: &str) -> Result<()> {
     if repo.capability() != RepositoryCapability::GitOverlay {
         return Ok(());
     }
-    let Some(config_path) = git_overlay_config_path_for_write(repo) else {
+    let Some(ctx) = GitConfigContext::discover(repo.root()) else {
         return Ok(());
     };
-    remove_git_remote_config(&config_path, name)
-}
-
-fn git_overlay_config_path_for_write(repo: &Repository) -> Option<std::path::PathBuf> {
-    let git = gix::discover(repo.root()).ok()?;
-    Some(git.common_dir().join("config"))
+    for config_path in ctx.remove_layers_for(name) {
+        remove_git_remote_config(&config_path, name)?;
+    }
+    Ok(())
 }
 
 fn validate_git_overlay_remote_name(name: &str) -> Result<()> {
@@ -1336,6 +1357,85 @@ mod tests {
         assert_eq!(
             remotes.get("origin").map(String::as_str),
             Some("https://example.com/local"),
+        );
+    }
+
+    #[test]
+    fn remove_clears_worktree_layer_when_extension_enabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[extensions]\n\tworktreeConfig = true\n\
+             [remote \"origin\"]\n\turl = https://example.com/common\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config.worktree"),
+            "[remote \"origin\"]\n\turl = https://example.com/worktree\n",
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        for path in ctx.remove_layers_for("origin") {
+            remove_git_remote_config(&path, "origin").unwrap();
+        }
+
+        // The visible (per-worktree) remote must be gone after a remove;
+        // a common-only removal would leave it winning on the next read.
+        assert!(!plain_git_remote_items(tmp.path()).contains_key("origin"));
+    }
+
+    #[test]
+    fn add_targets_worktree_layer_so_next_read_reflects_it() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[extensions]\n\tworktreeConfig = true\n",
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("config.worktree"),
+            "[remote \"origin\"]\n\turl = https://example.com/old\n",
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        upsert_git_remote_config(&ctx.write_layer_for("origin"), "origin", "https://example.com/new")
+            .unwrap();
+
+        // The upsert must hit the per-worktree layer (where the remote
+        // lives and wins on read); writing to common would leave the
+        // stale per-worktree url winning, a silent read/write divergence.
+        assert_eq!(
+            plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
+            Some("https://example.com/new"),
+        );
+    }
+
+    #[test]
+    fn add_new_remote_targets_common_layer() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_git(tmp.path());
+        let git_dir = tmp.path().join(".git");
+        fs::write(
+            git_dir.join("config"),
+            "[extensions]\n\tworktreeConfig = true\n",
+        )
+        .unwrap();
+
+        let ctx = GitConfigContext::discover(tmp.path()).unwrap();
+        // A brand-new remote (no layer defines it yet) follows git's
+        // default: the common config.
+        assert_eq!(ctx.write_layer_for("origin"), git_dir.join("config"));
+        upsert_git_remote_config(&ctx.write_layer_for("origin"), "origin", "https://example.com/new")
+            .unwrap();
+        assert_eq!(
+            plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
+            Some("https://example.com/new"),
         );
     }
 }

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -605,6 +605,79 @@ fn git_overlay_remote_list_show_labels_local_bare_git_remote_as_git_overlay() {
     );
 }
 
+#[test]
+fn git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated() {
+    // Regression: a git-overlay remote defined in BOTH `.heddle/remotes.toml`
+    // and a Git config pulled in via an include from OUTSIDE the Git directory
+    // must not be half-removed. The removal has to refuse on the uneditable
+    // include BEFORE persisting the Heddle side — either both configs drop the
+    // remote or neither does. The old order saved the Heddle removal first and
+    // only then hit the include refusal, stranding partial state.
+    let work = TempDir::new().unwrap();
+    gix::init(work.path()).expect("init git worktree");
+    heddle(&["init"], Some(work.path())).unwrap();
+
+    // A `[remote "origin"]` section in a config file outside the repository's
+    // own Git directory, reachable only through `include.path`.
+    let external = work.path().join("external.config");
+    std::fs::write(
+        &external,
+        "[remote \"origin\"]\n\turl = https://example.com/repo\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n",
+    )
+    .unwrap();
+    let git_config = work.path().join(".git").join("config");
+    std::fs::write(
+        &git_config,
+        format!(
+            "[core]\n\trepositoryformatversion = 0\n[include]\n\tpath = {}\n",
+            external.display()
+        ),
+    )
+    .unwrap();
+    // The same remote also adopted into the native Heddle config.
+    let remotes_toml = work.path().join(".heddle").join("remotes.toml");
+    std::fs::write(
+        &remotes_toml,
+        "default = \"origin\"\n\n[remotes.origin]\nurl = \"https://example.com/repo\"\n",
+    )
+    .unwrap();
+
+    let before_remotes_toml = std::fs::read_to_string(&remotes_toml).unwrap();
+    let before_git_config = std::fs::read_to_string(&git_config).unwrap();
+    let before_external = std::fs::read_to_string(&external).unwrap();
+
+    let output = heddle_output(
+        &["--output", "json", "remote", "remove", "origin"],
+        Some(work.path()),
+    )
+    .expect("invoke remote remove");
+    assert!(
+        !output.status.success(),
+        "removing a remote defined in an uneditable include must refuse, not partially apply"
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value = serde_json::from_str(stderr)
+        .unwrap_or_else(|err| panic!("uneditable-include refusal should emit JSON: {err}: {stderr}"));
+    assert_eq!(envelope["kind"], "git_remote_in_included_config", "{stderr}");
+
+    // No partial state: every config the command could have touched is unchanged.
+    assert_eq!(
+        std::fs::read_to_string(&remotes_toml).unwrap(),
+        before_remotes_toml,
+        "Heddle remote config must be untouched when the git-side removal refuses"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&git_config).unwrap(),
+        before_git_config,
+        "Git config must be untouched when the removal refuses"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&external).unwrap(),
+        before_external,
+        "included config must be untouched when the removal refuses"
+    );
+}
+
 fn setup_git_overlay_push_fixture() -> (TempDir, TempDir, gix::Repository) {
     let work = TempDir::new().unwrap();
     let remote = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `.git/config` remote parser in `remote_ops.rs` with `gix_config::File::from_paths_metadata_buf`, so quoted values containing `=`, inline `#`/`;` comments, `\` escapes, `include.path`, and `includeIf gitdir:`/`onbranch:` directives are handled correctly instead of silently mis-parsed.
- Replace `pointed_git_dir` + `common_git_dir` (hand-rolled gitdir-file / commondir-file resolution) with `gix::discover` → `git_dir()` / `common_dir()`, consistent with the 11 existing `gix::discover` sites.
- New `GitConfigContext` layers the standard repo config files highest-precedence-first, honouring `extensions.worktreeConfig` for `config.worktree`; the git-overlay path additionally appends `.heddle/git/config`.
- `git_overlay_config_path_for_write` now resolves its write target via `gix::common_dir()`. Adds `gix-config = "0.53"` to `crates/cli` (already in the lockfile transitively via `gix`).

Closes HeddleCo/heddle#262

## Red commit
`3416fdf`

## Test evidence
```
$ cargo test --locked -p heddle-cli --lib remote::remote_ops::tests
running 5 tests
test cli::commands::remote::remote_ops::tests::follows_include_directives ... ok
test cli::commands::remote::remote_ops::tests::ignores_worktree_config_when_extension_disabled ... ok
test cli::commands::remote::remote_ops::tests::parses_quoted_url_with_equals_and_strips_quotes ... ok
test cli::commands::remote::remote_ops::tests::strips_inline_comments_from_url ... ok
test cli::commands::remote::remote_ops::tests::worktree_config_overrides_local_when_extension_enabled ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 472 filtered out

$ cargo test --locked --workspace
test result: ok.   # (all suites green; 0 failed across workspace)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished   # clean

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code

$ cargo deny check bans licenses sources
bans ok, licenses ok, sources ok
```

## Manual verification
N/A — covered by tests. The four red tests (quoted-`=`, inline comment, include directive, worktree-config layering) demonstrate the behaviours the hand-rolled parser got wrong; `git_replacement_matrix` integration tests confirm `remote list` still surfaces git-overlay origins without `git` on PATH.

## Round 2 (Codex)
- cid 3320354429 — honor `config.worktree` when **writing** overlay remotes. r1 made the reader prefer the per-worktree layer; the write helper still always targeted `common_dir/config`, so `remote add`/`remove` reported success while a per-worktree definition kept winning on the next `remote list` (silent read/write divergence).
- Fix (`35c8c29`): write ops resolve the config layer through the **same** `layered_paths` precedence the reader uses — `write_layer_for` targets the highest-precedence layer that defines the remote (per-worktree `config.worktree` when `extensions.worktreeConfig` is on, else common; common for a brand-new remote, matching git's default); `remove_layers_for` clears **every** defining layer so a per-worktree definition can't survive a "successful" removal. Add/upsert/remove now share one resolver, so the class can't reopen on a sibling verb.
- Tests: `remove_clears_worktree_layer_when_extension_enabled`, `add_targets_worktree_layer_so_next_read_reflects_it`, `add_new_remote_targets_common_layer`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782590698&installation_id=132405951&pr_number=288&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F288&signature=88a316028140fca49de5eb6d6104e89ee955ac55165764b7c5c680c889506522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 3
- Closed the read/write-divergence class through include indirection: remote add/set-url/remove resolve the `[remote]` section through `include.path`/`includeIf` to the file it physically lives in (via gix-config section metadata) and edit there, rather than the top-level layer that merely *follows* the include (cid 3321966186).
- Un-editable defining file (outside the repo's Git directory) now returns a clear `git_remote_in_included_config` error instead of a silent no-op.
- Tests: include-defined remote removal reflected by next `remote list`; upsert targets the included file; external-include remote errors rather than no-ops. r1/r2 behavior preserved.


## Round 4 (structural close-the-class — gix writer)
The reader migrated to gix_config in r1, but the WRITER stayed hand-rolled
(string-matching only `[remote "x"]`-style headers), so r2 (worktree layer),
r3 (include indirection), and now header forms kept dripping as new
reader/writer divergences. r4 closes the class structurally:
- **Part 1 — writer on gix_config.** `upsert_git_remote_config` /
  `remove_git_remote_config` now do structured read-modify-write via
  `gix_config::File` (`from_path_no_includes` → `remove_section` /
  `new_section` → `to_bstring`), resolving the same parsed `[remote "<name>"]`
  section the reader does — quoted, legacy dotted `[remote.x]`, or
  comment-suffixed `[remote "x"] # c`. No remote is visible-but-unwritable
  anymore. Deleted `parse_git_remote_section_name` + the hand-rolled
  quote/unescape helpers (cid 3322058177).
- **Part 2 — transactional remove.** `cmd_remote` Remove runs the git-overlay
  removal (whose uneditable-include refusal fires before any file is touched)
  BEFORE saving `.heddle/remotes.toml`, so a refusal leaves BOTH configs
  unmutated instead of stranding the Heddle removal against a still-present
  Git remote (cid 3322058180).
- Tests: remove/upsert of comment-suffixed + dotted headers reflected by the
  reader; `git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated`
  asserts byte-for-byte-unchanged configs on refusal. r1/r2/r3 preserved.
