### PR TITLE
heddle#258: current-thread drop recovery suggests switch/create, not circular thread list

### DIFF
--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -546,6 +546,22 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
         &["thread"],
         true,
     ),
+    // Current-thread drop recovery (heddle#258): switch to a sibling
+    // thread first (or create one) instead of the circular `thread list`.
+    // The `<other>` slot is agent-fillable so a JSON caller can run it
+    // after picking a real sibling thread name.
+    (
+        "heddle thread switch <other>",
+        &["heddle", "thread", "switch", "<other>"],
+        &["other"],
+        true,
+    ),
+    (
+        "heddle thread create <other>",
+        &["heddle", "thread", "create", "<other>"],
+        &["other"],
+        true,
+    ),
     (
         "heddle thread show <THREAD>",
         &["heddle", "thread", "show", "<thread>"],

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2950,19 +2950,58 @@ pub(crate) fn show_thread_summary(
     Ok(())
 }
 
+/// Recovery advice for refusing to drop or delete the *current*
+/// checkout thread. The original advice pointed users at
+/// `heddle thread list`, which loops a junior who sees only the current
+/// thread (heddle#258): the real fix is to switch to a sibling thread
+/// first, or create one when none exists, then retry the drop. Returns
+/// `(primary_command, recovery_commands, hint)`; both the switch and
+/// create paths are exposed as `<other>` templates so JSON callers can
+/// fill in a real thread name.
+pub(crate) fn current_thread_drop_recovery(
+    repo: &Repository,
+    current: &str,
+) -> (String, Vec<String>, String) {
+    const SWITCH: &str = "heddle thread switch <other>";
+    const CREATE: &str = "heddle thread create <other>";
+    let has_other = repo
+        .refs()
+        .list_threads()
+        .map(|threads| threads.iter().any(|name| name.as_str() != current))
+        .unwrap_or(false);
+    if has_other {
+        (
+            SWITCH.to_string(),
+            vec![SWITCH.to_string(), CREATE.to_string()],
+            format!(
+                "Switch to another thread with `{SWITCH}` (or start one with `{CREATE}`), then retry `heddle thread drop {current}`."
+            ),
+        )
+    } else {
+        (
+            CREATE.to_string(),
+            vec![CREATE.to_string(), SWITCH.to_string()],
+            format!(
+                "No other thread exists yet. Create one with `{CREATE}`, switch to it, then retry `heddle thread drop {current}`."
+            ),
+        )
+    }
+}
+
 pub(crate) fn cmd_thread_delete(cli: &Cli, repo: &Repository, name: String) -> Result<()> {
     if let Head::Attached { thread } = repo.head_ref()?
         && thread == name
     {
+        let (primary, recovery, hint) = current_thread_drop_recovery(repo, &name);
         return Err(anyhow!(RecoveryAdvice::safety_refusal(
             "branch_delete_current",
             format!("Refusing to delete current thread '{name}'"),
-            "Inspect available threads with `heddle thread list`, switch to another thread, then retry.",
+            hint,
             format!("HEAD is attached to '{name}'"),
             "deleting the attached thread would strand the current checkout without its branch ref",
             "no refs were moved or deleted",
-            "heddle thread list",
-            vec!["heddle thread list".to_string()],
+            primary,
+            recovery,
         )));
     }
 

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2950,20 +2950,49 @@ pub(crate) fn show_thread_summary(
     Ok(())
 }
 
+/// The destructive intent the user originally expressed, so the
+/// recovery hint can suggest a retry that PRESERVES it. A bare
+/// `heddle thread drop {current}` retry only removes a thread that owns a
+/// managed record; a lightweight ref (no `Thread` record) needs the
+/// ref-deleting form, or the retry dead-ends at `thread_not_found`
+/// (heddle#258 r2).
+#[derive(Clone, Copy)]
+pub(crate) enum DropMode {
+    /// Plain `heddle thread drop` — keeps the managed-record teardown.
+    Drop,
+    /// Destructive `--delete-thread` / `branch -d` — removes the ref even
+    /// when no managed record exists.
+    DeleteThread,
+}
+
+impl DropMode {
+    /// The retry command to suggest, preserving the destructive mode.
+    fn retry_command(self, current: &str) -> String {
+        match self {
+            DropMode::Drop => format!("heddle thread drop {current}"),
+            DropMode::DeleteThread => format!("heddle thread drop {current} --delete-thread"),
+        }
+    }
+}
+
 /// Recovery advice for refusing to drop or delete the *current*
 /// checkout thread. The original advice pointed users at
 /// `heddle thread list`, which loops a junior who sees only the current
 /// thread (heddle#258): the real fix is to switch to a sibling thread
-/// first, or create one when none exists, then retry the drop. Returns
+/// first, or create one when none exists, then retry the drop. The
+/// retry command preserves the caller's [`DropMode`] so a lightweight
+/// ref can actually be removed on retry (heddle#258 r2). Returns
 /// `(primary_command, recovery_commands, hint)`; both the switch and
 /// create paths are exposed as `<other>` templates so JSON callers can
 /// fill in a real thread name.
 pub(crate) fn current_thread_drop_recovery(
     repo: &Repository,
     current: &str,
+    mode: DropMode,
 ) -> (String, Vec<String>, String) {
     const SWITCH: &str = "heddle thread switch <other>";
     const CREATE: &str = "heddle thread create <other>";
+    let retry = mode.retry_command(current);
     let has_other = repo
         .refs()
         .list_threads()
@@ -2974,7 +3003,7 @@ pub(crate) fn current_thread_drop_recovery(
             SWITCH.to_string(),
             vec![SWITCH.to_string(), CREATE.to_string()],
             format!(
-                "Switch to another thread with `{SWITCH}` (or start one with `{CREATE}`), then retry `heddle thread drop {current}`."
+                "Switch to another thread with `{SWITCH}` (or start one with `{CREATE}`), then retry `{retry}`."
             ),
         )
     } else {
@@ -2982,7 +3011,7 @@ pub(crate) fn current_thread_drop_recovery(
             CREATE.to_string(),
             vec![CREATE.to_string(), SWITCH.to_string()],
             format!(
-                "No other thread exists yet. Create one with `{CREATE}`, switch to it, then retry `heddle thread drop {current}`."
+                "No other thread exists yet. Create one with `{CREATE}`, switch to it, then retry `{retry}`."
             ),
         )
     }
@@ -2992,7 +3021,8 @@ pub(crate) fn cmd_thread_delete(cli: &Cli, repo: &Repository, name: String) -> R
     if let Head::Attached { thread } = repo.head_ref()?
         && thread == name
     {
-        let (primary, recovery, hint) = current_thread_drop_recovery(repo, &name);
+        let (primary, recovery, hint) =
+            current_thread_drop_recovery(repo, &name, DropMode::DeleteThread);
         return Err(anyhow!(RecoveryAdvice::safety_refusal(
             "branch_delete_current",
             format!("Refusing to delete current thread '{name}'"),

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -810,16 +810,18 @@ fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice
     )
 }
 
-fn current_thread_drop_advice(thread_id: &str) -> RecoveryAdvice {
+fn current_thread_drop_advice(repo: &Repository, thread_id: &str) -> RecoveryAdvice {
+    let (primary, recovery, hint) =
+        super::thread::current_thread_drop_recovery(repo, thread_id);
     RecoveryAdvice::safety_refusal(
         "current_thread_not_droppable",
         format!("Thread '{thread_id}' is the current checkout thread and cannot be dropped"),
-        "Use `heddle thread list` to inspect isolated threads that can be dropped.",
+        hint,
         format!("drop thread was requested for the attached checkout thread '{thread_id}'"),
         "dropping the current checkout would remove the thread that owns this working tree",
         "no thread refs, checkout directories, mounts, or agent reservations were changed",
-        "heddle thread list",
-        vec!["heddle thread list".to_string()],
+        primary,
+        recovery,
     )
 }
 
@@ -1196,7 +1198,7 @@ pub(crate) fn drop_thread_silent(
     let manager = thread_manager(repo);
     let Some(mut thread) = manager.load(thread_id)? else {
         if !delete_thread && repo.current_lane()?.as_deref() == Some(thread_id) {
-            return Err(anyhow!(current_thread_drop_advice(thread_id)));
+            return Err(anyhow!(current_thread_drop_advice(repo, thread_id)));
         }
         if delete_thread {
             return Ok(DropOutcome::Deleted);

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -811,8 +811,11 @@ fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice
 }
 
 fn current_thread_drop_advice(repo: &Repository, thread_id: &str) -> RecoveryAdvice {
-    let (primary, recovery, hint) =
-        super::thread::current_thread_drop_recovery(repo, thread_id);
+    let (primary, recovery, hint) = super::thread::current_thread_drop_recovery(
+        repo,
+        thread_id,
+        super::thread::DropMode::Drop,
+    );
     RecoveryAdvice::safety_refusal(
         "current_thread_not_droppable",
         format!("Thread '{thread_id}' is the current checkout thread and cannot be dropped"),

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6109,6 +6109,13 @@ fn thread_drop_current_recovery_points_to_create_when_no_sibling() {
     );
     assert_eq!(envelope["primary_command"], "heddle thread create <other>");
 
+    // Plain `thread drop` keeps its plain retry — the destructive
+    // `--delete-thread` flag must NOT leak into the non-destructive mode.
+    assert!(
+        hint.contains("heddle thread drop main") && !hint.contains("--delete-thread"),
+        "plain drop recovery should suggest the plain retry, not the destructive form: {stderr}"
+    );
+
     let templates = envelope["recovery_action_templates"]
         .as_array()
         .expect("recovery_action_templates should be an array");
@@ -6125,6 +6132,106 @@ fn thread_drop_current_recovery_points_to_create_when_no_sibling() {
             .as_array()
             .is_some_and(|argv| argv.iter().any(|arg| arg == "<other>")),
         "create template should mark <other> as a fillable slot: {stderr}"
+    );
+}
+
+/// heddle#258 r2 (cid 3327829289): when the user asks for the destructive
+/// `thread drop --delete-thread` on the current (lightweight, no-record)
+/// ref, the recovery retry hint must PRESERVE `--delete-thread`. The r1
+/// hint hardcoded a bare `heddle thread drop {current}`, which on retry
+/// re-enters with `manager.load == None && delete_thread == false` and
+/// dead-ends at `thread_not_found` — the user's destructive intent is lost.
+#[test]
+fn thread_drop_delete_thread_current_recovery_preserves_delete_flag() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let output = heddle_output(
+        &["--output", "json", "thread", "drop", "main", "--delete-thread"],
+        Some(temp.path()),
+    )
+    .expect("invoke destructive current thread drop");
+    assert!(
+        !output.status.success(),
+        "destructive current thread drop should still refuse"
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("destructive drop should emit JSON envelope");
+    assert_eq!(envelope["kind"], "branch_delete_current");
+
+    let hint = envelope["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("heddle thread drop main --delete-thread"),
+        "destructive drop recovery must preserve --delete-thread so a lightweight ref is removed on retry: {stderr}"
+    );
+    assert!(
+        !hint.contains("heddle thread list"),
+        "hint must not loop back to the circular `thread list`: {stderr}"
+    );
+}
+
+/// Same class via the `branch -d` entry point — it rewrites to a
+/// `--delete-thread` drop, so its recovery hint must also carry the
+/// destructive mode (close-the-class: both entries share one helper).
+#[test]
+fn branch_delete_current_recovery_preserves_delete_mode() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let output = heddle_output(
+        &["--output", "json", "branch", "-d", "main"],
+        Some(temp.path()),
+    )
+    .expect("invoke current branch delete");
+    assert!(!output.status.success(), "current branch delete should refuse");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("branch delete should emit JSON envelope");
+    assert_eq!(envelope["kind"], "branch_delete_current");
+
+    let hint = envelope["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("--delete-thread"),
+        "branch -d recovery must preserve the ref-deleting mode on retry: {stderr}"
+    );
+}
+
+/// End-to-end: after following the create+switch advice, the SUGGESTED
+/// destructive retry must actually remove the lightweight ref (not
+/// dead-end at `thread_not_found`).
+#[test]
+fn thread_drop_delete_thread_recovery_retry_actually_deletes_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    // Refused while `main` is the current checkout.
+    let refused = heddle_output(
+        &["--output", "json", "thread", "drop", "main", "--delete-thread"],
+        Some(temp.path()),
+    )
+    .expect("invoke destructive current thread drop");
+    assert!(!refused.status.success());
+
+    // Follow the advice: create a sibling and switch to it.
+    heddle(&["thread", "create", "feature"], Some(temp.path()))
+        .expect("create a sibling thread");
+    heddle(&["thread", "switch", "feature"], Some(temp.path()))
+        .expect("switch to the sibling thread");
+
+    // The SUGGESTED retry (mode preserved) must now succeed.
+    heddle(
+        &["thread", "drop", "main", "--delete-thread"],
+        Some(temp.path()),
+    )
+    .expect("suggested destructive retry should delete the lightweight ref");
+
+    let listed = json_value(temp.path(), &["thread", "list", "--output", "json"]);
+    assert!(
+        listed["threads"]
+            .as_array()
+            .is_some_and(|threads| threads.iter().all(|thread| thread["name"] != "main")),
+        "the lightweight `main` ref should be gone after the suggested retry: {listed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -4877,12 +4877,31 @@ fn branch_delete_current_refuses_with_typed_advice() {
             .is_some_and(|error| error.contains("Refusing to delete current thread")),
         "error should explain the unsafe branch delete: {envelope}"
     );
+    // The recovery is to switch/create a sibling thread first, never the
+    // circular `heddle thread list` that loops a junior (heddle#258).
     assert!(
         envelope["hint"]
             .as_str()
-            .is_some_and(|hint| hint.contains("heddle thread list")),
-        "hint should name the primary recovery command: {envelope}"
+            .is_some_and(|hint| hint.contains("heddle thread create <other>")),
+        "hint should name a non-circular recovery command: {envelope}"
     );
+    assert!(
+        envelope["hint"]
+            .as_str()
+            .is_some_and(|hint| !hint.contains("heddle thread list")),
+        "hint must not loop back to the circular `thread list`: {envelope}"
+    );
+    let templates = envelope["recovery_action_templates"]
+        .as_array()
+        .expect("recovery_action_templates should be an array");
+    let create = templates
+        .iter()
+        .find(|template| {
+            template["argv_template"]
+                == heddle_argv_json(["thread", "create", "<other>"])
+        })
+        .unwrap_or_else(|| panic!("create recovery template should be present: {envelope}"));
+    assert_eq!(create["agent_may_fill"], Value::Bool(true));
 }
 
 #[test]
@@ -6058,6 +6077,107 @@ fn thread_drop_current_checkout_refuses_instead_of_claiming_missing() {
         "current thread drop should refuse with the real reason: {stderr}"
     );
     assert_json_recovery_advice_fields(&envelope, &envelope.to_string());
+}
+
+#[test]
+fn thread_drop_current_recovery_points_to_create_when_no_sibling() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let output = heddle_output(
+        &["--output", "json", "thread", "drop", "main"],
+        Some(temp.path()),
+    )
+    .expect("invoke current thread drop");
+    assert!(!output.status.success(), "current thread drop should fail");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("current thread drop should emit JSON envelope");
+    assert_eq!(envelope["kind"], "current_thread_not_droppable");
+
+    // The circular `heddle thread list` hint is gone: with no sibling
+    // thread to switch to, the recovery is to create one, switch to it,
+    // then retry the drop (heddle#258).
+    let hint = envelope["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("heddle thread create <other>"),
+        "hint should suggest creating a sibling thread: {stderr}"
+    );
+    assert!(
+        !hint.contains("heddle thread list"),
+        "hint must not loop back to the circular `thread list`: {stderr}"
+    );
+    assert_eq!(envelope["primary_command"], "heddle thread create <other>");
+
+    let templates = envelope["recovery_action_templates"]
+        .as_array()
+        .expect("recovery_action_templates should be an array");
+    let create = templates
+        .iter()
+        .find(|template| {
+            template["argv_template"]
+                == heddle_argv_json(["thread", "create", "<other>"])
+        })
+        .unwrap_or_else(|| panic!("create recovery template should be present: {stderr}"));
+    assert_eq!(create["agent_may_fill"], Value::Bool(true));
+    assert!(
+        create["argv_template"]
+            .as_array()
+            .is_some_and(|argv| argv.iter().any(|arg| arg == "<other>")),
+        "create template should mark <other> as a fillable slot: {stderr}"
+    );
+}
+
+#[test]
+fn thread_drop_current_recovery_points_to_switch_when_sibling_exists() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["thread", "create", "feature"], Some(temp.path()))
+        .expect("create a sibling thread");
+
+    let output = heddle_output(
+        &["--output", "json", "thread", "drop", "main"],
+        Some(temp.path()),
+    )
+    .expect("invoke current thread drop");
+    assert!(!output.status.success(), "current thread drop should fail");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("current thread drop should emit JSON envelope");
+    assert_eq!(envelope["kind"], "current_thread_not_droppable");
+
+    // A sibling thread exists, so the recovery is to switch to it first
+    // (creating a fresh one stays available as a secondary path).
+    let hint = envelope["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("heddle thread switch <other>"),
+        "hint should suggest switching to a sibling thread first: {stderr}"
+    );
+    assert!(
+        !hint.contains("heddle thread list"),
+        "hint must not loop back to the circular `thread list`: {stderr}"
+    );
+    assert_eq!(envelope["primary_command"], "heddle thread switch <other>");
+
+    let templates = envelope["recovery_action_templates"]
+        .as_array()
+        .expect("recovery_action_templates should be an array");
+    let switch = templates
+        .iter()
+        .find(|template| {
+            template["argv_template"]
+                == heddle_argv_json(["thread", "switch", "<other>"])
+        })
+        .unwrap_or_else(|| panic!("switch recovery template should be present: {stderr}"));
+    assert_eq!(switch["agent_may_fill"], Value::Bool(true));
+    // Both recovery paths are exposed so machine callers can choose.
+    assert!(
+        templates.iter().any(|template| {
+            template["argv_template"]
+                == heddle_argv_json(["thread", "create", "<other>"])
+        }),
+        "create recovery template should also be present: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `heddle thread drop <current>` (and the `--delete-thread`/`branch -d` path) refused with `Next: heddle thread list`, which loops a junior who sees only the current thread. Now it points at the real fix: switch to a sibling thread first, or create one when none exists, then retry the drop.
- Recovery is context-aware: primary is `heddle thread switch <other>` when a sibling thread exists, otherwise `heddle thread create <other>`. Both paths are always exposed in `recovery_action_templates`.
- Registered `heddle thread switch <other>` and `heddle thread create <other>` in `RECOMMENDED_ACTION_TEMPLATES` with the `<other>` slot `agent_may_fill: true` (consumes the #254 canonical template shape).
- Closed the bug class: both sibling refusal sites (`current_thread_drop_advice` in `thread_cmd.rs` and `cmd_thread_delete` `branch_delete_current` in `thread.rs`) now route through one shared `current_thread_drop_recovery` helper.

Closes HeddleCo/heddle#258

## Red commit
`fb8fd4d`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- thread_drop_current_recovery branch_delete_current_refuses
running 3 tests
test oss_cli_polish::branch_delete_current_refuses_with_typed_advice ... ok
test oss_cli_polish::thread_drop_current_recovery_points_to_create_when_no_sibling ... ok
test oss_cli_polish::thread_drop_current_recovery_points_to_switch_when_sibling_exists ... ok
test result: ok. 3 passed; 0 failed; ...

$ cargo test -p heddle-cli --test cli_integration
test result: ok. 818 passed; 0 failed; 15 ignored; ...

$ cargo clippy --workspace --all-targets -- -D warnings
Finished (clean)

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code

$ heddle doctor docs --all   → no drift found across 56 file(s)
$ heddle doctor schemas      → No registered-schema/documented-sample drift detected.
```

## Manual verification
```
$ heddle init && heddle thread drop main
Error: Thread 'main' is the current checkout thread and cannot be dropped
Next: heddle thread create <other>
Also: heddle thread switch <other>

$ heddle thread create feature && heddle thread drop main
Error: Thread 'main' is the current checkout thread and cannot be dropped
Next: heddle thread switch <other>
Also: heddle thread create <other>
```

## Blocked by → resolved
N/A — #254 (the consumed template shape) is already closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782698032&installation_id=132405951&pr_number=337&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F337&signature=9dfea112ae8a48fabfb46e7e66ef2937bd97819418c1b5157eb4c811730549f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->