### PR TITLE
heddle#274: surface commit index-vs-worktree auto-switch + add --no-all

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -245,14 +245,13 @@ pub struct SnapshotArgs {
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Behavior:
-  With nothing staged in the Git index, `heddle commit -m ...` captures and checkpoints all modified, deleted, and untracked worktree paths.
-  When the Git index has staged paths, plain `heddle commit -m ...` checkpoints exactly the staged index and leaves extra unstaged/untracked paths in the worktree.
-  Add `--all` only when you intentionally want those extra paths included too.
+  Heddle's commit auto-switches on the Git index: with nothing staged it commits all worktree paths (like `git commit -a`, incl. untracked); with staged paths it commits only the index (like `git commit`). Pass `--no-all` to force index-only even when nothing is staged; pass `--all` to include unstaged/untracked paths even when the index has staged paths.
 
 Examples:
-  heddle commit -m 'add login route'       # save work; Git-overlay repos also checkpoint Git
-  heddle commit -m 'wip' --confidence 0.6  # record honest confidence
-  heddle commit --all -m 'save everything' # include unstaged/untracked paths even when the Git index is staged
+  heddle commit -m 'add login route'        # save work; Git-overlay repos also checkpoint Git
+  heddle commit -m 'wip' --confidence 0.6   # record honest confidence
+  heddle commit --no-all -m 'index only'    # commit only the Git index, never sweep the worktree
+  heddle commit --all -m 'save everything'  # include unstaged/untracked paths even when the Git index is staged
 ")]
 pub struct CommitArgs {
     /// Commit/capture message.
@@ -266,6 +265,10 @@ pub struct CommitArgs {
     /// Include unstaged and untracked paths when the Git index already has staged changes.
     #[arg(long)]
     pub all: bool,
+
+    /// Force an index-only commit even when nothing is staged, instead of sweeping the worktree.
+    #[arg(long = "no-all", conflicts_with = "all")]
+    pub no_all: bool,
 
     /// Allow a large or deletion-heavy capture without the safety preflight.
     #[arg(short, long)]

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -149,6 +149,14 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             && !git_index_intent(&repo)?.staged_paths.is_empty();
         if status.is_clean() && !has_staged_index_intent {
             let trust = build_repository_verification_state(&repo);
+            // `--no-all` forces an index-only commit and must never auto-commit
+            // the captured worktree state. On this fast-path the worktree is
+            // clean and the index has no staged intent, so an index-only commit
+            // has nothing to commit — surface that instead of silently
+            // checkpointing the pending capture into Git.
+            if args.no_all {
+                return Err(anyhow!(nothing_to_commit_advice()));
+            }
             if trust.status == "needs_checkpoint" {
                 preflight_git_checkpoint_identity(&repo, &user_config, "commit")?;
                 let git_previous_commit = git_head_oid(repo.root());

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -249,6 +249,15 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     let index_intent = git_index_intent(&repo)?;
     let pending_capture = pending_capture_before_commit(&repo)?;
     if !args.all && (args.no_all || !index_intent.staged_paths.is_empty()) {
+        // `--no-all` is index-only. Reaching here with no staged paths means
+        // the index is identical to HEAD (empty index, or index == HEAD), so
+        // there is nothing genuinely staged. Refuse with the standard
+        // nothing-to-commit outcome instead of letting `commit_staged_index`
+        // write a spurious empty / index-identical Git checkpoint. (The
+        // non-`--no-all` disjunct can only be taken with staged paths present.)
+        if index_intent.staged_paths.is_empty() {
+            return Err(anyhow!(nothing_to_commit_advice()));
+        }
         commit_staged_index(
             cli,
             &repo,

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -243,21 +243,26 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         return Ok(());
     }
 
+    let index_intent = git_index_intent(&repo)?;
+    if args.no_all && !args.all && index_intent.staged_paths.is_empty() {
+        // `--no-all` is index-only. With no staged paths the index is identical
+        // to HEAD (empty index, or index == HEAD), so there is nothing genuinely
+        // staged. Surface the standard nothing-to-commit outcome BEFORE the
+        // commit preflights: identity config and ref-update availability are
+        // irrelevant for a commit that was never going to write anything, so an
+        // unconfigured identity or blocked ref update must not mask the
+        // nothing-to-commit result.
+        return Err(anyhow!(nothing_to_commit_advice()));
+    }
+
     preflight_git_checkpoint_identity(&repo, &user_config, "commit")?;
     preflight_git_checkpoint_ref_update(&repo, "commit")?;
     let git_previous_commit = git_head_oid(repo.root());
-    let index_intent = git_index_intent(&repo)?;
     let pending_capture = pending_capture_before_commit(&repo)?;
     if !args.all && (args.no_all || !index_intent.staged_paths.is_empty()) {
-        // `--no-all` is index-only. Reaching here with no staged paths means
-        // the index is identical to HEAD (empty index, or index == HEAD), so
-        // there is nothing genuinely staged. Refuse with the standard
-        // nothing-to-commit outcome instead of letting `commit_staged_index`
-        // write a spurious empty / index-identical Git checkpoint. (The
-        // non-`--no-all` disjunct can only be taken with staged paths present.)
-        if index_intent.staged_paths.is_empty() {
-            return Err(anyhow!(nothing_to_commit_advice()));
-        }
+        // The `--no-all` + empty-index case short-circuited above, so reaching
+        // here always has staged paths present (either via `--no-all` with real
+        // staged changes, or the non-`--no-all` disjunct that requires them).
         commit_staged_index(
             cli,
             &repo,

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -240,7 +240,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     let git_previous_commit = git_head_oid(repo.root());
     let index_intent = git_index_intent(&repo)?;
     let pending_capture = pending_capture_before_commit(&repo)?;
-    if !args.all && !index_intent.staged_paths.is_empty() {
+    if !args.all && (args.no_all || !index_intent.staged_paths.is_empty()) {
         commit_staged_index(
             cli,
             &repo,
@@ -383,7 +383,7 @@ fn commit_staged_index(
         git_previous_commit,
         summary: staged_commit_summary(&record.summary, &intent),
         confidence: captured_state.confidence,
-        git_index: Some(GitIndexPlan::from_intent(&intent, false)),
+        git_index: Some(GitIndexPlan::index_only(&intent)),
         included_pending_capture: pending_capture.map(|state| state.short()),
         principal: captured_state.attribution.principal.into(),
         agent: captured_state
@@ -514,6 +514,22 @@ impl GitIndexPlan {
             untracked_paths,
             will_commit,
             preserved_after_commit,
+        }
+    }
+
+    /// Plan for an index-only commit: checkpoint exactly the staged index (which
+    /// may be empty, as on the `--no-all` path) and preserve every unstaged or
+    /// untracked worktree path. Never sweeps the worktree.
+    pub(crate) fn index_only(intent: &GitIndexIntent) -> Self {
+        let (unstaged_paths, untracked_paths) = split_extra_paths(&intent.extra_paths);
+        Self {
+            commit_mode: "staged_index",
+            has_staged_changes: !intent.staged_paths.is_empty(),
+            staged_paths: intent.staged_paths.clone(),
+            unstaged_paths,
+            untracked_paths,
+            will_commit: intent.staged_paths.clone(),
+            preserved_after_commit: intent.extra_paths.clone(),
         }
     }
 }

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -805,6 +805,60 @@ fn git_overlay_matrix_commit_without_any_identity_refuses_before_capture() {
 }
 
 #[test]
+fn git_overlay_matrix_commit_no_all_nothing_staged_refuses_before_identity_preflight() {
+    // `--no-all` with the index identical to HEAD has nothing to commit. That
+    // nothing-to-commit short-circuit must run BEFORE the identity / ref-update
+    // preflights: a repo with no configured identity must still get the
+    // nothing-to-commit outcome, not an identity-required refusal on a commit
+    // that was never going to write anything.
+    let temp = TempDir::new().unwrap();
+    let global_home = TempDir::new().unwrap();
+    init_git_repo_with_branch(temp.path(), "main");
+    std::fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+    git_commit_all(temp.path(), "seed");
+    git(&["config", "--unset", "user.name"], temp.path());
+    git(&["config", "--unset", "user.email"], temp.path());
+
+    let before_head = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
+    heddle_adopt(temp.path());
+
+    // Nothing genuinely staged (index == HEAD); only worktree edits + an
+    // untracked file make the worktree dirty.
+    std::fs::write(temp.path().join("base.txt"), "base\nworktree edit\n").unwrap();
+    std::fs::write(temp.path().join("scratch.txt"), "untracked\n").unwrap();
+
+    let output = heddle_output_with_env(
+        &["--output", "json", "commit", "--no-all", "-m", "index only"],
+        Some(temp.path()),
+        &[
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("HOME", global_home.path().to_str().unwrap()),
+            ("XDG_CONFIG_HOME", global_home.path().to_str().unwrap()),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .expect("heddle commit --no-all should run");
+    assert!(
+        !output.status.success(),
+        "commit --no-all with nothing staged must refuse: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("refusal should emit JSON envelope");
+    assert_eq!(
+        envelope["kind"], "nothing_to_commit",
+        "--no-all with nothing staged must surface nothing-to-commit before the identity preflight, not an identity refusal: {stderr}"
+    );
+    assert_eq!(
+        git_stdout(temp.path(), &["rev-parse", "HEAD"]),
+        before_head,
+        "--no-all must not create a commit when nothing is staged"
+    );
+}
+
+#[test]
 fn git_overlay_matrix_plain_git_no_commit_bootstrap_commands() {
     let temp = TempDir::new().unwrap();
     init_git_repo_with_branch(temp.path(), "trunk");

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -2528,6 +2528,93 @@ fn git_overlay_commit_no_all_forces_index_only_with_empty_index() {
 }
 
 #[test]
+fn git_overlay_commit_no_all_does_not_checkpoint_pending_capture() {
+    // Regression for the clean-worktree `needs_checkpoint` fast-path: after a
+    // `heddle capture`, the worktree matches Heddle's tree (status is clean)
+    // while Git HEAD is behind, so commit would normally checkpoint the
+    // captured worktree change into Git. `--no-all` must force an INDEX-ONLY
+    // commit and refuse to auto-checkpoint that pending capture.
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
+
+    // Capture a worktree edit into Heddle only. The Git index/HEAD still match
+    // the seed commit, and the worktree now matches Heddle's captured tree, so
+    // commit sees a clean worktree with an empty index that nonetheless needs a
+    // Git checkpoint.
+    std::fs::write(temp.path().join("file.txt"), "base\ncaptured\n").unwrap();
+    heddle(&["capture", "-m", "recoverable save"], Some(temp.path())).unwrap();
+    assert_eq!(
+        git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]),
+        "base",
+        "capture must not have moved Git HEAD"
+    );
+
+    // `--no-all`: index is empty, so there is nothing to commit. The captured
+    // worktree change must NOT be written into Git.
+    let output = heddle_output(
+        &["--output", "json", "commit", "--no-all", "-m", "index only"],
+        Some(temp.path()),
+    )
+    .expect("commit --no-all should run");
+    assert!(
+        !output.status.success(),
+        "commit --no-all with an empty index must refuse with nothing-to-commit: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
+    assert_eq!(
+        envelope["kind"], "nothing_to_commit",
+        "--no-all must surface nothing-to-commit, not a silent capture checkpoint: {envelope}"
+    );
+    assert_eq!(
+        git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]),
+        "base",
+        "--no-all must not checkpoint the pending capture into Git"
+    );
+}
+
+#[test]
+fn git_overlay_commit_without_no_all_checkpoints_pending_capture() {
+    // Contrast: the same clean-worktree `needs_checkpoint` scenario WITHOUT
+    // `--no-all` must still checkpoint the pending capture into Git (the
+    // default fast-path behavior).
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
+
+    std::fs::write(temp.path().join("file.txt"), "base\ncaptured\n").unwrap();
+    let capture = json_value(
+        temp.path(),
+        &["capture", "-m", "recoverable save", "--output", "json"],
+    );
+    let captured_state = capture["change_id"]
+        .as_str()
+        .expect("capture should report change id")
+        .to_string();
+
+    let commit = json_value(
+        temp.path(),
+        &["commit", "-m", "checkpoint capture", "--output", "json"],
+    );
+    assert_eq!(
+        commit["included_pending_capture"], captured_state,
+        "without --no-all the fast-path should checkpoint the pending capture: {commit}"
+    );
+    assert_eq!(
+        git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]),
+        "base\ncaptured",
+        "without --no-all the captured worktree change must land in Git"
+    );
+}
+
+#[test]
 fn commit_help_surfaces_index_vs_worktree_auto_switch() {
     let commit = heddle(&["commit", "--help"], None).expect("heddle commit --help should render");
     assert!(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -2445,6 +2445,105 @@ fn git_overlay_commit_respects_staged_index_and_leaves_extra_work() {
 }
 
 #[test]
+fn git_overlay_commit_empty_index_sweeps_whole_worktree() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
+
+    // Nothing staged: a worktree edit plus an untracked file.
+    std::fs::write(temp.path().join("file.txt"), "base\nswept\n").unwrap();
+    std::fs::write(temp.path().join("scratch.txt"), "untracked\n").unwrap();
+
+    let commit = json_value(temp.path(), &["commit", "-m", "sweep all", "--output", "json"]);
+    assert_eq!(
+        commit["git_index"]["commit_mode"], "worktree_all",
+        "an empty index should commit all worktree paths: {commit}"
+    );
+    let names = git_stdout_for_json_contract(temp.path(), &["show", "--name-only", "--format="]);
+    assert!(
+        names.contains("file.txt") && names.contains("scratch.txt"),
+        "empty-index commit should sweep both the edited and the untracked path: {names}"
+    );
+}
+
+#[test]
+fn git_overlay_commit_no_all_forces_index_only_with_empty_index() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
+
+    // Nothing staged: only worktree edits + an untracked file exist.
+    std::fs::write(temp.path().join("file.txt"), "base\nworktree edit\n").unwrap();
+    std::fs::write(temp.path().join("scratch.txt"), "untracked\n").unwrap();
+
+    // `--no-all` forces the index-only path even though nothing is staged, so
+    // the worktree sweep never happens.
+    let output = heddle_output(
+        &["--output", "json", "commit", "--no-all", "-m", "index only"],
+        Some(temp.path()),
+    )
+    .expect("commit --no-all should run");
+    assert!(
+        output.status.success(),
+        "commit --no-all should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let commit: Value =
+        serde_json::from_slice(&output.stdout).expect("commit --no-all JSON should parse");
+    assert_eq!(
+        commit["git_index"]["commit_mode"], "staged_index",
+        "--no-all must report an index-only commit, not a worktree sweep: {commit}"
+    );
+    assert_eq!(
+        commit["git_index"]["will_commit"],
+        serde_json::json!([]),
+        "--no-all with an empty index must commit nothing from the worktree: {commit}"
+    );
+    assert_eq!(
+        commit["git_index"]["preserved_after_commit"],
+        serde_json::json!(["unstaged: file.txt", "untracked: scratch.txt"]),
+        "--no-all must preserve the unswept worktree paths: {commit}"
+    );
+
+    // The commit reflects only the (empty) index, so HEAD:file.txt keeps the
+    // base content and both the worktree edit and the untracked file remain.
+    let head_file = git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]);
+    assert_eq!(
+        head_file, "base",
+        "--no-all must not sweep worktree edits into the commit"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+        "base\nworktree edit\n",
+        "the worktree edit should remain after --no-all"
+    );
+    assert!(
+        temp.path().join("scratch.txt").exists(),
+        "the untracked file should remain after --no-all"
+    );
+}
+
+#[test]
+fn commit_help_surfaces_index_vs_worktree_auto_switch() {
+    let commit = heddle(&["commit", "--help"], None).expect("heddle commit --help should render");
+    assert!(
+        commit.contains("auto-switches on the Git index")
+            && commit.contains("with nothing staged it commits all worktree paths")
+            && commit.contains("with staged paths it commits only the index")
+            && commit.contains("--no-all"),
+        "commit help should surface the accurate index-vs-worktree auto-switch: {commit}"
+    );
+    assert!(
+        !commit.contains("by default behaves like `git commit -a`"),
+        "commit help must not use the misleading default-is-`git commit -a` framing: {commit}"
+    );
+}
+
+#[test]
 fn git_overlay_commit_discloses_pending_capture_when_checkpointing_later_delta() {
     let temp = TempDir::new().unwrap();
     init_git_repo_for_json_contract(temp.path(), "main");
@@ -8786,9 +8885,8 @@ fn op_id_help_is_visible_only_for_supported_commands() {
         "op-id capable command help should expose --op-id: {commit}"
     );
     assert!(
-        commit.contains(
-            "captures and checkpoints all modified, deleted, and untracked worktree paths"
-        ) && commit.contains("checkpoints exactly the staged index")
+        commit.contains("with nothing staged it commits all worktree paths")
+            && commit.contains("with staged paths it commits only the index")
             && commit.contains("--all"),
         "commit help should explain all-worktree and staged-index semantics for Git users: {commit}"
     );

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -2469,53 +2469,53 @@ fn git_overlay_commit_empty_index_sweeps_whole_worktree() {
 }
 
 #[test]
-fn git_overlay_commit_no_all_forces_index_only_with_empty_index() {
+fn git_overlay_commit_no_all_empty_index_refuses_nothing_to_commit() {
     let temp = TempDir::new().unwrap();
     init_git_repo_for_json_contract(temp.path(), "main");
     std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
     git_commit_all_for_json_contract(temp.path(), "seed");
     heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
 
-    // Nothing staged: only worktree edits + an untracked file exist.
+    // Nothing genuinely staged: the index matches HEAD. Only worktree edits +
+    // an untracked file exist, so the worktree is dirty.
     std::fs::write(temp.path().join("file.txt"), "base\nworktree edit\n").unwrap();
     std::fs::write(temp.path().join("scratch.txt"), "untracked\n").unwrap();
 
-    // `--no-all` forces the index-only path even though nothing is staged, so
-    // the worktree sweep never happens.
+    let before = git_stdout_for_json_contract(temp.path(), &["rev-parse", "HEAD"]);
+
+    // `--no-all` is index-only. With the index identical to HEAD there is
+    // nothing staged, so it must refuse with nothing-to-commit rather than
+    // writing a spurious empty / index-identical Git checkpoint.
     let output = heddle_output(
         &["--output", "json", "commit", "--no-all", "-m", "index only"],
         Some(temp.path()),
     )
     .expect("commit --no-all should run");
     assert!(
-        output.status.success(),
-        "commit --no-all should succeed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !output.status.success(),
+        "commit --no-all with an empty index must refuse, not create a commit: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
-    let commit: Value =
-        serde_json::from_slice(&output.stdout).expect("commit --no-all JSON should parse");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
     assert_eq!(
-        commit["git_index"]["commit_mode"], "staged_index",
-        "--no-all must report an index-only commit, not a worktree sweep: {commit}"
-    );
-    assert_eq!(
-        commit["git_index"]["will_commit"],
-        serde_json::json!([]),
-        "--no-all with an empty index must commit nothing from the worktree: {commit}"
-    );
-    assert_eq!(
-        commit["git_index"]["preserved_after_commit"],
-        serde_json::json!(["unstaged: file.txt", "untracked: scratch.txt"]),
-        "--no-all must preserve the unswept worktree paths: {commit}"
+        envelope["kind"], "nothing_to_commit",
+        "--no-all with no staged changes must surface nothing-to-commit: {envelope}"
     );
 
-    // The commit reflects only the (empty) index, so HEAD:file.txt keeps the
-    // base content and both the worktree edit and the untracked file remain.
+    // HEAD is unchanged: no spurious commit was created.
+    let after = git_stdout_for_json_contract(temp.path(), &["rev-parse", "HEAD"]);
+    assert_eq!(
+        before, after,
+        "--no-all must not create a commit when nothing is staged"
+    );
     let head_file = git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]);
     assert_eq!(
         head_file, "base",
-        "--no-all must not sweep worktree edits into the commit"
+        "--no-all must not sweep worktree edits into a commit"
     );
+    // The worktree edits remain untouched.
     assert_eq!(
         std::fs::read_to_string(temp.path().join("file.txt")).unwrap(),
         "base\nworktree edit\n",
@@ -2524,6 +2524,64 @@ fn git_overlay_commit_no_all_forces_index_only_with_empty_index() {
     assert!(
         temp.path().join("scratch.txt").exists(),
         "the untracked file should remain after --no-all"
+    );
+}
+
+#[test]
+fn git_overlay_commit_no_all_with_real_staged_changes_commits_index_only() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt", "--ref", "main"], Some(temp.path())).unwrap();
+
+    // Genuinely stage a change, then add an unstaged edit + untracked file on
+    // top so the worktree is dirty beyond the index.
+    std::fs::write(temp.path().join("file.txt"), "staged\n").unwrap();
+    git_ok_for_json_contract(temp.path(), &["add", "file.txt"]);
+    std::fs::write(temp.path().join("file.txt"), "staged\nunstaged\n").unwrap();
+    std::fs::write(temp.path().join("scratch.txt"), "do not sweep\n").unwrap();
+
+    let before = git_stdout_for_json_contract(temp.path(), &["rev-parse", "HEAD"]);
+    let output = heddle_output(
+        &["--output", "json", "commit", "--no-all", "-m", "index only"],
+        Some(temp.path()),
+    )
+    .expect("commit --no-all should run");
+    assert!(
+        output.status.success(),
+        "commit --no-all with real staged changes should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let commit: Value =
+        serde_json::from_slice(&output.stdout).expect("commit --no-all JSON should parse");
+    assert_eq!(
+        commit["git_index"]["commit_mode"], "staged_index",
+        "--no-all must report an index-only commit: {commit}"
+    );
+    assert_eq!(
+        commit["git_index"]["will_commit"],
+        serde_json::json!(["file.txt"]),
+        "--no-all must commit only the staged path: {commit}"
+    );
+    assert_eq!(
+        commit["git_index"]["preserved_after_commit"],
+        serde_json::json!(["unstaged: file.txt", "untracked: scratch.txt"]),
+        "--no-all must preserve the unstaged/untracked worktree paths: {commit}"
+    );
+
+    let after = git_stdout_for_json_contract(temp.path(), &["rev-parse", "HEAD"]);
+    assert_ne!(before, after, "--no-all should write a Git commit");
+    // The commit reflects the staged index version only.
+    let head_file = git_stdout_for_json_contract(temp.path(), &["show", "HEAD:file.txt"]);
+    assert_eq!(
+        head_file, "staged",
+        "--no-all must commit the staged index content, not the worktree edit"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+        "staged\nunstaged\n",
+        "the unstaged edit should remain in the worktree"
     );
 }
 


### PR DESCRIPTION
## Summary
- Rewrite the `commit --help` Behavior banner to state the index auto-switch **accurately**: nothing staged → commits all worktree paths (like `git commit -a`, incl. untracked); staged paths → commits only the index (like `git commit`). Drops the misleading "by default = `git commit -a`" framing the groom corrected.
- Add `--no-all` to `CommitArgs` (mutually exclusive with `--all`) to force the index-only path even when nothing is staged, instead of auto-sweeping the worktree.
- Wire `--no-all` into the `git_compat.rs` dispatch and report the index-only commit accurately via `GitIndexPlan::index_only` (the empty-index `--no-all` path previously misreported `commit_mode: worktree_all` / swept `will_commit` in JSON while the actual commit was index-only).

Closes HeddleCo/heddle#274

## Red commit
`f2ca6d7`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration commit_help_surfaces_index_vs_worktree
test oss_cli_polish::commit_help_surfaces_index_vs_worktree_auto_switch ... ok

$ cargo test -p heddle-cli --test cli_integration git_overlay_commit_no_all_forces_index_only
test oss_cli_polish::git_overlay_commit_no_all_forces_index_only_with_empty_index ... ok

$ cargo test -p heddle-cli --test cli_integration git_overlay_commit_empty_index_sweeps
test oss_cli_polish::git_overlay_commit_empty_index_sweeps_whole_worktree ... ok

$ cargo test -p heddle-cli --test cli_integration git_overlay_commit_respects_staged_index   # regression
test oss_cli_polish::git_overlay_commit_respects_staged_index_and_leaves_extra_work ... ok
```
Local gates green before push: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`.

## Manual verification
N/A — covered by tests. (`commit --help` banner also visually confirmed.)


## Round 2 (Codex cid 3324725968)
- `--no-all` was only consulted at the index-vs-worktree dispatch (`git_compat.rs:243`); the earlier clean-worktree `needs_checkpoint` fast-path (~:152) still checkpointed the pending capture into Git, silently ignoring the flag.
- Fix: `--no-all` now short-circuits that fast-path to force index-only — with a clean worktree and empty index it surfaces the normal `nothing_to_commit` outcome instead of writing the captured worktree change into Git.
- Swept every commit-decision branch: the :243 dispatch already routed `--no-all` to `commit_staged_index` (index tree only, no worktree sweep), and with the flag set that dispatch always wins, so the bottom worktree_all sweep is unreachable. No third leak.
- Tests (red→green): `git_overlay_commit_no_all_does_not_checkpoint_pending_capture` + `git_overlay_commit_without_no_all_checkpoints_pending_capture`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782654215&installation_id=132405951&pr_number=299&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F299&signature=f401d070a23739f5ab44938e639e9133fba4430c148bd25ba13ec6a21e535ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Round 3
- Fixed cid 3325671308 (P2): `--no-all` routed into `commit_staged_index` whenever `no_all` was set, so with an index identical to HEAD (empty index / index==HEAD) it wrote a spurious empty / index-identical Git checkpoint.
- Close-the-class: guard once at the `--no-all` dispatch boundary (`git_compat.rs`) — when there are no genuinely-staged paths, return the standard `nothing_to_commit` outcome instead of calling `commit_staged_index`. No path under `--no-all` can now create an empty/index-identical commit.
- r2 behavior intact: real staged changes still commit index-only; the clean-worktree `needs_checkpoint` short-circuit still refuses under `--no-all`.
- Tests (red→green): empty-index/index==HEAD + dirty worktree → nothing-to-commit, HEAD unchanged; added positive `--no-all` with real staged changes → index-only commit.

## Round 4
- Fixed cid 3325859826 (P2): the r3 `--no-all` nothing-to-commit guard ran only AFTER `preflight_git_checkpoint_identity` / `preflight_git_checkpoint_ref_update`, so `--no-all` with index==HEAD + a dirty worktree in a repo with no configured identity (or blocked ref updates) errored on a preflight instead of reporting nothing-to-commit.
- Fix: ordering only — move the `--no-all` + empty-index short-circuit ahead of both commit preflights (`git_compat.rs`). A commit that was never going to write anything now returns `nothing_to_commit` without requiring identity config or unblocked ref updates. Preflights themselves unchanged; staged-changes behavior unchanged.
- Tests (red→green): `git_overlay_matrix_commit_no_all_nothing_staged_refuses_before_identity_preflight` — `--no-all`, index==HEAD, dirty worktree, no identity configured → `nothing_to_commit` (not `git_checkpoint_identity_required`), HEAD unchanged. r1/r2/r3 tests still green.