### PR TITLE
heddle#304: make attempt diff_files ranking ignore-aware

### DIFF
--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -41,6 +41,7 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
+use objects::worktree::should_ignore;
 use repo::Repository;
 use serde::Serialize;
 
@@ -676,9 +677,11 @@ fn diff_file_count(repo: &Repository, parent_head: &str, thread_tip: &str) -> Re
 /// without standing up a full state-to-state diff.
 fn count_unignored_paths<'a>(
     paths: impl Iterator<Item = &'a str>,
-    _ignore_patterns: &[String],
+    ignore_patterns: &[String],
 ) -> usize {
-    paths.count()
+    paths
+        .filter(|path| !should_ignore(Path::new(path), ignore_patterns))
+        .count()
 }
 
 /// Sort key for ranking. Lower values rank earlier.

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -645,9 +645,17 @@ fn run_one_attempt(
     }
 }
 
-/// Compute the parent ↔ thread-tip diff and return its file count. The
-/// state IDs flow through `repo.resolve_state` so we accept either a
-/// short or full change-id without re-deriving the prefix arithmetic.
+/// Compute the parent ↔ thread-tip diff and return its file count,
+/// excluding ignored paths. The state IDs flow through
+/// `repo.resolve_state` so we accept either a short or full change-id
+/// without re-deriving the prefix arithmetic.
+///
+/// Ignored paths are filtered out of the count because the ranking
+/// signal must reflect *source* changes, not artifacts an attempt's
+/// command happened to materialize. An attempt that runs `npm ci`
+/// captures the freshly-installed (and ignored) `node_modules` tree;
+/// counting those thousands of files would swamp the ranking and make
+/// every attempt look equally huge.
 fn diff_file_count(repo: &Repository, parent_head: &str, thread_tip: &str) -> Result<usize> {
     let from = repo
         .resolve_state(parent_head)?
@@ -656,7 +664,21 @@ fn diff_file_count(repo: &Repository, parent_head: &str, thread_tip: &str) -> Re
         .resolve_state(thread_tip)?
         .ok_or_else(|| anyhow!("thread state '{}' not resolvable", thread_tip))?;
     let diff = compute_state_diff(repo, &from, &to, false, 0)?;
-    Ok(diff.changes.len())
+    let ignore_patterns = repo.ignore_patterns()?;
+    Ok(count_unignored_paths(
+        diff.changes.iter().map(|change| change.path.as_str()),
+        &ignore_patterns,
+    ))
+}
+
+/// Count paths that are not covered by the repo's ignore rules. Pulled
+/// out of `diff_file_count` so the ignore-aware ranking can be tested
+/// without standing up a full state-to-state diff.
+fn count_unignored_paths<'a>(
+    paths: impl Iterator<Item = &'a str>,
+    _ignore_patterns: &[String],
+) -> usize {
+    paths.count()
 }
 
 /// Sort key for ranking. Lower values rank earlier.
