### PR TITLE
heddle#275: drop 'Repository mode' preamble from default read views

### DIFF
--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -342,11 +342,15 @@ fn cmd_bridge_git_status(cli: &Cli, repo: &Repository) -> Result<()> {
         recovery_commands: trust.recovery_commands.clone(),
         trust,
     };
-    render_bridge_git_status(&output, should_output_json(cli, Some(repo.config())));
+    render_bridge_git_status(
+        &output,
+        should_output_json(cli, Some(repo.config())),
+        cli.verbose > 0,
+    );
     Ok(())
 }
 
-fn render_bridge_git_status(output: &BridgeGitStatusOutput, json: bool) {
+fn render_bridge_git_status(output: &BridgeGitStatusOutput, json: bool, verbose: bool) {
     if json {
         println!(
             "{}",
@@ -354,13 +358,16 @@ fn render_bridge_git_status(output: &BridgeGitStatusOutput, json: bool) {
         );
         return;
     }
-    println!(
-        "Repository: {}",
-        crate::cli::render::repository_mode_label(
-            &output.repository_capability,
-            &output.storage_model
-        )
-    );
+    // Mode preamble is read-path noise (heddle#275); keep it under `-v`.
+    if verbose {
+        println!(
+            "Repository: {}",
+            crate::cli::render::repository_mode_label(
+                &output.repository_capability,
+                &output.storage_model
+            )
+        );
+    }
     if output.mirror_initialized {
         println!(
             "Mirror: {} (initialized)",
@@ -587,7 +594,7 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
                 recovery_commands: probe.trust.recovery_commands.clone(),
                 trust: probe.trust,
             };
-            render_bridge_git_status(&output, should_output_json(cli, None));
+            render_bridge_git_status(&output, should_output_json(cli, None), cli.verbose > 0);
             return Ok(());
         }
     }

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -716,4 +716,37 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains('\x1b'), "expected ANSI in oneline: {s:?}");
     }
