### PR TITLE
heddle#289: report total commits in bridge export/sync summaries

### DIFF
--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1907,6 +1907,125 @@ fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
     );
 }
 
+/// heddle#289 r4: EVERY count in the export summary must be a partition of
+/// the single copied ref set, so a state minted into the mirror but
+/// reachable from no copied ref inflates none of them. r3 fixed
+/// `commits_total` but left `states_exported` ("newly") tallied inline over
+/// `list_states()`, so a Heddle-native thread created and dropped before
+/// export would still be minted and counted as newly-written even though it
+/// never lands in the destination — producing the impossible
+/// "1 total (2 newly written)" summary. This drives `states_exported` from
+/// the same walk as `commits_total`: the orphan is excluded from BOTH and
+/// `newly + already == total` holds by construction.
+#[test]
+fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
+    use objects::object::{Attribution, Principal, State};
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let bridge = GitBridge::new(&repo);
+
+    let attribution =
+        || Attribution::human(Principal::new("Alice", "alice@example.com"));
+    let put_state = |parents: Vec<ChangeId>| -> State {
+        let store = bridge.heddle_repo.store();
+        let blob_hash = store.put_blob(&Blob::from_slice(b"contents")).expect("put blob");
+        let tree_hash = store
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
+            .expect("put tree");
+        let state = State::new(tree_hash, parents, attribution());
+        store.put_state(&state).expect("put state");
+        state
+    };
+
+    // A native `main` thread with a two-commit history → both minted into
+    // the mirror and reachable from refs/heads/main, so both land in the
+    // destination.
+    let main_first = put_state(Vec::new());
+    let main_tip = put_state(vec![main_first.change_id]);
+    bridge
+        .heddle_repo
+        .refs()
+        .set_thread(&ThreadName::new("main"), &main_tip.change_id)
+        .expect("set main thread");
+
+    // A native `scratch` thread, dropped before export. Its state stays in
+    // the store (delete_thread only removes the ref), so the export walk
+    // over `list_states()` still mints it — but no copied ref points at it,
+    // so it reaches no destination and must inflate no count.
+    let orphan = put_state(Vec::new());
+    bridge
+        .heddle_repo
+        .refs()
+        .set_thread(&ThreadName::new("scratch"), &orphan.change_id)
+        .expect("set scratch thread");
+    bridge
+        .heddle_repo
+        .refs()
+        .delete_thread(&ThreadName::new("scratch"))
+        .expect("delete scratch thread");
+
+    // The orphan state is still present in the store — proving the walk
+    // would have minted (and, pre-r4, counted) it.
+    let mut bridge = bridge;
+    assert_eq!(
+        bridge.heddle_repo.store().list_states().expect("states").len(),
+        3,
+        "store holds main's two states plus the dropped scratch state"
+    );
+
+    let dest_temp = TempDir::new().expect("dest temp");
+    let dest_path = dest_temp.path().join("dest.git");
+    let stats = bridge.export_to_path(&dest_path).expect("export to path");
+
+    // Both summary counts are partitions of the copied ref set: total =
+    // main's two commits; newly = the same two (freshly minted this run).
+    // The orphan is in neither.
+    assert_eq!(
+        stats.commits_total, 2,
+        "total counts only the copied ref set (main's 2), not the orphan, got {}",
+        stats.commits_total
+    );
+    assert_eq!(
+        stats.states_exported, 2,
+        "newly counts only minted commits that landed (main's 2), not the orphan, got {}",
+        stats.states_exported
+    );
+
+    // The invariant the close-the-class fix guarantees: newly is a subset of
+    // total, so the "1 total (2 newly written)" impossibility cannot occur.
+    let already = stats.commits_total.saturating_sub(stats.states_exported);
+    assert!(
+        stats.states_exported <= stats.commits_total,
+        "newly ({}) must never exceed total ({})",
+        stats.states_exported,
+        stats.commits_total
+    );
+    assert_eq!(
+        stats.states_exported + already,
+        stats.commits_total,
+        "newly + already must equal total by construction"
+    );
+
+    // The orphan's commit reaches no ref in the destination.
+    let dest = gix::open(&dest_path).expect("open destination");
+    assert!(
+        dest.find_reference("refs/heads/main").is_ok(),
+        "destination must contain the main branch"
+    );
+    assert!(
+        dest.find_reference("refs/heads/scratch").is_err(),
+        "dropped scratch thread must not appear in the destination"
+    );
+    assert!(
+        !stats.branches.iter().any(|b| b.name == "scratch"),
+        "dropped scratch thread is not a synced branch: {:?}",
+        stats.branches
+    );
+}
+
 /// Phase A: `commits_imported` and `states_created` should both reflect new
 /// state writes for a fresh import.
 #[test]

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1810,6 +1810,79 @@ fn sync_export_and_import_report_consistent_total_and_new() {
     );
 }
 
