### PR TITLE
heddle#260: port parse_git_ref + RefSpec/NegativeRefSpec from jj

### DIFF
--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1033,6 +1033,38 @@ fn pull_imports_remote_branches_and_tags_from_authenticated_git_http_backend() {
 }
 
 #[test]
+fn fetch_rejects_reserved_git_remote_name_at_boundary() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut bridge = GitBridge::new(&repo);
+
+    let err = bridge
+        .fetch("git")
+        .expect_err("fetch of reserved remote name must be rejected");
+    let message = err.to_string();
+    assert!(
+        message.contains("reserved namespace") && message.contains("rename"),
+        "fetch error must explain the reserved-namespace collision and how to fix it, got: {message}"
+    );
+}
+
+#[test]
+fn pull_rejects_reserved_git_remote_name_at_boundary() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut bridge = GitBridge::new(&repo);
+
+    let err = bridge
+        .pull("git")
+        .expect_err("pull of reserved remote name must be rejected");
+    let message = err.to_string();
+    assert!(
+        message.contains("reserved namespace") && message.contains("rename"),
+        "pull error must explain the reserved-namespace collision and how to fix it, got: {message}"
+    );
+}
+
+#[test]
 fn import_handles_merge_history_without_missing_parent_mappings() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -130,6 +130,147 @@ pub(crate) struct RefUpdate {
     pub namespace: RefNamespace,
 }
 