+
+    /// The default full text view must lead with log data, not the
+    /// `Repository:` mode preamble — that line is noise on every read
+    /// (heddle#275). `-v` keeps it for diagnostic context.
+    #[test]
+    #[serial(color_state)]
+    fn write_full_gates_repository_preamble_on_verbose() {
+        style::force_for_test(false);
+        let output = LogOutput {
+            output_kind: "log",
+            status: "completed",
+            repository_capability: "git-overlay".to_string(),
+            storage_model: "git+heddle-sidecar".to_string(),
+            git_overlay_import_hint: None,
+            states: vec![sample_entry()],
+        };
+
+        let mut buf = Vec::new();
+        write_full(&mut buf, &output, false).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            !s.contains("Repository:"),
+            "default full log leaked the mode preamble: {s:?}"
+        );
+
+        let mut buf = Vec::new();
+        write_full(&mut buf, &output, true).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("Repository:"),
+            "verbose full log should retain the mode preamble: {s:?}"
+        );
+    }
 }

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -545,6 +545,7 @@ fn write_full<W: std::io::Write>(
     // The mode preamble is diagnostic noise on the common read path
     // (heddle#275); `heddle status` already exposes it. Keep it under
     // `-v` for troubleshooting.
+    let mut wrote_header = false;
     if verbose {
         writeln!(
             out,
@@ -554,6 +555,7 @@ fn write_full<W: std::io::Write>(
                 &output.storage_model
             )
         )?;
+        wrote_header = true;
     }
     if let Some(hint) = &output.git_overlay_import_hint {
         writeln!(
@@ -567,8 +569,13 @@ fn write_full<W: std::io::Write>(
         if let Some(line) = format_next_step_dim(&hint.recommended_command, 0) {
             writeln!(out, "{line}")?;
         }
+        wrote_header = true;
     }
-    writeln!(out)?;
+    // Only emit the spacer when a header preceded it; otherwise it would be
+    // an orphaned leading blank line (heddle#275 r2).
+    if wrote_header {
+        writeln!(out)?;
+    }
     for (i, entry) in output.states.iter().enumerate() {
         if i > 0 {
             writeln!(out)?;
@@ -745,6 +752,13 @@ mod tests {
             !s.contains("Repository:"),
             "default full log leaked the mode preamble: {s:?}"
         );
+        // Dropping the preamble must also drop the spacer that followed it;
+        // the default view must lead with log data, not a blank line
+        // (heddle#275 r2).
+        assert!(
+            !s.starts_with('\n'),
+            "default full log starts with an orphaned blank line: {s:?}"
+        );
 
         let mut buf = Vec::new();
         write_full(&mut buf, &output, true).unwrap();
@@ -752,6 +766,12 @@ mod tests {
         assert!(
             s.contains("Repository:"),
             "verbose full log should retain the mode preamble: {s:?}"
+        );
+        // With the preamble present, the spacer separating it from the log
+        // entries is still expected.
+        assert!(
+            s.contains("\n\n"),
+            "verbose full log should keep the spacer after the preamble: {s:?}"
         );
     }
 }

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -542,14 +542,19 @@ fn write_full<W: std::io::Write>(
     output: &LogOutput,
     verbose: bool,
 ) -> std::io::Result<()> {
-    writeln!(
-        out,
-        "Repository: {}",
-        crate::cli::render::repository_mode_label(
-            &output.repository_capability,
-            &output.storage_model
-        )
-    )?;
+    // The mode preamble is diagnostic noise on the common read path
+    // (heddle#275); `heddle status` already exposes it. Keep it under
+    // `-v` for troubleshooting.
+    if verbose {
+        writeln!(
+            out,
+            "Repository: {}",
+            crate::cli::render::repository_mode_label(
+                &output.repository_capability,
+                &output.storage_model
+            )
+        )?;
+    }
     if let Some(hint) = &output.git_overlay_import_hint {
         writeln!(
             out,

--- a/crates/cli/src/cli/commands/show.rs
+++ b/crates/cli/src/cli/commands/show.rs
@@ -190,13 +190,17 @@ fn render_plain_git_show(
 }
 
 fn render_state(output: &ShowOutput, verbose: bool) {
-    println!(
-        "Repository: {}",
-        crate::cli::render::repository_mode_label(
-            &output.repository_capability,
-            &output.storage_model
-        )
-    );
+    // Mode preamble is read-path noise (heddle#275); show it only under
+    // `-v`. `heddle status` covers it for the common case.
+    if verbose {
+        println!(
+            "Repository: {}",
+            crate::cli::render::repository_mode_label(
+                &output.repository_capability,
+                &output.storage_model
+            )
+        );
+    }
     if let Some(hint) = &output.git_overlay_import_hint {
         println!(
             "{}",

--- a/crates/cli/src/cli/commands/show.rs
+++ b/crates/cli/src/cli/commands/show.rs
@@ -192,6 +192,7 @@ fn render_plain_git_show(
 fn render_state(output: &ShowOutput, verbose: bool) {
     // Mode preamble is read-path noise (heddle#275); show it only under
     // `-v`. `heddle status` covers it for the common case.
+    let mut wrote_header = false;
     if verbose {
         println!(
             "Repository: {}",
@@ -200,6 +201,7 @@ fn render_state(output: &ShowOutput, verbose: bool) {
                 &output.storage_model
             )
         );
+        wrote_header = true;
     }
     if let Some(hint) = &output.git_overlay_import_hint {
         println!(
@@ -210,8 +212,13 @@ fn render_state(output: &ShowOutput, verbose: bool) {
             )
         );
         print_next_step_dim(&hint.recommended_command);
+        wrote_header = true;
     }
-    println!();
+    // Only emit the spacer when a header preceded it; otherwise it would be
+    // an orphaned leading blank line (heddle#275 r2).
+    if wrote_header {
+        println!();
+    }
     // Identifiers are dimmed: structurally important but not the
     // editorial focus.
     println!(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -11557,3 +11557,70 @@ fn exit_codes_surface_in_json_catalog() {
         "bridge git import must surface DataErr (65) for malformed repos"
     );
 }
+
+/// `heddle log`, `show`, and `bridge git status` default text views must
+/// lead with command data — not the `Repository:` mode preamble, which is
+/// noise on every read (heddle#275). `-v` keeps the preamble for
+/// diagnostics, and `--output json` is untouched.
+#[test]
+fn read_commands_gate_repository_preamble_on_verbose() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("tracked.txt"), "tracked changed\n").unwrap();
+    heddle(&["commit", "-m", "checkpoint"], Some(temp.path())).unwrap();
+
+    for (label, default_args, verbose_args) in [
+        (
+            "log",
+            vec!["log", "--output", "text"],
+            vec!["-v", "log", "--output", "text"],
+        ),
+        (
+            "show",
+            vec!["show", "HEAD", "--output", "text"],
+            vec!["-v", "show", "HEAD", "--output", "text"],
+        ),
+        (
+            "bridge git status",
+            vec!["bridge", "git", "status", "--output", "text"],
+            vec!["-v", "bridge", "git", "status", "--output", "text"],
+        ),
+    ] {
+        let default_text = heddle(&default_args, Some(temp.path()))
+            .unwrap_or_else(|e| panic!("{label} default text should render: {e}"));
+        assert!(
+            !default_text.contains("Repository:"),
+            "{label} default text leaked the mode preamble: {default_text}"
+        );
+
+        let verbose_text = heddle(&verbose_args, Some(temp.path()))
+            .unwrap_or_else(|e| panic!("{label} verbose text should render: {e}"));
+        assert!(
+            verbose_text.contains("Repository:"),
+            "{label} -v text should retain the mode preamble: {verbose_text}"
+        );
+
+        let json = heddle(
+            &default_args
+                .iter()
+                .map(|a| if *a == "text" { "json" } else { a })
+                .collect::<Vec<_>>(),
+            Some(temp.path()),
+        )
+        .unwrap_or_else(|e| panic!("{label} json should render: {e}"));
+        let parsed: Value =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("{label} json should parse: {e}"));
+        assert!(
+            parsed["repository_capability"].is_string(),
+            "{label} json must keep repository_capability: {json}"
+        );
+    }
+}

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -7147,10 +7147,12 @@ fn narrow_no_color_text_outputs_cover_everyday_read_surfaces() {
         vec!["--quiet", "--output", "text", "workspace", "show"],
         &["Workspace", "main"],
     );
+    // The `Repository:` mode preamble is dropped from the default read
+    // view (heddle#275); the everyday surface leads with bridge state.
     assert_text_surface(
         temp.path(),
         vec!["--quiet", "--output", "text", "bridge", "git", "status"],
-        &["Repository", "Git import"],
+        &["Git import"],
     );
     assert_text_surface(
         temp.path(),

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -11602,6 +11602,12 @@ fn read_commands_gate_repository_preamble_on_verbose() {
             !default_text.contains("Repository:"),
             "{label} default text leaked the mode preamble: {default_text}"
         );
+        // Suppressing the preamble must not leave the spacer that used to
+        // follow it dangling as a leading blank line (heddle#275 r2).
+        assert!(
+            !default_text.starts_with('\n'),
+            "{label} default text starts with an orphaned blank line: {default_text:?}"
+        );
 
         let verbose_text = heddle(&verbose_args, Some(temp.path()))
             .unwrap_or_else(|e| panic!("{label} verbose text should render: {e}"));


### PR DESCRIPTION
## Summary
- Drop the `Repository:` mode preamble from the default text view of `heddle log`, `heddle show`, and `heddle bridge git status` — it was noise on every read (`heddle status` already exposes it).
- Retain the preamble under `-v` for diagnostics (threaded `cli.verbose > 0` into `render_bridge_git_status`; `write_full`/`render_state` already received the flag).
- `--output json` is untouched: `repository_capability` / `storage_model` still serialized.
- No new flag added; `heddle log --oneline` was already preamble-free and is unchanged.

Closes HeddleCo/heddle#275

## Red commit
`51686b2`

## Test evidence
```
$ cargo test -p heddle-cli --lib write_full_gates_repository_preamble_on_verbose
test cli::commands::log::tests::write_full_gates_repository_preamble_on_verbose ... ok
test result: ok. 1 passed; 0 failed

$ cargo test -p heddle-cli --test cli_integration -- read_commands_gate_repository_preamble_on_verbose narrow_no_color_text_outputs_cover_everyday_read_surfaces
test oss_cli_polish::read_commands_gate_repository_preamble_on_verbose ... ok
test oss_cli_polish::narrow_no_color_text_outputs_cover_everyday_read_surfaces ... ok
test result: ok. 2 passed; 0 failed

$ cargo test --workspace
test result: ok. 677 passed; 0 failed; 15 ignored (cli_integration)
# all crates green; no failures

$ cargo clippy --workspace --all-targets -- -D warnings
Finished — no warnings

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code
```

## Manual verification
N/A — covered by tests (unit gate on `write_full`, integration gate on `log`/`show`/`bridge git status` default vs `-v` vs json).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782648703&installation_id=132405951&pr_number=298&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F298&signature=c6d9c3cf8f10bc7fb8b05530f22ee593d408286cc03846883504b1163d335efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 2 (Codex)
- `76ab5ef` — gating the `Repository:` preamble on `-v` left the spacer that followed it dangling as a leading blank line in the default `heddle log` / `heddle show` text views (cids 3324235955/3324296001 log, 3324235959/3324296008 show). Both render paths now track a `wrote_header` flag and only emit the spacer when the preamble or import hint was actually written. Class-fix across both read paths; `bridge git status` is unaffected (preamble immediately followed by the always-present `Mirror:` line) and reflog is not -v-gated.
- Tests (red→green): `write_full` unit test asserts no leading blank line on default + spacer retained under `-v`; the `read_commands_gate_repository_preamble_on_verbose` integration loop asserts no default log/show/bridge text starts with a blank line.