+/// heddle#289 r2: the export "total" must count only commits that land
+/// in the destination — i.e. states reachable from an exported ref. A
+/// state whose thread was dropped (its ref deleted) is orphaned in the
+/// store; it gets minted into the local mirror but never reaches the
+/// destination's ref graph, so it must NOT inflate `commits_total`.
+#[test]
+fn export_total_excludes_orphaned_unreferenced_states() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_source_temp, source_repo) = init_git_repo();
+
+    let tree_oid = empty_tree_oid(&source_repo);
+    // main: two-commit history → 2 states reachable from the branch tip.
+    let first = commit_with_tree(&source_repo, None, tree_oid, "first", &[]);
+    commit_with_tree(
+        &source_repo,
+        Some("refs/heads/main"),
+        tree_oid,
+        "second",
+        &[first],
+    );
+    // feature: an independent root commit → 1 state reachable only via
+    // this branch, sharing no history with main.
+    commit_with_tree(
+        &source_repo,
+        Some("refs/heads/feature"),
+        tree_oid,
+        "feature-only",
+        &[],
+    );
+
+    let mut bridge = GitBridge::new(&repo);
+    bridge
+        .import(Some(source_repo.workdir().expect("workdir")))
+        .expect("import from git");
+
+    // All three states now exist in the store.
+    assert_eq!(
+        bridge.heddle_repo.store().list_states().expect("states").len(),
+        3,
+        "import should have created three states (two on main, one on feature)"
+    );
+
+    // Drop the feature thread: its ref is gone, so its state is now an
+    // orphan — present in the store, reachable from no exported ref.
+    bridge
+        .heddle_repo
+        .refs()
+        .delete_thread(&ThreadName::new("feature"))
+        .expect("delete feature thread");
+
+    let stats = export_all(&mut bridge).expect("export");
+
+    // Only main's two commits land in the destination; the orphaned
+    // feature state is excluded from the total.
+    assert_eq!(
+        stats.commits_total, 2,
+        "export total must count only ref-reachable commits (main's 2), \
+         not the orphaned feature state, got {}",
+        stats.commits_total
+    );
+    assert!(
+        stats.branches.iter().any(|b| b.name == "main"),
+        "main branch should still be exported: {:?}",
+        stats.branches
+    );
+    assert!(
+        !stats.branches.iter().any(|b| b.name == "feature"),
+        "dropped feature thread must not appear as an exported branch: {:?}",
+        stats.branches
+    );
+}
+
 /// Phase A: `commits_imported` and `states_created` should both reflect new
 /// state writes for a fresh import.
 #[test]

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -23,7 +23,7 @@ use tempfile::TempDir;
 
 use crate::bridge::{
     git_core::{copy_local_repo_to_bare, delete_reference_if_present, set_reference, GitPushScope},
-    git_export::export_tree,
+    git_export::{export_all, export_tree},
     git_import::{import_all, import_git_tree},
     git_sync::{sync_branches, sync_tags, sync_track_to_branch},
     GitBridge,
@@ -1698,6 +1698,116 @@ fn export_to_path_is_idempotent_against_existing_destination() {
     bridge
         .export_to_path(&dest_path)
         .expect("second export against existing dest should not error");
+}
+
+/// heddle#289: in the common git-overlay case every state is already
+/// mapped to an original git commit, so `states_exported` (newly minted)
+/// is legitimately 0 — but `commits_total` must still count the commits
+/// that landed in the destination so the summary doesn't read a
+/// misleading "exported 0 states" against a fully-populated repo.
+#[test]
+fn export_stats_report_total_commits_when_all_states_pre_mapped() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_source_temp, source_repo) = init_git_repo();
+
+    let tree_oid = empty_tree_oid(&source_repo);
+    let first = commit_with_tree(&source_repo, None, tree_oid, "first", &[]);
+    let second = commit_with_tree(
+        &source_repo,
+        Some("refs/heads/main"),
+        tree_oid,
+        "second",
+        &[first],
+    );
+    create_annotated_tag(&source_repo, "v1.0", second, "release");
+
+    let mut bridge = GitBridge::new(&repo);
+    bridge
+        .import(Some(source_repo.workdir().expect("workdir")))
+        .expect("import from git");
+
+    let dest_root = TempDir::new().expect("dest temp");
+    let dest_path = dest_root.path().join("export-target");
+    let stats = bridge.export_to_path(&dest_path).expect("export");
+
+    // Every state came from git with its SHA preserved → nothing is
+    // freshly minted, yet the destination holds both commits.
+    assert_eq!(
+        stats.states_exported, 0,
+        "SHA-stable overlay export mints no new commits"
+    );
+    assert!(
+        stats.commits_total >= 2,
+        "commits_total must count every state that landed in the destination, got {}",
+        stats.commits_total
+    );
+    assert!(
+        stats.commits_total > stats.states_exported,
+        "total must exceed newly-minted in the overlay case"
+    );
+    // AC3: branch/tag detail carries tip SHAs for the summary.
+    assert!(
+        stats.branches.iter().any(|b| b.name == "main"),
+        "branch detail should list main with its tip: {:?}",
+        stats.branches
+    );
+    assert!(
+        stats.tags.iter().any(|t| t.name == "v1.0"),
+        "tag detail should list v1.0 with its tip: {:?}",
+        stats.tags
+    );
+}
+
+/// heddle#289: a sync of an already-synced overlay must report consistent
+/// "total vs. new" accounting on both halves — the export side gains the
+/// same total/new split the import side has carried since heddle#147.
+#[test]
+fn sync_export_and_import_report_consistent_total_and_new() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_source_temp, source_repo) = init_git_repo();
+
+    let tree_oid = empty_tree_oid(&source_repo);
+    let first = commit_with_tree(&source_repo, None, tree_oid, "first", &[]);
+    commit_with_tree(
+        &source_repo,
+        Some("refs/heads/main"),
+        tree_oid,
+        "second",
+        &[first],
+    );
+
+    let mut bridge = GitBridge::new(&repo);
+    bridge
+        .import(Some(source_repo.workdir().expect("workdir")))
+        .expect("import from git");
+
+    // Re-running the sync halves against the already-synced overlay: both
+    // sides should report the total they walked while their "new" count
+    // drops to 0 — the "already in sync" signal.
+    let export_stats = export_all(&mut bridge).expect("re-export");
+    let import_stats =
+        import_all(&mut bridge, Some(source_repo.workdir().expect("workdir"))).expect("re-import");
+
+    assert_eq!(
+        export_stats.states_exported, 0,
+        "nothing new to export on a synced overlay"
+    );
+    assert!(
+        export_stats.commits_total >= 2,
+        "export total still reflects the populated destination: {}",
+        export_stats.commits_total
+    );
+    assert_eq!(
+        import_stats.states_created, 0,
+        "nothing new to import on a synced overlay"
+    );
+    assert!(
+        import_stats.commits_imported >= 2,
+        "import total still reflects the walked commits: {}",
+        import_stats.commits_imported
+    );
 }
 
 /// Phase A: `commits_imported` and `states_created` should both reflect new

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1810,19 +1810,22 @@ fn sync_export_and_import_report_consistent_total_and_new() {
     );
 }
 
