### PR TITLE
heddle#278: progressive disclosure for capture's hidden agent flags

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -183,6 +183,9 @@ fn parse_confidence(s: &str) -> Result<f32, String> {
 Examples:
   heddle capture -m 'add login route'           # capture the worktree with intent
   heddle capture -m 'wip' --confidence 0.6      # honest confidence on a draft step
+
+Agent automation flags (provider/model/session/policy/split) are hidden here.
+Run `heddle help agent-flags`, or `heddle capture --help-agent` to list them inline.
 ")]
 pub struct SnapshotArgs {
     /// Natural language intent for this recoverable step.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -192,11 +192,12 @@ pub struct SnapshotArgs {
     /// A first-class clap flag so the whole command line (including global
     /// options in any spelling clap accepts) is parsed by clap; the dispatch
     /// arm inspects the parsed result rather than scanning raw tokens.
-    /// Visible (not `hide`d): it is documented publicly and the command
-    /// catalog that `doctor docs`/`doctor schemas` validate against only
-    /// enumerates non-hidden args — a documented-but-hidden flag would
-    /// drift the machine contract.
-    #[arg(long)]
+    /// `hide`d to keep everyday `capture --help` terse (the after-help
+    /// pointer is the discovery route). It is still a registered clap arg,
+    /// so `doctor docs` recognizes `heddle capture --help-agent` via the
+    /// registered-but-hidden flag seam — the machine contract stays in sync
+    /// without cluttering human help.
+    #[arg(long, hide = true)]
     pub help_agent: bool,
 
     /// Natural language intent for this recoverable step.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -192,7 +192,11 @@ pub struct SnapshotArgs {
     /// A first-class clap flag so the whole command line (including global
     /// options in any spelling clap accepts) is parsed by clap; the dispatch
     /// arm inspects the parsed result rather than scanning raw tokens.
-    #[arg(long, hide = true)]
+    /// Visible (not `hide`d): it is documented publicly and the command
+    /// catalog that `doctor docs`/`doctor schemas` validate against only
+    /// enumerates non-hidden args — a documented-but-hidden flag would
+    /// drift the machine contract.
+    #[arg(long)]
     pub help_agent: bool,
 
     /// Natural language intent for this recoverable step.

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -188,6 +188,13 @@ Agent automation flags (provider/model/session/policy/split) are hidden here.
 Run `heddle help agent-flags`, or `heddle capture --help-agent` to list them inline.
 ")]
 pub struct SnapshotArgs {
+    /// Reveal the hidden agent-automation flags inline instead of capturing.
+    /// A first-class clap flag so the whole command line (including global
+    /// options in any spelling clap accepts) is parsed by clap; the dispatch
+    /// arm inspects the parsed result rather than scanning raw tokens.
+    #[arg(long, hide = true)]
+    pub help_agent: bool,
+
     /// Natural language intent for this recoverable step.
     #[arg(short = 'm', long, visible_alias = "message")]
     pub intent: Option<String>,

--- a/crates/cli/src/cli/commands/doctor_docs.rs
+++ b/crates/cli/src/cli/commands/doctor_docs.rs
@@ -11,7 +11,7 @@
 //! docs --all --output json` into CI on every PR to catch doc drift.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
 };
 
@@ -587,6 +587,11 @@ fn check_invocation(
     // Now walk remaining tokens for `--flag` / `--flag=value` shapes.
     let mut i = tokens_used;
     let catalog_options = collect_catalog_options(catalog, &path_segments);
+    // The everyday catalog drops `hide = true` args, but they are still part
+    // of the registered CLI contract (e.g. `capture --help-agent`). Recognize
+    // them so docs that reference a hidden-but-real flag don't false-positive
+    // as drift. Closes the class for every hidden flag, not just one.
+    let hidden_long_flags = collect_hidden_long_flags(resolved_cmd);
     while i < inv.tokens.len() {
         let tok = &inv.tokens[i];
         if let Some(flag_body) = tok.strip_prefix("--") {
@@ -602,18 +607,20 @@ fn check_invocation(
             // Many docs use `--flag-name>` accidentally; guard.
             let flag_name = flag_name.trim_end_matches('>').to_string();
             if !catalog_options.contains_key(&flag_name) {
-                out.push(DocsIssue {
-                    file: file.to_string(),
-                    line: inv.line,
-                    invocation: inv.raw.clone(),
-                    kind: IssueKind::UnknownFlag,
-                    detail: format!(
-                        "`--{}` is not a flag on `heddle {}`",
-                        flag_name,
-                        path_segments.join(" "),
-                    ),
-                    suggestion: None,
-                });
+                if !hidden_long_flags.contains(&flag_name) {
+                    out.push(DocsIssue {
+                        file: file.to_string(),
+                        line: inv.line,
+                        invocation: inv.raw.clone(),
+                        kind: IssueKind::UnknownFlag,
+                        detail: format!(
+                            "`--{}` is not a flag on `heddle {}`",
+                            flag_name,
+                            path_segments.join(" "),
+                        ),
+                        suggestion: None,
+                    });
+                }
             } else {
                 // Check known-enum flags. Pull value from inline or
                 // next token (if not a flag/placeholder).
@@ -676,6 +683,34 @@ fn collect_catalog_options<'a>(
                 .iter()
                 .chain(option.aliases.iter())
                 .map(move |name| (name.clone(), option))
+        })
+        .collect()
+}
+
+/// Long flag names (and aliases) of the `hide = true` args on a resolved
+/// command. These are dropped from the everyday command catalog but remain
+/// part of the registered CLI surface, so `doctor docs` must still treat
+/// them as valid flags.
+fn collect_hidden_long_flags(command: &ClapCommand) -> BTreeSet<String> {
+    command
+        .get_arguments()
+        .filter(|arg| arg.is_hide_set())
+        .flat_map(|arg| {
+            arg.get_long()
+                .map(str::to_string)
+                .into_iter()
+                .chain(
+                    arg.get_all_aliases()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(str::to_string),
+                )
+                .chain(
+                    arg.get_visible_aliases()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(str::to_string),
+                )
         })
         .collect()
 }
@@ -866,6 +901,28 @@ mod tests {
                 .iter()
                 .any(|i| matches!(i.kind, IssueKind::UnknownFlag)),
             "expected at least one UnknownFlag issue, got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn hidden_but_registered_flag_is_not_drift() {
+        // heddle#278 r6 (cid 3327633095): `--help-agent` is `hide = true`,
+        // so it's dropped from the everyday catalog — but it's still a
+        // registered clap arg. Docs that reference `heddle capture
+        // --help-agent` (e.g. personas.md) must NOT be flagged as drift.
+        let mut issues = Vec::new();
+        scan_markdown(
+            "test.md",
+            "Run `heddle capture --help-agent` to reveal the agent flags.",
+            &cli(),
+            &mut issues,
+        );
+        assert!(
+            !issues
+                .iter()
+                .any(|i| matches!(i.kind, IssueKind::UnknownFlag)),
+            "hidden-but-registered `--help-agent` must not be drift, got: {:?}",
             issues
         );
     }

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -193,6 +193,57 @@ pub fn print_direct_help_for_raw(
     })
 }
 
+/// Clap arg ids of the agent-automation flags on `capture` that are
+/// `hide = true` in the everyday surface. Kept in sync with
+/// `SnapshotArgs` (see `cli_args/commands_args.rs`); the
+/// `capture_agent_flags_hidden_by_default_revealed_on_demand` test fails
+/// if an id here no longer maps to a hidden `capture` arg.
+const CAPTURE_AGENT_FLAG_IDS: &[&str] = &[
+    "agent_provider",
+    "agent_model",
+    "agent_session",
+    "agent_segment",
+    "policy",
+    "no_policy",
+    "no_agent",
+    "split",
+    "into",
+    "paths",
+];
+
+/// Return a copy of `command` with the agent-automation flags un-hidden,
+/// so `print_long_help` renders them. Used by `capture --help-agent`.
+fn reveal_capture_agent_flags(command: clap::Command) -> clap::Command {
+    command.mut_args(|arg| {
+        if CAPTURE_AGENT_FLAG_IDS.contains(&arg.get_id().as_str()) {
+            arg.hide(false)
+        } else {
+            arg
+        }
+    })
+}
+
+/// Intercept `heddle capture --help-agent`: render `capture`'s
+/// clap-derived help with the hidden agent-automation flags revealed.
+/// Returns `None` when the request isn't a `capture --help-agent`
+/// invocation, so `main` falls through to normal parsing.
+pub fn print_capture_agent_help_for_raw(
+    cmd: &clap::Command,
+    raw: &[String],
+) -> Option<std::io::Result<()>> {
+    if !raw.iter().any(|arg| arg == "--help-agent") {
+        return None;
+    }
+    let verb = raw.iter().find(|token| !token.starts_with('-'))?;
+    let subcommand = find_subcommand_or_alias(cmd, verb)?;
+    if subcommand.get_name() != "capture" {
+        return None;
+    }
+    let bin_name = format!("{} {}", cmd.get_name(), subcommand.get_name());
+    let mut help = reveal_capture_agent_flags(subcommand.clone()).bin_name(bin_name);
+    Some(help.print_long_help())
+}
+
 fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::Command> {
     if path.is_empty() {
         return None;
@@ -286,6 +337,7 @@ fn command_path_from_raw_help_request(cmd: &clap::Command, raw: &[String]) -> Op
 pub fn topic_text(topic: &str) -> Option<&'static str> {
     Some(match topic {
         "advanced" => ADVANCED_HELP,
+        "agent-flags" => AGENT_FLAGS_TOPIC,
         "agent" | "daemon" => DAEMON_TOPIC,
         "git-overlay" => GIT_OVERLAY_TOPIC,
         "model" | "mental-model" | "concepts" => MODEL_TOPIC,
@@ -313,6 +365,36 @@ docs.\n\
 This is intentional. The everyday surface stays minimal so first-time users aren't\n\
 overwhelmed; agents and power users reach for the advanced affordances when they\n\
 need them.\n";
+
+const AGENT_FLAGS_TOPIC: &str = r#"Agent automation flags for `heddle capture`.
+
+These flags are hidden from the everyday `heddle capture --help` so it stays
+terse for human use. They let an automated caller override agent attribution
+and split captures across threads. Run `heddle capture --help-agent` to see
+them inline in capture's own help.
+
+Attribution overrides (each falls back to the matching env var, then config):
+
+  --agent-provider <NAME>   Override HEDDLE_AGENT_PROVIDER.
+  --agent-model <NAME>      Override HEDDLE_AGENT_MODEL.
+  --agent-session <ID>      Override the active agent session id (HEDDLE_SESSION_ID).
+  --agent-segment <ID>      Override the active session segment (HEDDLE_SESSION_SEGMENT).
+  --policy <ID>             Override HEDDLE_AGENT_POLICY.
+  --no-policy               Omit policy attribution.
+  --no-agent                Omit agent attribution.
+
+Path splitting (no env equivalent):
+
+  --split                   Split selected paths into another thread instead of
+                            capturing the whole worktree.
+  --into <THREAD>           Target thread when using --split.
+  --path <PATH>             Repository-relative path prefix to include with
+                            --split (repeatable).
+
+Attribution precedence (highest first): explicit flag, active thread actor,
+env var, harness probe, active session, user config, repo config. See
+`crates/cli/src/cli/commands/snapshot.rs` for the full cascade.
+"#;
 
 const DAEMON_TOPIC: &str = "Two daemons — both have legitimate uses; they are not interchangeable.\n\
 \n\

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -223,28 +223,20 @@ fn reveal_capture_agent_flags(command: clap::Command) -> clap::Command {
     })
 }
 
-/// Intercept `heddle capture --help-agent`: render `capture`'s
-/// clap-derived help with the hidden agent-automation flags revealed.
-/// Returns `None` when the request isn't a `capture --help-agent`
-/// invocation, so `main` falls through to normal parsing.
-pub fn print_capture_agent_help_for_raw(
-    cmd: &clap::Command,
-    raw: &[String],
-) -> Option<std::io::Result<()>> {
-    if !raw.iter().any(|arg| arg == "--help-agent") {
-        return None;
-    }
-    // Run before clap parses, so skip any leading global options (and the
-    // values of valued ones, e.g. `-C <path>`, `--output <fmt>`) before
-    // reading the verb — otherwise a flag's value gets mistaken for the
-    // subcommand. Shares the valued-global skip with the `--help` path.
-    let subcommand = first_subcommand_after_globals(cmd, raw)?;
-    if subcommand.get_name() != "capture" {
-        return None;
-    }
-    let bin_name = format!("{} {}", cmd.get_name(), subcommand.get_name());
-    let mut help = reveal_capture_agent_flags(subcommand.clone()).bin_name(bin_name);
-    Some(help.print_long_help())
+/// Render `capture`'s clap-derived help with the hidden agent-automation
+/// flags revealed. Called from the `Commands::Capture` dispatch arm once
+/// clap has parsed `--help-agent` (a first-class flag on `capture`).
+///
+/// Because clap owns the parsing, every global spelling it accepts —
+/// `-C <path>`, `--output <fmt>`, clustered `-vC <path>`, attached forms, in
+/// any legal position — is handled natively; there is no hand-rolled
+/// pre-parse token scan to keep in sync with clap's grammar.
+pub fn print_capture_agent_help(cmd: &clap::Command) -> std::io::Result<()> {
+    let capture = find_subcommand_or_alias(cmd, "capture")
+        .expect("capture subcommand exists in the clap command tree");
+    let bin_name = format!("{} {}", cmd.get_name(), capture.get_name());
+    let mut help = reveal_capture_agent_flags(capture.clone()).bin_name(bin_name);
+    help.print_long_help()
 }
 
 fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::Command> {
@@ -283,16 +275,16 @@ fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::C
 
 /// Whether `token` names an option on `command` — in either its `--long`
 /// or `-x` separated spelling — and, if so, whether the following token is
-/// that option's value. The single source of truth for the valued-global
-/// skip shared by the `--help` and `--help-agent` intercepts, so they can't
-/// drift on which globals (`-C <path>`, `--output <fmt>`, ...) consume a
-/// following value. Derived from clap's own arg definitions, so short and
-/// long forms stay covered as globals are added or renamed.
+/// that option's value. Used by the `heddle <path> --help` pre-parse scan
+/// (`command_path_from_raw_help_request`) so a valued global before the verb
+/// (`-C <path>`, `--output <fmt>`) isn't mistaken for the command path.
+/// Derived from clap's own arg definitions, so short and long forms stay
+/// covered as globals are added or renamed.
 ///
 /// Only the *separated* spellings (`-C path`, `--output fmt`) need a
 /// following-value skip. Attached spellings (`--output=fmt`, `-Cpath`,
 /// `-C=path`) carry the value in the same token, so they never set
-/// `skip_next`; the leading-dash fall-through in the scan loops already
+/// `skip_next`; the leading-dash fall-through in the scan loop already
 /// drops them without consuming the next token.
 fn global_option_takes_value(command: &clap::Command, token: &str) -> Option<bool> {
     command
@@ -304,39 +296,6 @@ fn global_option_takes_value(command: &clap::Command, token: &str) -> Option<boo
                     .is_some_and(|short| token == format!("-{short}"))
         })
         .map(|arg| arg.get_action().takes_values())
-}
-
-/// Skip leading global options (and the values of valued ones) in `raw`,
-/// then return the first token that resolves to a subcommand. Used by the
-/// `--help-agent` intercept, which runs before clap parses and so must do
-/// its own global handling via [`global_option_takes_value`].
-fn first_subcommand_after_globals<'a>(
-    cmd: &'a clap::Command,
-    raw: &[String],
-) -> Option<&'a clap::Command> {
-    let mut skip_next = false;
-    for token in raw {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-        if token == "--help" || token == "-h" {
-            continue;
-        }
-        if let Some(takes_value) = global_option_takes_value(cmd, token) {
-            skip_next = takes_value;
-            continue;
-        }
-        if token.starts_with('-') {
-            continue;
-        }
-        if let Some(subcommand) = find_subcommand_or_alias(cmd, token) {
-            return Some(subcommand);
-        }
-        // A non-flag token that isn't a subcommand — e.g. the value after a
-        // short valued global like `-C <path>`. Keep scanning for the verb.
-    }
-    None
 }
 
 fn find_subcommand_or_alias<'a>(
@@ -984,95 +943,108 @@ mod tests {
         }
     }
 
-    /// heddle#278. `--help-agent` is intercepted only for `capture`.
+    /// heddle#278 r4 (cid 3327325850). Close-the-class: `--help-agent` is a
+    /// first-class clap flag on `capture`, so clap parses the whole command
+    /// line and the dispatch arm inspects the parsed result. Whether the
+    /// reveal help shows is exactly "did clap resolve `capture` with
+    /// `--help-agent` set?" — no hand-rolled pre-parse verb scan, so every
+    /// global spelling clap accepts is handled for free.
+    ///
+    /// `wants_reveal` mirrors the decision the `Commands::Capture` arm in
+    /// `main.rs` makes (`matches!(cli.command, Commands::Capture(a) if
+    /// a.help_agent)`), driven entirely by clap's parse.
+    fn wants_reveal(args: &[&str]) -> bool {
+        use crate::cli::cli_args::{Cli, Commands};
+        use clap::Parser;
+        let argv = std::iter::once("heddle").chain(args.iter().copied());
+        match Cli::try_parse_from(argv) {
+            Ok(cli) => matches!(&cli.command, Commands::Capture(a) if a.help_agent),
+            // A parse error (e.g. `--help-agent` on a verb that has no such
+            // flag) means: don't reveal — clap reports it as it would any
+            // other invalid invocation.
+            Err(_) => false,
+        }
+    }
+
+    /// heddle#278. `--help-agent` reveals capture's agent flags only for the
+    /// `capture` verb; plain `--help` and `--help-agent` on another verb do
+    /// not.
     #[test]
-    fn capture_help_agent_intercept_is_capture_scoped() {
-        use clap::CommandFactory;
-        let cmd = crate::cli::cli_args::Cli::command();
-        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    fn capture_help_agent_is_capture_scoped() {
         assert!(
-            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help-agent"])).is_some(),
-            "capture --help-agent should be intercepted"
+            wants_reveal(&["capture", "--help-agent"]),
+            "capture --help-agent should request the reveal help"
         );
         assert!(
-            print_capture_agent_help_for_raw(&cmd, &owned(&["status", "--help-agent"])).is_none(),
-            "--help-agent on a non-capture verb should fall through"
+            !wants_reveal(&["status", "--help-agent"]),
+            "--help-agent on a non-capture verb is not a capture reveal request"
         );
+        // `capture --help` is clap's own help; it exits during parse (a
+        // DisplayHelp error), so it is never a `help_agent` reveal request.
         assert!(
-            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help"])).is_none(),
-            "plain --help should fall through to normal help"
+            !wants_reveal(&["capture", "--help"]),
+            "plain --help is clap's help, not the agent reveal"
         );
     }
 
-    /// heddle#278 r2 (cids 3327112975 / 3327131739). The `--help-agent`
-    /// intercept runs before clap parses, so a VALUED global flag preceding
-    /// the verb (`-C <path>`, `--output <fmt>`) must not be mistaken for the
-    /// subcommand. The skip reuses the same valued-global logic as the
-    /// `--help` path so the two can't drift.
+    /// heddle#278 r2/r3/r4 (cids 3327112975 / 3327231819 / 3327325850).
+    /// Because clap now owns parsing, every global spelling it accepts —
+    /// long valued (`--output <fmt>`), short valued (`-C <path>`), and
+    /// clustered short (`-vC <path>`) — is handled natively. With a repo dir
+    /// literally named `capture`, the `-C` VALUE must not be read as the verb.
+    /// This is the whole class the per-form pre-scan kept missing.
     #[test]
-    fn capture_help_agent_intercept_skips_valued_globals_before_verb() {
-        use clap::CommandFactory;
-        let cmd = crate::cli::cli_args::Cli::command();
-        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    fn capture_help_agent_handles_every_global_form_clap_accepts() {
+        // Valued global before the verb: long and short, separated forms.
         assert!(
-            print_capture_agent_help_for_raw(
-                &cmd,
-                &owned(&["-C", "/tmp/repo", "capture", "--help-agent"])
-            )
-            .is_some(),
-            "`-C <path> capture --help-agent` should reveal the agent flags, \
-             not pick the path as the verb"
+            wants_reveal(&["-C", "/tmp/repo", "capture", "--help-agent"]),
+            "`-C <path> capture --help-agent` should reveal — clap parses the path"
         );
         assert!(
-            print_capture_agent_help_for_raw(
-                &cmd,
-                &owned(&["--output", "text", "capture", "--help-agent"])
-            )
-            .is_some(),
-            "`--output text capture --help-agent` should reveal the agent flags, \
-             not pick `text` as the verb"
+            wants_reveal(&["--output", "text", "capture", "--help-agent"]),
+            "`--output text capture --help-agent` should reveal"
+        );
+        // Repo dir named `capture`: the `-C` value is `capture`, the verb is
+        // the following `capture`.
+        assert!(
+            wants_reveal(&["-C", "capture", "capture", "--help-agent"]),
+            "`-C capture capture --help-agent` (repo dir named `capture`) should reveal"
+        );
+        // r4: clustered short global `-vC <path>` — `-v` then valued `-C`.
+        assert!(
+            wants_reveal(&["-vC", "/tmp/repo", "capture", "--help-agent"]),
+            "`-vC <path> capture --help-agent` (clustered short globals) should reveal"
         );
         assert!(
-            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help-agent"])).is_some(),
-            "plain `capture --help-agent` should still be intercepted"
+            wants_reveal(&["-vC", "capture", "capture", "--help-agent"]),
+            "`-vC capture capture --help-agent` (clustered, repo dir named `capture`) should reveal"
         );
+        // Attached short form `-C<path>`: value rides in the token.
         assert!(
-            print_capture_agent_help_for_raw(
-                &cmd,
-                &owned(&["--output", "text", "status", "--help-agent"])
-            )
-            .is_none(),
-            "a non-capture verb behind a valued global should still fall through"
+            wants_reveal(&["-C/tmp/repo", "capture", "--help-agent"]),
+            "`-C<path> capture --help-agent` (attached) should reveal"
         );
-    }
+        // Plain invocation still reveals.
+        assert!(
+            wants_reveal(&["capture", "--help-agent"]),
+            "plain `capture --help-agent` should reveal"
+        );
 
-    /// heddle#278 r3 (cid 3327231819). The valued-global skip must also cover
-    /// the SHORT spelling of valued globals — `-C <path>` — not just the long
-    /// `--output <fmt>`. With a repo dir literally named `capture`, the `-C`
-    /// VALUE must not be mistaken for the verb. Close-the-class: every valued
-    /// global is recognized in both `-x` and `--long` separated forms.
-    #[test]
-    fn capture_help_agent_intercept_skips_short_valued_globals_before_verb() {
-        use clap::CommandFactory;
-        let cmd = crate::cli::cli_args::Cli::command();
-        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // Fall-through cases: the verb is NOT capture, so no reveal. With a
+        // repo dir named `capture`, the `-C` value is consumed by clap and
+        // `status` is the verb — `status` has no `--help-agent`, so clap
+        // errors and we do not reveal.
         assert!(
-            print_capture_agent_help_for_raw(
-                &cmd,
-                &owned(&["-C", "capture", "capture", "--help-agent"])
-            )
-            .is_some(),
-            "`-C capture capture --help-agent` (repo dir named `capture`) should \
-             reveal the agent flags, not pick the `-C` value as the verb"
+            !wants_reveal(&["-C", "capture", "status", "--help-agent"]),
+            "`-C capture status --help-agent` — verb is `status`, no reveal"
         );
         assert!(
-            print_capture_agent_help_for_raw(
-                &cmd,
-                &owned(&["-C", "capture", "status", "--help-agent"])
-            )
-            .is_none(),
-            "`-C capture status --help-agent` should fall through — the `-C` \
-             value must not be read as the `capture` verb"
+            !wants_reveal(&["-vC", "capture", "status", "--help-agent"]),
+            "`-vC capture status --help-agent` (clustered) — verb is `status`, no reveal"
+        );
+        assert!(
+            !wants_reveal(&["--output", "text", "status", "--help-agent"]),
+            "`--output text status --help-agent` — verb is `status`, no reveal"
         );
     }
 

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -704,6 +704,7 @@ mod tests {
     fn topic_text_returns_some_for_advertised_topics() {
         for topic in [
             "advanced",
+            "agent-flags",
             "git-overlay",
             "agent",
             "daemon",
@@ -787,6 +788,83 @@ mod tests {
                 "`{verb}` belongs behind advanced/topic help, not the core-loop surface"
             );
         }
+    }
+
+    /// heddle#278. The hidden agent-automation flags on `capture` need a
+    /// discovery route: `heddle help agent-flags` must list them with their
+    /// env equivalents.
+    #[test]
+    fn agent_flags_topic_lists_hidden_capture_flags() {
+        let text = topic_text("agent-flags").expect("agent-flags topic should exist");
+        for flag in [
+            "--agent-provider",
+            "--agent-model",
+            "--agent-session",
+            "--agent-segment",
+            "--policy",
+            "--no-policy",
+            "--no-agent",
+            "--split",
+            "--into",
+            "--path",
+        ] {
+            assert!(text.contains(flag), "agent-flags topic missing `{flag}`");
+        }
+        for env in [
+            "HEDDLE_AGENT_PROVIDER",
+            "HEDDLE_AGENT_MODEL",
+            "HEDDLE_AGENT_POLICY",
+            "HEDDLE_SESSION_ID",
+            "HEDDLE_SESSION_SEGMENT",
+        ] {
+            assert!(text.contains(env), "agent-flags topic missing env `{env}`");
+        }
+    }
+
+    /// heddle#278. The agent flags stay `hide = true` in the default surface
+    /// but `--help-agent` reveals every one of them.
+    #[test]
+    fn capture_agent_flags_hidden_by_default_revealed_on_demand() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let capture = cmd
+            .find_subcommand("capture")
+            .expect("capture subcommand exists");
+        for id in CAPTURE_AGENT_FLAG_IDS {
+            let arg = capture
+                .get_arguments()
+                .find(|arg| arg.get_id().as_str() == *id)
+                .unwrap_or_else(|| panic!("capture has no `{id}` arg"));
+            assert!(arg.is_hide_set(), "`{id}` should be hidden by default");
+        }
+        let revealed = reveal_capture_agent_flags(capture.clone());
+        for id in CAPTURE_AGENT_FLAG_IDS {
+            let arg = revealed
+                .get_arguments()
+                .find(|arg| arg.get_id().as_str() == *id)
+                .expect("revealed arg present");
+            assert!(!arg.is_hide_set(), "`{id}` should be revealed by --help-agent");
+        }
+    }
+
+    /// heddle#278. `--help-agent` is intercepted only for `capture`.
+    #[test]
+    fn capture_help_agent_intercept_is_capture_scoped() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(
+            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help-agent"])).is_some(),
+            "capture --help-agent should be intercepted"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(&cmd, &owned(&["status", "--help-agent"])).is_none(),
+            "--help-agent on a non-capture verb should fall through"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help"])).is_none(),
+            "plain --help should fall through to normal help"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -234,8 +234,11 @@ pub fn print_capture_agent_help_for_raw(
     if !raw.iter().any(|arg| arg == "--help-agent") {
         return None;
     }
-    let verb = raw.iter().find(|token| !token.starts_with('-'))?;
-    let subcommand = find_subcommand_or_alias(cmd, verb)?;
+    // Run before clap parses, so skip any leading global options (and the
+    // values of valued ones, e.g. `-C <path>`, `--output <fmt>`) before
+    // reading the verb — otherwise a flag's value gets mistaken for the
+    // subcommand. Shares the valued-global skip with the `--help` path.
+    let subcommand = first_subcommand_after_globals(cmd, raw)?;
     if subcommand.get_name() != "capture" {
         return None;
     }
@@ -278,6 +281,54 @@ fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::C
     Some(help)
 }
 
+/// Whether `token` names an option on `command` (by its `--long` spelling)
+/// and, if so, whether the following token is that option's value. The
+/// single source of truth for the valued-global skip shared by the
+/// `--help` and `--help-agent` intercepts, so they can't drift on which
+/// globals (`-C <path>`, `--output <fmt>`, ...) consume a following value.
+fn global_option_takes_value(command: &clap::Command, token: &str) -> Option<bool> {
+    command
+        .get_arguments()
+        .find(|arg| {
+            arg.get_long()
+                .is_some_and(|long| token == format!("--{long}"))
+        })
+        .map(|arg| arg.get_action().takes_values())
+}
+
+/// Skip leading global options (and the values of valued ones) in `raw`,
+/// then return the first token that resolves to a subcommand. Used by the
+/// `--help-agent` intercept, which runs before clap parses and so must do
+/// its own global handling via [`global_option_takes_value`].
+fn first_subcommand_after_globals<'a>(
+    cmd: &'a clap::Command,
+    raw: &[String],
+) -> Option<&'a clap::Command> {
+    let mut skip_next = false;
+    for token in raw {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if token == "--help" || token == "-h" {
+            continue;
+        }
+        if let Some(takes_value) = global_option_takes_value(cmd, token) {
+            skip_next = takes_value;
+            continue;
+        }
+        if token.starts_with('-') {
+            continue;
+        }
+        if let Some(subcommand) = find_subcommand_or_alias(cmd, token) {
+            return Some(subcommand);
+        }
+        // A non-flag token that isn't a subcommand — e.g. the value after a
+        // short valued global like `-C <path>`. Keep scanning for the verb.
+    }
+    None
+}
+
 fn find_subcommand_or_alias<'a>(
     command: &'a clap::Command,
     name: &str,
@@ -311,14 +362,8 @@ fn command_path_from_raw_help_request(cmd: &clap::Command, raw: &[String]) -> Op
         if token == "--help" || token == "-h" {
             continue;
         }
-        if let Some(arg) = current.get_arguments().find(|arg| {
-            arg.get_long()
-                .is_some_and(|long| token == &format!("--{long}"))
-        }) {
-            skip_next = arg.get_action().takes_values();
-            continue;
-        }
-        if token.starts_with("--") {
+        if let Some(takes_value) = global_option_takes_value(current, token) {
+            skip_next = takes_value;
             continue;
         }
         if token.starts_with('-') {
@@ -946,6 +991,48 @@ mod tests {
         assert!(
             print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help"])).is_none(),
             "plain --help should fall through to normal help"
+        );
+    }
+
+    /// heddle#278 r2 (cids 3327112975 / 3327131739). The `--help-agent`
+    /// intercept runs before clap parses, so a VALUED global flag preceding
+    /// the verb (`-C <path>`, `--output <fmt>`) must not be mistaken for the
+    /// subcommand. The skip reuses the same valued-global logic as the
+    /// `--help` path so the two can't drift.
+    #[test]
+    fn capture_help_agent_intercept_skips_valued_globals_before_verb() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(
+            print_capture_agent_help_for_raw(
+                &cmd,
+                &owned(&["-C", "/tmp/repo", "capture", "--help-agent"])
+            )
+            .is_some(),
+            "`-C <path> capture --help-agent` should reveal the agent flags, \
+             not pick the path as the verb"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(
+                &cmd,
+                &owned(&["--output", "text", "capture", "--help-agent"])
+            )
+            .is_some(),
+            "`--output text capture --help-agent` should reveal the agent flags, \
+             not pick `text` as the verb"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(&cmd, &owned(&["capture", "--help-agent"])).is_some(),
+            "plain `capture --help-agent` should still be intercepted"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(
+                &cmd,
+                &owned(&["--output", "text", "status", "--help-agent"])
+            )
+            .is_none(),
+            "a non-capture verb behind a valued global should still fall through"
         );
     }
 

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -281,17 +281,27 @@ fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::C
     Some(help)
 }
 
-/// Whether `token` names an option on `command` (by its `--long` spelling)
-/// and, if so, whether the following token is that option's value. The
-/// single source of truth for the valued-global skip shared by the
-/// `--help` and `--help-agent` intercepts, so they can't drift on which
-/// globals (`-C <path>`, `--output <fmt>`, ...) consume a following value.
+/// Whether `token` names an option on `command` — in either its `--long`
+/// or `-x` separated spelling — and, if so, whether the following token is
+/// that option's value. The single source of truth for the valued-global
+/// skip shared by the `--help` and `--help-agent` intercepts, so they can't
+/// drift on which globals (`-C <path>`, `--output <fmt>`, ...) consume a
+/// following value. Derived from clap's own arg definitions, so short and
+/// long forms stay covered as globals are added or renamed.
+///
+/// Only the *separated* spellings (`-C path`, `--output fmt`) need a
+/// following-value skip. Attached spellings (`--output=fmt`, `-Cpath`,
+/// `-C=path`) carry the value in the same token, so they never set
+/// `skip_next`; the leading-dash fall-through in the scan loops already
+/// drops them without consuming the next token.
 fn global_option_takes_value(command: &clap::Command, token: &str) -> Option<bool> {
     command
         .get_arguments()
         .find(|arg| {
-            arg.get_long()
-                .is_some_and(|long| token == format!("--{long}"))
+            arg.get_long().is_some_and(|long| token == format!("--{long}"))
+                || arg
+                    .get_short()
+                    .is_some_and(|short| token == format!("-{short}"))
         })
         .map(|arg| arg.get_action().takes_values())
 }
@@ -1033,6 +1043,36 @@ mod tests {
             )
             .is_none(),
             "a non-capture verb behind a valued global should still fall through"
+        );
+    }
+
+    /// heddle#278 r3 (cid 3327231819). The valued-global skip must also cover
+    /// the SHORT spelling of valued globals — `-C <path>` — not just the long
+    /// `--output <fmt>`. With a repo dir literally named `capture`, the `-C`
+    /// VALUE must not be mistaken for the verb. Close-the-class: every valued
+    /// global is recognized in both `-x` and `--long` separated forms.
+    #[test]
+    fn capture_help_agent_intercept_skips_short_valued_globals_before_verb() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let owned = |args: &[&str]| args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(
+            print_capture_agent_help_for_raw(
+                &cmd,
+                &owned(&["-C", "capture", "capture", "--help-agent"])
+            )
+            .is_some(),
+            "`-C capture capture --help-agent` (repo dir named `capture`) should \
+             reveal the agent flags, not pick the `-C` value as the verb"
+        );
+        assert!(
+            print_capture_agent_help_for_raw(
+                &cmd,
+                &owned(&["-C", "capture", "status", "--help-agent"])
+            )
+            .is_none(),
+            "`-C capture status --help-agent` should fall through — the `-C` \
+             value must not be read as the `capture` verb"
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -142,6 +142,18 @@ async fn async_main() -> Result<()> {
             }
             return Ok(());
         }
