### PR TITLE
heddle#238: partial-clone perf characterization (audit: already productized)

### DIFF
--- a/crates/cli/tests/production_features/shallow_clone.rs
+++ b/crates/cli/tests/production_features/shallow_clone.rs
@@ -96,6 +96,94 @@ fn test_shallow_clone_depth_0() {
     fs::remove_dir_all(&local_path).ok();
 }
 
+/// Performance characterization for partial (shallow) clone — issue #238 AC4.
+///
+/// "Clone a representative large repo with and without partial-clone,
+/// document numbers." A wall-clock benchmark on linux/linux is neither
+/// hermetic nor CI-stable, so we measure the metric that actually drives
+/// transfer cost and is deterministic: the count of objects copied,
+/// reported by `clone --output json` (`objects` field). A deep synthetic
+/// history stands in for the large repo; `--depth 1` must copy strictly
+/// fewer objects than a full clone, and only a small bounded number
+/// (tip + immediate parents), independent of history length.
+#[test]
+fn test_partial_clone_copies_fewer_objects_than_full() {
+    const HISTORY_DEPTH: usize = 25;
+
+    let remote_temp = TempDir::new().unwrap();
+    let base = remote_temp.path().parent().unwrap();
+    let full_path = base.join("partial_clone_full");
+    let shallow_path = base.join("partial_clone_shallow");
+    for path in [&full_path, &shallow_path] {
+        if path.exists() {
+            fs::remove_dir_all(path).ok();
+        }
+    }
+
+    heddle(&["init"], Some(remote_temp.path())).unwrap();
+    // Each commit rewrites the same file with distinct content, so every
+    // generation introduces a fresh blob + tree + state. A full clone must
+    // ferry all of them; a depth-1 clone only needs the tip and its
+    // immediate parents.
+    for i in 0..HISTORY_DEPTH {
+        fs::write(
+            remote_temp.path().join("file.txt"),
+            format!("revision {i}\n"),
+        )
+        .unwrap();
+        heddle(
+            &["capture", "-m", &format!("commit {i}")],
+            Some(remote_temp.path()),
+        )
+        .unwrap();
+    }
+
+    let objects_copied = |dest: &std::path::Path, depth: Option<&str>| -> u64 {
+        let mut args = vec![
+            "--output",
+            "json",
+            "clone",
+            remote_temp.path().to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ];
+        if let Some(depth) = depth {
+            args.push("--depth");
+            args.push(depth);
+        }
+        let out = heddle(&args, None).expect("clone should succeed");
+        let parsed: Value = serde_json::from_str(&out).expect("clone output should be JSON");
+        parsed["objects"]
+            .as_u64()
+            .expect("clone JSON should report an `objects` count")
+    };
+
+    let full_objects = objects_copied(&full_path, None);
+    let shallow_objects = objects_copied(&shallow_path, Some("1"));
+
+    // Documented numbers (visible under `cargo test -- --nocapture`).
+    eprintln!(
+        "partial-clone perf [{HISTORY_DEPTH}-commit history]: full clone copied {full_objects} objects; --depth 1 copied {shallow_objects} objects ({:.1}x fewer)",
+        full_objects as f64 / shallow_objects.max(1) as f64,
+    );
+
+    assert!(
+        shallow_objects < full_objects,
+        "partial clone must copy fewer objects than a full clone: shallow={shallow_objects}, full={full_objects}"
+    );
+    // The shallow clone's cost is bounded by the depth window, not the
+    // history length: tip + immediate parents only. A generous ceiling
+    // (well under the full count for a 25-commit history) pins that the
+    // depth boundary actually truncates the walk.
+    assert!(
+        shallow_objects <= 12,
+        "depth-1 clone should copy only the tip + immediate parents, got {shallow_objects} objects"
+    );
+
+    for path in [&full_path, &shallow_path] {
+        fs::remove_dir_all(path).ok();
+    }
+}
+
 #[test]
 fn test_normal_clone_no_depth() {
     let remote_temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- **Audit (AC1):** The partial-clone primitives are **already productized** in the current tree — this issue was an audit + the one missing deliverable.
  - `heddle clone --depth=N` works and is user-facing: flag declared in `CloneArgs` (`crates/cli/src/cli/cli_args/commands_args.rs:1295`), wired through `cmd_clone` → `LocalSync::fetch_state_with_depth` (`crates/cli/src/client/local_sync.rs:64`) for native/local and through `pull_with_depth_and_materialization` for hosted. Help has a dedicated depth Behavior stanza; covered by `production_features/shallow_clone.rs`.
  - `heddle clone --filter blob:none` works: parsed by `parse_clone_filter_spec` (`commands_args.rs:1315`, only `blob:none` accepted), and on hosted/network remotes is a synonym for `--lazy` (`clone.rs:1210`). Git-overlay and local-path transports reject `--filter`/`--lazy` with typed recovery advice (`reject_unsupported_for_git_overlay`, `local_clone_option_unsupported_advice`).
  - gix plumbing for shallow + partial negotiation already exists in `bridge/git_core.rs` (`ShallowClone` handling); native Git-overlay lazy hydration remains the only un-shipped piece (rejected at the flag surface, labeled "planned for v0.3.1" in the help text). No code change needed there.
- **CLI surface + tests + docs (AC2):** surface (`--depth` visible; `--lazy`/`--filter` hidden) and help docs already shipped; this PR adds the missing **performance test**.
- **No spike needed (AC3):** primitives exist; nothing to split out.
- **Performance test (AC4):** new `test_partial_clone_copies_fewer_objects_than_full` in `crates/cli/tests/production_features/shallow_clone.rs`. A wall-clock linux/linux benchmark is neither hermetic nor CI-stable, so it measures the deterministic metric that actually drives transfer cost — the object count reported by `clone --output json` — over a deep synthetic history, comparing a full clone vs `--depth 1`.

**Measured numbers** (25-commit history, asserted + printed under `--nocapture`):

```
partial-clone perf [25-commit history]: full clone copied 77 objects; --depth 1 copied 6 objects (12.8x fewer)
```

The shallow clone's cost is bounded by the depth window (tip + immediate parents), independent of history length; the test asserts `shallow < full` and a small absolute ceiling so a regression that fails to truncate the walk is caught.

Closes HeddleCo/heddle#238

## Red commit

N/A — DoD Type is audit + characterization test of already-shipped behavior; no new product behavior, so no red commit. (PR description shape allows skipping when DoD Type ≠ TDD-Rust.)

## Test evidence

```
running 6 tests
test clone::test_clone_creates_local_copy ... ok
test clone::test_clone_with_thread ... ok
test shallow_clone::test_shallow_clone_depth_0 ... ok
test shallow_clone::test_normal_clone_no_depth ... ok
test shallow_clone::test_shallow_clone_depth_1 ... ok
partial-clone perf [25-commit history]: full clone copied 77 objects; --depth 1 copied 6 objects (12.8x fewer)
test shallow_clone::test_partial_clone_copies_fewer_objects_than_full ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 88 filtered out; finished in 2.85s
```

Also green: `cargo clippy -p heddle-cli --tests -- -D warnings`; `bash scripts/check-no-silent-default-tree-load.sh`.

## Manual verification

N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782756425&installation_id=132405951&pr_number=353&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F353&signature=95689455c5dd09ca82a1889ca3c0a4f160f638b3c58239d69e39911d310731af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->