-/// heddle#289 r2: the export "total" must count only commits that land
-/// in the destination — i.e. states reachable from an exported ref. A
-/// state whose thread was dropped (its ref deleted) is orphaned in the
-/// store; it gets minted into the local mirror but never reaches the
-/// destination's ref graph, so it must NOT inflate `commits_total`.
+/// heddle#289 r3: the export "total" must equal what actually lands in
+/// the destination. Export does NOT prune stale mirror refs, so a branch
+/// exported once and whose Heddle thread is later dropped still has a
+/// `refs/heads/<branch>` in the mirror — and `copy_mirror_to_path` copies
+/// that ref (and its commit) to the destination. The total is derived from
+/// the same `collect_ref_updates` set the copy uses, so it counts that
+/// still-copied commit. Counting only current Heddle refs (r2) diverged
+/// from reality; this guards that the count == the destination.
 #[test]
-fn export_total_excludes_orphaned_unreferenced_states() {
+fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let (_source_temp, source_repo) = init_git_repo();
 
     let tree_oid = empty_tree_oid(&source_repo);
-    // main: two-commit history → 2 states reachable from the branch tip.
+    // main: two-commit history → 2 commits reachable from the branch tip.
     let first = commit_with_tree(&source_repo, None, tree_oid, "first", &[]);
     commit_with_tree(
         &source_repo,
@@ -1831,9 +1834,9 @@ fn export_total_excludes_orphaned_unreferenced_states() {
         "second",
         &[first],
     );
-    // feature: an independent root commit → 1 state reachable only via
+    // feature: an independent root commit → 1 commit reachable only via
     // this branch, sharing no history with main.
-    commit_with_tree(
+    let feature_tip = commit_with_tree(
         &source_repo,
         Some("refs/heads/feature"),
         tree_oid,
@@ -1846,39 +1849,60 @@ fn export_total_excludes_orphaned_unreferenced_states() {
         .import(Some(source_repo.workdir().expect("workdir")))
         .expect("import from git");
 
-    // All three states now exist in the store.
+    // All three states now exist in the store, and the import populated
+    // the mirror with refs/heads/{main,feature}.
     assert_eq!(
         bridge.heddle_repo.store().list_states().expect("states").len(),
         3,
         "import should have created three states (two on main, one on feature)"
     );
 
-    // Drop the feature thread: its ref is gone, so its state is now an
-    // orphan — present in the store, reachable from no exported ref.
+    // Drop the feature *thread* (Heddle-side ref). Export never prunes the
+    // mirror's refs/heads/feature, so the stale mirror ref — and its
+    // commit — still travel to the destination.
     bridge
         .heddle_repo
         .refs()
         .delete_thread(&ThreadName::new("feature"))
         .expect("delete feature thread");
 
-    let stats = export_all(&mut bridge).expect("export");
+    let dest_temp = TempDir::new().expect("dest temp");
+    let dest_path = dest_temp.path().join("dest.git");
+    let stats = bridge.export_to_path(&dest_path).expect("export to path");
 
-    // Only main's two commits land in the destination; the orphaned
-    // feature state is excluded from the total.
+    // The total counts every commit that lands in the destination: main's
+    // two plus the stale feature ref's one. "What we report" == "what we
+    // copy".
     assert_eq!(
-        stats.commits_total, 2,
-        "export total must count only ref-reachable commits (main's 2), \
-         not the orphaned feature state, got {}",
+        stats.commits_total, 3,
+        "export total must count what lands in the destination — main's 2 \
+         plus the stale feature ref's 1, got {}",
         stats.commits_total
     );
-    assert!(
-        stats.branches.iter().any(|b| b.name == "main"),
-        "main branch should still be exported: {:?}",
-        stats.branches
+
+    // Prove the count matches reality: the destination really does contain
+    // refs/heads/feature at the feature tip.
+    let dest = gix::open(&dest_path).expect("open destination");
+    let feature_ref = dest
+        .find_reference("refs/heads/feature")
+        .expect("destination must contain the stale feature ref");
+    assert_eq!(
+        feature_ref.id().detach(),
+        feature_tip,
+        "the stale feature ref in the destination points at the feature tip"
     );
     assert!(
+        dest.find_reference("refs/heads/main").is_ok(),
+        "destination must contain the main branch"
+    );
+
+    // The dropped thread is not a *current* Heddle thread, so it is not
+    // reported as a synced branch — that gap between `branches` (current
+    // threads) and `commits_total` (what's copied) is exactly what this
+    // fix reconciles for the headline count.
+    assert!(
         !stats.branches.iter().any(|b| b.name == "feature"),
-        "dropped feature thread must not appear as an exported branch: {:?}",
+        "dropped feature thread is not a current synced branch: {:?}",
         stats.branches
     );
 }

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1957,15 +1957,37 @@ fn collect_ref_updates(repo: &gix::Repository) -> GitResult<Vec<RefUpdate>> {
     Ok(updates)
 }
 
-/// Count unique commits reachable from the branch and tag tips that
-/// `collect_ref_updates` writes to a destination. Derived from the SAME
-/// ref set `copy_mirror_to_path` copies, so the reported total equals what
+/// A partition of the commits that land in the destination, computed over
+/// the SINGLE copied ref set. `total` is every unique commit reachable from
+/// the copied branch/tag tips; `newly` is the subset minted during this
+/// export run. `already` is the remainder. Because `newly` is a subset of
+/// the same walk that produced `total`, `newly + already == total` holds by
+/// construction — the summary can never report more "newly written" than
+/// "total", and no orphan/unreferenced state (minted but reachable from no
+/// copied ref, hence never in the walk) can inflate any count.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ExportedCommitCounts {
+    pub total: usize,
+    pub newly: usize,
+}
+
+/// Count and partition the commits reachable from the branch and tag tips
+/// that `collect_ref_updates` writes to a destination. Derived from the SAME
+/// ref set `copy_mirror_to_path` copies, so the reported counts equal what
 /// actually lands in the destination — including stale mirror refs left
 /// behind by a dropped Heddle thread (export does not prune them, so the
 /// commit is still copied and must still be counted; pruning would be a
 /// separate behavior change). Notes refs are excluded: they carry
 /// metadata, not history, so they don't count as exported commits.
-pub(crate) fn count_exported_commits(repo: &gix::Repository) -> GitResult<usize> {
+///
+/// `newly_minted` is the set of git OIDs freshly minted during this export
+/// run; a commit in the walk that is in this set is counted as `newly`, the
+/// rest as `already`. Routing both the total and the newly count through
+/// this single walk guarantees they can never diverge.
+pub(crate) fn count_exported_commits(
+    repo: &gix::Repository,
+    newly_minted: &HashSet<ObjectId>,
+) -> GitResult<ExportedCommitCounts> {
     let tips: Vec<ObjectId> = collect_ref_updates(repo)?
         .into_iter()
         .filter(|update| matches!(update.namespace, RefNamespace::Branch | RefNamespace::Tag))
@@ -1974,7 +1996,7 @@ pub(crate) fn count_exported_commits(repo: &gix::Repository) -> GitResult<usize>
 
     let mut stack = tips;
     let mut seen = HashSet::new();
-    let mut commits = 0usize;
+    let mut counts = ExportedCommitCounts::default();
     while let Some(oid) = stack.pop() {
         if !seen.insert(oid) {
             continue;
@@ -1982,7 +2004,10 @@ pub(crate) fn count_exported_commits(repo: &gix::Repository) -> GitResult<usize>
         let object = repo.find_object(oid).map_err(git_err)?;
         match object.kind {
             gix::objs::Kind::Commit => {
-                commits += 1;
+                counts.total += 1;
+                if newly_minted.contains(&oid) {
+                    counts.newly += 1;
+                }
                 let commit = repo.find_commit(oid).map_err(git_err)?;
                 for parent in commit.parent_ids() {
                     stack.push(parent.detach());
@@ -1998,7 +2023,7 @@ pub(crate) fn count_exported_commits(repo: &gix::Repository) -> GitResult<usize>
             gix::objs::Kind::Tree | gix::objs::Kind::Blob => {}
         }
     }
-    Ok(commits)
+    Ok(counts)
 }
 
 fn collect_ref_updates_for_push(

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1957,6 +1957,50 @@ fn collect_ref_updates(repo: &gix::Repository) -> GitResult<Vec<RefUpdate>> {
     Ok(updates)
 }
 
+/// Count unique commits reachable from the branch and tag tips that
+/// `collect_ref_updates` writes to a destination. Derived from the SAME
+/// ref set `copy_mirror_to_path` copies, so the reported total equals what
+/// actually lands in the destination — including stale mirror refs left
+/// behind by a dropped Heddle thread (export does not prune them, so the
+/// commit is still copied and must still be counted; pruning would be a
+/// separate behavior change). Notes refs are excluded: they carry
+/// metadata, not history, so they don't count as exported commits.
+pub(crate) fn count_exported_commits(repo: &gix::Repository) -> GitResult<usize> {
+    let tips: Vec<ObjectId> = collect_ref_updates(repo)?
+        .into_iter()
+        .filter(|update| matches!(update.namespace, RefNamespace::Branch | RefNamespace::Tag))
+        .map(|update| update.target)
+        .collect();
+
+    let mut stack = tips;
+    let mut seen = HashSet::new();
+    let mut commits = 0usize;
+    while let Some(oid) = stack.pop() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        let object = repo.find_object(oid).map_err(git_err)?;
+        match object.kind {
+            gix::objs::Kind::Commit => {
+                commits += 1;
+                let commit = repo.find_commit(oid).map_err(git_err)?;
+                for parent in commit.parent_ids() {
+                    stack.push(parent.detach());
+                }
+            }
+            // An annotated tag dereferences to its target (commit, or a
+            // blob/tree for the rare blob/tree-pointing tag). Follow it;
+            // only a Commit at the end increments the count.
+            gix::objs::Kind::Tag => {
+                let tag = repo.find_tag(oid).map_err(git_err)?;
+                stack.push(tag.target_id().map_err(git_err)?.detach());
+            }
+            gix::objs::Kind::Tree | gix::objs::Kind::Blob => {}
+        }
+    }
+    Ok(commits)
+}
+
 fn collect_ref_updates_for_push(
     repo: &gix::Repository,
     scope: GitPushScope,

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -202,6 +202,13 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     bridge.mapping.retain_git_objects(&repo);
     bridge.seed_git_checkpoint_mappings_from_checkout(&repo)?;
 
+    // Git OIDs minted during this run. Used below to partition the copied
+    // ref set into newly-written vs already-mapped — so the "newly" count
+    // is a subset of the same walk that produces the total, never a
+    // parallel tally over `list_states()` that could include an orphan
+    // state reachable from no copied ref.
+    let mut newly_minted: HashSet<gix::hash::ObjectId> = HashSet::new();
+
     for state_id in sorted_states {
         // Skip states already mapped to a git object that exists in the
         // mirror — that's the common case for git-imported states whose
@@ -226,7 +233,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
             message_override,
         )?;
         bridge.mapping.insert(state_id, git_oid);
-        stats.states_exported += 1;
+        newly_minted.insert(git_oid);
 
         // Attach a heddle note to the freshly-created commit so the
         // change_id survives a fresh `git clone` of the destination
@@ -295,14 +302,19 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         }
     }
 
-    // Total = unique commits reachable from the mirror's branch/tag tips —
-    // the exact ref set `copy_mirror_to_path` writes to the destination via
-    // `collect_ref_updates`. Deriving the count from the copy path (rather
-    // than a parallel walk over current Heddle refs) structurally
-    // guarantees "what we report" == "what we copy": a stale mirror ref
-    // left by a dropped thread is still copied to the destination, so its
-    // commits are still counted here.
-    stats.commits_total = count_exported_commits(&repo)?;
+    // Every count in the summary is a partition of the SINGLE copied ref
+    // set: `total` is unique commits reachable from the mirror's branch/tag
+    // tips (the exact ref set `copy_mirror_to_path` writes via
+    // `collect_ref_updates`), and `states_exported` ("newly") is the subset
+    // of THAT walk minted this run. Deriving both from one walk — rather
+    // than tallying `states_exported` inline over `list_states()` — makes
+    // `newly + already == total` hold by construction: a state minted into
+    // the mirror but reachable from no copied ref (e.g. a dropped thread's
+    // orphan history) is in neither count, so the impossible
+    // "1 total (2 newly written)" summary cannot occur.
+    let counts = count_exported_commits(&repo, &newly_minted)?;
+    stats.commits_total = counts.total;
+    stats.states_exported = counts.newly;
 
     bridge.save_mapping_to_disk()?;
 

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -13,7 +13,8 @@ use repo::Repository as HeddleRepository;
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, LocalGitIdentity, SyncMapping,
-        git_config_identity_with_global_fallback, git_err, principal_is_default_unknown,
+        count_exported_commits, git_config_identity_with_global_fallback, git_err,
+        principal_is_default_unknown,
     },
     git_notes,
     git_sync::{sync_marker_to_tag, sync_track_to_branch},
@@ -265,13 +266,6 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                 .collect()
         }
     };
-    // State ids at the tip of every ref actually written to the
-    // destination. The export "total" is the count of states reachable
-    // from these tips — i.e. the commits that land in the destination's
-    // ref graph. States with no surviving ref (e.g. a dropped thread's
-    // orphaned history) are minted into the local mirror but never reach
-    // the destination, so they must not inflate the headline total.
-    let mut exported_ref_tips: Vec<ChangeId> = Vec::new();
     for track_name in threads {
         if let Some(state_id) = bridge.heddle_repo.refs().get_thread(&ThreadName::new(&track_name))?
             && let Some(git_oid) = bridge.mapping.get_git(&state_id)
@@ -282,7 +276,6 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                 name: track_name.clone(),
                 tip: git_oid,
             });
-            exported_ref_tips.push(state_id);
         }
     }
 
@@ -298,15 +291,18 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                     name: marker_name.to_string(),
                     tip: git_oid,
                 });