+        if let Some(result) =
+            cli::cli::help::print_capture_agent_help_for_raw(&Cli::command(), &raw)
+        {
+            result?;
+            if profile {
+                emit_profile(
+                    "help",
+                    &[ProfileField::duration("total_ms", total_start.elapsed())],
+                );
+            }
+            return Ok(());
+        }
         if let Some(result) = cli::cli::help::print_direct_help_for_raw(&Cli::command(), &raw) {
             result?;
             if profile {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -142,18 +142,6 @@ async fn async_main() -> Result<()> {
             }
             return Ok(());
         }
-        if let Some(result) =
-            cli::cli::help::print_capture_agent_help_for_raw(&Cli::command(), &raw)
-        {
-            result?;
-            if profile {
-                emit_profile(
-                    "help",
-                    &[ProfileField::duration("total_ms", total_start.elapsed())],
-                );
-            }
-            return Ok(());
-        }
         if let Some(result) = cli::cli::help::print_direct_help_for_raw(&Cli::command(), &raw) {
             result?;
             if profile {
@@ -185,6 +173,24 @@ async fn async_main() -> Result<()> {
             std::process::exit(HeddleExitCode::from_clap(&err).into());
         }
     };
+    // `heddle capture --help-agent`: clap has now parsed the entire command
+    // line — every global spelling it accepts (`-C <path>`, `--output <fmt>`,
+    // clustered `-vC <path>`, attached forms, any position) was handled by
+    // clap, not a hand-rolled token scan. Inspect the parsed result and render
+    // the reveal help before running capture. This is help, not diagnostics,
+    // so it exits before config/logging init.
+    if let Commands::Capture(args) = &cli.command
+        && args.help_agent
+    {
+        cli::cli::help::print_capture_agent_help(&Cli::command())?;
+        if profile {
+            emit_profile(
+                "help",
+                &[ProfileField::duration("total_ms", total_start.elapsed())],
+            );
+        }
+        return Ok(());
+    }
     // Resolve color decision once, before any rendering site fires.
     // The helpers in `cli::style` consult a process-wide OnceLock —
     // doing this inside each render path would re-query the env on

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -69,3 +69,45 @@ fn clone_help_pins_behavior_stanza() {
         "clone help should point at the threads topic: {help}"
     );
 }
+
+/// heddle#278 r4 (cid 3327325850). `capture --help-agent` is a first-class
+/// clap flag, so clap parses the whole command line and the dispatch arm
+/// renders the reveal help. End-to-end through the real binary: the hidden
+/// agent-automation flags appear, and every global spelling clap accepts —
+/// including the clustered short `-vC <path>` that the old hand-rolled
+/// pre-parse scan kept missing — reaches the reveal help.
+#[test]
+fn capture_help_agent_reveals_hidden_flags_through_clap() {
+    let expect_revealed = |help: &str, ctx: &str| {
+        for flag in [
+            "--agent-provider",
+            "--agent-model",
+            "--agent-session",
+            "--agent-segment",
+            "--policy",
+            "--no-policy",
+            "--no-agent",
+            "--split",
+            "--into",
+        ] {
+            assert!(
+                help.contains(flag),
+                "`{ctx}` should reveal `{flag}` inline: {help}"
+            );
+        }
+    };
+
+    let plain = heddle(&["capture", "--help-agent"], None).expect("capture --help-agent renders");
+    expect_revealed(&plain, "capture --help-agent");
+
+    // Clustered short globals before the verb: `-v` then valued `-C <path>`.
+    // clap parses the path natively; the verb is still `capture`.
+    let clustered = heddle(&["-vC", ".", "capture", "--help-agent"], None)
+        .expect("-vC <path> capture --help-agent renders");
+    expect_revealed(&clustered, "-vC <path> capture --help-agent");
+
+    // Long valued global before the verb.
+    let long_global = heddle(&["--output", "text", "capture", "--help-agent"], None)
+        .expect("--output text capture --help-agent renders");
+    expect_revealed(&long_global, "--output text capture --help-agent");
+}

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -111,3 +111,25 @@ fn capture_help_agent_reveals_hidden_flags_through_clap() {
         .expect("--output text capture --help-agent renders");
     expect_revealed(&long_global, "--output text capture --help-agent");
 }
+
+/// heddle#278 r6 (cid 3327633095). `--help-agent` is `hide = true`: the
+/// reveal still works (asserted above), but everyday `capture --help` stays
+/// terse — the flag itself must not appear, only the after-help pointer to
+/// the reveal surface. Progressive disclosure: discover via the pointer, not
+/// by seeing the flag in the human help.
+#[test]
+fn capture_help_keeps_help_agent_hidden_but_keeps_the_pointer() {
+    let help = heddle(&["capture", "--help"], None).expect("capture --help renders");
+    // The discovery pointer in after-help stays so agents can still find it.
+    assert!(
+        help.contains("heddle capture --help-agent"),
+        "`capture --help` should keep the after-help pointer to `--help-agent`: {help}"
+    );
+    // ...but the flag must not appear in the options listing. The only
+    // mention allowed is the single after-help pointer line.
+    assert_eq!(
+        help.matches("--help-agent").count(),
+        1,
+        "`capture --help` must not list the hidden `--help-agent` flag (only the after-help pointer): {help}"
+    );
+}

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -54,6 +54,8 @@ The three personas are NOT the only people who use heddle. They're chosen becaus
 
 **Friction NOT worth flagging:** text-rendering cosmetics that don't affect JSON shape.
 
+**Discovering hidden automation flags:** `heddle capture` carries agent-only flags (`--agent-provider`, `--agent-model`, `--agent-session`, `--agent-segment`, `--policy`, `--no-policy`, `--no-agent`, `--split`, `--into`, `--path`) that are `hide = true` so they don't clutter human `--help`. Agents reach them two ways: `heddle help agent-flags` (a topic page listing each flag with its `HEDDLE_AGENT_*` / `HEDDLE_SESSION_*` env equivalent) and `heddle capture --help-agent` (capture's own help with the hidden flags revealed inline). The default `heddle capture --help` stays terse but points at both. This progressive-disclosure pattern is the template for future hidden-flag discoverability.
+
 ## Mapping past findings to personas
 
 ### Round 3 (filed as #252-#258)


