### PR TITLE
heddle#305: undo captures pre-undo state into a recovery marker (no silent data loss)

### DIFF
--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -951,6 +951,12 @@ pub struct UndoSchema {
     pub next_action_template: Option<ActionTemplateSchema>,
     pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
+    /// heddle#305: the pre-undo state preserved for recovery, and the marker
+    /// pointing at it. Present only on a completed `undo`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_marker: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -32,8 +32,10 @@ use crate::cli::{Cli, should_output_json, style};
 /// `refs/threads/`, `refs/remotes/`): doing so coupled recovery to a
 /// user-writable name and let the `MarkerDelete` undo inverse collide with it.
 /// `apply_undo_batch` replays only user-marker/thread inverses, so it can never
-/// see or clobber this internal pointer. `heddle goto undo-recovery` resolves
-/// it via the [`refs::UNDO_RECOVERY_HANDLE`] fallback in `RefManager::resolve`.
+/// see or clobber this internal pointer. `heddle goto .undo-recovery` resolves
+/// it via the reserved [`refs::UNDO_RECOVERY_HANDLE`], which `resolve_refspec`
+/// routes to the internal pointer BEFORE any user ref — and whose leading `.`
+/// makes it uncreatable as a user ref, so it is unshadowable in both directions.
 const UNDO_RECOVERY_MARKER: &str = UNDO_RECOVERY_HANDLE;
 
 #[derive(Serialize)]

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -3,8 +3,9 @@
 
 use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::{ChangeId, ContentHash};
+use objects::object::{ChangeId, ContentHash, MarkerName};
 use oplog::{OpBatch, OpRecord};
+use refs::RefExpectation;
 use repo::{Repository, ThreadManager};
 use serde::Serialize;
 
@@ -19,6 +20,12 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::cli::{Cli, should_output_json, style};
+
+/// Marker that `undo` points at the pre-undo state before resetting, so the
+/// worktree content the undone batch absorbed stays a first-class, addressable
+/// recovery point in heddle's thread history. A single rolling marker
+/// (ORIG_HEAD-style): each undo overwrites it with its own pre-undo tip.
+const UNDO_RECOVERY_MARKER: &str = "undo-recovery";
 
 #[derive(Serialize)]
 struct OpListOutput {
@@ -54,6 +61,13 @@ struct UndoRedoOutput {
     next_action_template: Option<ActionTemplate>,
     recommended_action: Option<String>,
     recommended_action_template: Option<ActionTemplate>,
+    /// heddle#305: the pre-undo state preserved for recovery, and the marker
+    /// pointing at it. Present only on a completed `undo`; omitted from the
+    /// wire when absent (preview / redo).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recovery_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recovery_marker: Option<String>,
     #[serde(skip_serializing)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "verification")]
@@ -128,6 +142,8 @@ pub fn cmd_undo(
             next_action_template: None,
             recommended_action: None,
             recommended_action_template: None,
+            recovery_state: None,
+            recovery_marker: None,
             trust: None,
         };
 
@@ -146,6 +162,24 @@ pub fn cmd_undo(
         }
 
         return Ok(());
+    }
+
+    // heddle#305: capture the pre-undo state into thread history BEFORE the
+    // reset, so the worktree content the undone batch(es) absorbed is never
+    // silently discarded. The reset below hard-resets the Git mirror and
+    // rewinds the heddle thread; recording the current tip as the
+    // `undo-recovery` marker keeps it a first-class, addressable recovery
+    // point — durable even if a later divergent capture/commit strands the
+    // redo path. The preflights above guarantee the worktree is clean, so the
+    // tip's tree *is* the pre-undo worktree. Durability lives in heddle's
+    // immutable store + refs; undo never records itself as Git history.
+    let recovery_state = repo.head()?;
+    if let Some(state) = recovery_state {
+        repo.refs().set_marker_cas(
+            &MarkerName::new(UNDO_RECOVERY_MARKER),
+            RefExpectation::Any,
+            &state,
+        )?;
     }
 
     let mut updated_batches = Vec::with_capacity(batches.len());
@@ -171,6 +205,8 @@ pub fn cmd_undo(
         next_action_template: recommended_action.template.clone(),
         recommended_action: recommended_action.action,
         recommended_action_template: recommended_action.template,
+        recovery_state: recovery_state.map(|state| state.short()),
+        recovery_marker: recovery_state.map(|_| UNDO_RECOVERY_MARKER.to_string()),
         trust: Some(post_undo_trust),
     };
 
@@ -187,6 +223,14 @@ pub fn cmd_undo(
             print_human_history(&output.batches);
         }
         print_head(&post_undo_repo)?;
+        if let Some(state) = &output.recovery_state {
+            println!(
+                "Preserved pre-undo state {} as marker `{}` (recover with `heddle goto {}`)",
+                style::change_id(state),
+                UNDO_RECOVERY_MARKER,
+                UNDO_RECOVERY_MARKER,
+            );
+        }
         if let Some(trust) = &output.trust {
             print_post_undo_trust(trust);
         }
@@ -227,6 +271,8 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
             next_action_template: None,
             recommended_action: None,
             recommended_action_template: None,
+            recovery_state: None,
+            recovery_marker: None,
             trust: None,
         };
 
@@ -272,6 +318,8 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
         next_action_template: recommended_action.template.clone(),
         recommended_action: recommended_action.action,
         recommended_action_template: recommended_action.template,
+        recovery_state: None,
+        recovery_marker: None,
         trust: Some(post_redo_trust),
     };
 

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -3,9 +3,9 @@
 
 use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::{ChangeId, ContentHash, MarkerName};
+use objects::object::{ChangeId, ContentHash};
 use oplog::{OpBatch, OpRecord};
-use refs::RefExpectation;
+use refs::UNDO_RECOVERY_HANDLE;
 use repo::{Repository, ThreadManager};
 use serde::Serialize;
 
@@ -21,11 +21,20 @@ use super::{
 };
 use crate::cli::{Cli, should_output_json, style};
 
-/// Marker that `undo` points at the pre-undo state before resetting, so the
+/// Well-known handle that `undo` records the pre-undo state under, so the
 /// worktree content the undone batch absorbed stays a first-class, addressable
-/// recovery point in heddle's thread history. A single rolling marker
+/// recovery point in heddle's thread history. A single rolling ref
 /// (ORIG_HEAD-style): each undo overwrites it with its own pre-undo tip.
