### PR TITLE
heddle#303: regression-lock ignore-covers-symlink + mid-session refresh ACs

### DIFF
--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -117,6 +117,25 @@ mod tests {
     }
 
     #[test]
+    fn dir_only_rule_covers_symlinked_deps_dir() {
+        // heddle#303: a `node_modules` *symlink* (used as a workaround
+        // for the isolated-checkout hydrate gap) must be covered by a
+        // `node_modules/` (dir-only) rule, not treated as an uncaptured
+        // path that silently blocks `ready`. The matcher is path-based
+        // and always probes with `is_dir = true`, so it cannot — and
+        // must not — distinguish a symlink-to-dir from a real directory:
+        // the trailing-slash rule fires on the bare `node_modules` entry
+        // either way. Walker/scan callers never descend a symlink, so
+        // this is the entry that decides whether the link is ignored.
+        let patterns = vec!["node_modules/".to_string()];
+        assert!(should_ignore(&PathBuf::from("node_modules"), &patterns));
+        assert!(should_ignore(
+            &PathBuf::from("nested/node_modules"),
+            &patterns
+        ));
+    }
+
+    #[test]
     fn test_simple_pattern() {
         let patterns = vec!["node_modules".to_string()];
         assert!(should_ignore(

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1650,3 +1650,158 @@ mod s3_init_nested_runtime {
         }
     }
 }
+
+/// heddle#303 (AC: "a symlinked deps dir doesn't silently block
+/// `ready`"). In a native Heddle repo, a `node_modules` *symlink* —
+/// the workaround people reach for when an isolated checkout has no
+/// installed deps — must be covered by a `node_modules/` (dir-only)
+/// ignore rule, exactly as a real `node_modules/` directory would be.
+/// Otherwise the symlink shows up as an uncaptured path and silently
+/// blocks `ready`. The cached worktree compare is the path `ready`
+/// consumes via `worktree_dirty`/`worktree_dirty_paths`.
+#[cfg(unix)]
+#[test]
+fn dir_only_ignore_covers_node_modules_symlink_native() {
+    use std::os::unix::fs::symlink;
+
+    let (temp, repo) = create_test_repo();
+    let root = temp.path();
+
+    let real_deps = root.join("real_deps");
+    fs::create_dir(&real_deps).unwrap();
+    fs::write(real_deps.join("pkg.json"), "{}").unwrap();
+    symlink(&real_deps, root.join("node_modules")).unwrap();
+    fs::write(root.join("keep.txt"), "hi").unwrap();
+    // Only the symlink basename is ignored; the link target is left
+    // un-ignored so the assertion proves it's the `node_modules/` rule
+    // (matching the bare symlink entry) doing the work, not collateral.
+    fs::write(root.join(".heddleignore"), "node_modules/\n").unwrap();
+
+    let state = repo.current_state().unwrap().unwrap();
+    let tree = repo.require_tree(&state.tree).unwrap();
+    let status = repo.compare_worktree_cached(&tree).unwrap();
+
+    assert!(
+        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        "node_modules symlink must be ignored by `node_modules/`, not reported as added: {:?}",
+        status.added,
+    );
+    assert!(
+        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        "a non-ignored sibling must still be reported (proves the scan ran): {:?}",
+        status.added,
+    );
+}
+
+/// heddle#303 (AC: "a mid-session ignore broadening takes effect
+/// without `unlink`"). In a native repo, broadening `.heddleignore` to
+/// `node_modules` mid-session must retroactively mask a
+/// previously-seen *untracked* `node_modules/` tree on the very next
+/// status, with no `unlink`/removal. Guards against a stale first-seen
+/// cache decision surviving an ignore-set change.
+#[cfg(unix)]
+#[test]
+fn midsession_ignore_broadening_masks_untracked_without_unlink_native() {
+    let (temp, repo) = create_test_repo();
+    let root = temp.path();
+
+    let node_modules = root.join("node_modules");
+    fs::create_dir(&node_modules).unwrap();
+    fs::write(node_modules.join("dep.js"), "x").unwrap();
+    fs::write(root.join("keep.txt"), "hi").unwrap();
+
+    let state = repo.current_state().unwrap().unwrap();
+    let tree = repo.require_tree(&state.tree).unwrap();
+
+    // First status: no ignore yet, so the dep file is seen as untracked.
+    let before = repo.compare_worktree_cached(&tree).unwrap();
+    assert!(
+        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
+        before.added,
+    );
+
+    // Broaden the ignore mid-session — no removal of the path.
+    fs::write(root.join(".heddleignore"), "node_modules\n").unwrap();
+
+    let after = repo.compare_worktree_cached(&tree).unwrap();
+    assert!(
+        !after.added.iter().any(|p| p.starts_with("node_modules")),
+        "broadened ignore must mask the previously-seen node_modules tree without unlink: {:?}",
+        after.added,
+    );
+    assert!(
+        after.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        "non-ignored sibling must still be reported after the refresh: {:?}",
+        after.added,
+    );
+}
+
+/// heddle#303, git-overlay variant of the symlink AC. The dogfood that
+/// surfaced this ran on a Git repo, so `ready` consumed
+/// `git_overlay_worktree_status`. A `node_modules` symlink with a
+/// `node_modules/` rule in `.gitignore` must be ignored there too.
+#[cfg(unix)]
+#[test]
+fn dir_only_ignore_covers_node_modules_symlink_git_overlay() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    gix::init(root).expect("init real git repository");
+    let repo = Repository::init_default(root).unwrap();
+    assert_eq!(repo.capability(), RepositoryCapability::GitOverlay);
+
+    let real_deps = root.join("real_deps");
+    fs::create_dir(&real_deps).unwrap();
+    fs::write(real_deps.join("pkg.json"), "{}").unwrap();
+    symlink(&real_deps, root.join("node_modules")).unwrap();
+    fs::write(root.join("keep.txt"), "hi").unwrap();
+    fs::write(root.join(".gitignore"), "node_modules/\n").unwrap();
+
+    let status = repo.git_overlay_worktree_status().unwrap().unwrap();
+    assert!(
+        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        "node_modules symlink must be ignored in git-overlay status: {:?}",
+        status.added,
+    );
+    assert!(
+        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        "a non-ignored sibling must still be reported in git-overlay status: {:?}",
+        status.added,
+    );
+}
+
+/// heddle#303, git-overlay variant of the mid-session-refresh AC.
+/// Broadening `.gitignore` to `node_modules` mid-session must mask a
+/// previously-seen untracked tree on the next status, no `unlink`.
+#[cfg(unix)]
+#[test]
+fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    gix::init(root).expect("init real git repository");
+    let repo = Repository::init_default(root).unwrap();
+    assert_eq!(repo.capability(), RepositoryCapability::GitOverlay);
+
+    let node_modules = root.join("node_modules");
+    fs::create_dir(&node_modules).unwrap();
+    fs::write(node_modules.join("dep.js"), "x").unwrap();
+    fs::write(root.join("keep.txt"), "hi").unwrap();
+
+    let before = repo.git_overlay_worktree_status().unwrap().unwrap();
+    assert!(
+        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
+        before.added,
+    );
+
+    fs::write(root.join(".gitignore"), "node_modules\n").unwrap();
+
+    let after = repo.git_overlay_worktree_status().unwrap().unwrap();
+    assert!(
+        !after.added.iter().any(|p| p.starts_with("node_modules")),
+        "broadened .gitignore must mask the node_modules tree without unlink: {:?}",
+        after.added,
+    );
+}


