### PR TITLE
heddle#307: structured blame JSON attribution + actor spawn --no-thread

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1393,6 +1393,12 @@ pub struct ActorSpawnArgs {
     #[arg(long)]
     pub thread: Option<String>,
 
+    /// Attach the actor to the current thread instead of minting a new
+    /// `actor/<session>` thread. Use this to record the detected agent
+    /// identity without leaving a stray thread behind.
+    #[arg(long, conflicts_with = "thread")]
+    pub no_thread: bool,
+
     /// AI provider name (e.g. `anthropic`).
     #[arg(long)]
     pub provider: Option<String>,

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -262,6 +262,7 @@ impl ActorOutput {
 pub async fn cmd_actor_spawn(
     cli: &Cli,
     thread: Option<String>,
+    no_thread: bool,
     provider: Option<String>,
     model: Option<String>,
 ) -> Result<()> {
@@ -272,6 +273,18 @@ pub async fn cmd_actor_spawn(
             "actor spawn"
         ))
     })?;
+
+    // `--no-thread` attaches the actor to the current thread rather than
+    // minting a fresh `actor/<session>` thread. Resolve it up front so a
+    // detached HEAD fails cleanly before we create any registry entry.
+    let attach_thread = if no_thread {
+        match repo.head_ref()? {
+            Head::Attached { thread } => Some(thread),
+            _ => return Err(anyhow!(actor_spawn_no_thread_detached_advice())),
+        }
+    } else {
+        None
+    };
 
     let explicit_identity = provider
         .as_ref()
