### PR TITLE
heddle#263: mark captured new files intent-to-add in colocated Git index

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -25,7 +25,7 @@ use gix_transport::{
 };
 use objects::{
     error::HeddleError,
-    object::{ChangeId, ChangeIdParseError, Principal, ThreadName, Tree},
+    object::{ChangeId, ChangeIdParseError, FileMode, Principal, ThreadName, Tree},
     store::ObjectStore,
 };
 use refs::Head;
@@ -1162,6 +1162,96 @@ impl<'a> GitBridge<'a> {
         self.write_through_current_checkout()
     }
 
+    /// Mark files that Heddle has captured but that Git still sees as
+    /// untracked as `intent-to-add` in the colocated checkout's index,
+    /// so a colocated developer's `git status` shows `AM new_file`
+    /// ("Heddle knows about it; no Git blob committed yet") instead of
+    /// `?? new_file` ("untracked — Git knows nothing"). The placeholder
+    /// entry uses the empty-blob oid and a zeroed stat, so Git always
+    /// reports the working-tree content as modified-against-index.
+    ///
+    /// Ported from jujutsu's `update_intent_to_add` (`lib/src/git.rs`),
+    /// which diffs `old_tree` vs `new_tree` and flags paths present in
+    /// the new tree but absent from the old one. Here `new_tree` is the
+    /// just-captured Heddle state's tree and `old_tree` is whatever the
+    /// checkout's index already tracks — paths already in the index are
+    /// not `??`, so they are left untouched (no spurious marking of
+    /// tracked or unchanged files).
+    ///
+    /// Call frequency mirrors jj: this fires at a Heddle parent/state
+    /// change (`capture`), not on every command. A later `checkpoint`
+    /// rebuilds the index from the committed tree via
+    /// [`Self::write_through_current_checkout`], replacing these
+    /// placeholder entries with real ones — so the index is never
+    /// churned by read-only invocations.
+    pub fn update_intent_to_add(&self, state_id: &ChangeId) -> GitResult<()> {
+        let root = self.heddle_repo.root();
+        if !root.join(".git").exists() {
+            return Ok(());
+        }
+        let checkout_repo = gix::discover(root).map_err(git_err)?;
+        // Skip detached HEAD: write-through only mirrors attached
+        // threads, and there is no branch context to reason about here.
+        if checkout_repo
+            .head()
+            .map(|head| head.is_detached())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
+        // `new_tree`: every file the just-captured state contains.
+        let Some(state) = self.heddle_repo.store().get_state(state_id)? else {
+            return Ok(());
+        };
+        let Some(tree) = self.heddle_repo.store().get_tree(&state.tree)? else {
+            return Ok(());
+        };
+        let mut captured: Vec<(String, FileMode)> = Vec::new();
+        collect_capture_paths(self.heddle_repo.store(), &tree, "", &mut captured)?;
+        if captured.is_empty() {
+            return Ok(());
+        }
+
+        // `old_tree`: paths the checkout's index already tracks. Anything
+        // present here is not `??`, so it needs no intent-to-add entry.
+        let mut index = checkout_repo.open_index().map_err(git_err)?;
+        let tracked: HashSet<String> = index
+            .entries_with_paths_by_filter_map(|path, _| Some(path.to_str_lossy().into_owned()))
+            .map(|(_, path)| path)
+            .collect();
+
+        let empty_blob = checkout_repo.object_hash().empty_blob();
+        let mut added = false;
+        for (path, mode) in &captured {
+            if tracked.contains(path) {
+                continue;
+            }
+            let entry_mode = match mode {
+                FileMode::Executable => gix_index::entry::Mode::FILE_EXECUTABLE,
+                FileMode::Symlink => gix_index::entry::Mode::SYMLINK,
+                FileMode::Normal => gix_index::entry::Mode::FILE,
+            };
+            index.dangerously_push_entry(
+                gix_index::entry::Stat::default(),
+                empty_blob,
+                gix_index::entry::Flags::INTENT_TO_ADD | gix_index::entry::Flags::EXTENDED,
+                entry_mode,
+                path.as_bytes().as_bstr(),
+            );
+            added = true;
+        }
+        if added {
+            // `dangerously_push_entry` appends without preserving sort
+            // order; restore it so subsequent path lookups stay correct.
+            index.sort_entries();
+            index
+                .write(gix_index::write::Options::default())
+                .map_err(git_err)?;
+        }
+        Ok(())
+    }
+
     /// Make the checkout's real `.git` view agree with a specific Heddle
     /// thread. `thread switch` uses this after writing Heddle HEAD because
     /// resolving "current" through Git-overlay discovery can still see the