-                exported_ref_tips.push(state_id);
             }
         }
     }
 
-    // Total = unique states reachable from the exported ref tips. This is
-    // exactly what lands in the destination (newly-minted + already-mapped
-    // commits under an exported branch/tag); orphaned states are excluded.
-    stats.commits_total = reachable_states(bridge.heddle_repo, &exported_ref_tips)?.len();
+    // Total = unique commits reachable from the mirror's branch/tag tips —
+    // the exact ref set `copy_mirror_to_path` writes to the destination via
+    // `collect_ref_updates`. Deriving the count from the copy path (rather
+    // than a parallel walk over current Heddle refs) structurally
+    // guarantees "what we report" == "what we copy": a stale mirror ref
+    // left by a dropped thread is still copied to the destination, so its
+    // commits are still counted here.
+    stats.commits_total = count_exported_commits(&repo)?;
 
     bridge.save_mapping_to_disk()?;
 

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -207,10 +207,9 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         // original commit bytes are already present (and whose SHAs we
         // want to preserve verbatim, which means NOT recreating them).
         if bridge.mapping.has_heddle(&state_id) {
-            // Already mapped to an existing commit — it still lands in
-            // the destination, so it counts toward the total even though
-            // nothing is minted here.
-            stats.commits_total += 1;
+            // Already mapped to an existing commit — nothing to mint.
+            // Whether it counts toward the total is decided below by
+            // ref-reachability, not by membership in the walked set.
             continue;
         }
         let message_override = bridge