@@ -304,11 +317,18 @@ pub async fn cmd_actor_spawn(
 
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = registry.create_generated_entry(|session_id| {
-        let thread_name = ThreadName::new(thread
-            .clone()
-            .unwrap_or_else(|| format!("actor/{session_id}")));
+        let thread_name = match &attach_thread {
+            Some(current) => current.clone(),
+            None => ThreadName::new(
+                thread
+                    .clone()
+                    .unwrap_or_else(|| format!("actor/{session_id}")),
+            ),
+        };
 
-        if repo.refs().get_thread(&thread_name)?.is_none() {
+        // In `--no-thread` mode we attach to the existing current thread
+        // and never create a ref, so no stray thread is left behind.
+        if attach_thread.is_none() && repo.refs().get_thread(&thread_name)?.is_none() {
             repo.refs().set_thread(&thread_name, &base_state)?;
         }
 
@@ -338,11 +358,25 @@ pub async fn cmd_actor_spawn(
             usage_summary: AgentUsageSummary::default(),
             last_progress_at: None,
             report_flush_state: None,
-            attach_reason: Some(format!(
-                "actor {session_id} was spawned explicitly on thread {thread_name}"
-            )),
-            attach_precedence: vec!["explicit-actor-spawn".to_string()],
-            winning_attach_rule: Some("explicit-actor-spawn".to_string()),
+            attach_reason: Some(if attach_thread.is_some() {
+                format!(
+                    "actor {session_id} was attached to the current thread {thread_name} without minting a new thread"
+                )
+            } else {
+                format!("actor {session_id} was spawned explicitly on thread {thread_name}")
+            }),
+            attach_precedence: vec![
+                if attach_thread.is_some() {
+                    "no-thread-attach".to_string()
+                } else {
+                    "explicit-actor-spawn".to_string()
+                },
+            ],
+            winning_attach_rule: Some(if attach_thread.is_some() {
+                "no-thread-attach".to_string()
+            } else {
+                "explicit-actor-spawn".to_string()
+            }),
             probe_source: probe_source.clone(),
             probe_confidence,
             status: AgentStatus::Active,
@@ -706,8 +740,10 @@ fn actor_identity_env_signals() -> Vec<String> {
 
 fn detected_actor_next_action(provider: Option<&str>, model: Option<&str>) -> Option<String> {
     match (provider, model) {
+        // Recommend `--no-thread` so the detected identity is attached to
+        // the current thread without leaving a stray `actor/<session>`.
         (Some(provider), Some(model)) => Some(format!(
-            "heddle actor spawn --provider {provider} --model {model}"
+            "heddle actor spawn --no-thread --provider {provider} --model {model}"
         )),
         _ => None,
     }
@@ -749,6 +785,23 @@ fn is_no_active_actor_error(err: &anyhow::Error) -> bool {
     err.chain()
         .filter_map(|cause| cause.downcast_ref::<RecoveryAdvice>())
         .any(|advice| advice.kind == "no_active_actor")
+}
+
+fn actor_spawn_no_thread_detached_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "actor_spawn_no_thread_detached",
+        "Cannot attach to the current thread",
+        "`--no-thread` attaches the actor to the thread HEAD points at. Check out a thread first (`heddle thread switch <name>`), or run `heddle actor spawn` without `--no-thread` to mint a dedicated thread.",
+        "HEAD is not attached to a thread, so there is no current thread to attach the actor to",
+        "minting a thread implicitly would create exactly the stray thread `--no-thread` is meant to avoid",
+        "no actor registry entries, refs, repository objects, or worktree files were changed",
+        "heddle thread switch <name>",
+        vec![
+            "heddle thread list".to_string(),
+            "heddle thread switch <name>".to_string(),
+            "heddle actor spawn".to_string(),
+        ],
+    )
 }
 
 fn no_active_actor_advice() -> RecoveryAdvice {

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -274,13 +274,17 @@ pub async fn cmd_actor_spawn(
         ))
     })?;
 
-    // `--no-thread` attaches the actor to the current thread rather than
-    // minting a fresh `actor/<session>` thread. Resolve it up front so a
-    // detached HEAD fails cleanly before we create any registry entry.
+    // `--no-thread` attaches the actor to the current lane rather than minting
+    // a fresh `actor/<session>` thread. `current_lane()` is the single source
+    // of truth for "is there a lane to attach to?": it consults the git-overlay
+    // HEAD state, so a detached Git HEAD reports no lane even when `.heddle/HEAD`
+    // still names a stale attached thread. Resolve it up front so we fail
+    // cleanly before creating any registry entry. The same predicate drives the
+    // `actor explain` recommendation, so recommend and execute never disagree.
     let attach_thread = if no_thread {
-        match repo.head_ref()? {
-            Head::Attached { thread } => Some(thread),
-            _ => return Err(anyhow!(actor_spawn_no_thread_detached_advice())),
+        match repo.current_lane()? {
+            Some(lane) => Some(ThreadName::new(lane)),
+            None => return Err(anyhow!(actor_spawn_no_thread_detached_advice())),
         }
     } else {
         None
@@ -645,11 +649,15 @@ fn explain_detected_actor_identity(cli: &Cli, repo: &Repository) -> Result<()> {
         std::env::var("HEDDLE_AGENT_POLICY").ok(),
     )?;
     let env_signals = actor_identity_env_signals();
-    let head_detached = matches!(repo.head_ref()?, Head::Detached { .. });
+    // Route through the same "is there a current lane?" predicate that
+    // `actor spawn --no-thread` uses, so the recommendation is always runnable
+    // in this context. `current_lane()` is git-overlay-aware: a detached Git
+    // HEAD reports no lane even when `.heddle/HEAD` still names a stale thread.
+    let no_current_lane = repo.current_lane()?.is_none();
     let next_action = detected_actor_next_action(
         probe.provider.as_deref(),
         probe.model.as_deref(),
-        head_detached,
+        no_current_lane,
     );
     let next_action_template = next_action.as_deref().and_then(action_template);
 
@@ -746,16 +754,16 @@ fn actor_identity_env_signals() -> Vec<String> {
 fn detected_actor_next_action(
     provider: Option<&str>,
     model: Option<&str>,
-    head_detached: bool,
+    no_current_lane: bool,
 ) -> Option<String> {
     match (provider, model) {
         // The recommendation must be runnable as-is from the current context.
-        // On a detached HEAD there is no current thread to attach to, so
-        // `--no-thread` would fail (`actor_spawn_no_thread_detached`); mint a
-        // dedicated thread instead. On a thread, `--no-thread` attaches the
-        // detected identity to the current thread without leaving a stray
-        // `actor/<session>`.
-        (Some(provider), Some(model)) if head_detached => Some(format!(
+        // With no current lane (e.g. a detached HEAD) there is no thread to
+        // attach to, so `--no-thread` would fail
+        // (`actor_spawn_no_thread_detached`); mint a dedicated thread instead.
+        // On a lane, `--no-thread` attaches the detected identity to the current
+        // thread without leaving a stray `actor/<session>`.
+        (Some(provider), Some(model)) if no_current_lane => Some(format!(
             "heddle actor spawn --provider {provider} --model {model}"
         )),
         (Some(provider), Some(model)) => Some(format!(

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -645,7 +645,12 @@ fn explain_detected_actor_identity(cli: &Cli, repo: &Repository) -> Result<()> {
         std::env::var("HEDDLE_AGENT_POLICY").ok(),
     )?;
     let env_signals = actor_identity_env_signals();
-    let next_action = detected_actor_next_action(probe.provider.as_deref(), probe.model.as_deref());
+    let head_detached = matches!(repo.head_ref()?, Head::Detached { .. });
+    let next_action = detected_actor_next_action(
+        probe.provider.as_deref(),
+        probe.model.as_deref(),
+        head_detached,
+    );
     let next_action_template = next_action.as_deref().and_then(action_template);
 
     if should_output_json(cli, None) {
@@ -738,10 +743,21 @@ fn actor_identity_env_signals() -> Vec<String> {
     signals
 }
 
-fn detected_actor_next_action(provider: Option<&str>, model: Option<&str>) -> Option<String> {
+fn detected_actor_next_action(
+    provider: Option<&str>,
+    model: Option<&str>,
+    head_detached: bool,
+) -> Option<String> {
     match (provider, model) {
-        // Recommend `--no-thread` so the detected identity is attached to
-        // the current thread without leaving a stray `actor/<session>`.
+        // The recommendation must be runnable as-is from the current context.
+        // On a detached HEAD there is no current thread to attach to, so
+        // `--no-thread` would fail (`actor_spawn_no_thread_detached`); mint a
+        // dedicated thread instead. On a thread, `--no-thread` attaches the
+        // detected identity to the current thread without leaving a stray
+        // `actor/<session>`.
+        (Some(provider), Some(model)) if head_detached => Some(format!(
+            "heddle actor spawn --provider {provider} --model {model}"
+        )),
         (Some(provider), Some(model)) => Some(format!(
             "heddle actor spawn --no-thread --provider {provider} --model {model}"
         )),

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -9,7 +9,6 @@ use anyhow::{Result, anyhow};
 use chrono::Utc;
 use objects::object::ThreadName;
 use objects::store::{ActorChainNode, AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary};
-use refs::Head;
 use repo::Repository;
 use serde::Serialize;
 
@@ -784,11 +783,20 @@ fn resolve_actor_entry(
             .ok_or_else(|| anyhow!("Actor not found for session: {}", session_id));
     }
 
-    if let Head::Attached { thread } = repo.head_ref()?
+    // Single git-overlay-aware oracle for "what lane is THIS checkout on?".
+    // `current_lane()` consults the git-overlay HEAD state, so a detached Git
+    // HEAD reports no lane even when `.heddle/HEAD` still names a stale attached
+    // thread. Deriving the implicit actor lookup from it — instead of
+    // `head_ref()` / `.heddle/HEAD` directly — keeps `actor explain`/`show`/`done`
+    // in agreement with `actor spawn --no-thread`, which rejects on the same
+    // no-lane predicate. There must be exactly one answer to "current lane?".
+    let current_lane = repo.current_lane()?;
+
+    if let Some(thread) = current_lane.as_deref()
         && let Some(entry) = registry
             .list()?
             .into_iter()
-            .filter(|entry| entry.status == AgentStatus::Active && thread == entry.thread)
+            .filter(|entry| entry.status == AgentStatus::Active && entry.thread == thread)
             .max_by_key(|entry| entry.started_at)
     {
         return Ok(entry);
@@ -798,11 +806,21 @@ fn resolve_actor_entry(
         return Ok(entry);
     }
 
-    registry
-        .list()?
-        .into_iter()
-        .find(|entry| entry.status == AgentStatus::Active)
-        .ok_or_else(|| anyhow!(no_active_actor_advice()))
+    // The "any active actor" fallback only applies when this checkout is on a
+    // lane. With no current lane (a detached Git HEAD whose `.heddle/HEAD` is
+    // stale, or a genuinely detached HEAD), resolving an arbitrary active actor
+    // would contradict `actor spawn --no-thread`'s rejection and re-introduce
+    // the recommend/execute split this oracle exists to prevent.
+    if current_lane.is_some()
+        && let Some(entry) = registry
+            .list()?
+            .into_iter()
+            .find(|entry| entry.status == AgentStatus::Active)
+    {
+        return Ok(entry);
+    }
+
+    Err(anyhow!(no_active_actor_advice()))
 }
 
 fn is_no_active_actor_error(err: &anyhow::Error) -> bool {

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -6,7 +6,8 @@ use std::{collections::HashMap, path::Path};
 
 use anyhow::{Result, anyhow};
 use objects::object::{
-    AnnotationStatus, ChangeId, ContentHash, ContextTarget, FileProvenance, ProvenanceError, Tree,
+    AnnotationStatus, Attribution, ChangeId, ContentHash, ContextTarget, FileProvenance,
+    ProvenanceError, Tree,
 };
 use repo::Repository;
 use serde::Serialize;
@@ -21,12 +22,46 @@ use crate::{
     config::UserConfig,
 };
 
+#[derive(Clone, Serialize)]
+struct PrincipalInfo {
+    name: String,
+    email: String,
+}
+
+#[derive(Clone, Serialize)]
+struct AgentInfo {
+    provider: String,
+    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_id: Option<String>,
+}
+
+/// Split an `Attribution` into the structured `principal` / `agent`
+/// shape used by `log` and `show`, so `blame --output json` consumers
+/// never have to string-parse `"Name <email> (via provider/model)"`.
+fn attribution_parts(attribution: &Attribution) -> (PrincipalInfo, Option<AgentInfo>) {
+    let principal = PrincipalInfo {
+        name: attribution.principal.name.clone(),
+        email: attribution.principal.email.clone(),
+    };
+    let agent = attribution.agent.as_ref().map(|a| AgentInfo {
+        provider: a.provider.clone(),
+        model: a.model.clone(),
+        session_id: a.session_id.clone(),
+        policy_id: a.policy_id.clone(),
+    });
+    (principal, agent)
+}
+
 #[derive(Serialize)]
 struct BlameLine {
     line_number: usize,
     content: String,
     change_id: String,
-    author: String,
+    principal: PrincipalInfo,
+    agent: Option<AgentInfo>,
     timestamp: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     origins: Option<Vec<BlameOrigin>>,
@@ -45,7 +80,8 @@ struct BlameOutput {
 #[derive(Clone, Serialize)]
 struct BlameOrigin {
     change_id: String,
-    author: String,
+    principal: PrincipalInfo,
+    agent: Option<AgentInfo>,
     timestamp: String,
 }
 
@@ -60,9 +96,25 @@ struct ContextSnippet {
 #[derive(Clone)]
 struct LineInfo {
     change_id: ChangeId,
-    author: String,
+    attribution: Attribution,
+    /// Count of additional origins beyond the primary, used only to
+    /// render the `+N` suffix in the human-readable author column.
+    extra_origins: usize,
     timestamp: String,
     origins: Vec<BlameOrigin>,
+}
+
+impl LineInfo {
+    /// Author string for the human-readable (non-JSON) renderer. JSON
+    /// consumers use the structured `principal` / `agent` fields and
+    /// never see this.
+    fn author_display(&self) -> String {
+        if self.extra_origins == 0 {
+            self.attribution.to_string()
+        } else {
+            format!("{} +{}", self.attribution, self.extra_origins)
+        }
+    }
 }
 
 pub fn cmd_blame(cli: &Cli, file: String, state: Option<String>, show_context: bool) -> Result<()> {
@@ -132,21 +184,16 @@ pub fn cmd_blame(cli: &Cli, file: String, state: Option<String>, show_context: b
             .iter()
             .enumerate()
             .map(|(i, line)| {
-                let info = line_infos.get(&i).cloned().unwrap_or_else(|| LineInfo {
-                    change_id: target_state_id,
-                    author: state_obj.attribution.to_string(),
-                    timestamp: state_display_ts.clone(),
-                    origins: vec![BlameOrigin {
-                        change_id: target_state_id.to_string(),
-                        author: state_obj.attribution.to_string(),
-                        timestamp: state_display_ts.clone(),
-                    }],
+                let info = line_infos.get(&i).cloned().unwrap_or_else(|| {
+                    state_fallback_line_info(target_state_id, &state_obj, &state_display_ts)
                 });
+                let (principal, agent) = attribution_parts(&info.attribution);
                 BlameLine {
                     line_number: i + 1,
                     content: line.to_string(),
                     change_id: info.change_id.to_string(),
-                    author: info.author,
+                    principal,
+                    agent,
                     timestamp: info.timestamp,
                     origins: (!info.origins.is_empty()).then_some(info.origins),
                 }
@@ -182,26 +229,42 @@ pub fn cmd_blame(cli: &Cli, file: String, state: Option<String>, show_context: b
             println!();
         }
         for (i, line) in lines.iter().enumerate() {
-            let info = line_infos.get(&i).cloned().unwrap_or_else(|| LineInfo {
-                change_id: target_state_id,
-                author: state_obj.attribution.to_string(),
-                timestamp: state_display_ts.clone(),
-                origins: vec![BlameOrigin {
-                    change_id: target_state_id.to_string(),
-                    author: state_obj.attribution.to_string(),
-                    timestamp: state_display_ts.clone(),
-                }],
+            let info = line_infos.get(&i).cloned().unwrap_or_else(|| {
+                state_fallback_line_info(target_state_id, &state_obj, &state_display_ts)
             });
             println!(
                 "{:12} {:20} {}",
                 info.change_id.short(),
-                fit_author(&info.author, 20),
+                fit_author(&info.author_display(), 20),
                 line
             );
         }
     }
 
     Ok(())
+}
+
+/// Per-line attribution fallback when provenance has no origin set for
+/// a line (e.g. freshly bootstrapped git-overlay): attribute the whole
+/// line to the selected state.
+fn state_fallback_line_info(
+    state_id: ChangeId,
+    state: &objects::object::State,
+    display_ts: &str,
+) -> LineInfo {
+    let (principal, agent) = attribution_parts(&state.attribution);
+    LineInfo {
+        change_id: state_id,
+        attribution: state.attribution.clone(),
+        extra_origins: 0,
+        timestamp: display_ts.to_string(),
+        origins: vec![BlameOrigin {
+            change_id: state_id.to_string(),
+            principal,
+            agent,
+            timestamp: display_ts.to_string(),
+        }],
+    }
 }
 
 fn collect_file_context(
@@ -302,9 +365,11 @@ fn compute_blame_from_provenance(provenance: &FileProvenance) -> Result<HashMap<
             .iter()
             .map(|origin_index| {
                 let origin = &provenance.origins[*origin_index as usize];
+                let (principal, agent) = attribution_parts(&origin.attribution);
                 BlameOrigin {
                     change_id: origin.state_id.to_string(),
-                    author: origin.attribution.to_string(),
+                    principal,
+                    agent,
                     // Prefer the authoring time when we have it
                     // (imported git history) — matches git blame's
                     // default. Falls back to `created_at` (committer
@@ -322,11 +387,8 @@ fn compute_blame_from_provenance(provenance: &FileProvenance) -> Result<HashMap<
             index,
             LineInfo {
                 change_id: primary.state_id,
-                author: if origins.len() == 1 {
-                    primary.attribution.to_string()
-                } else {
-                    format!("{} +{}", primary.attribution, origins.len() - 1)
-                },
+                attribution: primary.attribution.clone(),
+                extra_origins: origins.len().saturating_sub(1),
                 // Same author-vs-committer preference as the per-
                 // origin timestamp above: prefer authored_at when we
                 // have it (imported git history), fall back to

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -435,3 +435,106 @@ fn fit_author(s: &str, max_len: usize) -> String {
     }
     truncate(s, max_len)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use objects::object::{Agent, Attribution, Principal, State};
+
+    fn human() -> Attribution {
+        Attribution::human(Principal::new("Ada Lovelace", "ada@example.com"))
+    }
+
+    fn agentic() -> Attribution {
+        Attribution::with_agent(
+            Principal::new("Ada Lovelace", "ada@example.com"),
+            Agent::new("anthropic", "claude-opus-4-7")
+                .with_session("sess-1", "seg-1")
+                .with_policy("pol-1"),
+        )
+    }
+
+    #[test]
+    fn attribution_parts_splits_principal_and_agent() {
+        let (principal, agent) = attribution_parts(&agentic());
+        assert_eq!(principal.name, "Ada Lovelace");
+        assert_eq!(principal.email, "ada@example.com");
+        let agent = agent.expect("agent attribution should be structured");
+        assert_eq!(agent.provider, "anthropic");
+        assert_eq!(agent.model, "claude-opus-4-7");
+        assert_eq!(agent.session_id.as_deref(), Some("sess-1"));
+        assert_eq!(agent.policy_id.as_deref(), Some("pol-1"));
+    }
+
+    #[test]
+    fn attribution_parts_omits_agent_for_human_only() {
+        let (principal, agent) = attribution_parts(&human());
+        assert_eq!(principal.name, "Ada Lovelace");
+        assert!(agent.is_none(), "human-only attribution must not synthesize an agent");
+    }
+
+    #[test]
+    fn agent_info_skips_none_session_and_policy() {
+        // `session_id` / `policy_id` are `skip_serializing_if = None`, so a
+        // bare agent serializes to just provider + model — no null keys.
+        let (_, agent) = attribution_parts(&Attribution::with_agent(
+            Principal::new("Ada", "ada@example.com"),
+            Agent::new("openai", "gpt-5"),
+        ));
+        let json = serde_json::to_value(agent.unwrap()).unwrap();
+        assert_eq!(json["provider"], "openai");
+        assert_eq!(json["model"], "gpt-5");
+        assert!(json.get("session_id").is_none(), "absent session_id must be omitted, not null");
+        assert!(json.get("policy_id").is_none(), "absent policy_id must be omitted, not null");
+    }
+
+    #[test]
+    fn author_display_appends_extra_origin_count() {
+        let info = LineInfo {
+            change_id: ChangeId::generate(),
+            attribution: human(),
+            extra_origins: 2,
+            timestamp: "2026-01-01T00:00:00+00:00".to_string(),
+            origins: Vec::new(),
+        };
+        // Multi-origin lines render `Name <email> +N` in the human column.
+        assert_eq!(info.author_display(), "Ada Lovelace <ada@example.com> +2");
+    }
+
+    #[test]
+    fn author_display_single_origin_has_no_suffix() {
+        let info = LineInfo {
+            change_id: ChangeId::generate(),
+            attribution: human(),
+            extra_origins: 0,
+            timestamp: "2026-01-01T00:00:00+00:00".to_string(),
+            origins: Vec::new(),
+        };
+        assert_eq!(info.author_display(), "Ada Lovelace <ada@example.com>");
+    }
+
+    #[test]
+    fn state_fallback_line_info_attributes_whole_line_to_state() {
+        let state_id = ChangeId::generate();
+        let state = State::new(ContentHash::from_bytes([7u8; 32]), vec![], agentic());
+        let ts = "2026-02-03T04:05:06+00:00";
+
+        let info = state_fallback_line_info(state_id, &state, ts);
+
+        assert_eq!(info.change_id, state_id);
+        assert_eq!(info.extra_origins, 0);
+        assert_eq!(info.timestamp, ts);
+        assert_eq!(info.attribution, state.attribution);
+        // Exactly one synthesized origin mirroring the state, in the same
+        // structured shape the JSON renderer emits.
+        assert_eq!(info.origins.len(), 1);
+        let origin = &info.origins[0];
+        assert_eq!(origin.change_id, state_id.to_string());
+        assert_eq!(origin.timestamp, ts);
+        assert_eq!(origin.principal.name, "Ada Lovelace");
+        assert_eq!(
+            origin.agent.as_ref().map(|a| a.provider.as_str()),
+            Some("anthropic")
+        );
+    }
+}

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -613,7 +613,8 @@ pub struct BlameLineSchema {
     pub line_number: usize,
     pub content: String,
     pub change_id: String,
-    pub author: String,
+    pub principal: BlamePrincipalSchema,
+    pub agent: Option<BlameAgentSchema>,
     pub timestamp: String,
     pub origins: Option<Vec<BlameOriginSchema>>,
 }
@@ -621,8 +622,25 @@ pub struct BlameLineSchema {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct BlameOriginSchema {
     pub change_id: String,
-    pub author: String,
+    pub principal: BlamePrincipalSchema,
+    pub agent: Option<BlameAgentSchema>,
     pub timestamp: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BlamePrincipalSchema {
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BlameAgentSchema {
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -812,6 +812,7 @@ async fn async_main() -> Result<()> {
                 cmd_actor_spawn(
                     &cli,
                     args.thread.clone(),
+                    args.no_thread,
                     args.provider.clone(),
                     args.model.clone(),
                 )

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -8452,3 +8452,142 @@ fn git_overlay_matrix_continue_retry_loops_block_then_succeed_after_resolution()
     );
     assert_operator_json_contract(&continued_git, "merge");
 }
+
+// ---------------------------------------------------------------------------
+// `--no-thread` lane-existence conformance (heddle#307, Codex cid 3327525677).
+//
+// The bug class: `actor explain` (recommend) and `actor spawn --no-thread`
+// (execute) decided "is there a current lane to attach to?" with *different*
+// predicates. In a git-overlay repo, Git HEAD can be detached while
+// `.heddle/HEAD` still names a stale attached thread; `head_ref()` then falls
+// back to that stale `Attached`, so the execute path attached the actor to a
+// dead branch and the recommend path advertised a `--no-thread` command that
+// cannot succeed. The fix routes BOTH paths through the single
+// git-overlay-aware predicate `Repository::current_lane()`. This harness pins
+// the invariant across the whole matrix: recommend and execute must agree.
+
+/// `actor explain` recommends `--no-thread` iff a current lane exists.
+fn explain_recommends_no_thread(path: &std::path::Path) -> bool {
+    let output = heddle_output_with_env(
+        &["actor", "explain", "--output", "json"],
+        Some(path),
+        &[
+            ("CODEX_THREAD_ID", "thread-cold-agent"),
+            ("CODEX_MODEL", "gpt-5.3-codex"),
+            ("CODEX_REASONING_EFFORT", "high"),
+        ],
+    )
+    .expect("actor explain should run");
+    assert!(
+        output.status.success(),
+        "actor explain should succeed; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("actor explain JSON should parse: {err}: {stdout}"));
+    parsed["recommended_action"]
+        .as_str()
+        .expect("recommended_action should be a string")
+        .contains("--no-thread")
+}
+
+/// `actor spawn --no-thread` succeeds iff a current lane exists.
+fn spawn_no_thread_succeeds(path: &std::path::Path) -> bool {
+    heddle(
+        &[
+            "actor",
+            "spawn",
+            "--no-thread",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.3-codex",
+        ],
+        Some(path),
+    )
+    .is_ok()
+}
+
+#[test]
+fn git_overlay_no_thread_lane_predicate_recommend_and_execute_agree() {
+    // (c) On-lane: adopted git-overlay repo sits attached to `main`. A lane
+    // exists, so recommend and execute both accept `--no-thread`.
+    let on_lane = TempDir::new().unwrap();
+    init_git_repo_with_branch(on_lane.path(), "main");
+    std::fs::write(on_lane.path().join("base.txt"), "base\n").unwrap();
+    git_commit_all(on_lane.path(), "base");
+    heddle_adopt(on_lane.path());
+    assert_eq!(
+        Repository::open(on_lane.path())
+            .unwrap()
+            .current_lane()
+            .unwrap(),
+        Some("main".to_string()),
+        "adopted git-overlay repo should report `main` as the current lane"
+    );
+    assert!(
+        explain_recommends_no_thread(on_lane.path()),
+        "on-lane: explain should recommend --no-thread"
+    );
+    assert!(
+        spawn_no_thread_succeeds(on_lane.path()),
+        "on-lane: spawn --no-thread should succeed"
+    );
+
+    // (a) Detached Git HEAD whose commit has NO Heddle mapping. We adopt, then
+    // detach and make a *fresh* Git commit directly (bypassing heddle) so the
+    // detached commit is provably unmapped. `read_head_state` defaults to
+    // `Attached{main}` when `.heddle/HEAD` is absent, so the old `head_ref()`
+    // fell back to that stale `main` thread — but there is no lane to attach to.
+    let detached_no_mapping = TempDir::new().unwrap();
+    init_git_repo_with_branch(detached_no_mapping.path(), "main");
+    std::fs::write(detached_no_mapping.path().join("base.txt"), "base\n").unwrap();
+    git_commit_all(detached_no_mapping.path(), "base");
+    heddle_adopt(detached_no_mapping.path());
+    git(&["checkout", "--detach"], detached_no_mapping.path());
+    git(
+        &["commit", "--allow-empty", "-m", "unmapped detached commit"],
+        detached_no_mapping.path(),
+    );
+    assert_eq!(
+        Repository::open(detached_no_mapping.path())
+            .unwrap()
+            .current_lane()
+            .unwrap(),
+        None,
+        "detached Git HEAD with no Heddle mapping must report no current lane, \
+         not the stale `.heddle/HEAD` thread"
+    );
+    assert!(
+        !explain_recommends_no_thread(detached_no_mapping.path()),
+        "detached-no-mapping: explain must NOT recommend --no-thread (mint instead)"
+    );
+    assert!(
+        !spawn_no_thread_succeeds(detached_no_mapping.path()),
+        "detached-no-mapping: spawn --no-thread must be rejected, not attached to a stale branch"
+    );
+
+    // (b) Detached Git HEAD whose commit DOES map to a Heddle change (the
+    // adopted tip). It is still detached — no attached lane — so recommend and
+    // execute must agree on rejecting `--no-thread`.
+    let detached_mapped = TempDir::new().unwrap();
+    init_git_repo_with_branch(detached_mapped.path(), "main");
+    std::fs::write(detached_mapped.path().join("base.txt"), "base\n").unwrap();
+    git_commit_all(detached_mapped.path(), "base");
+    std::fs::write(detached_mapped.path().join("next.txt"), "next\n").unwrap();
+    git_commit_all(detached_mapped.path(), "next");
+    heddle_adopt(detached_mapped.path());
+    let mapped_tip = git_stdout(detached_mapped.path(), &["rev-parse", "HEAD"]);
+    git(&["checkout", &mapped_tip], detached_mapped.path());
+    let recommend = explain_recommends_no_thread(detached_mapped.path());
+    let execute = spawn_no_thread_succeeds(detached_mapped.path());
+    assert_eq!(
+        recommend, execute,
+        "detached-with-mapping: recommend and execute must agree on --no-thread"
+    );
+    assert!(
+        !execute,
+        "detached-with-mapping: a detached HEAD has no attached lane, so --no-thread is rejected"
+    );
+}

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -8454,17 +8454,27 @@ fn git_overlay_matrix_continue_retry_loops_block_then_succeed_after_resolution()
 }
 
 // ---------------------------------------------------------------------------
-// `--no-thread` lane-existence conformance (heddle#307, Codex cid 3327525677).
+// `--no-thread` lane-existence conformance (heddle#307, Codex cid 3327525677
+// + cid 3327725478).
 //
-// The bug class: `actor explain` (recommend) and `actor spawn --no-thread`
-// (execute) decided "is there a current lane to attach to?" with *different*
-// predicates. In a git-overlay repo, Git HEAD can be detached while
-// `.heddle/HEAD` still names a stale attached thread; `head_ref()` then falls
-// back to that stale `Attached`, so the execute path attached the actor to a
-// dead branch and the recommend path advertised a `--no-thread` command that
-// cannot succeed. The fix routes BOTH paths through the single
-// git-overlay-aware predicate `Repository::current_lane()`. This harness pins
-// the invariant across the whole matrix: recommend and execute must agree.
+// The bug class: every actor-surface site that asks "is there a current lane /
+// active actor for THIS checkout?" must consult the single git-overlay-aware
+// oracle `Repository::current_lane()`. In a git-overlay repo, Git HEAD can be
+// detached while `.heddle/HEAD` still names a stale attached thread; any site
+// that reads `head_ref()` / `.heddle/HEAD` directly then falls back to that
+// stale `Attached`, so the execute path attached the actor to a dead branch and
+// the recommend path either advertised a `--no-thread` command that cannot
+// succeed or resolved a stale actor instead of recommending a mint.
+//
+// Round 2 routed `actor spawn --no-thread` (execute) and the recommend fallback
+// through `current_lane()`. Round 3 (cid 3327725478) closes the *upstream*
+// leak: `resolve_actor_entry` decided "is there an attached actor?" off
+// `head_ref()` and the unconditional "any active actor" fallback, so an active
+// actor on `main` plus a detached-unmapped HEAD resolved the stale `main` actor
+// and `actor explain` printed it — never reaching the mint recommendation —
+// while `actor spawn --no-thread` rejected. This harness pins the invariant
+// across the whole matrix: recommend and execute must agree, including when an
+// active actor exists.
 
 /// `actor explain` recommends `--no-thread` iff a current lane exists.
 fn explain_recommends_no_thread(path: &std::path::Path) -> bool {
@@ -8589,5 +8599,87 @@ fn git_overlay_no_thread_lane_predicate_recommend_and_execute_agree() {
     assert!(
         !execute,
         "detached-with-mapping: a detached HEAD has no attached lane, so --no-thread is rejected"
+    );
+
+    // (d) The leak round 2 missed (cid 3327725478): an *active actor* attached
+    // to `main`, then Git HEAD detached to an UNMAPPED commit so `.heddle/HEAD`
+    // still says `Attached(main)`. `resolve_actor_entry` used to resolve that
+    // stale `main` actor off `head_ref()` (and the unconditional "any active
+    // actor" fallback), so `actor explain` printed the stale actor — never
+    // reaching the mint recommendation — while `actor spawn --no-thread`
+    // rejected. The single `current_lane()` oracle reports no lane here, so
+    // explain must fall through to the minting recommendation and agree with
+    // execute's rejection.
+    let active_then_detached = TempDir::new().unwrap();
+    init_git_repo_with_branch(active_then_detached.path(), "main");
+    std::fs::write(active_then_detached.path().join("base.txt"), "base\n").unwrap();
+    git_commit_all(active_then_detached.path(), "base");
+    heddle_adopt(active_then_detached.path());
+    // Spawn an actor attached to the current lane (`main`). It records
+    // `path: None`, so it is reachable only via the lane oracle / the "any
+    // active actor" fallback — exactly the surfaces under test.
+    heddle(
+        &[
+            "actor",
+            "spawn",
+            "--no-thread",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.3-codex",
+        ],
+        Some(active_then_detached.path()),
+    )
+    .expect("spawn an active actor attached to `main`");
+    git(&["checkout", "--detach"], active_then_detached.path());
+    git(
+        &["commit", "--allow-empty", "-m", "unmapped detached commit"],
+        active_then_detached.path(),
+    );
+    assert_eq!(
+        Repository::open(active_then_detached.path())
+            .unwrap()
+            .current_lane()
+            .unwrap(),
+        None,
+        "active-actor-on-main + detached-unmapped HEAD must report no current lane"
+    );
+    // Recommend: `actor explain` must NOT resolve the stale `main` actor. It
+    // must report no active actor (`attached: false`) and recommend the minting
+    // spawn form, not `--no-thread`.
+    let explained = heddle_output_with_env(
+        &["actor", "explain", "--output", "json"],
+        Some(active_then_detached.path()),
+        &[
+            ("CODEX_THREAD_ID", "thread-cold-agent"),
+            ("CODEX_MODEL", "gpt-5.3-codex"),
+            ("CODEX_REASONING_EFFORT", "high"),
+        ],
+    )
+    .expect("actor explain should run");
+    assert!(
+        explained.status.success(),
+        "actor explain should succeed; stderr={}",
+        String::from_utf8_lossy(&explained.stderr)
+    );
+    let explained_json: Value = serde_json::from_slice(&explained.stdout)
+        .unwrap_or_else(|err| panic!("actor explain JSON should parse: {err}"));
+    assert_eq!(
+        explained_json["attached"], false,
+        "detached-unmapped HEAD with a stale `.heddle/HEAD` must not resolve the \
+         stale `main` actor: {explained_json}"
+    );
+    let recommended = explained_json["recommended_action"]
+        .as_str()
+        .unwrap_or_else(|| panic!("recommended_action should be present: {explained_json}"));
+    assert!(
+        recommended.contains("actor spawn") && !recommended.contains("--no-thread"),
+        "active-actor-on-main + detached-unmapped: explain must recommend the minting \
+         spawn form, not `--no-thread`: {explained_json}"
+    );
+    // Execute agrees: `--no-thread` is rejected because there is no current lane.
+    assert!(
+        !spawn_no_thread_succeeds(active_then_detached.path()),
+        "active-actor-on-main + detached-unmapped: spawn --no-thread must be rejected"
     );
 }

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10028,6 +10028,8 @@ fn actor_explain_json_detects_harness_without_active_actor() {
             .any(|signal| signal == "CODEX_THREAD_ID"),
         "actor explain should name detected signal keys without leaking unrelated values: {parsed}"
     );
+    // On-thread context (fresh `init` leaves HEAD attached to a thread):
+    // `--no-thread` attaches the detected identity to the current thread.
     assert_eq!(
         parsed["recommended_action"],
         "heddle actor spawn --no-thread --provider openai --model gpt-5.3-codex"
@@ -10049,6 +10051,79 @@ fn actor_explain_json_detects_harness_without_active_actor() {
     assert!(
         parsed.get("verification").is_some(),
         "actor explain should prove repository verify for agents: {parsed}"
+    );
+}
+
+#[test]
+fn actor_explain_detached_head_recommends_minting_spawn_not_no_thread() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("tracked.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "base"], Some(temp.path())).unwrap();
+    let base = Repository::open(temp.path())
+        .unwrap()
+        .current_state()
+        .unwrap()
+        .unwrap()
+        .change_id
+        .to_string();
+    std::fs::write(temp.path().join("tracked.txt"), "next\n").unwrap();
+    heddle(&["capture", "-m", "next"], Some(temp.path())).unwrap();
+    // `goto` to an earlier state detaches HEAD — there is no current thread
+    // to attach an actor to, so `--no-thread` would fail.
+    heddle(&["goto", &base, "--force"], Some(temp.path())).unwrap();
+    assert!(
+        matches!(
+            Repository::open(temp.path()).unwrap().head_ref().unwrap(),
+            refs::Head::Detached { .. }
+        ),
+        "goto should leave HEAD detached for this test"
+    );
+
+    let output = heddle_output_with_env(
+        &["actor", "explain", "--output", "json"],
+        Some(temp.path()),
+        &[
+            ("CODEX_THREAD_ID", "thread-cold-agent"),
+            ("CODEX_MODEL", "gpt-5.3-codex"),
+            ("CODEX_REASONING_EFFORT", "high"),
+        ],
+    )
+    .expect("invoke actor explain");
+    assert!(
+        output.status.success(),
+        "actor explain should succeed on detached HEAD; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("actor explain JSON should parse: {err}: {stdout}"));
+    assert_eq!(parsed["attached"], false);
+    // Detached HEAD: recommend the minting form (mints a dedicated thread),
+    // NOT `--no-thread`, which cannot succeed without a current thread.
+    assert_eq!(
+        parsed["recommended_action"],
+        "heddle actor spawn --provider openai --model gpt-5.3-codex",
+        "detached HEAD should recommend the thread-minting spawn form: {parsed}"
+    );
+    assert!(
+        !parsed["recommended_action"]
+            .as_str()
+            .expect("recommended_action should be a string")
+            .contains("--no-thread"),
+        "detached HEAD must not recommend `--no-thread`: {parsed}"
+    );
+    assert_eq!(
+        parsed["recommended_action_template"]["argv_template"],
+        heddle_argv_json([
+            "actor",
+            "spawn",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.3-codex"
+        ]),
+        "actor explain should expose replayable argv for the minting spawn action: {parsed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10030,13 +10030,14 @@ fn actor_explain_json_detects_harness_without_active_actor() {
     );
     assert_eq!(
         parsed["recommended_action"],
-        "heddle actor spawn --provider openai --model gpt-5.3-codex"
+        "heddle actor spawn --no-thread --provider openai --model gpt-5.3-codex"
     );
     assert_eq!(
         parsed["recommended_action_template"]["argv_template"],
         heddle_argv_json([
             "actor",
             "spawn",
+            "--no-thread",
             "--provider",
             "openai",
             "--model",

--- a/crates/cli/tests/comprehensive/blame.rs
+++ b/crates/cli/tests/comprehensive/blame.rs
@@ -61,6 +61,86 @@ fn test_blame_empty_file() {
 }
 
 #[test]
+fn test_blame_json_attribution_is_structured() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    fs::write(temp.path().join("tracked.txt"), "line 1\n").unwrap();
+    heddle(&["capture", "-m", "First line"], Some(temp.path())).unwrap();
+
+    let output = heddle(
+        &["--output", "json", "blame", "tracked.txt"],
+        Some(temp.path()),
+    )
+    .expect("blame --output json should succeed");
+    let v: Value = serde_json::from_str(&output).expect("blame should emit JSON");
+
+    let line = &v["lines"][0];
+    // No flattened `author` string — attribution is structured like
+    // `log` / `show` so consumers don't have to string-parse.
+    assert!(
+        line.get("author").is_none(),
+        "blame line should not carry a flattened `author` string: {output}"
+    );
+    assert_eq!(line["principal"]["name"], "Heddle Test");
+    assert_eq!(line["principal"]["email"], "test@heddle.dev");
+    // Agent is either absent (`null`) or a structured object — never a
+    // string baked into the principal field.
+    let agent = &line["agent"];
+    assert!(
+        agent.is_null() || agent.is_object(),
+        "blame agent must be structured or null, got: {agent}"
+    );
+
+    // Origins mirror the same structured shape.
+    let origin = &line["origins"][0];
+    assert!(
+        origin.get("author").is_none(),
+        "blame origin should not carry a flattened `author` string: {output}"
+    );
+    assert_eq!(origin["principal"]["name"], "Heddle Test");
+    assert_eq!(origin["principal"]["email"], "test@heddle.dev");
+}
+
+#[test]
+fn test_blame_json_agent_is_structured_object() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    fs::write(temp.path().join("tracked.txt"), "line 1\n").unwrap();
+    heddle(
+        &[
+            "capture",
+            "-m",
+            "Agent line",
+            "--agent-provider",
+            "anthropic",
+            "--agent-model",
+            "claude-opus-4-7",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    let output = heddle(
+        &["--output", "json", "blame", "tracked.txt"],
+        Some(temp.path()),
+    )
+    .expect("blame --output json should succeed");
+    let v: Value = serde_json::from_str(&output).expect("blame should emit JSON");
+
+    let agent = &v["lines"][0]["agent"];
+    assert_eq!(
+        agent["provider"], "anthropic",
+        "blame should expose the agent provider as a field: {output}"
+    );
+    assert_eq!(
+        agent["model"], "claude-opus-4-7",
+        "blame should expose the agent model as a field: {output}"
+    );
+}
+
+#[test]
 fn test_blame_multiple_commits_attribution() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/multi_agent_worktrees/agent_registry.rs
+++ b/crates/cli/tests/multi_agent_worktrees/agent_registry.rs
@@ -311,3 +311,84 @@ fn actor_spawn_no_thread_attaches_to_current_thread_without_minting() {
         serde_json::to_string(&after).unwrap()
     );
 }
+
+#[test]
+fn actor_spawn_no_thread_conflicts_with_explicit_thread() {
+    let main = setup_repo("base.txt", "base");
+
+    // `--no-thread` and `--thread` are mutually exclusive: one attaches
+    // to the current thread, the other targets a named thread.
+    let err = heddle(
+        &[
+            "actor",
+            "spawn",
+            "--no-thread",
+            "--thread",
+            "main",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-sonnet-4-6",
+        ],
+        Some(main.path()),
+    )
+    .expect_err("--no-thread with --thread should be rejected");
+    assert!(
+        err.contains("cannot be used with"),
+        "clap should report the --no-thread/--thread conflict: {err}"
+    );
+}
+
+#[test]
+fn actor_spawn_no_thread_on_detached_head_fails_cleanly() {
+    let main = setup_repo("base.txt", "base");
+    // A second state so `goto HEAD~1` lands on a real prior change and
+    // detaches HEAD (no current thread to attach an actor to).
+    fs::write(main.path().join("base.txt"), "base updated").unwrap();
+    heddle(&["capture", "-m", "second"], Some(main.path())).unwrap();
+    heddle(&["goto", "HEAD~1"], Some(main.path())).unwrap();
+
+    let before: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "thread", "list"], Some(main.path())).unwrap(),
+    )
+    .unwrap();
+    let before_count = before["threads"].as_array().unwrap().len();
+
+    let err = heddle(
+        &[
+            "actor",
+            "spawn",
+            "--no-thread",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-sonnet-4-6",
+        ],
+        Some(main.path()),
+    )
+    .expect_err("--no-thread on detached HEAD should fail cleanly");
+    assert!(
+        err.contains("current thread"),
+        "detached-HEAD spawn should explain there is no current thread to attach to: {err}"
+    );
+
+    // Clean failure: no actor thread minted, no registry side effects.
+    let after: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "thread", "list"], Some(main.path())).unwrap(),
+    )
+    .unwrap();
+    let threads = after["threads"].as_array().unwrap();
+    assert_eq!(
+        threads.len(),
+        before_count,
+        "failed --no-thread spawn must not add a thread: {}",
+        serde_json::to_string(&after).unwrap()
+    );
+    assert!(
+        threads
+            .iter()
+            .all(|thread| !thread["name"].as_str().unwrap_or("").starts_with("actor/")),
+        "no actor/* thread should exist after a failed --no-thread spawn: {}",
+        serde_json::to_string(&after).unwrap()
+    );
+}

--- a/crates/cli/tests/multi_agent_worktrees/agent_registry.rs
+++ b/crates/cli/tests/multi_agent_worktrees/agent_registry.rs
@@ -241,3 +241,73 @@ fn start_without_name_is_rejected() {
     let result = heddle(&["start"], Some(main.path()));
     assert!(result.is_err(), "start without a thread name should fail");
 }
+
+#[test]
+fn actor_spawn_no_thread_attaches_to_current_thread_without_minting() {
+    let main = setup_repo("base.txt", "base");
+    let current = head_track(main.path());
+    assert!(
+        !current.is_empty(),
+        "repo should be on a thread after init + capture"
+    );
+
+    let before: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "thread", "list"], Some(main.path())).unwrap(),
+    )
+    .unwrap();
+    let before_count = before["threads"].as_array().unwrap().len();
+
+    let out = heddle(
+        &[
+            "--output",
+            "json",
+            "actor",
+            "spawn",
+            "--no-thread",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-sonnet-4-6",
+        ],
+        Some(main.path()),
+    )
+    .expect("actor spawn --no-thread should succeed");
+    let v: Value = serde_json::from_str(&out).unwrap();
+
+    // The detected agent is attached to the current thread, not a fresh
+    // `actor/<session>` thread.
+    assert_eq!(
+        v["actor"]["thread"].as_str(),
+        Some(current.as_str()),
+        "no-thread spawn should attach to the current thread: {out}"
+    );
+    assert!(
+        !v["actor"]["thread"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("actor/"),
+        "no-thread spawn must not mint a stray actor/<session> thread: {out}"
+    );
+    assert_eq!(v["actor"]["provider"].as_str(), Some("anthropic"));
+    assert_eq!(v["actor"]["model"].as_str(), Some("claude-sonnet-4-6"));
+
+    // No new thread ref was created by the spawn.
+    let after: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "thread", "list"], Some(main.path())).unwrap(),
+    )
+    .unwrap();
+    let threads = after["threads"].as_array().unwrap();
+    assert_eq!(
+        threads.len(),
+        before_count,
+        "no-thread spawn must not add a thread: {}",
+        serde_json::to_string(&after).unwrap()
+    );
+    assert!(
+        threads
+            .iter()
+            .all(|thread| !thread["name"].as_str().unwrap_or("").starts_with("actor/")),
+        "no actor/* thread should exist after --no-thread spawn: {}",
+        serde_json::to_string(&after).unwrap()
+    );
+}

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -354,12 +354,8 @@ mod resolve {
         )
         .unwrap();
         let parsed: Value = serde_json::from_str(&blame).unwrap();
-        assert!(
-            parsed["lines"][0]["author"]
-                .as_str()
-                .unwrap()
-                .contains("openai/gpt-feature")
-        );
+        assert_eq!(parsed["lines"][0]["agent"]["provider"], "openai");
+        assert_eq!(parsed["lines"][0]["agent"]["model"], "gpt-feature");
     }
 
     #[test]
@@ -399,12 +395,8 @@ mod resolve {
         )
         .unwrap();
         let parsed: Value = serde_json::from_str(&blame).unwrap();
-        assert!(
-            parsed["lines"][0]["author"]
-                .as_str()
-                .unwrap()
-                .contains("openai/gpt-resolver")
-        );
+        assert_eq!(parsed["lines"][0]["agent"]["provider"], "openai");
+        assert_eq!(parsed["lines"][0]["agent"]["model"], "gpt-resolver");
     }
 }
 
@@ -936,18 +928,10 @@ mod blame {
         .unwrap();
         let parsed: Value = serde_json::from_str(&output).unwrap();
         let lines = parsed["lines"].as_array().unwrap();
-        assert!(
-            lines[0]["author"]
-                .as_str()
-                .unwrap()
-                .contains("anthropic/claude-sonnet-a")
-        );
-        assert!(
-            lines[1]["author"]
-                .as_str()
-                .unwrap()
-                .contains("openai/gpt-4.1-b")
-        );
+        assert_eq!(lines[0]["agent"]["provider"], "anthropic");
+        assert_eq!(lines[0]["agent"]["model"], "claude-sonnet-a");
+        assert_eq!(lines[1]["agent"]["provider"], "openai");
+        assert_eq!(lines[1]["agent"]["model"], "gpt-4.1-b");
     }
 
     #[test]
@@ -979,18 +963,10 @@ mod blame {
         .unwrap();
         let parsed: Value = serde_json::from_str(&output).unwrap();
         let lines = parsed["lines"].as_array().unwrap();
-        assert!(
-            lines[0]["author"]
-                .as_str()
-                .unwrap()
-                .contains("anthropic/claude-opus-base")
-        );
-        assert!(
-            lines[1]["author"]
-                .as_str()
-                .unwrap()
-                .contains("openai/gpt-4.1-feature")
-        );
+        assert_eq!(lines[0]["agent"]["provider"], "anthropic");
+        assert_eq!(lines[0]["agent"]["model"], "claude-opus-base");
+        assert_eq!(lines[1]["agent"]["provider"], "openai");
+        assert_eq!(lines[1]["agent"]["model"], "gpt-4.1-feature");
     }
 }
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2960,10 +2960,15 @@ outside clean verification coverage.
 {"output_kind": "bisect_start", "status": "started"}
 ```
 
-`heddle blame --output json` emits:
+`heddle blame --output json` emits structured attribution that mirrors
+`log` / `show`: each line (and each entry in `origins`) carries a
+`principal` object (`name`, `email`) and an `agent` field that is either
+a structured object (`provider`, `model`, optional `session_id` /
+`policy_id`) or `null` for human-only changes — no string-parsing
+required:
 
 ```json
-{"file": "src/lib.rs", "context": [], "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "author": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "author": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z"}]}]}
+{"file": "src/lib.rs", "context": [], "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
 ```
 
 `heddle bridge git ingest|reason --output json` emit:

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1186,7 +1186,7 @@ array.
     "principal_email": "agent@example.com",
     "signals": ["CODEX_THREAD_ID"]
   },
-  "recommended_action": "heddle actor spawn --provider openai --model gpt-5",
+  "recommended_action": "heddle actor spawn --no-thread --provider openai --model gpt-5",
   "verification": {
     "verified": true,
     "status": "clean",


### PR DESCRIPTION
## Summary
- **(a) Structured `blame --output json`.** Each line — and each entry in `origins` — now carries a `principal` object (`name`, `email`) and an `agent` field that is either a structured object (`provider`, `model`, optional `session_id`/`policy_id`) or `null`, matching `log`/`show`. The flattened `author` string (`"Name <email> (via provider/model)"`) is gone; consumers no longer string-parse. `BlameSchema` and `docs/json-schemas.md` updated; `heddle doctor schemas` confirms no drift. The human-readable (text) renderer is unchanged.
- **(b) `actor spawn --no-thread`.** Attaches the detected/declared agent to the **current** thread instead of minting a stray `actor/<session>` thread (conflicts with `--thread`; detached HEAD fails cleanly with recovery advice). This records the agent in the registry — so subsequent captures pick it up via the existing thread-actor precedence — without leaving a stray thread. `actor explain`'s recommended next action now suggests the `--no-thread` path.

Closes HeddleCo/heddle#307

## Red commit
`f7a564a`

## Test evidence
```
$ cargo test -p heddle-cli --test comprehensive test_blame_json
test blame_comprehensive::test_blame_json_agent_is_structured_object ... ok
test blame_comprehensive::test_blame_json_attribution_is_structured ... ok
test result: ok. 2 passed; 0 failed; 61 filtered out

$ cargo test -p heddle-cli --test multi_agent_worktrees agent_registry::
test agent_registry::actor_spawn_no_thread_attaches_to_current_thread_without_minting ... ok
... 8 passed; 0 failed; 61 filtered out

$ cargo test -p heddle-cli --test production_features blame
... 5 passed; 0 failed; 88 filtered out

$ cargo test -p heddle-cli --test cli_integration -- doctor_schemas output_kind blame_drops_email
test result: ok. 32 passed; 0 failed; 1 ignored; 796 filtered out

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (514 file(s) scanned)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile  (no warnings)

$ cargo test -p heddle-mount
... 4 passed; 0 failed
```

## Manual verification
N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682929&installation_id=132405951&pr_number=322&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F322&signature=5501b1729eb41341f851a7da7167cc0d166000f8cfe04487809f62573e61a5d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->