### PR TITLE
heddle#239: per-crate codecov coverage floors + CI-fail gate (E3)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -663,15 +663,32 @@ jobs:
 
       # Per-crate coverage gate. Keep the --gate thresholds in sync with
       # codecov.yml's `coverage.status.project.<crate>.target` and with
-      # the table in CONTRIBUTING.md. See heddle-devtools::run_audit_coverage
-      # for the parsing and reporting logic.
-      - name: Coverage gate (objects / repo / refs)
+      # the table in docs/contributor-guide/coverage.md. See
+      # heddle-devtools::run_audit_coverage for the parsing and reporting
+      # logic. This step fails the job BEFORE the Codecov upload, so a
+      # per-crate regression turns the build red on both `main` pushes and
+      # PRs regardless of whether Codecov is reachable.
+      #
+      # `crates/grpc` is intentionally not gated: its surface is tonic-
+      # generated code emitted to OUT_DIR, which never lands under
+      # `crates/grpc/` in lcov, so audit-coverage would `bail` with
+      # "no lines counted". Its 60% goal is tracked in the doc only.
+      - name: Coverage gate (per crate)
         run: |
           cargo run -p heddle-devtools --quiet -- \
             audit-coverage lcov.info \
               --gate objects=80 \
-              --gate repo=78.66 \
-              --gate refs=80
+              --gate refs=80 \
+              --gate repo=82 \
+              --gate cli=75 \
+              --gate mount=68 \
+              --gate semantic=78 \
+              --gate oplog=78 \
+              --gate proto=60 \
+              --gate state_review=76 \
+              --gate crypto=64 \
+              --gate daemon=80 \
+              --gate ingest=80
 
       - name: Upload coverage to Codecov
         if: ${{ env.HAVE_CODECOV_TOKEN == 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,67 +327,24 @@ need, the PR should explain why the alternative isn't viable.
 
 The `Coverage` job in
 [`.github/workflows/rust-tests.yml`](.github/workflows/rust-tests.yml)
-runs `cargo llvm-cov` over the OSS feature set and then enforces a
-per-crate line-coverage floor on the resulting `lcov.info`. The gate
-is the `Coverage gate (objects / repo / refs)` step; it shells out to
-the `audit-coverage` subcommand of `heddle-devtools`:
+runs `cargo llvm-cov` over the OSS feature set and enforces a
+**per-crate line-coverage floor** on the resulting `lcov.info` via the
+`audit-coverage` subcommand of `heddle-devtools`. The step exits
+non-zero — failing the build before the Codecov upload, on both `main`
+pushes and PRs — when any gated crate drops below its floor.
+[`codecov.yml`](codecov.yml) mirrors the same floors as per-crate
+status checks so the PR comment matches CI enforcement.
 
-```bash
-cargo run -p heddle-devtools --quiet -- \
-  audit-coverage lcov.info \
-    --gate objects=80 \
-    --gate repo=78.66 \
-    --gate refs=80
-```
+The full per-crate floor/goal table, the rationale for the
+floor-vs-goal split, the reason `grpc` isn't gated, the local-run
+recipe, and **how to request a target bump** all live in the canonical
+policy doc:
 
-`audit-coverage` parses `SF:` / `LF:` / `LH:` records in the lcov
-output, aggregates by workspace crate (matched on
-`crates/<name>/...`), and exits non-zero when any gated crate is
-below its threshold. The CI step fails *before* the Codecov upload,
-so the build stays red whether or not Codecov is reachable.
+> [`docs/contributor-guide/coverage.md`](docs/contributor-guide/coverage.md)
 
-### Current thresholds
-
-| Crate | Threshold | Goal |
-|---|---|---|
-| `objects` | 80% | 80% |
-| `repo` | 78.66% | 80% (ratchet) |
-| `refs` | 80% | 80% |
-
-The `repo` threshold is a ratchet floor: current main is **78.66%**,
-so the gate locks that as the no-regression line. Raise the number
-in this table, in
-[`.github/workflows/rust-tests.yml`](.github/workflows/rust-tests.yml),
-and in [`codecov.yml`](codecov.yml) in the same PR that adds the
-tests that push `repo`'s coverage to ≥80%.
-
-### Codecov mirror
-
-[`codecov.yml`](codecov.yml) declares `coverage.status.project.<crate>`
-entries with the same `target:` values as the CI gate, so Codecov's
-PR comment reports the same numbers the build enforces. Codecov is
-not the gate of record — the in-CI step is — but the two must agree.
-When you change a threshold, change it in all three places
-(`rust-tests.yml`, `codecov.yml`, this table).
-
-### Running the gate locally
-
-```bash
-cargo llvm-cov --locked --workspace \
-  --features git-overlay,native,semantic,zstd \
-  --lcov --output-path lcov.info
-
-cargo run -p heddle-devtools --quiet -- \
-  audit-coverage lcov.info \
-    --gate objects=80 --gate repo=78.66 --gate refs=80
-```
-
-A green local run means a green CI run, modulo lcov's normal
-sensitivity to feature flags. The `--features` list above mirrors
-the one the CI `Coverage` job uses (see
-[`.github/workflows/rust-tests.yml`](.github/workflows/rust-tests.yml)
-— the comment above the `Generate coverage report` step explains why
-this set, not `--all-features`).
+When you change a floor, change it in all three places it appears
+(`rust-tests.yml`, `codecov.yml`, and that doc's table) in the same PR
+that adds the tests justifying the change.
 
 ## Getting unstuck
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,11 @@
 #
 # Keep the per-component `target` values in sync with the
 # `--gate <crate>=<pct>` flags in `.github/workflows/rust-tests.yml`
-# (job `coverage`, step `Coverage gate`) and with the table in
-# `CONTRIBUTING.md` § "Coverage gate". The Rust-side gate in
-# `heddle-devtools audit-coverage` is the authoritative check (it
-# fails the CI job before the Codecov upload runs); Codecov mirrors
+# (job `coverage`, step `Coverage gate`) and with the per-crate table
+# in `docs/contributor-guide/coverage.md` (the canonical policy; the
+# CONTRIBUTING.md § "Coverage gate" summary links to it). The Rust-side
+# gate in `heddle-devtools audit-coverage` is the authoritative check
+# (it fails the CI job before the Codecov upload runs); Codecov mirrors
 # the same numbers so PR-level reporting matches CI-level enforcement.
 
 coverage:
@@ -23,6 +24,18 @@ coverage:
         threshold: 1%
         informational: true
 
+      # Per-crate project floors. Each `target` MUST equal the matching
+      # `--gate <crate>=<pct>` in `.github/workflows/rust-tests.yml` and
+      # the row in `docs/contributor-guide/coverage.md`. `threshold: 0%`
+      # makes any drop below `target` a failing status. Where a crate's
+      # current coverage is below its policy GOAL, the enforced floor is
+      # ratcheted to (just under) current main — see the coverage doc for
+      # the goal-vs-floor split and how to request a bump.
+      #
+      # `crates/grpc` is intentionally absent: its surface is tonic-
+      # generated code emitted to `OUT_DIR`, which never appears under
+      # `crates/grpc/` in lcov, so there are no lines to gate. Its 60%
+      # goal is tracked in the doc, not enforced here.
       objects:
         target: 80%
         threshold: 0%
@@ -31,16 +44,6 @@ coverage:
         paths:
           - crates/objects/
 
-      repo:
-        # Ratchet floor: pinned at current main (78.66%). Goal is 80% —
-        # raise this as the `repo` crate gains tests. See CONTRIBUTING.md.
-        target: 78.66%
-        threshold: 0%
-        flags:
-          - rust
-        paths:
-          - crates/repo/
-
       refs:
         target: 80%
         threshold: 0%
@@ -48,6 +51,95 @@ coverage:
           - rust
         paths:
           - crates/refs/
+
+      repo:
+        # Ratchet floor at 82% (current main 82.48%). Goal is 85% —
+        # raise this as the `repo` crate gains tests. See the coverage doc.
+        target: 82%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/repo/
+
+      cli:
+        target: 75%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/cli/
+
+      mount:
+        # Ratchet floor at 68% (current main 68.64%, platform-gated).
+        # Goal is 70%.
+        target: 68%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/mount/
+
+      semantic:
+        # Ratchet floor at 78% (current main 78.38%). Goal is 80%.
+        target: 78%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/semantic/
+
+      oplog:
+        # Ratchet floor at 78% (current main 78.25%). Goal is 80%.
+        target: 78%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/oplog/
+
+      proto:
+        # Ratchet floor at 60% (current main 60.27%). Goal is 80%.
+        target: 60%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/proto/
+
+      state_review:
+        # Ratchet floor at 76% (current main 76.59%). Goal is 80%.
+        target: 76%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/state_review/
+
+      crypto:
+        # Ratchet floor at 64% (current main 64.36%). Goal is 80%.
+        target: 64%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/crypto/
+
+      daemon:
+        target: 80%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/daemon/
+
+      ingest:
+        target: 80%
+        threshold: 0%
+        flags:
+          - rust
+        paths:
+          - crates/ingest/
 
     patch:
       # New-or-changed lines in a PR must clear 80% — this is the
@@ -78,11 +170,47 @@ component_management:
       name: objects
       paths:
         - crates/objects/**
-    - component_id: repo
-      name: repo
-      paths:
-        - crates/repo/**
     - component_id: refs
       name: refs
       paths:
         - crates/refs/**
+    - component_id: repo
+      name: repo
+      paths:
+        - crates/repo/**
+    - component_id: cli
+      name: cli
+      paths:
+        - crates/cli/**
+    - component_id: mount
+      name: mount
+      paths:
+        - crates/mount/**
+    - component_id: semantic
+      name: semantic
+      paths:
+        - crates/semantic/**
+    - component_id: oplog
+      name: oplog
+      paths:
+        - crates/oplog/**
+    - component_id: proto
+      name: proto
+      paths:
+        - crates/proto/**
+    - component_id: state_review
+      name: state_review
+      paths:
+        - crates/state_review/**
+    - component_id: crypto
+      name: crypto
+      paths:
+        - crates/crypto/**
+    - component_id: daemon
+      name: daemon
+      paths:
+        - crates/daemon/**
+    - component_id: ingest
+      name: ingest
+      paths:
+        - crates/ingest/**

--- a/docs/contributor-guide/coverage.md
+++ b/docs/contributor-guide/coverage.md
@@ -1,0 +1,119 @@
+# Per-crate coverage policy
+
+Heddle enforces a **per-crate line-coverage floor**. The gate is
+per-crate (not workspace-global) so a low-coverage crate can't be
+masked by high-coverage neighbours. This page is the canonical source
+for the policy and the per-crate numbers; `codecov.yml`,
+`.github/workflows/rust-tests.yml`, and the `CONTRIBUTING.md` summary
+all point here.
+
+## How the gate fails CI
+
+The `Coverage` job in
+[`.github/workflows/rust-tests.yml`](../../.github/workflows/rust-tests.yml)
+runs `cargo llvm-cov` over the OSS feature set
+(`git-overlay,native,semantic,zstd`) to produce `lcov.info`, then runs:
+
+```bash
+cargo run -p heddle-devtools --quiet -- \
+  audit-coverage lcov.info \
+    --gate objects=80 \
+    --gate refs=80 \
+    --gate repo=82 \
+    --gate cli=75 \
+    --gate mount=68 \
+    --gate semantic=78 \
+    --gate oplog=78 \
+    --gate proto=60 \
+    --gate state_review=76 \
+    --gate crypto=64 \
+    --gate daemon=80 \
+    --gate ingest=80
+```
+
+`audit-coverage` aggregates `LF:`/`LH:` lcov records by workspace crate
+(matched on `crates/<name>/`) and **exits non-zero** when any gated
+crate is below its threshold. The step runs *before* the Codecov
+upload, so the build goes red whether or not Codecov is reachable, and
+on both `main` pushes and pull requests. This is the **gate of record.**
+
+Codecov mirrors the same floors as per-crate `coverage.status.project`
+entries in [`codecov.yml`](../../codecov.yml) (`threshold: 0%`, so any
+drop fails the status). Codecov posts the per-crate delta in the PR
+comment, but it is not the gate of record — the in-CI step is.
+
+## Floors vs. goals
+
+Two numbers per crate:
+
+- **Floor** — the enforced `--gate`/`target` value. Dropping below it
+  fails CI. Pinned at or just under current `main` coverage, rounded
+  down to a whole percent so normal measurement jitter doesn't flap.
+- **Goal** — the coverage we want the crate to reach. Where the goal is
+  above current coverage, the floor is *ratcheted* (pinned near current)
+  and the goal is documented here. Raise the floor toward the goal in
+  the same PR that adds the tests pushing coverage up — never ahead of
+  the tests, or you turn `main` red.
+
+| Crate | Floor (enforced) | Goal | Notes |
+|---|---|---|---|
+| `objects` | 80% | 80% | at goal |
+| `refs` | 80% | 80% | at goal |
+| `repo` | 82% | 85% | ratchet — current ≈ 82.5% |
+| `cli` | 75% | 75% | at goal |
+| `mount` | 68% | 70% | ratchet — platform-gated (FUSE/projfs) |
+| `semantic` | 78% | 80% | ratchet — current ≈ 78.4% |
+| `oplog` | 78% | 80% | ratchet — current ≈ 78.3% |
+| `proto` | 60% | 80% | ratchet — current ≈ 60.3% |
+| `state_review` | 76% | 80% | ratchet — current ≈ 76.6% |
+| `crypto` | 64% | 80% | ratchet — current ≈ 64.4% |
+| `daemon` | 80% | 80% | at goal |
+| `ingest` | 80% | 80% | at goal |
+| `grpc` | not gated | 60% | see below |
+
+### Why `grpc` is not gated
+
+`crates/grpc`'s surface is tonic-generated code emitted to `OUT_DIR` at
+build time. Those files never appear under `crates/grpc/` in `lcov.info`,
+so `audit-coverage` would `bail` with "no lines counted" if it were
+listed. The 60% goal is tracked here as policy, but enforcing it needs a
+strategy to measure generated-code coverage first (a separate piece of
+work). Do not add `grpc` to the `--gate` list until that exists.
+
+## Running the gate locally
+
+```bash
+cargo llvm-cov --locked --workspace \
+  --features git-overlay,native,semantic,zstd \
+  --lcov --output-path lcov.info
+
+cargo run -p heddle-devtools --quiet -- \
+  audit-coverage lcov.info --gate repo=82 --gate cli=75   # …etc
+```
+
+A green local run means a green CI run, modulo lcov's normal sensitivity
+to feature flags. Pass `--gate <crate>=0` for a crate to read its current
+percentage without enforcing anything.
+
+## Requesting a target bump
+
+The floors are deliberately conservative; raising one is encouraged.
+
+1. **Add the tests** that move the crate's coverage above the new floor.
+2. In the **same PR**, raise the number in all three places — they must
+   agree or the in-CI gate and the Codecov status will diverge:
+   - the `--gate <crate>=<pct>` flag in
+     [`.github/workflows/rust-tests.yml`](../../.github/workflows/rust-tests.yml),
+   - the `coverage.status.project.<crate>.target` in
+     [`codecov.yml`](../../codecov.yml),
+   - the **Floor** column in the table above.
+3. Run the gate locally (above) to confirm the new floor passes before
+   pushing.
+4. To add a *new* crate to the gate, give it an entry in all three
+   places. Confirm it actually has lines under `crates/<name>/` in
+   `lcov.info` first — crates whose code is generated into `OUT_DIR`
+   (like `grpc`) can't be line-gated.
+
+Lowering a floor is a regression and should be rare — it needs a reason
+in the PR description (e.g. a crate's tested surface was intentionally
+removed). The CI gate and Codecov status both block silent drift.


### PR DESCRIPTION
Closes #239.

## What this does

Adds a **per-crate coverage floor** that fails CI when any crate drops below its target — on both `main` pushes and PRs.

The repo already had a per-crate gate of record: the `audit-coverage` step in `rust-tests.yml` (`objects`/`repo`/`refs`), with `codecov.yml` mirroring the same numbers. This PR extends that mechanism to every line-gateable workspace crate rather than inventing a parallel one, and adds the canonical policy doc.

## How the gate fails CI (which check, project vs patch)

- **Gate of record:** the `Coverage gate (per crate)` step in `.github/workflows/rust-tests.yml` runs `heddle-devtools audit-coverage lcov.info --gate <crate>=<pct> …`. It aggregates lcov `LF:`/`LH:` by `crates/<name>/` and **exits non-zero** if any gated crate is below its floor. It runs *before* the Codecov upload, so the build is red regardless of whether Codecov is reachable, on `main` and on PRs (the coverage job's gate step is unconditional — only the HTML-report steps are push-only).
- **PR-level mirror:** `codecov.yml` declares per-crate `coverage.status.project.<crate>` entries with `threshold: 0%`, so the `codecov/project/<crate>` status fails a PR on any drop below target. The global `codecov/patch` 80% floor is unchanged (not lowered).

## Floors chosen (and an important divergence from the issue table)

I measured current coverage with the CI-parity command (`cargo llvm-cov --locked --workspace --features git-overlay,native,semantic,zstd`) before setting floors. **7 of the issue's target numbers are above current coverage**, so enforcing them literally would turn `main` red immediately, and `grpc` has zero line data (generated code lives in `OUT_DIR`, never under `crates/grpc/` — `audit-coverage` would `bail` "no lines counted").

Following the repo's existing ratchet pattern (the old `repo` entry: *"pinned at current main… Goal is 80%"*), I enforce a floor at/under current coverage and document the issue's number as the **goal**:

| Crate | Issue target | Current | Enforced floor | Note |
|---|---|---|---|---|
| objects | 80% | 83.43% | **80%** | at goal |
| refs | 80% | 85.02% | **80%** | at goal |
| repo | 85% | 82.48% | **82%** | ratchet, goal 85% |
| cli | 75% | 81.25% | **75%** | at goal |
| mount | 70% | 68.64% | **68%** | ratchet, goal 70% |
| semantic | 80% | 78.38% | **78%** | ratchet, goal 80% |
| oplog | 80% | 78.25% | **78%** | ratchet, goal 80% |
| proto | 80% | 60.27% | **60%** | ratchet, goal 80% |
| state_review | 80% | 76.59% | **76%** | ratchet, goal 80% |
| crypto | 80% | 64.36% | **64%** | ratchet, goal 80% |
| daemon | 80% | 82.67% | **80%** | at goal |
| ingest | 80% | 88.45% | **80%** | at goal |
| grpc | 60% | *no data* | **not gated** | generated code; goal documented only |

Ratchet floors are rounded down to a whole percent so measurement jitter doesn't flap the gate. Raising a floor toward its goal happens in the same PR that adds the tests — documented in the new doc. **Flagging this for review:** if maintainers want the aspirational targets enforced *now*, that requires backfilling tests first (separate work) — enforcing them in this PR would break `main`.

## Docs
- New canonical policy: `docs/contributor-guide/coverage.md` — floor/goal table, why `grpc` isn't gated, local-run recipe, and the **target-bump request process** (add tests → bump the number in all 3 places → verify locally).
- `CONTRIBUTING.md` § "Coverage gate" trimmed to a summary that links the canonical doc (kills the triple-maintenance table).

## Validation
- `audit-coverage` with the new floors passes on current coverage (12/12 OK, exit 0).
- `codecov.yml` passes `https://codecov.io/validate` → **"Valid!"**.
- `rust-tests.yml` parses as YAML.
- No orchestration-plumbing touched (`project-card-sync.yml` / blacksmith untouched). No Rust source changes.

## Test plan
- [ ] CI `Coverage` job green (gate passes at current coverage).
- [ ] Codecov posts per-crate project statuses on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782746400&installation_id=132405951&pr_number=350&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F350&signature=610d3f4646d695e2a0fd7e82ac3dde436585b92d6a52e4301f445276048ca30d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->