@@ -227,7 +226,6 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         )?;
         bridge.mapping.insert(state_id, git_oid);
         stats.states_exported += 1;
-        stats.commits_total += 1;
 
         // Attach a heddle note to the freshly-created commit so the
         // change_id survives a fresh `git clone` of the destination
@@ -267,6 +265,13 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                 .collect()
         }
     };
+    // State ids at the tip of every ref actually written to the
+    // destination. The export "total" is the count of states reachable
+    // from these tips — i.e. the commits that land in the destination's
+    // ref graph. States with no surviving ref (e.g. a dropped thread's
+    // orphaned history) are minted into the local mirror but never reach
+    // the destination, so they must not inflate the headline total.
+    let mut exported_ref_tips: Vec<ChangeId> = Vec::new();
     for track_name in threads {
         if let Some(state_id) = bridge.heddle_repo.refs().get_thread(&ThreadName::new(&track_name))?
             && let Some(git_oid) = bridge.mapping.get_git(&state_id)
@@ -277,6 +282,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                 name: track_name.clone(),
                 tip: git_oid,
             });
+            exported_ref_tips.push(state_id);
         }
     }
 
@@ -292,9 +298,15 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                     name: marker_name.to_string(),
                     tip: git_oid,
                 });
+                exported_ref_tips.push(state_id);
             }
         }
     }
+
+    // Total = unique states reachable from the exported ref tips. This is
+    // exactly what lands in the destination (newly-minted + already-mapped
+    // commits under an exported branch/tag); orphaned states are excluded.
+    stats.commits_total = reachable_states(bridge.heddle_repo, &exported_ref_tips)?.len();
 
     bridge.save_mapping_to_disk()?;
 

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -17,7 +17,7 @@ use crate::bridge::{
     },
     git_notes,
     git_sync::{sync_marker_to_tag, sync_track_to_branch},
-    git_util::ExportStats,
+    git_util::{ExportStats, ExportedRef},
 };
 
 const SUBMODULE_PREFIX: &str = "heddle-submodule:";
