### PR TITLE
heddle#283: genericize Repository over ObjectStore via AnyStore enum (Phase 2)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -26,18 +26,22 @@ tests/             # integration and property tests
 ### 1. Repository as Central Coordinator
 
 ```rust
-pub struct Repository {
+pub struct Repository<R = RefManager, O = OpLog, S = AnyStore> {
     root: PathBuf,             // working directory (checkout root)
     heddle_dir: PathBuf,         // shared .heddle directory (may differ from root/.heddle in agent checkouts)
-    store: Box<dyn ObjectStore>, // filesystem or S3 backend
-    refs: RefManager,          // threads, markers, HEAD (HEAD may be per-checkout)
-    oplog: OpLog,
+    store: S,                  // object store backend; AnyStore = FsStore | S3Store (static dispatch)
+    refs: R,                   // threads, markers, HEAD (HEAD may be per-checkout)
+    oplog: O,
     config: Config,
     shallow: ShallowInfo,
 }
 ```
 
 The Repository type coordinates between all subsystems. Most operations use it as the primary interface.
+The backends are type parameters (heddle#259 / #283) so the CLI monomorphizes to the on-disk
+local flavor — the bare name `Repository` resolves to `Repository<RefManager, OpLog, AnyStore>` — while
+the hosted server can swap in Postgres-backed ref/oplog backends. `AnyStore` is an enum over the
+concrete object stores, so the `FsStore`-vs-`S3Store` choice stays a runtime decision without a vtable.
 
 In a standard repo `heddle_dir == root/.heddle`. In an agent checkout `root` is the checkout
 directory and `heddle_dir` is the *shared* `.heddle` from the main repo — both are set by

--- a/crates/cli/src/bench.rs
+++ b/crates/cli/src/bench.rs
@@ -25,7 +25,7 @@ pub fn three_way_merge_for_bench(
 }
 
 pub fn detect_renames_for_bench(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_tree: &Tree,
     branch_tree: &Tree,
 ) -> anyhow::Result<(usize, usize, usize)> {

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Export Heddle states to Git commits functionality.
 
+use objects::store::ObjectStore;
 use std::collections::HashSet;
 
 use gix::bstr::ByteSlice;

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git commits into Heddle states functionality.
 
+use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use chrono::{TimeZone, Utc};

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git trees as Heddle trees.
 
+use objects::store::ObjectStore;
 use std::collections::HashMap;
 
 use objects::object::{Blob, ContentHash, FileMode, Tree, TreeEntry};

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stable JSON-first agent reservation API.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 use objects::object::ThreadName;

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Blame command - show line-by-line attribution for files.
 
+use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -12,6 +12,7 @@
 //! to match main's `pub use checkpoint::run as cmd_checkpoint;`
 //! convention.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::ThreadName;
 use oplog::OpRecord;

--- a/crates/cli/src/cli/commands/cherry_pick.rs
+++ b/crates/cli/src/cli/commands/cherry_pick.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Cherry-pick command - apply specific commits.
 
+use objects::store::ObjectStore;
 use anyhow::Result;
 use objects::object::Attribution;
 use repo::Repository;

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Clone command - clone from remote.
 
+use objects::store::ObjectStore;
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Collapse command: squash multiple states into one.
 
+use objects::store::ObjectStore;
 use std::time::Instant;
 
 use anyhow::Result;

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -7,6 +7,7 @@
 //! active merge first so the command users see during recovery is the same
 //! command that can show the conflict they just listed.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Context, Result};

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -4,6 +4,7 @@
 mod context_mutate;
 mod context_query;
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 pub use context_mutate::*;
 pub use context_query::*;

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Core diff command logic.
 
+use objects::store::ObjectStore;
 use std::collections::BTreeSet;
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -2,6 +2,8 @@
 //! Fetch command - download objects and refs from remote.
 
 #[cfg(feature = "client")]
+use objects::store::ObjectStore;
+#[cfg(feature = "client")]
 use std::collections::HashSet;
 
 #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Fork command: create exploration branch.
 
+use objects::store::ObjectStore;
 use anyhow::Result;
 use objects::object::{State, ThreadName};
 use refs::{Head, RefExpectation, RefUpdate};

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Fsck command - verify repository integrity.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use repo::Repository;
 use serde::Serialize;

--- a/crates/cli/src/cli/commands/fsck_checks/objects.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/objects.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::collections::HashSet;
 
 use anyhow::Result;

--- a/crates/cli/src/cli/commands/fsck_checks/refs.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/refs.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use anyhow::Result;
 use objects::object::ContentHash;
 use repo::Repository;

--- a/crates/cli/src/cli/commands/fsck_checks/state.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/state.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{
     collections::{HashMap, HashSet},
     path::Path,

--- a/crates/cli/src/cli/commands/fsck_checks/tests.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/tests.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use crypto::{Ed25519Signer, StateSigningExt};
 use objects::object::{
     Attribution, Blob, FileProvenance, LineSpan, Origin, OriginSet, Principal, State, Tree,

--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -11,6 +11,7 @@
 //! pass. We report the pinned count so the audit trail in `heddle gc`
 //! output makes the invariant visible to operators.
 
+use objects::store::ObjectStore;
 use anyhow::Result;
 use repo::Repository;
 use serde::Serialize;

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Git-muscle-memory compatibility shims.
 
+use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,

--- a/crates/cli/src/cli/commands/history_target.rs
+++ b/crates/cli/src/cli/commands/history_target.rs
@@ -23,6 +23,7 @@
 //! [`resolve_state_id_bytes`] when you need the wire-form 16-byte
 //! representation (e.g. when handing it to a gRPC service stub).
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::{
     error::HeddleError,

--- a/crates/cli/src/cli/commands/marker.rs
+++ b/crates/cli/src/cli/commands/marker.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Marker commands.
 
+use objects::store::ObjectStore;
 use anyhow::{anyhow, Result};
 use objects::object::MarkerName;
 use repo::Repository;

--- a/crates/cli/src/cli/commands/merge/git_commit.rs
+++ b/crates/cli/src/cli/commands/merge/git_commit.rs
@@ -7,6 +7,7 @@
 //! merge introduced. The default (`--git-commit` not set) is preserved
 //! — heddle state advances and git is unaware.
 
+use objects::store::ObjectStore;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/cli/src/cli/commands/merge/merge_algo/apply.rs
+++ b/crates/cli/src/cli/commands/merge/merge_algo/apply.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{collections::HashMap, fs, path::Path};
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
+++ b/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
@@ -82,7 +82,7 @@ pub(super) fn merge_without_renames(
 }
 
 fn apply_renames(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     active_renames: &HashMap<String, crate::cli::commands::merge::rename_matcher::RenameMatch>,
     opposing_renames: &HashMap<String, crate::cli::commands::merge::rename_matcher::RenameMatch>,
     opposing_flat: &HashMap<String, (ContentHash, objects::object::EntryType)>,
@@ -141,7 +141,7 @@ fn apply_renames(
 }
 
 fn merge_remaining_paths(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_flat: &HashMap<String, (ContentHash, objects::object::EntryType)>,
     our_flat: &HashMap<String, (ContentHash, objects::object::EntryType)>,
     their_flat: &HashMap<String, (ContentHash, objects::object::EntryType)>,
@@ -213,7 +213,7 @@ fn merge_remaining_paths(
 }
 
 fn three_way_content_merge(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_hash: &ContentHash,
     our_hash: &ContentHash,
     their_hash: &ContentHash,
@@ -237,7 +237,7 @@ fn three_way_content_merge(
 }
 
 fn text_hunk_merge_blobs(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_hash: &ContentHash,
     our_hash: &ContentHash,
     their_hash: &ContentHash,
@@ -314,7 +314,7 @@ fn text_hunk_merge_blobs(
 /// causes the merger to silently produce a result where the other side
 /// "wins" with no markers, committing a merge that loses data. Bail loudly
 /// so the user sees the corruption instead of inheriting a silent rewrite.
-fn load_blob_content(store: &dyn ObjectStore, hash: &ContentHash, path: &str) -> Result<Vec<u8>> {
+fn load_blob_content(store: &impl ObjectStore, hash: &ContentHash, path: &str) -> Result<Vec<u8>> {
     let blob = store.get_blob(hash)?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::merge_integrity_refusal(
             "merge input blob {hash} for path {path:?} is missing from the object store; \
@@ -339,7 +339,7 @@ fn load_blob_content(store: &dyn ObjectStore, hash: &ContentHash, path: &str) ->
 /// `label` is folded into the error message so the operator can locate
 /// the corrupt entry — typically the recursive-merge path or the
 /// merge-side entry name.
-fn require_subtree(store: &dyn ObjectStore, hash: &ContentHash, label: &str) -> Result<Tree> {
+fn require_subtree(store: &impl ObjectStore, hash: &ContentHash, label: &str) -> Result<Tree> {
     store.get_tree(hash)?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::merge_integrity_refusal(
             "merge input subtree {hash} for {label} is missing from the object store; \
@@ -352,7 +352,7 @@ fn require_subtree(store: &dyn ObjectStore, hash: &ContentHash, label: &str) -> 
 }
 
 fn content_conflict_merge(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     our_hash: &ContentHash,
     their_hash: &ContentHash,
     path: &str,
@@ -372,7 +372,7 @@ fn content_conflict_merge(
 }
 
 fn modify_delete_conflict_merge(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     kept_hash: &ContentHash,
     path: &str,
     conflicts: &mut Vec<String>,
@@ -414,7 +414,7 @@ fn format_conflict_content(
     .into_bytes()
 }
 
-fn build_nested_tree(store: &dyn ObjectStore, flat: &HashMap<String, ContentHash>) -> Result<Tree> {
+fn build_nested_tree(store: &impl ObjectStore, flat: &HashMap<String, ContentHash>) -> Result<Tree> {
     let mut top_files = Vec::new();
     let mut subdirs: HashMap<String, HashMap<String, ContentHash>> = HashMap::new();
 

--- a/crates/cli/src/cli/commands/merge/merge_plan.rs
+++ b/crates/cli/src/cli/commands/merge/merge_plan.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared merge planning seam for preview and apply flows.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::ChangeId;
 use repo::{CommitGraphIndex, Repository};

--- a/crates/cli/src/cli/commands/merge/merge_renames/mod.rs
+++ b/crates/cli/src/cli/commands/merge/merge_renames/mod.rs
@@ -25,7 +25,7 @@ pub(super) struct MergeRenameMap {
 }
 
 pub(super) fn detect_merge_renames(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_tree: &Tree,
     our_tree: &Tree,
     their_tree: &Tree,

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -1673,7 +1673,7 @@ pub(crate) fn bench_three_way_merge(
 }
 
 pub(crate) fn bench_detect_renames(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base_tree: &Tree,
     branch_tree: &Tree,
 ) -> Result<(usize, rename_matcher::RenameMatcherStats)> {

--- a/crates/cli/src/cli/commands/merge/rename_matcher.rs
+++ b/crates/cli/src/cli/commands/merge/rename_matcher.rs
@@ -92,7 +92,7 @@ struct AddedIndex<'a> {
     sorted_by_size: Vec<usize>,
 }
 
-pub(crate) fn flatten_tree(store: &dyn ObjectStore, tree: &Tree, prefix: &str) -> Result<FlatTree> {
+pub(crate) fn flatten_tree(store: &impl ObjectStore, tree: &Tree, prefix: &str) -> Result<FlatTree> {
     let mut result = HashMap::new();
 
     for entry in tree.entries() {
@@ -118,7 +118,7 @@ pub(crate) fn flatten_tree(store: &dyn ObjectStore, tree: &Tree, prefix: &str) -
 }
 
 pub(crate) fn detect_renames(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base: &FlatTree,
     branch: &FlatTree,
     config: RenameMatcherConfig,
@@ -127,7 +127,7 @@ pub(crate) fn detect_renames(
 }
 
 pub(crate) fn detect_renames_with_stats(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     base: &FlatTree,
     branch: &FlatTree,
     config: RenameMatcherConfig,
@@ -337,7 +337,7 @@ fn match_exact_hashes(
 }
 
 fn load_candidate_files<'a>(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     entries: &[(usize, &'a str, &ContentHash)],
     load_content: bool,
     stats: &mut RenameMatcherStats,
@@ -367,7 +367,7 @@ fn load_candidate_files<'a>(
 }
 
 fn build_added_index<'a>(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     entries: &[(usize, &'a str, &ContentHash)],
     load_content: bool,
     stats: &mut RenameMatcherStats,

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{collections::BTreeSet, path::Path};
 
 use anyhow::Result;

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase command - replay commits onto another thread.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase operation execution — applying commits onto a new base.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase state persistence and commit-graph traversal.
 
+use objects::store::ObjectStore;
 use std::{fs, io::Write};
 
 use anyhow::{anyhow, Result};

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -15,6 +15,7 @@
 //! path) so a leaked secret is scrubbed everywhere it appears — across
 //! renames, copies, and parallel branches.
 
+use objects::store::ObjectStore;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pull, remote management, and serve commands.
 
+use objects::store::ObjectStore;
 #[cfg(feature = "client")]
 use std::net::SocketAddr;
 use std::{collections::BTreeMap, fs, path::Path};

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Resolve command implementation.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -17,6 +17,7 @@
 //! intentionally biases toward "what happened in this turn" rather than
 //! a long backlog, because retros surface most often at end-of-turn.
 
+use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use anyhow::{Context, Result};

--- a/crates/cli/src/cli/commands/stash.rs
+++ b/crates/cli/src/cli/commands/stash.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stash command implementation.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::ContentHash;
 use repo::{DiffKind, Repository};

--- a/crates/cli/src/cli/commands/stash_ops.rs
+++ b/crates/cli/src/cli/commands/stash_ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stash worktree helper operations.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread commands.
 
+use objects::store::ObjectStore;
 use std::{
     collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread command implementation.
 
+use objects::store::ObjectStore;
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Heddle-native thread shaping helpers.
 
+use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
 use anyhow::{Result, anyhow};

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Undo and redo commands.
 
+use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::{ChangeId, ContentHash};
 use oplog::{OpBatch, OpRecord};

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -32,6 +32,7 @@
 //! the print sites short-circuit on JSON mode before any styled
 //! helper runs.
 
+use objects::store::ObjectStore;
 use std::{
     path::{Path, PathBuf},
     sync::{

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::{OpBatch, OpRecord};

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -3,6 +3,7 @@
 //!
 //! Direct access to local repositories without network protocol overhead.
 
+use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use anyhow::{anyhow, Result};

--- a/crates/cli/src/harness/claude_hook.rs
+++ b/crates/cli/src/harness/claude_hook.rs
@@ -23,6 +23,7 @@
 //! All handlers are best-effort. Errors are logged via `tracing` and
 //! swallowed so a transient failure cannot block the harness.
 
+use objects::store::ObjectStore;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -6,6 +6,7 @@
 //! NOTE: These tests run the built binary via CARGO_BIN_EXE_heddle so they can
 //! execute from temporary directories without relying on `cargo run`.
 
+use objects::store::ObjectStore;
 use std::{
     io::Write,
     process::{Command, Output, Stdio},

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use cli::config::UserConfig;
 use objects::object::ThreadName;
 

--- a/crates/cli/tests/cli_integration/thread_cleanup.rs
+++ b/crates/cli/tests/cli_integration/thread_cleanup.rs
@@ -18,6 +18,7 @@
 //! storage and visibility halves are what `thread list` and
 //! `thread cleanup` actually read.
 
+use objects::store::ObjectStore;
 use std::fs;
 
 use chrono::{Duration, Utc};

--- a/crates/cli/tests/comprehensive/performance.rs
+++ b/crates/cli/tests/comprehensive/performance.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{path::Path, process::Command};
 
 use repo::Repository;

--- a/crates/cli/tests/conflict_resolution.rs
+++ b/crates/cli/tests/conflict_resolution.rs
@@ -5,6 +5,7 @@
 //! the lifecycle a stack-aware rebase produces — start → resolve →
 //! finish / abort / carry_forward.
 
+use objects::store::ObjectStore;
 use objects::object::{ChangeId, ThreadName};
 use repo::{MergeState, MergeStateManager, Repository};
 use tempfile::TempDir;

--- a/crates/cli/tests/core_functionality/history_navigation.rs
+++ b/crates/cli/tests/core_functionality/history_navigation.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use super::*;
 
 #[test]

--- a/crates/cli/tests/lazy_blob_hydration_kernel.rs
+++ b/crates/cli/tests/lazy_blob_hydration_kernel.rs
@@ -21,6 +21,7 @@
 //!   on-read hydration completes against a real promisor remote. Run
 //!   it with `cargo test -p heddle-cli --test lazy_blob_hydration_kernel -- --include-ignored`.
 
+use objects::store::ObjectStore;
 use std::{
     path::Path,
     sync::Arc,

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -2,6 +2,7 @@
 //!
 //! Tests for verifying system behavior with large repositories and files.
 
+use objects::store::ObjectStore;
 use std::{
     path::Path,
     process::Command,

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -3,6 +3,7 @@
 //!
 //! Tests for resolve, fetch, fsck, clone, cherry-pick, rebase, bisect, blame, gc.
 
+use objects::store::ObjectStore;
 use std::{fs, process::Command, str};
 
 use ntest::timeout;

--- a/crates/cli/tests/production_features/state_signing.rs
+++ b/crates/cli/tests/production_features/state_signing.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use crypto::{Ed25519Signer, P256Signer, RsaSigner, Signer, SignerError};
 
 use super::*;

--- a/crates/cli/tests/semantic_diff_integration.rs
+++ b/crates/cli/tests/semantic_diff_integration.rs
@@ -2,6 +2,7 @@
 //!
 //! These tests verify that semantic analysis actually works with real code changes.
 
+use objects::store::ObjectStore;
 use repo::Repository;
 use semantic::{
     analysis::{SimilarityMethod, detect_file_renames, detect_function_changes},

--- a/crates/cli/tests/state_management/merge_store_integrity.rs
+++ b/crates/cli/tests/state_management/merge_store_integrity.rs
@@ -11,6 +11,7 @@
 //! than committing data loss. The second one exercises a legitimate
 //! "tree doesn't exist at this path" case (a directory rename) and
 //! asserts the new error path doesn't false-positive.
+use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
 use objects::object::ThreadName;

--- a/crates/cli/tests/state_management/missing_tree_integrity.rs
+++ b/crates/cli/tests/state_management/missing_tree_integrity.rs
@@ -13,6 +13,7 @@
 //! `heddle fsck` — pre-fix the same scenario produced silent, plausible-
 //! looking output that masked store corruption.
 
+use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
 use objects::object::ContentHash;

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -6,6 +6,7 @@ mod hydration;
 mod sync;
 mod user;
 
+use objects::store::ObjectStore;
 use cli_shared::ClientConfig;
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::v1::{

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -1,3 +1,4 @@
+use objects::store::ObjectStore;
 use std::{
     collections::HashMap,
     time::{Duration, Instant},

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -11,6 +11,7 @@
 //! state's blob only. A cross-state index is W2 follow-up work and is
 //! flagged with `// TODO(W2-followup):` comments.
 
+use objects::store::ObjectStore;
 use grpc::heddle::v1::{
     AppendTurnRequest, Discussion as ProtoDiscussion,
     DiscussionResolution as ProtoDiscussionResolution, DiscussionTurn as ProtoDiscussionTurn,

--- a/crates/daemon/src/grpc_local_impl/signal.rs
+++ b/crates/daemon/src/grpc_local_impl/signal.rs
@@ -4,6 +4,7 @@
 //! window. The actual signal *computation* lands in R3 (`crates/state_review`);
 //! this service exposes whatever's already on disk.
 
+use objects::store::ObjectStore;
 use std::{collections::HashMap, pin::Pin};
 
 use futures::Stream;

--- a/crates/daemon/src/grpc_local_impl/state_review.rs
+++ b/crates/daemon/src/grpc_local_impl/state_review.rs
@@ -8,6 +8,7 @@
 // `::state_review` disambiguates from this module's own name
 // (`grpc_local_impl::state_review`), the same way the hosted impl
 // disambiguates by being in a sibling module.
+use objects::store::ObjectStore;
 use ::state_review::{
     PathSymbol, ReadingOrderPartition, SymbolKind, build_review_payload_partition,
 };

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -66,14 +66,15 @@ pub struct ImportStats {
 
 /// Orchestrates one import pass.
 ///
-/// Generic over the ref and oplog backends. The object store stays
-/// `&dyn ObjectStore` (it has no `async` methods — see heddle#259). `O`
-/// defaults to `OpLog` so [`Importer::new`] (which starts without an oplog
-/// backend) has a concrete type; [`Importer::with_oplog`] rebinds `O` to
-/// whatever backend the caller attaches.
-pub struct Importer<'a, R: RefBackend, O: OpLogBackend = OpLog> {
+/// Generic over the ref, object-store, and oplog backends — the store `S`
+/// is threaded as a borrowed concrete type so writes statically dispatch
+/// through the heddle#283 enum rather than a vtable. `O` defaults to `OpLog`
+/// so [`Importer::new`] (which starts without an oplog backend) has a
+/// concrete type; [`Importer::with_oplog`] rebinds `O` to whatever backend
+/// the caller attaches.
+pub struct Importer<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend = OpLog> {
     git: &'a GitSource,
-    store: &'a dyn ObjectStore,
+    store: &'a S,
     refs: &'a R,
     map: &'a mut ShaMap,
     oplog: Option<&'a O>,
@@ -87,10 +88,10 @@ pub struct Importer<'a, R: RefBackend, O: OpLogBackend = OpLog> {
     pack_staging_dir: Option<PathBuf>,
 }
 
-impl<'a, R: RefBackend> Importer<'a, R, OpLog> {
+impl<'a, R: RefBackend, S: ObjectStore> Importer<'a, R, S, OpLog> {
     pub fn new(
         git: &'a GitSource,
-        store: &'a dyn ObjectStore,
+        store: &'a S,
         refs: &'a R,
         map: &'a mut ShaMap,
     ) -> Self {
@@ -105,14 +106,14 @@ impl<'a, R: RefBackend> Importer<'a, R, OpLog> {
     }
 }
 
-impl<'a, R: RefBackend, O: OpLogBackend> Importer<'a, R, O> {
+impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
     /// Attach an oplog backend so the importer also translates reflog
     /// entries into `OpRecord`s. Without one the import still produces a
     /// valid Heddle repo — you just don't get `heddle undo` reach past the
     /// import boundary.
     ///
     /// Rebinds the oplog type parameter to the attached backend's type.
-    pub fn with_oplog<O2: OpLogBackend>(self, oplog: &'a O2) -> Importer<'a, R, O2> {
+    pub fn with_oplog<O2: OpLogBackend>(self, oplog: &'a O2) -> Importer<'a, R, S, O2> {
         Importer {
             git: self.git,
             store: self.store,

--- a/crates/ingest/src/reasoning_emit.rs
+++ b/crates/ingest/src/reasoning_emit.rs
@@ -44,6 +44,7 @@
 //! (`session:{session_id}`), so operators can traverse from an
 //! annotation back to the transcript on disk.
 
+use objects::store::ObjectStore;
 use std::collections::HashMap;
 
 use chrono::Utc;

--- a/crates/ingest/src/state_writer.rs
+++ b/crates/ingest/src/state_writer.rs
@@ -45,13 +45,13 @@ use crate::{
 
 /// Writes Heddle [`State`]s from [`CommitEntry`] inputs. Holds short-lived
 /// borrows — construct one per commit or per batch, not a long-lived field.
-pub struct StateWriter<'a> {
-    store: &'a dyn ObjectStore,
+pub struct StateWriter<'a, S: ObjectStore> {
+    store: &'a S,
     map: &'a mut ShaMap,
 }
 
-impl<'a> StateWriter<'a> {
-    pub fn new(store: &'a dyn ObjectStore, map: &'a mut ShaMap) -> Self {
+impl<'a, S: ObjectStore> StateWriter<'a, S> {
+    pub fn new(store: &'a S, map: &'a mut ShaMap) -> Self {
         Self { store, map }
     }
 

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -42,14 +42,14 @@ use crate::{
 /// Holds a short-lived borrow of the store, sha map, and git source for
 /// the duration of one commit's translation. Cheap to construct per
 /// commit — the memoization state lives in `ShaMap`, not in this struct.
-pub struct TreeTranslator<'a> {
+pub struct TreeTranslator<'a, S: ObjectStore> {
     git: &'a GitSource,
-    store: &'a dyn ObjectStore,
+    store: &'a S,
     map: &'a mut ShaMap,
 }
 
-impl<'a> TreeTranslator<'a> {
-    pub fn new(git: &'a GitSource, store: &'a dyn ObjectStore, map: &'a mut ShaMap) -> Self {
+impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
+    pub fn new(git: &'a GitSource, store: &'a S, map: &'a mut ShaMap) -> Self {
         Self { git, store, map }
     }
 

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -19,6 +19,7 @@ libc.workspace = true
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2" }
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
 repo = { path = "../repo", package = "heddle-repo", version = "0.2" }
 # `serde`/`serde_json` carry the framed control-plane messages between
@@ -75,7 +76,6 @@ criterion = "0.8"
 # `fuse_mount_serves_mmap_readers` regression test that locks in
 # `FUSE_DIRECT_IO_ALLOW_MMAP` opt-in (kernel 5.16+).
 memmap2.workspace = true
-oplog = { path = "../oplog", package = "heddle-oplog" }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -70,9 +70,10 @@ use objects::{
     object::{
         Attribution, Blob, ChangeId, ContentHash, EntryType, FileMode, State, Tree, TreeEntry,
     },
-    store::ObjectStore,
+    store::{AnyStore, ObjectStore},
 };
-use refs::Head;
+use oplog::OpLog;
+use refs::{Head, RefManager};
 use repo::Repository;
 use tracing::{debug, instrument, warn};
 
@@ -644,8 +645,8 @@ impl<'brand> Pending<'brand> {
 /// Writes never modify the immutable state; they accumulate in
 /// [`Pending`] until [`ContentAddressedMount::capture`] folds them
 /// into a fresh state.
-pub struct ContentAddressedMount {
-    inner: Arc<MountInner>,
+pub struct ContentAddressedMount<S: ObjectStore + 'static = AnyStore> {
+    inner: Arc<MountInner<S>>,
     /// Background safety-sweep worker. Held in an `Option` so the
     /// `Drop` impl can `take()` it, signal shutdown, and join cleanly
     /// without needing to borrow `&mut self`.
@@ -691,8 +692,8 @@ pub struct ContentAddressedMount {
 /// templates — search for `state.write` / `state.read` and trace
 /// the subsequent `pending.lock()` / `inodes.lock()` to see the
 /// pattern in action.
-pub(crate) struct MountInner {
-    repo: Repository,
+pub(crate) struct MountInner<S: ObjectStore> {
+    repo: Repository<RefManager, OpLog, S>,
     thread: String,
     state: RwLock<MountState>,
     inodes: Mutex<Inodes>,
@@ -839,7 +840,7 @@ pub struct PrewarmHandle {
 }
 
 impl PrewarmHandle {
-    fn start(weak: Weak<MountInner>) -> Self {
+    fn start<S: ObjectStore + 'static>(weak: Weak<MountInner<S>>) -> Self {
         let cancel = Arc::new(AtomicBool::new(false));
         let cancel_for_worker = Arc::clone(&cancel);
         let join = std::thread::Builder::new()
@@ -886,7 +887,10 @@ impl Drop for PrewarmHandle {
 /// Coordinator thread body: walk the tree to collect blob hashes,
 /// then fan the hashes out across [`PREWARM_WORKERS`] worker
 /// threads. Returns aggregate stats.
-fn prewarm_run(weak: Weak<MountInner>, cancel: Arc<AtomicBool>) -> PrewarmStats {
+fn prewarm_run<S: ObjectStore + 'static>(
+    weak: Weak<MountInner<S>>,
+    cancel: Arc<AtomicBool>,
+) -> PrewarmStats {
     let Some(inner) = weak.upgrade() else {
         return PrewarmStats::default();
     };
@@ -1010,7 +1014,7 @@ fn prewarm_run(weak: Weak<MountInner>, cancel: Arc<AtomicBool>) -> PrewarmStats 
     stats
 }
 
-impl Drop for ContentAddressedMount {
+impl<S: ObjectStore + 'static> Drop for ContentAddressedMount<S> {
     fn drop(&mut self) {
         // Signal the worker before dropping the Arc<MountInner> so
         // it observes the shutdown promptly rather than waiting for
@@ -1041,7 +1045,7 @@ pub struct MountOptions {
     pub blob_cache: Option<Arc<BlobCachePool>>,
 }
 
-impl ContentAddressedMount {
+impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
     /// Open a writable mount of `thread` against `repo`.
     ///
     /// Resolves the thread once, up front, so every subsequent
@@ -1053,7 +1057,7 @@ impl ContentAddressedMount {
     /// a fresh per-mount blob cache. Daemon callers that want
     /// cross-mount cache reuse should construct an
     /// [`Arc<BlobCachePool>`] once and use `with_options` instead.
-    pub fn new(repo: Repository, thread: impl Into<String>) -> Result<Self> {
+    pub fn new(repo: Repository<RefManager, OpLog, S>, thread: impl Into<String>) -> Result<Self> {
         Self::with_options(repo, thread, MountOptions::default())
     }
 
@@ -1061,7 +1065,7 @@ impl ContentAddressedMount {
     /// a blob cache across mounts in the same process — see
     /// [`MountOptions::blob_cache`].
     pub fn with_options(
-        repo: Repository,
+        repo: Repository<RefManager, OpLog, S>,
         thread: impl Into<String>,
         options: MountOptions,
     ) -> Result<Self> {
@@ -1134,7 +1138,7 @@ impl ContentAddressedMount {
         self.inner.state.read().expect("mount state lock").change_id
     }
 
-    fn store(&self) -> &dyn ObjectStore {
+    fn store(&self) -> &S {
         self.inner.repo.store()
     }
 
@@ -2825,7 +2829,7 @@ enum PendingChildKind {
     Dir,
 }
 
-impl MountInner {
+impl<S: ObjectStore> MountInner<S> {
     /// Drain any hot buffer whose `last_touched` is older than
     /// `idle_after`. Mirrors `ContentAddressedMount::promote_idle_buffers`
     /// but is callable from the worker thread which only holds a
@@ -2985,7 +2989,9 @@ impl MountInner {
 /// weak handle and drains any hot buffer that's been idle longer
 /// than `idle_after`. A `None` `sweep_interval` returns `None`,
 /// meaning event-driven promotion only.
-fn spawn_sweep_worker(inner: &Arc<MountInner>) -> Option<SweepHandle> {
+fn spawn_sweep_worker<S: ObjectStore + 'static>(
+    inner: &Arc<MountInner<S>>,
+) -> Option<SweepHandle> {
     let interval = inner
         .promotion
         .read()
@@ -3008,8 +3014,8 @@ fn spawn_sweep_worker(inner: &Arc<MountInner>) -> Option<SweepHandle> {
 /// condvar until either the timer interval elapses (run a sweep) or
 /// `signal_and_join` wakes us (exit). Also exits when the weak
 /// `MountInner` reference can no longer be upgraded.
-fn sweep_worker_loop(
-    inner: std::sync::Weak<MountInner>,
+fn sweep_worker_loop<S: ObjectStore + 'static>(
+    inner: std::sync::Weak<MountInner<S>>,
     state: Arc<SweepShutdown>,
     interval: Duration,
 ) {
@@ -3031,7 +3037,10 @@ fn sweep_worker_loop(
     }
 }
 
-fn resolve_thread(repo: &Repository, thread: &str) -> Result<MountState> {
+fn resolve_thread<S: ObjectStore>(
+    repo: &Repository<RefManager, OpLog, S>,
+    thread: &str,
+) -> Result<MountState> {
     let thread_name = objects::object::ThreadName::from(thread);
     let change_id = repo
         .refs()
@@ -3047,7 +3056,7 @@ fn resolve_thread(repo: &Repository, thread: &str) -> Result<MountState> {
     })
 }
 
-impl PlatformShell for ContentAddressedMount {
+impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
     fn lookup(&self, parent: NodeId, name: &OsStr) -> Result<Option<Entry>> {
         let record = self.record_for(parent)?;
         let parent_path = match self.dir_path_of(&record) {
@@ -3868,6 +3877,11 @@ impl PlatformShell for ContentAddressedMount {
 
 // --- Capture --------------------------------------------------------------
 
+// The capture/snapshot write path drives the repository's snapshot,
+// attribution, and oplog-recording methods, which live on the default
+// local flavor (`Repository<RefManager, OpLog, AnyStore>`). Mounts are only
+// ever captured against that flavor, so this block stays concrete rather
+// than threading `S` through the snapshot surface.
 impl ContentAddressedMount {
     /// Drain the pending tier into a fresh heddle state and update
     /// the thread to point at it.
@@ -4050,7 +4064,7 @@ impl ContentAddressedMount {
 /// Returns the root tree's content hash. The caller writes this to
 /// the new state.
 fn apply_pending_to_tree(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     parent: &Tree,
     pending: &Pending,
     inodes: &Inodes,
@@ -4229,7 +4243,7 @@ fn apply_pending_to_tree(
     fn materialize(
         v: &VDir,
         captured: &Tree,
-        store: &dyn ObjectStore,
+        store: &impl ObjectStore,
     ) -> Result<Option<ContentHash>> {
         let mut entries: BTreeMap<String, TreeEntry> = captured
             .entries()
@@ -4328,7 +4342,7 @@ fn apply_pending_to_tree(
     Ok(hash)
 }
 
-impl ContentAddressedMount {
+impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
     /// Test-only accessor for the warm tier so unit tests can verify
     /// promotions landed without going through `read`. Returns paths
     /// resolved via the inode registry (warm is NodeId-keyed under
@@ -4390,7 +4404,7 @@ impl ContentAddressedMount {
 
     /// Test-only accessor for the wrapped repository.
     #[cfg(test)]
-    pub(crate) fn repo_handle(&self) -> &Repository {
+    pub(crate) fn repo_handle(&self) -> &Repository<RefManager, OpLog, S> {
         &self.inner.repo
     }
 

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -488,7 +488,7 @@ fn invalidate_drops_the_mapping() {
 /// prove `enumerate`/`attrs` don't pull blob contents through
 /// `get_blob` when only the size is needed.
 struct CountingStore {
-    inner: Box<dyn ObjectStore>,
+    inner: objects::store::FsStore,
     get_blob_calls: Arc<AtomicUsize>,
     blob_size_calls: Arc<AtomicUsize>,
 }
@@ -561,14 +561,13 @@ fn enumerate_serves_size_without_loading_blob_bytes() {
 
     let get_blob_calls = Arc::new(AtomicUsize::new(0));
     let blob_size_calls = Arc::new(AtomicUsize::new(0));
-    let inner: Box<dyn ObjectStore> =
-        Box::new(objects::store::FsStore::new(temp.path().join(".heddle")));
+    let inner = objects::store::FsStore::new(temp.path().join(".heddle"));
     let store = CountingStore {
         inner,
         get_blob_calls: get_blob_calls.clone(),
         blob_size_calls: blob_size_calls.clone(),
     };
-    let repo = Repository::open_with_store(temp.path().join(".heddle"), Box::new(store)).unwrap();
+    let repo = Repository::open_with_store(temp.path().join(".heddle"), store).unwrap();
     let mount = ContentAddressedMount::new(repo, "main").unwrap();
 
     let entries = mount.enumerate(NodeId::ROOT).unwrap();
@@ -4111,7 +4110,7 @@ mod capture_write_ops {
 
     use super::*;
 
-    fn dump_tree(store: &dyn ObjectStore, hash: &ContentHash) -> Tree {
+    fn dump_tree(store: &impl ObjectStore, hash: &ContentHash) -> Tree {
         store.get_tree(hash).unwrap().unwrap()
     }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -664,3 +664,145 @@ pub trait ObjectStore: Send + Sync {
         Ok(Vec::new())
     }
 }
+
+#[cfg(test)]
+mod any_store_tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::object::{Attribution, Operation, Principal};
+
+    fn fs_any_store() -> (TempDir, AnyStore) {
+        let temp = TempDir::new().unwrap();
+        let store = FsStore::new(temp.path().join(".heddle"));
+        store.init().unwrap();
+        (temp, AnyStore::Fs(store))
+    }
+
+    /// Drive every `ObjectStore` method through the `AnyStore::Fs` dispatch arm
+    /// so the enum's match-dispatch is exercised end-to-end. This is the
+    /// coverage seam for heddle#283: each arm forwards to the inner concrete
+    /// store, and a missing arm would fail to compile or silently fall back to
+    /// a trait default.
+    #[test]
+    fn fs_variant_dispatches_every_object_store_method() {
+        let (_temp, store) = fs_any_store();
+
+        // ── Blobs ──
+        let blob = Blob::from("any-store dispatch blob");
+        let blob_hash = store.put_blob(&blob).unwrap();
+        assert_eq!(store.get_blob(&blob_hash).unwrap().unwrap().content(), blob.content());
+        assert!(store.has_blob(&blob_hash).unwrap());
+        assert_eq!(
+            store.get_blob_bytes(&blob_hash).unwrap().unwrap().as_ref(),
+            blob.content()
+        );
+        assert_eq!(store.blob_size(&blob_hash).unwrap().unwrap(), blob.content().len() as u64);
+        assert!(store.loose_blob_path(&blob_hash).is_some());
+        store.promote_to_loose_uncompressed(&blob_hash).unwrap();
+        assert!(store.list_blobs().unwrap().contains(&blob_hash));
+
+        let bytes_blob = Blob::from("put-with-hash blob");
+        let bytes_hash = bytes_blob.hash();
+        assert_eq!(
+            store.put_blob_with_hash(&bytes_blob, bytes_hash).unwrap(),
+            bytes_hash
+        );
+        let raw_blob = Blob::from("raw bytes blob");
+        let raw_hash = raw_blob.hash();
+        assert_eq!(
+            store
+                .put_blob_bytes_with_hash(raw_blob.content(), raw_hash)
+                .unwrap(),
+            raw_hash
+        );
+
+        // ── Trees ──
+        let tree = Tree::new();
+        let tree_hash = store.put_tree(&tree).unwrap();
+        assert!(store.get_tree(&tree_hash).unwrap().is_some());
+        assert!(store.has_tree(&tree_hash).unwrap());
+        assert!(store.list_trees().unwrap().contains(&tree_hash));
+        let tree2 = Tree::new();
+        let tree2_bytes = rmp_serde::to_vec_named(&tree2).unwrap();
+        assert_eq!(
+            store.put_tree_serialized(&tree2_bytes, tree2.hash()).unwrap(),
+            tree2.hash()
+        );
+
+        // ── States ──
+        let attribution =
+            Attribution::human(Principal::new("AnyStore Test", "anystore@example.com"));
+        let state = State::new(tree_hash, vec![], attribution.clone());
+        let change_id = state.change_id;
+        store.put_state(&state).unwrap();
+        assert!(store.get_state(&change_id).unwrap().is_some());
+        assert!(store.has_state(&change_id).unwrap());
+        assert!(store.list_states().unwrap().contains(&change_id));
+        let state2 = State::new(tree2.hash(), vec![], attribution.clone());
+        let state2_bytes = rmp_serde::to_vec_named(&state2).unwrap();
+        store
+            .put_state_serialized(&state2_bytes, state2.change_id)
+            .unwrap();
+
+        // ── Actions ──
+        let mut action = Action::new(
+            None,
+            ChangeId::generate(),
+            Operation::Snapshot,
+            "any-store action",
+            attribution,
+        );
+        let action_id = store.put_action(&mut action).unwrap();
+        assert!(store.get_action(&action_id).unwrap().is_some());
+        assert!(store.list_actions().unwrap().contains(&action_id));
+        let action_bytes = rmp_serde::to_vec_named(&action).unwrap();
+        store
+            .put_action_serialized(&action_bytes, action_id)
+            .unwrap();
+
+        // ── Packs ──
+        let packed = Blob::from("packed-via-any-store");
+        let packed_hash = packed.hash();
+        store
+            .put_blobs_packed(vec![(packed_hash, packed.into_content())])
+            .unwrap();
+        assert!(
+            store
+                .get_pack_object(&pack::PackObjectId::Hash(packed_hash))
+                .unwrap()
+                .is_some()
+        );
+        store.pack_objects(false).unwrap();
+        store.prune_loose_objects().unwrap();
+        // install_pack / install_pack_streaming need valid packfile inputs;
+        // exercising the dispatch arm with bogus data is enough — we only
+        // assert the call routes through the enum, not the backend behaviour.
+        let _ = store.install_pack(&[], &[]);
+        let _ = store.install_pack_streaming(
+            std::path::Path::new("/nonexistent/pack"),
+            std::path::Path::new("/nonexistent/idx"),
+        );
+
+        // ── Snapshot write batch ──
+        store.begin_snapshot_write_batch().unwrap();
+        store.flush_snapshot_write_batch().unwrap();
+        store.begin_snapshot_write_batch().unwrap();
+        store.abort_snapshot_write_batch();
+
+        // ── Redactions ──
+        let redaction = b"any-store redaction bytes";
+        store
+            .put_redactions_bytes_for_blob(&blob_hash, redaction)
+            .unwrap();
+        assert!(store.has_redactions_for_blob(&blob_hash).unwrap());
+        assert_eq!(
+            store.get_redactions_bytes_for_blob(&blob_hash).unwrap().as_deref(),
+            Some(redaction.as_slice())
+        );
+        assert!(store.list_blobs_with_redactions().unwrap().contains(&blob_hash));
+
+        // ── Caches ──
+        store.clear_recent_caches();
+    }
+}

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -150,6 +150,163 @@ impl ObjectStore for SharedStore {
     }
 }
 
+/// Static-dispatch enum over the concrete object stores Heddle ships.
+///
+/// This is the default `S` for [`Repository`](crate) so the store backend
+/// can be chosen at *runtime* (from `[storage.s3]` config in
+/// `Repository::build_store`) while remaining a compile-time-monomorphized
+/// type — no vtable. Each [`ObjectStore`] method `match`-dispatches to the
+/// inner variant, so the compiler inlines through the enum to the concrete
+/// backend's implementation (including its overridden default methods).
+///
+/// Sealed by construction: only the variants enumerated here are valid
+/// stores. Heddle is the sole implementer (heddle#259 / #283) — `AnyStore`
+/// is not a public extension point.
+pub enum AnyStore {
+    Fs(FsStore),
+    #[cfg(feature = "s3")]
+    S3(S3Store),
+}
+
+/// Forward an [`ObjectStore`] call to the active [`AnyStore`] variant.
+///
+/// Every arm calls the *same* method on the inner concrete store, so a
+/// backend's override of a defaulted trait method (e.g. `FsStore::blob_size`)
+/// is preserved rather than falling back to the trait default.
+macro_rules! any_store_dispatch {
+    ($self:ident, $method:ident ( $($arg:expr),* )) => {
+        match $self {
+            AnyStore::Fs(inner) => inner.$method($($arg),*),
+            #[cfg(feature = "s3")]
+            AnyStore::S3(inner) => inner.$method($($arg),*),
+        }
+    };
+}
+
+impl ObjectStore for AnyStore {
+    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
+        any_store_dispatch!(self, get_blob(hash))
+    }
+    fn put_blob(&self, blob: &Blob) -> Result<ContentHash> {
+        any_store_dispatch!(self, put_blob(blob))
+    }
+    fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
+        any_store_dispatch!(self, get_blob_bytes(hash))
+    }
+    fn blob_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
+        any_store_dispatch!(self, blob_size(hash))
+    }
+    fn loose_blob_path(&self, hash: &ContentHash) -> Option<PathBuf> {
+        any_store_dispatch!(self, loose_blob_path(hash))
+    }
+    fn promote_to_loose_uncompressed(&self, hash: &ContentHash) -> Result<bool> {
+        any_store_dispatch!(self, promote_to_loose_uncompressed(hash))
+    }
+    fn clear_recent_caches(&self) {
+        any_store_dispatch!(self, clear_recent_caches())
+    }
+    fn put_blob_with_hash(&self, blob: &Blob, hash: ContentHash) -> Result<ContentHash> {
+        any_store_dispatch!(self, put_blob_with_hash(blob, hash))
+    }
+    fn has_blob(&self, hash: &ContentHash) -> Result<bool> {
+        any_store_dispatch!(self, has_blob(hash))
+    }
+    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        any_store_dispatch!(self, get_tree(hash))
+    }
+    fn put_tree(&self, tree: &Tree) -> Result<ContentHash> {
+        any_store_dispatch!(self, put_tree(tree))
+    }
+    fn has_tree(&self, hash: &ContentHash) -> Result<bool> {
+        any_store_dispatch!(self, has_tree(hash))
+    }
+    fn get_state(&self, id: &ChangeId) -> Result<Option<State>> {
+        any_store_dispatch!(self, get_state(id))
+    }
+    fn put_state(&self, state: &State) -> Result<()> {
+        any_store_dispatch!(self, put_state(state))
+    }
+    fn has_state(&self, id: &ChangeId) -> Result<bool> {
+        any_store_dispatch!(self, has_state(id))
+    }
+    fn list_states(&self) -> Result<Vec<ChangeId>> {
+        any_store_dispatch!(self, list_states())
+    }
+    fn get_action(&self, id: &ActionId) -> Result<Option<Action>> {
+        any_store_dispatch!(self, get_action(id))
+    }
+    fn put_action(&self, action: &mut Action) -> Result<ActionId> {
+        any_store_dispatch!(self, put_action(action))
+    }
+    fn list_actions(&self) -> Result<Vec<ActionId>> {
+        any_store_dispatch!(self, list_actions())
+    }
+    fn list_blobs(&self) -> Result<Vec<ContentHash>> {
+        any_store_dispatch!(self, list_blobs())
+    }
+    fn list_trees(&self) -> Result<Vec<ContentHash>> {
+        any_store_dispatch!(self, list_trees())
+    }
+    fn put_blob_bytes_with_hash(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
+        any_store_dispatch!(self, put_blob_bytes_with_hash(data, hash))
+    }
+    fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
+        any_store_dispatch!(self, put_tree_serialized(data, hash))
+    }
+    fn put_state_serialized(&self, data: &[u8], id: ChangeId) -> Result<()> {
+        any_store_dispatch!(self, put_state_serialized(data, id))
+    }
+    fn put_action_serialized(&self, data: &[u8], id: ActionId) -> Result<()> {
+        any_store_dispatch!(self, put_action_serialized(data, id))
+    }
+    fn get_pack_object(
+        &self,
+        id: &pack::PackObjectId,
+    ) -> Result<Option<(pack::ObjectType, Vec<u8>)>> {
+        any_store_dispatch!(self, get_pack_object(id))
+    }
+    fn put_blobs_packed(&self, blobs: Vec<(ContentHash, Vec<u8>)>) -> Result<()> {
+        any_store_dispatch!(self, put_blobs_packed(blobs))
+    }
+    fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<pack::PackObjectId>> {
+        any_store_dispatch!(self, install_pack(pack_data, index_data))
+    }
+    fn install_pack_streaming(
+        &self,
+        pack_path: &std::path::Path,
+        index_path: &std::path::Path,
+    ) -> Result<()> {
+        any_store_dispatch!(self, install_pack_streaming(pack_path, index_path))
+    }
+    fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {
+        any_store_dispatch!(self, pack_objects(aggressive))
+    }
+    fn prune_loose_objects(&self) -> Result<(u64, u64)> {
+        any_store_dispatch!(self, prune_loose_objects())
+    }
+    fn begin_snapshot_write_batch(&self) -> Result<()> {
+        any_store_dispatch!(self, begin_snapshot_write_batch())
+    }
+    fn flush_snapshot_write_batch(&self) -> Result<()> {
+        any_store_dispatch!(self, flush_snapshot_write_batch())
+    }
+    fn abort_snapshot_write_batch(&self) {
+        any_store_dispatch!(self, abort_snapshot_write_batch())
+    }
+    fn has_redactions_for_blob(&self, blob: &ContentHash) -> Result<bool> {
+        any_store_dispatch!(self, has_redactions_for_blob(blob))
+    }
+    fn get_redactions_bytes_for_blob(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        any_store_dispatch!(self, get_redactions_bytes_for_blob(blob))
+    }
+    fn put_redactions_bytes_for_blob(&self, blob: &ContentHash, bytes: &[u8]) -> Result<()> {
+        any_store_dispatch!(self, put_redactions_bytes_for_blob(blob, bytes))
+    }
+    fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
+        any_store_dispatch!(self, list_blobs_with_redactions())
+    }
+}
+
 /// Trait for object storage backends.
 pub trait ObjectStore: Send + Sync {
     fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>>;

--- a/crates/objects/src/store/store_compliance.rs
+++ b/crates/objects/src/store/store_compliance.rs
@@ -19,7 +19,7 @@ fn attribution() -> Attribution {
 /// Panics on the first assertion failure. Designed to be called from unit or
 /// integration tests — including from `spawn_blocking` when testing async
 /// backends like [`S3Store`].
-pub fn run_compliance_tests(store: &dyn ObjectStore) {
+pub fn run_compliance_tests<S: ObjectStore>(store: &S) {
     blob_round_trip(store);
     blob_missing_returns_none(store);
     blob_has(store);
@@ -33,7 +33,7 @@ pub fn run_compliance_tests(store: &dyn ObjectStore) {
 
 // ── Blob ─────────────────────────────────────────────────────────────────────
 
-fn blob_round_trip(store: &dyn ObjectStore) {
+fn blob_round_trip<S: ObjectStore>(store: &S) {
     let blob = Blob::from("compliance: blob round-trip");
     let hash = store.put_blob(&blob).expect("put_blob failed");
     let got = store
@@ -47,7 +47,7 @@ fn blob_round_trip(store: &dyn ObjectStore) {
     );
 }
 
-fn blob_missing_returns_none(store: &dyn ObjectStore) {
+fn blob_missing_returns_none<S: ObjectStore>(store: &S) {
     let hash = ContentHash::compute(b"compliance-nonexistent-blob");
     let result = store
         .get_blob(&hash)
@@ -58,7 +58,7 @@ fn blob_missing_returns_none(store: &dyn ObjectStore) {
     );
 }
 
-fn blob_has(store: &dyn ObjectStore) {
+fn blob_has<S: ObjectStore>(store: &S) {
     let blob = Blob::from("compliance: has_blob");
     let hash = store.put_blob(&blob).expect("put_blob failed");
     assert!(
@@ -67,7 +67,7 @@ fn blob_has(store: &dyn ObjectStore) {
     );
 }
 
-fn blob_list(store: &dyn ObjectStore) {
+fn blob_list<S: ObjectStore>(store: &S) {
     let blob = Blob::from("compliance: list_blobs");
     let hash = store.put_blob(&blob).expect("put_blob failed");
     let list = store.list_blobs().expect("list_blobs failed");
@@ -79,7 +79,7 @@ fn blob_list(store: &dyn ObjectStore) {
 
 // ── Tree ──────────────────────────────────────────────────────────────────────
 
-fn tree_round_trip(store: &dyn ObjectStore) {
+fn tree_round_trip<S: ObjectStore>(store: &S) {
     let tree = Tree::new();
     let hash = store.put_tree(&tree).expect("put_tree failed");
     let got = store
@@ -89,7 +89,7 @@ fn tree_round_trip(store: &dyn ObjectStore) {
     assert_eq!(got.hash(), hash, "tree hash changed after round-trip");
 }
 
-fn tree_missing_returns_none(store: &dyn ObjectStore) {
+fn tree_missing_returns_none<S: ObjectStore>(store: &S) {
     let hash = ContentHash::compute(b"compliance-nonexistent-tree");
     let result = store
         .get_tree(&hash)
@@ -102,7 +102,7 @@ fn tree_missing_returns_none(store: &dyn ObjectStore) {
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
-fn state_round_trip(store: &dyn ObjectStore) {
+fn state_round_trip<S: ObjectStore>(store: &S) {
     let tree = Tree::new();
     let tree_hash = store
         .put_tree(&tree)
@@ -121,7 +121,7 @@ fn state_round_trip(store: &dyn ObjectStore) {
     assert_eq!(got.tree, tree_hash, "tree hash changed after round-trip");
 }
 
-fn state_has(store: &dyn ObjectStore) {
+fn state_has<S: ObjectStore>(store: &S) {
     let tree = Tree::new();
     let tree_hash = store
         .put_tree(&tree)
@@ -135,7 +135,7 @@ fn state_has(store: &dyn ObjectStore) {
     );
 }
 
-fn state_list(store: &dyn ObjectStore) {
+fn state_list<S: ObjectStore>(store: &S) {
     let tree = Tree::new();
     let tree_hash = store
         .put_tree(&tree)

--- a/crates/proto/src/native_pack.rs
+++ b/crates/proto/src/native_pack.rs
@@ -30,7 +30,7 @@ impl PackChunkState {
 }
 
 pub fn build_native_pack(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     objects: &[ObjectInfo],
 ) -> Result<NativePackBundle> {
     let mut builder = PackBuilder::new(sync_pack_compression());
@@ -68,7 +68,7 @@ fn sync_pack_compression() -> CompressionConfig {
 }
 
 pub fn install_received_pack(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     pack_data: &[u8],
     index_data: &[u8],
 ) -> Result<Vec<PackObjectId>> {

--- a/crates/proto/src/object_availability.rs
+++ b/crates/proto/src/object_availability.rs
@@ -14,7 +14,7 @@ pub struct ObjectAvailabilityPlan {
     pub partial_fetch_allowed: bool,
 }
 
-pub fn has_object(store: &dyn ObjectStore, info: &ObjectInfo) -> Result<bool> {
+pub fn has_object(store: &impl ObjectStore, info: &ObjectInfo) -> Result<bool> {
     match (&info.id, info.obj_type) {
         (ObjectId::Hash(hash), ObjectType::Blob) => Ok(store.has_blob(hash)?),
         (ObjectId::Hash(hash), ObjectType::Tree) => Ok(store.has_tree(hash)?),
@@ -31,7 +31,7 @@ pub fn has_object(store: &dyn ObjectStore, info: &ObjectInfo) -> Result<bool> {
 }
 
 pub fn plan_object_availability(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     objects: &[ObjectInfo],
 ) -> Result<ObjectAvailabilityPlan> {
     let mut plan = ObjectAvailabilityPlan::default();

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -50,14 +50,14 @@ pub struct StateClosureOptions {
 }
 
 pub fn enumerate_state_closure(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     state_id: ChangeId,
 ) -> Result<Vec<ObjectInfo>> {
     enumerate_state_closure_with_options(store, state_id, StateClosureOptions::default())
 }
 
 pub fn enumerate_state_closure_with_options(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     state_id: ChangeId,
     options: StateClosureOptions,
 ) -> Result<Vec<ObjectInfo>> {
@@ -126,14 +126,14 @@ pub fn enumerate_state_closure_with_options(
 }
 
 pub fn enumerate_state_closure_plan(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     state_id: ChangeId,
 ) -> Result<Vec<PlannedObject>> {
     enumerate_state_closure_plan_with_options(store, state_id, StateClosureOptions::default())
 }
 
 pub fn enumerate_state_closure_plan_with_options(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     state_id: ChangeId,
     options: StateClosureOptions,
 ) -> Result<Vec<PlannedObject>> {
@@ -199,7 +199,7 @@ pub fn enumerate_state_closure_plan_with_options(
 }
 
 fn enumerate_tree_closure_filtered(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     tree_hash: ContentHash,
     excluded: &HashSet<ContentHash>,
     seen: &mut HashSet<ContentHash>,
@@ -281,7 +281,7 @@ fn enumerate_tree_closure_filtered(
 /// the closure (dedup'd by hash), so its redaction can only be emitted
 /// once too.
 fn emit_redaction_info(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     blob: &ContentHash,
     out: &mut Vec<ObjectInfo>,
 ) -> Result<()> {
@@ -297,7 +297,7 @@ fn emit_redaction_info(
 }
 
 fn enumerate_tree_plan_filtered(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     tree_hash: ContentHash,
     excluded: &HashSet<ContentHash>,
     seen: &mut HashSet<ContentHash>,
@@ -344,7 +344,7 @@ fn enumerate_tree_plan_filtered(
 }
 
 fn emit_redaction_plan(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     blob: &ContentHash,
     out: &mut Vec<PlannedObject>,
 ) -> Result<()> {
@@ -358,7 +358,7 @@ fn emit_redaction_plan(
 }
 
 fn collect_excluded(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     roots: &[ChangeId],
 ) -> Result<(HashSet<ChangeId>, HashSet<ContentHash>)> {
     if roots.is_empty() {
@@ -400,7 +400,7 @@ fn collect_excluded(
 }
 
 fn collect_tree_hashes(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     tree_hash: ContentHash,
     excluded: &mut HashSet<ContentHash>,
 ) -> Result<()> {
@@ -428,7 +428,7 @@ fn collect_tree_hashes(
 }
 
 pub fn is_ancestor(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     ancestor: ChangeId,
     descendant: ChangeId,
 ) -> Result<bool> {
@@ -463,6 +463,7 @@ pub fn is_ancestor(
 mod tests {
     use chrono::Utc;
     use objects::object::{Principal, Redaction};
+    use objects::store::ObjectStore;
     use repo::Repository;
     use tempfile::TempDir;
 

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -37,7 +37,7 @@ pub fn chunk_offset(chunk_index: usize, chunk_size: usize) -> Option<usize> {
     chunk_index.checked_mul(chunk_size)
 }
 
-pub fn load_requested_object(store: &dyn ObjectStore, req: &ObjectRequest) -> Result<ObjectData> {
+pub fn load_requested_object(store: &impl ObjectStore, req: &ObjectRequest) -> Result<ObjectData> {
     // Note on Redaction objects: a redaction sidecar is content-addressed by
     // the *redacted blob's* hash, which also identifies a real blob in the
     // store. `load_requested_object` resolves blob-vs-tree by content
@@ -71,7 +71,7 @@ pub fn load_requested_object(store: &dyn ObjectStore, req: &ObjectRequest) -> Re
 }
 
 pub fn load_object_data(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     id: &ObjectId,
     obj_type: ObjectType,
 ) -> Result<ObjectData> {
@@ -111,7 +111,7 @@ pub fn load_object_data(
     })
 }
 
-pub fn store_received_object(store: &dyn ObjectStore, data: &ObjectData) -> Result<()> {
+pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Result<()> {
     match (&data.id, data.obj_type) {
         (ObjectId::Hash(hash), ObjectType::Blob) => {
             store.put_blob_bytes_with_hash(&data.data, *hash)?;

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! In-memory commit graph index with persistence and Bloom filter support.
 
+use objects::store::ObjectStore;
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,

--- a/crates/repo/src/context_suggestions.rs
+++ b/crates/repo/src/context_suggestions.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Context rewrite scoring and low-noise suggestion heuristics.
 
+use objects::store::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
 use objects::object::{ContextTarget, State};

--- a/crates/repo/src/lazy_hydrator.rs
+++ b/crates/repo/src/lazy_hydrator.rs
@@ -248,6 +248,7 @@ mod tests {
     };
 
     use objects::object::{Blob, ContentHash};
+    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -73,7 +73,7 @@ use objects::{
     fs_atomic::write_file_atomic,
     lock::{RepoLock, RepositoryLockExt},
     object::{Attribution, ChangeId, ContentHash, MarkerName, Principal, State, ThreadName, Tree},
-    store::{FsStore, ObjectStore, ShallowInfo},
+    store::{AnyStore, FsStore, ObjectStore, ShallowInfo},
     worktree::{WorktreeStatus, should_ignore as should_ignore_path},
 };
 use oplog::{OpLog, OpLogBackend, OpRecord};
@@ -258,25 +258,28 @@ pub trait BlobHydrator: Send + Sync {
 
 /// A Heddle repository.
 ///
-/// Generic over its reference and operation-log backends. The CLI uses the
-/// defaults — `Repository<RefManager, OpLog>` (the on-disk local
-/// backends) — so the bare name `Repository` resolves to the local flavor
-/// everywhere. The hosted server instantiates
-/// `Repository<PgRefBackend, PgOpLogBackend>` via [`Repository::from_parts`].
+/// Generic over its reference, operation-log, and object-store backends.
+/// The CLI uses the defaults — `Repository<RefManager, OpLog, AnyStore>`
+/// (the on-disk local backends) — so the bare name `Repository` resolves to
+/// the local flavor everywhere. The hosted server instantiates
+/// `Repository<PgRefBackend, PgOpLogBackend, …>` via [`Repository::from_parts`].
 ///
-/// The object store stays `Box<dyn ObjectStore>` because [`Repository::open`]
-/// selects `FsStore` vs `S3Store` at *runtime* from config — a choice that
-/// can't be a compile-time type parameter without re-introducing dynamic
-/// dispatch via an enum. See heddle#259 for the Phase-2 follow-up.
-pub struct Repository<R = RefManager, O = OpLog>
+/// The object store is the [`AnyStore`] enum by default: [`Repository::open`]
+/// selects `FsStore` vs `S3Store` at *runtime* from config (`build_store`),
+/// but the choice is a concrete enum variant rather than a `Box<dyn>`, so
+/// every object access is static-dispatched through the enum to the inner
+/// store — no vtable (heddle#283). `S` goes last so existing
+/// `Repository<R, O>` references keep resolving with `S = AnyStore`.
+pub struct Repository<R = RefManager, O = OpLog, S = AnyStore>
 where
     R: RefBackend,
     O: OpLogBackend,
+    S: ObjectStore,
 {
     root: PathBuf,
     heddle_dir: PathBuf,
     capability: RepositoryCapability,
-    store: Box<dyn ObjectStore>,
+    store: S,
     refs: R,
     oplog: O,
     config: RepoConfig,
@@ -284,7 +287,7 @@ where
     blob_hydrator: RwLock<Option<Arc<dyn BlobHydrator>>>,
 }
 
-impl<R: RefBackend, O: OpLogBackend> RepositoryLockExt for Repository<R, O> {
+impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repository<R, O, S> {
     fn locker(&self) -> RepoLock {
         let lock_root = self.heddle_dir.parent().expect(
             "heddle_dir has no parent component; cannot determine lock root. This indicates a misconfigured repository.",
@@ -293,7 +296,7 @@ impl<R: RefBackend, O: OpLogBackend> RepositoryLockExt for Repository<R, O> {
     }
 }
 
-impl<R: RefBackend, O: OpLogBackend> Repository<R, O> {
+impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
     /// Expert-only constructor for callers that already own the repository's
     /// component backends and invariant state.
     ///
@@ -305,7 +308,7 @@ impl<R: RefBackend, O: OpLogBackend> Repository<R, O> {
     pub fn from_parts(
         root: PathBuf,
         heddle_dir: PathBuf,
-        store: Box<dyn ObjectStore>,
+        store: S,
         refs: R,
         oplog: O,
         config: RepoConfig,
@@ -326,8 +329,8 @@ impl<R: RefBackend, O: OpLogBackend> Repository<R, O> {
     }
 
     /// The object store backing this repository.
-    pub fn store(&self) -> &dyn ObjectStore {
-        self.store.as_ref()
+    pub fn store(&self) -> &S {
+        &self.store
     }
 
     /// The reference backend (threads, markers, HEAD).
@@ -341,11 +344,18 @@ impl<R: RefBackend, O: OpLogBackend> Repository<R, O> {
     }
 }
 
-impl Repository {
+/// Local-flavor opens generic over the object store `S`.
+///
+/// `open_raw` assembles a repository from already-resolved pieces and runs
+/// none of the local-only open hooks (migrations, hydrator reconstruction) —
+/// those are bound to the default `AnyStore` flavor and live in
+/// [`Repository::run_open_hooks`], which the config-driven [`Repository::open`]
+/// invokes after `open_raw`.
+impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
     fn open_raw(
         root: PathBuf,
         heddle_dir: PathBuf,
-        store: Box<dyn ObjectStore>,
+        store: S,
         config: RepoConfig,
         refs: RefManager,
     ) -> Result<Self> {
@@ -356,20 +366,46 @@ impl Repository {
             .unwrap_or_else(|| objects::object::Principal::new("<unknown>", ""));
         let oplog = OpLog::new(&heddle_dir, actor);
         let shallow = ShallowInfo::load(&heddle_dir)?;
-        let repo = Self::from_parts(
-            root,
-            heddle_dir,
-            store,
-            refs,
-            oplog,
-            config,
-            shallow,
-        );
+        Ok(Self::from_parts(
+            root, heddle_dir, store, refs, oplog, config, shallow,
+        ))
+    }
+
+    /// Open an existing Heddle repository using a custom object store backend.
+    ///
+    /// Expert/test injection point: takes the store by value (any
+    /// [`ObjectStore`]) and skips the local-only open hooks (declarative
+    /// migrations, lazy-clone hydrator reconstruction) that [`Repository::open`]
+    /// runs for the default `AnyStore` flavor.
+    pub fn open_with_store(heddle_dir: impl AsRef<Path>, store: S) -> Result<Self> {
+        let heddle_dir = heddle_dir.as_ref().to_path_buf();
+        let root = heddle_dir
+            .parent()
+            .ok_or_else(|| {
+                HeddleError::Config(format!(
+                    "heddle_dir '{}' has no parent directory",
+                    heddle_dir.display()
+                ))
+            })?
+            .to_path_buf();
+        let config = RepoConfig::load(&heddle_dir.join("config.toml"))?;
+        let refs = RefManager::new(&heddle_dir);
+        Self::open_raw(root, heddle_dir, store, config, refs)
+    }
+}
+
+impl Repository {
+    /// Run the local-only hooks that follow a config-driven [`Repository::open`]:
+    /// declarative migrations + lazy-clone hydrator reconstruction. Both are
+    /// bound to the default `AnyStore` flavor (`apply_pending` and
+    /// `BlobHydrator` operate on the bare `Repository`), so they live here
+    /// rather than in the generic `open_raw`.
+    fn run_open_hooks(&self) {
         // Run any pending declarative migrations. Idempotent:
         // re-opening a repo a second time is a no-op for the migration pass.
         // Failures here are logged but non-fatal; surfacing migration errors
         // through `open` is worse than letting the repo open and warning later.
-        if let Err(err) = crate::migration::apply_pending(&repo) {
+        if let Err(err) = crate::migration::apply_pending(self) {
             tracing::warn!("declarative migrations failed during repo open: {err}");
         }
         // Reconstruct any persisted lazy-clone blob hydrator. When
@@ -379,8 +415,8 @@ impl Repository {
         // missing-blob marker can fetch transparently — without this
         // reconstruction, lazy clones would only work inside the single
         // `cmd_clone` process. See `lazy_hydrator.rs` for the shape.
-        match crate::lazy_hydrator::try_reconstruct(repo.root(), repo.heddle_dir()) {
-            Ok(Some(hydrator)) => repo.set_blob_hydrator(hydrator),
+        match crate::lazy_hydrator::try_reconstruct(self.root(), self.heddle_dir()) {
+            Ok(Some(hydrator)) => self.set_blob_hydrator(hydrator),
             Ok(None) => {}
             Err(err) => {
                 // Hydrator construction failed (factory error or
@@ -392,14 +428,14 @@ impl Repository {
                 tracing::warn!("lazy hydrator reconstruction failed during open: {err}");
             }
         }
-        Ok(repo)
     }
 
     /// Build an object store from the repository configuration.
     ///
     /// Returns an [`S3Store`] when `[storage.s3]` is configured and the `s3`
-    /// feature is enabled, otherwise falls back to [`FsStore`].
-    fn build_store(config: &RepoConfig, heddle_dir: &Path) -> Result<Box<dyn ObjectStore>> {
+    /// feature is enabled, otherwise falls back to [`FsStore`] — wrapped in
+    /// the [`AnyStore`] enum so the runtime choice stays statically dispatched.
+    fn build_store(config: &RepoConfig, heddle_dir: &Path) -> Result<AnyStore> {
         #[cfg(feature = "s3")]
         {
             if let Some(s3) = &config.storage.s3 {
@@ -407,12 +443,12 @@ impl Repository {
             }
         }
         let _ = config; // suppress unused warning when s3 feature is off
-        Ok(Box::new(FsStore::new(heddle_dir)))
+        Ok(AnyStore::Fs(FsStore::new(heddle_dir)))
     }
 
     /// Construct an [`S3Store`] from the repository's S3 storage configuration.
     #[cfg(feature = "s3")]
-    fn build_s3_store(s3: &repo_config::S3StorageConfig) -> Result<Box<dyn ObjectStore>> {
+    fn build_s3_store(s3: &repo_config::S3StorageConfig) -> Result<AnyStore> {
         use objects::store::S3StoreBuilder;
 
         let mut builder = S3StoreBuilder::new().bucket(&s3.bucket);
@@ -450,7 +486,7 @@ impl Repository {
         let store = builder
             .build_blocking()
             .map_err(|e| HeddleError::Config(format!("S3 store initialization failed: {e}")))?;
-        Ok(Box::new(store))
+        Ok(AnyStore::S3(store))
     }
 
     /// Initialize a new bare repository at the given path.
@@ -496,7 +532,7 @@ impl Repository {
             root,
             heddle_dir: heddle_dir.clone(),
             capability,
-            store: Box::new(store),
+            store: AnyStore::Fs(store),
             refs,
             oplog,
             config,
@@ -542,26 +578,6 @@ impl Repository {
     /// artifacts must be covered by `.gitignore` or `.heddleignore`.
     pub fn ensure_git_overlay_local_excludes(path: impl AsRef<Path>) -> Result<()> {
         ensure_git_overlay_exclude(path.as_ref())
-    }
-
-    /// Open an existing Heddle repository using a custom object store backend.
-    pub fn open_with_store(
-        heddle_dir: impl AsRef<Path>,
-        store: Box<dyn ObjectStore>,
-    ) -> Result<Self> {
-        let heddle_dir = heddle_dir.as_ref().to_path_buf();
-        let root = heddle_dir
-            .parent()
-            .ok_or_else(|| {
-                HeddleError::Config(format!(
-                    "heddle_dir '{}' has no parent directory",
-                    heddle_dir.display()
-                ))
-            })?
-            .to_path_buf();
-        let config = RepoConfig::load(&heddle_dir.join("config.toml"))?;
-        let refs = RefManager::new(&heddle_dir);
-        Self::open_raw(root, heddle_dir, store, config, refs)
     }
 
     /// Open an existing repository.
@@ -638,29 +654,28 @@ impl Repository {
                     }
 
                     let config = RepoConfig::load(&shared_galeed_dir.join("config.toml"))?;
-                    let store: Box<dyn ObjectStore> =
-                        Self::build_store(&config, &shared_galeed_dir)?;
+                    let store = Self::build_store(&config, &shared_galeed_dir)?;
                     let local_head_path = heddle_path.join("HEAD");
                     let refs = RefManager::new(&shared_galeed_dir).with_local_head(local_head_path);
-                    return Self::open_raw(
-                        dir.to_path_buf(),
-                        shared_galeed_dir,
-                        store,
-                        config,
-                        refs,
-                    );
+                    let repo =
+                        Self::open_raw(dir.to_path_buf(), shared_galeed_dir, store, config, refs)?;
+                    repo.run_open_hooks();
+                    return Ok(repo);
                 }
 
                 if objects_dir.is_dir() {
                     // Main repo mode.
                     let config = RepoConfig::load(&heddle_path.join("config.toml"))?;
-                    let store: Box<dyn ObjectStore> = Self::build_store(&config, &heddle_path)?;
+                    let store = Self::build_store(&config, &heddle_path)?;
                     let refs = RefManager::new(&heddle_path);
                     let repo = Self::open_raw(dir.to_path_buf(), heddle_path, store, config, refs)?;
+                    repo.run_open_hooks();
                     if repo.capability() == RepositoryCapability::GitOverlay {
                         match detect_git_head_state(dir) {
                             Ok(Some(GitHeadState::Attached(thread))) => {
-                                let git_head = Head::Attached { thread: ThreadName::from(thread) };
+                                let git_head = Head::Attached {
+                                    thread: ThreadName::from(thread),
+                                };
                                 // Avoid the disk write when our HEAD already matches
                                 // git's. Reading the existing head is a small file
                                 // read; the write that follows hits atomic-rename

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Context annotation helpers for attaching metadata to file and state targets.
 
+use objects::store::ObjectStore;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},

--- a/crates/repo/src/repository_diff.rs
+++ b/crates/repo/src/repository_diff.rs
@@ -11,7 +11,7 @@ use super::{Repository, Result};
 impl Repository {
     /// Get the difference between two trees.
     pub fn diff_trees(&self, from: &ContentHash, to: &ContentHash) -> Result<FileChangeSet> {
-        diff_trees(self.store.as_ref(), from, to)
+        diff_trees(&self.store, from, to)
             .map_err(|error| HeddleError::InvalidObject(format!("tree diff failed: {error}")))
     }
 }

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Worktree movement operations.
 
+use objects::store::ObjectStore;
 use std::time::Instant;
 
 use objects::{lock::RepositoryLockExt, object::ChangeId};

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared history traversal and filtering primitives.
 
+use objects::store::ObjectStore;
 use std::path::{Component, Path};
 
 use objects::object::{ChangeId, State, Tree};

--- a/crates/repo/src/repository_maintenance.rs
+++ b/crates/repo/src/repository_maintenance.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{
     collections::HashSet,
     fs, io,

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree materialization helpers.
 
+use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,
@@ -806,6 +807,7 @@ fn requested_materialization_threads() -> Option<NonZeroUsize> {
 mod tests {
     use std::{num::NonZeroUsize, path::PathBuf};
 
+    use objects::store::ObjectStore;
     use objects::{fs_clone::filesystem_supports_reflink, object::Blob};
     use tempfile::TempDir;
 

--- a/crates/repo/src/repository_provenance/blame_file.rs
+++ b/crates/repo/src/repository_provenance/blame_file.rs
@@ -56,6 +56,7 @@
 //! path, so every caller — `heddle blame`, the gRPC `GetBlame` RPC,
 //! the web app — benefits without any client-side change.
 
+use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
 use objects::object::{ChangeId, ContentHash, FileProvenance, Origin, State};

--- a/crates/repo/src/repository_provenance/helpers.rs
+++ b/crates/repo/src/repository_provenance/helpers.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
 use objects::object::{

--- a/crates/repo/src/repository_provenance/merge.rs
+++ b/crates/repo/src/repository_provenance/merge.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::path::Path;
 
 use objects::object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry};

--- a/crates/repo/src/repository_provenance/mod.rs
+++ b/crates/repo/src/repository_provenance/mod.rs
@@ -10,6 +10,7 @@ mod storage;
 #[cfg(test)]
 mod tests;
 
+use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
 use objects::object::{ChangeId, ContentHash, FileProvenance, State};

--- a/crates/repo/src/repository_provenance/snapshot.rs
+++ b/crates/repo/src/repository_provenance/snapshot.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{collections::BTreeSet, path::Path};
 
 use objects::object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry};

--- a/crates/repo/src/repository_provenance/storage.rs
+++ b/crates/repo/src/repository_provenance/storage.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::path::Path;
 
 use objects::object::{Blob, ContentHash, FileProvenance};

--- a/crates/repo/src/repository_provenance/tests.rs
+++ b/crates/repo/src/repository_provenance/tests.rs
@@ -22,7 +22,7 @@ fn lcs_preserves_existing_line_matches() {
 /// return the resulting state. Each call invents a fresh principal so
 /// the per-state attribution differs across the chain.
 fn put_state_with_file(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     file: &str,
     content: &[u8],
     parents: Vec<ChangeId>,

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -22,6 +22,7 @@
 //! identical ids, which preserves the "redact is idempotent" property
 //! from the build brief.
 
+use objects::store::ObjectStore;
 use std::{collections::HashSet, fs, path::PathBuf};
 
 use anyhow::{Context, Result};

--- a/crates/repo/src/repository_resolve.rs
+++ b/crates/repo/src/repository_resolve.rs
@@ -2,6 +2,7 @@
 //! State resolution helpers for the Repository.
 
 use objects::object::{Agent, ChangeId};
+use objects::store::ObjectStore;
 
 use super::{HeddleError, Repository, Result};
 
@@ -134,6 +135,7 @@ mod tests {
     use std::fs;
 
     use objects::object::{ChangeId, MarkerName};
+    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use crate::{HeddleError, Repository};

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -13,6 +13,7 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
+use objects::store::ObjectStore;
 use objects::object::{Blob, ContentHash, RiskSignalBlob, State};
 use state_review::{
     ReviewSignalsConfig, SemanticContext,

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -3,6 +3,7 @@
 
 use crypto::{Signer, StateSigningExt, load_signer, verify_state_signature_bytes};
 use objects::object::{ChangeId, SignatureStatus, StateSignature};
+use objects::store::ObjectStore;
 use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result};

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Snapshot operations for Repository.
 
+use objects::store::ObjectStore;
 use objects::{
     lock::RepositoryLockExt,
     object::{Attribution, ChangeId, State, Tree},

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -37,6 +37,31 @@ fn test_init_creates_structure() {
 }
 
 #[test]
+fn test_open_with_store_threads_a_custom_object_store() {
+    // heddle#283: `Repository::open_with_store` is generic over the object
+    // store `S`, so the whole `Repository<RefManager, OpLog, S>` plumbing has
+    // to compile and run with a concrete store that is *not* the default
+    // `AnyStore`. Inject a bare `FsStore` and round-trip an object through it.
+    use objects::store::FsStore;
+
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let heddle_dir = repo.heddle_dir().to_path_buf();
+    drop(repo);
+
+    let store = FsStore::new(&heddle_dir);
+    let repo: Repository<_, _, FsStore> =
+        Repository::open_with_store(&heddle_dir, store).unwrap();
+
+    let blob = objects::object::Blob::from("open_with_store round-trip");
+    let hash = repo.store().put_blob(&blob).unwrap();
+    assert_eq!(
+        repo.store().get_blob(&hash).unwrap().unwrap().content(),
+        blob.content()
+    );
+}
+
+#[test]
 fn test_init_fails_if_exists() {
     let temp_dir = TempDir::new().unwrap();
     Repository::init_default(temp_dir.path()).unwrap();

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::fs;
 
 use objects::object::{ChangeId, ThreadName};
@@ -1167,6 +1168,8 @@ mod blob_hydrator_callback {
         object::{Blob, ContentHash},
     };
 
+    use objects::store::ObjectStore;
+
     use super::create_test_repo;
     use crate::{BlobHydrator, HeddleError, Repository};
 
@@ -1458,6 +1461,7 @@ mod require_tree_callback {
     //! cover the on-disk wiring.
 
     use objects::object::{ContentHash, Tree};
+    use objects::store::ObjectStore;
 
     use super::create_test_repo;
     use crate::{HeddleError, Repository};

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -12,6 +12,7 @@
 //! userspace FS callbacks in the hot path. Disk usage is the
 //! ~zero-cost clonefile share until the agent diverges blocks.
 
+use objects::store::ObjectStore;
 use std::{
     collections::BTreeMap,
     fs,

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree building and materialization helpers.
 
+use objects::store::ObjectStore;
 use std::{collections::HashSet, fs, path::Path, time::Instant};
 
 use objects::{

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared worktree apply planning and execution.
 
+use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -13,6 +13,7 @@
 //! logic in one place and lets `crates/mount` avoid pulling in
 //! `crates/cli` deps.
 
+use objects::store::ObjectStore;
 use std::path::Path;
 
 use chrono::Utc;

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -213,7 +213,7 @@ fn resolve_current_symbol(
 
 /// Resolve a blob at a file path within a tree by walking the tree hierarchy.
 fn get_blob_at_path(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     tree: &Tree,
     path: &str,
 ) -> Result<Option<Blob>, anyhow::Error> {
@@ -222,7 +222,7 @@ fn get_blob_at_path(
 }
 
 fn get_blob_recursive(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     tree: &Tree,
     parts: &[&str],
 ) -> Result<Option<Blob>, anyhow::Error> {

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread storage and lifecycle management.
 
+use objects::store::ObjectStore;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared worktree walking infrastructure.
 
+use objects::store::ObjectStore;
 use std::{
     fs::{self, File},
     io::Read,

--- a/crates/semantic/src/analysis/hot_spots.rs
+++ b/crates/semantic/src/analysis/hot_spots.rs
@@ -18,7 +18,7 @@
 //!
 //! # Where this sits
 //!
-//! Pure function over `&dyn ObjectStore`. Both the CLI (against the FS
+//! Pure function over `&impl ObjectStore`. Both the CLI (against the FS
 //! store) and the gRPC service (against any server-side store) call the
 //! same entry point — no host-specific glue required. The walker
 //! follows `state.first_parent()` through the imported ancestry,
@@ -216,7 +216,7 @@ pub struct HotSpotsReport {
 /// `(walk_from, walk_from.first_parent())`. If `walk_from` has no
 /// parent, the report is empty.
 pub fn analyze_hot_spots(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     walk_from: ChangeId,
     params: &HotSpotParams,
 ) -> Result<HotSpotsReport, anyhow::Error> {
@@ -432,7 +432,7 @@ fn path_passes_filter(path: &Path, includes: &[String], excludes: &[String]) -> 
 /// `attribution`. Useful for the "who's been working here" panel
 /// that doesn't need file-granularity output.
 pub fn analyze_actor_histogram(
-    store: &dyn ObjectStore,
+    store: &impl ObjectStore,
     walk_from: ChangeId,
     limit_states: Option<usize>,
 ) -> Result<BTreeMap<String, usize>, anyhow::Error> {


### PR DESCRIPTION
## Summary

Phase 2 of heddle#259 — add the object-store type parameter to `Repository`, removing the last `dyn` backend dispatch (the only payoff here is vtable-overhead removal; the store has no async methods).

- **`AnyStore` enum (static dispatch).** New `objects::store::AnyStore` enumerates the concrete stores (`Fs(FsStore)`, `S3(S3Store)` under the `s3` feature) and implements `ObjectStore` by `match`-dispatching **every** trait method to the inner variant — no vtable, while `Repository::open`/`build_store` still pick the backend at runtime from `[storage.s3]` config. All trait methods are forwarded (including defaulted ones backends override, e.g. `FsStore::blob_size`/`pack_objects`) so no override is lost.
- **`Repository<R = RefManager, O = OpLog, S = AnyStore>`.** `S` goes **last** with a default, so the bare `Repository` and existing `Repository<R, O>` references keep resolving (CLI unaffected — matches #282's default-type-param convention). `store()` returns `&S`; `build_store` returns `AnyStore`; `from_parts`/`open_with_store` are generic over `S`.
- **Threaded `S` / `&impl ObjectStore` through the ~72 `dyn ObjectStore` sites** across proto, ingest, semantic, mount, repo, cli, objects. Owned/field sites (Repository, ingest `Importer`/`StateWriter`/`TreeTranslator`, mount `ContentAddressedMount<S>`/`MountInner<S>`) carry a named `S`; borrow-only free functions take `&impl ObjectStore` (anonymous generic — same monomorphization, no vtable). **No `Box<dyn ObjectStore>` remains** (grep-clean).

## Design notes & deviations

- **No-backcompat:** the dynamic-dispatch path is deleted, not shimmed. `build_store` returns the enum directly; no `Box<dyn>` fallback or feature flag.
- **Concrete-type fallout (the many `+1 import` files):** call sites that relied on `&dyn ObjectStore` auto-resolving trait methods now need `ObjectStore` in scope, because the trait is **not** auto-imported for a concrete `&AnyStore`/`&S`. Hence the mechanical one-line `use objects::store::ObjectStore;` additions across many files. This is the unavoidable cost of static dispatch.
- **mount capture/snapshot write path stays concrete** (`Repository<RefManager, OpLog, AnyStore>`): it drives the default-flavor snapshot/attribution/oplog surface (`get_attribution`/`head`/`config`/`head_ref` + `snapshot_metadata::*`), which lives on the concrete local repo. The read/enumerate path (and the `CountingStore` test) is fully generic over `S`. `mount` gains a regular `oplog` dep (was dev-only) so it can name the default `OpLog` backend in the `S`-generic struct.
- **Sealed interface** (inherited from #259): Heddle is the sole implementer; `AnyStore` enumerates the known stores and is not a public extension point. The unused `SharedStore(Arc<dyn ObjectStore>)` helper is left as-is — it's orthogonal to the Repository store path and is `Arc<dyn>`, not `Box<dyn>`.

Closes HeddleCo/heddle#283

## Red commit

N/A — behavior-preserving type-system refactor (DoD Type ≠ TDD-Rust). The decided design is the `AnyStore` enum (static dispatch), per the issue's load-bearing store-selection call. The existing suite is the regression guard.

## Test evidence

```
bash scripts/check-no-silent-default-tree-load.sh   → clean (513 files scanned)

cargo build --workspace --tests                                   → ok
cargo test --workspace                                            → ok (all suites pass; 0 failed)
cargo test -p heddle-repo                                         → ok. 321 passed; 0 failed
cargo test -p heddle-mount  (incl. enumerate_serves_size_without_loading_blob_bytes
                             over a CountingStore-backed Repository<…, S>) → ok. 162 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings             → clean

# --features postgres (Pg-backed generic Repository)
cargo build  --workspace --tests        --features postgres                  → ok
cargo clippy --workspace --all-targets  --features postgres -- -D warnings   → clean

# OSS build flavors + s3 + fuse
cargo check -p heddle-cli --no-default-features --features git-overlay,semantic,zstd → ok
cargo check -p heddle-cli --no-default-features --features native,semantic,zstd      → ok
cargo build -p heddle-repo  --features s3      (build_s3_store → AnyStore::S3)        → ok
cargo build -p heddle-mount --features fuse --tests                                  → ok

grep -rn "Box<dyn ObjectStore>" crates → 0 matches
```

## Manual verification

N/A — covered by tests (no UI surface).

## Blocked by → resolved

heddle#283's `## Blocked by` was #259 (Phase 1 / PR #282, merged). This PR completes the store half of that genericization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782625149&installation_id=132405951&pr_number=293&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F293&signature=08cc6ab377d275c70fba025333009eb6041374bfc55658b4eb54f9a757f8a8c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->