### PR TITLE
heddle#347: add aarch64-pc-windows-msvc to the release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release binaries
 # Trigger: stable-semver tag push (vX.Y.Z) OR manual workflow_dispatch
 # with an existing tag (used for RC dry-runs). The job tree:
 #
-#   validate-tag ──► build (matrix, 5 targets) ──┐
+#   validate-tag ──► build (matrix, 6 targets) ──┐
 #                                                ├─► sign + checksum (per artifact, in-matrix)
 #                                                └─► release (aggregates, publishes, posts SHA256SUMS)
 #
@@ -198,6 +198,9 @@ jobs:
             archive: tar.gz
           - target: x86_64-pc-windows-msvc
             runner: windows-2022
+            archive: zip
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
             archive: zip
     steps:
       - uses: actions/checkout@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,6 +127,7 @@ Targets (`<target>`):
 - `aarch64-unknown-linux-gnu` — Linux arm64 (glibc)
 - `x86_64-unknown-linux-gnu` — Linux x64 (glibc)
 - `x86_64-pc-windows-msvc` — Windows x64 (MSVC)
+- `aarch64-pc-windows-msvc` — Windows arm64 (MSVC)
 
 Each archive contains:
 

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -84,13 +84,14 @@ else
   err "validate-tag must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
 fi
 
-# All five target triples.
+# All six target triples.
 targets=(
   "aarch64-apple-darwin"
   "x86_64-apple-darwin"
   "aarch64-unknown-linux-gnu"
   "x86_64-unknown-linux-gnu"
   "x86_64-pc-windows-msvc"
+  "aarch64-pc-windows-msvc"
 )
 for t in "${targets[@]}"; do
   if grep -F "$t" "$WF" >/dev/null; then


### PR DESCRIPTION
## Summary

Adds `aarch64-pc-windows-msvc` to `release.yml`'s build matrix so tagged releases produce an arm64 Windows binary. Closes the class for any future Windows-arm64 channel and unblocks the Scoop arm64 manifest (#233).

Closes #347.

## Change

New matrix entry, mirroring the existing `x86_64-pc-windows-msvc` row exactly:

| field | x86_64 (existing) | aarch64 (new) |
|---|---|---|
| `target` | `x86_64-pc-windows-msvc` | `aarch64-pc-windows-msvc` |
| `runner` | `windows-2022` | `windows-11-arm` |
| `archive` | `zip` | `zip` |

- **Native, not cross.** Consistent with the workflow's stated strategy (one runner per target). The GitHub-hosted `windows-11-arm` runner is the Windows-arm64 analogue of the `ubuntu-24.04-arm` / `macos-14` runners already used for the other ARM targets — no new toolchain mechanism introduced.
- **Toolchain.** `dtolnay/rust-toolchain@stable` installs `targets: ${{ matrix.target }}`, so the arm64 target is added automatically — same as every other row.
- **Artifact naming unchanged.** Staging, signing, checksum, and upload steps are all driven by `${{ matrix.target }}` / `${{ matrix.archive }}`. The new artifact is `heddle-v<version>-aarch64-pc-windows-msvc.zip` (+ `.sha256`/`.sig`/`.pem`), matching the existing scheme, so downstream manifest renderers (Scoop/etc.) find it the same way.

Also updated the supported-targets list in `RELEASING.md` and the "(matrix, N targets)" header comment to keep them in sync.

## Validation

- YAML parses (`yaml.safe_load`); matrix is well-formed.
- A release dry-run isn't possible locally; the new entry is a pure mirror of the proven x86_64 Windows row, differing only in the triple and the runner label — no x86_64 regression (its row is untouched).
- No orchestration-plumbing workflow touched (`project-card-sync.yml` / blacksmith-runner untouched). No Rust source changes.

## DoD
- [x] `aarch64-pc-windows-msvc` added to release.yml's build matrix, mirroring the existing x86_64 Windows target; artifact naming consistent.
- [x] No orchestration-plumbing workflow touched; no x86_64 regression. Linked #347.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782750692&installation_id=132405951&pr_number=351&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F351&signature=d44e21e46138f0889db8df4017f1c430c76f1bd29ff62341b070be6e466af1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->