@@ -1925,6 +2015,33 @@ pub(crate) fn set_reference(
     };
     repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
         .map_err(git_err)?;
+    Ok(())
+}
+
+/// Recursively collect every file path (blob and symlink) in `tree`,
+/// resolving subtrees through `store`. Missing subtree objects are
+/// skipped rather than treated as errors, matching the repo's other
+/// tree walks. Paths use `/` separators, the form Git's index expects.
+fn collect_capture_paths<S: ObjectStore + ?Sized>(
+    store: &S,
+    tree: &Tree,
+    prefix: &str,
+    out: &mut Vec<(String, FileMode)>,
+) -> GitResult<()> {
+    for entry in tree.iter() {
+        let path = if prefix.is_empty() {
+            entry.name.clone()
+        } else {
+            format!("{prefix}/{}", entry.name)
+        };
+        if entry.is_tree() {
+            if let Some(subtree) = store.get_tree(&entry.hash)? {
+                collect_capture_paths(store, &subtree, &path, out)?;
+            }
+        } else {
+            out.push((path, entry.mode));
+        }
+    }
     Ok(())
 }
 

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1213,18 +1213,47 @@ impl<'a> GitBridge<'a> {
             return Ok(());
         }
 
-        // `old_tree`: paths the checkout's index already tracks. Anything
-        // present here is not `??`, so it needs no intent-to-add entry.
+        // Reconcile the index's intent-to-add set against the captured
+        // state. Real (committed) entries are left untouched; the
+        // intent-to-add set must end up equal to the captured paths that
+        // are not yet real entries. So we both ADD newly-captured paths
+        // and PRUNE intent-to-add entries whose path left the captured
+        // set (deleted, or now committed) — otherwise a stale entry
+        // surfaces as a phantom ` D path` in `git status`.
         let mut index = checkout_repo.open_index().map_err(git_err)?;
-        let tracked: HashSet<String> = index
-            .entries_with_paths_by_filter_map(|path, _| Some(path.to_str_lossy().into_owned()))
-            .map(|(_, path)| path)
-            .collect();
 
+        // Partition existing entries: real tracked paths vs. the
+        // intent-to-add placeholders we manage here.
+        let mut real_tracked: HashSet<String> = HashSet::new();
+        let mut existing_ita: HashSet<String> = HashSet::new();
+        for entry in index.entries() {
+            let path = entry.path_in(index.path_backing()).to_str_lossy().into_owned();
+            if entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD) {
+                existing_ita.insert(path);
+            } else {
+                real_tracked.insert(path);
+            }
+        }
+
+        // Desired intent-to-add set: captured paths not backed by a real
+        // (committed) index entry.
+        let captured_paths: HashSet<&str> = captured.iter().map(|(p, _)| p.as_str()).collect();
+
+        // PRUNE: any intent-to-add entry whose path is no longer desired.
+        let mut changed = false;
+        index.remove_entries(|_, path, entry| {
+            let stale = entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD)
+                && !captured_paths.contains(path.to_str_lossy().as_ref());
+            if stale {
+                changed = true;
+            }
+            stale
+        });
+
+        // ADD: newly-captured paths not already tracked or marked.
         let empty_blob = checkout_repo.object_hash().empty_blob();
