### PR TITLE
heddle#306: keep thread_state lifecycle-only so status and thread list agree

### DIFF
--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -958,11 +958,10 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         } else {
             output.coordination_status
         },
-        thread_state: if blocked_by_trust && !needs_checkpoint && output.thread_state.is_some() {
-            Some(ThreadState::Blocked)
-        } else {
-            output.thread_state
-        },
+        // `thread_state` is lifecycle-only and must match `thread list` for the
+        // same thread/instant (heddle#306). The verification/dirty-worktree
+        // blocker is a health signal, surfaced via `coordination_status` above.
+        thread_state: output.thread_state,
         changed_path_count: if trust.verified {
             changed_path_count(thread_summary.as_ref(), &output.changes)
         } else {
@@ -1410,10 +1409,7 @@ fn render_status_details(output: &StatusOutput, verbose: bool) {
             println!("{}", style::dim("Worktree"));
             emitted = true;
         }
-        println!(
-            "Lifecycle: {}",
-            style::thread_state(&human_thread_state(output, state))
-        );
+        println!("Lifecycle: {}", style::thread_state(&state.to_string()));
     }
     if let Some(freshness) = &output.freshness
         && *freshness != ThreadFreshness::Unknown
@@ -1990,14 +1986,6 @@ fn human_coordination_status(output: &StatusOutput) -> String {
         "work in progress".to_string()
     } else {
         output.coordination_status.to_string()
-    }
-}
-
-fn human_thread_state(output: &StatusOutput, state: &ThreadState) -> String {
-    if local_work_in_progress(output) && matches!(state, ThreadState::Blocked) {
-        "active".to_string()
-    } else {
-        state.to_string()
     }
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6790,7 +6790,10 @@ fn verification_blocked_status_and_ready_do_not_claim_actionable_readiness() {
     let status = json_value(temp.path(), &["status", "--output", "json"]);
     assert_eq!(status["verification"]["status"], "needs_import");
     assert_eq!(status["coordination_status"], "blocked");
-    assert_eq!(status["thread_state"], "blocked");
+    assert_ne!(
+        status["thread_state"], "blocked",
+        "verification blocker is a health signal carried by coordination_status, not a lifecycle state: {status}"
+    );
     assert!(
         status["blockers"]
             .as_array()
@@ -6882,6 +6885,50 @@ fn verification_blocked_status_and_ready_do_not_claim_actionable_readiness() {
         !merge_stderr.contains("Merge is up to date, but repository verify is blocked")
             && !merge_stderr.contains("Already up to date"),
         "blocked merge preview should not claim a merge verdict: {merge_stderr}"
+    );
+}
+
+// Regression: heddle#306. `status` synthesized `thread_state: "blocked"` from a
+// repository health/verification signal while `thread list` reported the
+// thread record's lifecycle state, so the two verbs disagreed for the same
+// thread at the same instant and `status` emitted a value outside the
+// documented lifecycle enum. `thread_state` is lifecycle-only; the blocker
+// signal belongs to the documented `coordination_status` health field.
+#[test]
+fn thread_state_agrees_across_status_and_thread_list_for_blocked_verification() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    // init without adopt → repository verification is blocked (needs_import),
+    // a health signal that must not rewrite the thread's lifecycle state.
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let status = json_value(temp.path(), &["status", "--output", "json"]);
+    let threads = json_value(temp.path(), &["thread", "list", "--output", "json"]);
+    let thread = threads["threads"]
+        .as_array()
+        .and_then(|threads| threads.iter().find(|thread| thread["name"] == "main"))
+        .expect("main thread should be listed");
+
+    // Same thread, same instant: thread_state must agree across the two verbs.
+    assert_eq!(
+        status["thread_state"], thread["thread_state"],
+        "thread_state must agree across status and thread list:\nstatus={status:#}\nlist={thread:#}"
+    );
+    // ...and stay a lifecycle value, not the health-derived "blocked".
+    assert_ne!(
+        status["thread_state"], "blocked",
+        "verification/dirty-worktree health is not a lifecycle state: {status:#}"
+    );
+    // The blocker still surfaces through the documented health field, on both verbs.
+    assert_eq!(
+        status["coordination_status"], "blocked",
+        "verification blocker should surface via status coordination_status: {status:#}"
+    );
+    assert_eq!(
+        thread["coordination_status"], "blocked",
+        "verification blocker should surface via thread list coordination_status: {threads:#}"
     );
 }
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -292,7 +292,7 @@ in-progress operation.
 | `execution_path` | string \| null | required | Effective execution root. |
 | `actor` | object \| null | required | `{provider, model}`. `null` when no agent is attached. |
 | `thread_mode` | enum \| null | required | `lightweight` / `materialized` / `virtualized`. |
-| `thread_state` | enum \| null | required | `active` / `ready` / `merged` / `abandoned`. |
+| `thread_state` | enum \| null | required | Thread lifecycle: `active` / `ready` / `blocked` / `merged` / `abandoned` / `promoted`. Same values and meaning as `thread list`; repository-health/verification blockers surface via `coordination_status`, not here. |
 | `freshness` | enum \| null | required | `current` / `stale` / `unknown`. |
 | `child_threads` | array<string> | required | Names; empty array if none. |
 | `impact_categories` | array<enum> | required | Empty array if none. |


### PR DESCRIPTION
## Summary
- `status --output json` synthesized `thread_state: "blocked"` from a repository verification/dirty-worktree **health** signal, while `thread list --output json` reported the thread record's lifecycle state — so the two verbs disagreed for the same thread at the same instant, and `status` emitted `"blocked"`, a value outside the documented lifecycle enum (`active`/`ready`/`merged`/`abandoned`).
- Fix (option A): `thread_state` is now lifecycle-only and always reflects the thread record's state, identical across `status` and `thread list`. The dirty/unverified blocker still surfaces through the documented `coordination_status: "blocked"` health field (plus `thread_health`/`blockers`).
- Removed the now-dead `human_thread_state` `Blocked`→`active` coercion that existed only to mask the override in human text; the `Lifecycle:` line renders the record state directly (a genuinely blocked thread no longer mis-displays as active).
- Documented the full `thread_state` lifecycle enum in `docs/json-schemas.md` (adds `blocked`/`promoted`, all grounded against persisting call sites) and noted that health/verification blockers live in `coordination_status`, not `thread_state`.

Closes HeddleCo/heddle#306

## Red commit
`56980d3` — `oss_cli_polish::thread_state_agrees_across_status_and_thread_list_for_blocked_verification` (status `thread_state="blocked"` vs thread list `"active"`).

## Test evidence
```
test oss_cli_polish::thread_state_agrees_across_status_and_thread_list_for_blocked_verification ... ok
test oss_cli_polish::verification_blocked_status_and_ready_do_not_claim_actionable_readiness ... ok
test oss_cli_polish::captured_git_overlay_work_recommends_checkpoint_not_recapture ... ok
test cli_premium_output::status_text_counts_dirty_worktree_paths ... ok
test result: ok. 4 passed; 0 failed
```
Local gates: `check-no-silent-default-tree-load.sh` clean (514 files), `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo test --workspace` passes against a freshly-built binary; a transient run showed 7 failures (the new test + #299 help/commit tests) caused by a concurrent build in a sibling worktree clobbering the shared-target `heddle` binary mid-run — all pass when re-run against the rebuilt binary.

## Manual verification
N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782671941&installation_id=132405951&pr_number=313&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F313&signature=e5962fc8b9deccdb52bf91c66508cc52a466690e5de90763288544db9d4ac534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->