+/// Sentinel remote name for refs owned by the local repository
+/// (`refs/heads/*` and `refs/tags/*`). Ported from jj's
+/// `REMOTE_NAME_FOR_LOCAL_GIT_REPO` (`lib/src/git.rs`). Because a remote
+/// literally named `git` would collide with this sentinel, such a name must
+/// be rejected when remotes are configured.
+pub const REMOTE_NAME_FOR_LOCAL_GIT_REPO: &str = "git";
+
+/// The kind of Git ref [`parse_git_ref`] recognizes. Ported from jj's
+/// `GitRefKind` (`lib/src/git.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitRefKind {
+    /// `refs/heads/<name>` or `refs/remotes/<remote>/<name>`.
+    Branch,
+    /// `refs/tags/<name>`.
+    Tag,
+}
+
+/// A parsed Git ref name: its kind, short name, and owning remote. Borrows
+/// from the input ref name. Ported from jj's `RemoteRefSymbol` shape
+/// (`lib/src/git.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedGitRef<'a> {
+    pub kind: GitRefKind,
+    /// Short name beneath the namespace, e.g. `main` for `refs/heads/main`
+    /// or `feature/x` for `refs/remotes/origin/feature/x`.
+    pub name: &'a str,
+    /// Owning remote. Local refs (`refs/heads/*`, `refs/tags/*`) report
+    /// [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`].
+    pub remote: &'a str,
+}
+
+/// Parse a fully-qualified Git ref name into its [`GitRefKind`], short name,
+/// and owning remote. Returns `None` for refs outside the
+/// branch/remote-branch/tag namespaces (e.g. `refs/notes/*`, `HEAD`).
+///
+/// Ported from jj's `parse_git_ref` (`lib/src/git.rs`); like jj, the symbolic
+/// `HEAD` and `refs/remotes/<remote>/HEAD` entries are not treated as refs.
+pub fn parse_git_ref(ref_name: &str) -> Option<ParsedGitRef<'_>> {
+    if let Some(name) = ref_name.strip_prefix("refs/heads/") {
+        // Git rejects `HEAD` as a branch name.
+        (name != "HEAD").then_some(ParsedGitRef {
+            kind: GitRefKind::Branch,
+            name,
+            remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+        })
+    } else if let Some(remote_and_name) = ref_name.strip_prefix("refs/remotes/") {
+        let (remote, name) = remote_and_name.split_once('/')?;
+        // `refs/remotes/<remote>/HEAD` is the remote's symbolic default, not a
+        // real remote-tracking branch.
+        (name != "HEAD").then_some(ParsedGitRef {
+            kind: GitRefKind::Branch,
+            name,
+            remote,
+        })
+    } else {
+        ref_name
+            .strip_prefix("refs/tags/")
+            .map(|name| ParsedGitRef {
+                kind: GitRefKind::Tag,
+                name,
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            })
+    }
+}
+
+/// A Git refspec: an optional `source`, a `destination`, and a `forced` (`+`)
+/// marker. Ported from jj's `RefSpec` (`lib/src/git.rs`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefSpec {
+    forced: bool,
+    /// `None` encodes a delete refspec (`:destination`).
+    source: Option<String>,
+    destination: String,
+}
+
+impl RefSpec {
+    /// A forced (`+`) refspec mapping `source` onto `destination`.
+    pub fn forced(source: impl Into<String>, destination: impl Into<String>) -> Self {
+        Self {
+            forced: true,
+            source: Some(source.into()),
+            destination: destination.into(),
+        }
+    }
+
+    /// A delete refspec (`:destination`). Not forced: deleting a destination
+    /// that has no source cannot lose work.
+    pub fn delete(destination: impl Into<String>) -> Self {
+        Self {
+            forced: false,
+            source: None,
+            destination: destination.into(),
+        }
+    }
+
+    /// Render in `git` refspec syntax, including the leading `+` when forced.
+    pub fn to_git_format(&self) -> String {
+        format!(
+            "{}{}",
+            if self.forced { "+" } else { "" },
+            self.to_git_format_not_forced()
+        )
+    }
+
+    /// Render in `git` refspec syntax without the leading `+`, even when forced.
+    pub fn to_git_format_not_forced(&self) -> String {
+        format!("{}:{}", self.source.as_deref().unwrap_or(""), self.destination)
+    }
+}
+
+/// A negative refspec (`^source`) excluding refs from a fetch or push. Ported
+/// from jj's `NegativeRefSpec` (`lib/src/git.rs`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegativeRefSpec {
+    source: String,
+}
+
+impl NegativeRefSpec {
+    /// A negative refspec excluding `source`.
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+
+    /// Render in `git` refspec syntax (`^source`).
+    pub fn to_git_format(&self) -> String {
+        format!("^{}", self.source)
+    }
+}
+
+/// The fetch refspecs heddle uses to mirror a remote: every branch and every
+/// heddle note, forced. Built through [`RefSpec`] so the wire format has a
+/// single typed source of truth.
+fn heddle_mirror_fetch_refspecs() -> [String; 2] {
+    [
+        RefSpec::forced("refs/heads/*", "refs/heads/*").to_git_format(),
+        RefSpec::forced("refs/notes/*", "refs/notes/*").to_git_format(),
+    ]
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitPushScope {
     CurrentThread,
@@ -2319,7 +2460,7 @@ fn clone_url_to_bare_via_gix(
     let mut remote = repo.remote_at(url.clone()).map_err(git_err)?;
     remote
         .replace_refspecs(
-            ["+refs/heads/*:refs/heads/*", "+refs/notes/*:refs/notes/*"],
+            heddle_mirror_fetch_refspecs().iter().map(String::as_str),
             gix::remote::Direction::Fetch,
         )
         .map_err(git_err)?;
@@ -2469,7 +2610,7 @@ fn fetch_network_remote(
     let mut remote = mirror_repo.remote_at(url.clone()).map_err(git_err)?;
     remote
         .replace_refspecs(
-            ["+refs/heads/*:refs/heads/*", "+refs/notes/*:refs/notes/*"],
+            heddle_mirror_fetch_refspecs().iter().map(String::as_str),
             gix::remote::Direction::Fetch,
         )
         .map_err(git_err)?;

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -146,6 +146,23 @@ pub(crate) fn is_reserved_git_remote_name(remote: &str) -> bool {
     remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
 }
 
+/// Reject a remote name that collides with [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`].
+/// Surfaced at the public fetch/pull accept boundary with an actionable
+/// message, and re-applied as an invariant net at every
+/// `refs/remotes/{name}/...` write site, so a remote named `git` can never be
+/// treated as a normal remote-tracking namespace — keeping the writers
+/// consistent with [`parse_git_ref`], which already rejects such refs.
+fn reject_reserved_git_remote_name(remote: &str) -> GitResult<()> {
+    if is_reserved_git_remote_name(remote) {
+        return Err(GitBridgeError::Git(format!(
+            "a Git remote named '{remote}' collides with heddle's reserved namespace \
+             (local refs are recorded under the '{REMOTE_NAME_FOR_LOCAL_GIT_REPO}' sentinel); \
+             rename the remote (e.g. `git remote rename {remote} origin`) and retry"
+        )));
+    }
+    Ok(())
+}
+
 /// The kind of Git ref [`parse_git_ref`] recognizes. Ported from jj's
 /// `GitRefKind` (`lib/src/git.rs`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -816,12 +833,19 @@ impl<'a> GitBridge<'a> {
         scope: GitFetchScope,
         refresh_checkout: RefreshCheckoutAfterFetch,
     ) -> GitResult<()> {
+        reject_reserved_git_remote_name(remote_name)?;
         self.init_mirror()?;
         let current_branch = self.heddle_repo.git_overlay_current_branch()?;
         let tracking_remote = checkout_tracking_remote_name(self.heddle_repo.root(), remote_name)?
             .or_else(|| {
                 (!looks_like_remote_location(remote_name)).then(|| remote_name.to_string())
             });
+        // A URL/path remote can still resolve onto a configured remote literally
+        // named `git`; reject that here too so the constructed tracking refs
+        // never land under the reserved namespace.
+        if let Some(tracking_remote) = tracking_remote.as_deref() {
+            reject_reserved_git_remote_name(tracking_remote)?;
+        }
 
         let mirror_repo = self.open_git_repo()?;
         match self.resolve_remote(remote_name, gix::remote::Direction::Fetch)? {
@@ -1315,6 +1339,7 @@ impl<'a> GitBridge<'a> {
         else {
             return Ok(());
         };
+        reject_reserved_git_remote_name(&tracking_remote)?;
 
         let mirror_repo = self.open_git_repo()?;
         let branch_ref = format!("refs/heads/{branch}");
@@ -1348,6 +1373,7 @@ impl<'a> GitBridge<'a> {
         else {
             return Ok(());
         };
+        reject_reserved_git_remote_name(&tracking_remote)?;
 
         let mirror_repo = self.open_git_repo()?;
         let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
@@ -2310,6 +2336,7 @@ fn apply_remote_tracking_ref_updates(
     updates: &[RefUpdate],
     log_message: &str,
 ) -> GitResult<()> {
+    reject_reserved_git_remote_name(remote_name)?;
     for update in updates
         .iter()
         .filter(|update| update.namespace == RefNamespace::Branch)

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -137,6 +137,15 @@ pub(crate) struct RefUpdate {
 /// be rejected when remotes are configured.
 pub const REMOTE_NAME_FOR_LOCAL_GIT_REPO: &str = "git";
 
+/// Whether `remote` collides with [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`], the
+/// sentinel reserved for refs owned by the local repository. A user remote
+/// with this name cannot be represented unambiguously against local refs, so
+/// it must be rejected at every site that parses or accepts a remote name.
+/// Single source of truth for the reserved-namespace check.
+pub(crate) fn is_reserved_git_remote_name(remote: &str) -> bool {
+    remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
+}
+
 /// The kind of Git ref [`parse_git_ref`] recognizes. Ported from jj's
 /// `GitRefKind` (`lib/src/git.rs`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -178,8 +187,12 @@ pub fn parse_git_ref(ref_name: &str) -> Option<ParsedGitRef<'_>> {
     } else if let Some(remote_and_name) = ref_name.strip_prefix("refs/remotes/") {
         let (remote, name) = remote_and_name.split_once('/')?;
         // `refs/remotes/<remote>/HEAD` is the remote's symbolic default, not a
-        // real remote-tracking branch.
-        (name != "HEAD").then_some(ParsedGitRef {
+        // real remote-tracking branch. A remote literally named `git` collides
+        // with the local sentinel ([`REMOTE_NAME_FOR_LOCAL_GIT_REPO`]); aliasing
+        // it onto local refs would make remote-tracking branches
+        // indistinguishable from `refs/heads/*`, so it is rejected here —
+        // matching jj's parser and the sentinel ownership contract.
+        (name != "HEAD" && !is_reserved_git_remote_name(remote)).then_some(ParsedGitRef {
             kind: GitRefKind::Branch,
             name,
             remote,
@@ -2880,6 +2893,16 @@ mod tests {
         assert_eq!(parse_git_ref("HEAD"), None);
         // A remote ref with no branch component beneath the remote name.
         assert_eq!(parse_git_ref("refs/remotes/origin"), None);
+    }
+
+    #[test]
+    fn parse_git_ref_rejects_reserved_git_remote_namespace() {
+        // A user remote literally named `git` collides with the local sentinel;
+        // it must not be aliased onto local refs at the parse site.
+        assert_eq!(parse_git_ref("refs/remotes/git/main"), None);
+        assert_eq!(parse_git_ref("refs/remotes/git/feature/x"), None);
+        assert!(is_reserved_git_remote_name(REMOTE_NAME_FOR_LOCAL_GIT_REPO));
+        assert!(!is_reserved_git_remote_name("origin"));
     }
 
     #[test]

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -2703,6 +2703,79 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parse_git_ref_local_branch() {
+        let parsed = parse_git_ref("refs/heads/main").expect("local branch parses");
+        assert_eq!(parsed.kind, GitRefKind::Branch);
+        assert_eq!(parsed.name, "main");
+        assert_eq!(parsed.remote, REMOTE_NAME_FOR_LOCAL_GIT_REPO);
+    }
+
+    #[test]
+    fn parse_git_ref_remote_branch_keeps_nested_name() {
+        let parsed =
+            parse_git_ref("refs/remotes/origin/feature/x").expect("remote branch parses");
+        assert_eq!(parsed.kind, GitRefKind::Branch);
+        assert_eq!(parsed.name, "feature/x");
+        assert_eq!(parsed.remote, "origin");
+    }
+
+    #[test]
+    fn parse_git_ref_tag() {
+        let parsed = parse_git_ref("refs/tags/v1.0").expect("tag parses");
+        assert_eq!(parsed.kind, GitRefKind::Tag);
+        assert_eq!(parsed.name, "v1.0");
+        assert_eq!(parsed.remote, REMOTE_NAME_FOR_LOCAL_GIT_REPO);
+    }
+
+    #[test]
+    fn parse_git_ref_skips_head_symrefs() {
+        assert_eq!(parse_git_ref("refs/heads/HEAD"), None);
+        assert_eq!(parse_git_ref("refs/remotes/origin/HEAD"), None);
+    }
+
+    #[test]
+    fn parse_git_ref_rejects_unknown_or_malformed() {
+        assert_eq!(parse_git_ref("refs/notes/heddle"), None);
+        assert_eq!(parse_git_ref("HEAD"), None);
+        // A remote ref with no branch component beneath the remote name.
+        assert_eq!(parse_git_ref("refs/remotes/origin"), None);
+    }
+
+    #[test]
+    fn refspec_forced_round_trips_git_format() {
+        let spec = RefSpec::forced("refs/heads/main", "refs/heads/main");
+        assert_eq!(spec.to_git_format(), "+refs/heads/main:refs/heads/main");
+        assert_eq!(
+            spec.to_git_format_not_forced(),
+            "refs/heads/main:refs/heads/main"
+        );
+    }
+
+    #[test]
+    fn refspec_delete_has_empty_source() {
+        let spec = RefSpec::delete("refs/heads/stale");
+        assert_eq!(spec.to_git_format(), ":refs/heads/stale");
+        assert_eq!(spec.to_git_format_not_forced(), ":refs/heads/stale");
+    }
+
+    #[test]
+    fn negative_refspec_prefixes_caret() {
+        let spec = NegativeRefSpec::new("refs/heads/wip/*");
+        assert_eq!(spec.to_git_format(), "^refs/heads/wip/*");
+    }
+
+    #[test]
+    fn mirror_fetch_refspecs_cover_branches_and_notes() {
+        assert_eq!(
+            heddle_mirror_fetch_refspecs(),
+            [
+                "+refs/heads/*:refs/heads/*".to_string(),
+                "+refs/notes/*:refs/notes/*".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn fast_forward_guard_reports_exact_rewrite_before_after() {
         let tmp = tempfile::TempDir::new().unwrap();
         let repo = gix::init_bare(tmp.path()).expect("init bare repo");

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -14,7 +14,7 @@ pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, RefNamespace, RefUpdate, SyncMapping,
-        apply_ref_updates, copy_reachable_objects, git_err, open_repo,
+        apply_ref_updates, copy_reachable_objects, git_err, open_repo, parse_git_ref,
         thread_is_unclaimed_bootstrap,
     },
     git_notes,
@@ -83,6 +83,7 @@ fn remote_tracking_ref_suggestions(
         let Some(_) = reference.target().try_id() else {
             continue;
         };
+        let full = reference.name().as_bstr().to_string();
         let short = reference.name().shorten().to_string();
         if short.ends_with("/HEAD") {
             continue;
@@ -90,10 +91,10 @@ fn remote_tracking_ref_suggestions(
         if peel_to_commit_oid(repo, &mut reference)?.is_err() {
             continue;
         }
-        let Some((_remote, branch)) = short.split_once('/') else {
+        let Some(parsed) = parse_git_ref(&full) else {
             continue;
         };
-        if missing.contains(branch) {
+        if missing.contains(parsed.name) {
             suggestions.push(format!(
                 "Remote-tracking branch '{short}' exists. Import it with `heddle bridge git import --ref {short}`. If you want a local branch with the shorter name later, create it in Heddle and sync it back through `heddle push`."
             ));


### PR DESCRIPTION
## Summary
- Port jj's ref-name primitives into `crates/cli/src/bridge/git_core.rs`, adapted to heddle idioms: `parse_git_ref` (returns a borrowed `ParsedGitRef { kind, name, remote }`), the `GitRefKind` enum, the `REMOTE_NAME_FOR_LOCAL_GIT_REPO` (`"git"`) sentinel, and the `RefSpec` / `NegativeRefSpec` refspec types with `to_git_format[_not_forced]`.
- Replace the hand-rolled `short.split_once('/')` remote/branch parse in `remote_tracking_ref_suggestions` (`git_import.rs`) with `parse_git_ref`.
- Build the clone mirror fetch refspecs through `RefSpec::forced(...).to_git_format()` (via a `heddle_mirror_fetch_refspecs` helper) instead of the open-coded `"+refs/heads/*:refs/heads/*"` string literals at both clone sites.
- Scope limited to #260: the `intent_to_add` port (#263), which also touches `git_core.rs`, is untouched.

Closes HeddleCo/heddle#260

## Red commit
`0ef72ad`

## Test evidence
```
$ cargo test -p heddle-cli --lib bridge::git_core::tests::
running 12 tests
test bridge::git_core::tests::negative_refspec_prefixes_caret ... ok
test bridge::git_core::tests::parse_git_ref_local_branch ... ok
test bridge::git_core::tests::parse_git_ref_remote_branch_keeps_nested_name ... ok
test bridge::git_core::tests::parse_git_ref_rejects_unknown_or_malformed ... ok
test bridge::git_core::tests::mirror_fetch_refspecs_cover_branches_and_notes ... ok
test bridge::git_core::tests::parse_git_ref_skips_head_symrefs ... ok
test bridge::git_core::tests::refspec_delete_has_empty_source ... ok
test bridge::git_core::tests::refspec_forced_round_trips_git_format ... ok
test bridge::git_core::tests::parse_git_ref_tag ... ok
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 492 filtered out

$ cargo test --workspace        # all suites: 60 "test result: ok", 0 failed
$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ bash scripts/check-no-silent-default-tree-load.sh        # clean (513 files scanned)
```

## Manual verification
N/A — covered by unit tests.

## Blocked by → resolved
Unblocks HeddleCo/heddle#261 (next in the jj-port chain — needs the typed `RefName`/refspec primitives).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782645739&installation_id=132405951&pr_number=296&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F296&signature=0db44230ed23ac24e95838b5fd71d2e045d32b8c03476dfc6e66235039671206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 2 (Codex)
Addressed P2 cids 3323996463 / 3324110099 (reserved `git` remote namespace) in 8af1569. Close-the-class: single `is_reserved_git_remote_name` predicate guards the only remote-name-accepting site in the ported code (the `refs/remotes/` arm of `parse_git_ref`), so a user remote named `git` is rejected at parse time rather than aliasing onto the local sentinel. New test: `parse_git_ref_rejects_reserved_git_remote_namespace`. Local: lib tests (505) + clippy -D warnings + check-no-silent-default-tree-load all green.

## Round 3 (cid 3324388218)
- Closed the reserved-`git`-remote class end-to-end: rejected at the fetch/pull accept boundary (user-passed name + resolved tracking-remote) with an actionable rename hint, plus an invariant net at every `refs/remotes/{name}/...` write site. Parser rejection at :195 retained, now consistent with the writers.
- Red→green: `fetch_rejects_reserved_git_remote_name_at_boundary`, `pull_rejects_reserved_git_remote_name_at_boundary` (green sha 350eab6).