-        let mut added = false;
         for (path, mode) in &captured {
-            if tracked.contains(path) {
+            if real_tracked.contains(path) || existing_ita.contains(path) {
                 continue;
             }
             let entry_mode = match mode {
@@ -1239,9 +1268,10 @@ impl<'a> GitBridge<'a> {
                 entry_mode,
                 path.as_bytes().as_bstr(),
             );
-            added = true;
+            changed = true;
         }
-        if added {
+
+        if changed {
             // `dangerously_push_entry` appends without preserving sort
             // order; restore it so subsequent path lookups stay correct.
             index.sort_entries();

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1257,6 +1257,19 @@ impl<'a> GitBridge<'a> {
             if real_tracked.contains(path) || existing_ita.contains(path) {
                 continue;
             }
+            // Git's index cannot hold both a blob `foo` and a blob
+            // `foo/bar` — a path is either a file or a directory. An
+            // added path that file↔directory-PREFIX-conflicts with a
+            // still-tracked real entry is not a clean "new file": the
+            // real entry wins. Writing an intent-to-add placeholder for
+            // it would corrupt the index into a file/dir conflict, so
+            // skip it (checked in both directions).
+            if real_tracked
+                .iter()
+                .any(|tracked| path_prefix_conflict(path, tracked))
+            {
+                continue;
+            }
             let entry_mode = match mode {
                 FileMode::Executable => gix_index::entry::Mode::FILE_EXECUTABLE,
                 FileMode::Symlink => gix_index::entry::Mode::SYMLINK,
@@ -2047,6 +2060,20 @@ pub(crate) fn set_reference(
     repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
         .map_err(git_err)?;
     Ok(())
+}
+
+/// Whether two index paths file↔directory-PREFIX-conflict: one names a
+/// blob that is a directory prefix of the other (`foo` vs `foo/bar`, in
+/// either order). Git's index cannot hold both, since a path is either a
+/// file or a directory. Equal paths do NOT count here — that case is an
+/// exact match handled separately by the caller.
+fn path_prefix_conflict(a: &str, b: &str) -> bool {
+    let child_of = |parent: &str, child: &str| {
+        child
+            .strip_prefix(parent)
+            .is_some_and(|rest| rest.starts_with('/'))
+    };
+    child_of(a, b) || child_of(b, a)
 }
 
 /// Recursively collect every file path (blob and symlink) in `tree`,

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1209,9 +1209,10 @@ impl<'a> GitBridge<'a> {
         };
         let mut captured: Vec<(String, FileMode)> = Vec::new();
         collect_capture_paths(self.heddle_repo.store(), &tree, "", &mut captured)?;
-        if captured.is_empty() {
-            return Ok(());
-        }
+        // No early return on an empty captured set: the reconcile below must
+        // run on EVERY recapture path. When the recaptured state is empty,
+        // `captured_paths` is empty too, so the PRUNE pass clears every prior
+        // intent-to-add entry (all are now stale) and the ADD loop is a no-op.
 
         // Reconcile the index's intent-to-add set against the captured
         // state. Real (committed) entries are left untouched; the

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -32,6 +32,7 @@ use super::{
     thread_cmd::current_thread,
 };
 use crate::{
+    bridge::GitBridge,
     cli::{Cli, should_output_json, style},
     config::UserConfig,
 };
@@ -171,6 +172,26 @@ pub async fn cmd_snapshot(
 
     let as_json = should_output_json(cli, Some(repo.config()));
     let git_overlay = repo.capability() == repo::RepositoryCapability::GitOverlay;
+
+    // In a colocated checkout, mark newly-captured files as intent-to-add
+    // in the real `.git/index` so `git status` shows `AM` ("Heddle knows
+    // about it") instead of `??` ("untracked"). Best-effort: the state is
+    // already durably captured, so a presentation-only index update must
+    // not fail the command. `capture` is a Heddle parent/state change —
+    // the call frequency jj's `update_intent_to_add` is designed for.
+    if git_overlay {
+        match repo.current_state() {
+            Ok(Some(state)) => {
+                let bridge = GitBridge::new(&repo);
+                if let Err(err) = bridge.update_intent_to_add(&state.change_id) {
+                    debug!("intent-to-add index update skipped: {err}");
+                }
+            }
+            Ok(None) => {}
+            Err(err) => debug!("intent-to-add index update skipped: {err}"),
+        }
+    }
+
     if as_json {
         println!("{}", serde_json::to_string(&output)?);
     } else {

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -232,6 +232,94 @@ fn recapture_to_empty_tree_prunes_stale_intent_to_add() {
     );
 }
 
+/// Git's index cannot hold both `foo` (a blob) and `foo/bar` (a blob
+/// under a directory) — they are mutually exclusive (a path is either a
+/// file or a directory). When a recapture introduces a path that
+/// file/dir-PREFIX-conflicts with a still-tracked real entry, the ADD
+/// pass must NOT write an intent-to-add entry for it: the real entry
+/// wins, and a conflicting placeholder would corrupt the index into a
+/// file/dir conflict.
+///
+/// Direction A: Git tracks `foo` (a file); the worktree replaces it with
+/// a directory `foo/` holding `foo/bar`. Recapture must not add an
+/// intent-to-add entry for `foo/bar` alongside the tracked `foo`.
+#[test]
+fn recapture_skips_intent_to_add_that_conflicts_with_tracked_file() {
+    let source = TempDir::new().unwrap();
+    init_colocated_git_repo(source.path());
+
+    std::fs::write(source.path().join("foo"), "i am a file\n").unwrap();
+    git_commit_all_in(source.path(), "initial");
+
+    heddle(&["adopt", "--ref", "main"], Some(source.path()))
+        .expect("adopt should import Git history into Heddle");
+
+    // Replace the tracked file `foo` with a directory `foo/` containing
+    // `foo/bar`. The captured state now has `foo/bar`, but the real
+    // index entry `foo` is still present (no checkpoint has committed
+    // the change). Adding intent-to-add for `foo/bar` would conflict.
+    std::fs::remove_file(source.path().join("foo")).unwrap();
+    std::fs::create_dir(source.path().join("foo")).unwrap();
+    std::fs::write(source.path().join("foo").join("bar"), "now a dir\n").unwrap();
+    heddle(&["capture", "-m", "file becomes directory"], Some(source.path()))
+        .expect("recapture should record the file→dir change");
+
+    // The index must stay valid: never both `foo` and `foo/bar`.
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8(staged.stdout).unwrap();
+    let has_foo = staged.lines().any(|l| l.ends_with("\tfoo"));
+    let has_foo_bar = staged.lines().any(|l| l.ends_with("\tfoo/bar"));
+    assert!(
+        !(has_foo && has_foo_bar),
+        "index must not hold both `foo` and `foo/bar` (file/dir conflict). ls-files:\n{staged}"
+    );
+    // git status must still run cleanly over the index.
+    let _ = git_status_porcelain(source.path());
+}
+
+/// Direction B (reverse): Git tracks `foo/bar` (a blob under a dir); the
+/// worktree replaces the directory with a file `foo`. The captured state
+/// has `foo`, but the real index entry `foo/bar` is still present.
+/// Adding intent-to-add for `foo` would conflict with the tracked
+/// `foo/bar`, so it must be skipped.
+#[test]
+fn recapture_skips_intent_to_add_that_conflicts_with_tracked_dir() {
+    let source = TempDir::new().unwrap();
+    init_colocated_git_repo(source.path());
+
+    std::fs::create_dir(source.path().join("foo")).unwrap();
+    std::fs::write(source.path().join("foo").join("bar"), "i am under a dir\n").unwrap();
+    git_commit_all_in(source.path(), "initial");
+
+    heddle(&["adopt", "--ref", "main"], Some(source.path()))
+        .expect("adopt should import Git history into Heddle");
+
+    // Replace the directory `foo/` with a file `foo`. The captured state
+    // now has `foo`, but the real index entry `foo/bar` is still present.
+    std::fs::remove_dir_all(source.path().join("foo")).unwrap();
+    std::fs::write(source.path().join("foo"), "now a file\n").unwrap();
+    heddle(&["capture", "-m", "dir becomes file"], Some(source.path()))
+        .expect("recapture should record the dir→file change");
+
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8(staged.stdout).unwrap();
+    let has_foo = staged.lines().any(|l| l.ends_with("\tfoo"));
+    let has_foo_bar = staged.lines().any(|l| l.ends_with("\tfoo/bar"));
+    assert!(
+        !(has_foo && has_foo_bar),
+        "index must not hold both `foo` and `foo/bar` (file/dir conflict). ls-files:\n{staged}"
+    );
+    let _ = git_status_porcelain(source.path());
+}
+
 #[test]
 fn test_cli_bridge_git_init() {
     let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -54,11 +54,19 @@ fn git_status_porcelain(path: &std::path::Path) -> String {
     String::from_utf8(out.stdout).unwrap()
 }
 
+/// The empty-blob object id (SHA-1). An intent-to-add index entry points
+/// at this rather than a real blob — that is what makes Git treat the
+/// path as "added, content not yet staged".
+const EMPTY_BLOB_OID: &str = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+
 /// After `heddle capture` records a NEW file in a colocated checkout,
-/// `git status` should report it as `AM` (intent-to-add: Heddle knows
-/// about it, the blob isn't a real Git commit yet) rather than `??`
-/// (untracked, "Heddle knows nothing"). Already-tracked, unchanged files
-/// must NOT be touched.
+/// `git status` should report it as intent-to-add ("Heddle knows about
+/// it; no Git blob committed yet") rather than `??` (untracked, "Git
+/// knows nothing"). This is byte-for-byte the state `git add -N`
+/// produces — Git 2.43 renders the porcelain code as ` A` (older docs,
+/// and the issue, call it `AM`); the version-stable invariant is the
+/// empty-blob index entry, which we assert directly. Already-tracked,
+/// unchanged files must NOT be touched.
 #[test]
 fn capture_marks_new_file_intent_to_add_in_colocated_index() {
     let source = TempDir::new().unwrap();
@@ -76,14 +84,34 @@ fn capture_marks_new_file_intent_to_add_in_colocated_index() {
 
     let status = git_status_porcelain(source.path());
 
+    let new_file_line = status
+        .lines()
+        .find(|line| line.ends_with("new_file.txt"))
+        .unwrap_or_else(|| panic!("new_file.txt must appear in git status. Status was:\n{status}"));
+    // Intent-to-add shows an `A` in the status code (` A`, `AM`, or `A `
+    // across Git versions) — never `??`.
     assert!(
-        status.lines().any(|line| line == "AM new_file.txt"),
-        "new file should be intent-to-add (AM), not untracked. Status was:\n{status}"
+        new_file_line[..2].contains('A'),
+        "new file should be intent-to-add (contains `A`), got {new_file_line:?}. Status was:\n{status}"
     );
     assert!(
         !status.contains("?? new_file.txt"),
         "new file must no longer show as untracked (??). Status was:\n{status}"
     );
+
+    // The version-stable proof of intent-to-add: the staged entry points
+    // at the empty blob, not a real object copied into `.git/objects`.
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage", "new_file.txt"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8(staged.stdout).unwrap();
+    assert!(
+        staged.contains(EMPTY_BLOB_OID),
+        "new file's index entry must be intent-to-add (empty-blob oid), got: {staged:?}"
+    );
+
     assert!(
         !status.lines().any(|line| line.ends_with("tracked.txt")),
         "an already-tracked, unchanged file must not be marked. Status was:\n{status}"

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -2,6 +2,94 @@
 use super::*;
 use objects::object::ThreadName;
 
+/// Initialize a colocated (drop-in) Git repo on `main` with one
+/// committed file, mirroring the bootstrap the overlay tests use.
+fn init_colocated_git_repo(path: &std::path::Path) {
+    assert!(Command::new("git")
+        .arg("init")
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    for (k, v) in [
+        ("user.name", "Heddle Test"),
+        ("user.email", "heddle@example.com"),
+        ("init.defaultBranch", "main"),
+    ] {
+        Command::new("git")
+            .args(["config", k, v])
+            .current_dir(path)
+            .status()
+            .unwrap();
+    }
+    Command::new("git")
+        .args(["checkout", "-B", "main"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+}
+
+fn git_commit_all_in(path: &std::path::Path, message: &str) {
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(path)
+        .status()
+        .unwrap()
+        .success());
+}
+
+fn git_status_porcelain(path: &std::path::Path) -> String {
+    let out = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git status --porcelain must succeed");
+    String::from_utf8(out.stdout).unwrap()
+}
+
+/// After `heddle capture` records a NEW file in a colocated checkout,
+/// `git status` should report it as `AM` (intent-to-add: Heddle knows
+/// about it, the blob isn't a real Git commit yet) rather than `??`
+/// (untracked, "Heddle knows nothing"). Already-tracked, unchanged files
+/// must NOT be touched.
+#[test]
+fn capture_marks_new_file_intent_to_add_in_colocated_index() {
+    let source = TempDir::new().unwrap();
+    init_colocated_git_repo(source.path());
+
+    std::fs::write(source.path().join("tracked.txt"), "already tracked\n").unwrap();
+    git_commit_all_in(source.path(), "initial");
+
+    heddle(&["adopt", "--ref", "main"], Some(source.path()))
+        .expect("adopt should import Git history into Heddle");
+
+    std::fs::write(source.path().join("new_file.txt"), "brand new content\n").unwrap();
+    heddle(&["capture", "-m", "add new file"], Some(source.path()))
+        .expect("capture should record the new file");
+
+    let status = git_status_porcelain(source.path());
+
+    assert!(
+        status.lines().any(|line| line == "AM new_file.txt"),
+        "new file should be intent-to-add (AM), not untracked. Status was:\n{status}"
+    );
+    assert!(
+        !status.contains("?? new_file.txt"),
+        "new file must no longer show as untracked (??). Status was:\n{status}"
+    );
+    assert!(
+        !status.lines().any(|line| line.ends_with("tracked.txt")),
+        "an already-tracked, unchanged file must not be marked. Status was:\n{status}"
+    );
+}
+
 #[test]
 fn test_cli_bridge_git_init() {
     let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -118,6 +118,60 @@ fn capture_marks_new_file_intent_to_add_in_colocated_index() {
     );
 }
 
+/// `update_intent_to_add` must RECONCILE, not just append: when a file
+/// that was previously marked intent-to-add is no longer in the captured
+/// state (e.g. it was created, captured, then deleted before checkpoint),
+/// its stale index entry must be pruned. A surviving intent-to-add entry
+/// whose worktree file is gone makes `git status` report a phantom ` D`
+/// deletion that Heddle never intended.
+#[test]
+fn recapture_prunes_stale_intent_to_add_for_removed_file() {
+    let source = TempDir::new().unwrap();
+    init_colocated_git_repo(source.path());
+
+    std::fs::write(source.path().join("tracked.txt"), "already tracked\n").unwrap();
+    git_commit_all_in(source.path(), "initial");
+
+    heddle(&["adopt", "--ref", "main"], Some(source.path()))
+        .expect("adopt should import Git history into Heddle");
+
+    // Capture a new file: it becomes intent-to-add in the colocated index.
+    std::fs::write(source.path().join("new_file.txt"), "brand new content\n").unwrap();
+    heddle(&["capture", "-m", "add new file"], Some(source.path()))
+        .expect("capture should record the new file");
+
+    let status = git_status_porcelain(source.path());
+    assert!(
+        status.lines().any(|line| line.ends_with("new_file.txt")),
+        "precondition: new_file.txt must be intent-to-add after first capture. Status was:\n{status}"
+    );
+
+    // Delete the file before any checkpoint commits it, then recapture.
+    // The captured state no longer contains new_file.txt, so its
+    // intent-to-add index entry is now stale and must be pruned.
+    std::fs::remove_file(source.path().join("new_file.txt")).unwrap();
+    heddle(&["capture", "-m", "remove new file"], Some(source.path()))
+        .expect("recapture should record the deletion");
+
+    let status = git_status_porcelain(source.path());
+    assert!(
+        !status.lines().any(|line| line.ends_with("new_file.txt")),
+        "stale intent-to-add for a deleted file must be pruned — no phantom ` D` entry. Status was:\n{status}"
+    );
+
+    // The index entry must be gone entirely, not merely re-pointed.
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage", "new_file.txt"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8(staged.stdout).unwrap();
+    assert!(
+        staged.trim().is_empty(),
+        "stale intent-to-add index entry must be removed, got: {staged:?}"
+    );
+}
+
 #[test]
 fn test_cli_bridge_git_init() {
     let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -172,6 +172,66 @@ fn recapture_prunes_stale_intent_to_add_for_removed_file() {
     );
 }
 
+/// The prune must run on EVERY recapture path, including the one where
+/// the recaptured state is EMPTY (no files at all). An early `captured
+/// .is_empty()` fast path that returns before the reconcile lets stale
+/// intent-to-add entries survive: capture a new file (it becomes
+/// intent-to-add), then delete every file so the next capture yields an
+/// empty tree — the old intent-to-add entry must still be pruned, not
+/// left behind as a phantom.
+#[test]
+fn recapture_to_empty_tree_prunes_stale_intent_to_add() {
+    let source = TempDir::new().unwrap();
+    init_colocated_git_repo(source.path());
+
+    std::fs::write(source.path().join("tracked.txt"), "already tracked\n").unwrap();
+    git_commit_all_in(source.path(), "initial");
+
+    heddle(&["adopt", "--ref", "main"], Some(source.path()))
+        .expect("adopt should import Git history into Heddle");
+
+    // Capture a new file: it becomes intent-to-add in the colocated index.
+    std::fs::write(source.path().join("new_file.txt"), "brand new content\n").unwrap();
+    heddle(&["capture", "-m", "add new file"], Some(source.path()))
+        .expect("capture should record the new file");
+
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage", "new_file.txt"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8(staged.stdout).unwrap().contains(EMPTY_BLOB_OID),
+        "precondition: new_file.txt must be intent-to-add after first capture"
+    );
+
+    // Delete EVERY file so the recaptured state is an empty tree, hitting
+    // the `captured.is_empty()` fast path. The intent-to-add entry for
+    // new_file.txt is now stale and must still be pruned.
+    std::fs::remove_file(source.path().join("new_file.txt")).unwrap();
+    std::fs::remove_file(source.path().join("tracked.txt")).unwrap();
+    heddle(&["capture", "-m", "remove everything"], Some(source.path()))
+        .expect("recapture should record the empty tree");
+
+    let status = git_status_porcelain(source.path());
+    assert!(
+        !status.lines().any(|line| line.ends_with("new_file.txt")),
+        "stale intent-to-add must be pruned even when the recapture yields an empty tree. Status was:\n{status}"
+    );
+
+    // The intent-to-add index entry must be gone entirely.
+    let staged = Command::new("git")
+        .args(["ls-files", "--stage", "new_file.txt"])
+        .current_dir(source.path())
+        .output()
+        .unwrap();
+    let staged = String::from_utf8(staged.stdout).unwrap();
+    assert!(
+        staged.trim().is_empty(),
+        "stale intent-to-add index entry must be removed on the empty-tree path, got: {staged:?}"
+    );
+}
+
 #[test]
 fn test_cli_bridge_git_init() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- Port jujutsu's `update_intent_to_add` into the bridge (`git_core.rs`): after a capture, diff the captured state's tree against the paths the colocated Git index already tracks and write `INTENT_TO_ADD` index entries (empty-blob oid, zeroed stat) for the **added** paths only.
- A colocated developer's `git status` now shows a heddle-captured new file as **intent-to-add** ("Heddle knows about it; no Git blob committed yet") instead of `??` (untracked). This is byte-for-byte the state `git add -N` produces.
- Wired into `cmd_snapshot` (the `heddle capture` path) — a Heddle parent/state-change point — gated to colocated (`GitOverlay`) repos. Tracked/unchanged files are left untouched; the update is best-effort so it never fails an already-durable capture.

Closes HeddleCo/heddle#263

## Red commit
`6050072`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration capture_marks_new_file_intent_to_add
running 1 test
test bridge::capture_marks_new_file_intent_to_add_in_colocated_index ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 815 filtered out; finished in 0.40s
```
Local CI-parity gates (all green):
```
$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (514 file(s) scanned)
$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo test --workspace                                  # 0 failures across all suites
```

## Manual verification
N/A — covered by the integration test. (Behavior also reproduced by hand: colocated `git init` + `heddle adopt` + new file + `heddle capture` → `git status` reports the file as intent-to-add, identical to `git add -N`.)

## Plan & deviations
The brief asked to wire `update_intent_to_add` into `write_through_current_checkout`. Empirically that call site is wrong for the issue's DoD, and I deviated with evidence (documented here and in the CLARIFY comment on the issue):

1. **`heddle capture` does not call `write_through_current_checkout`** — only `checkpoint` does (`checkpoint.rs:175`). After `capture`, Git HEAD/index are untouched, so `git status` shows `??`. So wiring only into write-through would never fire on `capture` and the DoD test (`capture` → not-`??`) could not pass.
2. **`write_through` advances Git HEAD to the captured commit** (`update_checkout_head_ref`), with the blob present in `.git/objects` → after `checkpoint` the file is fully committed and `git status` is *clean*. Marking it intent-to-add there (empty blob) would be wrong.
3. **jj's invariant** is that Git HEAD == `old_tree` (the parent) and files in `new_tree` but not HEAD get `INTENT_TO_ADD` — HEAD stays at the parent. In heddle that state is exactly **post-`capture`, pre-`checkpoint`**. So the jj-faithful, DoD-satisfying call site is the capture/snapshot path. A later `checkpoint` overwrites the placeholder entries via `index_from_tree` → clean. The capture→checkpoint lifecycle is: `capture` ⇒ intent-to-add, `checkpoint` ⇒ real commit.

**`AM` vs ` A`:** the issue describes the porcelain code as `AM`. On Git 2.43 a pure intent-to-add entry (identical to `git add -N`) renders as ` A` (long-form: "new file:" under "Changes not staged for commit"). The version-stable invariant is the empty-blob index entry, which the test asserts directly (`git ls-files --stage` shows `e69de29…`); the porcelain-code assertion accepts any `A`-bearing code and rejects `??`.

## Round 2 (Codex cid 3325147057)
`update_intent_to_add` was append-only: it added intent-to-add entries for newly-captured paths but never removed entries for paths that left the captured set. Repro: capture a new file (intent-to-add), delete it before checkpoint, recapture → the stale index entry survived and `git status` showed a phantom ` D path`.

Fix (close-the-class): the method now performs a single **reconcile** pass. It partitions existing index entries into real-tracked vs. intent-to-add, **prunes** every intent-to-add entry whose path is no longer in the captured added-set (`remove_entries`), and **adds** newly-captured paths. Post-call, the index's intent-to-add set equals exactly the current captured added-paths — no add-only or prune-only residue. Genuinely-tracked/committed entries are untouched.

Red→green test `recapture_prunes_stale_intent_to_add_for_removed_file` (commit `6b9cba2`); r1 happy-path test stays green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782655650&installation_id=132405951&pr_number=300&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F300&signature=ac6326c5b00d96dd928c369b750c03244d4dd7ac8ee0816e0bda9bd58be728cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


## Round 3 (Codex cid 3325333119)
The r2 reconcile pass was bypassed by an early `captured.is_empty()` fast path: when a recapture left the Heddle state with no files (empty tree), the method `return`ed before the prune, so prior intent-to-add entries survived as phantoms. This is a sibling of the r2 finding — the prune existed on the main path but an early return short-circuited it.

Fix (close-the-class): removed the early return so the single reconcile pass runs on **every** recapture path. When the captured set is empty, `captured_paths` is empty too, so the PRUNE clears every prior intent-to-add entry (all now stale) and the ADD loop is a no-op. No early return bypasses the reconcile anymore.

Red→green test `recapture_to_empty_tree_prunes_stale_intent_to_add` (red `8bec690`, green `0c1bcbc`); r1 + r2 tests stay green.


## Round 4 (Codex cid 3325554229)
The ADD pass used an exact-path check, so it ignored file↔directory **prefix** conflicts. Git's index cannot hold both a blob `foo` and a blob `foo/bar` — a path is either a file or a directory. A recapture that turns a tracked file into a directory (`foo` → `foo/bar`) or vice-versa would add an intent-to-add placeholder alongside the still-tracked real entry, corrupting the index into a file/dir conflict.

Fix: before pushing an intent-to-add placeholder, skip any captured path that prefix-conflicts with a still-tracked real entry, checked in **both** directions (new path is a child of a tracked file; new path is a parent dir of a tracked path). The real entry wins — intent-to-add is only for genuinely-new added paths that don't collide. New helper `path_prefix_conflict`. Consistent with the r2/r3 reconcile: the intent-to-add set never introduces an entry that conflicts with a real tracked entry.

Red→green tests `recapture_skips_intent_to_add_that_conflicts_with_tracked_file` and `..._tracked_dir` (red `e2c2daf`, green `6f86029`); r1/r2/r3 tests stay green.