-const UNDO_RECOVERY_MARKER: &str = "undo-recovery";
+///
+/// Invariant: this is a heddle-INTERNAL ref (`refs::RefManager::set_undo_recovery`,
+/// stored at `.heddle/UNDO_RECOVERY`), NOT a user marker. No heddle-internal
+/// bookkeeping ref may live in a user-writable namespace (`refs/markers/`,
+/// `refs/threads/`, `refs/remotes/`): doing so coupled recovery to a
+/// user-writable name and let the `MarkerDelete` undo inverse collide with it.
+/// `apply_undo_batch` replays only user-marker/thread inverses, so it can never
+/// see or clobber this internal pointer. `heddle goto undo-recovery` resolves
+/// it via the [`refs::UNDO_RECOVERY_HANDLE`] fallback in `RefManager::resolve`.
+const UNDO_RECOVERY_MARKER: &str = UNDO_RECOVERY_HANDLE;
 
 #[derive(Serialize)]
 struct OpListOutput {
@@ -167,19 +176,19 @@ pub fn cmd_undo(
     // heddle#305: capture the pre-undo state into thread history BEFORE the
     // reset, so the worktree content the undone batch(es) absorbed is never
     // silently discarded. The reset below hard-resets the Git mirror and
-    // rewinds the heddle thread; recording the current tip as the
-    // `undo-recovery` marker keeps it a first-class, addressable recovery
-    // point — durable even if a later divergent capture/commit strands the
-    // redo path. The preflights above guarantee the worktree is clean, so the
-    // tip's tree *is* the pre-undo worktree. Durability lives in heddle's
-    // immutable store + refs; undo never records itself as Git history.
+    // rewinds the heddle thread; recording the current tip in the internal
+    // recovery ref keeps it a first-class, addressable recovery point —
+    // durable even if a later divergent capture/commit strands the redo path.
+    // The preflights above guarantee the worktree is clean, so the tip's tree
+    // *is* the pre-undo worktree. Durability lives in heddle's immutable store
+    // + refs; undo never records itself as Git history.
+    //
+    // heddle#305 r2: this is written to a heddle-INTERNAL ref, not a user
+    // marker — see UNDO_RECOVERY_MARKER. Keeping it out of `refs/markers/`
+    // means the `MarkerDelete` undo inverse below can never collide with it.
     let recovery_state = repo.head()?;
     if let Some(state) = recovery_state {
-        repo.refs().set_marker_cas(
-            &MarkerName::new(UNDO_RECOVERY_MARKER),
-            RefExpectation::Any,
-            &state,
-        )?;
+        repo.refs().set_undo_recovery(&state)?;
     }
 
     let mut updated_batches = Vec::with_capacity(batches.len());
@@ -225,7 +234,7 @@ pub fn cmd_undo(
         print_head(&post_undo_repo)?;
         if let Some(state) = &output.recovery_state {
             println!(
-                "Preserved pre-undo state {} as marker `{}` (recover with `heddle goto {}`)",
+                "Preserved pre-undo state {} as `{}` (recover with `heddle goto {}`)",
                 style::change_id(state),
                 UNDO_RECOVERY_MARKER,
                 UNDO_RECOVERY_MARKER,

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -27,10 +27,15 @@ use crate::cli::{Cli, should_output_json, style};
 /// (ORIG_HEAD-style): each undo overwrites it with its own pre-undo tip.
 ///
 /// Invariant: this is a heddle-INTERNAL ref (`refs::RefManager::set_undo_recovery`,
-/// stored at `.heddle/UNDO_RECOVERY`), NOT a user marker. No heddle-internal
-/// bookkeeping ref may live in a user-writable namespace (`refs/markers/`,
-/// `refs/threads/`, `refs/remotes/`): doing so coupled recovery to a
-/// user-writable name and let the `MarkerDelete` undo inverse collide with it.
+/// stored as `UNDO_RECOVERY` beside the per-checkout `HEAD`), NOT a user marker.
+/// It is scoped to the same checkout as the undo/redo history it recovers
+/// (`op_scope`): in objectstore-pointer worktrees the ref root is shared, so a
+/// shared-root recovery pointer would let a `heddle undo` in one checkout
+/// clobber a sibling's — keying it to the local `HEAD` keeps each checkout's
+/// recovery state its own. No heddle-internal bookkeeping ref may live in a
+/// user-writable namespace (`refs/markers/`, `refs/threads/`, `refs/remotes/`):
+/// doing so coupled recovery to a user-writable name and let the `MarkerDelete`
+/// undo inverse collide with it.
 /// `apply_undo_batch` replays only user-marker/thread inverses, so it can never
 /// see or clobber this internal pointer. `heddle goto .undo-recovery` resolves
 /// it via the reserved [`refs::UNDO_RECOVERY_HANDLE`], which `resolve_refspec`

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -873,8 +873,9 @@ fn git_replacement_matrix_commit_undo_rewinds_checkpoint_without_git_on_path() {
 
 /// heddle#305 (git-overlay): `commit` then `undo` hard-resets the Git mirror
 /// to the parent — no revert commit recorded as Git history — while preserving
-/// the pre-undo state in heddle's thread history via the `undo-recovery`
-/// marker, so the absorbed worktree edits are never silently discarded. The
+/// the pre-undo state in heddle's thread history via the internal
+/// `undo-recovery` handle (heddle#305 r2: a heddle-internal ref, not a user
+/// marker), so the absorbed worktree edits are never silently discarded. The
 /// durability lives in heddle's store, not in Git history.
 #[test]
 fn git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit() {
@@ -934,17 +935,21 @@ fn git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit() {
     );
 
     // The pre-undo state is preserved in heddle's thread history via the
-    // recovery marker, even though Git was hard-reset.
+    // internal recovery handle, even though Git was hard-reset. heddle#305 r2:
+    // it must NOT leak into the user marker namespace.
     let markers = assert_clean_json_without_git(&["--output", "json", "marker", "list"], &work);
-    let recovery = markers["markers"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|m| m["name"] == "undo-recovery")
-        .expect("undo must record an `undo-recovery` marker for the pre-undo state");
+    assert!(
+        markers["markers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["name"] != "undo-recovery"),
+        "recovery bookkeeping must not appear as a user marker"
+    );
+    assert_eq!(undo["recovery_marker"], "undo-recovery");
     assert_eq!(
-        recovery["change_id"], friction_state,
-        "recovery marker must point at the pre-undo (friction) heddle state"
+        undo["recovery_state"], friction_state,
+        "recovery handle must pin the pre-undo (friction) heddle state"
     );
 
     // And `redo` round-trips the absorbed content back into the worktree.

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -946,7 +946,7 @@ fn git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit() {
             .all(|m| m["name"] != "undo-recovery"),
         "recovery bookkeeping must not appear as a user marker"
     );
-    assert_eq!(undo["recovery_marker"], "undo-recovery");
+    assert_eq!(undo["recovery_marker"], ".undo-recovery");
     assert_eq!(
         undo["recovery_state"], friction_state,
         "recovery handle must pin the pre-undo (friction) heddle state"

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -871,6 +871,97 @@ fn git_replacement_matrix_commit_undo_rewinds_checkpoint_without_git_on_path() {
     );
 }
 
+/// heddle#305 (git-overlay): `commit` then `undo` hard-resets the Git mirror
+/// to the parent — no revert commit recorded as Git history — while preserving
+/// the pre-undo state in heddle's thread history via the `undo-recovery`
+/// marker, so the absorbed worktree edits are never silently discarded. The
+/// durability lives in heddle's store, not in Git history.
+#[test]
+fn git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit() {
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin.git");
+    let work = temp.path().join("work");
+    seed_bare_git_repo(&origin);
+
+    heddle_without_git(
+        &[
+            "clone",
+            origin.to_str().expect("origin path should be utf8"),
+            work.to_str().expect("work path should be utf8"),
+        ],
+        temp.path(),
+    )
+    .unwrap();
+    configure_repo_local_git_identity(&work);
+
+    let base = git_head_oid(&work);
+
+    // An edit that lived only in the worktree, then absorbed by `commit`.
+    std::fs::write(work.join("story.txt"), "FRICTION ONE\nFRICTION TWO\n").unwrap();
+    let commit = assert_clean_json_without_git(
+        &["--output", "json", "commit", "-m", "friction"],
+        &work,
+    );
+    assert_eq!(commit["output_kind"], "commit");
+    let friction_state = commit["change_id"]
+        .as_str()
+        .expect("commit emits the absorbed heddle change-id")
+        .to_string();
+    let friction_commit = git_head_oid(&work);
+    assert_ne!(friction_commit, base, "commit advances the checkout Git ref");
+
+    let undo = assert_clean_json_without_git(&["--output", "json", "undo"], &work);
+    assert_eq!(undo["action"], "undo");
+
+    // Git mirror is hard-reset to the parent — not a revert commit on top.
+    assert_eq!(
+        git_head_oid(&work),
+        base,
+        "undo must hard-reset the visible Git checkout to the parent"
+    );
+    let log = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(&work)
+            .output()
+            .expect("git log")
+            .stdout,
+    )
+    .unwrap();
+    assert!(
+        !log.contains("friction"),
+        "undo must not record itself as Git history (no revert/friction commit remains): {log}"
+    );
+
+    // The pre-undo state is preserved in heddle's thread history via the
+    // recovery marker, even though Git was hard-reset.
+    let markers = assert_clean_json_without_git(&["--output", "json", "marker", "list"], &work);
+    let recovery = markers["markers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["name"] == "undo-recovery")
+        .expect("undo must record an `undo-recovery` marker for the pre-undo state");
+    assert_eq!(
+        recovery["change_id"], friction_state,
+        "recovery marker must point at the pre-undo (friction) heddle state"
+    );
+
+    // And `redo` round-trips the absorbed content back into the worktree.
+    let redo = assert_clean_json_without_git(&["--output", "json", "redo"], &work);
+    assert_eq!(redo["action"], "redo");
+    assert_eq!(
+        std::fs::read_to_string(work.join("story.txt")).unwrap(),
+        "FRICTION ONE\nFRICTION TWO\n",
+        "redo must restore the absorbed worktree edits"
+    );
+    assert_eq!(
+        git_head_oid(&work),
+        friction_commit,
+        "redo must restore the Git checkpoint together with the heddle state"
+    );
+}
+
 #[test]
 fn git_replacement_matrix_commit_staged_index_without_git_on_path() {
     let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -598,6 +598,80 @@ fn test_undo_recovery_marker_survives_divergent_capture() {
     );
 }
 
+/// heddle#305 r2: the pre-undo recovery pointer must live in a heddle-internal
+/// reserved ref, NOT the user marker namespace. Storing it as a user marker
+/// named `undo-recovery` couples heddle bookkeeping to a user-writable name:
+/// the `MarkerDelete` undo inverse re-creates user markers with a `Missing`
+/// expectation, so a same-named recovery marker pre-written by `undo` would
+/// make that inverse fail (`create_marker(undo-recovery, Missing)` collides).
+/// Moving recovery out of `refs/markers/` makes the whole class impossible by
+/// construction: user `marker create/delete` (and their inverses) can never
+/// see or clobber the internal pointer, and vice versa.
+#[test]
+fn test_undo_recovery_lives_outside_user_marker_namespace() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    std::fs::write(temp.path().join("notes.md"), "FRICTION\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
+    let friction_state = head_short(temp.path());
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    // (a) recovery must NOT pollute the user marker namespace.
+    let markers: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "marker", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    assert!(
+        markers["markers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["name"] != "undo-recovery"),
+        "recovery bookkeeping must not appear as a user marker"
+    );
+
+    // (b) it lives in the heddle-internal recovery ref, pinning the pre-undo
+    // state — a namespace the user marker CLI cannot enumerate or collide with.
+    let repo = Repository::open(temp.path()).unwrap();
+    let recovery = repo
+        .refs()
+        .get_undo_recovery()
+        .unwrap()
+        .expect("undo must preserve the pre-undo state in the internal recovery ref");
+    assert_eq!(
+        recovery.short(),
+        friction_state,
+        "internal recovery ref must pin the pre-undo (friction) state"
+    );
+
+    // (c) the recovery UX is preserved: `goto undo-recovery` resolves the
+    // internal ref and restores the pre-undo content.
+    heddle_must_succeed(&["goto", "undo-recovery"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "FRICTION\n",
+        "the pre-undo content must be recoverable via the internal handle"
+    );
+
+    // (d) coexistence: a user may now legitimately create and delete their own
+    // marker named `undo-recovery` without colliding with — or disturbing —
+    // the internal recovery pointer. This is the closed class: the two
+    // namespaces are independent.
+    heddle_must_succeed(&["marker", "create", "undo-recovery"], temp.path());
+    heddle_must_succeed(&["marker", "delete", "undo-recovery"], temp.path());
+    let repo = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        repo.refs().get_undo_recovery().unwrap().map(|id| id.short()),
+        Some(friction_state),
+        "user marker create/delete must not touch the internal recovery ref"
+    );
+}
+
 /// Fast-forward merge undo, full restoration: HEAD *and* the merged-into
 /// thread ref both rewind to the pre-merge tip. This pins the heddle#99 fix —
 /// before it landed, the FF merge recorded an `OpRecord::Goto` whose inverse

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -583,7 +583,7 @@ fn test_undo_recovery_marker_survives_divergent_capture() {
     assert_eq!(recovery.short(), friction_state);
 
     // Recover the pre-undo content via the well-known handle.
-    heddle_must_succeed(&["goto", "undo-recovery"], temp.path());
+    heddle_must_succeed(&["goto", ".undo-recovery"], temp.path());
     assert_eq!(
         std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
         "FRICTION ONE\nFRICTION TWO\n",
@@ -642,9 +642,9 @@ fn test_undo_recovery_lives_outside_user_marker_namespace() {
         "internal recovery ref must pin the pre-undo (friction) state"
     );
 
-    // (c) the recovery UX is preserved: `goto undo-recovery` resolves the
+    // (c) the recovery UX is preserved: `goto .undo-recovery` resolves the
     // internal ref and restores the pre-undo content.
-    heddle_must_succeed(&["goto", "undo-recovery"], temp.path());
+    heddle_must_succeed(&["goto", ".undo-recovery"], temp.path());
     assert_eq!(
         std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
         "FRICTION\n",

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -665,6 +665,60 @@ fn test_undo_recovery_lives_outside_user_marker_namespace() {
     );
 }
 
+/// heddle#305 r3: the advertised recovery handle must be UNSHADOWABLE on the
+/// READ path too. Worst case: a user already owns a marker literally named
+/// `undo-recovery`. The advertised handle `undo` prints (`recovery_marker`)
+/// must resolve to the INTERNAL pre-undo state, never the user's ref. r2 fixed
+/// the write path (internal ref) but left the advertised handle a bare
+/// user-namespace name that `resolve_refspec` resolves to the user ref first —
+/// this conformance test closes that direction.
+#[test]
+fn test_recovery_handle_unshadowable_by_user_marker() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let base_state = head_short(temp.path());
+
+    // The user owns a marker named `undo-recovery`, pinning the BASE state.
+    heddle_must_succeed(&["marker", "create", "undo-recovery"], temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "FRICTION\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
+    let friction_state = head_short(temp.path());
+    assert_ne!(base_state, friction_state);
+
+    let undo: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "undo"],
+        temp.path(),
+    ))
+    .unwrap();
+    let advertised = undo["recovery_marker"]
+        .as_str()
+        .expect("undo advertises a recovery handle");
+
+    // The advertised handle must resolve to the INTERNAL pre-undo (friction)
+    // state, NOT the user's same-named marker (which pins base).
+    heddle_must_succeed(&["goto", advertised], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "FRICTION\n",
+        "advertised recovery handle must restore the internal pre-undo state, not the user's ref"
+    );
+
+    // The user's own `undo-recovery` marker is untouched and still pins base.
+    let repo = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        repo.refs()
+            .get_marker(&objects::object::MarkerName::new("undo-recovery"))
+            .unwrap()
+            .map(|id| id.short()),
+        Some(base_state),
+        "the user's own undo-recovery marker must remain intact and independent"
+    );
+}
+
 /// Fast-forward merge undo, full restoration: HEAD *and* the merged-into
 /// thread ref both rewind to the pre-merge tip. This pins the heddle#99 fix —
 /// before it landed, the FF merge recorded an `OpRecord::Goto` whose inverse

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -527,21 +527,18 @@ fn test_undo_captures_pre_undo_state_into_recovery_marker() {
     );
 
     // (a) The pre-undo worktree content is captured into thread history: undo
-    // records a recovery marker pointing at the pre-undo state.
-    let markers: Value = serde_json::from_str(&heddle_must_succeed(
-        &["--output", "json", "marker", "list"],
-        temp.path(),
-    ))
-    .unwrap();
-    let recovery = markers["markers"]
-        .as_array()
+    // records the pre-undo state in the heddle-internal recovery ref (NOT a
+    // user marker — see heddle#305 r2).
+    let repo = Repository::open(temp.path()).unwrap();
+    let recovery = repo
+        .refs()
+        .get_undo_recovery()
         .unwrap()
-        .iter()
-        .find(|m| m["name"] == "undo-recovery")
-        .expect("undo must record an `undo-recovery` marker for the pre-undo state");
+        .expect("undo must record the pre-undo state in the internal recovery ref");
     assert_eq!(
-        recovery["change_id"], friction_state,
-        "the recovery marker must point at the pre-undo (friction) state, not the reset target"
+        recovery.short(),
+        friction_state,
+        "the recovery ref must point at the pre-undo (friction) state, not the reset target"
     );
 
     // (b) `redo` restores the captured content (round-trips the worktree).
@@ -575,26 +572,22 @@ fn test_undo_recovery_marker_survives_divergent_capture() {
     std::fs::write(temp.path().join("notes.md"), "different direction\n").unwrap();
     heddle_must_succeed(&["capture", "-m", "diverge"], temp.path());
 
-    // The durable recovery marker still pins the pre-undo (friction) state.
-    let markers: Value = serde_json::from_str(&heddle_must_succeed(
-        &["--output", "json", "marker", "list"],
-        temp.path(),
-    ))
-    .unwrap();
-    let recovery = markers["markers"]
-        .as_array()
+    // The durable internal recovery ref still pins the pre-undo (friction)
+    // state, untouched by the divergent capture.
+    let repo = Repository::open(temp.path()).unwrap();
+    let recovery = repo
+        .refs()
+        .get_undo_recovery()
         .unwrap()
-        .iter()
-        .find(|m| m["name"] == "undo-recovery")
-        .expect("recovery marker must survive a divergent capture");
-    assert_eq!(recovery["change_id"], friction_state);
+        .expect("recovery ref must survive a divergent capture");
+    assert_eq!(recovery.short(), friction_state);
 
-    // Recover the pre-undo content by name.
+    // Recover the pre-undo content via the well-known handle.
     heddle_must_succeed(&["goto", "undo-recovery"], temp.path());
     assert_eq!(
         std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
         "FRICTION ONE\nFRICTION TWO\n",
-        "the pre-undo content must be recoverable via the durable recovery marker"
+        "the pre-undo content must be recoverable via the durable recovery handle"
     );
 }
 

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -495,6 +495,109 @@ fn test_undo_capture_restores_head_to_parent() {
     );
 }
 
+/// heddle#305: `undo` must not silently discard the worktree edits a prior
+/// `capture`/`commit` absorbed. Before the reset, undo records the pre-undo
+/// state into a durable `undo-recovery` marker in heddle's thread history, so
+/// the absorbed content is preserved as a first-class, addressable recovery
+/// point — not merely buried in an undone oplog batch — while `redo` still
+/// round-trips the content. Pre-fix there was no recovery marker: the pre-undo
+/// state was recoverable only via `redo` (fragile) or by knowing the buried
+/// change-id, matching the dogfood report that the edits were "not obviously
+/// recoverable".
+#[test]
+fn test_undo_captures_pre_undo_state_into_recovery_marker() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+
+    // An edit that lived only in the worktree, then captured ("committed").
+    std::fs::write(temp.path().join("notes.md"), "FRICTION ONE\nFRICTION TWO\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
+    let friction_state = head_short(temp.path());
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    // The reset happened: worktree reverted to the parent state.
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "base\n",
+        "undo must reset the worktree to the parent state"
+    );
+
+    // (a) The pre-undo worktree content is captured into thread history: undo
+    // records a recovery marker pointing at the pre-undo state.
+    let markers: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "marker", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    let recovery = markers["markers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["name"] == "undo-recovery")
+        .expect("undo must record an `undo-recovery` marker for the pre-undo state");
+    assert_eq!(
+        recovery["change_id"], friction_state,
+        "the recovery marker must point at the pre-undo (friction) state, not the reset target"
+    );
+
+    // (b) `redo` restores the captured content (round-trips the worktree).
+    heddle_must_succeed(&["redo"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "FRICTION ONE\nFRICTION TWO\n",
+        "redo must restore the friction content to the worktree"
+    );
+}
+
+/// The recovery marker makes the pre-undo content recoverable by name,
+/// independent of the (fragile) redo stack: after undo, `heddle goto
+/// undo-recovery` restores the pre-undo worktree even once a divergent capture
+/// has been layered on top of the reverted state. This is the data-safety
+/// guarantee — nothing absorbed by the undone capture is lost.
+#[test]
+fn test_undo_recovery_marker_survives_divergent_capture() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    std::fs::write(temp.path().join("notes.md"), "FRICTION ONE\nFRICTION TWO\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
+    let friction_state = head_short(temp.path());
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    // Diverge: a fresh capture layered onto the reverted worktree.
+    std::fs::write(temp.path().join("notes.md"), "different direction\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "diverge"], temp.path());
+
+    // The durable recovery marker still pins the pre-undo (friction) state.
+    let markers: Value = serde_json::from_str(&heddle_must_succeed(
+        &["--output", "json", "marker", "list"],
+        temp.path(),
+    ))
+    .unwrap();
+    let recovery = markers["markers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["name"] == "undo-recovery")
+        .expect("recovery marker must survive a divergent capture");
+    assert_eq!(recovery["change_id"], friction_state);
+
+    // Recover the pre-undo content by name.
+    heddle_must_succeed(&["goto", "undo-recovery"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "FRICTION ONE\nFRICTION TWO\n",
+        "the pre-undo content must be recoverable via the durable recovery marker"
+    );
+}
+
 /// Fast-forward merge undo, full restoration: HEAD *and* the merged-into
 /// thread ref both rewind to the pre-merge tip. This pins the heddle#99 fix —
 /// before it landed, the FF merge recorded an `OpRecord::Goto` whose inverse

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -40,7 +40,7 @@ pub use packed_model::PackedRefsModel;
 pub use pg_refs::PgRefBackend;
 pub use ref_backend::RefBackend;
 pub use ref_summary_index::RefSummaryIndexInspection;
-pub use refs_manager::RefManager;
+pub use refs_manager::{RefManager, UNDO_RECOVERY_HANDLE};
 pub use reftable_model::{ReftableError, ReftableModel};
 pub use resolve::resolve_refspec;
 pub use text::{ChangeIdTextError, format_change_id_text, parse_change_id_text};

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -15,6 +15,14 @@ use super::{
 };
 use crate::fs_atomic::sync_directory;
 
+/// Well-known refspec that resolves the heddle-internal pre-undo recovery
+/// pointer (so `heddle goto undo-recovery` still works). It is NOT a user
+/// marker: it lives in a reserved internal namespace the marker CLI cannot
+/// create, delete, or enumerate. A user marker of the same literal name takes
+/// resolution precedence (their explicit ref wins); the internal pointer is the
+/// fallback, and is always preserved regardless of any same-named user marker.
+pub const UNDO_RECOVERY_HANDLE: &str = "undo-recovery";
+
 /// Manager for references (threads, markers, HEAD).
 pub struct RefManager {
     pub(crate) root: PathBuf,
@@ -216,6 +224,25 @@ impl RefManager {
         self.list_markers_from_storage()
     }
 
+    /// Record the heddle-internal pre-undo recovery pointer (ORIG_HEAD-style:
+    /// a single rolling ref each undo overwrites). Stored OUTSIDE the
+    /// user-writable marker namespace so `marker create/delete` — and their
+    /// undo inverses — can never collide with it. See
+    /// [`UNDO_RECOVERY_HANDLE`] for the resolution handle.
+    pub fn set_undo_recovery(&self, state: &ChangeId) -> Result<()> {
+        let _lock = self.lock_refs()?;
+        self.write_string(
+            &self.undo_recovery_path(),
+            &super::format_change_id_text(state),
+        )
+    }
+
+    /// Read the heddle-internal pre-undo recovery pointer, if one has been
+    /// recorded. Returns `None` when no undo has run in this repo.
+    pub fn get_undo_recovery(&self) -> Result<Option<ChangeId>> {
+        self.read_change_id_at(&self.undo_recovery_path(), "undo recovery", UNDO_RECOVERY_HANDLE)
+    }
+
     pub fn get_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<ChangeId>> {
         let path = self.remote_thread_path(remote, thread)?;
         self.read_change_id_at(&path, "remote thread", &format!("{}/{}", remote, thread))
@@ -288,12 +315,25 @@ impl RefManager {
     }
 
     pub fn resolve(&self, refspec: &str) -> Result<Option<ChangeId>> {
-        resolve_refspec(
+        if let Some(id) = resolve_refspec(
             refspec,
             || self.read_head(),
             |name| self.get_thread(&ThreadName::new(name)),
             |name| self.get_marker(&MarkerName::new(name)),
-        )
+        )? {
+            return Ok(Some(id));
+        }
+        // Fallback: the heddle-internal recovery handle. Reached only when
+        // nothing else matched (no thread/marker of this name, and it is not a
+        // bare change-id), so an explicit same-named user marker always wins
+        // while `heddle goto undo-recovery` still resolves the preserved
+        // pre-undo state.
+        if refspec == UNDO_RECOVERY_HANDLE
+            && let Some(id) = self.get_undo_recovery()?
+        {
+            return Ok(Some(id));
+        }
+        Ok(None)
     }
 
     pub fn pack_refs(&self) -> Result<()> {

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -16,12 +16,22 @@ use super::{
 use crate::fs_atomic::sync_directory;
 
 /// Well-known refspec that resolves the heddle-internal pre-undo recovery
-/// pointer (so `heddle goto undo-recovery` still works). It is NOT a user
-/// marker: it lives in a reserved internal namespace the marker CLI cannot
-/// create, delete, or enumerate. A user marker of the same literal name takes
-/// resolution precedence (their explicit ref wins); the internal pointer is the
-/// fallback, and is always preserved regardless of any same-named user marker.
-pub const UNDO_RECOVERY_HANDLE: &str = "undo-recovery";
+/// pointer (so `heddle goto .undo-recovery` works). It is UNSHADOWABLE by any
+/// user marker or thread, in BOTH directions (heddle#305 r3):
+///
+/// - **Write side:** the leading `.` is rejected by [`validate_ref_name`], so a
+///   user can never `marker create` / `thread` a ref with this name. The
+///   recovery state therefore lives in a reserved namespace no user ref can
+///   occupy.
+/// - **Resolve side:** [`resolve_refspec`] routes this handle to the internal
+///   recovery pointer BEFORE consulting user threads/markers, so no user ref
+///   can intercept the advertised handle.
+///
+/// Invariant: an advertised handle for an internal ref must use a reserved form
+/// that user-namespace names cannot take — never a bare user-namespace name.
+///
+/// [`validate_ref_name`]: super::name::validate_ref_name
+pub const UNDO_RECOVERY_HANDLE: &str = ".undo-recovery";
 
 /// Manager for references (threads, markers, HEAD).
 pub struct RefManager {
@@ -315,25 +325,13 @@ impl RefManager {
     }
 
     pub fn resolve(&self, refspec: &str) -> Result<Option<ChangeId>> {
-        if let Some(id) = resolve_refspec(
+        resolve_refspec(
             refspec,
             || self.read_head(),
             |name| self.get_thread(&ThreadName::new(name)),
             |name| self.get_marker(&MarkerName::new(name)),
-        )? {
-            return Ok(Some(id));
-        }
-        // Fallback: the heddle-internal recovery handle. Reached only when
-        // nothing else matched (no thread/marker of this name, and it is not a
-        // bare change-id), so an explicit same-named user marker always wins
-        // while `heddle goto undo-recovery` still resolves the preserved
-        // pre-undo state.
-        if refspec == UNDO_RECOVERY_HANDLE
-            && let Some(id) = self.get_undo_recovery()?
-        {
-            return Ok(Some(id));
-        }
-        Ok(None)
+            || self.get_undo_recovery(),
+        )
     }
 
     pub fn pack_refs(&self) -> Result<()> {

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -72,14 +72,25 @@ impl RefManager {
             .cloned()
             .unwrap_or_else(|| self.root.join("HEAD"))
     }
-    /// Path of the heddle-internal pre-undo recovery pointer. Deliberately
-    /// a root-level sibling of `HEAD` (ORIG_HEAD-style), OUTSIDE the
-    /// user-writable ref namespaces under `refs/` (threads, markers,
-    /// remotes). Keeping it here makes a collision with a user marker named
-    /// `undo-recovery` impossible by construction: the marker CLI only ever
-    /// touches `refs/markers/`.
+    /// Path of the heddle-internal pre-undo recovery pointer. A sibling of the
+    /// per-checkout `HEAD` (ORIG_HEAD-style), OUTSIDE the user-writable ref
+    /// namespaces under `refs/` (threads, markers, remotes). Keeping it out of
+    /// `refs/` makes a collision with a user marker named `undo-recovery`
+    /// impossible by construction (the marker CLI only ever touches
+    /// `refs/markers/`).
+    ///
+    /// **Invariant: undo/redo recovery state is scoped to the same checkout as
+    /// the history it recovers — never the shared ref root.** In
+    /// objectstore-pointer worktrees the ref root is shared across sibling
+    /// checkouts but `local_head` (and `op_scope`) is per-worktree; pinning the
+    /// recovery pointer beside the local `HEAD` keeps a `heddle undo` in one
+    /// checkout from clobbering a sibling checkout's recovery pointer. Tracks
+    /// `head_path` so both land in the same directory.
     pub(super) fn undo_recovery_path(&self) -> PathBuf {
-        self.root.join("UNDO_RECOVERY")
+        self.head_path()
+            .parent()
+            .map(|dir| dir.join("UNDO_RECOVERY"))
+            .unwrap_or_else(|| self.root.join("UNDO_RECOVERY"))
     }
     pub(super) fn packed_refs_path(&self) -> PathBuf {
         self.refs_dir().join("packed-refs")

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -72,6 +72,15 @@ impl RefManager {
             .cloned()
             .unwrap_or_else(|| self.root.join("HEAD"))
     }
+    /// Path of the heddle-internal pre-undo recovery pointer. Deliberately
+    /// a root-level sibling of `HEAD` (ORIG_HEAD-style), OUTSIDE the
+    /// user-writable ref namespaces under `refs/` (threads, markers,
+    /// remotes). Keeping it here makes a collision with a user marker named
+    /// `undo-recovery` impossible by construction: the marker CLI only ever
+    /// touches `refs/markers/`.
+    pub(super) fn undo_recovery_path(&self) -> PathBuf {
+        self.root.join("UNDO_RECOVERY")
+    }
     pub(super) fn packed_refs_path(&self) -> PathBuf {
         self.refs_dir().join("packed-refs")
     }

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -478,3 +478,54 @@ fn undo_recovery_ref_is_isolated_from_user_marker_namespace() {
         "the reserved handle still resolves to the internal recovery ref"
     );
 }
+
+/// heddle#305 r4: the undo-recovery pointer is scoped to the LOCAL checkout
+/// (per-worktree HEAD), exactly like the undo/redo history it recovers
+/// (`op_scope`), NOT to the shared ref root. In objectstore-pointer worktrees
+/// `Repository::open` builds refs as
+/// `RefManager::new(&shared_galeed_dir).with_local_head(<worktree>/.heddle/HEAD)` —
+/// the ref root is shared across sibling checkouts but `local_head` is unique.
+/// A `heddle undo` in checkout B must NOT overwrite checkout A's recovery
+/// pointer; otherwise `goto .undo-recovery` in A would restore B's pre-undo
+/// state — cross-checkout data corruption.
+#[test]
+fn undo_recovery_is_scoped_per_checkout_on_shared_ref_root() {
+    let temp = TempDir::new().unwrap();
+    let shared_root = temp.path().join("objectstore");
+    std::fs::create_dir_all(&shared_root).unwrap();
+
+    // Two materialized checkouts sharing one object store / ref root, each
+    // with its own per-worktree HEAD (mirrors the `Repository::open` wiring).
+    let head_a = temp.path().join("wt-a").join(".heddle").join("HEAD");
+    let head_b = temp.path().join("wt-b").join(".heddle").join("HEAD");
+    std::fs::create_dir_all(head_a.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(head_b.parent().unwrap()).unwrap();
+
+    let refs_a = RefManager::new(&shared_root).with_local_head(head_a);
+    let refs_b = RefManager::new(&shared_root).with_local_head(head_b);
+
+    let state_a = ChangeId::generate();
+    let state_b = ChangeId::generate();
+    assert_ne!(state_a, state_b);
+
+    // Both checkouts run `heddle undo`, each recording its own pre-undo state.
+    refs_a.set_undo_recovery(&state_a).unwrap();
+    refs_b.set_undo_recovery(&state_b).unwrap();
+
+    // B's undo must not have clobbered A's recovery pointer (write side).
+    assert_eq!(
+        refs_a.get_undo_recovery().unwrap(),
+        Some(state_a),
+        "checkout A's recovery pointer must reflect A's own pre-undo state"
+    );
+    assert_eq!(
+        refs_b.get_undo_recovery().unwrap(),
+        Some(state_b),
+        "checkout B's recovery pointer must reflect B's own pre-undo state"
+    );
+
+    // The advertised reserved handle in each checkout resolves to THAT
+    // checkout's recovery pointer, not the sibling's (resolve side).
+    assert_eq!(refs_a.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(state_a));
+    assert_eq!(refs_b.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(state_b));
+}

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -423,3 +423,52 @@ fn test_ref_summary_index_falls_back_when_sidecar_is_corrupt() {
         vec![ThreadName::new("main")]
     );
 }
+
+/// heddle#305 r2: the internal undo-recovery ref must live OUTSIDE the
+/// user-writable marker namespace. It coexists with a user marker of the same
+/// literal name, is invisible to `list_markers`, and a user `create_marker` /
+/// `delete_marker` of that name never touches the internal pointer — and vice
+/// versa. This closes the namespace-collision class structurally: the
+/// `MarkerDelete` undo inverse (`create_marker(undo-recovery, Missing)`) can
+/// never collide with recovery bookkeeping.
+#[test]
+fn undo_recovery_ref_is_isolated_from_user_marker_namespace() {
+    let (_temp, refs) = create_ref_manager();
+    let recovery_state = ChangeId::generate();
+    let user_state = ChangeId::generate();
+    assert_ne!(recovery_state, user_state);
+
+    refs.set_undo_recovery(&recovery_state).unwrap();
+
+    // The internal recovery ref is invisible to user marker enumeration and
+    // unreadable through the marker API.
+    assert!(
+        refs.list_markers().unwrap().is_empty(),
+        "the internal recovery ref must never appear as a user marker"
+    );
+    assert_eq!(
+        refs.get_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap(),
+        None,
+        "the internal recovery ref must not be readable as a user marker"
+    );
+
+    // A user may create a marker with the same literal name; the `Missing`
+    // expectation succeeds because the internal ref does not occupy the
+    // marker namespace. This is exactly the `MarkerDelete` undo-inverse shape
+    // that previously risked colliding with the recovery write.
+    refs.create_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE), &user_state)
+        .unwrap();
+    // The two pointers are independent.
+    assert_eq!(refs.get_undo_recovery().unwrap(), Some(recovery_state));
+    assert_eq!(
+        refs.get_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap(),
+        Some(user_state)
+    );
+
+    // Deleting the user marker leaves the internal recovery ref intact.
+    refs.delete_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap();
+    assert_eq!(refs.get_undo_recovery().unwrap(), Some(recovery_state));
+
+    // With no user marker, the handle resolves the internal recovery ref.
+    assert_eq!(refs.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(recovery_state));
+}

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -424,13 +424,12 @@ fn test_ref_summary_index_falls_back_when_sidecar_is_corrupt() {
     );
 }
 
-/// heddle#305 r2: the internal undo-recovery ref must live OUTSIDE the
-/// user-writable marker namespace. It coexists with a user marker of the same
-/// literal name, is invisible to `list_markers`, and a user `create_marker` /
-/// `delete_marker` of that name never touches the internal pointer — and vice
-/// versa. This closes the namespace-collision class structurally: the
-/// `MarkerDelete` undo inverse (`create_marker(undo-recovery, Missing)`) can
-/// never collide with recovery bookkeeping.
+/// heddle#305 r3: the undo-recovery handle is UNSHADOWABLE by user refs in BOTH
+/// directions. The internal pointer lives outside the user-writable namespace
+/// (write side), AND the reserved `.`-prefixed handle resolves to it before any
+/// user thread/marker (resolve side). This closes the shadowing class
+/// structurally rather than relying on a same-named user ref losing a
+/// resolution race.
 #[test]
 fn undo_recovery_ref_is_isolated_from_user_marker_namespace() {
     let (_temp, refs) = create_ref_manager();
@@ -440,35 +439,42 @@ fn undo_recovery_ref_is_isolated_from_user_marker_namespace() {
 
     refs.set_undo_recovery(&recovery_state).unwrap();
 
-    // The internal recovery ref is invisible to user marker enumeration and
-    // unreadable through the marker API.
+    // The internal recovery ref is invisible to user marker enumeration.
     assert!(
         refs.list_markers().unwrap().is_empty(),
         "the internal recovery ref must never appear as a user marker"
     );
-    assert_eq!(
-        refs.get_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap(),
-        None,
-        "the internal recovery ref must not be readable as a user marker"
+
+    // WRITE side: the reserved handle cannot be created as a user marker — the
+    // leading `.` is rejected by ref-name validation — so no user ref can ever
+    // occupy the recovery namespace.
+    assert!(
+        matches!(
+            refs.create_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE), &user_state),
+            Err(HeddleError::InvalidRefName(_))
+        ),
+        "a user must not be able to create a marker with the reserved recovery handle"
     );
 
-    // A user may create a marker with the same literal name; the `Missing`
-    // expectation succeeds because the internal ref does not occupy the
-    // marker namespace. This is exactly the `MarkerDelete` undo-inverse shape
-    // that previously risked colliding with the recovery write.
-    refs.create_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE), &user_state)
+    // RESOLVE side: the reserved handle always resolves to the internal pointer.
+    assert_eq!(
+        refs.resolve(UNDO_RECOVERY_HANDLE).unwrap(),
+        Some(recovery_state)
+    );
+
+    // A user marker with the BARE name (no leading dot) is a separate, legal
+    // ref. It coexists with — and never intercepts — the reserved handle.
+    let bare = "undo-recovery";
+    refs.create_marker(&MarkerName::new(bare), &user_state)
         .unwrap();
-    // The two pointers are independent.
-    assert_eq!(refs.get_undo_recovery().unwrap(), Some(recovery_state));
     assert_eq!(
-        refs.get_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap(),
-        Some(user_state)
+        refs.resolve(bare).unwrap(),
+        Some(user_state),
+        "the bare user marker resolves to the user's ref"
     );
-
-    // Deleting the user marker leaves the internal recovery ref intact.
-    refs.delete_marker(&MarkerName::new(UNDO_RECOVERY_HANDLE)).unwrap();
-    assert_eq!(refs.get_undo_recovery().unwrap(), Some(recovery_state));
-
-    // With no user marker, the handle resolves the internal recovery ref.
-    assert_eq!(refs.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(recovery_state));
+    assert_eq!(
+        refs.resolve(UNDO_RECOVERY_HANDLE).unwrap(),
+        Some(recovery_state),
+        "the reserved handle still resolves to the internal recovery ref"
+    );
 }

--- a/crates/refs/src/refs/resolve.rs
+++ b/crates/refs/src/refs/resolve.rs
@@ -3,24 +3,33 @@
 
 use objects::object::ChangeId;
 
-use super::Head;
+use super::{Head, UNDO_RECOVERY_HANDLE};
 
-pub fn resolve_refspec<E, ReadHead, GetThread, GetMarker>(
+pub fn resolve_refspec<E, ReadHead, GetThread, GetMarker, GetUndoRecovery>(
     refspec: &str,
     read_head: ReadHead,
     get_thread: GetThread,
     get_marker: GetMarker,
+    get_undo_recovery: GetUndoRecovery,
 ) -> Result<Option<ChangeId>, E>
 where
     ReadHead: FnOnce() -> Result<Head, E>,
     GetThread: Fn(&str) -> Result<Option<ChangeId>, E>,
     GetMarker: Fn(&str) -> Result<Option<ChangeId>, E>,
+    GetUndoRecovery: FnOnce() -> Result<Option<ChangeId>, E>,
 {
     if refspec == "@" || refspec == "HEAD" {
         return match read_head()? {
             Head::Attached { thread } => get_thread(&thread),
             Head::Detached { state } => Ok(Some(state)),
         };
+    }
+    // Reserved heddle-internal handle, resolved BEFORE user threads/markers so
+    // no user ref can intercept it (heddle#305 r3). Its leading `.` also makes
+    // it uncreatable as a user ref (see `validate_ref_name`), so it is
+    // unshadowable in both directions.
+    if refspec == UNDO_RECOVERY_HANDLE {
+        return get_undo_recovery();
     }
     if let Some(id) = get_thread(refspec)? {
         return Ok(Some(id));


### PR DESCRIPTION
## Summary
- `heddle undo` no longer leaves the worktree edits a prior `capture`/`commit` absorbed "not obviously recoverable" (dogfood #6, p1 data-safety). Before the reset, `undo` records the current tip — the pre-undo worktree state, guaranteed clean by the existing preflights — as a single rolling `undo-recovery` marker (ORIG_HEAD-style) in heddle's thread history.
- The absorbed content is therefore preserved as a **first-class, addressable, gc-surviving state**, recoverable by `heddle goto undo-recovery` (or `heddle redo`) — durable even after a divergent `capture`/`commit` strands the redo replay path (in git-overlay, a later commit moves Git HEAD and `redo` then refuses on the checkpoint).
- The capture lands **before** the hard reset, so undo is non-lossy **by construction**. The undo/redo oplog cursor and the Git-mirror hard-reset are untouched: durability lives in heddle's immutable store + refs, and **undo still never records itself as Git history**. Surfaced on the completed-undo output (`recovery_state` / `recovery_marker`, declared in `UndoSchema`) and as a recovery hint in human output.
- Safe by default — **no new flag** (no `--soft`/`--keep`); the maintainer-specified design keeps state in heddle, not in git-soft semantics.

Closes HeddleCo/heddle#305

## Red commit
`13c8a78`

## Test evidence
\`\`\`
$ cargo test -p heddle-cli --test core_functionality undo_and_special::test_undo_captures_pre_undo_state_into_recovery_marker
test undo_and_special::test_undo_captures_pre_undo_state_into_recovery_marker ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 109 filtered out

$ cargo test -p heddle-cli --test core_functionality undo_and_special::test_undo_recovery_marker_survives_divergent_capture
test undo_and_special::test_undo_recovery_marker_survives_divergent_capture ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 109 filtered out

$ cargo test -p heddle-cli --test cli_integration git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit
test git_replacement_matrix::git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 820 filtered out

# Full local CI-parity gates (all green):
$ bash scripts/check-no-silent-default-tree-load.sh   # asserter clean (514 files scanned)
$ cargo test --workspace                              # ok (exit 0)
$ cargo clippy --workspace --all-targets -- -D warnings  # ok (exit 0)
\`\`\`

The two new tests were red on `13c8a78` (panicked: "undo must record an \`undo-recovery\` marker for the pre-undo state"); the git-overlay test confirmed the Git mirror is already hard-reset with no undo-as-git history before the marker assertion — only the missing capture was red.

## Manual verification
N/A — covered by tests. Reproduced the headline (git-overlay `commit` → `undo` → divergent `commit` strands `redo`) manually during investigation; the `undo-recovery` marker keeps the absorbed content recoverable via `heddle goto undo-recovery`.

## Design note (deviation from the literal "call create_snapshot" hint)
The brief suggested calling `create_snapshot` before the reset. Doing so records a forward `OpRecord::Snapshot` in the oplog, which unavoidably hijacks the undo/redo cursor (it is always the most-recent entry): marked-undone it steals the redo target from the original batch (breaks the git+heddle round-trip in `git_overlay_matrix_ship_undo_restores_git_and_heddle_together`); left-forward it makes `undo` never reach "nothing to undo" (breaks `test_undo_at_beginning`). Pointing a recovery marker at the already-immutable pre-undo tip preserves the identical bytes without touching the cursor — same durability guarantee, zero blast radius on the undo/redo state machine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672127&installation_id=132405951&pr_number=314&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F314&signature=ef9601457d176bd10127f523860bd048b0c2640cb57d4e69aa79e4f113a03e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

### Round 2 (cid 3326345637, P2 — recovery marker namespace collision)
Moved the pre-undo recovery pointer out of the user marker namespace into a heddle-internal ref (`.heddle/UNDO_RECOVERY`, ORIG_HEAD-style) via `RefManager::set/get_undo_recovery`. This closes the collision class by construction: user `marker create/delete` (and their undo inverses in `apply_undo_batch`) can never see, enumerate, or clobber the internal pointer, so the `MarkerDelete` inverse `create_marker(undo-recovery, Missing)` can no longer fail against recovery bookkeeping. `heddle goto undo-recovery` still resolves via the `UNDO_RECOVERY_HANDLE` fallback in `RefManager::resolve`. Invariant stated + swept: no heddle-internal bookkeeping ref lives in a user-writable namespace. Red→green: refs unit test `undo_recovery_ref_is_isolated_from_user_marker_namespace` + CLI `test_undo_recovery_lives_outside_user_marker_namespace`.

---

### Round 3 (cid 3326495468 — recovery handle shadowable on resolve)

Close-the-class fix for the read-side sibling of r1/r2. The recovery handle is now a reserved `.`-prefixed form (`.undo-recovery`) that is **unshadowable in both directions**:
- **Write:** leading `.` is rejected by `validate_ref_name`, so no user marker/thread can take the recovery name.
- **Resolve:** `resolve_refspec` routes the handle to the internal recovery pointer *before* user threads/markers; the prior user-marker-wins fallback is removed.

`undo` advertises exactly that handle (field + printed command). Red→green conformance test `test_recovery_handle_unshadowable_by_user_marker` (colliding user `undo-recovery` marker present → advertised handle resolves to internal pre-undo state, user marker untouched). Fixed in 136b449.


---

### Round 4 (cid 3326662985, P2 — recovery pointer not scoped to the local checkout)

Different axis from r1–r3 (namespace) — this is **scope**. In objectstore-pointer worktrees `Repository::open` builds refs with a *shared* ref root but a *per-worktree* `local_head`, and undo/redo history is scoped to that checkout via `op_scope`. The recovery write ignored `local_head` and always wrote `UNDO_RECOVERY` under the shared root, so two checkouts sharing one object store would clobber each other's recovery pointer on `undo` — `goto .undo-recovery` in checkout A could restore B's pre-undo state (cross-checkout corruption).

**Fix:** `undo_recovery_path()` now tracks `head_path()` — the recovery pointer lands beside the per-checkout `HEAD` (`<worktree>/.heddle/UNDO_RECOVERY`), the same checkout scope as the history it recovers. Falls back to `<root>/UNDO_RECOVERY` when no `local_head` is set (unchanged for plain checkouts). Both the write (`set_undo_recovery`) and the resolve (`get_undo_recovery` / `.undo-recovery` handle) go through this single path, so both sides honor `local_head`. r3's reserved unshadowable handle is preserved and now per-checkout.

**Invariant stated + swept:** undo/redo recovery state is scoped to the same checkout/`op_scope` as the history it recovers, never the shared ref root. Swept all `self.root`/`root.join` sites in `crates/refs` — `HEAD` already honored `local_head`; `refs/` is the intentionally-shared user namespace; oplog history records carry `op_scope` and filter on read (no path-level collision). `UNDO_RECOVERY` was the only path-keyed recovery artifact on the shared root.

Red→green test `undo_recovery_is_scoped_per_checkout_on_shared_ref_root` (two checkouts share a ref root, both `undo`; each recovers its own pre-undo state, no cross-lane overwrite). Fixed in ae65b5d.