### PR DESCRIPTION
## Summary

- Both frictions in #303 — a `node_modules` *symlink* defeating a `node_modules/` (dir-only) ignore and silently blocking `ready`, and mid-session ignore broadening not refreshing — were reported against **heddle 0.2.4** and are **already resolved on `main`**. This PR locks the acceptance criteria with regression tests across both code paths `ready` consumes (native cached-compare and git-overlay status).
- Why they already pass: the ignore matcher probes with `is_dir = true` (`crates/objects/src/worktree/worktree_ignore.rs:85`, `crates/repo/src/worktree_ignore.rs:95`), so a trailing-slash rule fires on the *bare* `node_modules` entry — and since walkers never descend a symlink, the symlink entry is what decides ignoring. Untracked status re-derives ignore decisions every run: the native path keys its untracked-dir cache on the matcher fingerprint (`crates/repo/src/status_untracked_scan.rs:208`) and the git-overlay path re-reads patterns per call (`crates/repo/src/repository.rs:1330`).
- New coverage so a future change to the matcher's dir-handling can't silently reintroduce the symlink block:
  - matcher unit test: `node_modules/` covers a `node_modules` path (`crates/objects/src/worktree/worktree_ignore.rs`)
  - native + git-overlay: a real `node_modules` symlink is ignored, not reported as uncaptured
  - native + git-overlay: broadening the ignore mid-session masks a previously-seen untracked tree with **no** `unlink`

## Acceptance criteria

- ✅ *A mid-session ignore broadening takes effect without `unlink`* — `midsession_ignore_broadening_masks_untracked_without_unlink_{native,git_overlay}`.
- ✅ *A symlinked deps dir doesn't silently block `ready`* — `dir_only_ignore_covers_node_modules_symlink_{native,git_overlay}`. (It is ignored, so `ready` is never blocked; the "name the path + reason" fallback applies only when a path *does* block, and the existing `ready` block message already enumerates the uncaptured paths.)

Closes HeddleCo/heddle#303

## Red commit

N/A — DoD Type ≠ TDD-Rust. No production behavior change: the defects were already fixed post-0.2.4, so the tests are green on first run. They are regression locks, not a red→green fix. Flagging for the orchestrator/groomer: if a test-only artifact isn't the desired resolution for this issue, it can be closed as already-fixed with this PR as the evidence.

## Test evidence

```
$ cargo test -p heddle-objects --lib dir_only_rule_covers_symlinked_deps_dir
test worktree::worktree_ignore::tests::dir_only_rule_covers_symlinked_deps_dir ... ok
test result: ok. 1 passed; 0 failed

$ cargo test -p heddle-repo --lib -- node_modules_symlink midsession_ignore_broadening
test repository::repository_tests::dir_only_ignore_covers_node_modules_symlink_git_overlay ... ok
test repository::repository_tests::dir_only_ignore_covers_node_modules_symlink_native ... ok
test repository::repository_tests::midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay ... ok
test repository::repository_tests::midsession_ignore_broadening_masks_untracked_without_unlink_native ... ok
test result: ok. 4 passed; 0 failed

$ cargo test -p heddle-objects --lib   # 299 passed; 1 ignored
$ cargo test -p heddle-repo --lib      # 327 passed; 0 failed
$ cargo clippy -p heddle-repo -p heddle-objects --all-targets -- -D warnings   # clean
$ bash scripts/check-no-silent-default-tree-load.sh   # clean (514 files)
```

## Manual verification

N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782681965&installation_id=132405951&pr_number=321&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F321&signature=924b2eaed2b5b7f04b543ff6a051e337fe15e0616908840639f32bf09b84d3e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->