### PR DESCRIPTION
## Summary
- Add a `heddle help agent-flags` topic listing the hidden `capture` agent-automation flags (`--agent-provider`, `--agent-model`, `--agent-session`, `--agent-segment`, `--policy`, `--no-policy`, `--no-agent`, `--split`, `--into`, `--path`) with their `HEDDLE_AGENT_*` / `HEDDLE_SESSION_*` env equivalents and the attribution precedence cascade.
- Add a `capture --help-agent` mode — intercepted in `main.rs` before clap parses — that renders `capture`'s help with the hidden agent flags revealed inline.
- Add a one-line pointer in the default `capture --help` (`after_help`) toward both routes; the default view stays terse and the flags stay `hide = true`.
- Document the discovery path in `docs/personas.md` (Agent persona section).

Closes HeddleCo/heddle#278

## Red commit
`6db27ce`

## Test evidence
```
$ cargo test -p heddle-cli --lib cli::help
test cli::help::tests::agent_flags_topic_lists_hidden_capture_flags ... ok
test cli::help::tests::capture_agent_flags_hidden_by_default_revealed_on_demand ... ok
test cli::help::tests::capture_help_agent_intercept_is_capture_scoped ... ok
test cli::help::tests::topic_text_returns_some_for_advertised_topics ... ok
test result: ok. 11 passed; 0 failed; 0 ignored

$ cargo test --workspace            # green (one flaky rerun; see note)
$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ bash scripts/check-no-silent-default-tree-load.sh       # clean (514 files)
```

Note: under full-parallel `cargo test --workspace`, four pre-existing `#[serial]` + `#[timeout(15000)]` attribution tests in `production_features.rs` (untouched by this diff) intermittently starve and panic; they pass deterministically in isolation, in their own test binary, and on a clean rerun of the full suite.

## Manual verification
Built `heddle` and exercised all three surfaces:
- `heddle help agent-flags` — lists every hidden flag + env equivalent.
- `heddle capture --help-agent` — capture help with the agent flags revealed.
- `heddle capture --help` — terse; no agent flags shown, just the pointer line.

## Blocked by → resolved
N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782683833&installation_id=132405951&pr_number=323&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F323&signature=0398cc16b04000761aafd0a4ac1707469be3751c222c6aec4b0bab698dbf739d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->