@@ -836,6 +858,27 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         (temp, repo)
+    }
+
+    #[test]
+    fn diff_file_count_ranking_excludes_ignored_paths() {
+        // Regression for heddle#304: an attempt whose command runs
+        // `npm ci` captures the freshly-installed `node_modules` tree.
+        // Those paths are ignored, so they must NOT inflate the
+        // `diff_files` ranking signal — only real source changes count.
+        let patterns = vec!["node_modules".to_string(), "target".to_string()];
+        let paths = [
+            "src/main.rs",
+            "src/lib.rs",
+            "node_modules/left-pad/index.js",
+            "node_modules/.package-lock.json",
+            "target/debug/build/foo",
+        ];
+        assert_eq!(
+            count_unignored_paths(paths.iter().copied(), &patterns),
+            2,
+            "only the two source files should count; ignored deps must not dominate"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -41,7 +41,7 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
-use objects::worktree::should_ignore;
+use objects::worktree::{WorktreeIgnoreMatcher, build_worktree_ignore};
 use repo::Repository;
 use serde::Serialize;
 
@@ -665,22 +665,28 @@ fn diff_file_count(repo: &Repository, parent_head: &str, thread_tip: &str) -> Re
         .resolve_state(thread_tip)?
         .ok_or_else(|| anyhow!("thread state '{}' not resolvable", thread_tip))?;
     let diff = compute_state_diff(repo, &from, &to, false, 0)?;
-    let ignore_patterns = repo.ignore_patterns()?;
+    // Compile the ignore matcher ONCE per diff, then match each path
+    // against it. `diff.changes` can hold thousands of ignored paths
+    // (e.g. a `node_modules` tree from `npm ci`); rebuilding the glob
+    // set per path would make ranking O(changed_paths × patterns).
+    let matcher = build_worktree_ignore(&repo.ignore_patterns()?);
     Ok(count_unignored_paths(
         diff.changes.iter().map(|change| change.path.as_str()),
-        &ignore_patterns,
+        &matcher,
     ))
 }
 
 /// Count paths that are not covered by the repo's ignore rules. Pulled
 /// out of `diff_file_count` so the ignore-aware ranking can be tested
-/// without standing up a full state-to-state diff.
+/// without standing up a full state-to-state diff. Takes a prebuilt
+/// matcher so the caller pays the glob-compile cost once per diff, not
+/// once per path.
 fn count_unignored_paths<'a>(
     paths: impl Iterator<Item = &'a str>,
-    ignore_patterns: &[String],
+    matcher: &WorktreeIgnoreMatcher,
 ) -> usize {
     paths
-        .filter(|path| !should_ignore(Path::new(path), ignore_patterns))
+        .filter(|path| !matcher.is_ignored(Path::new(path)))
         .count()
 }
 
