### PR TITLE
heddle#308: reshape worktree diff --output json to category arrays

### DIFF
--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -416,7 +416,14 @@ pub fn cmd_diff(
     }
 
     if json {
-        println!("{}", serde_json::to_string(&output)?);
+        // Worktree-mode diff (`to.is_none()`) groups `changes` into
+        // `{modified, added, deleted}` category arrays mirroring `status`;
+        // a state-to-state diff keeps the flat array.
+        if to.is_none() {
+            println!("{}", worktree_diff_json_string(&output)?);
+        } else {
+            println!("{}", serde_json::to_string(&output)?);
+        }
     } else if name_only {
         for change in &output.changes {
             println!("{}", change.path);
@@ -454,6 +461,52 @@ fn populate_patch_text(output: &mut DiffOutput) {
     if !text.is_empty() {
         output.patch = Some(text);
     }
+}
+
+/// Serialize a worktree-mode diff to JSON with the per-file `changes`
+/// grouped into `{modified, added, deleted}` category arrays, mirroring the
+/// `status` command's `changes` shape (see `StatusOutput`'s `ChangesInfo`)
+/// so a UI can derive add/modify/delete badges from `diff` alone — one
+/// concept, one shape across the two verbs.
+///
+/// Only worktree-mode diff regroups; a state-to-state diff (`diff <a> <b>`)
+/// keeps the flat `changes: [...]` array (its embedders, e.g. `merge
+/// --with-diff`, depend on that). A `renamed` entry buckets under
+/// `modified` — it is an existing file whose identity changed, and its
+/// `kind`/`old_path` fields are retained so a consumer that wants the rename
+/// detail still has it — keeping exactly the three status field names rather
+/// than introducing a divergent fourth bucket.
+fn worktree_diff_json_string(output: &DiffOutput) -> Result<String> {
+    let mut value = serde_json::to_value(output)?;
+    if let serde_json::Value::Object(map) = &mut value {
+        map.insert(
+            "changes".to_string(),
+            group_changes_by_category(&output.changes),
+        );
+    }
+    Ok(serde_json::to_string(&value)?)
+}
+
+/// Bucket each `FileChange` under its add/modify/delete category, serialized
+/// with all its per-file fields. `renamed` (and any non-add/delete kind)
+/// lands in `modified`.
+fn group_changes_by_category(changes: &[FileChange]) -> serde_json::Value {
+    let mut modified = Vec::new();
+    let mut added = Vec::new();
+    let mut deleted = Vec::new();
+    for change in changes {
+        let entry = serde_json::to_value(change).unwrap_or(serde_json::Value::Null);
+        match change.kind.as_str() {
+            "added" => added.push(entry),
+            "deleted" => deleted.push(entry),
+            _ => modified.push(entry),
+        }
+    }
+    let mut map = serde_json::Map::new();
+    map.insert("modified".to_string(), serde_json::Value::Array(modified));
+    map.insert("added".to_string(), serde_json::Value::Array(added));
+    map.insert("deleted".to_string(), serde_json::Value::Array(deleted));
+    serde_json::Value::Object(map)
 }
 
 /// Order a state-to-state change list deterministically by path. `diff_trees`
@@ -525,7 +578,9 @@ fn render_status_changes(
     }
 
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        // HEAD-vs-worktree (plain-Git) is a worktree-mode diff: group
+        // `changes` into `{modified, added, deleted}` to mirror `status`.
+        println!("{}", worktree_diff_json_string(&output)?);
     } else if name_only {
         for change in &output.changes {
             println!("{}", change.path);
@@ -901,7 +956,9 @@ fn render_worktree_status_diff(
     }
 
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        // HEAD-vs-worktree status diff is worktree-mode: group `changes`
+        // into `{modified, added, deleted}` to mirror `status`.
+        println!("{}", worktree_diff_json_string(&output)?);
     } else if name_only {
         for change in &output.changes {
             println!("{}", change.path);

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -992,7 +992,12 @@ pub struct DiffSchema {
     pub to_state: Option<String>,
     pub changed_path_count: usize,
     pub stats: DiffStatsSchema,
-    pub changes: Vec<Value>,
+    /// Worktree-mode diff (`heddle diff` with no revision args) groups the
+    /// per-file changes into `{modified, added, deleted}` category arrays,
+    /// mirroring the `status` command's `changes` shape so a UI can derive
+    /// add/modify/delete badges from `diff` alone. A state-to-state diff
+    /// (`heddle diff <a> <b>`) instead emits a flat `array<object>` here.
+    pub changes: DiffChangesSchema,
     pub semantic_changes: Option<Vec<Value>>,
     pub context: Option<Vec<Value>>,
     pub broader_guidance: Option<Vec<Value>>,
@@ -1000,6 +1005,18 @@ pub struct DiffSchema {
     /// Present whenever line-level hunks exist, regardless of the
     /// `--patch` CLI flag — JSON consumers always get a parseable diff.
     pub patch: Option<String>,
+}
+
+/// Worktree-mode `changes`: per-file diff entries bucketed by category,
+/// mirroring the `status` command's `{modified, added, deleted}` field
+/// names. Each entry carries its path plus the per-file diff fields
+/// (`kind`, `old_path`, `lines`, …). A `renamed` entry buckets under
+/// `modified` (its `kind`/`old_path` identify the rename).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiffChangesSchema {
+    pub modified: Vec<Value>,
+    pub added: Vec<Value>,
+    pub deleted: Vec<Value>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1007,13 +1007,27 @@ pub struct DiffSchema {
     pub patch: Option<String>,
 }
 
-/// Worktree-mode `changes`: per-file diff entries bucketed by category,
-/// mirroring the `status` command's `{modified, added, deleted}` field
-/// names. Each entry carries its path plus the per-file diff fields
-/// (`kind`, `old_path`, `lines`, …). A `renamed` entry buckets under
-/// `modified` (its `kind`/`old_path` identify the rename).
+/// `changes` admits the two documented shapes the `diff` command emits:
+/// worktree mode (`heddle diff` with no revision args) groups entries into
+/// `{modified, added, deleted}` category arrays; a state-to-state diff
+/// (`heddle diff <a> <b>`) emits a flat `array<object>`. The schema is a
+/// union of both so either documented output validates.
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct DiffChangesSchema {
+#[serde(untagged)]
+#[allow(dead_code)]
+pub enum DiffChangesSchema {
+    /// Worktree-mode: per-file diff entries bucketed by category, mirroring
+    /// the `status` command's `{modified, added, deleted}` field names. Each
+    /// entry carries its path plus the per-file diff fields (`kind`,
+    /// `old_path`, `lines`, …). A `renamed` entry buckets under `modified`
+    /// (its `kind`/`old_path` identify the rename).
+    Grouped(DiffChangesGroupedSchema),
+    /// State-to-state: a flat array of per-file diff entries.
+    Flat(Vec<Value>),
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiffChangesGroupedSchema {
     pub modified: Vec<Value>,
     pub added: Vec<Value>,
     pub deleted: Vec<Value>,

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -1066,12 +1066,12 @@ fn test_cli_diff_head_to_worktree_in_plain_git_repo_uses_git_overlay_baseline() 
         "diff HEAD in a plain Git repo must be observe-only"
     );
     assert!(
-        parsed["changes"]
+        parsed["changes"]["modified"]
             .as_array()
             .unwrap()
             .iter()
             .any(|change| change["path"] == "tracked.txt"),
-        "diff from HEAD should reflect tracked modification: {parsed}"
+        "diff from HEAD should reflect tracked modification under the modified category: {parsed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/diff_patch_conformance.rs
+++ b/crates/cli/tests/cli_integration/diff_patch_conformance.rs
@@ -387,25 +387,32 @@ fn json_diff_value(cwd: &Path, base: &[&str], mode: &[&str]) -> Value {
 /// a type-change split) produces a *different* signature here — which is
 /// exactly the mode-divergence class we are closing.
 fn change_signature(value: &Value) -> Vec<(String, String, String)> {
-    let mut sig: Vec<(String, String, String)> = value
-        .get("changes")
-        .and_then(Value::as_array)
-        .map(|changes| {
-            changes
-                .iter()
-                .map(|change| {
-                    let field = |key| {
-                        change
-                            .get(key)
-                            .and_then(Value::as_str)
-                            .unwrap_or("")
-                            .to_string()
-                    };
-                    (field("kind"), field("path"), field("old_path"))
-                })
-                .collect()
+    // Worktree-mode diffs group `changes` into `{modified, added, deleted}`
+    // category arrays; state-to-state diffs keep a flat array. Flatten both
+    // to the same triple list so the signature is shape-independent.
+    let entries: Vec<&Value> = match value.get("changes") {
+        Some(Value::Array(arr)) => arr.iter().collect(),
+        Some(Value::Object(map)) => ["modified", "added", "deleted"]
+            .iter()
+            .filter_map(|key| map.get(*key))
+            .filter_map(Value::as_array)
+            .flatten()
+            .collect(),
+        _ => Vec::new(),
+    };
+    let mut sig: Vec<(String, String, String)> = entries
+        .iter()
+        .map(|change| {
+            let field = |key| {
+                change
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string()
+            };
+            (field("kind"), field("path"), field("old_path"))
         })
-        .unwrap_or_default();
+        .collect();
     sig.sort();
     sig
 }

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -4303,8 +4303,10 @@ fn git_overlay_matrix_subdirectory_dirty_commands() {
 
     let diff = json(&nested, &["diff", "HEAD"]);
     assert!(
-        diff["changes"].as_array().is_some(),
-        "diff should remain well-formed after nested-path bootstrap/show/log sequencing: {diff}"
+        diff["changes"]["modified"].as_array().is_some()
+            && diff["changes"]["added"].as_array().is_some()
+            && diff["changes"]["deleted"].as_array().is_some(),
+        "diff should remain well-formed (category object) after nested-path bootstrap/show/log sequencing: {diff}"
     );
 
     let thread_list = json(&nested, &["thread", "list", "--output", "json"]);
@@ -4457,8 +4459,13 @@ fn git_overlay_matrix_manual_git_commit_after_bootstrap_commands() {
         "diagnose must not resurrect stale Heddle-vs-state paths when Git is clean but import is needed: {diagnose}"
     );
     let diff = json(temp.path(), &["diff", "--output", "json", "--stat"]);
+    let diff_changes = diff["changes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("worktree diff changes should be a category object: {diff}"));
     assert!(
-        diff["changes"].as_array().unwrap().is_empty(),
+        ["modified", "added", "deleted"]
+            .iter()
+            .all(|key| diff_changes[*key].as_array().is_some_and(|a| a.is_empty())),
         "diff must not report stale paths when Git is clean but import is needed: {diff}"
     );
 
@@ -4472,9 +4479,16 @@ fn git_overlay_matrix_manual_git_commit_after_bootstrap_commands() {
         "diagnose should show the same current Git dirty set as status under needs_import: {dirty_diagnose}"
     );
     let dirty_diff = json(temp.path(), &["diff", "--output", "json", "--stat"]);
+    let dirty_changes = dirty_diff["changes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("worktree diff changes should be a category object: {dirty_diff}"));
+    let dirty_total: usize = ["modified", "added", "deleted"]
+        .iter()
+        .filter_map(|key| dirty_changes[*key].as_array())
+        .map(Vec::len)
+        .sum();
     assert_eq!(
-        dirty_diff["changes"].as_array().unwrap().len(),
-        1,
+        dirty_total, 1,
         "diff should show the same current Git dirty set as status under needs_import: {dirty_diff}"
     );
 
@@ -5632,12 +5646,12 @@ fn git_overlay_matrix_diff_added_symlink_renders_link_target() {
 
     symlink("README.md", temp.path().join("link-to-readme")).unwrap();
     let diff = json(temp.path(), &["--output", "json", "diff"]);
-    let link_change = diff["changes"]
+    let link_change = diff["changes"]["added"]
         .as_array()
         .unwrap()
         .iter()
         .find(|change| change["path"] == "link-to-readme")
-        .unwrap_or_else(|| panic!("diff should include added symlink: {diff}"));
+        .unwrap_or_else(|| panic!("diff should include added symlink under the added category: {diff}"));
     assert_eq!(link_change["kind"], "added");
     let added_line = link_change["lines"]
         .as_array()

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8262,8 +8262,8 @@ fn isolated_thread_status_and_diff_report_untracked_only_work() {
         "isolated diff must share the same worktree observation as status: {diff}"
     );
     assert_eq!(
-        diff["changes"][0]["path"], "docs/new.md",
-        "isolated diff should list the new file without needing a tracked-file edit: {diff}"
+        diff["changes"]["added"][0]["path"], "docs/new.md",
+        "isolated diff should list the new file under the added category without needing a tracked-file edit: {diff}"
     );
 }
 

--- a/crates/cli/tests/core_functionality/diff_and_status.rs
+++ b/crates/cli/tests/core_functionality/diff_and_status.rs
@@ -52,6 +52,81 @@ fn test_diff_between_arbitrary_states() {
 }
 
 #[test]
+fn test_diff_worktree_json_groups_changes_by_category() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("modified.txt"), "original\n").unwrap();
+    std::fs::write(temp.path().join("delete.txt"), "remove me\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Initial"], temp.path());
+
+    std::fs::write(temp.path().join("modified.txt"), "changed\n").unwrap();
+    std::fs::remove_file(temp.path().join("delete.txt")).unwrap();
+    std::fs::write(temp.path().join("added.txt"), "brand new\n").unwrap();
+
+    let json = heddle(&["diff", "--output", "json"], Some(temp.path())).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json)
+        .unwrap_or_else(|_| panic!("worktree diff should emit JSON. Got: {json}"));
+
+    // A consumer must derive add/modify/delete from `diff` alone: `changes`
+    // is a category object, not a flat array.
+    let changes = parsed["changes"].as_object().unwrap_or_else(|| {
+        panic!("worktree diff `changes` should be a category object, not a flat array. Got: {json}")
+    });
+    assert!(
+        changes.contains_key("modified")
+            && changes.contains_key("added")
+            && changes.contains_key("deleted"),
+        "changes must mirror the status command's {{modified,added,deleted}} shape. Got: {json}"
+    );
+
+    let paths = |key: &str| -> Vec<String> {
+        changes[key]
+            .as_array()
+            .unwrap_or_else(|| panic!("changes.{key} should be an array. Got: {json}"))
+            .iter()
+            .map(|entry| entry["path"].as_str().unwrap_or_default().to_string())
+            .collect()
+    };
+    assert_eq!(paths("modified"), vec!["modified.txt".to_string()], "{json}");
+    assert_eq!(paths("added"), vec!["added.txt".to_string()], "{json}");
+    assert_eq!(paths("deleted"), vec!["delete.txt".to_string()], "{json}");
+}
+
+#[test]
+fn test_diff_worktree_changes_shape_matches_status() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "original\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Initial"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "changed\n").unwrap();
+
+    let diff_json = heddle(&["diff", "--output", "json"], Some(temp.path())).unwrap();
+    let status_json = heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
+    let diff: serde_json::Value = serde_json::from_str(&diff_json).unwrap();
+    let status: serde_json::Value = serde_json::from_str(&status_json).unwrap();
+
+    let mut diff_keys: Vec<String> = diff["changes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("diff changes should be an object. Got: {diff_json}"))
+        .keys()
+        .cloned()
+        .collect();
+    let mut status_keys: Vec<String> = status["changes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("status changes should be an object. Got: {status_json}"))
+        .keys()
+        .cloned()
+        .collect();
+    diff_keys.sort();
+    status_keys.sort();
+    assert_eq!(
+        diff_keys, status_keys,
+        "diff and status `changes` must share the same category field names. \
+         diff={diff_json}\nstatus={status_json}"
+    );
+}
+
+#[test]
 fn test_diff_with_deletions() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
@@ -85,25 +160,34 @@ fn test_diff_stat_detects_clear_rename_with_small_edit() {
     let json = heddle(&["diff", "--stat", "--output", "json"], Some(temp.path())).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json)
         .unwrap_or_else(|_| panic!("diff --stat should emit JSON in tests. Got: {json}"));
+    // Worktree-mode diff groups `changes` into {modified, added, deleted};
+    // a collapsed rename buckets under `modified` (it is an existing file
+    // whose identity changed, with `old_path`/`kind` carrying the detail).
     let changes = parsed["changes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("worktree changes should be a category object. Got: {json}"));
+    let modified = changes["modified"]
         .as_array()
-        .unwrap_or_else(|| panic!("changes should be an array. Got: {json}"));
+        .unwrap_or_else(|| panic!("changes.modified should be an array. Got: {json}"));
     assert_eq!(
-        changes.len(),
+        modified.len(),
         1,
-        "rename should collapse add/delete: {json}"
+        "rename should collapse add/delete into one modified-bucket entry: {json}"
     );
-    assert_eq!(
-        changes[0]["kind"], "renamed",
-        "expected renamed row: {json}"
+    let entry = &modified[0];
+    assert_eq!(entry["kind"], "renamed", "expected renamed row: {json}");
+    assert_eq!(entry["old_path"], "src/renamed.txt");
+    assert_eq!(entry["path"], "src/final-name.txt");
+    assert!(
+        changes["added"].as_array().is_some_and(|a| a.is_empty())
+            && changes["deleted"].as_array().is_some_and(|a| a.is_empty()),
+        "collapsed rename must not leave stray add/delete entries: {json}"
     );
-    assert_eq!(changes[0]["old_path"], "src/renamed.txt");
-    assert_eq!(changes[0]["path"], "src/final-name.txt");
     assert_eq!(parsed["changed_path_count"], 1);
     assert_eq!(parsed["stats"]["files_changed"], 1);
     assert_eq!(parsed["stats"]["renames"], 1);
     assert!(
-        changes[0].get("lines").is_none(),
+        entry.get("lines").is_none(),
         "diff --stat JSON should be a stat payload, not a hunk payload: {json}"
     );
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -589,6 +589,27 @@ state and worktree/default comparison target.
 
 ### Sample
 
+Worktree-mode diff (`heddle diff` with no revision args) groups the
+per-file changes into `{modified, added, deleted}` category arrays,
+mirroring the `status` command's `changes` shape so a UI can derive
+add/modify/delete badges from `diff` alone:
+
+```json
+{
+  "output_kind": "diff",
+  "from_state": "hd-base123",
+  "to_state": null,
+  "changes": {
+    "modified": [{"path": "src/lib.rs", "kind": "modified"}],
+    "added": [{"path": "src/new.rs", "kind": "added"}],
+    "deleted": [{"path": "src/old.rs", "kind": "deleted"}]
+  }
+}
+```
+
+A state-to-state diff (`heddle diff <a> <b>`) instead emits `changes` as a
+flat `array<object>` (the shape `merge --with-diff` embeds):
+
 ```json
 {
   "output_kind": "diff",
@@ -602,8 +623,8 @@ state and worktree/default comparison target.
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
-| `from_state`, `to_state` | string \| null | required | State identifiers resolved for the comparison. |
-| `changes` | array<object> | required | Structured file-level or semantic changes. Empty when there are no changes. |
+| `from_state`, `to_state` | string \| null | required | State identifiers resolved for the comparison. Worktree-mode diffs leave `to_state` null. |
+| `changes` | object \| array<object> | required | Worktree mode: `{modified, added, deleted}` category arrays (each entry carries `path`, `kind`, and the other per-file diff fields; a `renamed` entry buckets under `modified`). State-to-state mode: a flat `array<object>` of file-level or semantic changes. Empty when there are no changes. |
 | `semantic_changes` | array<object> \| null | optional | Semantic diff entries when semantic analysis is requested and available. |
 | `context`, `broader_guidance` | array<object> \| null | optional | Context snippets and broader guidance when requested. |
 


### PR DESCRIPTION
## Summary

Closes #308. Worktree-mode `diff --output json` now emits the per-file
`changes` as `{modified, added, deleted}` category arrays, mirroring the
`status` command's `changes` shape. A UI can now derive add/modify/delete
badges from `diff` alone — one concept, one shape across the two verbs.

- Each entry keeps its `path` plus the per-file diff fields (`kind`, `old_path`, `lines`, …). A `renamed` entry buckets under `modified` (its `kind`/`old_path` carry the rename detail), so the object carries exactly the three `status` field names rather than a divergent fourth bucket.
- **Only worktree mode regroups.** State-to-state diffs (`heddle diff <a> <b>`) keep the flat `changes: [...]` array that their embedders (e.g. `merge --with-diff`) depend on. Pre-1.0, so reshaped directly with no backcompat shim.
- All three worktree-mode JSON emit paths regroup: the main `cmd_diff` worktree branch, the plain-Git HEAD-vs-worktree path, and the HEAD-vs-worktree status-diff path.

## Implementation

- `diff_compute.rs`: `worktree_diff_json_string` serializes a `DiffOutput` and replaces `changes` with the grouped object via `group_changes_by_category`. `DiffOutput` itself is unchanged, so patch rendering / stats / state-to-state / merge-embedded diffs are untouched.
- `schemas.rs`: new `DiffChangesSchema`; `DiffSchema.changes` documents the worktree grouped shape and notes the state-to-state array variant (diff section only — `status` schema untouched).
- `docs/json-schemas.md`: diff section now shows both the worktree grouped sample and the state-to-state array sample, with an updated field table.

## Test plan

- [x] Red→green: new `test_diff_worktree_json_groups_changes_by_category` + `test_diff_worktree_changes_shape_matches_status` (asserts diff's `changes` keys == status's). Red commit `ae26144`, green `e3a262b`.
- [x] Updated the existing worktree-mode consumers (rename `--stat` test, patch-conformance `change_signature` now shape-independent, plain-git/isolated/nested-path matrix cells).
- [x] State-to-state diff + `merge --with-diff` JSON unaffected (still flat array — covered by existing tests).
- [x] `cargo test -p heddle-cli --test cli_integration` (823 pass), `cargo test --workspace` (all green), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `bash scripts/check-no-silent-default-tree-load.sh` (clean).
- [x] `heddle doctor docs --all` and `heddle doctor schemas` both report **no drift** (diff JSON contract + schema gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782708178&installation_id=132405951&pr_number=348&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F348&signature=981fb917640bff07f516229a27bd0fc0a968cece4228d11c490414db0bb8f0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->