### PR TITLE
heddle#273: feat(show): default to HEAD when no state arg

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -246,8 +246,8 @@ Examples:
 
     /// Show state details.
     Show {
-        /// State by change ID or hash prefix.
-        state: String,
+        /// State by change ID or hash prefix. Defaults to HEAD when omitted.
+        state: Option<String>,
     },
 
     /// Summarize a working session.

--- a/crates/cli/src/cli/commands/show.rs
+++ b/crates/cli/src/cli/commands/show.rs
@@ -72,7 +72,8 @@ struct ShowGitOverlayImportHintOutput {
     recommended_command: String,
 }
 
-pub fn cmd_show(cli: &Cli, state_spec: String) -> Result<()> {
+pub fn cmd_show(cli: &Cli, state_spec: Option<String>) -> Result<()> {
+    let state_spec = state_spec.unwrap_or_else(|| "HEAD".to_string());
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
     if let Some(probe) = build_plain_git_verification_probe(start)? {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -452,14 +452,14 @@ async fn async_main() -> Result<()> {
             if let Some(state) = target
                 && is_plain_git_without_heddle(start)
             {
-                return cmd_show(&cli, state.clone());
+                return cmd_show(&cli, Some(state.clone()));
             }
             let repo = repo::Repository::open(start)?;
             match target {
                 Some(name) if repo.refs().get_thread(&objects::object::ThreadName::new(name.as_str()))?.is_some() => {
                     cmd_thread_show(&cli, &repo, Some(name.clone()))
                 }
-                Some(state) => cmd_show(&cli, state.clone()),
+                Some(state) => cmd_show(&cli, Some(state.clone())),
                 None => cmd_thread_show(&cli, &repo, None),
             }
         }

--- a/crates/cli/tests/core_functionality/history_navigation.rs
+++ b/crates/cli/tests/core_functionality/history_navigation.rs
@@ -68,3 +68,23 @@ fn test_collapse_two_states() {
         .unwrap_or("");
     assert!(intent.contains("Combined"));
 }
+
+#[test]
+fn test_show_no_arg_defaults_to_head() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "content").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Test"], temp.path());
+
+    let no_arg = heddle(&["show", "--output", "json"], Some(temp.path()))
+        .expect("show with no arg should succeed");
+    let explicit_head = heddle(&["show", "HEAD", "--output", "json"], Some(temp.path()))
+        .expect("show HEAD should succeed");
+
+    let no_arg_json: Value = serde_json::from_str(&no_arg).expect("no-arg show JSON");
+    let head_json: Value = serde_json::from_str(&explicit_head).expect("HEAD show JSON");
+    assert_eq!(
+        no_arg_json, head_json,
+        "bare `show` should render the same state as `show HEAD`"
+    );
+}


### PR DESCRIPTION
## Summary
- Make the positional `state` arg of `heddle show` optional in the clap definition (`commands_main.rs`).
- Default to `HEAD` in `cmd_show` when omitted, reusing the existing HEAD resolution/bootstrap path — no new flag.
- `heddle show` now mirrors `git show` and the sibling `heddle log`, both of which default to HEAD.
- Explicit `heddle show <state>` behavior is unchanged.

Closes HeddleCo/heddle#273

## Red commit
`4d31368`

## Test evidence
```
running 1 test
test history_navigation::test_show_no_arg_defaults_to_head ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 107 filtered out; finished in 0.39s
```
Full gates green: `cargo test --workspace` (exit 0), `cargo clippy --workspace --all-targets -- -D warnings` (exit 0), `bash scripts/check-no-silent-default-tree-load.sh` (clean, 513 files scanned).

## Manual verification
N/A — covered by tests. The new test asserts bare `heddle show --output json` renders byte-identical JSON to `heddle show HEAD --output json`.

## Blocked by → resolved
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782645133&installation_id=132405951&pr_number=295&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F295&signature=4446c537d35888cc9e7e42b167d0af15aae753888e61cf4dd2432861995de603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->