@@ -207,6 +207,10 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         // original commit bytes are already present (and whose SHAs we
         // want to preserve verbatim, which means NOT recreating them).
         if bridge.mapping.has_heddle(&state_id) {
+            // Already mapped to an existing commit — it still lands in
+            // the destination, so it counts toward the total even though
+            // nothing is minted here.
+            stats.commits_total += 1;
             continue;
         }
         let message_override = bridge
@@ -223,6 +227,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         )?;
         bridge.mapping.insert(state_id, git_oid);
         stats.states_exported += 1;
+        stats.commits_total += 1;
 
         // Attach a heddle note to the freshly-created commit so the
         // change_id survives a fresh `git clone` of the destination
@@ -268,6 +273,10 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         {
             sync_track_to_branch(&repo, &track_name, git_oid)?;
             stats.threads_synced += 1;
+            stats.branches.push(ExportedRef {
+                name: track_name.clone(),
+                tip: git_oid,
+            });
         }
     }
 
@@ -279,6 +288,10 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
             {
                 sync_marker_to_tag(&repo, &marker_name, git_oid)?;
                 stats.markers_synced += 1;
+                stats.tags.push(ExportedRef {
+                    name: marker_name.to_string(),
+                    tip: git_oid,
+                });
             }
         }
     }

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -137,24 +137,29 @@ impl<'a> GitBridge<'a> {
 
 /// Statistics for export operation.
 ///
-/// `commits_total` counts every heddle state that lands in the
-/// destination as a git commit — both freshly-minted commits and states
-/// already mapped to an existing commit (the common git-overlay case,
-/// where `heddle commit` wrote the checkpoint inline). `states_exported`
-/// counts only the freshly-minted subset. They diverge whenever the
-/// destination is already populated: an overlay re-export reports
-/// `commits_total = N` and `states_exported = 0` — the signal that
-/// surfaces "already in sync" instead of a misleading bare
-/// "exported 0 states" (heddle#289, mirroring the import-side
-/// `commits_imported`/`states_created` split from heddle#147).
+/// `commits_total` counts the commits that actually land in the
+/// destination: it is derived from the same branch/tag ref set
+/// (`collect_ref_updates`) that `copy_mirror_to_path` copies, by walking
+/// the commit ancestry of those tips. Counting from the copy path — rather
+/// than a parallel walk over current Heddle refs — guarantees the reported
+/// total equals what's copied, including a stale mirror ref left behind by
+/// a dropped thread (export does not prune mirror refs, so that commit
+/// still travels and is still counted). `states_exported` counts only the
+/// freshly-minted subset. They diverge whenever the destination is already
+/// populated: an overlay re-export reports `commits_total = N` and
+/// `states_exported = 0` — the signal that surfaces "already in sync"
+/// instead of a misleading bare "exported 0 states" (heddle#289, mirroring
+/// the import-side `commits_imported`/`states_created` split from
+/// heddle#147).
 #[derive(Debug, Default)]
 pub struct ExportStats {
     /// Freshly-minted git commits (heddle-native states with no
     /// preserved git_oid). Stays at 0 when every state was already
     /// mapped to an existing commit.
     pub states_exported: usize,
-    /// Every state that maps to a commit present in the destination,
-    /// including ones whose commit already existed. Mirrors
+    /// Unique commits reachable from the branch/tag tips copied to the
+    /// destination, including ones whose commit already existed and any
+    /// carried by a stale mirror ref. Mirrors
     /// [`ImportStats::commits_imported`].
     pub commits_total: usize,
     pub threads_synced: usize,

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -136,11 +136,42 @@ impl<'a> GitBridge<'a> {
 }
 
 /// Statistics for export operation.
+///
+/// `commits_total` counts every heddle state that lands in the
+/// destination as a git commit — both freshly-minted commits and states
+/// already mapped to an existing commit (the common git-overlay case,
+/// where `heddle commit` wrote the checkpoint inline). `states_exported`
+/// counts only the freshly-minted subset. They diverge whenever the
+/// destination is already populated: an overlay re-export reports
+/// `commits_total = N` and `states_exported = 0` — the signal that
+/// surfaces "already in sync" instead of a misleading bare
+/// "exported 0 states" (heddle#289, mirroring the import-side
+/// `commits_imported`/`states_created` split from heddle#147).
 #[derive(Debug, Default)]
 pub struct ExportStats {
+    /// Freshly-minted git commits (heddle-native states with no
+    /// preserved git_oid). Stays at 0 when every state was already
+    /// mapped to an existing commit.
     pub states_exported: usize,
+    /// Every state that maps to a commit present in the destination,
+    /// including ones whose commit already existed. Mirrors
+    /// [`ImportStats::commits_imported`].
+    pub commits_total: usize,
     pub threads_synced: usize,
     pub markers_synced: usize,
+    /// Branches written to the destination, paired with their tip
+    /// commit so the summary can show tip short-SHAs.
+    pub branches: Vec<ExportedRef>,
+    /// Tags written to the destination, paired with their tip commit.
+    pub tags: Vec<ExportedRef>,
+}
+
+/// A ref written to the export destination, paired with the commit it
+/// points at (so the export summary can render tip short-SHAs).
+#[derive(Debug, Clone)]
+pub struct ExportedRef {
+    pub name: String,
+    pub tip: gix::hash::ObjectId,
 }
 
 /// Statistics for import operation.

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -144,18 +144,23 @@ impl<'a> GitBridge<'a> {
 /// than a parallel walk over current Heddle refs — guarantees the reported
 /// total equals what's copied, including a stale mirror ref left behind by
 /// a dropped thread (export does not prune mirror refs, so that commit
-/// still travels and is still counted). `states_exported` counts only the
-/// freshly-minted subset. They diverge whenever the destination is already
-/// populated: an overlay re-export reports `commits_total = N` and
-/// `states_exported = 0` — the signal that surfaces "already in sync"
-/// instead of a misleading bare "exported 0 states" (heddle#289, mirroring
-/// the import-side `commits_imported`/`states_created` split from
-/// heddle#147).
+/// still travels and is still counted). `states_exported` is the
+/// freshly-minted *subset of that same copied ref set* — both counts are
+/// partitions of one walk, so `states_exported + already == commits_total`
+/// holds by construction and a state minted into the mirror but reachable
+/// from no copied ref (an orphan dropped-thread history) inflates neither.
+/// They diverge whenever the destination is already populated: an overlay
+/// re-export reports `commits_total = N` and `states_exported = 0` — the
+/// signal that surfaces "already in sync" instead of a misleading bare
+/// "exported 0 states" (heddle#289, mirroring the import-side
+/// `commits_imported`/`states_created` split from heddle#147).
 #[derive(Debug, Default)]
 pub struct ExportStats {
-    /// Freshly-minted git commits (heddle-native states with no
-    /// preserved git_oid). Stays at 0 when every state was already
-    /// mapped to an existing commit.
+    /// Freshly-minted git commits that land in the destination — the
+    /// subset of the copied ref set's commits minted during this export
+    /// (no preserved git_oid). Stays at 0 when every copied commit was
+    /// already mapped to an existing commit. A minted commit reachable
+    /// from no copied ref is excluded (it never reaches the destination).
     pub states_exported: usize,
     /// Unique commits reachable from the branch/tag tips copied to the
     /// destination, including ones whose commit already existed and any

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -30,6 +30,7 @@ use crate::{
         git_core::clone_url_to_bare,
         git_export::export_all,
         git_import::{import_all, import_selected_refs},
+        git_util::ExportedRef,
         GitBridge,
     },
     cli::{cli_args::GitSource, should_output_json, style, Cli, GitCommands},
@@ -257,6 +258,7 @@ struct BridgeGitSyncOutput {
     action: &'static str,
     summary: String,
     states_exported: usize,
+    commits_exported_total: usize,
     commits_imported: usize,
     threads_synced: usize,
     markers_synced: usize,
@@ -269,6 +271,58 @@ struct BridgeGitSyncOutput {
     #[serde(skip_serializing)]
     #[serde(rename = "verification")]
     trust: RepositoryVerificationState,
+}
+
+/// Render the `commits:` line for an export/sync summary: the total
+/// commits written to the destination, broken down into newly-minted vs.
+/// already-present. In the common git-overlay case `newly` is 0 and this
+/// reads "N total (already in sync)" rather than a misleading bare 0.
+fn export_commits_summary(total: usize, newly: usize) -> String {
+    let already = total.saturating_sub(newly);
+    let breakdown = if total == 0 {
+        String::new()
+    } else if newly == 0 {
+        format!(" ({})", style::accent("already in sync"))
+    } else if already == 0 {
+        format!(" ({} newly written)", style::bold(&newly.to_string()))
+    } else {
+        format!(
+            " ({} newly written, {} already in sync)",
+            style::bold(&newly.to_string()),
+            style::bold(&already.to_string())
+        )
+    };
+    format!("{} total{}", style::bold(&total.to_string()), breakdown)
+}
+
+/// Render a `branches:`/`tags:` line: the count, then each ref name with
+/// its tip short-SHA, e.g. `3   main af25b9d · spike-ok 7f1002c`.
+fn exported_refs_summary(refs: &[ExportedRef]) -> String {
+    let count = style::bold(&refs.len().to_string());
+    if refs.is_empty() {
+        return count;
+    }
+    let listing = refs
+        .iter()
+        .map(|r| {
+            format!(
+                "{} {}",
+                r.name,
+                style::dim(&r.tip.to_hex_with_len(7).to_string())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" · ");
+    format!("{count}   {listing}")
+}
+
+/// JSON projection of exported refs: `[{"name":..,"tip":<full sha>}]`.
+fn exported_refs_json(refs: &[ExportedRef]) -> serde_json::Value {
+    serde_json::Value::Array(
+        refs.iter()
+            .map(|r| serde_json::json!({ "name": r.name, "tip": r.tip.to_string() }))
+            .collect(),
+    )
 }
 
 fn cmd_bridge_git_status(cli: &Cli, repo: &Repository) -> Result<()> {
@@ -603,37 +657,34 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
             if should_output_json(cli, Some(repo.config())) {
                 let out = serde_json::json!({
                     "states_exported": stats.states_exported,
+                    "commits_total": stats.commits_total,
                     "threads_synced": stats.threads_synced,
                     "markers_synced": stats.markers_synced,
+                    "branches": exported_refs_json(&stats.branches),
+                    "tags": exported_refs_json(&stats.tags),
                     "destination": destination.display().to_string(),
                 });
                 println!("{out}");
             } else {
                 println!(
-                    "{} exported {} to {}",
+                    "{} exported to {}",
                     style::ok_marker(),
-                    style::count(stats.states_exported, "state"),
                     style::dim(&destination.display().to_string())
                 );
                 println!(
                     "  {}",
                     style::field(
-                        "threads",
-                        &format!(
-                            "{} synced to branches",
-                            style::bold(&stats.threads_synced.to_string())
-                        )
+                        "commits",
+                        &export_commits_summary(stats.commits_total, stats.states_exported)
                     )
                 );
                 println!(
                     "  {}",
-                    style::field(
-                        "markers",
-                        &format!(
-                            "{} synced to tags",
-                            style::bold(&stats.markers_synced.to_string())
-                        )
-                    )
+                    style::field("branches", &exported_refs_summary(&stats.branches))
+                );
+                println!(
+                    "  {}",
+                    style::field("tags", &exported_refs_summary(&stats.tags))
                 );
             }
         }
@@ -760,6 +811,7 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
                     )
                 },
                 states_exported: export_stats.states_exported,
+                commits_exported_total: export_stats.commits_total,
                 commits_imported: sync_commits_imported,
                 threads_synced,
                 markers_synced,
@@ -778,7 +830,10 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
                     "  {}",
                     style::field(
                         "exported",
-                        &style::count(sync_output.states_exported, "state")
+                        &export_commits_summary(
+                            sync_output.commits_exported_total,
+                            sync_output.states_exported
+                        )
                     )
                 );
                 println!(

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2517,10 +2517,19 @@ pub struct BridgeInitSchema {
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
+pub struct ExportedRefSchema {
+    pub name: String,
+    pub tip: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct BridgeExportSchema {
     pub states_exported: u64,
+    pub commits_total: u64,
     pub threads_synced: u64,
     pub markers_synced: u64,
+    pub branches: Vec<ExportedRefSchema>,
+    pub tags: Vec<ExportedRefSchema>,
     pub destination: String,
 }
 
@@ -2551,6 +2560,7 @@ pub struct BridgeSyncSchema {
     pub action: Option<String>,
     pub summary: String,
     pub states_exported: u64,
+    pub commits_exported_total: u64,
     pub commits_imported: u64,
     pub threads_synced: u64,
     pub markers_synced: u64,


### PR DESCRIPTION
## Summary
- `ExportStats` gains `commits_total` (every state that lands in the destination as a git commit) alongside `states_exported` (only the freshly-minted subset), mirroring the import-side `commits_imported`/`states_created` split shipped in heddle#147.
- The `export` summary no longer headlines a misleading bare "exported 0 states" against a populated destination. It reports total commits with a `newly written` / `already in sync` breakdown, and lists branches/tags with their tip short-SHAs.
- `bridge git sync`'s `exported:` line uses the same total+new accounting that its `imported:` line already uses.
- JSON output is **additive**: export adds `commits_total`, `branches[]`, `tags[]`; sync adds `commits_exported_total`. No keys removed or renamed. Schemas (`BridgeExportSchema`, `BridgeSyncSchema`) updated to match.

Closes HeddleCo/heddle#289

## Red commit
`62e0ad9` — `export_stats_report_total_commits_when_all_states_pre_mapped` + `sync_export_and_import_report_consistent_total_and_new` fail to compile against the old `ExportStats` (no `commits_total`/`branches`/`tags`).

## Before / after

**Before** (per issue body — bug):
```text
[ok] exported 1 state to /tmp/heddle-demo-export2
  threads: 3 synced to branches
  markers: 0 synced to tags
```
(and "exported 0 states" once every state is already mapped.)

**After — `export`** (fresh dest, states pre-mapped via SHA-stable import):
```text
[ok] exported to /tmp/.../dest1
  commits: 4 total (1 newly written, 3 already in sync)
  branches: 2   add-validation 67184e9 · main af61a39
  tags: 1   v1.0 67184e9
```
```json
{"branches":[{"name":"add-validation","tip":"67184e90..."},{"name":"main","tip":"af61a391..."}],"commits_total":4,"destination":".../dest1","markers_synced":1,"states_exported":0,"tags":[{"name":"v1.0","tip":"67184e90..."}],"threads_synced":2}
```

**After — `sync`** (already in sync):
```text
[ok] synced Git overlay
  exported: 4 total (already in sync)
  imported: 0 commits
  threads: 4 synced with branches
  markers: 2 synced with tags
```
```json
{"output_kind":"bridge_git_sync",...,"states_exported":0,"commits_exported_total":4,"commits_imported":0,"threads_synced":4,"markers_synced":2,...}
```

## Test evidence
```
test bridge::git_bridge_tests::export_stats_report_total_commits_when_all_states_pre_mapped ... ok
test bridge::git_bridge_tests::sync_export_and_import_report_consistent_total_and_new ... ok
test result: ok. 48 passed; 0 failed (bridge lib suite)

cli_integration: 659 passed; 0 failed; 15 ignored
doctor_schemas_has_no_drift_or_unmatched_registered_verbs ... ok
git_replacement_matrix: 32 passed
cargo clippy --workspace --all-targets -- -D warnings: clean
bash scripts/check-no-silent-default-tree-load.sh: clean
```

## Manual verification
N/A — covered by tests; before/after CLI output captured above from a real `heddle` binary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782595818&installation_id=132405951&pr_number=292&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F292&signature=312eb7ee2cc346aaa44aa6fa358787a1e89afdb53fb86fb67c37dfb771a81a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 2 (Codex r2 — cid 3320799467)
- Scoped the export `commits_total` to **ref-reachable** commits: it now counts the unique states reachable from refs actually written to the destination (exported branches + tags), not every walked state.
- Orphaned states (dropped-thread / deleted-ref history that mints into the local mirror but never lands in the destination ref graph) are excluded; `states_exported` (newly-minted) is unchanged.
- Added regression test `export_total_excludes_orphaned_unreferenced_states` (drops a feature thread, asserts its state is not counted). Fixed in `4cd58dc`.

## Round 3 (Codex cid 3321102175)
Export total no longer diverges from what's copied. `commits_total` is now derived from the same `collect_ref_updates()` ref set `copy_mirror_to_path()` writes (new `count_exported_commits()` walks the commit ancestry of the mirror's branch/tag tips), so "what we report" == "what we copy" structurally. A stale mirror ref left by a dropped thread is still copied to the destination, so its commit is now counted. Test rewritten to assert the post-thread-drop total is 3 and that the destination actually contains `refs/heads/feature`. Stale-mirror-ref pruning is a separate behavior change, out of scope.


## Round 4 (Codex cid 3321963343)
Close-the-class: r3 derived `commits_total` from the copied ref set but left the "newly" count (`states_exported`) tallied inline over `list_states()` during the mint loop — so a Heddle-native thread created and dropped before export was still minted and counted as newly-written despite landing in no destination ref, producing the impossible `1 total (2 newly written)` summary. Every summary count is now a partition of the **single** `count_exported_commits()` walk over the copied branch/tag tips: it takes the set of OIDs minted this run and returns `{ total, newly }`, with `already = total - newly`. `newly` is a subset of the same walk that produces `total`, so `newly + already == total` holds by construction and an orphan state (minted but reachable from no copied ref) inflates no count. No summary number reads from `list_states()` anymore. Test `export_counts_exclude_orphan_minted_state_from_total_and_newly` asserts the orphan is excluded from BOTH counts and `newly <= total`. Fixed in `9e7da5e`.