@@ -870,6 +876,7 @@ mod tests {
         // Those paths are ignored, so they must NOT inflate the
         // `diff_files` ranking signal — only real source changes count.
         let patterns = vec!["node_modules".to_string(), "target".to_string()];
+        let matcher = build_worktree_ignore(&patterns);
         let paths = [
             "src/main.rs",
             "src/lib.rs",
@@ -878,9 +885,35 @@ mod tests {
             "target/debug/build/foo",
         ];
         assert_eq!(
-            count_unignored_paths(paths.iter().copied(), &patterns),
+            count_unignored_paths(paths.iter().copied(), &matcher),
             2,
             "only the two source files should count; ignored deps must not dominate"
+        );
+    }
+
+    #[test]
+    fn diff_file_count_ranking_correct_at_scale() {
+        // heddle#304 r2: the `npm ci` scenario can produce thousands of
+        // ignored paths in one diff. The matcher must be compiled ONCE
+        // and reused per path (O(1) compile, O(changed_paths) matches),
+        // and the result must still be correct at that scale — every
+        // ignored path excluded, every source path counted.
+        let patterns = vec!["node_modules".to_string(), "target".to_string()];
+        let matcher = build_worktree_ignore(&patterns);
+
+        let ignored: Vec<String> =
+            (0..5_000).map(|i| format!("node_modules/pkg-{i}/index.js")).collect();
+        let sources: Vec<String> = (0..7).map(|i| format!("src/mod-{i}.rs")).collect();
+        let all: Vec<&str> = ignored
+            .iter()
+            .chain(sources.iter())
+            .map(String::as_str)
+            .collect();
+
+        assert_eq!(
+            count_unignored_paths(all.into_iter(), &matcher),
+            sources.len(),
+            "only source files count, regardless of how large the ignored tree is"
         );
     }
 

--- a/crates/objects/src/worktree/mod.rs
+++ b/crates/objects/src/worktree/mod.rs
@@ -11,5 +11,5 @@ mod worktree_tests;
 
 pub use worktree_compare::compare_worktree;
 pub use worktree_diff::{DiffLine, diff_blobs};
-pub use worktree_ignore::should_ignore;
+pub use worktree_ignore::{WorktreeIgnoreMatcher, build_worktree_ignore, should_ignore};
 pub use worktree_types::{FileStatus, WorktreeChange, WorktreeStatus};

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -36,7 +36,37 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 /// unaffected — gitignore-spec rules without a trailing slash match
 /// regardless of the `is_dir` flag.
 pub fn should_ignore(path: &Path, patterns: &[String]) -> bool {
-    matched(&build_matcher(patterns), path)
+    build_worktree_ignore(patterns).is_ignored(path)
+}
+
+/// A compiled `.heddleignore` matcher. Compiling the glob set is the
+/// expensive part; matching a single path against an already-built
+/// matcher is cheap. Callers that test many paths against the same
+/// patterns (e.g. counting unignored entries across a large diff)
+/// should build the matcher once and reuse it, rather than paying the
+/// per-path compile cost that the [`should_ignore`] convenience wrapper
+/// incurs.
+pub struct WorktreeIgnoreMatcher {
+    gi: Gitignore,
+}
+
+impl WorktreeIgnoreMatcher {
+    /// Whether `path` is covered by any of the compiled patterns. See
+    /// [`should_ignore`] for the matching semantics (`is_dir = true`,
+    /// negation handling).
+    pub fn is_ignored(&self, path: &Path) -> bool {
+        matched(&self.gi, path)
+    }
+}
+
+/// Compile a [`WorktreeIgnoreMatcher`] from the given pattern strings,
+/// once, for reuse across many path checks. This is the compile-once
+/// counterpart to [`should_ignore`], which rebuilds the matcher on
+/// every call.
+pub fn build_worktree_ignore(patterns: &[String]) -> WorktreeIgnoreMatcher {
+    WorktreeIgnoreMatcher {
+        gi: build_matcher(patterns),
+    }
 }
 
 /// Build a `Gitignore` matcher from the given pattern strings,
@@ -263,6 +293,33 @@ mod tests {
         let patterns = vec!["# comment".to_string(), "".to_string(), "*.log".to_string()];
         assert!(should_ignore(&PathBuf::from("foo.log"), &patterns));
         assert!(!should_ignore(&PathBuf::from("foo.txt"), &patterns));
+    }
+
+    #[test]
+    fn prebuilt_matcher_matches_same_as_should_ignore() {
+        // The compile-once API must produce identical match results to
+        // the per-call `should_ignore` wrapper — it only hoists WHEN
+        // the glob set is compiled, not WHAT it matches.
+        let patterns = vec!["node_modules".to_string(), "*.log".to_string()];
+        let matcher = build_worktree_ignore(&patterns);
+        let cases = [
+            "node_modules/left-pad/index.js",
+            "debug.log",
+            "src/main.rs",
+            "config/app.toml",
+        ];
+        for case in cases {
+            let p = PathBuf::from(case);
+            assert_eq!(
+                matcher.is_ignored(&p),
+                should_ignore(&p, &patterns),
+                "prebuilt matcher and should_ignore disagree on {case}"
+            );
+        }
+        // Reusing the same matcher across many paths is the whole point;
+        // assert a couple of explicit outcomes too.
+        assert!(matcher.is_ignored(&PathBuf::from("node_modules/x")));
+        assert!(!matcher.is_ignored(&PathBuf::from("src/lib.rs")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `heddle attempt`'s `diff_files` ranking signal now excludes ignored paths, so an attempt whose command runs `npm ci` (or similar) ranks by *source* changes rather than the thousands of freshly-installed, ignored `node_modules` files.
- `diff_file_count` filters the parent↔thread-tip diff through `repo.ignore_patterns()` + `objects::worktree::should_ignore` before counting.
- Extracted `count_unignored_paths` as a pure, unit-tested helper.

Closes HeddleCo/heddle#304

## Red commit
`32fd119`

## Test evidence
```
test cli::commands::attempt::tests::diff_file_count_ranking_excludes_ignored_paths ... ok
test cli::commands::attempt::tests::cmd_attempt_preflight_refuses_when_middle_name_collides ... ok
test cli::commands::attempt::tests::cmd_attempt_preflight_refuses_when_any_synthesized_name_collides ... ok
```
Red (`32fd119`) failed with `left: 5, right: 2`; green (`count_unignored_paths` filter) passes.

Local CI-parity gates:
- `cargo test -p heddle-cli` — green
- `cargo clippy -p heddle-cli --all-targets -- -D warnings` — clean
- `bash scripts/check-no-silent-default-tree-load.sh` — clean (514 files scanned)

## Manual verification
N/A — covered by tests.

## Scope note
This fixes the ranking/count per the issue's acceptance criterion. What `merge` actually carries is governed by capture's ignore-awareness, tracked separately under the #301 epic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782697525&installation_id=132405951&pr_number=336&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F336&signature=51bbe78e205fe63389fc076b4488db1a58e752c5277e6b0b45efd6849192ba5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->