### PR TITLE
heddle#231: feat(cli) — heddle init --quickstart one-command first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ Prerequisites: Rust 1.85+, `cargo`, `rustfmt`, `clippy`.
 
 ## Quickstart
 
+New to Heddle? One command takes a fresh directory to a first
+checkpointed change:
+
+```bash
+heddle init --quickstart --principal-name "Ada Lovelace" --principal-email ada@example.com
+```
+
+This initializes the repository, records your identity, starts a
+`quickstart` thread, makes one capture, and — in a Git-overlay repo —
+one matching Git checkpoint. Run it interactively without the
+`--principal-*` flags and Heddle prompts for your name and email; pass
+`--quickstart-thread <name>` to name the thread something other than
+`quickstart`. It finishes by pointing you at `heddle log` so you can see
+the change it just recorded. (`heddle status` on a freshly-initialized
+repo with no history suggests this command too.)
+
+### The verb-by-verb tour
+
+If you would rather drive each step yourself:
+
 ```bash
 # In an ordinary Git repo: inspect, adopt, and verify
 heddle status

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -8,6 +8,7 @@ Examples:
   heddle init                                  # initialize the current directory
   heddle init my-project                       # initialize a subdirectory
   heddle init --principal-name 'Ada Lovelace'  # set attribution at init time
+  heddle init --quickstart                     # init, identity, first capture + checkpoint in one step
 ")]
 pub struct InitArgs {
     /// Directory to initialize (default: current directory).
@@ -20,6 +21,21 @@ pub struct InitArgs {
     /// Principal email for attribution.
     #[arg(long)]
     pub principal_email: Option<String>,
+
+    /// Walk from a fresh directory to a first checkpointed commit in one
+    /// command: after the normal init steps, resolve identity, start a
+    /// thread, make one capture, and (on Git-overlay repos) one checkpoint.
+    #[arg(long)]
+    pub quickstart: bool,
+
+    /// Name for the thread `--quickstart` starts (default: `quickstart`).
+    #[arg(long, value_name = "NAME")]
+    pub quickstart_thread: Option<String>,
+
+    /// Skip the `--quickstart` confirmation gate before writing into a
+    /// directory that already has Heddle data or non-empty Git history.
+    #[arg(long)]
+    pub yes: bool,
 
     /// Install harness integrations after init.
     #[arg(long)]

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -638,6 +638,21 @@ fn quickstart_preflight(
         ));
     }
 
+    // A Git-overlay quickstart attaches the requested thread to the CURRENT
+    // state and write-through-points `refs/heads/<thread>` at it. If a `<thread>`
+    // Git branch already exists at a DIVERGENT tip (the checkout is on another
+    // branch), that write would silently move the user's branch onto the current
+    // branch's commit — data loss. Refuse here, before any write, when it would
+    // actually move the branch; the idempotent case (already on `<thread>`) and
+    // a quickstart-owned rerun where the tip already matches are not clobbers
+    // (cid 3335757978).
+    if is_git_overlay
+        && git_has_commits(root)
+        && git_quickstart_branch_would_be_clobbered(root, thread)
+    {
+        bail!(quickstart_thread_branch_collision_advice(thread));
+    }
+
     // Confirmation gate before touching a directory that already holds
     // work. Truly fresh directories skip straight through.
     let heddle_exists = root.join(".heddle").exists();
@@ -907,6 +922,39 @@ fn git_has_commits(path: &Path) -> bool {
     false
 }
 
+/// Whether running quickstart would CLOBBER a pre-existing Git branch named
+/// `thread` by silently moving it. After `import_all`, `ensure_quickstart_thread`
+/// repoints the `thread` Heddle thread to the CURRENT state and
+/// `write_through_thread_checkout` writes that back to `refs/heads/<thread>`. If
+/// the checkout is on a DIFFERENT branch and a `<thread>` branch already exists
+/// at a divergent tip, that write would move the user's branch to the current
+/// branch's commit — silent data loss (cid 3335757978).
+///
+/// Read-only: probes refs via `gix` without opening the Heddle repo. Returns
+/// `true` only when the branch exists AND its tip is NOT the commit quickstart
+/// would repoint it to (the current HEAD commit) — so the idempotent case
+/// (already on `<thread>`, tip == HEAD) and the absent-branch case do not refuse.
+fn git_quickstart_branch_would_be_clobbered(path: &Path, thread: &str) -> bool {
+    let Ok(repo) = gix::discover(path) else {
+        return false;
+    };
+    let Ok(Some(mut reference)) = repo.try_find_reference(&format!("refs/heads/{thread}")) else {
+        return false;
+    };
+    let Ok(branch_tip) = reference.peel_to_id() else {
+        return false;
+    };
+    // The commit quickstart would repoint `<thread>` to is the current branch's
+    // HEAD commit. If HEAD resolves to that exact commit (we are ON `<thread>`,
+    // or it already points there), no move happens — not a clobber. Anything
+    // else (a different branch, or an unborn HEAD with the branch carrying
+    // history) would move the user's branch to unrelated state — refuse.
+    match repo.head_id() {
+        Ok(head) => head.detach() != branch_tip.detach(),
+        Err(_) => true,
+    }
+}
+
 /// Whether `name` is valid as a Git BRANCH — the shorthand written under
 /// `refs/heads/` — matching `git check-ref-format --branch`. This is stricter
 /// than validating the assembled `refs/heads/<name>` full ref: a syntactically
@@ -1139,6 +1187,22 @@ fn quickstart_needs_confirmation_advice() -> RecoveryAdvice {
         "no repository objects, refs, metadata, or worktree files were changed",
         "heddle init --quickstart --yes",
         vec!["heddle init --quickstart --yes".to_string()],
+    )
+}
+
+fn quickstart_thread_branch_collision_advice(thread: &str) -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "quickstart_thread_branch_collision",
+        format!("Refusing to run --quickstart: a Git branch named '{thread}' already exists at a different commit than the current checkout"),
+        format!("Pass `--quickstart-thread <name>` to use a different thread name, or switch to '{thread}' (`git switch {thread}`) and run the normal capture flow."),
+        format!("a Git branch '{thread}' already exists and points at history unrelated to the current branch"),
+        format!("quickstart would attach the '{thread}' thread to the current branch's state and move refs/heads/{thread} onto it, silently discarding the existing branch's history"),
+        "no repository objects, refs, metadata, or worktree files were changed",
+        "heddle init --quickstart --quickstart-thread <name>",
+        vec![
+            "heddle init --quickstart --quickstart-thread <name>".to_string(),
+            format!("git switch {thread}"),
+        ],
     )
 }
 

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -96,6 +96,7 @@ struct QuickstartSummary {
 struct QuickstartPreflight {
     proceed: bool,
     persist_principal: Option<(String, String)>,
+    attachment: QuickstartAttachmentPlan,
     /// Harnesses the user agreed to connect, decided at the prompt before
     /// any write. Installed only after the repo is created so a Ctrl-C at
     /// the harness prompt leaves the directory untouched.
@@ -107,9 +108,32 @@ impl Default for QuickstartPreflight {
         Self {
             proceed: true,
             persist_principal: None,
+            attachment: QuickstartAttachmentPlan::SkipUnborn,
             harness_install: Vec::new(),
         }
     }
+}
+
+/// Pre-capture Git checkout attachment plan, computed read-only in preflight.
+///
+/// The write path must not re-discover these preconditions after bootstrap or
+/// import has already written `.heddle/`: every edge that decides whether it is
+/// safe and meaningful to call `write_through_thread_checkout` belongs here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QuickstartAttachmentPlan {
+    /// Current Git HEAD has an exportable commit state and the requested branch
+    /// is absent or already points at that commit.
+    Attach,
+    /// Current Git HEAD has no exportable state yet (fresh/unborn/orphan), so
+    /// the first capture should establish the requested thread state.
+    SkipUnborn,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QuickstartAttachmentDecision {
+    Attach,
+    SkipUnborn,
+    RefuseCollision,
 }
 
 /// The single directory a `--quickstart` operates on, resolved ONCE by
@@ -342,7 +366,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         // content — skipping the `QUICKSTART.md` placeholder and recording
         // integration files as the first state. The install decision was made
         // up front in the preflight; only the write runs here, post-capture.
-        let summary = run_quickstart_actions(&repo, &args)?;
+        let summary = run_quickstart_actions(&repo, &args, preflight.attachment)?;
         super::perform_init_install(cli, &repo, &args, &preflight.harness_install)?;
         Some(summary)
     } else {
@@ -638,20 +662,19 @@ fn quickstart_preflight(
         ));
     }
 
-    // A Git-overlay quickstart attaches the requested thread to the CURRENT
-    // state and write-through-points `refs/heads/<thread>` at it. If a `<thread>`
-    // Git branch already exists at a DIVERGENT tip (the checkout is on another
-    // branch), that write would silently move the user's branch onto the current
-    // branch's commit — data loss. Refuse here, before any write, when it would
-    // actually move the branch; the idempotent case (already on `<thread>`) and
-    // a quickstart-owned rerun where the tip already matches are not clobbers
-    // (cid 3335757978).
-    if is_git_overlay
-        && git_has_commits(root)
-        && git_quickstart_branch_would_be_clobbered(root, thread)
-    {
-        bail!(quickstart_thread_branch_collision_advice(thread));
-    }
+    // Decide the whole pre-capture Git checkout attachment path up front,
+    // read-only. This is the single gate for the attachment class: attach only
+    // when current HEAD has an exportable commit and the target branch is
+    // absent or already at that commit; skip for unborn/no-state HEADs so the
+    // first capture establishes the thread; refuse divergent target branches
+    // before any `.heddle/` writes.
+    let attachment = match quickstart_attachment_decision(root, is_git_overlay, thread) {
+        QuickstartAttachmentDecision::Attach => QuickstartAttachmentPlan::Attach,
+        QuickstartAttachmentDecision::SkipUnborn => QuickstartAttachmentPlan::SkipUnborn,
+        QuickstartAttachmentDecision::RefuseCollision => {
+            bail!(quickstart_thread_branch_collision_advice(thread));
+        }
+    };
 
     // Confirmation gate before touching a directory that already holds
     // work. Truly fresh directories skip straight through.
@@ -704,6 +727,7 @@ fn quickstart_preflight(
     Ok(QuickstartPreflight {
         proceed: true,
         persist_principal,
+        attachment,
         harness_install,
     })
 }
@@ -922,36 +946,42 @@ fn git_has_commits(path: &Path) -> bool {
     false
 }
 
-/// Whether running quickstart would CLOBBER a pre-existing Git branch named
-/// `thread` by silently moving it. After `import_all`, `ensure_quickstart_thread`
-/// repoints the `thread` Heddle thread to the CURRENT state and
-/// `write_through_thread_checkout` writes that back to `refs/heads/<thread>`. If
-/// the checkout is on a DIFFERENT branch and a `<thread>` branch already exists
-/// at a divergent tip, that write would move the user's branch to the current
-/// branch's commit — silent data loss (cid 3335757978).
+/// Read-only decision for the Git-overlay quickstart's pre-capture checkout
+/// attachment.
 ///
-/// Read-only: probes refs via `gix` without opening the Heddle repo. Returns
-/// `true` only when the branch exists AND its tip is NOT the commit quickstart
-/// would repoint it to (the current HEAD commit) — so the idempotent case
-/// (already on `<thread>`, tip == HEAD) and the absent-branch case do not refuse.
-fn git_quickstart_branch_would_be_clobbered(path: &Path, thread: &str) -> bool {
+/// After `import_all`, `ensure_quickstart_thread` may point the requested
+/// Heddle thread at the CURRENT state and `write_through_thread_checkout` would
+/// then write that state to `refs/heads/<thread>`. That is valid only when the
+/// current Git HEAD resolves to a real commit and an existing target branch is
+/// already at that same commit. An unborn/orphan current HEAD has no exportable
+/// state yet, so attachment must be deferred to the first capture. A divergent
+/// target branch must refuse before any write, because attachment would move
+/// the user's branch onto unrelated history (cid 3335757978, cid 3336080241).
+fn quickstart_attachment_decision(
+    path: &Path,
+    is_git_overlay: bool,
+    thread: &str,
+) -> QuickstartAttachmentDecision {
+    if !is_git_overlay || !path.join(".git").exists() || !git_has_commits(path) {
+        return QuickstartAttachmentDecision::SkipUnborn;
+    }
+
     let Ok(repo) = gix::discover(path) else {
-        return false;
+        return QuickstartAttachmentDecision::SkipUnborn;
+    };
+    let Ok(head) = repo.head_id() else {
+        return QuickstartAttachmentDecision::SkipUnborn;
     };
     let Ok(Some(mut reference)) = repo.try_find_reference(&format!("refs/heads/{thread}")) else {
-        return false;
+        return QuickstartAttachmentDecision::Attach;
     };
     let Ok(branch_tip) = reference.peel_to_id() else {
-        return false;
+        return QuickstartAttachmentDecision::Attach;
     };
-    // The commit quickstart would repoint `<thread>` to is the current branch's
-    // HEAD commit. If HEAD resolves to that exact commit (we are ON `<thread>`,
-    // or it already points there), no move happens — not a clobber. Anything
-    // else (a different branch, or an unborn HEAD with the branch carrying
-    // history) would move the user's branch to unrelated state — refuse.
-    match repo.head_id() {
-        Ok(head) => head.detach() != branch_tip.detach(),
-        Err(_) => true,
+    if head.detach() == branch_tip.detach() {
+        QuickstartAttachmentDecision::Attach
+    } else {
+        QuickstartAttachmentDecision::RefuseCollision
     }
 }
 
@@ -1030,7 +1060,11 @@ fn parse_objectstore_pointer(content: &str) -> Option<PathBuf> {
 /// capture, and (Git-overlay only) one checkpoint. Runs only after the
 /// preflight has confirmed and resolved identity, so every fallible
 /// prompt is already behind us.
-fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<QuickstartSummary> {
+fn run_quickstart_actions(
+    repo: &Repository,
+    args: &InitArgs,
+    attachment: QuickstartAttachmentPlan,
+) -> Result<QuickstartSummary> {
     // A Git-overlay repo that already has commits must have that history
     // imported into Heddle before a capture/checkpoint has a base to
     // build on — the same import `heddle adopt` performs. Fresh/empty
@@ -1051,31 +1085,28 @@ fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<Quicksta
     // `.heddle/HEAD = Attached{thread}` above is NOT enough: the capture and
     // checkpoint below both target `head_ref()`, and would advance the Git
     // branch while the quickstart thread stays at the imported tip, even though
-    // the output says `Thread: <thread>` (cid 3329409824). Attach the Git
-    // checkout to the thread's branch via the SAME write-through `heddle thread
-    // switch` uses, so `head_ref()` resolves to `<thread>` and the
-    // capture+checkpoint land on it. Gated on `git_has_commits` to match the
-    // import above: the write-through needs the thread's state mapped to a Git
-    // commit, which only exists once history has been imported. (The unborn
-    // case has no mapped commit yet and the capture creates the thread's root.)
-    if repo.capability() == RepositoryCapability::GitOverlay
-        && repo.root().join(".git").exists()
-        && git_has_commits(repo.root())
-    {
-        let mut bridge = GitBridge::new(repo);
-        if let WriteThroughOutcome::Skipped(reason) = bridge.write_through_thread_checkout(&thread)?
-        {
-            bail!(RecoveryAdvice::safety_refusal(
-                "quickstart_thread_checkout_skipped",
-                format!("Could not attach the Git checkout to thread '{thread}': {reason}"),
-                "Resolve the Git checkout issue and re-run `heddle init --quickstart`.",
-                reason.to_string(),
-                "quickstart would capture and checkpoint on the requested thread, but the Git checkout could not be attached to its branch",
-                "the current Heddle state was preserved",
-                "heddle init --quickstart",
-                vec!["heddle init --quickstart".to_string()],
-            ));
+    // the output says `Thread: <thread>` (cid 3329409824). The preflight has
+    // already decided whether all attachment preconditions hold; execute that
+    // plan here without re-discovering partial after-the-fact guards.
+    match attachment {
+        QuickstartAttachmentPlan::Attach => {
+            let mut bridge = GitBridge::new(repo);
+            if let WriteThroughOutcome::Skipped(reason) =
+                bridge.write_through_thread_checkout(&thread)?
+            {
+                bail!(RecoveryAdvice::safety_refusal(
+                    "quickstart_thread_checkout_skipped",
+                    format!("Could not attach the Git checkout to thread '{thread}': {reason}"),
+                    "Resolve the Git checkout issue and re-run `heddle init --quickstart`.",
+                    reason.to_string(),
+                    "quickstart would capture and checkpoint on the requested thread, but the Git checkout could not be attached to its branch",
+                    "the current Heddle state was preserved",
+                    "heddle init --quickstart",
+                    vec!["heddle init --quickstart".to_string()],
+                ));
+            }
         }
+        QuickstartAttachmentPlan::SkipUnborn => {}
     }
 
     let user_config = UserConfig::load_default().unwrap_or_default();

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -18,7 +18,7 @@ use super::{
     action_line::print_next,
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
-    snapshot::{SnapshotAgentOverrides, create_snapshot, ensure_current_state},
+    snapshot::{SnapshotAgentOverrides, create_snapshot},
 };
 use crate::{
     bridge::{
@@ -521,11 +521,22 @@ fn resolve_quickstart_identity(
 }
 
 /// Whether a real (non-placeholder) principal is already resolvable
-/// without writing one — from the environment, the user config, or, in
-/// a Git repo, Git's own `user.name`/`user.email`.
+/// without writing one. Mirrors `resolve_principal`'s precedence so the
+/// preflight never refuses a repo whose capture would in fact be
+/// attributable: environment, then the repo-level
+/// `.heddle/config.toml` `[principal]` (which outranks user and Git
+/// config in `resolve_principal`), then the user config, then — in a Git
+/// repo — Git's own `user.name`/`user.email`.
 fn quickstart_identity_available(path: &Path, has_git: bool) -> bool {
     if let Some(principal) = Principal::from_env()
         && !principal_is_unconfigured(&principal)
+    {
+        return true;
+    }
+    let repo_config_path = path.join(".heddle").join("config.toml");
+    if let Ok(repo_config) = repo::RepoConfig::load(&repo_config_path)
+        && let Some(config) = &repo_config.principal
+        && !principal_is_unconfigured(&Principal::new(&config.name, &config.email))
     {
         return true;
     }
@@ -622,19 +633,23 @@ fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<Quicksta
     })
 }
 
-/// Create the named quickstart thread at the current state and attach
-/// HEAD to it. Idempotent: a re-run that is already on the thread is a
-/// no-op. `ensure_current_state` returns the existing state for a
-/// freshly-seeded native repo without creating an extra capture.
+/// Create the named quickstart thread and attach HEAD to it. Idempotent:
+/// a re-run that is already on the thread is a no-op.
+///
+/// When a current state already exists (a freshly-seeded native repo, or
+/// a Git overlay whose history we just imported) the thread is pointed at
+/// it. An unborn Git overlay has NO current state yet: we must NOT
+/// fabricate a bootstrap snapshot here, or the quickstart would land an
+/// extra empty parent commit before `QUICKSTART.md` is even written —
+/// breaking the promised single initial capture/checkpoint. Instead we
+/// just attach HEAD to the thread; the subsequent quickstart capture
+/// creates the thread's first (root) state and advances the ref.
 fn ensure_quickstart_thread(repo: &Repository, name: &str) -> Result<()> {
     let target = ThreadName::new(name);
-    let current = ensure_current_state(
-        repo,
-        &UserConfig::load_default().unwrap_or_default(),
-        Some(format!("Bootstrap before quickstart thread {name}")),
-    )?;
-    if repo.refs().get_thread(&target)?.is_none() {
-        repo.refs().set_thread(&target, &current)?;
+    if let Some(state) = repo.current_state()?
+        && repo.refs().get_thread(&target)?.is_none()
+    {
+        repo.refs().set_thread(&target, &state.change_id)?;
     }
     let already_attached =
         matches!(repo.head_ref()?, Head::Attached { thread } if thread == target);

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -547,10 +547,8 @@ fn quickstart_identity_available(path: &Path, has_git: bool) -> bool {
         return true;
     }
     if has_git
-        && git_config_identity_with_global_fallback(path)
-            .ok()
-            .flatten()
-            .is_some()
+        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(path)
+        && !principal_is_unconfigured(&Principal::new(&identity.name, &identity.email))
     {
         return true;
     }

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -18,7 +18,7 @@ use super::{
     action_line::print_next,
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
-    snapshot::{SnapshotAgentOverrides, create_snapshot},
+    snapshot::{SnapshotAgentOverrides, create_snapshot, resolve_principal},
 };
 use crate::{
     bridge::{
@@ -419,20 +419,56 @@ fn quickstart_preflight(
     path: &Path,
     has_git: bool,
 ) -> Result<QuickstartPreflight> {
-    // Resolve the repo's on-disk config the way `Repository::open` does
-    // (following an objectstore pointer to the shared dir for a materialized
-    // checkout) so the confirmation prompt's format matches the final
-    // render. A repo whose `[output].format` is `json` must not get a text
-    // prompt before a JSON envelope.
-    let repo_config = resolve_existing_repo_config(path);
-    let json = should_output_json(cli, repo_config.as_ref());
+    // The quickstart preflight is a DRY-RUN of the real init/identity path:
+    // every viability decision below delegates to the SAME predicate the
+    // write path uses — repository capability via `Repository::open`, identity
+    // via `resolve_principal`, the thread name via the ref/branch validators,
+    // and the harness scope via the install path's `IntegrationScope::parse`
+    // — never a parallel hand-rolled re-implementation. A parallel copy
+    // inevitably diverges (a new repo-state, identity source, or argument case
+    // passes preflight then fails at write); delegating makes that impossible.
 
-    // A detached Git HEAD has no branch for the checkpoint to advance.
-    // `create_git_checkpoint` refuses it, but only AFTER the import/capture
-    // have written `.heddle/` state — leaving a half-initialized repo.
-    // Refuse here, before any write, so a detached HEAD leaves the directory
-    // exactly as it was found.
-    if has_git && git_head_is_detached(path) {
+    // Open the repository the write path will operate on, when it already
+    // exists, so capability + identity come from the real repo (following an
+    // objectstore pointer to the shared dir, honoring the on-disk config)
+    // rather than a `gix::discover` probe. `Repository::open` decides
+    // native-vs-Git-overlay from `.git` AT the repo root, so a native repo
+    // nested inside an ancestor Git checkout stays native here — exactly as
+    // the capture treats it (unlike `gix::discover`, which walks to the
+    // ancestor and reports Git). A fresh directory has no repo to open yet;
+    // the write path then picks a Git overlay iff `gix::discover` finds Git
+    // (the `has_git` flag), so mirror that single branch.
+    let existing_repo = if path.join(".heddle").is_dir() {
+        Some(Repository::open(path)?)
+    } else {
+        None
+    };
+    let is_git_overlay = match &existing_repo {
+        Some(repo) => repo.capability() == RepositoryCapability::GitOverlay,
+        None => has_git,
+    };
+
+    // Honor the repo's on-disk `[output].format` so a `json`-configured repo
+    // never gets a text confirmation prompt before a JSON envelope. Read it
+    // from the opened repo when present, else from disk for a fresh directory.
+    let fallback_config = if existing_repo.is_none() {
+        resolve_existing_repo_config(path)
+    } else {
+        None
+    };
+    let repo_config = existing_repo
+        .as_ref()
+        .map(|repo| repo.config())
+        .or(fallback_config.as_ref());
+    let json = should_output_json(cli, repo_config);
+
+    // A detached Git HEAD has no branch for the checkpoint to advance, and
+    // `create_git_checkpoint` refuses it only AFTER the import/capture have
+    // written `.heddle/` state. Refuse here, before any write — but ONLY when
+    // the repo will actually run as a Git overlay. A native repo nested inside
+    // an ancestor Git checkout creates no checkpoint, so it must not be refused
+    // for the ancestor's detached HEAD.
+    if is_git_overlay && git_head_is_detached(path) {
         bail!(quickstart_detached_head_advice());
     }
 
@@ -451,20 +487,18 @@ fn quickstart_preflight(
         ));
     }
 
-    // A Git-overlay quickstart creates a real `refs/heads/<name>`. Git's
-    // ref-name rules are stricter than Heddle's `validate_ref_name` (they
-    // reject a space, `~`, `^`, `:`, `?`, `*`, `[`, …), so a name Heddle
-    // accepts but Git rejects would pass preflight and then fail when the
-    // branch is created — after `create_snapshot` has written Heddle state.
-    // Validate against Git's rules here too so it fails before any write.
-    // Native (non-Git) quickstarts keep Heddle's rules only.
-    if has_git
-        && gix::refs::FullName::try_from(format!("refs/heads/{thread}").as_str()).is_err()
-    {
+    // A Git-overlay quickstart creates a real `refs/heads/<thread>`, so the
+    // name must additionally satisfy Git's BRANCH-shorthand rules. These are
+    // stricter than validating the assembled `refs/heads/<thread>` full ref:
+    // a full ref accepts names Git refuses as a branch (e.g. `HEAD`, a leading
+    // `-`). Validate the shorthand here so such a name fails before any write
+    // rather than after `create_snapshot` has written Heddle state. Native
+    // (non-Git) quickstarts keep Heddle's rules only.
+    if is_git_overlay && !git_branch_name_is_valid(thread) {
         bail!(RecoveryAdvice::invalid_usage(
             "quickstart_thread_name_invalid",
             format!("'{thread}' is not a valid Git branch name"),
-            "Choose a thread name Git accepts as a branch: no spaces, '~', '^', ':', '?', '*', '[', backslashes, or control characters.",
+            "Choose a thread name Git accepts as a branch: no spaces, '~', '^', ':', '?', '*', '[', backslashes, control characters, a leading '-', or the reserved name 'HEAD'.",
             "heddle init --quickstart --quickstart-thread <name>",
         ));
     }
@@ -472,7 +506,7 @@ fn quickstart_preflight(
     // Confirmation gate before touching a directory that already holds
     // work. Truly fresh directories skip straight through.
     let heddle_exists = path.join(".heddle").exists();
-    let git_nonempty = has_git && git_has_commits(path);
+    let git_nonempty = is_git_overlay && git_has_commits(path);
     if (heddle_exists || git_nonempty) && !args.yes {
         if !json {
             println!(
@@ -510,7 +544,8 @@ fn quickstart_preflight(
         }
     }
 
-    let persist_principal = resolve_quickstart_identity(cli, args, path, has_git, json)?;
+    let persist_principal =
+        resolve_quickstart_identity(cli, args, path, existing_repo.as_ref(), is_git_overlay, json)?;
     // The harness-install prompt is the LAST interactive gate, decided
     // here before any write so Ctrl-C at it leaves the directory
     // untouched. The install itself runs post-write in `cmd_init`.
@@ -542,7 +577,8 @@ fn resolve_quickstart_identity(
     cli: &Cli,
     args: &InitArgs,
     path: &Path,
-    has_git: bool,
+    existing_repo: Option<&Repository>,
+    is_git_overlay: bool,
     json: bool,
 ) -> Result<Option<(String, String)>> {
     // `resolve_principal` lets env win OUTRIGHT — it returns the env identity
@@ -585,13 +621,17 @@ fn resolve_quickstart_identity(
         return Ok(Some((name, email)));
     }
 
-    // No flags: ask the REAL resolution (mirroring `resolve_principal`'s
-    // stop-at-first-present precedence) what the capture would be
-    // attributed to. A usable identity → proceed without writing one. A
-    // sentinel result — including a higher-precedence sentinel that shadows
-    // a lower valid source — means the capture would be rejected, so we
-    // must prompt (if interactive) or fail before any write.
-    let resolved = resolve_quickstart_principal(path, has_git);
+    // No flags: ask what the capture would be attributed to. When the repo
+    // already exists, call the REAL `resolve_principal` over the opened repo
+    // — byte-identical to what the capture does, so a shared-dir `[principal]`
+    // or a shared-checkout parent's Git identity (reached only through
+    // `Repository::get_principal`) is honored here too. A fresh directory has
+    // no repo to open, and none of those repo-bound sources exist yet, so the
+    // pre-init mirror suffices for it.
+    let resolved = match existing_repo {
+        Some(repo) => resolve_principal(repo, &UserConfig::load_default().unwrap_or_default())?,
+        None => resolve_quickstart_principal(path, is_git_overlay),
+    };
     if !principal_is_unconfigured(&resolved) {
         return Ok(None);
     }
@@ -611,28 +651,26 @@ fn resolve_quickstart_identity(
     bail!(quickstart_identity_required_advice())
 }
 
-/// Resolve the ambient principal the quickstart capture WOULD be attributed
-/// to (with no `--principal-*` flags), at preflight time, before the repo
-/// exists. This is the single source of truth for "is there a usable
-/// identity?": it mirrors `resolve_principal` (snapshot.rs) EXACTLY — same
-/// sources, same order, and crucially the same STOP-at-first-present
-/// semantics — so the preflight can never diverge from the real resolution
-/// the way a fall-through check can. (Flag/prompt identities are validated
-/// separately at their source in `resolve_quickstart_identity`, since they
-/// occupy the repo-config slot by being written there before the capture.)
+/// Resolve the ambient principal a FRESH (not-yet-initialized) quickstart
+/// would be attributed to (with no `--principal-*` flags), before the repo
+/// exists on disk. When the repo ALREADY exists, the caller instead delegates
+/// to the real `resolve_principal` over the opened repo — so this pre-init
+/// mirror only runs for a fresh directory, where the repo-bound sources it
+/// cannot reach (a shared-checkout parent's Git identity via
+/// `Repository::get_principal`) do not exist yet anyway.
+///
+/// It mirrors `resolve_principal` (snapshot.rs) for the pre-init sources —
+/// same order, same STOP-at-first-present semantics — so even the fresh path
+/// cannot diverge from the real resolution. (Flag/prompt identities are
+/// validated separately at their source in `resolve_quickstart_identity`,
+/// since they occupy the repo-config slot by being written there before the
+/// capture.)
 ///
 /// Precedence (identical to `resolve_principal`): env → repo
 /// `.heddle/config.toml` `[principal]` → Git config (only when it isn't the
 /// sentinel, matching `resolve_principal`'s fall-through) → user config →
 /// the `Unknown` sentinel.
-///
-/// Returns the resolved principal (possibly the sentinel); callers apply
-/// `principal_is_unconfigured` to decide whether to fail. STOP semantics are
-/// the whole point: a higher-precedence sentinel (e.g. a repo config pinning
-/// `Unknown <unknown@example.com>`) shadows a lower valid source here just as
-/// it would in `resolve_principal`, so the preflight rejects what the capture
-/// would reject.
-fn resolve_quickstart_principal(path: &Path, has_git: bool) -> Principal {
+fn resolve_quickstart_principal(path: &Path, is_git_overlay: bool) -> Principal {
     // env wins outright — `resolve_principal` returns it unconditionally
     // (even when it is the sentinel), so mirror that: stop here.
     if let Some(principal) = Principal::from_env() {
@@ -653,7 +691,7 @@ fn resolve_quickstart_principal(path: &Path, has_git: bool) -> Principal {
     // Git config: `resolve_principal` falls through to user config when
     // Git's identity is the sentinel, so only a non-sentinel Git identity
     // stops here.
-    if has_git
+    if is_git_overlay
         && let Ok(Some(identity)) = git_config_identity_with_global_fallback(path)
     {
         let principal = Principal::new(&identity.name, &identity.email);
@@ -708,6 +746,23 @@ fn git_has_commits(path: &Path) -> bool {
         }
     }
     false
+}
+
+/// Whether `name` is valid as a Git BRANCH — the shorthand written under
+/// `refs/heads/` — matching `git check-ref-format --branch`. This is stricter
+/// than validating the assembled `refs/heads/<name>` full ref: a syntactically
+/// valid full ref can still name an unusable branch. `git check-ref-format
+/// refs/heads/HEAD` accepts the full ref, but `git check-ref-format --branch
+/// HEAD` rejects it; the same holds for a leading `-` or a bare `@`. The Git
+/// checkpoint write-through points `.git/HEAD` at `refs/heads/<name>`, so
+/// reject here exactly what Git's porcelain would refuse there.
+fn git_branch_name_is_valid(name: &str) -> bool {
+    if gix::refs::FullName::try_from(format!("refs/heads/{name}").as_str()).is_err() {
+        return false;
+    }
+    // Branch-shorthand rules `--branch` adds on top of full-ref syntax: not
+    // the reserved `HEAD`, not a bare `@`, and no leading `-`.
+    !(name == "HEAD" || name == "@" || name.starts_with('-'))
 }
 
 /// Whether the discovered Git repository at `path` has a detached HEAD

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Initialize command.
 
-use std::path::PathBuf;
+use std::{
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Result, bail};
-use objects::object::Principal;
+use objects::object::{Principal, ThreadName, Tree};
+use refs::Head;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
 use tracing::{debug, info};
@@ -12,12 +16,34 @@ use tracing::{debug, info};
 use super::{
     RecoveryAdvice,
     action_line::print_next,
+    checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
+    snapshot::{SnapshotAgentOverrides, create_snapshot, ensure_current_state},
 };
 use crate::{
-    cli::{Cli, InitArgs, should_output_json},
+    bridge::{
+        GitBridge, git_core::git_config_identity_with_global_fallback, git_import::import_all,
+    },
+    cli::{Cli, InitArgs, is_tty, should_output_json, style, worktree_status_options},
     config::UserConfig,
 };
+
+/// Short pointer file Heddle writes (and captures) when `--quickstart`
+/// runs in a directory with no capturable user files yet, so the first
+/// `heddle log` has a user-visible state to show.
+const QUICKSTART_PLACEHOLDER: &str = "\
+# Quickstart
+
+This repository was bootstrapped with `heddle init --quickstart`.
+
+Heddle captured this file as your first state so `heddle log` has
+something to show. Replace it with your own work and run
+`heddle capture -m \"...\"` to record your next step.
+
+Next:
+  heddle log       # see the history Heddle is tracking
+  heddle status    # check what changed
+";
 
 #[derive(Serialize)]
 struct InitOutput {
@@ -38,6 +64,11 @@ struct InitOutput {
     message: String,
     next_action: Option<String>,
     recommended_action: Option<String>,
+    /// Quickstart actions (thread/capture/checkpoint). Render-only;
+    /// excluded from the JSON contract so the `init` output schema is
+    /// unchanged whether or not `--quickstart` was passed.
+    #[serde(skip)]
+    quickstart: Option<QuickstartSummary>,
     #[allow(dead_code)]
     #[serde(skip_serializing)]
     #[serde(rename = "verification")]
@@ -48,6 +79,31 @@ struct InitOutput {
 struct InitPrincipalOutput {
     name: String,
     email: String,
+}
+
+/// What `--quickstart` did after the normal init steps.
+struct QuickstartSummary {
+    thread: String,
+    change_id: String,
+    git_commit: Option<String>,
+    wrote_placeholder: bool,
+}
+
+/// Outcome of the pre-write quickstart phase (confirmation + identity).
+/// Resolved before any filesystem write so a Ctrl-C at a prompt leaves
+/// the directory exactly as it was found.
+struct QuickstartPreflight {
+    proceed: bool,
+    persist_principal: Option<(String, String)>,
+}
+
+impl Default for QuickstartPreflight {
+    fn default() -> Self {
+        Self {
+            proceed: true,
+            persist_principal: None,
+        }
+    }
 }
 
 pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
@@ -76,7 +132,25 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     // empty-tree snapshot. Otherwise, seed `main` so the repo is immediately
     // usable for snapshot/history/etc.
     let has_git = gix::discover(&path).is_ok();
-    let repo = if has_git {
+
+    // Quickstart confirms and resolves identity BEFORE any write so a
+    // Ctrl-C (or declined prompt) leaves the directory untouched — no
+    // half-written `.heddle/`.
+    let preflight = if args.quickstart {
+        quickstart_preflight(cli, &args, &path, has_git)?
+    } else {
+        QuickstartPreflight::default()
+    };
+    if !preflight.proceed {
+        return Ok(());
+    }
+
+    let repo = if args.quickstart && path.join(".heddle").exists() {
+        // Confirmed (or `--yes`) quickstart over a directory that already
+        // has Heddle data: open it and run the quickstart actions rather
+        // than re-initializing (which would refuse).
+        Repository::open(&path)?
+    } else if has_git {
         Repository::bootstrap_git_overlay(&path)?
     } else {
         Repository::init_default(&path)?
@@ -88,7 +162,25 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 
     let mut user_config = UserConfig::load_default()?;
     let mut principal_configured = false;
-    if args.principal_name.is_some() || args.principal_email.is_some() {
+    // Quickstart writes the resolved identity to the *repo* config
+    // (`.heddle/config.toml`) rather than the global user config: the
+    // flag/prompt identity must win over an ambient Git `user.*`, and
+    // `resolve_principal`'s precedence ranks repo config above Git
+    // config but ranks user config below it. Re-open the repo afterwards
+    // so the in-memory `repo.config()` the capture reads reflects it.
+    let mut repo = repo;
+    if args.quickstart {
+        if let Some((name, email)) = &preflight.persist_principal {
+            let config_path = repo.heddle_dir().join("config.toml");
+            let mut repo_config = repo::RepoConfig::load(&config_path).unwrap_or_default();
+            repo_config.set_principal(name.clone(), email.clone());
+            repo_config.save(&config_path)?;
+            info!(principal_name = %name, principal_email = %email, "Principal configured");
+            debug!(config_path = %config_path.display(), "Repo config updated");
+            repo = Repository::open(&path)?;
+            principal_configured = true;
+        }
+    } else if args.principal_name.is_some() || args.principal_email.is_some() {
         let name = args.principal_name.clone().ok_or_else(|| {
             anyhow::anyhow!(RecoveryAdvice::init_principal_field_required(
                 "--principal-name"
@@ -108,6 +200,12 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 
     super::maybe_prompt_init_install(cli, &repo, &args)?;
 
+    let quickstart = if args.quickstart {
+        Some(run_quickstart_actions(&repo, &args)?)
+    } else {
+        None
+    };
+
     let message = if has_git {
         format!(
             "Initialized Heddle data in {} for Git-overlay workflows",
@@ -121,8 +219,13 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     };
 
     let trust = build_repository_verification_state(&repo);
-    let next_action =
-        (!trust.recommended_action.is_empty()).then(|| trust.recommended_action.clone());
+    // After a quickstart the user has a captured state to inspect, so
+    // point them at `heddle log` regardless of the trust-derived action.
+    let next_action = if quickstart.is_some() {
+        Some("heddle log".to_string())
+    } else {
+        (!trust.recommended_action.is_empty()).then(|| trust.recommended_action.clone())
+    };
     let principal_status = init_principal_status(&repo, &user_config)?;
     let output = InitOutput {
         output_kind: "init",
@@ -142,6 +245,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         message,
         next_action: next_action.clone(),
         recommended_action: next_action,
+        quickstart,
         trust,
     };
 
@@ -186,6 +290,22 @@ fn render_init(output: &InitOutput, json: bool) -> Result<()> {
             println!("Side effects:");
             for effect in &output.side_effects {
                 println!("  - {effect}");
+            }
+        }
+        if let Some(quickstart) = output.quickstart.as_ref() {
+            if quickstart.wrote_placeholder {
+                println!(
+                    "Wrote {} and captured it as your first state.",
+                    style::accent("QUICKSTART.md")
+                );
+            }
+            println!("Thread: {}", style::bold(&quickstart.thread));
+            println!("Captured: {}", style::change_id(&quickstart.change_id));
+            if let Some(commit) = quickstart.git_commit.as_deref() {
+                println!(
+                    "Checkpoint: {}",
+                    style::dim(&commit[..commit.len().min(12)])
+                );
             }
         }
         if let Some(next) = output.recommended_action.as_deref() {
@@ -276,4 +396,283 @@ fn init_side_effects(has_git: bool, principal_configured: bool) -> Vec<String> {
         side_effects.push("updated default principal attribution".to_string());
     }
     side_effects
+}
+
+/// Pre-write phase of `--quickstart`: run the confirmation gate and
+/// resolve the principal identity. Everything here happens before the
+/// first filesystem write so a Ctrl-C (or a declined prompt) leaves the
+/// directory exactly as it was found.
+fn quickstart_preflight(
+    cli: &Cli,
+    args: &InitArgs,
+    path: &Path,
+    has_git: bool,
+) -> Result<QuickstartPreflight> {
+    let json = should_output_json(cli, None);
+
+    // Confirmation gate before touching a directory that already holds
+    // work. Truly fresh directories skip straight through.
+    let heddle_exists = path.join(".heddle").exists();
+    let git_nonempty = has_git && git_has_commits(path);
+    if (heddle_exists || git_nonempty) && !args.yes {
+        let thread = args.quickstart_thread.as_deref().unwrap_or("quickstart");
+        if !json {
+            println!(
+                "{}",
+                style::warn(
+                    "heddle init --quickstart would act on a directory that already has work:"
+                )
+            );
+            if heddle_exists {
+                println!("  - existing .heddle/ data is present");
+            }
+            if git_nonempty {
+                println!("  - this Git repository already has commits");
+            }
+            println!(
+                "It would resolve your identity, start the '{thread}' thread, capture once, and (on Git-overlay) checkpoint once."
+            );
+            println!("Existing files are not modified.");
+        }
+        // No interactive terminal to confirm at: require an explicit
+        // `--yes` rather than proceeding silently.
+        if json || cli.quiet || !is_tty() {
+            bail!(quickstart_needs_confirmation_advice());
+        }
+        print!("Proceed? [y/N] ");
+        io::stdout().flush().ok();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            println!("Aborted; no changes made.");
+            return Ok(QuickstartPreflight {
+                proceed: false,
+                persist_principal: None,
+            });
+        }
+    }
+
+    let persist_principal = resolve_quickstart_identity(cli, args, path, has_git, json)?;
+    Ok(QuickstartPreflight {
+        proceed: true,
+        persist_principal,
+    })
+}
+
+/// Resolve the principal for `--quickstart`. Priority: explicit
+/// `--principal-*` flags → an already-resolvable identity (env, user
+/// config, or Git config) → an interactive prompt. Returns the
+/// `(name, email)` to persist when it came from flags or the prompt, or
+/// `None` when an identity is already available without writing. Fails
+/// fast (no placeholder) when nothing is resolvable and there is no TTY
+/// to prompt.
+fn resolve_quickstart_identity(
+    cli: &Cli,
+    args: &InitArgs,
+    path: &Path,
+    has_git: bool,
+    json: bool,
+) -> Result<Option<(String, String)>> {
+    match (args.principal_name.clone(), args.principal_email.clone()) {
+        (Some(name), Some(email)) => return Ok(Some((name, email))),
+        (Some(_), None) => {
+            bail!(RecoveryAdvice::init_principal_field_required(
+                "--principal-email"
+            ))
+        }
+        (None, Some(_)) => {
+            bail!(RecoveryAdvice::init_principal_field_required(
+                "--principal-name"
+            ))
+        }
+        (None, None) => {}
+    }
+
+    if quickstart_identity_available(path, has_git) {
+        return Ok(None);
+    }
+
+    if is_tty() && !cli.quiet && !json {
+        let name = prompt_line("Your name: ")?;
+        let email = prompt_line("Your email: ")?;
+        if name.is_empty() || email.is_empty() {
+            bail!(quickstart_identity_required_advice());
+        }
+        return Ok(Some((name, email)));
+    }
+
+    bail!(quickstart_identity_required_advice())
+}
+
+/// Whether a real (non-placeholder) principal is already resolvable
+/// without writing one — from the environment, the user config, or, in
+/// a Git repo, Git's own `user.name`/`user.email`.
+fn quickstart_identity_available(path: &Path, has_git: bool) -> bool {
+    if let Some(principal) = Principal::from_env()
+        && !principal_is_unconfigured(&principal)
+    {
+        return true;
+    }
+    if let Ok(user_config) = UserConfig::load_default()
+        && let Some(config) = &user_config.principal
+        && !principal_is_unconfigured(&Principal::new(&config.name, &config.email))
+    {
+        return true;
+    }
+    if has_git
+        && git_config_identity_with_global_fallback(path)
+            .ok()
+            .flatten()
+            .is_some()
+    {
+        return true;
+    }
+    false
+}
+
+fn prompt_line(label: &str) -> Result<String> {
+    print!("{label}");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(input.trim().to_string())
+}
+
+/// Whether the discovered Git repository at `path` already has at least
+/// one commit (a non-empty history). An unborn branch reads as empty.
+fn git_has_commits(path: &Path) -> bool {
+    gix::discover(path)
+        .ok()
+        .map(|repo| repo.head_id().is_ok())
+        .unwrap_or(false)
+}
+
+/// The write batch of `--quickstart`: start the thread, make one
+/// capture, and (Git-overlay only) one checkpoint. Runs only after the
+/// preflight has confirmed and resolved identity, so every fallible
+/// prompt is already behind us.
+fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<QuickstartSummary> {
+    // A Git-overlay repo that already has commits must have that history
+    // imported into Heddle before a capture/checkpoint has a base to
+    // build on — the same import `heddle adopt` performs. Fresh/empty
+    // Git repos (no commits) and native repos skip this.
+    if repo.capability() == RepositoryCapability::GitOverlay && git_has_commits(repo.root()) {
+        let mut bridge = GitBridge::new(repo);
+        import_all(&mut bridge, Some(repo.root()))?;
+    }
+
+    let thread = args
+        .quickstart_thread
+        .clone()
+        .unwrap_or_else(|| "quickstart".to_string());
+    ensure_quickstart_thread(repo, &thread)?;
+
+    let user_config = UserConfig::load_default().unwrap_or_default();
+    let wrote_placeholder = ensure_capturable_content(repo)?;
+    let snapshot = create_snapshot(
+        repo,
+        &user_config,
+        Some("quickstart: initial capture".to_string()),
+        None,
+        SnapshotAgentOverrides {
+            provider: None,
+            model: None,
+            session: None,
+            segment: None,
+            policy: None,
+            no_policy: false,
+            no_agent: false,
+        },
+    )?;
+
+    // Checkpoint is Git-overlay only; on native repos the capture above
+    // is the user-visible "first commit".
+    let git_commit = if repo.capability() == RepositoryCapability::GitOverlay {
+        let record = create_git_checkpoint(
+            repo,
+            Some("quickstart: first commit"),
+            worktree_status_options(Some(repo.config())),
+        )?;
+        Some(record.git_commit)
+    } else {
+        None
+    };
+
+    Ok(QuickstartSummary {
+        thread,
+        change_id: snapshot.change_id,
+        git_commit,
+        wrote_placeholder,
+    })
+}
+
+/// Create the named quickstart thread at the current state and attach
+/// HEAD to it. Idempotent: a re-run that is already on the thread is a
+/// no-op. `ensure_current_state` returns the existing state for a
+/// freshly-seeded native repo without creating an extra capture.
+fn ensure_quickstart_thread(repo: &Repository, name: &str) -> Result<()> {
+    let target = ThreadName::new(name);
+    let current = ensure_current_state(
+        repo,
+        &UserConfig::load_default().unwrap_or_default(),
+        Some(format!("Bootstrap before quickstart thread {name}")),
+    )?;
+    if repo.refs().get_thread(&target)?.is_none() {
+        repo.refs().set_thread(&target, &current)?;
+    }
+    let already_attached =
+        matches!(repo.head_ref()?, Head::Attached { thread } if thread == target);
+    if !already_attached {
+        repo.refs().write_head(&Head::Attached { thread: target })?;
+    }
+    Ok(())
+}
+
+/// Ensure there is something user-visible to capture. When the worktree
+/// has no capturable files (a fresh empty directory), write the
+/// root-level `QUICKSTART.md` pointer and report that we did. The
+/// root-level path matters: the default ignore list excludes `.heddle/`
+/// (`repo_config::default_ignore`), so a placeholder under `.heddle/`
+/// would be silently dropped by the capture walk. Non-destructive: an
+/// existing `QUICKSTART.md` is left untouched.
+fn ensure_capturable_content(repo: &Repository) -> Result<bool> {
+    let options = worktree_status_options(Some(repo.config()));
+    let (status, _) = repo.compare_worktree_cached_profiled_with_options(&Tree::new(), &options)?;
+    if !status.added.is_empty() {
+        return Ok(false);
+    }
+    let placeholder = repo.root().join("QUICKSTART.md");
+    if !placeholder.exists() {
+        std::fs::write(&placeholder, QUICKSTART_PLACEHOLDER)?;
+    }
+    Ok(true)
+}
+
+fn quickstart_needs_confirmation_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "quickstart_needs_confirmation",
+        "Refusing to run --quickstart non-interactively against a directory that already has Heddle data or Git history",
+        "Re-run with `--yes` to confirm, or run `heddle init --quickstart` in an interactive terminal to answer the prompt.",
+        "the target directory already has .heddle/ data or non-empty Git history and no interactive terminal is available to confirm",
+        "quickstart would start a thread and capture in a directory that already holds work",
+        "no repository objects, refs, metadata, or worktree files were changed",
+        "heddle init --quickstart --yes",
+        vec!["heddle init --quickstart --yes".to_string()],
+    )
+}
+
+fn quickstart_identity_required_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "quickstart_identity_required",
+        "Refusing to run --quickstart without an accountable identity",
+        "Pass `--principal-name <name> --principal-email <email>`, configure identity first, or run in an interactive terminal to be prompted.",
+        "no principal was resolvable from flags, environment, user config, or Git config, and no interactive terminal is available to prompt",
+        "quickstart would capture history attributed to Unknown <unknown@example.com>",
+        "no repository objects, refs, metadata, or worktree files were changed",
+        "heddle init --quickstart --principal-name <name> --principal-email <email>",
+        vec![
+            "heddle init --quickstart --principal-name <name> --principal-email <email>"
+                .to_string(),
+        ],
+    )
 }

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -18,7 +18,7 @@ use super::{
     action_line::print_next,
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
-    snapshot::{SnapshotAgentOverrides, create_snapshot, resolve_principal},
+    snapshot::{SnapshotAgentOverrides, create_snapshot},
 };
 use crate::{
     bridge::{
@@ -111,6 +111,111 @@ impl Default for QuickstartPreflight {
     }
 }
 
+/// The single directory a `--quickstart` operates on, resolved ONCE by
+/// read-only discovery and shared by BOTH the preflight (a read-only viability
+/// probe) and the write path.
+///
+/// THE QUICKSTART INVARIANT (do not let this class regress): the preflight is a
+/// read-only viability probe on a SINGLE resolved root shared with the write
+/// path; every write — `Repository::open`'s HEAD-sync, the repo config, the
+/// capture/checkpoint, and the harness install — happens only AFTER the
+/// confirmation gate, capture-before-install. So no new repo-state / cwd /
+/// config / identity case can pass the preflight and then (a) diverge on WHICH
+/// root it writes to, or (b) mutate before a refusal. Resolving the root here,
+/// once, is what makes (a) impossible; never re-derive it from the raw cwd in
+/// one half and by discovery in the other (the bug that created nested native
+/// repos and misclassified Git overlays on subdirectory invocations).
+enum QuickstartTarget {
+    /// An existing Heddle repo found by ancestor discovery at `root` (the
+    /// read-only half of `Repository::open`'s walk). The write path opens it.
+    /// `git_overlay` mirrors `repository_capability_for_root(root)` — Git
+    /// metadata AT the repo root, so a native repo nested inside an ancestor
+    /// Git checkout stays native, exactly as the opened repo would.
+    Existing { root: PathBuf, git_overlay: bool },
+    /// No Heddle yet, but `root` is a Git checkout root (discovered from a
+    /// possibly-deeper cwd): a fresh Git-overlay bootstrap targets the Git
+    /// ROOT — the same root `Repository::open`'s final fallback bootstraps —
+    /// never the cwd subdirectory.
+    FreshGitOverlay { root: PathBuf },
+    /// Neither Heddle nor Git anywhere up the tree: a fresh native init at the
+    /// cwd.
+    FreshNative { root: PathBuf },
+}
+
+impl QuickstartTarget {
+    fn root(&self) -> &Path {
+        match self {
+            QuickstartTarget::Existing { root, .. }
+            | QuickstartTarget::FreshGitOverlay { root }
+            | QuickstartTarget::FreshNative { root } => root,
+        }
+    }
+
+    /// Whether the resolved repo runs as a Git overlay (and thus imports
+    /// history + writes a Git checkpoint through a branch). Mirrors
+    /// `repository_capability_for_root`.
+    fn is_git_overlay(&self) -> bool {
+        match self {
+            QuickstartTarget::Existing { git_overlay, .. } => *git_overlay,
+            QuickstartTarget::FreshGitOverlay { .. } => true,
+            QuickstartTarget::FreshNative { .. } => false,
+        }
+    }
+}
+
+/// Resolve, by READ-ONLY discovery, the single root a `--quickstart` operates
+/// on. This is the discovery half of [`Repository::open`] WITHOUT its writes
+/// (bootstrap, HEAD-sync) so the preflight can classify the target without
+/// mutating anything — every write is deferred to the post-gate write path,
+/// which consumes this SAME root. See [`QuickstartTarget`] for the invariant.
+fn resolve_quickstart_target(path: &Path) -> Result<QuickstartTarget> {
+    // Walk ancestors for an existing Heddle repo — a `.heddle/` holding either
+    // an `objects/` main store or an `objectstore` worktree pointer. The first
+    // such ancestor is the root the write path will `Repository::open`. This
+    // mirrors `Repository::open`'s ancestor walk; running it here (rather than
+    // checking only `path/.heddle`) is what makes a subdirectory invocation
+    // target the discovered repo instead of creating a nested one.
+    let mut current: Option<&Path> = Some(path);
+    while let Some(dir) = current {
+        let heddle = dir.join(".heddle");
+        if heddle.is_dir()
+            && (heddle.join("objects").is_dir() || heddle.join("objectstore").is_file())
+        {
+            return Ok(QuickstartTarget::Existing {
+                root: dir.to_path_buf(),
+                git_overlay: dir_is_git_root(dir),
+            });
+        }
+        current = dir.parent();
+    }
+
+    // No Heddle anywhere above: inside a Git checkout, the fresh bootstrap
+    // targets the Git ROOT, not the cwd subdirectory.
+    match discover_git_root(path) {
+        Some(root) => Ok(QuickstartTarget::FreshGitOverlay { root }),
+        None => Ok(QuickstartTarget::FreshNative {
+            root: path.to_path_buf(),
+        }),
+    }
+}
+
+/// The working-tree root of the Git checkout containing `path`, if any.
+/// Canonicalized to match the cwd canonicalization in `cmd_init`.
+fn discover_git_root(path: &Path) -> Option<PathBuf> {
+    let repo = gix::discover(path).ok()?;
+    let workdir = repo.workdir()?;
+    Some(workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf()))
+}
+
+/// Whether `dir` is itself a Git checkout root — Git metadata AT `dir`, mirroring
+/// the repo crate's `has_git_metadata`/`repository_capability_for_root`. (A
+/// `gix::discover` probe would instead walk to an ANCESTOR Git checkout, which
+/// is exactly the misclassification this avoids.)
+fn dir_is_git_root(dir: &Path) -> bool {
+    let dot_git = dir.join(".git");
+    (dot_git.is_dir() || dot_git.is_file()) && gix::discover(dir).is_ok()
+}
+
 pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     let path = match (args.path.clone(), cli.repo.clone()) {
         (Some(positional), Some(repo_path)) => {
@@ -138,27 +243,40 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     // usable for snapshot/history/etc.
     let has_git = gix::discover(&path).is_ok();
 
+    // Resolve the single quickstart root ONCE, by read-only discovery, so the
+    // preflight (a read-only viability probe) and the write path below operate
+    // on the SAME directory — see [`QuickstartTarget`] for the invariant.
+    let target = if args.quickstart {
+        Some(resolve_quickstart_target(&path)?)
+    } else {
+        None
+    };
+
     // Quickstart confirms and resolves identity BEFORE any write so a
     // Ctrl-C (or declined prompt) leaves the directory untouched — no
-    // half-written `.heddle/`.
-    let preflight = if args.quickstart {
-        quickstart_preflight(cli, &args, &path, has_git)?
-    } else {
-        QuickstartPreflight::default()
+    // half-written `.heddle/`. The preflight reads only: it never opens the
+    // repo (whose HEAD-sync would write), so a refused/declined quickstart
+    // performs zero writes.
+    let preflight = match target.as_ref() {
+        Some(target) => quickstart_preflight(cli, &args, target)?,
+        None => QuickstartPreflight::default(),
     };
     if !preflight.proceed {
         return Ok(());
     }
 
-    let repo = if args.quickstart && path.join(".heddle").exists() {
-        // Confirmed (or `--yes`) quickstart over a directory that already
-        // has Heddle data: open it and run the quickstart actions rather
-        // than re-initializing (which would refuse).
-        Repository::open(&path)?
-    } else if has_git {
-        Repository::bootstrap_git_overlay(&path)?
-    } else {
-        Repository::init_default(&path)?
+    // Writes begin here — only after the preflight returned `proceed`, and on
+    // the SAME root it validated. For quickstart, branch on the resolved
+    // target so a subdirectory invocation opens the discovered repo / boots the
+    // discovered Git root rather than creating a nested repo at the cwd.
+    let repo = match target.as_ref() {
+        Some(QuickstartTarget::Existing { root, .. }) => Repository::open(root)?,
+        Some(QuickstartTarget::FreshGitOverlay { root }) => {
+            Repository::bootstrap_git_overlay(root)?
+        }
+        Some(QuickstartTarget::FreshNative { root }) => Repository::init_default(root)?,
+        None if has_git => Repository::bootstrap_git_overlay(&path)?,
+        None => Repository::init_default(&path)?,
     };
 
     debug!(heddle_dir = %repo.heddle_dir().display(), "Repository initialized");
@@ -174,6 +292,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     // config but ranks user config below it. Re-open the repo afterwards
     // so the in-memory `repo.config()` the capture reads reflects it.
     let mut repo = repo;
+    let repo_root = repo.root().to_path_buf();
     if args.quickstart {
         if let Some((name, email)) = &preflight.persist_principal {
             let config_path = repo.heddle_dir().join("config.toml");
@@ -182,7 +301,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
             repo_config.save(&config_path)?;
             info!(principal_name = %name, principal_email = %email, "Principal configured");
             debug!(config_path = %config_path.display(), "Repo config updated");
-            repo = Repository::open(&path)?;
+            repo = Repository::open(&repo_root)?;
             principal_configured = true;
         }
     } else if args.principal_name.is_some() || args.principal_email.is_some() {
@@ -203,21 +322,32 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         principal_configured = true;
     }
 
-    if args.quickstart {
-        // Decision was made up front in the preflight; only the install
-        // (a write) runs here, after the repo exists.
+    let quickstart = if args.quickstart {
+        // Capture FIRST, then install harnesses. The initial capture must
+        // record the user's own first state; installing harness scaffolding
+        // (`.claude/settings.json`, …) before the capture would make
+        // `ensure_capturable_content` treat that scaffolding as the user's
+        // content — skipping the `QUICKSTART.md` placeholder and recording
+        // integration files as the first state. The install decision was made
+        // up front in the preflight; only the write runs here, post-capture.
+        let summary = run_quickstart_actions(&repo, &args)?;
         super::perform_init_install(cli, &repo, &args, &preflight.harness_install)?;
+        Some(summary)
     } else {
         super::maybe_prompt_init_install(cli, &repo, &args)?;
-    }
-
-    let quickstart = if args.quickstart {
-        Some(run_quickstart_actions(&repo, &args)?)
-    } else {
         None
     };
 
-    let message = if has_git {
+    // Output reflects the repo that was actually created/opened. For quickstart
+    // that is the resolved target's capability (a subdirectory invocation may
+    // have opened a native repo even though `gix::discover` finds an ancestor
+    // Git checkout); the non-quickstart path keeps its prior `has_git` framing.
+    let repo_is_git_overlay = if args.quickstart {
+        repo.capability() == RepositoryCapability::GitOverlay
+    } else {
+        has_git
+    };
+    let message = if repo_is_git_overlay {
         format!(
             "Initialized Heddle data in {} for Git-overlay workflows",
             repo.heddle_dir().display()
@@ -244,7 +374,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         action: "init".to_string(),
         path: repo.heddle_dir().to_path_buf(),
         repository_mode: repo.capability_label().to_string(),
-        git_detected: has_git,
+        git_detected: repo_is_git_overlay,
         heddle_initialized: true,
         installed_heddleignore,
         principal_configured,
@@ -252,7 +382,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         principal_source: principal_status.source,
         principal: principal_status.principal,
         principal_recommended_action: principal_status.recommended_action,
-        side_effects: init_side_effects(has_git, principal_configured),
+        side_effects: init_side_effects(repo_is_git_overlay, principal_configured),
         message,
         next_action: next_action.clone(),
         recommended_action: next_action,
@@ -410,57 +540,38 @@ fn init_side_effects(has_git: bool, principal_configured: bool) -> Vec<String> {
 }
 
 /// Pre-write phase of `--quickstart`: run the confirmation gate and
-/// resolve the principal identity. Everything here happens before the
-/// first filesystem write so a Ctrl-C (or a declined prompt) leaves the
+/// resolve the principal identity. Everything here is READ-ONLY — it never
+/// opens the repository (whose HEAD-sync would write) nor touches the
+/// filesystem — so a Ctrl-C, a declined prompt, or any refusal leaves the
 /// directory exactly as it was found.
 fn quickstart_preflight(
     cli: &Cli,
     args: &InitArgs,
-    path: &Path,
-    has_git: bool,
+    target: &QuickstartTarget,
 ) -> Result<QuickstartPreflight> {
-    // The quickstart preflight is a DRY-RUN of the real init/identity path:
-    // every viability decision below delegates to the SAME predicate the
-    // write path uses — repository capability via `Repository::open`, identity
-    // via `resolve_principal`, the thread name via the ref/branch validators,
-    // and the harness scope via the install path's `IntegrationScope::parse`
-    // — never a parallel hand-rolled re-implementation. A parallel copy
-    // inevitably diverges (a new repo-state, identity source, or argument case
-    // passes preflight then fails at write); delegating makes that impossible.
-
-    // Open the repository the write path will operate on, when it already
-    // exists, so capability + identity come from the real repo (following an
-    // objectstore pointer to the shared dir, honoring the on-disk config)
-    // rather than a `gix::discover` probe. `Repository::open` decides
-    // native-vs-Git-overlay from `.git` AT the repo root, so a native repo
-    // nested inside an ancestor Git checkout stays native here — exactly as
-    // the capture treats it (unlike `gix::discover`, which walks to the
-    // ancestor and reports Git). A fresh directory has no repo to open yet;
-    // the write path then picks a Git overlay iff `gix::discover` finds Git
-    // (the `has_git` flag), so mirror that single branch.
-    let existing_repo = if path.join(".heddle").is_dir() {
-        Some(Repository::open(path)?)
-    } else {
-        None
-    };
-    let is_git_overlay = match &existing_repo {
-        Some(repo) => repo.capability() == RepositoryCapability::GitOverlay,
-        None => has_git,
-    };
+    // The quickstart preflight is a READ-ONLY DRY-RUN of the real init/identity
+    // path: every viability decision below shares the SAME predicate the write
+    // path uses — capability from the resolved target (mirroring
+    // `repository_capability_for_root`), identity via the read-only mirror of
+    // `resolve_principal` (`resolve_quickstart_principal`, which follows the
+    // objectstore pointer and the shared-checkout parent Git config exactly as
+    // `Repository::get_principal` does), the thread name via the ref/branch
+    // validators, and the harness scope via the install path's
+    // `IntegrationScope::parse`. It must NOT call `Repository::open`: for a
+    // Git-overlay repo `open` synchronizes `.heddle/HEAD` to Git's HEAD — a
+    // write that would fire before a refusal. The single resolved `target` (see
+    // [`QuickstartTarget`]) means the write path opens that SAME root, so the
+    // read-only probe and the eventual open never disagree on which dir or
+    // whether it is a Git overlay.
+    let root = target.root();
+    let is_git_overlay = target.is_git_overlay();
 
     // Honor the repo's on-disk `[output].format` so a `json`-configured repo
     // never gets a text confirmation prompt before a JSON envelope. Read it
-    // from the opened repo when present, else from disk for a fresh directory.
-    let fallback_config = if existing_repo.is_none() {
-        resolve_existing_repo_config(path)
-    } else {
-        None
-    };
-    let repo_config = existing_repo
-        .as_ref()
-        .map(|repo| repo.config())
-        .or(fallback_config.as_ref());
-    let json = should_output_json(cli, repo_config);
+    // off disk (following an objectstore pointer to the shared dir) without
+    // opening — `None` for a fresh directory.
+    let repo_config = resolve_existing_repo_config(root);
+    let json = should_output_json(cli, repo_config.as_ref());
 
     // A detached Git HEAD has no branch for the checkpoint to advance, and
     // `create_git_checkpoint` refuses it only AFTER the import/capture have
@@ -468,7 +579,7 @@ fn quickstart_preflight(
     // the repo will actually run as a Git overlay. A native repo nested inside
     // an ancestor Git checkout creates no checkpoint, so it must not be refused
     // for the ancestor's detached HEAD.
-    if is_git_overlay && git_head_is_detached(path) {
+    if is_git_overlay && git_head_is_detached(root) {
         bail!(quickstart_detached_head_advice());
     }
 
@@ -505,8 +616,8 @@ fn quickstart_preflight(
 
     // Confirmation gate before touching a directory that already holds
     // work. Truly fresh directories skip straight through.
-    let heddle_exists = path.join(".heddle").exists();
-    let git_nonempty = is_git_overlay && git_has_commits(path);
+    let heddle_exists = root.join(".heddle").exists();
+    let git_nonempty = is_git_overlay && git_has_commits(root);
     if (heddle_exists || git_nonempty) && !args.yes {
         if !json {
             println!(
@@ -544,12 +655,13 @@ fn quickstart_preflight(
         }
     }
 
-    let persist_principal =
-        resolve_quickstart_identity(cli, args, path, existing_repo.as_ref(), is_git_overlay, json)?;
+    let persist_principal = resolve_quickstart_identity(cli, args, root, is_git_overlay, json)?;
     // The harness-install prompt is the LAST interactive gate, decided
     // here before any write so Ctrl-C at it leaves the directory
-    // untouched. The install itself runs post-write in `cmd_init`.
-    let harness_install = super::prompt_init_install_decision(cli, path, args, json)?;
+    // untouched. Detect/prompt at the SAME resolved root the install writes
+    // to (`repo.root()` in `cmd_init`), not the raw cwd. The install itself
+    // runs post-write in `cmd_init`.
+    let harness_install = super::prompt_init_install_decision(cli, root, args, json)?;
     Ok(QuickstartPreflight {
         proceed: true,
         persist_principal,
@@ -572,12 +684,13 @@ fn quickstart_preflight(
 /// flags, prompt, repo config, user config, and Git config (and a
 /// higher-precedence sentinel shadowing a lower valid source) are all
 /// caught HERE, before any write, instead of by `build_attribution` after
-/// `.heddle/` already exists.
+/// `.heddle/` already exists. It resolves identity READ-ONLY — without opening
+/// the repository — so a refusal (sentinel env/flag, or no resolvable identity
+/// with no TTY) never triggers `Repository::open`'s HEAD-sync write.
 fn resolve_quickstart_identity(
     cli: &Cli,
     args: &InitArgs,
-    path: &Path,
-    existing_repo: Option<&Repository>,
+    root: &Path,
     is_git_overlay: bool,
     json: bool,
 ) -> Result<Option<(String, String)>> {
@@ -621,17 +734,14 @@ fn resolve_quickstart_identity(
         return Ok(Some((name, email)));
     }
 
-    // No flags: ask what the capture would be attributed to. When the repo
-    // already exists, call the REAL `resolve_principal` over the opened repo
-    // — byte-identical to what the capture does, so a shared-dir `[principal]`
-    // or a shared-checkout parent's Git identity (reached only through
-    // `Repository::get_principal`) is honored here too. A fresh directory has
-    // no repo to open, and none of those repo-bound sources exist yet, so the
-    // pre-init mirror suffices for it.
-    let resolved = match existing_repo {
-        Some(repo) => resolve_principal(repo, &UserConfig::load_default().unwrap_or_default())?,
-        None => resolve_quickstart_principal(path, is_git_overlay),
-    };
+    // No flags: ask what the capture would be attributed to, READ-ONLY.
+    // `resolve_quickstart_principal` mirrors `resolve_principal`'s full
+    // precedence off disk — including a shared-dir `[principal]` and a
+    // shared-checkout parent's Git identity (the sources `resolve_principal`
+    // reaches only through `Repository::get_principal`) — so it is faithful to
+    // the capture without opening the repo (whose HEAD-sync would write before
+    // this can still refuse).
+    let resolved = resolve_quickstart_principal(root, is_git_overlay);
     if !principal_is_unconfigured(&resolved) {
         return Ok(None);
     }
@@ -651,53 +761,58 @@ fn resolve_quickstart_identity(
     bail!(quickstart_identity_required_advice())
 }
 
-/// Resolve the ambient principal a FRESH (not-yet-initialized) quickstart
-/// would be attributed to (with no `--principal-*` flags), before the repo
-/// exists on disk. When the repo ALREADY exists, the caller instead delegates
-/// to the real `resolve_principal` over the opened repo — so this pre-init
-/// mirror only runs for a fresh directory, where the repo-bound sources it
-/// cannot reach (a shared-checkout parent's Git identity via
-/// `Repository::get_principal`) do not exist yet anyway.
-///
-/// It mirrors `resolve_principal` (snapshot.rs) for the pre-init sources —
-/// same order, same STOP-at-first-present semantics — so even the fresh path
-/// cannot diverge from the real resolution. (Flag/prompt identities are
-/// validated separately at their source in `resolve_quickstart_identity`,
-/// since they occupy the repo-config slot by being written there before the
-/// capture.)
+/// Resolve, READ-ONLY (without opening the repository), the ambient principal a
+/// quickstart with no `--principal-*` flags would be attributed to. This is the
+/// faithful mirror of `resolve_principal` (snapshot.rs) → `get_principal`
+/// (repo crate): same order, same STOP-at-first-present semantics, same sources
+/// — resolved off disk so it never triggers `Repository::open`'s HEAD-sync
+/// (a write that must not happen before a refusal). Handles BOTH a fresh
+/// directory and an already-initialized repo (including a materialized
+/// checkout, whose `.heddle/` is just an objectstore pointer). Flag/prompt
+/// identities are validated separately at their source in
+/// `resolve_quickstart_identity`, since they occupy the repo-config slot by
+/// being written there before the capture.
 ///
 /// Precedence (identical to `resolve_principal`): env → repo
-/// `.heddle/config.toml` `[principal]` → Git config (only when it isn't the
-/// sentinel, matching `resolve_principal`'s fall-through) → user config →
-/// the `Unknown` sentinel.
-fn resolve_quickstart_principal(path: &Path, is_git_overlay: bool) -> Principal {
+/// `.heddle/config.toml` `[principal]` (following the objectstore pointer) →
+/// the repo's own Git config (Git-overlay only, when non-sentinel) → a
+/// materialized checkout's shared-dir parent Git config (when non-sentinel) →
+/// user config → the `Unknown` sentinel. The two Git sources stop only on a
+/// non-sentinel identity, matching `resolve_principal`'s fall-through.
+fn resolve_quickstart_principal(root: &Path, is_git_overlay: bool) -> Principal {
     // env wins outright — `resolve_principal` returns it unconditionally
     // (even when it is the sentinel), so mirror that: stop here.
     if let Some(principal) = Principal::from_env() {
         return principal;
     }
     // Repo-level config slot: stop at the on-disk repo `[principal]` if
-    // present, even the sentinel — `resolve_principal` does. (This is the
-    // "already has .heddle/" quickstart path.) Resolve config the way
-    // `Repository::open` does: in a materialized checkout the local
+    // present, even the sentinel — `resolve_principal` does. Resolve config the
+    // way `Repository::open` does: in a materialized checkout the local
     // `.heddle/` is just an objectstore pointer and the real `[principal]`
     // lives in the SHARED dir it points at, so a local-only probe would
     // wrongly report "no identity" there.
-    if let Some(repo_config) = resolve_existing_repo_config(path)
+    if let Some(repo_config) = resolve_existing_repo_config(root)
         && let Some(config) = &repo_config.principal
     {
         return Principal::new(&config.name, &config.email);
     }
-    // Git config: `resolve_principal` falls through to user config when
-    // Git's identity is the sentinel, so only a non-sentinel Git identity
-    // stops here.
+    // Git config: `resolve_principal` falls through when Git's identity is the
+    // sentinel, so only a non-sentinel Git identity stops here.
     if is_git_overlay
-        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(path)
+        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(root)
     {
         let principal = Principal::new(&identity.name, &identity.email);
         if !principal_is_unconfigured(&principal) {
             return principal;
         }
+    }
+    // Materialized-checkout source: `get_principal` reaches a shared-dir
+    // parent's Git identity via `shared_checkout_parent_git_principal`. Mirror
+    // it read-only so the existing-repo case no longer needs `Repository::open`.
+    if let Some(principal) = quickstart_shared_checkout_parent_principal(root)
+        && !principal_is_unconfigured(&principal)
+    {
+        return principal;
     }
     if let Ok(user_config) = UserConfig::load_default()
         && let Some(config) = &user_config.principal
@@ -705,6 +820,26 @@ fn resolve_quickstart_principal(path: &Path, is_git_overlay: bool) -> Principal 
         return Principal::new(&config.name, &config.email);
     }
     Principal::new("Unknown", "unknown@example.com")
+}
+
+/// Read-only mirror of `Repository::shared_checkout_parent_git_principal`: in a
+/// materialized checkout the local `.heddle/` is an objectstore pointer to a
+/// SHARED dir; when that shared dir sits inside a Git checkout, a capture can be
+/// attributed through the shared dir's PARENT Git config. Follow the pointer
+/// here (no open, no HEAD-sync) so a quickstart that will refuse writes nothing.
+fn quickstart_shared_checkout_parent_principal(root: &Path) -> Option<Principal> {
+    let pointer = root.join(".heddle").join("objectstore");
+    if !pointer.is_file() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&pointer).ok()?;
+    let shared = parse_objectstore_pointer(&content)?.canonicalize().ok()?;
+    let parent = shared.parent()?;
+    if parent == root {
+        return None;
+    }
+    let identity = git_config_identity_with_global_fallback(parent).ok()??;
+    Some(Principal::new(&identity.name, &identity.email))
 }
 
 fn prompt_line(label: &str) -> Result<String> {

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -22,7 +22,8 @@ use super::{
 };
 use crate::{
     bridge::{
-        GitBridge, git_core::git_config_identity_with_global_fallback, git_import::import_all,
+        GitBridge, WriteThroughOutcome, git_core::git_config_identity_with_global_fallback,
+        git_import::import_all,
     },
     cli::{Cli, InitArgs, is_tty, should_output_json, style, worktree_status_options},
     config::UserConfig,
@@ -169,18 +170,35 @@ impl QuickstartTarget {
 /// mutating anything — every write is deferred to the post-gate write path,
 /// which consumes this SAME root. See [`QuickstartTarget`] for the invariant.
 fn resolve_quickstart_target(path: &Path) -> Result<QuickstartTarget> {
-    // Walk ancestors for an existing Heddle repo — a `.heddle/` holding either
-    // an `objects/` main store or an `objectstore` worktree pointer. The first
-    // such ancestor is the root the write path will `Repository::open`. This
-    // mirrors `Repository::open`'s ancestor walk; running it here (rather than
-    // checking only `path/.heddle`) is what makes a subdirectory invocation
-    // target the discovered repo instead of creating a nested one.
+    // Mirror `Repository::open`'s ancestor walk EXACTLY (same loop, same
+    // predicates, minus the writes) so the read-only probe and the eventual
+    // `open` never disagree on which root they target. Track the nearest
+    // enclosing Git checkout going up — `has_git_metadata`'s mirror,
+    // `dir_is_git_root` — so the nested-Git special case below can fire.
+    let mut discovered_git_root: Option<PathBuf> = None;
     let mut current: Option<&Path> = Some(path);
     while let Some(dir) = current {
+        if discovered_git_root.is_none() && dir_is_git_root(dir) {
+            discovered_git_root = Some(dir.to_path_buf());
+        }
         let heddle = dir.join(".heddle");
         if heddle.is_dir()
             && (heddle.join("objects").is_dir() || heddle.join("objectstore").is_file())
         {
+            // `Repository::open`'s nested-Git special case: a Git checkout
+            // BELOW this ancestor `.heddle` (and without its own `.heddle`)
+            // bootstraps the NESTED Git root, not the ancestor — so quickstart
+            // imports the nested Git history rather than writing the thread
+            // into the parent and ignoring the nested repo (cid 3329409822).
+            if let Some(git_root) = discovered_git_root.as_ref()
+                && git_root != dir
+                && git_root.starts_with(dir)
+                && !git_root.join(".heddle").exists()
+            {
+                return Ok(QuickstartTarget::FreshGitOverlay {
+                    root: git_root.clone(),
+                });
+            }
             return Ok(QuickstartTarget::Existing {
                 root: dir.to_path_buf(),
                 git_overlay: dir_is_git_root(dir),
@@ -190,21 +208,15 @@ fn resolve_quickstart_target(path: &Path) -> Result<QuickstartTarget> {
     }
 
     // No Heddle anywhere above: inside a Git checkout, the fresh bootstrap
-    // targets the Git ROOT, not the cwd subdirectory.
-    match discover_git_root(path) {
+    // targets the Git ROOT (the nearest enclosing checkout discovered by the
+    // walk above), not the cwd subdirectory — the same root `Repository::open`'s
+    // final fallback bootstraps.
+    match discovered_git_root {
         Some(root) => Ok(QuickstartTarget::FreshGitOverlay { root }),
         None => Ok(QuickstartTarget::FreshNative {
             root: path.to_path_buf(),
         }),
     }
-}
-
-/// The working-tree root of the Git checkout containing `path`, if any.
-/// Canonicalized to match the cwd canonicalization in `cmd_init`.
-fn discover_git_root(path: &Path) -> Option<PathBuf> {
-    let repo = gix::discover(path).ok()?;
-    let workdir = repo.workdir()?;
-    Some(workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf()))
 }
 
 /// Whether `dir` is itself a Git checkout root — Git metadata AT `dir`, mirroring
@@ -583,6 +595,18 @@ fn quickstart_preflight(
         bail!(quickstart_detached_head_advice());
     }
 
+    // A shallow Git checkout (`.git/shallow`) can't be imported until full
+    // ancestry is available — `import_all` refuses it, but only AFTER
+    // `bootstrap_git_overlay` has created `.heddle/` and edited the Git
+    // excludes, leaving a half-initialized sidecar. Detect it here, read-only,
+    // and refuse before any write — but only when the repo will run as a Git
+    // overlay AND has history to import (the exact condition under which
+    // `run_quickstart_actions` calls `import_all`). Mirrors `import_all`'s own
+    // `git_dir()/shallow` probe (cid 3329409826).
+    if is_git_overlay && git_has_commits(root) && git_is_shallow(root) {
+        bail!(quickstart_shallow_clone_advice());
+    }
+
     // Validate the requested thread name BEFORE any write, using the same
     // ref-name rules the thread machinery enforces when the ref is actually
     // created. A bad name (`.bad`, `a..b`, …) must fail here rather than
@@ -900,6 +924,18 @@ fn git_branch_name_is_valid(name: &str) -> bool {
     !(name == "HEAD" || name == "@" || name.starts_with('-'))
 }
 
+/// Whether the discovered Git repository at `path` is a shallow checkout — its
+/// `git_dir` holds a `shallow` file. Mirrors the exact probe `import_all` uses
+/// (`repo.git_dir().join("shallow").is_file()`) so the preflight refuses a
+/// shallow clone before any write rather than after `bootstrap_git_overlay`
+/// already created `.heddle/`.
+fn git_is_shallow(path: &Path) -> bool {
+    gix::discover(path)
+        .ok()
+        .map(|repo| repo.git_dir().join("shallow").is_file())
+        .unwrap_or(false)
+}
+
 /// Whether the discovered Git repository at `path` has a detached HEAD
 /// (HEAD points directly at a commit instead of an attached branch). An
 /// unborn HEAD reads as not-detached.
@@ -961,6 +997,38 @@ fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<Quicksta
         .clone()
         .unwrap_or_else(|| "quickstart".to_string());
     ensure_quickstart_thread(repo, &thread)?;
+
+    // On a Git overlay with imported history, `head_ref()` deliberately
+    // resolves back to the live Git branch (e.g. `main`) — so merely writing
+    // `.heddle/HEAD = Attached{thread}` above is NOT enough: the capture and
+    // checkpoint below both target `head_ref()`, and would advance the Git
+    // branch while the quickstart thread stays at the imported tip, even though
+    // the output says `Thread: <thread>` (cid 3329409824). Attach the Git
+    // checkout to the thread's branch via the SAME write-through `heddle thread
+    // switch` uses, so `head_ref()` resolves to `<thread>` and the
+    // capture+checkpoint land on it. Gated on `git_has_commits` to match the
+    // import above: the write-through needs the thread's state mapped to a Git
+    // commit, which only exists once history has been imported. (The unborn
+    // case has no mapped commit yet and the capture creates the thread's root.)
+    if repo.capability() == RepositoryCapability::GitOverlay
+        && repo.root().join(".git").exists()
+        && git_has_commits(repo.root())
+    {
+        let mut bridge = GitBridge::new(repo);
+        if let WriteThroughOutcome::Skipped(reason) = bridge.write_through_thread_checkout(&thread)?
+        {
+            bail!(RecoveryAdvice::safety_refusal(
+                "quickstart_thread_checkout_skipped",
+                format!("Could not attach the Git checkout to thread '{thread}': {reason}"),
+                "Resolve the Git checkout issue and re-run `heddle init --quickstart`.",
+                reason.to_string(),
+                "quickstart would capture and checkpoint on the requested thread, but the Git checkout could not be attached to its branch",
+                "the current Heddle state was preserved",
+                "heddle init --quickstart",
+                vec!["heddle init --quickstart".to_string()],
+            ));
+        }
+    }
 
     let user_config = UserConfig::load_default().unwrap_or_default();
     let wrote_placeholder = ensure_capturable_content(repo)?;
@@ -1085,6 +1153,22 @@ fn quickstart_detached_head_advice() -> RecoveryAdvice {
         "git switch -c <branch>",
         vec![
             "git switch -c <branch>".to_string(),
+            "heddle init --quickstart".to_string(),
+        ],
+    )
+}
+
+fn quickstart_shallow_clone_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "quickstart_shallow_clone",
+        "Refusing to run --quickstart on a shallow Git clone",
+        "Fetch full history first with `git fetch --unshallow`, then re-run `heddle init --quickstart`.",
+        "the Git checkout is shallow (.git/shallow is present)",
+        "quickstart would import Git history, but Heddle cannot import a shallow clone until its full ancestry is available",
+        "no repository objects, refs, metadata, or worktree files were changed",
+        "git fetch --unshallow",
+        vec![
+            "git fetch --unshallow".to_string(),
             "heddle init --quickstart".to_string(),
         ],
     )

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -95,6 +95,10 @@ struct QuickstartSummary {
 struct QuickstartPreflight {
     proceed: bool,
     persist_principal: Option<(String, String)>,
+    /// Harnesses the user agreed to connect, decided at the prompt before
+    /// any write. Installed only after the repo is created so a Ctrl-C at
+    /// the harness prompt leaves the directory untouched.
+    harness_install: Vec<String>,
 }
 
 impl Default for QuickstartPreflight {
@@ -102,6 +106,7 @@ impl Default for QuickstartPreflight {
         Self {
             proceed: true,
             persist_principal: None,
+            harness_install: Vec::new(),
         }
     }
 }
@@ -198,7 +203,13 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         principal_configured = true;
     }
 
-    super::maybe_prompt_init_install(cli, &repo, &args)?;
+    if args.quickstart {
+        // Decision was made up front in the preflight; only the install
+        // (a write) runs here, after the repo exists.
+        super::perform_init_install(cli, &repo, &args, &preflight.harness_install)?;
+    } else {
+        super::maybe_prompt_init_install(cli, &repo, &args)?;
+    }
 
     let quickstart = if args.quickstart {
         Some(run_quickstart_actions(&repo, &args)?)
@@ -447,15 +458,20 @@ fn quickstart_preflight(
             println!("Aborted; no changes made.");
             return Ok(QuickstartPreflight {
                 proceed: false,
-                persist_principal: None,
+                ..QuickstartPreflight::default()
             });
         }
     }
 
     let persist_principal = resolve_quickstart_identity(cli, args, path, has_git, json)?;
+    // The harness-install prompt is the LAST interactive gate, decided
+    // here before any write so Ctrl-C at it leaves the directory
+    // untouched. The install itself runs post-write in `cmd_init`.
+    let harness_install = super::prompt_init_install_decision(cli, path, args, json)?;
     Ok(QuickstartPreflight {
         proceed: true,
         persist_principal,
+        harness_install,
     })
 }
 

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -419,7 +419,22 @@ fn quickstart_preflight(
     path: &Path,
     has_git: bool,
 ) -> Result<QuickstartPreflight> {
-    let json = should_output_json(cli, None);
+    // Resolve the repo's on-disk config the way `Repository::open` does
+    // (following an objectstore pointer to the shared dir for a materialized
+    // checkout) so the confirmation prompt's format matches the final
+    // render. A repo whose `[output].format` is `json` must not get a text
+    // prompt before a JSON envelope.
+    let repo_config = resolve_existing_repo_config(path);
+    let json = should_output_json(cli, repo_config.as_ref());
+
+    // A detached Git HEAD has no branch for the checkpoint to advance.
+    // `create_git_checkpoint` refuses it, but only AFTER the import/capture
+    // have written `.heddle/` state — leaving a half-initialized repo.
+    // Refuse here, before any write, so a detached HEAD leaves the directory
+    // exactly as it was found.
+    if has_git && git_head_is_detached(path) {
+        bail!(quickstart_detached_head_advice());
+    }
 
     // Validate the requested thread name BEFORE any write, using the same
     // ref-name rules the thread machinery enforces when the ref is actually
@@ -432,6 +447,24 @@ fn quickstart_preflight(
             "quickstart_thread_name_invalid",
             format!("'{thread}' is not a valid thread name"),
             "Choose a thread name without '..', a leading '.', a trailing '/' or '.lock', backslashes, or control characters.",
+            "heddle init --quickstart --quickstart-thread <name>",
+        ));
+    }
+
+    // A Git-overlay quickstart creates a real `refs/heads/<name>`. Git's
+    // ref-name rules are stricter than Heddle's `validate_ref_name` (they
+    // reject a space, `~`, `^`, `:`, `?`, `*`, `[`, …), so a name Heddle
+    // accepts but Git rejects would pass preflight and then fail when the
+    // branch is created — after `create_snapshot` has written Heddle state.
+    // Validate against Git's rules here too so it fails before any write.
+    // Native (non-Git) quickstarts keep Heddle's rules only.
+    if has_git
+        && gix::refs::FullName::try_from(format!("refs/heads/{thread}").as_str()).is_err()
+    {
+        bail!(RecoveryAdvice::invalid_usage(
+            "quickstart_thread_name_invalid",
+            format!("'{thread}' is not a valid Git branch name"),
+            "Choose a thread name Git accepts as a branch: no spaces, '~', '^', ':', '?', '*', '[', backslashes, or control characters.",
             "heddle init --quickstart --quickstart-thread <name>",
         ));
     }
@@ -512,6 +545,20 @@ fn resolve_quickstart_identity(
     has_git: bool,
     json: bool,
 ) -> Result<Option<(String, String)>> {
+    // `resolve_principal` lets env win OUTRIGHT — it returns the env identity
+    // even when it is the sentinel, before considering repo config (where
+    // flags land), Git, or user config. So a sentinel env identity shadows a
+    // valid `--principal-*` flag: the capture would still be attributed to the
+    // env sentinel and rejected by `build_attribution`, but only AFTER init has
+    // written `.heddle/config.toml` (and quickstart may have written
+    // QUICKSTART.md). Reject the env sentinel here, before any write, instead
+    // of persisting lower-precedence flags that env will shadow.
+    if let Some(env_principal) = Principal::from_env()
+        && principal_is_unconfigured(&env_principal)
+    {
+        bail!(quickstart_identity_required_advice());
+    }
+
     // Explicit flags become the repo-level `[principal]` — the highest
     // precedence source after env in `resolve_principal`. Validate them
     // against the sentinel here so `--principal-name Unknown
@@ -593,9 +640,12 @@ fn resolve_quickstart_principal(path: &Path, has_git: bool) -> Principal {
     }
     // Repo-level config slot: stop at the on-disk repo `[principal]` if
     // present, even the sentinel — `resolve_principal` does. (This is the
-    // "already has .heddle/" quickstart path.)
-    let repo_config_path = path.join(".heddle").join("config.toml");
-    if let Ok(repo_config) = repo::RepoConfig::load(&repo_config_path)
+    // "already has .heddle/" quickstart path.) Resolve config the way
+    // `Repository::open` does: in a materialized checkout the local
+    // `.heddle/` is just an objectstore pointer and the real `[principal]`
+    // lives in the SHARED dir it points at, so a local-only probe would
+    // wrongly report "no identity" there.
+    if let Some(repo_config) = resolve_existing_repo_config(path)
         && let Some(config) = &repo_config.principal
     {
         return Principal::new(&config.name, &config.email);
@@ -627,13 +677,79 @@ fn prompt_line(label: &str) -> Result<String> {
     Ok(input.trim().to_string())
 }
 
-/// Whether the discovered Git repository at `path` already has at least
-/// one commit (a non-empty history). An unborn branch reads as empty.
+/// Whether the discovered Git repository at `path` has any commits on ANY
+/// local ref — not just the current HEAD. A repo with commits on another
+/// ref (e.g. after `git switch --orphan scratch`, where the current HEAD is
+/// unborn but `main` still carries history) must be treated as having
+/// existing history so the quickstart confirms AND imports rather than
+/// acting as if the repo were empty (which would leave partial/wrong state).
 fn git_has_commits(path: &Path) -> bool {
+    let Ok(repo) = gix::discover(path) else {
+        return false;
+    };
+    if repo.head_id().is_ok() {
+        return true;
+    }
+    let Ok(platform) = repo.references() else {
+        return false;
+    };
+    let Ok(refs) = platform.all() else {
+        return false;
+    };
+    for reference in refs.filter_map(Result::ok) {
+        let mut reference = reference;
+        if let Ok(id) = reference.peel_to_id()
+            && repo
+                .find_object(id.detach())
+                .map(|object| object.kind == gix::objs::Kind::Commit)
+                .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether the discovered Git repository at `path` has a detached HEAD
+/// (HEAD points directly at a commit instead of an attached branch). An
+/// unborn HEAD reads as not-detached.
+fn git_head_is_detached(path: &Path) -> bool {
     gix::discover(path)
         .ok()
-        .map(|repo| repo.head_id().is_ok())
+        .and_then(|repo| repo.head().ok().map(|head| head.is_detached()))
         .unwrap_or(false)
+}
+
+/// Resolve the on-disk repo config the way `Repository::open` does: when the
+/// local `.heddle/` is a worktree pointer (`.heddle/objectstore`), the real
+/// config lives in the shared dir it points at; otherwise it is the local
+/// `.heddle/config.toml`. Returns `None` when there is no readable `.heddle`
+/// config yet (a fresh directory).
+fn resolve_existing_repo_config(path: &Path) -> Option<repo::RepoConfig> {
+    let heddle_dir = path.join(".heddle");
+    if !heddle_dir.is_dir() {
+        return None;
+    }
+    let pointer = heddle_dir.join("objectstore");
+    let config_path = if pointer.is_file() {
+        let content = std::fs::read_to_string(&pointer).ok()?;
+        let shared = parse_objectstore_pointer(&content)?;
+        shared.canonicalize().ok()?.join("config.toml")
+    } else {
+        heddle_dir.join("config.toml")
+    };
+    repo::RepoConfig::load(&config_path).ok()
+}
+
+/// Minimal mirror of the repo crate's objectstore pointer parse: the file
+/// holds a line of the form `objectstore: <absolute path>`.
+fn parse_objectstore_pointer(content: &str) -> Option<PathBuf> {
+    content.lines().find_map(|line| {
+        line.strip_prefix("objectstore:")
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+    })
 }
 
 /// The write batch of `--quickstart`: start the thread, make one
@@ -765,6 +881,22 @@ fn quickstart_needs_confirmation_advice() -> RecoveryAdvice {
         "no repository objects, refs, metadata, or worktree files were changed",
         "heddle init --quickstart --yes",
         vec!["heddle init --quickstart --yes".to_string()],
+    )
+}
+
+fn quickstart_detached_head_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "quickstart_detached_head",
+        "Refusing to run --quickstart on a detached Git HEAD",
+        "Attach a branch first with `git switch -c <branch>` (or `git switch <branch>`), then re-run `heddle init --quickstart`.",
+        "Git HEAD points directly at a commit instead of an attached branch",
+        "quickstart would import history and write a Git checkpoint through a branch, but a detached HEAD has no branch to advance and could reattach or move the wrong ref",
+        "no repository objects, refs, metadata, or worktree files were changed",
+        "git switch -c <branch>",
+        vec![
+            "git switch -c <branch>".to_string(),
+            "heddle init --quickstart".to_string(),
+        ],
     )
 }
 

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{Result, bail};
 use objects::object::{Principal, ThreadName, Tree};
-use refs::Head;
+use refs::{Head, validate_ref_name};
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
 use tracing::{debug, info};
@@ -421,12 +421,26 @@ fn quickstart_preflight(
 ) -> Result<QuickstartPreflight> {
     let json = should_output_json(cli, None);
 
+    // Validate the requested thread name BEFORE any write, using the same
+    // ref-name rules the thread machinery enforces when the ref is actually
+    // created. A bad name (`.bad`, `a..b`, …) must fail here rather than
+    // after init/bootstrap/import have already written `.heddle/` data,
+    // leaving a half-initialized repo for a pure argument error.
+    let thread = args.quickstart_thread.as_deref().unwrap_or("quickstart");
+    if validate_ref_name(thread).is_err() {
+        bail!(RecoveryAdvice::invalid_usage(
+            "quickstart_thread_name_invalid",
+            format!("'{thread}' is not a valid thread name"),
+            "Choose a thread name without '..', a leading '.', a trailing '/' or '.lock', backslashes, or control characters.",
+            "heddle init --quickstart --quickstart-thread <name>",
+        ));
+    }
+
     // Confirmation gate before touching a directory that already holds
     // work. Truly fresh directories skip straight through.
     let heddle_exists = path.join(".heddle").exists();
     let git_nonempty = has_git && git_has_commits(path);
     if (heddle_exists || git_nonempty) && !args.yes {
-        let thread = args.quickstart_thread.as_deref().unwrap_or("quickstart");
         if !json {
             println!(
                 "{}",
@@ -476,12 +490,21 @@ fn quickstart_preflight(
 }
 
 /// Resolve the principal for `--quickstart`. Priority: explicit
-/// `--principal-*` flags → an already-resolvable identity (env, user
-/// config, or Git config) → an interactive prompt. Returns the
-/// `(name, email)` to persist when it came from flags or the prompt, or
-/// `None` when an identity is already available without writing. Fails
-/// fast (no placeholder) when nothing is resolvable and there is no TTY
-/// to prompt.
+/// `--principal-*` flags → an already-resolvable identity (env, repo
+/// config, Git config, or user config) → an interactive prompt. Returns
+/// the `(name, email)` to persist when it came from flags or the prompt,
+/// or `None` when an identity is already available without writing. Fails
+/// fast (no placeholder) when nothing usable is resolvable and there is no
+/// TTY to prompt.
+///
+/// Every path that yields an identity is checked against the SAME sentinel
+/// predicate (`principal_is_unconfigured`) the real capture uses, over the
+/// SAME precedence `resolve_principal` walks — see
+/// [`resolve_quickstart_principal`]. This is the single source of truth:
+/// flags, prompt, repo config, user config, and Git config (and a
+/// higher-precedence sentinel shadowing a lower valid source) are all
+/// caught HERE, before any write, instead of by `build_attribution` after
+/// `.heddle/` already exists.
 fn resolve_quickstart_identity(
     cli: &Cli,
     args: &InitArgs,
@@ -489,8 +512,13 @@ fn resolve_quickstart_identity(
     has_git: bool,
     json: bool,
 ) -> Result<Option<(String, String)>> {
-    match (args.principal_name.clone(), args.principal_email.clone()) {
-        (Some(name), Some(email)) => return Ok(Some((name, email))),
+    // Explicit flags become the repo-level `[principal]` — the highest
+    // precedence source after env in `resolve_principal`. Validate them
+    // against the sentinel here so `--principal-name Unknown
+    // --principal-email unknown@example.com` fails before any write rather
+    // than being persisted and then rejected by `build_attribution`.
+    let flag_principal = match (args.principal_name.clone(), args.principal_email.clone()) {
+        (Some(name), Some(email)) => Some((name, email)),
         (Some(_), None) => {
             bail!(RecoveryAdvice::init_principal_field_required(
                 "--principal-email"
@@ -501,17 +529,33 @@ fn resolve_quickstart_identity(
                 "--principal-name"
             ))
         }
-        (None, None) => {}
+        (None, None) => None,
+    };
+    if let Some((name, email)) = flag_principal {
+        if principal_is_unconfigured(&Principal::new(&name, &email)) {
+            bail!(quickstart_identity_required_advice());
+        }
+        return Ok(Some((name, email)));
     }
 
-    if quickstart_identity_available(path, has_git) {
+    // No flags: ask the REAL resolution (mirroring `resolve_principal`'s
+    // stop-at-first-present precedence) what the capture would be
+    // attributed to. A usable identity → proceed without writing one. A
+    // sentinel result — including a higher-precedence sentinel that shadows
+    // a lower valid source — means the capture would be rejected, so we
+    // must prompt (if interactive) or fail before any write.
+    let resolved = resolve_quickstart_principal(path, has_git);
+    if !principal_is_unconfigured(&resolved) {
         return Ok(None);
     }
 
     if is_tty() && !cli.quiet && !json {
         let name = prompt_line("Your name: ")?;
         let email = prompt_line("Your email: ")?;
-        if name.is_empty() || email.is_empty() {
+        // Validate the collected identity with the same sentinel predicate
+        // so a prompted `Unknown / unknown@example.com` is rejected before
+        // any write, exactly like the flag path.
+        if principal_is_unconfigured(&Principal::new(&name, &email)) {
             bail!(quickstart_identity_required_advice());
         }
         return Ok(Some((name, email)));
@@ -520,39 +564,59 @@ fn resolve_quickstart_identity(
     bail!(quickstart_identity_required_advice())
 }
 
-/// Whether a real (non-placeholder) principal is already resolvable
-/// without writing one. Mirrors `resolve_principal`'s precedence so the
-/// preflight never refuses a repo whose capture would in fact be
-/// attributable: environment, then the repo-level
-/// `.heddle/config.toml` `[principal]` (which outranks user and Git
-/// config in `resolve_principal`), then the user config, then — in a Git
-/// repo — Git's own `user.name`/`user.email`.
-fn quickstart_identity_available(path: &Path, has_git: bool) -> bool {
-    if let Some(principal) = Principal::from_env()
-        && !principal_is_unconfigured(&principal)
-    {
-        return true;
+/// Resolve the ambient principal the quickstart capture WOULD be attributed
+/// to (with no `--principal-*` flags), at preflight time, before the repo
+/// exists. This is the single source of truth for "is there a usable
+/// identity?": it mirrors `resolve_principal` (snapshot.rs) EXACTLY — same
+/// sources, same order, and crucially the same STOP-at-first-present
+/// semantics — so the preflight can never diverge from the real resolution
+/// the way a fall-through check can. (Flag/prompt identities are validated
+/// separately at their source in `resolve_quickstart_identity`, since they
+/// occupy the repo-config slot by being written there before the capture.)
+///
+/// Precedence (identical to `resolve_principal`): env → repo
+/// `.heddle/config.toml` `[principal]` → Git config (only when it isn't the
+/// sentinel, matching `resolve_principal`'s fall-through) → user config →
+/// the `Unknown` sentinel.
+///
+/// Returns the resolved principal (possibly the sentinel); callers apply
+/// `principal_is_unconfigured` to decide whether to fail. STOP semantics are
+/// the whole point: a higher-precedence sentinel (e.g. a repo config pinning
+/// `Unknown <unknown@example.com>`) shadows a lower valid source here just as
+/// it would in `resolve_principal`, so the preflight rejects what the capture
+/// would reject.
+fn resolve_quickstart_principal(path: &Path, has_git: bool) -> Principal {
+    // env wins outright — `resolve_principal` returns it unconditionally
+    // (even when it is the sentinel), so mirror that: stop here.
+    if let Some(principal) = Principal::from_env() {
+        return principal;
     }
+    // Repo-level config slot: stop at the on-disk repo `[principal]` if
+    // present, even the sentinel — `resolve_principal` does. (This is the
+    // "already has .heddle/" quickstart path.)
     let repo_config_path = path.join(".heddle").join("config.toml");
     if let Ok(repo_config) = repo::RepoConfig::load(&repo_config_path)
         && let Some(config) = &repo_config.principal
-        && !principal_is_unconfigured(&Principal::new(&config.name, &config.email))
     {
-        return true;
+        return Principal::new(&config.name, &config.email);
+    }
+    // Git config: `resolve_principal` falls through to user config when
+    // Git's identity is the sentinel, so only a non-sentinel Git identity
+    // stops here.
+    if has_git
+        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(path)
+    {
+        let principal = Principal::new(&identity.name, &identity.email);
+        if !principal_is_unconfigured(&principal) {
+            return principal;
+        }
     }
     if let Ok(user_config) = UserConfig::load_default()
         && let Some(config) = &user_config.principal
-        && !principal_is_unconfigured(&Principal::new(&config.name, &config.email))
     {
-        return true;
+        return Principal::new(&config.name, &config.email);
     }
-    if has_git
-        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(path)
-        && !principal_is_unconfigured(&Principal::new(&identity.name, &identity.email))
-    {
-        return true;
-    }
-    false
+    Principal::new("Unknown", "unknown@example.com")
 }
 
 fn prompt_line(label: &str) -> Result<String> {
@@ -631,26 +695,40 @@ fn run_quickstart_actions(repo: &Repository, args: &InitArgs) -> Result<Quicksta
     })
 }
 
-/// Create the named quickstart thread and attach HEAD to it. Idempotent:
-/// a re-run that is already on the thread is a no-op.
+/// Create (or repoint) the named quickstart thread and attach HEAD to it.
+/// Idempotent: a re-run that is already on the thread is a no-op.
 ///
-/// When a current state already exists (a freshly-seeded native repo, or
-/// a Git overlay whose history we just imported) the thread is pointed at
-/// it. An unborn Git overlay has NO current state yet: we must NOT
-/// fabricate a bootstrap snapshot here, or the quickstart would land an
-/// extra empty parent commit before `QUICKSTART.md` is even written —
-/// breaking the promised single initial capture/checkpoint. Instead we
-/// just attach HEAD to the thread; the subsequent quickstart capture
-/// creates the thread's first (root) state and advances the ref.
+/// When a current state exists (a freshly-seeded native repo, a Git overlay
+/// whose history we just imported, or simply another thread the user is
+/// currently on) the quickstart thread is pointed AT that current state, so
+/// the subsequent capture's parent is the current worktree's state. This
+/// covers two cases that must behave identically:
+///   - the thread does not exist yet → create it at the current state;
+///   - the thread already exists but is NOT the one we're attached to →
+///     repoint it to the current state. Otherwise `write_head` would attach
+///     to the thread's STALE tip without checking out its tree, and the
+///     capture would record the current worktree as a child of that stale
+///     tip — the wrong parent (corrupting history when `--quickstart --yes`
+///     is rerun after switching away from an existing quickstart thread).
+///
+/// When already attached to the thread, its tip already IS the current
+/// state, so it is left untouched (the idempotent no-op rerun).
+///
+/// An unborn Git overlay has NO current state yet: we must NOT fabricate a
+/// bootstrap snapshot here, or the quickstart would land an extra empty
+/// parent commit before `QUICKSTART.md` is even written — breaking the
+/// promised single initial capture/checkpoint. In that case we just attach
+/// HEAD to the thread; the subsequent quickstart capture creates the
+/// thread's first (root) state and advances the ref.
 fn ensure_quickstart_thread(repo: &Repository, name: &str) -> Result<()> {
     let target = ThreadName::new(name);
-    if let Some(state) = repo.current_state()?
-        && repo.refs().get_thread(&target)?.is_none()
+    let already_attached =
+        matches!(repo.head_ref()?, Head::Attached { thread } if thread == target);
+    if !already_attached
+        && let Some(state) = repo.current_state()?
     {
         repo.refs().set_thread(&target, &state.change_id)?;
     }
-    let already_attached =
-        matches!(repo.head_ref()?, Head::Attached { thread } if thread == target);
     if !already_attached {
         repo.refs().write_head(&Head::Attached { thread: target })?;
     }

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -161,32 +161,43 @@ pub fn prompt_init_install_decision(
     args: &crate::cli::InitArgs,
     json: bool,
 ) -> Result<Vec<String>> {
-    if json || cli.quiet || !is_tty() || args.no_harness_install {
+    let harnesses = if json || cli.quiet || !is_tty() || args.no_harness_install {
         // Non-interactive: only an explicit `--install-harnesses`
         // selection installs anything; detection never auto-installs.
-        return match &args.install_harnesses {
-            Some(selection) => resolve_selection_for_root(root, selection),
-            None => Ok(Vec::new()),
-        };
-    }
-
-    let harnesses = if let Some(selection) = &args.install_harnesses {
-        resolve_selection_for_root(root, selection)?
+        match &args.install_harnesses {
+            Some(selection) => resolve_selection_for_root(root, selection)?,
+            None => Vec::new(),
+        }
     } else {
-        detect_harnesses_for_root(root)
+        let harnesses = if let Some(selection) = &args.install_harnesses {
+            resolve_selection_for_root(root, selection)?
+        } else {
+            detect_harnesses_for_root(root)
+        };
+        if harnesses.is_empty() {
+            Vec::new()
+        } else {
+            println!(
+                "Connect Heddle to detected harnesses for ambient actor tracking? [{}] [y/N]",
+                harnesses.join(", ")
+            );
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            if matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+                harnesses
+            } else {
+                Vec::new()
+            }
+        }
     };
-    if harnesses.is_empty() {
-        return Ok(Vec::new());
-    }
 
-    println!(
-        "Connect Heddle to detected harnesses for ambient actor tracking? [{}] [y/N]",
-        harnesses.join(", ")
-    );
-    let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-    if !matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
-        return Ok(Vec::new());
+    // Validate the install scope with the SAME parser the install path
+    // (`perform_init_install`) uses, in this pre-write decision phase, so an
+    // invalid `--harness-install-scope` fails before any repo is created
+    // instead of after — keeping the quickstart fail-before-writes contract.
+    // Only matters when something will actually be installed.
+    if !harnesses.is_empty() {
+        IntegrationScope::parse(&args.harness_install_scope)?;
     }
     Ok(harnesses)
 }

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -141,35 +141,42 @@ pub fn maybe_prompt_init_install(
     repo: &Repository,
     args: &crate::cli::InitArgs,
 ) -> Result<()> {
-    if should_output_json(cli, Some(repo.config()))
-        || cli.quiet
-        || !is_tty()
-        || args.no_harness_install
-    {
-        if let Some(selection) = &args.install_harnesses {
-            let harnesses = resolve_selection(repo, selection)?;
-            if !harnesses.is_empty() {
-                install_selected(
-                    cli,
-                    repo,
-                    &harnesses,
-                    IntegrationScope::parse(&args.harness_install_scope)?,
-                    args.harness_install_force,
-                    PathMode::Relative,
-                )?;
-            }
-        }
-        return Ok(());
+    let json = should_output_json(cli, Some(repo.config()));
+    let harnesses = prompt_init_install_decision(cli, repo.root(), args, json)?;
+    perform_init_install(cli, repo, args, &harnesses)
+}
+
+/// Pre-write phase of the harness-install prompt: detect harnesses and
+/// (interactively) ask the user whether to connect them, WITHOUT writing
+/// anything. Returns the harnesses to install once writes are safe.
+///
+/// `--quickstart` calls this before any filesystem mutation so a Ctrl-C
+/// at the harness prompt leaves the directory untouched — the install
+/// itself is deferred to [`perform_init_install`] after the writes land.
+/// Only the directory `root` is needed (PATH lookups + `.claude`/
+/// `.opencode` probes), so it works before the repository exists on disk.
+pub fn prompt_init_install_decision(
+    cli: &Cli,
+    root: &Path,
+    args: &crate::cli::InitArgs,
+    json: bool,
+) -> Result<Vec<String>> {
+    if json || cli.quiet || !is_tty() || args.no_harness_install {
+        // Non-interactive: only an explicit `--install-harnesses`
+        // selection installs anything; detection never auto-installs.
+        return match &args.install_harnesses {
+            Some(selection) => resolve_selection_for_root(root, selection),
+            None => Ok(Vec::new()),
+        };
     }
 
-    let detected = detect_harnesses(repo)?;
     let harnesses = if let Some(selection) = &args.install_harnesses {
-        resolve_selection(repo, selection)?
+        resolve_selection_for_root(root, selection)?
     } else {
-        detected
+        detect_harnesses_for_root(root)
     };
     if harnesses.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     println!(
@@ -179,13 +186,27 @@ pub fn maybe_prompt_init_install(
     let mut input = String::new();
     io::stdin().read_line(&mut input)?;
     if !matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        return Ok(Vec::new());
+    }
+    Ok(harnesses)
+}
+
+/// Post-write phase: install the harnesses chosen by
+/// [`prompt_init_install_decision`]. No prompting happens here, so it is
+/// safe to run after the repository has been created.
+pub fn perform_init_install(
+    cli: &Cli,
+    repo: &Repository,
+    args: &crate::cli::InitArgs,
+    harnesses: &[String],
+) -> Result<()> {
+    if harnesses.is_empty() {
         return Ok(());
     }
-
     install_selected(
         cli,
         repo,
-        &harnesses,
+        harnesses,
         IntegrationScope::parse(&args.harness_install_scope)?,
         args.harness_install_force,
         PathMode::Relative,
@@ -517,6 +538,14 @@ fn integration_status(
 }
 
 fn detect_harnesses(repo: &Repository) -> Result<Vec<String>> {
+    Ok(detect_harnesses_for_root(repo.root()))
+}
+
+/// Path-based harness detection: PATH lookups for the harness binaries
+/// plus `.claude`/`.opencode` directory probes under `root`. Works
+/// before the repository exists, which the pre-write quickstart prompt
+/// relies on.
+fn detect_harnesses_for_root(root: &Path) -> Vec<String> {
     let mut found = BTreeSet::new();
     for harness in ["codex", "claude", "opencode"] {
         if command_on_path(harness) {
@@ -527,13 +556,13 @@ fn detect_harnesses(repo: &Repository) -> Result<Vec<String>> {
             found.insert(normalized.to_string());
         }
     }
-    if repo.root().join(".claude").exists() {
+    if root.join(".claude").exists() {
         found.insert("claude-code".to_string());
     }
-    if repo.root().join(".opencode").exists() {
+    if root.join(".opencode").exists() {
         found.insert("opencode".to_string());
     }
-    Ok(found.into_iter().collect())
+    found.into_iter().collect()
 }
 
 fn command_on_path(bin: &str) -> bool {
@@ -544,10 +573,10 @@ fn command_on_path(bin: &str) -> bool {
         .any(|dir| dir.join(bin).exists())
 }
 
-fn resolve_selection(repo: &Repository, selection: &str) -> Result<Vec<String>> {
+fn resolve_selection_for_root(root: &Path, selection: &str) -> Result<Vec<String>> {
     match selection {
         "none" => Ok(Vec::new()),
-        "auto" => detect_harnesses(repo),
+        "auto" => Ok(detect_harnesses_for_root(root)),
         value => normalize_harnesses(value.split(',').map(|item| item.to_string()).collect()),
     }
 }

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -191,13 +191,14 @@ pub fn prompt_init_install_decision(
         }
     };
 
-    // Validate the install scope with the SAME parser the install path
-    // (`perform_init_install`) uses, in this pre-write decision phase, so an
-    // invalid `--harness-install-scope` fails before any repo is created
+    // Validate the install plan with the SAME predicates the install path
+    // uses, in this pre-write decision phase, so an invalid
+    // `--harness-install-scope` OR a harness that rejects the chosen scope
+    // (e.g. `codex` requires `--scope user`) fails before any repo is created
     // instead of after — keeping the quickstart fail-before-writes contract.
     // Only matters when something will actually be installed.
     if !harnesses.is_empty() {
-        IntegrationScope::parse(&args.harness_install_scope)?;
+        validate_install_plan(&harnesses, &args.harness_install_scope)?;
     }
     Ok(harnesses)
 }
@@ -628,6 +629,41 @@ fn target_harnesses(manifest: &IntegrationManifest, requested: Vec<String>) -> R
     normalize_harnesses(requested)
 }
 
+/// Single source of truth for which install scopes a harness accepts. Both the
+/// pre-write preflight ([`validate_install_plan`], so a scope a harness will
+/// reject fails BEFORE any repository is created) and the actual install path
+/// ([`install_codex`] et al.) call this, so the two can never disagree — a
+/// future scope-restricted harness adds its rule here and is automatically
+/// enforced in the preflight. This closes the class behind cid 3329409818: a
+/// `--quickstart --install-harnesses codex` with the default `--scope repo`
+/// must fail in the preflight, not after `.heddle/`/capture/checkpoint exist.
+fn validate_harness_scope(harness: &str, scope: &IntegrationScope) -> Result<()> {
+    match harness {
+        "codex" if *scope != IntegrationScope::User => {
+            Err(anyhow!(RecoveryAdvice::invalid_usage(
+                "integration_codex_scope_invalid",
+                "codex integration currently requires --scope user",
+                "Rerun the install with `--scope user`.",
+                "heddle integration install codex --scope user",
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Pre-write validation of a harness-install plan: the scope string parses AND
+/// every selected harness accepts that scope. The quickstart preflight runs
+/// this before any filesystem write so a harness/scope combination that the
+/// install would reject (e.g. `codex` + `repo`) fails before a repo is created,
+/// not midway through `install_selected` after `.heddle/` already exists.
+fn validate_install_plan(harnesses: &[String], scope_value: &str) -> Result<()> {
+    let scope = IntegrationScope::parse(scope_value)?;
+    for harness in harnesses {
+        validate_harness_scope(harness, &scope)?;
+    }
+    Ok(())
+}
+
 fn install_codex(
     repo: &Repository,
     manifest: &mut IntegrationManifest,
@@ -635,14 +671,7 @@ fn install_codex(
     force: bool,
     path_mode: PathMode,
 ) -> Result<()> {
-    if *scope != IntegrationScope::User {
-        return Err(anyhow!(RecoveryAdvice::invalid_usage(
-            "integration_codex_scope_invalid",
-            "codex integration currently requires --scope user",
-            "Rerun the install with `--scope user`.",
-            "heddle integration install codex --scope user",
-        )));
-    }
+    validate_harness_scope("codex", scope)?;
     let home = env::var("HOME").context("HOME is required for codex integration install")?;
     let config_path = PathBuf::from(home).join(".codex").join("config.toml");
     let existing = if config_path.exists() {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -168,7 +168,9 @@ pub use heddle_client::{
 pub use hook::cmd_hook;
 pub use index::cmd_index;
 pub use init::cmd_init;
-pub use integration::{cmd_integration, maybe_prompt_init_install};
+pub use integration::{
+    cmd_integration, maybe_prompt_init_install, perform_init_install, prompt_init_install_decision,
+};
 pub use log::{LogCommandOptions, cmd_log};
 pub use maintenance::cmd_maintenance;
 pub use marker::cmd_marker;

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -241,7 +241,11 @@ fn quickstart_init_recommendation(
         return None;
     }
     let empty_log = current_state.map(is_synthetic_root).unwrap_or(true);
-    empty_log.then(|| "heddle init --quickstart".to_string())
+    // The repo already has `.heddle/` (it has been init'd to reach this
+    // branch), so a bare `heddle init --quickstart` hits the confirmation
+    // gate and is refused non-interactively. Recommend the runnable form —
+    // `--yes` clears the gate — so an agent/script can run it verbatim.
+    empty_log.then(|| "heddle init --quickstart --yes".to_string())
 }
 
 fn changes_from_status(status: &WorktreeStatus) -> ChangesInfo {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -12,9 +12,9 @@ use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use objects::worktree::WorktreeStatus;
 use repo::{
-    AgentUsageSummary, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus, Thread,
-    ThreadFreshness, ThreadImpactCategory, ThreadMode, ThreadState, WorktreeCompareProfile,
-    describe_thread_advice_with_initial, is_synthetic_root,
+    AgentUsageSummary, GitRemoteTrackingStatus, Repository, RepositoryCapability,
+    RepositoryOperationStatus, Thread, ThreadFreshness, ThreadImpactCategory, ThreadMode,
+    ThreadState, WorktreeCompareProfile, describe_thread_advice_with_initial, is_synthetic_root,
 };
 #[cfg(feature = "client")]
 use serde::Deserialize;
@@ -224,6 +224,24 @@ struct PlainGitStatusOutput {
     changed_path_count: usize,
     changes: ChangesInfo,
     git_index: Option<GitIndexPlan>,
+}
+
+/// Recommend the one-command first run when a native Heddle repository
+/// has been initialized but has no user-visible history yet (the log
+/// shows only the filtered synthetic root) and the worktree is clean —
+/// i.e. there is genuinely nothing to act on yet. A dirty worktree
+/// already has its own advice (`heddle commit`), and Git-overlay repos
+/// have their own onboarding (import/adopt), so both are left alone.
+fn quickstart_init_recommendation(
+    repo: &Repository,
+    current_state: Option<&objects::object::State>,
+    worktree_clean: bool,
+) -> Option<String> {
+    if !worktree_clean || repo.capability() != RepositoryCapability::NativeHeddle {
+        return None;
+    }
+    let empty_log = current_state.map(is_synthetic_root).unwrap_or(true);
+    empty_log.then(|| "heddle init --quickstart".to_string())
 }
 
 fn changes_from_status(status: &WorktreeStatus) -> ChangesInfo {
@@ -486,6 +504,12 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         } else {
             trust.recommended_action.clone()
         };
+        let worktree_clean = changes.modified.is_empty()
+            && changes.added.is_empty()
+            && changes.deleted.is_empty();
+        let recommended_action =
+            quickstart_init_recommendation(&repo, current_state.as_ref(), worktree_clean)
+                .unwrap_or(recommended_action);
         debug!(
             repo_open_ms,
             body_ms = body_start.elapsed().as_millis(),
@@ -929,6 +953,12 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
     {
         override_trust_recommended_action(&mut trust, recommended_action.clone());
     }
+    // A freshly-`init`'d native repo whose log is still empty (only the
+    // synthetic root) and whose worktree is clean has nothing to act on
+    // yet — point the user at the one-command first run.
+    let recommended_action =
+        quickstart_init_recommendation(&repo, current_state.as_ref(), !has_changes)
+            .unwrap_or(recommended_action);
     let recommended_action_fields = ActionFields::from_action(&recommended_action);
     let thread_health = if trust.verified {
         advice

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -66,6 +66,8 @@ mod output_kind_runtime;
 mod output_mode_no_auto;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
+#[path = "cli_integration/quickstart.rs"]
+mod quickstart;
 #[path = "cli_integration/realworld_git.rs"]
 mod realworld_git;
 #[path = "cli_integration/redact_purge.rs"]

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -363,6 +363,133 @@ fn quickstart_checkpoints_on_git_overlay() {
     );
 }
 
+/// On an unborn Git overlay (a fresh `git init` with NO commits),
+/// quickstart must produce exactly ONE capture + ONE checkpoint — the
+/// promised single initial commit. Previously it fabricated a "Bootstrap
+/// before quickstart" snapshot before `QUICKSTART.md` was written,
+/// leaving an extra empty parent commit (Codex r3 cid 3328971408).
+#[test]
+fn quickstart_unborn_git_yields_single_capture_and_checkpoint() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir); // unborn: no commits yet
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart should succeed on an unborn Git repo: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Exactly one Heddle state: the bug left a "Bootstrap before
+    // quickstart" parent in front of the real capture.
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states.len(),
+        1,
+        "exactly one capture, no extra bootstrap parent: {log}"
+    );
+    let intent = states[0]["intent"].as_str().unwrap_or_default();
+    assert!(
+        intent.contains("quickstart"),
+        "the single state is the quickstart capture, not a bootstrap: {intent:?}"
+    );
+
+    // And exactly one Git checkpoint commit (no extra bootstrap parent in
+    // the exported history).
+    let grepo = gix::open(dir).expect("open git repo");
+    let tip = grepo
+        .head_id()
+        .expect("HEAD resolves to a checkpoint commit");
+    let commit_count = grepo
+        .rev_walk([tip.detach()])
+        .all()
+        .expect("rev-walk checkpoint history")
+        .count();
+    assert_eq!(
+        commit_count, 1,
+        "exactly one checkpoint commit, no extra bootstrap parent"
+    );
+}
+
+/// The quickstart identity preflight must honor a repo-level
+/// `.heddle/config.toml` `[principal]`: it outranks user and Git config
+/// in `resolve_principal`, so a repo whose ONLY resolvable identity is
+/// its repo-level principal must NOT be refused before it is opened
+/// (Codex r3 cid 3328971410).
+#[test]
+fn quickstart_preflight_honors_repo_level_principal() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    // A Git repo so the test harness skips seeding a user-config identity;
+    // combined with the cleared env below, the repo-level principal we pin
+    // is the ONLY identity available.
+    git_hermetic(&["init"], dir);
+
+    let isolate: &[(&str, &str)] = &[
+        ("GIT_CONFIG_GLOBAL", "/dev/null"),
+        ("GIT_CONFIG_SYSTEM", "/dev/null"),
+        ("GIT_CONFIG_NOSYSTEM", "1"),
+        ("HEDDLE_PRINCIPAL_NAME", ""),
+        ("HEDDLE_PRINCIPAL_EMAIL", ""),
+    ];
+
+    let init =
+        heddle_output_with_env(&["init", "--no-harness-install"], Some(dir), isolate).unwrap();
+    assert!(
+        init.status.success(),
+        "plain init should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr),
+    );
+
+    // Pin a repo-level principal as the sole identity, merged into the
+    // config `init` already wrote (which carries the required
+    // `[repository]` section).
+    let cfg_path = dir.join(".heddle").join("config.toml");
+    let mut cfg = repo::RepoConfig::load(&cfg_path).unwrap_or_default();
+    cfg.set_principal("Repo Local", "repo@example.invalid");
+    cfg.save(&cfg_path).unwrap();
+
+    let out = heddle_output_with_env(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(dir),
+        isolate,
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "repo-level principal must satisfy the quickstart preflight: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("Repo Local <repo@example.invalid>"),
+        "capture is attributed to the repo-level principal: {log}"
+    );
+}
+
 /// Non-interactive `--install-harnesses` installs the named harness as a
 /// post-write step (the decision is resolved up front, the install runs
 /// after the repo exists).

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -490,6 +490,62 @@ fn quickstart_preflight_honors_repo_level_principal() {
     );
 }
 
+/// Codex r4 (cid 3329024451): Git's sentinel-default identity
+/// (`user.name=Unknown` / `user.email=unknown@example.com`) is what
+/// `resolve_principal`/`build_attribution` treat as UNCONFIGURED and
+/// reject. The preflight must filter it the SAME way — a repo whose only
+/// Git identity is the sentinel must fail BEFORE any `.heddle` write, not
+/// pass the preflight and then have the capture refuse mid-write.
+#[test]
+fn quickstart_rejects_git_sentinel_identity_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    // Persist the sentinel "unconfigured" identity into the repo's local
+    // Git config (the `-c` flags `git_hermetic` passes do NOT persist).
+    git_hermetic(&["config", "user.name", "Unknown"], dir);
+    git_hermetic(&["config", "user.email", "unknown@example.com"], dir);
+
+    let out = heddle_output_with_env(
+        &[
+            "init",
+            "--quickstart",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+        &[
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_SYSTEM", "/dev/null"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "sentinel-only Git identity must not satisfy the preflight: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_identity_required"),
+        "must fail with the quickstart_identity_required advice: stderr={stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a sentinel-only identity must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
 /// Non-interactive `--install-harnesses` installs the named harness as a
 /// post-write step (the decision is resolved up front, the install runs
 /// after the repo exists).

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1192,3 +1192,246 @@ fn quickstart_install_none_installs_nothing() {
         "selecting `none` installs no harness integration"
     );
 }
+
+/// Codex r7 (cid 3329270261): the preflight used `gix::discover` to decide
+/// `has_git`, which walks to an ANCESTOR Git checkout — so a native Heddle
+/// repo nested inside an ancestor Git checkout was wrongly treated as a Git
+/// overlay and refused for the ancestor's detached HEAD, even though
+/// `Repository::open` keeps it native and runs no Git checkpoint. The preflight
+/// now derives capability from the opened repo, so the nested-native quickstart
+/// proceeds.
+#[test]
+fn quickstart_native_repo_nested_in_git_checkout_is_not_overlay_refused() {
+    let outer = TempDir::new().unwrap();
+    let inner = outer.path().join("project");
+    std::fs::create_dir(&inner).unwrap();
+
+    // Native Heddle repo created BEFORE any Git exists anywhere, so it is a
+    // genuine NativeHeddle repo (no `.git` at its own root).
+    heddle(&["init", "--no-harness-install"], Some(&inner)).unwrap();
+    assert!(inner.join(".heddle").is_dir());
+
+    // Now wrap it in an ancestor Git checkout with a DETACHED HEAD.
+    git_hermetic(&["init"], outer.path());
+    std::fs::write(outer.path().join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], outer.path());
+    git_hermetic(&["commit", "-m", "initial"], outer.path());
+    git_hermetic(&["checkout", "--detach"], outer.path());
+
+    // The nested repo is native, so quickstart creates no Git checkpoint and
+    // the ancestor's detached HEAD is irrelevant. It must NOT be refused.
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(&inner),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "a native repo nested in a detached-HEAD Git checkout must proceed: stdout={stdout} stderr={stderr}",
+    );
+    assert!(
+        !stderr.contains("quickstart_detached_head"),
+        "must NOT refuse with the Git-overlay detached-HEAD advice: {stderr}"
+    );
+
+    // It is initialized NATIVE — capability comes from the opened repo, not the
+    // ancestor Git checkout — so no Git checkpoint is attempted.
+    let init: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        init["repository_mode"].as_str(),
+        Some("native-heddle"),
+        "the nested repo stays native, not a Git overlay: {init}"
+    );
+    assert!(inner.join(".heddle").is_dir(), "native .heddle/ was created");
+}
+
+/// Codex r7 (cid 3329270259): in a materialized checkout whose `.heddle/`
+/// objectstore points to a shared repo INSIDE a Git checkout, `resolve_principal`
+/// can attribute the capture through `Repository::get_principal` →
+/// `shared_checkout_parent_git_principal` (the shared dir's parent Git config).
+/// The preflight's hand-rolled probe missed that source, refusing a runnable
+/// quickstart. Delegating to the real `resolve_principal` over the opened repo
+/// fixes it.
+#[test]
+fn quickstart_resolves_shared_checkout_parent_git_identity() {
+    let main = TempDir::new().unwrap();
+    let checkout = TempDir::new().unwrap();
+    let empty_cfg = TempDir::new().unwrap();
+    let empty_cfg_path = empty_cfg.path().join("user.toml");
+    std::fs::write(&empty_cfg_path, "").unwrap();
+
+    // Native main repo with a capture, so a thread can be materialized. NO
+    // `[principal]` is written to the shared config — identity must come solely
+    // from the shared dir's PARENT Git config below.
+    heddle(&["init", "--no-harness-install"], Some(main.path())).unwrap();
+    std::fs::write(main.path().join("file.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(main.path())).unwrap();
+
+    heddle(
+        &[
+            "start",
+            "feature/mat",
+            "--workspace",
+            "materialized",
+            "--path",
+            checkout.path().to_str().unwrap(),
+        ],
+        Some(main.path()),
+    )
+    .unwrap();
+    assert!(
+        checkout.path().join(".heddle").join("objectstore").is_file(),
+        "checkout must be a materialized (objectstore-pointer) checkout"
+    );
+
+    // Make the shared repo's containing dir a Git checkout whose ONLY identity
+    // is its Git `user.*` — reachable from the checkout solely via
+    // `shared_checkout_parent_git_principal`.
+    git_hermetic(&["init"], main.path());
+    git_hermetic(&["config", "user.name", "Parent Git"], main.path());
+    git_hermetic(
+        &["config", "user.email", "parent@example.invalid"],
+        main.path(),
+    );
+
+    // Quickstart in the checkout with NO other identity source: empty user
+    // config + cleared principal env.
+    let out = heddle_output_with_env(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(checkout.path()),
+        &[
+            ("HEDDLE_CONFIG", empty_cfg_path.to_str().unwrap()),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "preflight must resolve identity from the shared dir's parent Git config: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(checkout.path())).unwrap())
+            .unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("Parent Git <parent@example.invalid>"),
+        "capture is attributed to the shared-checkout parent Git identity: {log}"
+    );
+}
+
+/// Codex r7 (cid 3329270260): `refs/heads/<thread>` can be a syntactically
+/// valid FULL ref even when `<thread>` is not a usable Git BRANCH name (e.g.
+/// the reserved `HEAD`, or a leading `-`). Validating only the full ref let
+/// such names pass preflight and fail at branch creation — after Heddle state
+/// was written. The preflight now validates the branch shorthand too.
+#[test]
+fn quickstart_rejects_git_branch_invalid_shorthand_before_writes() {
+    for bad in ["HEAD", "-leading"] {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+        git_hermetic(&["init"], dir);
+
+        // `=` form so clap accepts a value that begins with `-`.
+        let thread_arg = format!("--quickstart-thread={bad}");
+        let out = heddle_output(
+            &[
+                "init",
+                "--quickstart",
+                &thread_arg,
+                "--principal-name",
+                "CI Sentinel",
+                "--principal-email",
+                "ci@example.invalid",
+                "--no-harness-install",
+                "--yes",
+                "--output",
+                "json",
+            ],
+            Some(dir),
+        )
+        .unwrap();
+
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "'{bad}' is not a usable Git branch name and must be rejected: stdout={} stderr={stderr}",
+            String::from_utf8_lossy(&out.stdout),
+        );
+        assert!(
+            stderr.contains("quickstart_thread_name_invalid"),
+            "'{bad}' must fail with the quickstart_thread_name_invalid advice: {stderr}"
+        );
+        assert!(
+            !dir.join(".heddle").exists(),
+            "fail-before-writes: '{bad}' must leave NO partial .heddle/"
+        );
+    }
+}
+
+/// Codex r7 (cid 3329270262): an invalid `--harness-install-scope` was not
+/// parsed until the post-init install step, so a pure argument error left a
+/// partially initialized repo. The pre-write decision now validates the scope
+/// with the same `IntegrationScope::parse` the install uses.
+#[test]
+fn quickstart_rejects_invalid_harness_scope_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--install-harnesses",
+            "claude-code",
+            "--harness-install-scope",
+            "bogus",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "an invalid harness scope must be rejected before writes: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("integration_scope_invalid"),
+        "must fail with the integration_scope_invalid advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: an invalid harness scope must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join(".claude").exists(),
+        "no harness integration may be installed on a scope error"
+    );
+}

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1387,6 +1387,307 @@ fn quickstart_rejects_git_branch_invalid_shorthand_before_writes() {
     }
 }
 
+/// Recursively snapshot every file under `dir` as `(relative_path, bytes)`,
+/// sorted — a content fingerprint used to prove a refused quickstart performed
+/// ZERO writes (no metadata so it can't flake on mtime/atime).
+fn snapshot_tree(dir: &std::path::Path) -> Vec<(std::path::PathBuf, Vec<u8>)> {
+    fn walk(
+        base: &std::path::Path,
+        dir: &std::path::Path,
+        out: &mut Vec<(std::path::PathBuf, Vec<u8>)>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => walk(base, &path, out),
+                Ok(ft) if ft.is_file() => {
+                    let rel = path.strip_prefix(base).unwrap().to_path_buf();
+                    out.push((rel, std::fs::read(&path).unwrap_or_default()));
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(dir, dir, &mut out);
+    out.sort();
+    out
+}
+
+/// Codex r8 (cid 3329342102 / 3329342201): run from a SUBDIRECTORY of an
+/// existing NATIVE Heddle repo, quickstart used to `init_default(<cwd>)` — a
+/// nested `.heddle/` at the subdir — because both the preflight and the write
+/// path keyed on `<cwd>/.heddle`. With a single root resolved by ancestor
+/// discovery, it must operate on the DISCOVERED repo, creating no nested repo.
+#[test]
+fn quickstart_from_subdir_targets_discovered_native_repo() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    heddle(&["init", "--no-harness-install"], Some(root)).unwrap();
+    assert!(root.join(".heddle").is_dir(), "native repo created at the root");
+
+    let sub = root.join("nested").join("deeper");
+    std::fs::create_dir_all(&sub).unwrap();
+
+    let out = heddle_output(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(&sub),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart from a subdir of a native repo must proceed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // The discovered repo is the target — NOT a nested repo at the subdir.
+    assert!(
+        !sub.join(".heddle").exists(),
+        "must NOT create a nested .heddle/ at the subdirectory"
+    );
+    assert!(
+        root.join(".heddle").is_dir(),
+        "the discovered repo root stays the single repo"
+    );
+    // The quickstart ran against the discovered repo: it has the thread.
+    let status = status_json(root);
+    assert_eq!(
+        status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "the discovered repo carries the quickstart thread: {status}"
+    );
+    // The placeholder/capture landed at the discovered root, not the subdir.
+    assert!(
+        root.join("QUICKSTART.md").is_file(),
+        "the capture wrote QUICKSTART.md at the discovered root"
+    );
+    assert!(
+        !sub.join("QUICKSTART.md").exists(),
+        "nothing was written into the subdirectory"
+    );
+}
+
+/// Codex r8 (cid 3329342104 / 3329342205): run from a SUBDIRECTORY of a Git
+/// checkout (no Heddle yet), quickstart used to `bootstrap_git_overlay(<cwd>)`
+/// — a `.heddle/` at the subdir whose root has no `.git`, so it came up NATIVE
+/// and never imported/checkpointed, while the preflight had classified it a Git
+/// overlay (and could refuse on the ancestor's detached HEAD). It must now
+/// bootstrap at the DISCOVERED Git root and run as a real Git overlay.
+#[test]
+fn quickstart_from_subdir_targets_discovered_git_root() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    git_hermetic(&["init"], root);
+    std::fs::write(root.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], root);
+    git_hermetic(&["commit", "-m", "initial"], root);
+
+    let sub = root.join("src").join("inner");
+    std::fs::create_dir_all(&sub).unwrap();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(&sub),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart from a subdir of a Git checkout must proceed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Targets the discovered Git ROOT, not a nested repo at the subdir.
+    assert!(
+        !sub.join(".heddle").exists(),
+        "must NOT create a nested .heddle/ at the subdirectory"
+    );
+    assert!(
+        root.join(".heddle").is_dir(),
+        "Heddle data is created at the discovered Git root"
+    );
+
+    // It runs as a real Git overlay (not the native repo the subdir bug made).
+    let init: Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+    assert_eq!(
+        init["repository_mode"].as_str(),
+        Some("git-overlay"),
+        "the discovered Git root is a Git overlay: {init}"
+    );
+    assert_eq!(
+        init["git_detected"].as_bool(),
+        Some(true),
+        "git is detected for the discovered root: {init}"
+    );
+
+    // The checkpoint advanced a real branch — impossible if it had come up as a
+    // native repo at the subdir. History (initial) plus the checkpoint commit.
+    let grepo = gix::open(root).expect("open git repo at the discovered root");
+    let tip = grepo.head_id().expect("HEAD resolves to a commit");
+    let commit_count = grepo
+        .rev_walk([tip.detach()])
+        .all()
+        .expect("rev-walk checkpoint history")
+        .count();
+    assert!(
+        commit_count >= 2,
+        "the Git-overlay quickstart imported history and added a checkpoint commit: count={commit_count}"
+    );
+}
+
+/// Codex r8 (cid 3329342100 / 3329342200): the preflight used to
+/// `Repository::open` the existing repo to read its capability/identity. For a
+/// Git-overlay repo, `open` synchronizes `.heddle/HEAD` to Git's HEAD — a WRITE
+/// that fired BEFORE the confirmation gate could refuse. A refused quickstart
+/// (existing repo, non-interactive, no `--yes`) must now perform ZERO writes:
+/// the preflight is fully read-only and never opens the repo.
+#[test]
+fn quickstart_refusal_on_existing_git_overlay_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+    // Existing Heddle Git-overlay repo: `.heddle/HEAD` now exists and matches
+    // Git's current branch.
+    heddle(&["init", "--no-harness-install"], Some(dir)).unwrap();
+    // Drift Git's HEAD away from Heddle's HEAD so that opening the repo WOULD
+    // re-sync `.heddle/HEAD` (the exact write the old preflight performed).
+    git_hermetic(&["switch", "-c", "feature"], dir);
+
+    let heddle_dir = dir.join(".heddle");
+    let before = snapshot_tree(&heddle_dir);
+
+    // Non-interactive, no `--yes`: the existing-history confirmation gate must
+    // refuse — before any write.
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "must refuse without --yes on an existing repo: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_needs_confirmation"),
+        "the refusal is the confirmation gate: {stderr}"
+    );
+
+    let after = snapshot_tree(&heddle_dir);
+    assert!(
+        before == after,
+        "a refused quickstart must not write to .heddle/ (HEAD-sync must not fire): \
+         the preflight is read-only and must not open the repo"
+    );
+}
+
+/// Codex r8 (cid 3329342103 / 3329342203): harness installs used to run BEFORE
+/// the first capture, so `ensure_capturable_content` saw the generated
+/// scaffolding (`.claude/settings.json`, …) as the user's content — skipping
+/// the `QUICKSTART.md` placeholder and recording integration files as the first
+/// state. Capture must run first: the first state is the user's content; the
+/// install lands after and stays uncaptured.
+#[test]
+fn quickstart_captures_before_installing_harness() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--install-harnesses",
+            "claude-code",
+            "--harness-install-scope",
+            "repo",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart with a harness install must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // The install ran (after the capture).
+    assert!(
+        dir.join(".claude").join("settings.json").is_file(),
+        "the selected harness was installed"
+    );
+    // Capture-before-install: an EMPTY dir still got the QUICKSTART.md
+    // placeholder. With install-first, `.claude/` would have made the dir look
+    // non-empty and the placeholder would have been skipped.
+    assert!(
+        dir.join("QUICKSTART.md").is_file(),
+        "the capture ran before the install, so the empty dir got QUICKSTART.md"
+    );
+
+    // Exactly one capture, and it recorded the user's content — not the harness
+    // scaffolding, which remains UNTRACKED (installed after the capture).
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    assert_eq!(
+        log["states"].as_array().map(Vec::len),
+        Some(1),
+        "exactly one capture: {log}"
+    );
+    let status = status_json(dir);
+    let added: Vec<String> = status["changes"]["added"]
+        .as_array()
+        .map(|paths| {
+            paths
+                .iter()
+                .filter_map(|p| p.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        added.iter().any(|p| p.contains(".claude")),
+        "harness scaffolding is UNTRACKED — it was installed after the capture: {status}"
+    );
+    assert!(
+        !added.iter().any(|p| p.contains("QUICKSTART.md")),
+        "QUICKSTART.md was the captured first state, not untracked: {status}"
+    );
+}
+
 /// Codex r7 (cid 3329270262): an invalid `--harness-install-scope` was not
 /// parsed until the post-init install step, so a pure argument error left a
 /// partially initialized repo. The pre-write decision now validates the scope

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `heddle init --quickstart` — first-run UX (heddle#231).
+
+use super::*;
+
+/// §5 sentinel from the spike (`docs/spikes/heddle-26-quickstart-ux.md`):
+/// a fresh runner with no prior Heddle state reaches the success state
+/// from a single, fully flag-driven command — no stdin.
+#[test]
+fn quickstart_sentinel_reaches_first_commit_from_one_command() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // init landed
+    assert!(dir.join(".heddle").is_dir(), "init created .heddle");
+
+    // a thread exists
+    let status = status_json(dir);
+    assert_eq!(
+        status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "status surfaces the quickstart thread: {status}"
+    );
+
+    // at least one user-visible capture whose message matches `quickstart`
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert!(!states.is_empty(), "at least one capture: {log}");
+    let intent = states[0]["intent"].as_str().unwrap_or_default();
+    assert!(
+        intent.contains("quickstart"),
+        "first capture intent mentions quickstart: {intent:?}"
+    );
+    // identity from the flags must win over any ambient config
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("CI Sentinel <ci@example.invalid>"),
+        "capture is attributed to the flag identity: {log}"
+    );
+}
+
+/// On an empty native directory, no capturable files exist yet, so
+/// quickstart writes a root-level `QUICKSTART.md` pointer and captures
+/// it (a `.heddle/`-nested placeholder would be dropped by the default
+/// ignore list).
+#[test]
+fn quickstart_writes_placeholder_when_directory_is_empty() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    assert!(
+        dir.join("QUICKSTART.md").is_file(),
+        "quickstart wrote the root-level placeholder"
+    );
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    assert_eq!(
+        log["states"].as_array().map(Vec::len),
+        Some(1),
+        "exactly one capture: {log}"
+    );
+}
+
+/// `heddle status` on a freshly-`init`'d native repo whose log is empty
+/// surfaces `heddle init --quickstart` in `recommended_action`.
+#[test]
+fn status_recommends_quickstart_on_empty_native_repo() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(&["init", "--no-harness-install"], Some(dir)).unwrap();
+
+    let status = status_json(dir);
+    assert_eq!(
+        status["recommended_action"].as_str(),
+        Some("heddle init --quickstart"),
+        "fresh native repo recommends quickstart: {status}"
+    );
+
+    // Once quickstart has produced a capture, the log is no longer empty
+    // and the recommendation steps aside.
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    let status = status_json(dir);
+    assert_ne!(
+        status["recommended_action"].as_str(),
+        Some("heddle init --quickstart"),
+        "after quickstart the recommendation no longer fires: {status}"
+    );
+}
+
+/// The confirmation gate refuses to act non-interactively on a directory
+/// that already holds Heddle data unless `--yes` is passed.
+#[test]
+fn quickstart_confirmation_gate_blocks_existing_repo_without_yes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    // Re-running without `--yes` in a non-interactive context must refuse.
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        !out.status.success(),
+        "must refuse without --yes on an existing repo"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("--yes"),
+        "the refusal points at --yes: {combined}"
+    );
+}

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1998,3 +1998,90 @@ fn quickstart_git_overlay_capture_and_checkpoint_land_on_quickstart_thread() {
         "quickstart advanced: imported tip + the checkpoint commit"
     );
 }
+
+/// Codex r9 regression (cid 3335757978): a Git overlay where a `quickstart`
+/// branch ALREADY exists with divergent history, while the checkout is on
+/// another branch. The r9 thread-attachment would `import_all` that branch as a
+/// thread, repoint it to the current branch's state, and write-through-move
+/// `refs/heads/quickstart` onto the current branch — silently destroying the
+/// user's branch. Quickstart must REFUSE before any write, leaving the existing
+/// branch untouched and no `.heddle/` behind.
+#[test]
+fn quickstart_refuses_clobbering_existing_divergent_quickstart_branch() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init", "-b", "main"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+
+    // A pre-existing `quickstart` branch with its OWN distinct commit.
+    git_hermetic(&["checkout", "-b", "quickstart"], dir);
+    std::fs::write(dir.join("their-work.txt"), "precious\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "their quickstart work"], dir);
+    git_hermetic(&["checkout", "main"], dir);
+
+    let tip_before = {
+        let grepo = gix::open(dir).expect("open git repo");
+        grepo
+            .find_reference("quickstart")
+            .expect("quickstart branch exists")
+            .peel_to_id()
+            .expect("peels")
+            .detach()
+    };
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a pre-existing divergent quickstart branch must be refused: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_thread_branch_collision"),
+        "must fail with the collision advice pointing at --quickstart-thread: {stderr}"
+    );
+
+    // The user's branch is UNCHANGED.
+    let tip_after = {
+        let grepo = gix::open(dir).expect("open git repo");
+        grepo
+            .find_reference("quickstart")
+            .expect("quickstart branch still exists")
+            .peel_to_id()
+            .expect("peels")
+            .detach()
+    };
+    assert_eq!(
+        tip_before, tip_after,
+        "the user's pre-existing quickstart branch must not be moved"
+    );
+
+    // Fail-before-writes: nothing landed.
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a collision must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -110,8 +110,8 @@ fn status_recommends_quickstart_on_empty_native_repo() {
     let status = status_json(dir);
     assert_eq!(
         status["recommended_action"].as_str(),
-        Some("heddle init --quickstart"),
-        "fresh native repo recommends quickstart: {status}"
+        Some("heddle init --quickstart --yes"),
+        "fresh native repo recommends the runnable quickstart command: {status}"
     );
 
     // Once quickstart has produced a capture, the log is no longer empty
@@ -803,6 +803,329 @@ fn quickstart_rerun_repoints_existing_noncurrent_thread() {
     assert_eq!(
         chain[1], b_id,
         "new capture's parent is the current state B, not the stale quickstart tip: chain={chain:?} b={b_id}"
+    );
+}
+
+/// Codex r6 (cid 3329175134): a detached Git HEAD has no branch for the
+/// checkpoint to advance. The later `create_git_checkpoint` refuses it, but
+/// only AFTER the import/capture have written `.heddle/`. The preflight must
+/// refuse a detached HEAD BEFORE any write — leaving no partial `.heddle/`.
+#[test]
+fn quickstart_refuses_detached_git_head_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+    git_hermetic(&["checkout", "--detach"], dir);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a detached Git HEAD must be refused: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_detached_head"),
+        "must fail with the quickstart_detached_head advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a detached HEAD must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Codex r6 (cid 3329175135): a Git-overlay quickstart creates a real
+/// `refs/heads/<name>`. Git's ref-name rules reject names Heddle's
+/// `validate_ref_name` accepts (here a `~`), so such a name would pass
+/// preflight and then fail when the branch is created — after `create_snapshot`
+/// has written Heddle state. The preflight must validate against Git's rules
+/// too so it fails before any write.
+#[test]
+fn quickstart_rejects_git_invalid_thread_name_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--quickstart-thread",
+            "bad~name",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a Git-invalid thread name must be rejected on a Git overlay: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_thread_name_invalid"),
+        "must fail with the quickstart_thread_name_invalid advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a Git-invalid thread name must leave NO partial .heddle/"
+    );
+}
+
+/// Codex r6 (cid 3329175137): in a materialized thread checkout the local
+/// `.heddle/` holds only an objectstore pointer; the real `[principal]` lives
+/// in the SHARED dir that `Repository::open` loads. The preflight must resolve
+/// identity by following the pointer — not probe the local `config.toml` only,
+/// which would wrongly report "no identity" and refuse a runnable quickstart.
+#[test]
+fn quickstart_resolves_principal_from_shared_dir_in_materialized_checkout() {
+    let main = TempDir::new().unwrap();
+    let checkout = TempDir::new().unwrap();
+    let empty_cfg = TempDir::new().unwrap();
+    let empty_cfg_path = empty_cfg.path().join("user.toml");
+    std::fs::write(&empty_cfg_path, "").unwrap();
+
+    // Native main repo with a capture, so a thread can be materialized.
+    heddle(&["init", "--no-harness-install"], Some(main.path())).unwrap();
+    std::fs::write(main.path().join("file.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(main.path())).unwrap();
+
+    // Pin the ONLY identity into the SHARED `.heddle/config.toml`.
+    let shared_cfg = main.path().join(".heddle").join("config.toml");
+    let mut cfg = repo::RepoConfig::load(&shared_cfg).unwrap_or_default();
+    cfg.set_principal("Shared Principal", "shared@example.invalid");
+    cfg.save(&shared_cfg).unwrap();
+
+    // Materialize a thread checkout whose `.heddle/` is an objectstore pointer.
+    heddle(
+        &[
+            "start",
+            "feature/mat",
+            "--workspace",
+            "materialized",
+            "--path",
+            checkout.path().to_str().unwrap(),
+        ],
+        Some(main.path()),
+    )
+    .unwrap();
+    assert!(
+        checkout.path().join(".heddle").join("objectstore").is_file(),
+        "checkout must be a materialized (objectstore-pointer) checkout"
+    );
+
+    // Quickstart in the checkout with NO other identity source: an empty user
+    // config + cleared env. The ONLY resolvable identity is the shared
+    // `[principal]`, reachable solely by following the objectstore pointer.
+    let out = heddle_output_with_env(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(checkout.path()),
+        &[
+            ("HEDDLE_CONFIG", empty_cfg_path.to_str().unwrap()),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "a materialized checkout must resolve [principal] from the shared dir: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(checkout.path())).unwrap())
+            .unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("Shared Principal <shared@example.invalid>"),
+        "capture is attributed to the shared-dir principal: {log}"
+    );
+}
+
+/// Codex r6 (cid 3329175136): when a repo's only `[output].format` is repo-level
+/// `json`, the preflight (which computed format from CLI/user config only) used
+/// to print a TEXT confirmation prompt before the final JSON render — mixing
+/// formats. The preflight must load the repo's `[output].format` so the
+/// confirmation output matches the final render.
+#[test]
+fn quickstart_confirmation_respects_repo_json_format() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    // Existing native repo whose ONLY format setting is repo-level json.
+    heddle(&["init", "--no-harness-install"], Some(dir)).unwrap();
+    let cfg_path = dir.join(".heddle").join("config.toml");
+    let mut cfg = repo::RepoConfig::load(&cfg_path).unwrap_or_default();
+    cfg.output.format = Some(repo::OutputFormat::Json);
+    cfg.save(&cfg_path).unwrap();
+
+    // Re-run quickstart WITHOUT --yes: the confirmation gate fires. With the
+    // repo format honored, it must refuse with a clean JSON envelope and emit
+    // NO human-readable text prompt to stdout.
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "the confirmation gate must refuse without --yes"
+    );
+    // The fix: with the repo format honored as json, the preflight must NOT
+    // emit the human-readable text confirmation prompt (it would otherwise
+    // mix with the JSON final render). Before the fix this warning block was
+    // printed to stdout because the preflight computed format without the
+    // repo config.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("would act on a directory that already has work"),
+        "repo json format must suppress the text confirmation prompt on stdout: stdout={stdout}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "no stray text output when the repo format is json: stdout={stdout}"
+    );
+}
+
+/// Codex r6 (cid 3329175139): a repo with commits on another ref but an unborn
+/// current HEAD (e.g. after `git switch --orphan scratch`) must be treated as
+/// having existing history — not history-free. History detection must key on
+/// ANY local ref, so the existing-history confirmation gate fires (and, with
+/// `--yes`, the history is imported) rather than skipping both.
+#[test]
+fn quickstart_treats_orphan_branch_repo_as_existing_history() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+    // Unborn current HEAD, but `main` still carries the commit.
+    git_hermetic(&["switch", "--orphan", "scratch"], dir);
+
+    // Without --yes: the existing-history confirmation gate must fire — proof
+    // the orphan repo is treated as having history, not as empty.
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "an orphan-branch repo must hit the existing-history confirmation gate: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_needs_confirmation"),
+        "must be the existing-history confirmation refusal, not a history-free skip: {stderr}"
+    );
+}
+
+/// Codex r6 (cid 3329175133): `resolve_principal` lets env win OUTRIGHT, so a
+/// sentinel env identity shadows even valid `--principal-*` flags — the capture
+/// would still be attributed to the env sentinel and rejected by
+/// `build_attribution`, but only AFTER init has written `.heddle/`. The
+/// preflight must reject the env sentinel BEFORE accepting lower-precedence
+/// flags, leaving no partial state.
+#[test]
+fn quickstart_rejects_env_sentinel_even_with_valid_flags_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output_with_env(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "Valid Name",
+            "--principal-email",
+            "valid@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+        &[
+            ("HEDDLE_PRINCIPAL_NAME", "Unknown"),
+            ("HEDDLE_PRINCIPAL_EMAIL", "unknown@example.com"),
+        ],
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a sentinel env identity must shadow valid flags and fail: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_identity_required"),
+        "must fail with the quickstart_identity_required advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: an env sentinel must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
     );
 }
 

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1984,7 +1984,7 @@ fn quickstart_git_overlay_capture_and_checkpoint_land_on_quickstart_thread() {
         let mut reference = grepo
             .find_reference(branch)
             .unwrap_or_else(|_| panic!("ref {branch} exists"));
-        let tip = reference.peel_to_id_in_place().expect("ref peels");
+        let tip = reference.peel_to_id().expect("ref peels");
         grepo
             .rev_walk([tip.detach()])
             .all()

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1736,3 +1736,265 @@ fn quickstart_rejects_invalid_harness_scope_before_writes() {
         "no harness integration may be installed on a scope error"
     );
 }
+
+/// Codex r9 (cid 3329409818): `--install-harnesses codex` with the default
+/// `--harness-install-scope repo` passed the generic-scope preflight (the enum
+/// parses), but `install_codex` rejects any non-`user` scope — AFTER `.heddle/`,
+/// `QUICKSTART.md`, and the capture/checkpoint were already written. The
+/// preflight now mirrors each harness's OWN scope rule, so a scope a harness
+/// will reject fails before any write.
+#[test]
+fn quickstart_rejects_codex_repo_scope_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--install-harnesses",
+            "codex",
+            "--harness-install-scope",
+            "repo",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "codex + repo scope must be rejected before writes: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("integration_codex_scope_invalid"),
+        "must fail with the harness-specific scope advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a harness/scope mismatch must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Codex r9 (cid 3329409826): a shallow Git checkout (`.git/shallow`) is
+/// rejected by `import_all` — but only AFTER `bootstrap_git_overlay` created
+/// `.heddle/` and edited the Git excludes, leaving a half-initialized sidecar.
+/// The preflight must detect the shallow clone and refuse before any write.
+#[test]
+fn quickstart_rejects_shallow_git_clone_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+    // Mark the checkout shallow the way a `--depth` clone would: a `.git/shallow`
+    // file listing the shallow boundary. `import_all` keys on its presence
+    // (`git_dir()/shallow`), and so does the preflight's `git_is_shallow`.
+    let grepo = gix::open(dir).unwrap();
+    let head = grepo.head_id().unwrap().to_string();
+    std::fs::write(dir.join(".git").join("shallow"), format!("{head}\n")).unwrap();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a shallow clone must be rejected before writes: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_shallow_clone"),
+        "must fail with the quickstart_shallow_clone advice: {stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a shallow clone must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Codex r9 (cid 3329409822): run inside a nested Git checkout below an ancestor
+/// Heddle repo, quickstart used to return the ancestor `.heddle` root — but
+/// `Repository::open` has a special case that bootstraps the NESTED Git root
+/// instead. Quickstart would then write the thread into the parent and never
+/// import the nested Git history. Target resolution now mirrors
+/// `Repository::open`'s nested-Git-first walk, so the nested Git root is
+/// bootstrapped and imported.
+#[test]
+fn quickstart_nested_git_below_ancestor_heddle_targets_nested_git() {
+    let outer = TempDir::new().unwrap();
+    let ancestor = outer.path();
+    // Ancestor native Heddle repo (no Git at its own root).
+    heddle(&["init", "--no-harness-install"], Some(ancestor)).unwrap();
+    assert!(ancestor.join(".heddle").is_dir());
+
+    // A nested Git checkout below it, with history and NO `.heddle` of its own.
+    let nested = ancestor.join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    git_hermetic(&["init"], &nested);
+    std::fs::write(nested.join("n.txt"), "nested\n").unwrap();
+    git_hermetic(&["add", "."], &nested);
+    git_hermetic(&["commit", "-m", "nested initial"], &nested);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(&nested),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart in a nested Git checkout must bootstrap the nested root: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // The nested Git root is the target: it gets its OWN `.heddle/`, as a Git
+    // overlay — NOT a write into the ancestor.
+    assert!(
+        nested.join(".heddle").is_dir(),
+        "the nested Git root was bootstrapped with its own .heddle/"
+    );
+    let init: Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+    assert_eq!(
+        init["repository_mode"].as_str(),
+        Some("git-overlay"),
+        "the nested Git root runs as a Git overlay: {init}"
+    );
+    // The nested quickstart carries the thread; the ancestor is untouched.
+    let nested_status = status_json(&nested);
+    assert_eq!(
+        nested_status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "the nested repo carries the quickstart thread: {nested_status}"
+    );
+    let ancestor_status = status_json(ancestor);
+    assert_ne!(
+        ancestor_status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "the ancestor Heddle repo must NOT have been written into: {ancestor_status}"
+    );
+    // The nested Git history was imported AND checkpointed: the nested Git root
+    // now has the original commit plus the checkpoint commit.
+    let grepo = gix::open(&nested).expect("open nested git repo");
+    let tip = grepo.head_id().expect("nested HEAD resolves");
+    let commit_count = grepo
+        .rev_walk([tip.detach()])
+        .all()
+        .expect("rev-walk nested history")
+        .count();
+    assert!(
+        commit_count >= 2,
+        "the nested Git history was imported and a checkpoint added: count={commit_count}"
+    );
+}
+
+/// Codex r9 (cid 3329409824): in an existing Git-overlay repo, writing only
+/// `.heddle/HEAD = quickstart` is not enough — `head_ref()` deliberately
+/// resolves back to the live Git branch (`main`), so the capture/checkpoint
+/// advanced `main` while the `quickstart` thread stayed at the imported tip,
+/// even though the output said `Thread: quickstart`. Quickstart now attaches the
+/// Git checkout to the thread's branch (the same write-through `thread switch`
+/// uses), so the capture AND checkpoint land on `quickstart` — `main` does not
+/// move.
+#[test]
+fn quickstart_git_overlay_capture_and_checkpoint_land_on_quickstart_thread() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init", "-b", "main"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart on a Git overlay must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // The active thread is `quickstart`, matching the reported output.
+    let status = status_json(dir);
+    assert_eq!(
+        status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "the active thread is quickstart: {status}"
+    );
+
+    let grepo = gix::open(dir).expect("open git repo");
+    // `quickstart` advanced past the imported tip (initial + checkpoint = 2),
+    // while `main` stayed at the imported tip (1 commit) — proof the capture and
+    // checkpoint landed on the requested thread, not on main.
+    let count_on = |branch: &str| -> usize {
+        let mut reference = grepo
+            .find_reference(branch)
+            .unwrap_or_else(|_| panic!("ref {branch} exists"));
+        let tip = reference.peel_to_id_in_place().expect("ref peels");
+        grepo
+            .rev_walk([tip.detach()])
+            .all()
+            .expect("rev-walk")
+            .count()
+    };
+    assert_eq!(count_on("main"), 1, "main stayed at the imported tip");
+    assert_eq!(
+        count_on("quickstart"),
+        2,
+        "quickstart advanced: imported tip + the checkpoint commit"
+    );
+}

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -546,6 +546,266 @@ fn quickstart_rejects_git_sentinel_identity_before_writes() {
     );
 }
 
+/// Codex r5 (cid 3329078130): the `Unknown <unknown@example.com>` sentinel
+/// passed via `--principal-*` flags is what `build_attribution` rejects. The
+/// preflight must reject it the SAME way — fail BEFORE any `.heddle`/
+/// `QUICKSTART.md` write, not persist the sentinel and then have the capture
+/// refuse mid-write.
+#[test]
+fn quickstart_rejects_sentinel_principal_flags_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "Unknown",
+            "--principal-email",
+            "unknown@example.com",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "sentinel principal flags must be rejected: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_identity_required"),
+        "must fail with the quickstart_identity_required advice: stderr={stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: a sentinel identity must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Codex r5 (cid 3329078132): a higher-precedence sentinel must SHADOW a
+/// lower valid source, exactly as `resolve_principal` would. A repo-level
+/// `[principal]` pinning the sentinel outranks a valid Git identity, so
+/// `resolve_principal` stops at the sentinel and the capture is rejected —
+/// the preflight must mirror that STOP-at-first-present precedence and fail
+/// before writing the placeholder, NOT fall through to the valid Git source.
+#[test]
+fn quickstart_higher_precedence_sentinel_shadows_valid_lower_source() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    // A VALID lower-precedence Git identity. The old fall-through preflight
+    // would have accepted this and let the capture proceed, only for
+    // `resolve_principal` (stopping at the repo-config sentinel) to reject it
+    // after `.heddle` writes.
+    git_hermetic(&["config", "user.name", "Git Valid"], dir);
+    git_hermetic(&["config", "user.email", "valid@example.com"], dir);
+
+    let isolate: &[(&str, &str)] = &[
+        ("GIT_CONFIG_GLOBAL", "/dev/null"),
+        ("GIT_CONFIG_SYSTEM", "/dev/null"),
+        ("GIT_CONFIG_NOSYSTEM", "1"),
+        ("HEDDLE_PRINCIPAL_NAME", ""),
+        ("HEDDLE_PRINCIPAL_EMAIL", ""),
+    ];
+
+    // Plain init to create `.heddle`, then pin a sentinel repo-level
+    // principal that OUTRANKS the valid Git identity.
+    heddle_output_with_env(&["init", "--no-harness-install"], Some(dir), isolate).unwrap();
+    let cfg_path = dir.join(".heddle").join("config.toml");
+    let mut cfg = repo::RepoConfig::load(&cfg_path).unwrap_or_default();
+    cfg.set_principal("Unknown", "unknown@example.com");
+    cfg.save(&cfg_path).unwrap();
+
+    let out = heddle_output_with_env(
+        &[
+            "init",
+            "--quickstart",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+        isolate,
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a higher-precedence sentinel must shadow the valid lower source and fail: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_identity_required"),
+        "must fail with the quickstart_identity_required advice: stderr={stderr}"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Genuine identity still proceeds: with no flags, no repo principal, and
+/// no user config, a valid Git `user.*` identity (the lowest-precedence
+/// source that the preflight's mirror of `resolve_principal` consults)
+/// satisfies the preflight and attributes the capture.
+#[test]
+fn quickstart_resolves_genuine_git_identity_without_flags() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    git_hermetic(&["config", "user.name", "Git Valid"], dir);
+    git_hermetic(&["config", "user.email", "valid@example.com"], dir);
+
+    let out = heddle_output_with_env(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(dir),
+        &[
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_SYSTEM", "/dev/null"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "a valid Git identity must satisfy the preflight: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("Git Valid <valid@example.com>"),
+        "capture is attributed to the genuine Git identity: {log}"
+    );
+}
+
+/// Codex r5 (cid 3329078133): an invalid `--quickstart-thread` (a name the
+/// ref machinery would reject, e.g. `a..b`) must fail in the preflight,
+/// BEFORE init/bootstrap/import write any `.heddle` data — not leave a
+/// half-initialized repo for a pure argument error.
+#[test]
+fn quickstart_rejects_invalid_thread_name_before_writes() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--quickstart-thread",
+            "a..b",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "an invalid thread name must be rejected: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("quickstart_thread_name_invalid"),
+        "must fail with the quickstart_thread_name_invalid advice: stderr={stderr}"
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "fail-before-writes: an invalid thread name must leave NO partial .heddle/"
+    );
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "fail-before-writes: no QUICKSTART.md placeholder may be written"
+    );
+}
+
+/// Codex r5 (cid 3329078135): re-running `--quickstart --yes` after switching
+/// away from an existing quickstart thread must repoint that thread to the
+/// CURRENT state before attaching, so the new capture's parent is the current
+/// worktree's state — not the thread's stale tip. Previously the code skipped
+/// repointing an existing thread and attached HEAD to the stale tip, recording
+/// the wrong parent and corrupting history.
+#[test]
+fn quickstart_rerun_repoints_existing_noncurrent_thread() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    // First quickstart on the default "quickstart" thread → state A (root).
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    // Move to a different thread and advance it to a new state B, so the
+    // quickstart thread is no longer current and its tip A is stale.
+    heddle(&["thread", "create", "work"], Some(dir)).unwrap();
+    heddle(&["thread", "switch", "work"], Some(dir)).unwrap();
+    std::fs::write(dir.join("work.txt"), "work\n").unwrap();
+    heddle(&["capture", "-m", "work state"], Some(dir)).unwrap();
+    let b_id = state_chain_ids(dir, 1)[0].clone();
+
+    // Re-run quickstart while attached to `work`, with a fresh change so the
+    // capture is a real new state C.
+    std::fs::write(dir.join("more.txt"), "more\n").unwrap();
+    let out = heddle_output(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "rerun quickstart should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // HEAD is now the new quickstart capture C; its parent must be B (the
+    // state we were on), NOT the stale quickstart tip A.
+    let chain = state_chain_ids(dir, 2);
+    assert_eq!(chain.len(), 2, "the new capture has a parent: {chain:?}");
+    assert_eq!(
+        chain[1], b_id,
+        "new capture's parent is the current state B, not the stale quickstart tip: chain={chain:?} b={b_id}"
+    );
+}
+
 /// Non-interactive `--install-harnesses` installs the named harness as a
 /// post-write step (the decision is resolved up front, the install runs
 /// after the repo exists).

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -188,3 +188,241 @@ fn quickstart_confirmation_gate_blocks_existing_repo_without_yes() {
         "the refusal points at --yes: {combined}"
     );
 }
+
+/// Identity priority: with no `--principal-*` flags, quickstart resolves
+/// the identity already available in the user config and attributes the
+/// capture to it — without writing a repo-level principal.
+#[test]
+fn quickstart_resolves_identity_from_user_config_without_flags() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    let out = heddle_output(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart should resolve identity from user config: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    let states = log["states"].as_array().expect("log emits a states array");
+    assert_eq!(
+        states[0]["principal"].as_str(),
+        Some("Heddle Test <heddle@example.com>"),
+        "capture is attributed to the seeded user-config identity: {log}"
+    );
+}
+
+/// ESC-safety / fail-fast ordering: when no identity is resolvable and
+/// there is no interactive terminal to prompt, quickstart must refuse
+/// BEFORE any filesystem write — leaving no partial `.heddle/`.
+#[test]
+fn quickstart_identity_failfast_leaves_no_partial_heddle() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+
+    // `--yes` clears the confirmation gate so we isolate the identity
+    // gate; no flags + no resolvable identity + non-interactive => bail.
+    let out = heddle_output_with_env(
+        &["init", "--quickstart", "--no-harness-install", "--yes"],
+        Some(dir),
+        &[
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_SYSTEM", "/dev/null"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("HEDDLE_PRINCIPAL_NAME", ""),
+            ("HEDDLE_PRINCIPAL_EMAIL", ""),
+        ],
+    )
+    .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "must refuse without a resolvable identity: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !dir.join(".heddle").exists(),
+        "a declined/aborted preflight must leave NO partial .heddle/"
+    );
+}
+
+/// `--quickstart-thread` names the thread the quickstart starts.
+#[test]
+fn quickstart_uses_custom_thread_name() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--quickstart-thread",
+            "research",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let status = status_json(dir);
+    assert_eq!(
+        status.get("thread").and_then(Value::as_str),
+        Some("research"),
+        "status surfaces the custom thread: {status}"
+    );
+}
+
+/// When the directory already has capturable files, quickstart captures
+/// them and does NOT write the `QUICKSTART.md` placeholder.
+#[test]
+fn quickstart_captures_existing_files_without_placeholder() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    std::fs::write(dir.join("notes.txt"), "my work\n").unwrap();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    assert!(
+        !dir.join("QUICKSTART.md").exists(),
+        "no placeholder when real files exist to capture"
+    );
+    let log: Value =
+        serde_json::from_str(&heddle(&["log", "--output", "json"], Some(dir)).unwrap()).unwrap();
+    assert_eq!(
+        log["states"].as_array().map(Vec::len),
+        Some(1),
+        "exactly one capture: {log}"
+    );
+}
+
+/// On a Git-overlay repo with history, quickstart imports the history,
+/// captures, and lands a Git checkpoint commit.
+#[test]
+fn quickstart_checkpoints_on_git_overlay() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    assert!(
+        out.status.success(),
+        "quickstart should checkpoint on git-overlay: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Checkpoint:"),
+        "git-overlay quickstart reports a checkpoint: {stdout}"
+    );
+}
+
+/// Non-interactive `--install-harnesses` installs the named harness as a
+/// post-write step (the decision is resolved up front, the install runs
+/// after the repo exists).
+#[test]
+fn quickstart_installs_selected_harness() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--install-harnesses",
+            "claude-code",
+            "--harness-install-scope",
+            "repo",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    let settings = dir.join(".claude").join("settings.json");
+    assert!(settings.is_file(), "claude-code integration was installed");
+    let contents = std::fs::read_to_string(&settings).unwrap();
+    assert!(
+        contents.contains("integration relay claude-code"),
+        "settings carry the relay hooks: {contents}"
+    );
+}
+
+/// `--install-harnesses none` resolves to an empty selection and installs
+/// nothing.
+#[test]
+fn quickstart_install_none_installs_nothing() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+
+    heddle(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--install-harnesses",
+            "none",
+            "--yes",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    assert!(
+        !dir.join(".claude").exists(),
+        "selecting `none` installs no harness integration"
+    );
+}

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -1077,6 +1077,61 @@ fn quickstart_treats_orphan_branch_repo_as_existing_history() {
     );
 }
 
+/// Codex r11 (cid 3336080241): when the current Git branch is unborn but
+/// another branch has commits, quickstart must not try the pre-capture
+/// write-through attachment. There is no current exportable state yet, so the
+/// first capture should establish the requested thread instead of crashing with
+/// "thread 'quickstart' has no state to export" after `.heddle/` was written.
+#[test]
+fn quickstart_orphan_unborn_head_with_history_defers_attachment_and_succeeds() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    git_hermetic(&["init"], dir);
+    std::fs::write(dir.join("a.txt"), "hi\n").unwrap();
+    git_hermetic(&["add", "."], dir);
+    git_hermetic(&["commit", "-m", "initial"], dir);
+    git_hermetic(&["switch", "--orphan", "scratch"], dir);
+
+    let out = heddle_output(
+        &[
+            "init",
+            "--quickstart",
+            "--principal-name",
+            "CI Sentinel",
+            "--principal-email",
+            "ci@example.invalid",
+            "--no-harness-install",
+            "--yes",
+            "--output",
+            "json",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "quickstart should succeed by deferring attachment on an unborn current branch: stdout={} stderr={stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        !stderr.contains("no state to export"),
+        "the write-through attachment path must not run on an unborn current branch: {stderr}"
+    );
+
+    let status = status_json(dir);
+    assert_eq!(
+        status.get("thread").and_then(Value::as_str),
+        Some("quickstart"),
+        "quickstart remains the active thread after the first capture: {status}"
+    );
+    assert_eq!(
+        state_chain_ids(dir, 1).len(),
+        1,
+        "the first capture established a state for the quickstart thread"
+    );
+}
+
 /// Codex r6 (cid 3329175133): `resolve_principal` lets env win OUTRIGHT, so a
 /// sentinel env identity shadows even valid `--principal-*` flags — the capture
 /// would still be attributed to the env sentinel and rejected by


### PR DESCRIPTION
## Summary
- Adds a `--quickstart` flag to `heddle init` (plus `--quickstart-thread <name>` and `--yes`) that takes a fresh directory to a first checkpointed change in one command, implementing the heddle#26 spike decision (Option D).
- After the normal init steps it resolves identity, starts a thread (default `quickstart`), makes one capture (`quickstart: initial capture`), and — on Git-overlay repos — one checkpoint (`quickstart: first commit`).
- Identity is resolved and the destructive-write confirmation gate is answered **before any filesystem write**, so a Ctrl-C or declined prompt leaves the directory untouched (ESC-safe).
- `heddle status` on a freshly-`init`'d native repo with an empty log and clean worktree now recommends `heddle init --quickstart`; README's `## Quickstart` leads with the single command, with the verb-by-verb tour kept as a follow-on section.

Closes HeddleCo/heddle#231

## Red commit
`fc61a7a` (tests added before the implementation; verified failing, then green at `bd8329d`)

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- quickstart::
running 4 tests
test quickstart::quickstart_writes_placeholder_when_directory_is_empty ... ok
test quickstart::quickstart_confirmation_gate_blocks_existing_repo_without_yes ... ok
test quickstart::quickstart_sentinel_reaches_first_commit_from_one_command ... ok
test quickstart::status_recommends_quickstart_on_empty_native_repo ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 842 filtered out
```

Full suite + gates run locally:
- `cargo test -p heddle-cli --test cli_integration` → 831 passed, 0 failed (no regressions; the native-dirty status test still gets `heddle commit`, not quickstart).
- `cargo clippy --locked --workspace --all-targets -- -D warnings` → clean.
- `heddle doctor docs --all` → no drift (56 files); `heddle doctor schemas` → no drift.
- `bash scripts/check-no-silent-default-tree-load.sh` → clean.
- No new dependencies (Cargo.toml/Cargo.lock unchanged); telemetry-free.

## Manual verification
N/A — covered by the integration tests above. Also exercised by hand: native empty dir (writes `QUICKSTART.md`), native dir with files, fresh `git init` (no commits, capture+checkpoint), and `git init` with existing history (history imported, flag identity wins over git `user.*`).

## Acceptance criteria notes
- **Placeholder path deviation (deliberate, grounded):** AC #3 literally says `.heddle/QUICKSTART.md`, but the default ignore list is `[".heddle"]` (`crates/repo/src/repo_config.rs:257-259`), so a placeholder under `.heddle/` would be silently dropped by the capture walk and the first `heddle log` would be empty. The spike §4 — which the issue says it inherits — corrects this to a **root-level** `QUICKSTART.md`; this PR follows the spike. The sentinel test asserts the resulting capture is non-empty.
- **Identity precedence:** the flag/prompt identity is written to the *repo* config (`.heddle/config.toml`), not the global user config, because `resolve_principal` ranks repo config above Git config but user config below it — writing to user config would let an ambient git `user.*` win. The repo is re-opened so the in-memory config the capture reads reflects it.
- **Git-overlay with existing history:** quickstart imports that history (the same `import_all` `heddle adopt` uses) before the capture/checkpoint, so the confirmation-gate path for non-empty Git history actually completes.

## Blocked by → resolved
N/A — blocker heddle#26 (PR #230) already merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782746058&installation_id=132405951&pr_number=349&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F349&signature=c74da73d655bfc9587a3b9b2268806c3b111ba60a68f6437d4656520ef5263e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->