### PR TITLE
heddle#327: spike — CLI schema-macro shape (schemars vs custom emitter + attribute design)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heddle-cli-macro-poc"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "heddle-cli-shared"
 version = "0.2.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/cli",
+    "crates/cli-macro-poc",
     "crates/cli-shared",
     "crates/client",
     "crates/crypto",

--- a/crates/cli-macro-poc/Cargo.toml
+++ b/crates/cli-macro-poc/Cargo.toml
@@ -1,0 +1,22 @@
+# Spike PoC for heddle#327 — CLI schema-macro shape exploration.
+#
+# THROWAWAY. This crate exists only to measure the schemars-vs-custom-emitter
+# tradeoff for the spike. heddle#205 (land `crates/cli-macro/`) deletes this
+# crate when it lands the production proc-macro. It is intentionally NOT wired
+# into `crates/cli` — it shadows ONE verb (`init`) in isolation so the two
+# schema-generation paths can be diffed side by side.
+[package]
+name = "heddle-cli-macro-poc"
+version = "0.0.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "Spike PoC (heddle#327): schemars vs custom JSON-schema emitter for one CLI verb. Deleted by heddle#205."
+
+[dependencies]
+clap = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/cli-macro-poc/src/args.rs
+++ b/crates/cli-macro-poc/src/args.rs
@@ -17,6 +17,13 @@
 //! half. The `Cli` / `Commands` wiring below proves the args struct slots into
 //! a real subcommand tree — exactly the integration #205's `HeddleVerbArgs`
 //! passthrough must preserve.
+//!
+//! COMPLETE FAITHFUL MIRROR: this `InitArgs` reproduces every derive, every
+//! `#[command(...)]` attribute (incl. the `after_help` examples block), and
+//! every field with its `#[arg(...)]` attributes from the real
+//! `commands_args.rs:5-39` `InitArgs`. The spike uses this crate to prove the
+//! `HeddleVerbArgs` passthrough preserves clap behavior — including help text —
+//! so the after_help block is load-bearing, not decoration.
 
 use clap::{Args, Parser, Subcommand};
 
@@ -40,6 +47,12 @@ pub enum Commands {
 /// Arguments for the `init` command. Derives **`clap::Args`** — the reusable
 /// argument set the subcommand enum consumes — copied from the real `InitArgs`.
 #[derive(Clone, Debug, Args)]
+#[command(after_help = "\
+Examples:
+  heddle init                                  # initialize the current directory
+  heddle init my-project                       # initialize a subdirectory
+  heddle init --principal-name 'Ada Lovelace'  # set attribution at init time
+")]
 pub struct InitArgs {
     /// Directory to initialize (default: current directory).
     pub path: Option<std::path::PathBuf>,

--- a/crates/cli-macro-poc/src/args.rs
+++ b/crates/cli-macro-poc/src/args.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Input shape (clap) — a FAITHFUL mirror of the real init args.
+//!
+//! This PoC mirrors the real `crates/cli/src/cli/cli_args/commands_args.rs:12`
+//! `InitArgs`, which derives **`clap::Args`** (NOT `clap::Parser`) and is wired
+//! as a tuple payload of the top-level subcommand enum
+//! (`Commands::Init(InitArgs)`). clap's derive model reserves `Parser` for the
+//! top-level parser and `Args` for reusable argument sets merged into a parent
+//! — subcommand tuple-variant payloads must implement `Args`. An earlier draft
+//! of this PoC derived `Parser` here, which measured the wrong clap shape: a
+//! standalone parser the existing `Commands::Init(_)` variant cannot consume.
+//!
+//! The spike question for the input side is NOT "can a macro emit a clap
+//! struct" (clap's own derive already does that) but "can ONE declaration emit
+//! BOTH this clap args struct AND the output schema". `InitArgs` is the input
+//! half of that single declaration; [`super::output::InitOutput`] is the output
+//! half. The `Cli` / `Commands` wiring below proves the args struct slots into
+//! a real subcommand tree — exactly the integration #205's `HeddleVerbArgs`
+//! passthrough must preserve.
+
+use clap::{Args, Parser, Subcommand};
+
+/// Top-level parser — `Parser` lives HERE (and only here), mirroring the real
+/// `Cli`. Verb-args types stay on `Args`.
+#[derive(Debug, Parser)]
+#[command(name = "heddle", bin_name = "heddle")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Subcommand enum whose tuple variants carry `clap::Args` payloads, mirroring
+/// the real `Commands` enum.
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Initialize Heddle metadata in a repository.
+    Init(InitArgs),
+}
+
+/// Arguments for the `init` command. Derives **`clap::Args`** — the reusable
+/// argument set the subcommand enum consumes — copied from the real `InitArgs`.
+#[derive(Clone, Debug, Args)]
+pub struct InitArgs {
+    /// Directory to initialize (default: current directory).
+    pub path: Option<std::path::PathBuf>,
+
+    /// Principal name for attribution.
+    #[arg(long)]
+    pub principal_name: Option<String>,
+
+    /// Principal email for attribution.
+    #[arg(long)]
+    pub principal_email: Option<String>,
+
+    /// Install harness integrations after init.
+    #[arg(long)]
+    pub install_harnesses: Option<String>,
+
+    /// Skip harness integration install prompts.
+    #[arg(long)]
+    pub no_harness_install: bool,
+
+    /// Preferred install scope (`repo` or `user`).
+    #[arg(long, visible_alias = "scope", default_value = "repo")]
+    pub harness_install_scope: String,
+
+    /// Overwrite Heddle-managed integration entries when needed.
+    #[arg(long)]
+    pub harness_install_force: bool,
+}

--- a/crates/cli-macro-poc/src/custom_path.rs
+++ b/crates/cli-macro-poc/src/custom_path.rs
@@ -22,7 +22,12 @@ struct Field {
     ty: Value,
     /// `///`-equivalent narrative.
     description: &'static str,
-    /// Whether the field is required (non-`Option`).
+    /// Whether the field's KEY is always present in the wire bytes — i.e.
+    /// JSON-Schema-`required`. This is NOT "is the field non-`Option`": the real
+    /// `InitOutput` Option fields carry NO `skip_serializing_if`, so serde always
+    /// emits the key (`null` when unset). heddle's JSON discipline treats an
+    /// always-present key as required, so every serialized field here is
+    /// `required: true` and nullability is expressed in `ty` instead.
     required: bool,
 }
 
@@ -120,19 +125,23 @@ fn fields() -> Vec<Field> {
             name: "principal_source",
             ty: nullable_string_ty(),
             description: "Where the principal identity was sourced from, if any.",
-            required: false,
+            // Option, but no `skip_serializing_if` on the real field → key always
+            // emitted (null when unset) → required.
+            required: true,
         },
         Field {
             name: "principal",
             ty: principal_ty(),
             description: "Resolved principal identity, if one was configured.",
-            required: false,
+            // Option, but no `skip_serializing_if` → key always emitted → required.
+            required: true,
         },
         Field {
             name: "principal_recommended_action",
             ty: nullable_string_ty(),
             description: "Suggested follow-up to configure a principal, if unset.",
-            required: false,
+            // Option, but no `skip_serializing_if` → key always emitted → required.
+            required: true,
         },
         Field {
             name: "side_effects",
@@ -150,13 +159,15 @@ fn fields() -> Vec<Field> {
             name: "next_action",
             ty: nullable_string_ty(),
             description: "Primary verification-guided next command.",
-            required: false,
+            // Option, but no `skip_serializing_if` → key always emitted → required.
+            required: true,
         },
         Field {
             name: "recommended_action",
             ty: nullable_string_ty(),
             description: "Alias of `next_action` for the shared recovery-advice contract.",
-            required: false,
+            // Option, but no `skip_serializing_if` → key always emitted → required.
+            required: true,
         },
     ]
 }

--- a/crates/cli-macro-poc/src/custom_path.rs
+++ b/crates/cli-macro-poc/src/custom_path.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+//! PATH B — hand-written emitter. Represents the code a *custom* heddle emitter
+//! macro would generate: an explicit field table → schema `Value`, no derive,
+//! no `schemars` dependency. The point of writing it by hand here is to measure
+//! what that control buys (and costs) versus the derive.
+//!
+//! A custom emitter walks the SERIALIZED field set, so it naturally omits
+//! `#[serde(skip_serializing)]` fields like `trust`/`verification` — the schema
+//! it produces matches the wire bytes by construction, with no phantom
+//! `verification` property. It also pins the `output_kind` discriminator as a
+//! `const`, which the schemars derive cannot do from a plain `&'static str`
+//! field. Both differences are measured in `tests/measure.rs`.
+
+use serde_json::{Value, json};
+
+use crate::output::init_example;
+
+/// A single field's contribution to the object schema.
+struct Field {
+    name: &'static str,
+    /// JSON Schema fragment for the field's type.
+    ty: Value,
+    /// `///`-equivalent narrative.
+    description: &'static str,
+    /// Whether the field is required (non-`Option`).
+    required: bool,
+}
+
+fn string_ty() -> Value {
+    json!({ "type": "string" })
+}
+fn bool_ty() -> Value {
+    json!({ "type": "boolean" })
+}
+fn nullable_string_ty() -> Value {
+    json!({ "type": ["string", "null"] })
+}
+fn string_array_ty() -> Value {
+    json!({ "type": "array", "items": { "type": "string" } })
+}
+fn principal_ty() -> Value {
+    json!({
+        "type": ["object", "null"],
+        "properties": {
+            "name": { "type": "string", "description": "Principal display name." },
+            "email": { "type": "string", "description": "Principal email." }
+        },
+        "required": ["name", "email"],
+        "additionalProperties": false
+    })
+}
+
+/// The explicit field table — the SERIALIZED fields only. In production this is
+/// exactly what the macro would emit from the annotated struct: one row per
+/// serialized field. `trust`/`verification` is `#[serde(skip_serializing)]`, so
+/// the wire bytes never carry it and the emitter omits it — no phantom property.
+fn fields() -> Vec<Field> {
+    vec![
+        Field {
+            name: "output_kind",
+            ty: json!({ "type": "string", "const": "init" }),
+            description: "Stable output discriminator. Always \"init\".",
+            required: true,
+        },
+        Field {
+            name: "status",
+            ty: string_ty(),
+            description: "Always `initialized` on success.",
+            required: true,
+        },
+        Field {
+            name: "action",
+            ty: string_ty(),
+            description: "Always `init` on success.",
+            required: true,
+        },
+        Field {
+            name: "path",
+            ty: string_ty(),
+            description: "Path to the initialized `.heddle` metadata directory.",
+            required: true,
+        },
+        Field {
+            name: "repository_mode",
+            ty: string_ty(),
+            description: "Repository capability after init, e.g. `git-overlay`.",
+            required: true,
+        },
+        Field {
+            name: "git_detected",
+            ty: bool_ty(),
+            description: "Whether init detected an existing Git repo.",
+            required: true,
+        },
+        Field {
+            name: "heddle_initialized",
+            ty: bool_ty(),
+            description: "Whether Heddle metadata is now present.",
+            required: true,
+        },
+        Field {
+            name: "installed_heddleignore",
+            ty: bool_ty(),
+            description: "Side effect outside `.heddle`. Currently always false.",
+            required: true,
+        },
+        Field {
+            name: "principal_configured",
+            ty: bool_ty(),
+            description: "Whether a signing principal was configured during init.",
+            required: true,
+        },
+        Field {
+            name: "principal_status",
+            ty: string_ty(),
+            description: "Principal configuration status string.",
+            required: true,
+        },
+        Field {
+            name: "principal_source",
+            ty: nullable_string_ty(),
+            description: "Where the principal identity was sourced from, if any.",
+            required: false,
+        },
+        Field {
+            name: "principal",
+            ty: principal_ty(),
+            description: "Resolved principal identity, if one was configured.",
+            required: false,
+        },
+        Field {
+            name: "principal_recommended_action",
+            ty: nullable_string_ty(),
+            description: "Suggested follow-up to configure a principal, if unset.",
+            required: false,
+        },
+        Field {
+            name: "side_effects",
+            ty: string_array_ty(),
+            description: "Human-readable, machine-preserved list of what init changed.",
+            required: true,
+        },
+        Field {
+            name: "message",
+            ty: string_ty(),
+            description: "Human summary line.",
+            required: true,
+        },
+        Field {
+            name: "next_action",
+            ty: nullable_string_ty(),
+            description: "Primary verification-guided next command.",
+            required: false,
+        },
+        Field {
+            name: "recommended_action",
+            ty: nullable_string_ty(),
+            description: "Alias of `next_action` for the shared recovery-advice contract.",
+            required: false,
+        },
+    ]
+}
+
+/// JSON Schema for `init --output json` built by the custom emitter.
+pub fn schema() -> Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+    for f in fields() {
+        let mut ty = f.ty;
+        if let Value::Object(ref mut map) = ty {
+            map.insert("description".into(), Value::String(f.description.into()));
+        }
+        properties.insert(f.name.into(), ty);
+        if f.required {
+            required.push(Value::String(f.name.into()));
+        }
+    }
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "InitOutput",
+        "description": "`heddle init --output json` response.",
+        "type": "object",
+        "properties": Value::Object(properties),
+        "required": Value::Array(required),
+        "additionalProperties": false,
+        "examples": [serde_json::to_value(init_example()).expect("example serializes")]
+    })
+}

--- a/crates/cli-macro-poc/src/lib.rs
+++ b/crates/cli-macro-poc/src/lib.rs
@@ -5,358 +5,39 @@
 //!
 //! This crate reproduces ONE real CLI verb — `heddle init` — in isolation and
 //! emits its `--output json` JSON Schema **two ways**, so the spike can measure
-//! the schemars-vs-custom-emitter tradeoff against a real shape:
+//! the schemars-vs-custom-emitter tradeoff against the REAL production shape:
 //!
 //! * [`schemars_path`] — derive `schemars::JsonSchema` on the output struct and
 //!   call `schema_for!`. This is the path heddle uses *today* (the hand-written
-//!   mirror structs in `crates/cli/src/cli/commands/schemas.rs` derive
-//!   `JsonSchema`). The spike question is whether a macro can emit this derive
-//!   from the SAME declaration that drives clap, deleting the mirror.
+//!   mirror struct `InitSchema` in `crates/cli/src/cli/commands/schemas.rs`
+//!   derives `JsonSchema`). The spike question is whether a macro can emit this
+//!   derive from the SAME declaration that drives clap, deleting the mirror.
 //! * [`custom_path`] — a hand-written emitter that walks an explicit field
 //!   table and builds the schema `serde_json::Value` directly, with no derive.
 //!   This is the "tighter, net-new code" alternative #205 names.
 //!
-//! The faithful reproduction target is the registered `InitSchema` mirror at
-//! `crates/cli/src/cli/commands/schemas.rs` (`pub struct InitSchema`) and the
-//! documented sample at `docs/json-schemas.md` (`## heddle init --output json`).
-//! Field set + doc-comment text are copied verbatim from those sources so the
-//! measurement reflects the production shape, not a toy.
+//! **This PoC mirrors the real `init.rs` arg/output types** so the measured
+//! drift/discriminator numbers reflect the production surface, not a toy:
+//! - [`args`] mirrors the real `InitArgs` (`clap::Args`, wired through a
+//!   `Subcommand` enum) — not a standalone `clap::Parser`.
+//! - [`output`] mirrors the real private `InitOutput` field-for-field, INCLUDING
+//!   the `#[serde(skip_serializing)] #[serde(rename = "verification")]` `trust`
+//!   field that the hand-written mirror drops. That field is why deriving on the
+//!   real struct is NOT semantics-free: schemars re-introduces a `verification`
+//!   schema property the wire bytes never emit.
 //!
 //! Run `cargo test -p heddle-cli-macro-poc -- --nocapture` to print both
-//! schemas + the measurement table the spike doc cites.
+//! schemas + the measurement table; the assertions in `tests/measure.rs` pin
+//! the drift, the discriminator gap, and the typed-example/doc-sample divergence.
 
-use clap::Parser;
-use schemars::JsonSchema;
-use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::Value;
 
-// ---------------------------------------------------------------------------
-// INPUT SHAPE (clap) — copied from the real `InitArgs`
-// (`crates/cli/src/cli/cli_args/commands_args.rs:12`).
-//
-// The spike question for the input side is NOT "can a macro emit a clap
-// struct" (clap's own derive already does that) but "can ONE declaration emit
-// BOTH this clap struct AND the output schema below". This struct is the input
-// half of that single declaration; `InitOutput` is the output half. See the
-// spec (`docs/spikes/heddle-327-cli-macro-shape.md`) for the unifying
-// `#[heddle_verb]` attribute that ties the two together.
-// ---------------------------------------------------------------------------
+pub mod args;
+pub mod custom_path;
+pub mod output;
+pub mod schemars_path;
 
-/// Initialize Heddle metadata in a repository.
-#[derive(Debug, Parser)]
-pub struct InitArgs {
-    /// Directory to initialize (default: current directory).
-    pub path: Option<std::path::PathBuf>,
-
-    /// Principal name for attribution.
-    #[arg(long)]
-    pub principal_name: Option<String>,
-
-    /// Principal email for attribution.
-    #[arg(long)]
-    pub principal_email: Option<String>,
-
-    /// Install harness integrations after init.
-    #[arg(long)]
-    pub install_harnesses: Option<String>,
-
-    /// Skip harness integration install prompts.
-    #[arg(long)]
-    pub no_harness_install: bool,
-
-    /// Preferred install scope (`repo` or `user`).
-    #[arg(long, visible_alias = "scope", default_value = "repo")]
-    pub harness_install_scope: String,
-
-    /// Overwrite Heddle-managed integration entries when needed.
-    #[arg(long)]
-    pub harness_install_force: bool,
-}
-
-// ---------------------------------------------------------------------------
-// OUTPUT SHAPE — field set copied from the registered `InitSchema` mirror
-// (`crates/cli/src/cli/commands/schemas.rs`, `pub struct InitSchema`).
-//
-// The doc comment on each field IS the attribute-design demonstration: schemars
-// lifts `///` doc comments into the schema's `description` natively (proven by
-// `schemars_emits_field_descriptions_from_doc_comments`). That answers spike
-// question #1 — narrative descriptions live in `#[doc]`, no sibling attribute
-// needed for them. Examples are the part schemars handles awkwardly; see
-// `init_example` + the spec's "examples" section.
-// ---------------------------------------------------------------------------
-
-/// `heddle init --output json` response.
-///
-/// Initialize Heddle metadata. In a plain Git repository this creates the
-/// `.heddle` sidecar and updates the local `.git/info/exclude` file for Heddle
-/// metadata only; it does not import Git history or write Git-tracked files.
-#[derive(Debug, Serialize, JsonSchema)]
-#[schemars(example = "init_example")]
-pub struct InitOutput {
-    /// Stable output discriminator. Always `"init"`.
-    pub output_kind: String,
-    /// Always `initialized` on success.
-    pub status: String,
-    /// Always `init` on success.
-    pub action: String,
-    /// Path to the initialized `.heddle` metadata directory.
-    pub path: String,
-    /// Repository capability after init, e.g. `git-overlay`.
-    pub repository_mode: String,
-    /// Whether init detected an existing Git repo.
-    pub git_detected: bool,
-    /// Whether Heddle metadata is now present.
-    pub heddle_initialized: bool,
-    /// Side effect outside `.heddle`. Currently always false.
-    pub installed_heddleignore: bool,
-    /// Whether a signing principal was configured during init.
-    pub principal_configured: bool,
-    /// Principal configuration status string.
-    pub principal_status: String,
-    /// Where the principal identity was sourced from, if any.
-    pub principal_source: Option<String>,
-    /// Resolved principal identity, if one was configured.
-    pub principal: Option<InitPrincipal>,
-    /// Suggested follow-up to configure a principal, if unset.
-    pub principal_recommended_action: Option<String>,
-    /// Human-readable, machine-preserved list of what init changed.
-    pub side_effects: Vec<String>,
-    /// Human summary line.
-    pub message: String,
-    /// Primary verification-guided next command.
-    pub next_action: Option<String>,
-    /// Alias of `next_action` for the shared recovery-advice contract.
-    pub recommended_action: Option<String>,
-}
-
-/// Resolved principal identity attached to an init reply.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct InitPrincipal {
-    /// Principal display name.
-    pub name: String,
-    /// Principal email.
-    pub email: String,
-}
-
-/// Canonical example payload — the same sample documented at
-/// `docs/json-schemas.md` (`## heddle init --output json`). schemars consumes
-/// this via `#[schemars(example = "init_example")]` and folds it into the
-/// schema's `examples`.
-pub fn init_example() -> InitOutput {
-    InitOutput {
-        output_kind: "init".into(),
-        status: "initialized".into(),
-        action: "init".into(),
-        path: "/repo/.heddle".into(),
-        repository_mode: "git-overlay".into(),
-        git_detected: true,
-        heddle_initialized: true,
-        installed_heddleignore: false,
-        principal_configured: false,
-        principal_status: "unset".into(),
-        principal_source: None,
-        principal: None,
-        principal_recommended_action: Some("heddle init --principal-name <name>".into()),
-        side_effects: vec![
-            "created Heddle sidecar for the existing Git repository".into(),
-            "updated .git/info/exclude for Heddle metadata".into(),
-            "left Git-tracked files untouched".into(),
-        ],
-        message: "Initialized Heddle data in /repo/.heddle for Git-overlay workflows".into(),
-        next_action: Some("heddle adopt --ref main".into()),
-        recommended_action: Some("heddle adopt --ref main".into()),
-    }
-}
-
-/// PATH A — schemars derive. One line at the call site once the macro emits the
-/// derive; this is what heddle does today via the hand-written mirror.
-pub mod schemars_path {
-    use super::*;
-
-    /// JSON Schema for `init --output json` via `schemars::schema_for!`.
-    pub fn schema() -> Value {
-        let root = schemars::schema_for!(InitOutput);
-        serde_json::to_value(&root).expect("schemars RootSchema serializes")
-    }
-}
-
-/// PATH B — hand-written emitter. Represents the code a *custom* heddle emitter
-/// macro would generate: an explicit field table → schema `Value`, no derive,
-/// no `schemars` dependency. The point of writing it by hand here is to measure
-/// what that control buys (and costs) versus the derive.
-pub mod custom_path {
-    use super::*;
-
-    /// A single field's contribution to the object schema.
-    struct Field {
-        name: &'static str,
-        /// JSON Schema fragment for the field's type.
-        ty: Value,
-        /// `///`-equivalent narrative.
-        description: &'static str,
-        /// Whether the field is required (non-`Option`).
-        required: bool,
-    }
-
-    fn string_ty() -> Value {
-        json!({ "type": "string" })
-    }
-    fn bool_ty() -> Value {
-        json!({ "type": "boolean" })
-    }
-    fn nullable_string_ty() -> Value {
-        json!({ "type": ["string", "null"] })
-    }
-    fn string_array_ty() -> Value {
-        json!({ "type": "array", "items": { "type": "string" } })
-    }
-    fn principal_ty() -> Value {
-        json!({
-            "type": ["object", "null"],
-            "properties": {
-                "name": { "type": "string", "description": "Principal display name." },
-                "email": { "type": "string", "description": "Principal email." }
-            },
-            "required": ["name", "email"],
-            "additionalProperties": false
-        })
-    }
-
-    /// The explicit field table. In production this is exactly what the macro
-    /// would emit from the annotated struct — one row per declared field.
-    fn fields() -> Vec<Field> {
-        vec![
-            Field {
-                name: "output_kind",
-                ty: json!({ "type": "string", "const": "init" }),
-                description: "Stable output discriminator. Always \"init\".",
-                required: true,
-            },
-            Field {
-                name: "status",
-                ty: string_ty(),
-                description: "Always `initialized` on success.",
-                required: true,
-            },
-            Field {
-                name: "action",
-                ty: string_ty(),
-                description: "Always `init` on success.",
-                required: true,
-            },
-            Field {
-                name: "path",
-                ty: string_ty(),
-                description: "Path to the initialized `.heddle` metadata directory.",
-                required: true,
-            },
-            Field {
-                name: "repository_mode",
-                ty: string_ty(),
-                description: "Repository capability after init, e.g. `git-overlay`.",
-                required: true,
-            },
-            Field {
-                name: "git_detected",
-                ty: bool_ty(),
-                description: "Whether init detected an existing Git repo.",
-                required: true,
-            },
-            Field {
-                name: "heddle_initialized",
-                ty: bool_ty(),
-                description: "Whether Heddle metadata is now present.",
-                required: true,
-            },
-            Field {
-                name: "installed_heddleignore",
-                ty: bool_ty(),
-                description: "Side effect outside `.heddle`. Currently always false.",
-                required: true,
-            },
-            Field {
-                name: "principal_configured",
-                ty: bool_ty(),
-                description: "Whether a signing principal was configured during init.",
-                required: true,
-            },
-            Field {
-                name: "principal_status",
-                ty: string_ty(),
-                description: "Principal configuration status string.",
-                required: true,
-            },
-            Field {
-                name: "principal_source",
-                ty: nullable_string_ty(),
-                description: "Where the principal identity was sourced from, if any.",
-                required: false,
-            },
-            Field {
-                name: "principal",
-                ty: principal_ty(),
-                description: "Resolved principal identity, if one was configured.",
-                required: false,
-            },
-            Field {
-                name: "principal_recommended_action",
-                ty: nullable_string_ty(),
-                description: "Suggested follow-up to configure a principal, if unset.",
-                required: false,
-            },
-            Field {
-                name: "side_effects",
-                ty: string_array_ty(),
-                description: "Human-readable, machine-preserved list of what init changed.",
-                required: true,
-            },
-            Field {
-                name: "message",
-                ty: string_ty(),
-                description: "Human summary line.",
-                required: true,
-            },
-            Field {
-                name: "next_action",
-                ty: nullable_string_ty(),
-                description: "Primary verification-guided next command.",
-                required: false,
-            },
-            Field {
-                name: "recommended_action",
-                ty: nullable_string_ty(),
-                description: "Alias of `next_action` for the shared recovery-advice contract.",
-                required: false,
-            },
-        ]
-    }
-
-    /// JSON Schema for `init --output json` built by the custom emitter.
-    pub fn schema() -> Value {
-        let mut properties = serde_json::Map::new();
-        let mut required = Vec::new();
-        for f in fields() {
-            let mut ty = f.ty;
-            if let Value::Object(ref mut map) = ty {
-                map.insert("description".into(), Value::String(f.description.into()));
-            }
-            properties.insert(f.name.into(), ty);
-            if f.required {
-                required.push(Value::String(f.name.into()));
-            }
-        }
-        json!({
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "title": "InitOutput",
-            "description": "`heddle init --output json` response.",
-            "type": "object",
-            "properties": Value::Object(properties),
-            "required": Value::Array(required),
-            "additionalProperties": false,
-            "examples": [serde_json::to_value(init_example()).expect("example serializes")]
-        })
-    }
-}
+pub use output::{InitOutput, InitPrincipalOutput, RepositoryVerificationState, init_example};
 
 /// Top-level keys the documented sample at `docs/json-schemas.md`
 /// (`## heddle init --output json`) asserts. The drift gate

--- a/crates/cli-macro-poc/src/lib.rs
+++ b/crates/cli-macro-poc/src/lib.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: Apache-2.0
+//! # heddle#327 spike PoC — one verb, both ways
+//!
+//! THROWAWAY crate. Deleted by heddle#205 when it lands `crates/cli-macro/`.
+//!
+//! This crate reproduces ONE real CLI verb — `heddle init` — in isolation and
+//! emits its `--output json` JSON Schema **two ways**, so the spike can measure
+//! the schemars-vs-custom-emitter tradeoff against a real shape:
+//!
+//! * [`schemars_path`] — derive `schemars::JsonSchema` on the output struct and
+//!   call `schema_for!`. This is the path heddle uses *today* (the hand-written
+//!   mirror structs in `crates/cli/src/cli/commands/schemas.rs` derive
+//!   `JsonSchema`). The spike question is whether a macro can emit this derive
+//!   from the SAME declaration that drives clap, deleting the mirror.
+//! * [`custom_path`] — a hand-written emitter that walks an explicit field
+//!   table and builds the schema `serde_json::Value` directly, with no derive.
+//!   This is the "tighter, net-new code" alternative #205 names.
+//!
+//! The faithful reproduction target is the registered `InitSchema` mirror at
+//! `crates/cli/src/cli/commands/schemas.rs` (`pub struct InitSchema`) and the
+//! documented sample at `docs/json-schemas.md` (`## heddle init --output json`).
+//! Field set + doc-comment text are copied verbatim from those sources so the
+//! measurement reflects the production shape, not a toy.
+//!
+//! Run `cargo test -p heddle-cli-macro-poc -- --nocapture` to print both
+//! schemas + the measurement table the spike doc cites.
+
+use clap::Parser;
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// INPUT SHAPE (clap) — copied from the real `InitArgs`
+// (`crates/cli/src/cli/cli_args/commands_args.rs:12`).
+//
+// The spike question for the input side is NOT "can a macro emit a clap
+// struct" (clap's own derive already does that) but "can ONE declaration emit
+// BOTH this clap struct AND the output schema below". This struct is the input
+// half of that single declaration; `InitOutput` is the output half. See the
+// spec (`docs/spikes/heddle-327-cli-macro-shape.md`) for the unifying
+// `#[heddle_verb]` attribute that ties the two together.
+// ---------------------------------------------------------------------------
+
+/// Initialize Heddle metadata in a repository.
+#[derive(Debug, Parser)]
+pub struct InitArgs {
+    /// Directory to initialize (default: current directory).
+    pub path: Option<std::path::PathBuf>,
+
+    /// Principal name for attribution.
+    #[arg(long)]
+    pub principal_name: Option<String>,
+
+    /// Principal email for attribution.
+    #[arg(long)]
+    pub principal_email: Option<String>,
+
+    /// Install harness integrations after init.
+    #[arg(long)]
+    pub install_harnesses: Option<String>,
+
+    /// Skip harness integration install prompts.
+    #[arg(long)]
+    pub no_harness_install: bool,
+
+    /// Preferred install scope (`repo` or `user`).
+    #[arg(long, visible_alias = "scope", default_value = "repo")]
+    pub harness_install_scope: String,
+
+    /// Overwrite Heddle-managed integration entries when needed.
+    #[arg(long)]
+    pub harness_install_force: bool,
+}
+
+// ---------------------------------------------------------------------------
+// OUTPUT SHAPE — field set copied from the registered `InitSchema` mirror
+// (`crates/cli/src/cli/commands/schemas.rs`, `pub struct InitSchema`).
+//
+// The doc comment on each field IS the attribute-design demonstration: schemars
+// lifts `///` doc comments into the schema's `description` natively (proven by
+// `schemars_emits_field_descriptions_from_doc_comments`). That answers spike
+// question #1 — narrative descriptions live in `#[doc]`, no sibling attribute
+// needed for them. Examples are the part schemars handles awkwardly; see
+// `init_example` + the spec's "examples" section.
+// ---------------------------------------------------------------------------
+
+/// `heddle init --output json` response.
+///
+/// Initialize Heddle metadata. In a plain Git repository this creates the
+/// `.heddle` sidecar and updates the local `.git/info/exclude` file for Heddle
+/// metadata only; it does not import Git history or write Git-tracked files.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(example = "init_example")]
+pub struct InitOutput {
+    /// Stable output discriminator. Always `"init"`.
+    pub output_kind: String,
+    /// Always `initialized` on success.
+    pub status: String,
+    /// Always `init` on success.
+    pub action: String,
+    /// Path to the initialized `.heddle` metadata directory.
+    pub path: String,
+    /// Repository capability after init, e.g. `git-overlay`.
+    pub repository_mode: String,
+    /// Whether init detected an existing Git repo.
+    pub git_detected: bool,
+    /// Whether Heddle metadata is now present.
+    pub heddle_initialized: bool,
+    /// Side effect outside `.heddle`. Currently always false.
+    pub installed_heddleignore: bool,
+    /// Whether a signing principal was configured during init.
+    pub principal_configured: bool,
+    /// Principal configuration status string.
+    pub principal_status: String,
+    /// Where the principal identity was sourced from, if any.
+    pub principal_source: Option<String>,
+    /// Resolved principal identity, if one was configured.
+    pub principal: Option<InitPrincipal>,
+    /// Suggested follow-up to configure a principal, if unset.
+    pub principal_recommended_action: Option<String>,
+    /// Human-readable, machine-preserved list of what init changed.
+    pub side_effects: Vec<String>,
+    /// Human summary line.
+    pub message: String,
+    /// Primary verification-guided next command.
+    pub next_action: Option<String>,
+    /// Alias of `next_action` for the shared recovery-advice contract.
+    pub recommended_action: Option<String>,
+}
+
+/// Resolved principal identity attached to an init reply.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct InitPrincipal {
+    /// Principal display name.
+    pub name: String,
+    /// Principal email.
+    pub email: String,
+}
+
+/// Canonical example payload — the same sample documented at
+/// `docs/json-schemas.md` (`## heddle init --output json`). schemars consumes
+/// this via `#[schemars(example = "init_example")]` and folds it into the
+/// schema's `examples`.
+pub fn init_example() -> InitOutput {
+    InitOutput {
+        output_kind: "init".into(),
+        status: "initialized".into(),
+        action: "init".into(),
+        path: "/repo/.heddle".into(),
+        repository_mode: "git-overlay".into(),
+        git_detected: true,
+        heddle_initialized: true,
+        installed_heddleignore: false,
+        principal_configured: false,
+        principal_status: "unset".into(),
+        principal_source: None,
+        principal: None,
+        principal_recommended_action: Some("heddle init --principal-name <name>".into()),
+        side_effects: vec![
+            "created Heddle sidecar for the existing Git repository".into(),
+            "updated .git/info/exclude for Heddle metadata".into(),
+            "left Git-tracked files untouched".into(),
+        ],
+        message: "Initialized Heddle data in /repo/.heddle for Git-overlay workflows".into(),
+        next_action: Some("heddle adopt --ref main".into()),
+        recommended_action: Some("heddle adopt --ref main".into()),
+    }
+}
+
+/// PATH A — schemars derive. One line at the call site once the macro emits the
+/// derive; this is what heddle does today via the hand-written mirror.
+pub mod schemars_path {
+    use super::*;
+
+    /// JSON Schema for `init --output json` via `schemars::schema_for!`.
+    pub fn schema() -> Value {
+        let root = schemars::schema_for!(InitOutput);
+        serde_json::to_value(&root).expect("schemars RootSchema serializes")
+    }
+}
+
+/// PATH B — hand-written emitter. Represents the code a *custom* heddle emitter
+/// macro would generate: an explicit field table → schema `Value`, no derive,
+/// no `schemars` dependency. The point of writing it by hand here is to measure
+/// what that control buys (and costs) versus the derive.
+pub mod custom_path {
+    use super::*;
+
+    /// A single field's contribution to the object schema.
+    struct Field {
+        name: &'static str,
+        /// JSON Schema fragment for the field's type.
+        ty: Value,
+        /// `///`-equivalent narrative.
+        description: &'static str,
+        /// Whether the field is required (non-`Option`).
+        required: bool,
+    }
+
+    fn string_ty() -> Value {
+        json!({ "type": "string" })
+    }
+    fn bool_ty() -> Value {
+        json!({ "type": "boolean" })
+    }
+    fn nullable_string_ty() -> Value {
+        json!({ "type": ["string", "null"] })
+    }
+    fn string_array_ty() -> Value {
+        json!({ "type": "array", "items": { "type": "string" } })
+    }
+    fn principal_ty() -> Value {
+        json!({
+            "type": ["object", "null"],
+            "properties": {
+                "name": { "type": "string", "description": "Principal display name." },
+                "email": { "type": "string", "description": "Principal email." }
+            },
+            "required": ["name", "email"],
+            "additionalProperties": false
+        })
+    }
+
+    /// The explicit field table. In production this is exactly what the macro
+    /// would emit from the annotated struct — one row per declared field.
+    fn fields() -> Vec<Field> {
+        vec![
+            Field {
+                name: "output_kind",
+                ty: json!({ "type": "string", "const": "init" }),
+                description: "Stable output discriminator. Always \"init\".",
+                required: true,
+            },
+            Field {
+                name: "status",
+                ty: string_ty(),
+                description: "Always `initialized` on success.",
+                required: true,
+            },
+            Field {
+                name: "action",
+                ty: string_ty(),
+                description: "Always `init` on success.",
+                required: true,
+            },
+            Field {
+                name: "path",
+                ty: string_ty(),
+                description: "Path to the initialized `.heddle` metadata directory.",
+                required: true,
+            },
+            Field {
+                name: "repository_mode",
+                ty: string_ty(),
+                description: "Repository capability after init, e.g. `git-overlay`.",
+                required: true,
+            },
+            Field {
+                name: "git_detected",
+                ty: bool_ty(),
+                description: "Whether init detected an existing Git repo.",
+                required: true,
+            },
+            Field {
+                name: "heddle_initialized",
+                ty: bool_ty(),
+                description: "Whether Heddle metadata is now present.",
+                required: true,
+            },
+            Field {
+                name: "installed_heddleignore",
+                ty: bool_ty(),
+                description: "Side effect outside `.heddle`. Currently always false.",
+                required: true,
+            },
+            Field {
+                name: "principal_configured",
+                ty: bool_ty(),
+                description: "Whether a signing principal was configured during init.",
+                required: true,
+            },
+            Field {
+                name: "principal_status",
+                ty: string_ty(),
+                description: "Principal configuration status string.",
+                required: true,
+            },
+            Field {
+                name: "principal_source",
+                ty: nullable_string_ty(),
+                description: "Where the principal identity was sourced from, if any.",
+                required: false,
+            },
+            Field {
+                name: "principal",
+                ty: principal_ty(),
+                description: "Resolved principal identity, if one was configured.",
+                required: false,
+            },
+            Field {
+                name: "principal_recommended_action",
+                ty: nullable_string_ty(),
+                description: "Suggested follow-up to configure a principal, if unset.",
+                required: false,
+            },
+            Field {
+                name: "side_effects",
+                ty: string_array_ty(),
+                description: "Human-readable, machine-preserved list of what init changed.",
+                required: true,
+            },
+            Field {
+                name: "message",
+                ty: string_ty(),
+                description: "Human summary line.",
+                required: true,
+            },
+            Field {
+                name: "next_action",
+                ty: nullable_string_ty(),
+                description: "Primary verification-guided next command.",
+                required: false,
+            },
+            Field {
+                name: "recommended_action",
+                ty: nullable_string_ty(),
+                description: "Alias of `next_action` for the shared recovery-advice contract.",
+                required: false,
+            },
+        ]
+    }
+
+    /// JSON Schema for `init --output json` built by the custom emitter.
+    pub fn schema() -> Value {
+        let mut properties = serde_json::Map::new();
+        let mut required = Vec::new();
+        for f in fields() {
+            let mut ty = f.ty;
+            if let Value::Object(ref mut map) = ty {
+                map.insert("description".into(), Value::String(f.description.into()));
+            }
+            properties.insert(f.name.into(), ty);
+            if f.required {
+                required.push(Value::String(f.name.into()));
+            }
+        }
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "InitOutput",
+            "description": "`heddle init --output json` response.",
+            "type": "object",
+            "properties": Value::Object(properties),
+            "required": Value::Array(required),
+            "additionalProperties": false,
+            "examples": [serde_json::to_value(init_example()).expect("example serializes")]
+        })
+    }
+}
+
+/// Top-level keys the documented sample at `docs/json-schemas.md`
+/// (`## heddle init --output json`) asserts. The drift gate
+/// (`heddle doctor schemas`) checks exactly these against the registered
+/// schema's `properties` keys, so any emitter the macro chooses MUST expose at
+/// least this set as properties.
+pub fn documented_sample_keys() -> Vec<&'static str> {
+    vec![
+        "output_kind",
+        "status",
+        "action",
+        "path",
+        "repository_mode",
+        "git_detected",
+        "heddle_initialized",
+        "installed_heddleignore",
+        "principal_configured",
+        "side_effects",
+        "message",
+        "next_action",
+        "recommended_action",
+    ]
+}
+
+/// Extract the `properties` keys from either path's schema, regardless of where
+/// the path puts them (schemars nests under `properties`; so does the custom
+/// emitter — but schemars may also use `$ref`/`definitions`, which this
+/// surfaces if present).
+pub fn property_keys(schema: &Value) -> Vec<String> {
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default()
+}

--- a/crates/cli-macro-poc/src/output.rs
+++ b/crates/cli-macro-poc/src/output.rs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Output shape for the spike — a FAITHFUL mirror of the real init output.
+//! Output shape for the spike — an ILLUSTRATIVE, DIRECTIONAL measurement aid.
 //!
-//! This PoC mirrors the real `crates/cli/src/cli/commands/init.rs` `InitOutput`
-//! arg/output types so the measured drift/discriminator numbers reflect the
-//! production surface, not a simplification. The real `InitOutput` is a private
-//! (`struct`, not `pub`) type in `crates/cli`, so this throwaway crate cannot
-//! import it; instead it replicates the EXACT field set, field types, and
-//! serde/schemars attributes — including the `#[serde(skip_serializing)]
-//! #[serde(rename = "verification")]` `trust` field (`init.rs:41-44`) that the
-//! hand-written `InitSchema` mirror (`schemas.rs:842`) deliberately drops.
+//! This is NOT a byte-faithful mirror of the real init output. It models the
+//! shape of `crates/cli/src/cli/commands/init.rs` `InitOutput` closely enough to
+//! demonstrate the schemars-vs-custom-emitter tradeoff *directionally* — which
+//! path pins the discriminator, which re-exposes a skip-serialized field — but
+//! exact field values, byte counts, and the `RepositoryVerificationState`
+//! stand-in are approximate/representative, not production-exact. heddle#205
+//! derives the real macro from `init.rs` directly, not from this throwaway crate.
+//!
+//! The load-bearing structural facts it DOES reproduce: the field is an
+//! `#[serde(skip_serializing)] #[serde(rename = "verification")]` `trust` field
+//! (mirroring `init.rs:41-44`) that the hand-written `InitSchema` mirror
+//! (`schemas.rs:842`) deliberately drops.
 //!
 //! That `trust` field is the load-bearing difference. The mirror omits it by
 //! hand, so today there is no schema/serialize drift. But heddle#205's plan is
@@ -87,12 +91,17 @@ pub struct InitPrincipalOutput {
     pub email: String,
 }
 
-/// Stand-in for the real `pub(crate)` `RepositoryVerificationState`
+/// Minimal stand-in for the real `pub(crate)` `RepositoryVerificationState`
 /// (`crates/cli/src/cli/commands/git_overlay_health.rs:51`). The real type is
-/// large and crate-private; only its presence as a `skip_serializing` /
-/// `rename = "verification"` field on `InitOutput` matters for the drift this
-/// PoC measures, so a minimal `Serialize + JsonSchema` stand-in is faithful for
-/// that purpose.
+/// large, crate-private, and has nested schema-bearing types; this stand-in is
+/// deliberately small. Only its PRESENCE as a `skip_serializing` /
+/// `rename = "verification"` field drives the drift fact this PoC asserts (a
+/// phantom `verification` property appears in the schemars schema but never on
+/// the wire). The schema *byte counts* printed by `print_measurement_table` are
+/// therefore APPROXIMATE/directional — the real type would expand larger under
+/// the naive derive, so the schemars-vs-custom size gap is understated here, not
+/// overstated. The measured contract is the directional inequality and the
+/// property presence/absence, not the exact byte magnitudes.
 #[allow(dead_code)]
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct RepositoryVerificationState {
@@ -101,16 +110,18 @@ pub struct RepositoryVerificationState {
     pub summary: String,
 }
 
-/// Canonical TYPED value the real `heddle init` emits.
+/// Illustrative TYPED value used to drive the example-carry-through measurement.
 ///
-/// NOTE: this is the real emitted shape, not the curated `docs/json-schemas.md`
-/// sample. The real `InitOutput` always serializes `principal_source`,
-/// `principal`, and `principal_recommended_action` (no `skip_serializing_if`),
-/// so they appear here as `null`/value even though the documented sample omits
-/// them. `tests/measure.rs` asserts this typed-example-vs-doc-sample divergence
-/// — it is itself evidence for the spike's "typed examples beat hand-curated
-/// prose samples" point, and flags that heddle#205 must rebaseline the prose
-/// sample. The `trust` block is built but never serialized (`skip_serializing`).
+/// This is a REPRESENTATIVE value, not the canonical `init` output and not a
+/// rebaseline source for heddle#205 (individual field values — e.g. the
+/// principal status string — are illustrative; the real command computes them).
+/// The DIRECTIONAL point it demonstrates: a typed example tracks the struct, so
+/// it always carries the always-serialized fields (`principal_source`,
+/// `principal`, `principal_recommended_action` — no `skip_serializing_if`) that
+/// a hand-curated prose sample can drift away from. `tests/measure.rs` asserts
+/// that *presence* divergence, not the literal values — evidence for the spike's
+/// "typed examples beat hand-curated prose samples" point. The `trust` block is
+/// built but never serialized (`skip_serializing`).
 pub fn init_example() -> InitOutput {
     InitOutput {
         output_kind: "init",

--- a/crates/cli-macro-poc/src/output.rs
+++ b/crates/cli-macro-poc/src/output.rs
@@ -26,9 +26,10 @@ use std::path::PathBuf;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-/// `heddle init --output json` response — field set, field types, and serde
-/// attributes copied verbatim from the real private `InitOutput`
-/// (`crates/cli/src/cli/commands/init.rs:22-45`).
+/// `heddle init --output json` response — modeled illustratively on the real
+/// private `InitOutput` (`crates/cli/src/cli/commands/init.rs:22-45`): the
+/// serde-relevant shape and attributes, not a verbatim copy (see
+/// `RepositoryVerificationState` below for a deliberate divergence).
 ///
 /// Initialize Heddle metadata. In a plain Git repository this creates the
 /// `.heddle` sidecar and updates the local `.git/info/exclude` file for Heddle

--- a/crates/cli-macro-poc/src/output.rs
+++ b/crates/cli-macro-poc/src/output.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Output shape for the spike — a FAITHFUL mirror of the real init output.
+//!
+//! This PoC mirrors the real `crates/cli/src/cli/commands/init.rs` `InitOutput`
+//! arg/output types so the measured drift/discriminator numbers reflect the
+//! production surface, not a simplification. The real `InitOutput` is a private
+//! (`struct`, not `pub`) type in `crates/cli`, so this throwaway crate cannot
+//! import it; instead it replicates the EXACT field set, field types, and
+//! serde/schemars attributes — including the `#[serde(skip_serializing)]
+//! #[serde(rename = "verification")]` `trust` field (`init.rs:41-44`) that the
+//! hand-written `InitSchema` mirror (`schemas.rs:842`) deliberately drops.
+//!
+//! That `trust` field is the load-bearing difference. The mirror omits it by
+//! hand, so today there is no schema/serialize drift. But heddle#205's plan is
+//! to DELETE the mirror and derive `JsonSchema` on the real `InitOutput`; once
+//! that happens schemars re-introduces a `verification` property the wire bytes
+//! never carry. Measuring against the mirror would have hidden this; measuring
+//! against the real shape surfaces it.
+
+use std::path::PathBuf;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// `heddle init --output json` response — field set, field types, and serde
+/// attributes copied verbatim from the real private `InitOutput`
+/// (`crates/cli/src/cli/commands/init.rs:22-45`).
+///
+/// Initialize Heddle metadata. In a plain Git repository this creates the
+/// `.heddle` sidecar and updates the local `.git/info/exclude` file for Heddle
+/// metadata only; it does not import Git history or write Git-tracked files.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(example = "init_example")]
+pub struct InitOutput {
+    /// Stable output discriminator. Always `"init"`.
+    pub output_kind: &'static str,
+    /// Always `initialized` on success.
+    pub status: String,
+    /// Always `init` on success.
+    pub action: String,
+    /// Path to the initialized `.heddle` metadata directory.
+    pub path: PathBuf,
+    /// Repository capability after init, e.g. `git-overlay`.
+    pub repository_mode: String,
+    /// Whether init detected an existing Git repo.
+    pub git_detected: bool,
+    /// Whether Heddle metadata is now present.
+    pub heddle_initialized: bool,
+    /// Side effect outside `.heddle`. Currently always false.
+    pub installed_heddleignore: bool,
+    /// Whether a signing principal was configured during init.
+    pub principal_configured: bool,
+    /// Principal configuration status string.
+    pub principal_status: String,
+    /// Where the principal identity was sourced from, if any.
+    pub principal_source: Option<String>,
+    /// Resolved principal identity, if one was configured.
+    pub principal: Option<InitPrincipalOutput>,
+    /// Suggested follow-up to configure a principal, if unset.
+    pub principal_recommended_action: Option<String>,
+    /// Human-readable, machine-preserved list of what init changed.
+    pub side_effects: Vec<String>,
+    /// Human summary line.
+    pub message: String,
+    /// Primary verification-guided next command.
+    pub next_action: Option<String>,
+    /// Alias of `next_action` for the shared recovery-advice contract.
+    pub recommended_action: Option<String>,
+    /// Repository verification block. Attributes copied verbatim from the real
+    /// `trust` field. serde DROPS it from `--output json`
+    /// (`#[serde(skip_serializing)]`); schemars' derive still emits a
+    /// `verification` property (a `writeOnly` field — it stays in the
+    /// deserialize contract). That asymmetry is the schema/serialize drift this
+    /// PoC measures and `tests/measure.rs` asserts.
+    #[allow(dead_code)]
+    #[serde(skip_serializing)]
+    #[serde(rename = "verification")]
+    pub trust: RepositoryVerificationState,
+}
+
+/// Resolved principal identity attached to an init reply.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct InitPrincipalOutput {
+    /// Principal display name.
+    pub name: String,
+    /// Principal email.
+    pub email: String,
+}
+
+/// Stand-in for the real `pub(crate)` `RepositoryVerificationState`
+/// (`crates/cli/src/cli/commands/git_overlay_health.rs:51`). The real type is
+/// large and crate-private; only its presence as a `skip_serializing` /
+/// `rename = "verification"` field on `InitOutput` matters for the drift this
+/// PoC measures, so a minimal `Serialize + JsonSchema` stand-in is faithful for
+/// that purpose.
+#[allow(dead_code)]
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RepositoryVerificationState {
+    pub verified: bool,
+    pub status: String,
+    pub summary: String,
+}
+
+/// Canonical TYPED value the real `heddle init` emits.
+///
+/// NOTE: this is the real emitted shape, not the curated `docs/json-schemas.md`
+/// sample. The real `InitOutput` always serializes `principal_source`,
+/// `principal`, and `principal_recommended_action` (no `skip_serializing_if`),
+/// so they appear here as `null`/value even though the documented sample omits
+/// them. `tests/measure.rs` asserts this typed-example-vs-doc-sample divergence
+/// — it is itself evidence for the spike's "typed examples beat hand-curated
+/// prose samples" point, and flags that heddle#205 must rebaseline the prose
+/// sample. The `trust` block is built but never serialized (`skip_serializing`).
+pub fn init_example() -> InitOutput {
+    InitOutput {
+        output_kind: "init",
+        status: "initialized".into(),
+        action: "init".into(),
+        path: PathBuf::from("/repo/.heddle"),
+        repository_mode: "git-overlay".into(),
+        git_detected: true,
+        heddle_initialized: true,
+        installed_heddleignore: false,
+        principal_configured: false,
+        principal_status: "unset".into(),
+        principal_source: None,
+        principal: None,
+        principal_recommended_action: Some(
+            "heddle init --principal-name <name> --principal-email <email>".into(),
+        ),
+        side_effects: vec![
+            "created Heddle sidecar for the existing Git repository".into(),
+            "updated .git/info/exclude for Heddle metadata".into(),
+            "left Git-tracked files untouched".into(),
+        ],
+        message: "Initialized Heddle data in /repo/.heddle for Git-overlay workflows".into(),
+        next_action: Some("heddle adopt --ref main".into()),
+        recommended_action: Some("heddle adopt --ref main".into()),
+        trust: RepositoryVerificationState {
+            verified: true,
+            status: "verified".into(),
+            summary: "Git-overlay repository initialized and verified".into(),
+        },
+    }
+}

--- a/crates/cli-macro-poc/src/schemars_path.rs
+++ b/crates/cli-macro-poc/src/schemars_path.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//! PATH A — schemars derive. One line at the call site once the macro emits the
+//! derive; this is what heddle does today via the hand-written mirror.
+
+use serde_json::Value;
+
+use crate::output::InitOutput;
+
+/// JSON Schema for `init --output json` via `schemars::schema_for!`, derived
+/// directly on the real-shaped [`InitOutput`] (the shape heddle#205 would
+/// migrate to). Because the real `trust` field is only `#[serde(skip_serializing)]`,
+/// this schema carries a `verification` property the wire output never emits —
+/// see `tests/measure.rs`.
+pub fn schema() -> Value {
+    let root = schemars::schema_for!(InitOutput);
+    serde_json::to_value(&root).expect("schemars RootSchema serializes")
+}

--- a/crates/cli-macro-poc/tests/measure.rs
+++ b/crates/cli-macro-poc/tests/measure.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Measurement harness for the heddle#327 spike. These tests ARE the
+//! "measure output quality" deliverable: they prove both emitters cover the
+//! documented contract, prove the attribute-design claims (doc comments →
+//! descriptions, example carry-through), and print the comparison table the
+//! spike doc cites. Run with `--nocapture` to see the table.
+
+use std::collections::BTreeSet;
+
+use heddle_cli_macro_poc::{
+    custom_path, documented_sample_keys, init_example, property_keys, schemars_path,
+};
+use serde_json::Value;
+
+/// The drift contract: every key the documented sample asserts must appear as a
+/// property in BOTH emitters' schemas. This is the property `heddle doctor
+/// schemas` enforces — the macro is only viable if whichever emitter it picks
+/// satisfies it.
+#[test]
+fn both_emitters_cover_the_documented_sample_keys() {
+    let documented: BTreeSet<&str> = documented_sample_keys().into_iter().collect();
+
+    let schemars_keys: BTreeSet<String> = property_keys(&schemars_path::schema())
+        .into_iter()
+        .collect();
+    let custom_keys: BTreeSet<String> = property_keys(&custom_path::schema()).into_iter().collect();
+
+    for key in &documented {
+        assert!(
+            schemars_keys.contains(*key),
+            "schemars schema is missing documented key `{key}`"
+        );
+        assert!(
+            custom_keys.contains(*key),
+            "custom-emitter schema is missing documented key `{key}`"
+        );
+    }
+}
+
+/// Spike question #1, part A: narrative descriptions can live in `#[doc]`.
+/// schemars lifts `///` doc comments into each property's `description` with no
+/// extra attribute. This is the empirical proof behind the spec's claim.
+#[test]
+fn schemars_emits_field_descriptions_from_doc_comments() {
+    let schema = schemars_path::schema();
+    let props = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("schemars schema has a properties object");
+
+    let desc = props
+        .get("path")
+        .and_then(|p| p.get("description"))
+        .and_then(Value::as_str)
+        .expect("`path` field carries a description lifted from its doc comment");
+
+    assert!(
+        desc.contains(".heddle"),
+        "description should be the doc-comment text, got: {desc:?}"
+    );
+}
+
+/// Spike question #1, part B: examples. schemars carries the
+/// `#[schemars(example = \"init_example\")]` payload into the schema. This is
+/// the awkward part the spec calls out — the example must be a free function,
+/// not inline data — but it DOES land in the output.
+#[test]
+fn schemars_carries_the_example_payload() {
+    let schema = schemars_path::schema();
+    // schemars 0.8 places examples under the root metadata as `examples`.
+    let has_example = schema
+        .get("examples")
+        .and_then(Value::as_array)
+        .map(|a| !a.is_empty())
+        .unwrap_or(false);
+    assert!(
+        has_example,
+        "schemars schema should carry the example: {schema}"
+    );
+}
+
+/// The custom emitter, by construction, embeds the same documented example.
+#[test]
+fn custom_emitter_embeds_the_documented_example() {
+    let schema = custom_path::schema();
+    let example = &schema["examples"][0];
+    assert_eq!(example["output_kind"], "init");
+    assert_eq!(example["next_action"], "heddle adopt --ref main");
+    // The example is exactly what serializing the canonical value produces.
+    assert_eq!(*example, serde_json::to_value(init_example()).unwrap());
+}
+
+/// Print the comparison table the spike doc cites. Not an assertion — a probe.
+#[test]
+fn print_measurement_table() {
+    let s = schemars_path::schema();
+    let c = custom_path::schema();
+
+    let s_pretty = serde_json::to_string_pretty(&s).unwrap();
+    let c_pretty = serde_json::to_string_pretty(&c).unwrap();
+
+    let s_keys = property_keys(&s).len();
+    let c_keys = property_keys(&c).len();
+
+    let s_has_defs = s.get("definitions").is_some() || s.get("$defs").is_some();
+    let s_const = s
+        .pointer("/properties/output_kind/const")
+        .or_else(|| s.pointer("/properties/output_kind/enum"))
+        .is_some();
+    let c_const = c.pointer("/properties/output_kind/const").is_some();
+
+    println!("\n=== heddle#327 PoC measurement — `init` verb, both ways ===");
+    println!("{:<34} | {:>10} | {:>10}", "metric", "schemars", "custom");
+    println!("{:-<34}-+-{:-<10}-+-{:-<10}", "", "", "");
+    println!(
+        "{:<34} | {:>10} | {:>10}",
+        "pretty-printed schema bytes",
+        s_pretty.len(),
+        c_pretty.len()
+    );
+    println!(
+        "{:<34} | {:>10} | {:>10}",
+        "top-level property keys", s_keys, c_keys
+    );
+    println!(
+        "{:<34} | {:>10} | {:>10}",
+        "uses $ref/definitions (nested)", s_has_defs, false
+    );
+    println!(
+        "{:<34} | {:>10} | {:>10}",
+        "output_kind pinned (const/enum)", s_const, c_const
+    );
+    println!("{:<34} | {:>10} | {:>10}", "carries example", true, true);
+    println!(
+        "{:<34} | {:>10} | {:>10}",
+        "needs schemars dep", true, false
+    );
+    println!("===========================================================\n");
+
+    println!("--- schemars schema ---\n{s_pretty}\n");
+    println!("--- custom-emitter schema ---\n{c_pretty}\n");
+}

--- a/crates/cli-macro-poc/tests/measure.rs
+++ b/crates/cli-macro-poc/tests/measure.rs
@@ -2,8 +2,12 @@
 //! Measurement harness for the heddle#327 spike. These tests ARE the
 //! "measure output quality" deliverable: they prove both emitters cover the
 //! documented contract, prove the attribute-design claims (doc comments →
-//! descriptions, example carry-through), and print the comparison table the
-//! spike doc cites. Run with `--nocapture` to see the table.
+//! descriptions, example carry-through), and — crucially — ASSERT the two
+//! schemars costs the decision doc cites: the unpinned `output_kind`
+//! discriminator and the phantom `verification` property schemars re-introduces
+//! from the real `#[serde(skip_serializing)]` `trust` field. The numbers in the
+//! doc are guarded by these assertions, not merely printed. Run with
+//! `--nocapture` to also see the comparison table.
 
 use std::collections::BTreeSet;
 
@@ -11,6 +15,23 @@ use heddle_cli_macro_poc::{
     custom_path, documented_sample_keys, init_example, property_keys, schemars_path,
 };
 use serde_json::Value;
+
+/// `output_kind` is "pinned" if the schema constrains it to a single value via
+/// `const` or a one-element `enum`.
+fn output_kind_pinned(schema: &Value) -> bool {
+    schema.pointer("/properties/output_kind/const").is_some()
+        || schema.pointer("/properties/output_kind/enum").is_some()
+}
+
+fn serialized_example_keys() -> BTreeSet<String> {
+    serde_json::to_value(init_example())
+        .unwrap()
+        .as_object()
+        .expect("init_example serializes to an object")
+        .keys()
+        .cloned()
+        .collect()
+}
 
 /// The drift contract: every key the documented sample asserts must appear as a
 /// property in BOTH emitters' schemas. This is the property `heddle doctor
@@ -20,9 +41,8 @@ use serde_json::Value;
 fn both_emitters_cover_the_documented_sample_keys() {
     let documented: BTreeSet<&str> = documented_sample_keys().into_iter().collect();
 
-    let schemars_keys: BTreeSet<String> = property_keys(&schemars_path::schema())
-        .into_iter()
-        .collect();
+    let schemars_keys: BTreeSet<String> =
+        property_keys(&schemars_path::schema()).into_iter().collect();
     let custom_keys: BTreeSet<String> = property_keys(&custom_path::schema()).into_iter().collect();
 
     for key in &documented {
@@ -90,7 +110,120 @@ fn custom_emitter_embeds_the_documented_example() {
     assert_eq!(*example, serde_json::to_value(init_example()).unwrap());
 }
 
-/// Print the comparison table the spike doc cites. Not an assertion — a probe.
+/// Spike answer Q2 — the measured discriminator gap, ASSERTED (not just
+/// printed). schemars renders `output_kind` as a bare `{"type":"string"}` from
+/// a plain `&'static str`; the custom emitter pins it to `"const":"init"`. The
+/// decision doc treats this as the single concrete schemars cost and proposes a
+/// #205 helper for it — so the gate must fail if a schemars upgrade starts
+/// emitting a const/enum here (making the helper unnecessary) or the custom
+/// emitter stops pinning it.
+#[test]
+fn discriminator_gap_is_real_schemars_unpinned_custom_pinned() {
+    let schemars_pinned = output_kind_pinned(&schemars_path::schema());
+    let custom_pinned = output_kind_pinned(&custom_path::schema());
+    assert!(
+        !schemars_pinned,
+        "schemars unexpectedly pinned output_kind — the discriminator gap (and \
+         the proposed #205 helper) is now stale; revisit the decision doc"
+    );
+    assert!(
+        custom_pinned,
+        "custom emitter stopped pinning output_kind as a const"
+    );
+}
+
+/// Spike answer Q2 — the skip_serializing drift, ASSERTED. The real
+/// `InitOutput.trust` field is `#[serde(skip_serializing)] #[serde(rename =
+/// "verification")]`. serde drops it from the wire bytes; schemars' derive
+/// re-introduces a `verification` property (as `writeOnly`) — and even lists it
+/// as REQUIRED. So deriving `JsonSchema` on the real struct is NOT
+/// semantics-free: the schema gains a required property the command never
+/// emits, and `doctor schemas` (keys-in-sample only) would not catch it. The
+/// custom emitter, walking the serialized field set, omits it by construction.
+#[test]
+fn schemars_re_exposes_skip_serialized_verification_field() {
+    let schemars_schema = schemars_path::schema();
+    let schemars_props: BTreeSet<String> =
+        property_keys(&schemars_schema).into_iter().collect();
+    let custom_props: BTreeSet<String> =
+        property_keys(&custom_path::schema()).into_iter().collect();
+    let wire_keys = serialized_example_keys();
+
+    assert!(
+        schemars_props.contains("verification"),
+        "schemars should re-expose the skip_serializing `verification` field; \
+         got props: {schemars_props:?}"
+    );
+    let required: BTreeSet<String> = schemars_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .unwrap_or_default();
+    assert!(
+        required.contains("verification"),
+        "schemars marks the phantom `verification` field REQUIRED — the drift is \
+         worse than optional; got required: {required:?}"
+    );
+    assert!(
+        !wire_keys.contains("verification"),
+        "the serialized init output must NOT carry `verification` (it is \
+         skip_serializing); got wire keys: {wire_keys:?}"
+    );
+    assert!(
+        !custom_props.contains("verification"),
+        "the custom emitter walks the serialized field set and must omit \
+         `verification`; got props: {custom_props:?}"
+    );
+    // The drift is exactly this one phantom property.
+    let schemars_minus_wire: BTreeSet<&String> = schemars_props.difference(&wire_keys).collect();
+    assert_eq!(
+        schemars_minus_wire,
+        BTreeSet::from([&"verification".to_string()]),
+        "schemars schema vs wire output should differ by exactly `verification`"
+    );
+}
+
+/// Spike answer Q1/examples — the typed example diverges from the curated
+/// `docs/json-schemas.md` sample, ASSERTED. The real `InitOutput` always
+/// serializes the principal fields (no `skip_serializing_if`), so a faithful
+/// typed example carries keys the hand-curated prose sample omits. This is the
+/// evidence for "typed examples beat prose samples": the example cannot drift
+/// from the struct, but the prose sample already has. heddle#205 must rebaseline
+/// the documented sample to the real shape.
+#[test]
+fn typed_example_diverges_from_curated_doc_sample() {
+    let documented: BTreeSet<String> = documented_sample_keys()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    let wire_keys = serialized_example_keys();
+
+    // The real output is a superset of the documented sample's keys.
+    assert!(
+        documented.is_subset(&wire_keys),
+        "every documented key must be present in the real output; documented: \
+         {documented:?}, wire: {wire_keys:?}"
+    );
+
+    // …and carries exactly these extra always-serialized fields the curated
+    // sample drops. Pinning the set turns Codex's "example diverges from docs"
+    // finding into a measured regression guard.
+    let extra: BTreeSet<String> = wire_keys.difference(&documented).cloned().collect();
+    let expected_extra = BTreeSet::from([
+        "principal".to_string(),
+        "principal_recommended_action".to_string(),
+        "principal_source".to_string(),
+        "principal_status".to_string(),
+    ]);
+    assert_eq!(
+        extra, expected_extra,
+        "typed example vs curated doc sample should differ by exactly the \
+         always-serialized principal fields"
+    );
+}
+
+/// Print the comparison table the spike doc cites. Not an assertion — a probe;
+/// the gap and drift it shows are asserted by the dedicated tests above.
 #[test]
 fn print_measurement_table() {
     let s = schemars_path::schema();
@@ -103,38 +236,38 @@ fn print_measurement_table() {
     let c_keys = property_keys(&c).len();
 
     let s_has_defs = s.get("definitions").is_some() || s.get("$defs").is_some();
-    let s_const = s
-        .pointer("/properties/output_kind/const")
-        .or_else(|| s.pointer("/properties/output_kind/enum"))
-        .is_some();
-    let c_const = c.pointer("/properties/output_kind/const").is_some();
+    let s_const = output_kind_pinned(&s);
+    let c_const = output_kind_pinned(&c);
+    let s_props: BTreeSet<String> = property_keys(&s).into_iter().collect();
+    let s_has_verification = s_props.contains("verification");
 
     println!("\n=== heddle#327 PoC measurement — `init` verb, both ways ===");
-    println!("{:<34} | {:>10} | {:>10}", "metric", "schemars", "custom");
-    println!("{:-<34}-+-{:-<10}-+-{:-<10}", "", "", "");
+    println!("{:<36} | {:>10} | {:>10}", "metric", "schemars", "custom");
+    println!("{:-<36}-+-{:-<10}-+-{:-<10}", "", "", "");
     println!(
-        "{:<34} | {:>10} | {:>10}",
+        "{:<36} | {:>10} | {:>10}",
         "pretty-printed schema bytes",
         s_pretty.len(),
         c_pretty.len()
     );
     println!(
-        "{:<34} | {:>10} | {:>10}",
+        "{:<36} | {:>10} | {:>10}",
         "top-level property keys", s_keys, c_keys
     );
     println!(
-        "{:<34} | {:>10} | {:>10}",
+        "{:<36} | {:>10} | {:>10}",
         "uses $ref/definitions (nested)", s_has_defs, false
     );
     println!(
-        "{:<34} | {:>10} | {:>10}",
+        "{:<36} | {:>10} | {:>10}",
         "output_kind pinned (const/enum)", s_const, c_const
     );
-    println!("{:<34} | {:>10} | {:>10}", "carries example", true, true);
     println!(
-        "{:<34} | {:>10} | {:>10}",
-        "needs schemars dep", true, false
+        "{:<36} | {:>10} | {:>10}",
+        "phantom `verification` property", s_has_verification, false
     );
+    println!("{:<36} | {:>10} | {:>10}", "carries example", true, true);
+    println!("{:<36} | {:>10} | {:>10}", "needs schemars dep", true, false);
     println!("===========================================================\n");
 
     println!("--- schemars schema ---\n{s_pretty}\n");

--- a/crates/cli-macro-poc/tests/measure.rs
+++ b/crates/cli-macro-poc/tests/measure.rs
@@ -16,11 +16,18 @@ use heddle_cli_macro_poc::{
 };
 use serde_json::Value;
 
-/// `output_kind` is "pinned" if the schema constrains it to a single value via
-/// `const` or a one-element `enum`.
+/// `output_kind` is "pinned" if the schema constrains it to EXACTLY ONE value —
+/// a `const`, or a single-element `enum`. A multi-element `enum` (e.g.
+/// `["init","status"]`) does NOT pin the discriminator: it still admits more
+/// than one value, so it must not satisfy this predicate.
 fn output_kind_pinned(schema: &Value) -> bool {
-    schema.pointer("/properties/output_kind/const").is_some()
-        || schema.pointer("/properties/output_kind/enum").is_some()
+    if schema.pointer("/properties/output_kind/const").is_some() {
+        return true;
+    }
+    schema
+        .pointer("/properties/output_kind/enum")
+        .and_then(Value::as_array)
+        .is_some_and(|variants| variants.len() == 1)
 }
 
 fn serialized_example_keys() -> BTreeSet<String> {

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -17,9 +17,12 @@ that renders one real verb (`heddle init`) both ways and measures the result.
 > is **proposed** — the `#[heddle_verb]` / `HeddleVerbOutput` macro names, the
 > `inventory`-style auto-registration, and the deletion of the
 > `schema_registry!` table do **not** exist yet; they are #205's work. The PoC
-> crate proves the *measurable* claims (both emitters cover the documented
-> keys; schemars lifts doc comments; the discriminator-const gap is real); it
-> does **not** implement the proc-macro itself.
+> crate proves the *measurable* claims by asserting them against types that
+> mirror the **real** `init.rs` (both emitters cover the documented keys;
+> schemars lifts doc comments; the discriminator-const gap is real; schemars
+> re-exposes the skip-serialized `verification` field; the typed example
+> diverges from the curated doc sample); it does **not** implement the
+> proc-macro itself.
 
 ---
 
@@ -40,6 +43,13 @@ The mirror is registered by the hand-maintained `schema_registry!` macro table
 threading `JsonSchema` through every workspace output type (`repo`, `objects`,
 …) — at the cost that "when a real output struct changes, the mirror here must
 change too."
+
+The mirror also does hand-curation the real struct can't: the real `InitOutput`
+carries a `#[serde(skip_serializing)] #[serde(rename = "verification")] trust`
+field (`init.rs:41-44`) that never reaches the wire, and `InitSchema`
+(`schemas.rs:842`) simply omits it. So the mirror and the wire bytes agree
+today *because a human kept them in agreement* — which is exactly the property a
+naive "derive on the real struct" migration loses (see §2 point 1).
 
 Drift is policed at PR time, not prevented:
 
@@ -63,9 +73,16 @@ share a verb key.
 
 ## 2. The PoC — one verb, both ways
 
-`crates/cli-macro-poc/` reproduces `init` faithfully: the field set and
-doc-comment text are copied from the registered `InitSchema` mirror and the
-`docs/json-schemas.md` sample. It emits the output schema two ways:
+`crates/cli-macro-poc/` reproduces `init` faithfully against the **real**
+`init.rs` types, not the simplified mirror: the args struct is modelled as the
+real `clap::Args` `InitArgs` wired through a `Subcommand` enum
+(`crates/cli-macro-poc/src/args.rs`), and the output struct replicates the real
+private `InitOutput` field-for-field — INCLUDING the `#[serde(skip_serializing)]
+#[serde(rename = "verification")] trust` field
+(`crates/cli-macro-poc/src/output.rs`). (The real `InitOutput` is a crate-private
+`struct`, so a throwaway crate can't import it; it replicates the exact field
+types and serde/schemars attributes instead.) It emits the output schema two
+ways:
 
 - **Path A — schemars** (`schemars_path::schema()`): `#[derive(JsonSchema)]` on
   the output struct + `schema_for!`. This is what heddle registers **today**.
@@ -76,31 +93,46 @@ doc-comment text are copied from the registered `InitSchema` mirror and the
 `cargo test -p heddle-cli-macro-poc -- --nocapture` prints both schemas and the
 table below; the assertions in `tests/measure.rs` are the contract checks.
 
-### Measured comparison (`init`, 17 output fields)
+### Measured comparison (`init`, 17 serialized fields + 1 skip-serialized)
 
 | metric | schemars | custom |
 |---|---|---|
-| pretty-printed schema bytes | 4435 | 4070 |
-| top-level property keys | 17 | 17 |
+| pretty-printed schema bytes | 5954 | 4096 |
+| top-level property keys | 18 | 17 |
 | covers all 13 documented sample keys | ✅ | ✅ |
+| phantom `verification` property (never on wire) | ❌ **present** (`writeOnly`, **required**) | ✅ absent |
 | JSON Schema dialect | draft-07 | draft 2020-12 |
-| nested types (`InitPrincipal`) | `$ref` + `definitions` | inlined |
+| nested types (`InitPrincipalOutput`) | `$ref` + `definitions` | inlined |
 | `output_kind` discriminator pinned | ❌ (`{"type":"string"}`) | ✅ (`"const":"init"`) |
 | field descriptions from `///` | ✅ (native) | ✅ (table column) |
 | carries example payload | ✅ | ✅ |
-| net-new schema code per verb | 0 (derive) | ~1 field-table row each |
+| net-new schema code per verb | 0 (derive) + skip-attrs as needed | ~1 field-table row each |
 | extra dependency | `schemars` (already in tree) | none |
 
-(Bytes/keys are emitted by `print_measurement_table`; coverage and the
-discriminator gap are asserted by the other four tests.)
+(Bytes/keys are emitted by `print_measurement_table`; the discriminator gap,
+the phantom-`verification` drift, and documented-key coverage are each pinned by
+a dedicated assertion in `tests/measure.rs`.)
 
 ### What the measurement decides
 
-1. **schemars is already the registered shape.** Path A *is* what
-   `heddle schemas init` returns today, so adopting it changes **zero** schema
-   semantics — the macro's only job is to move the derive from the throwaway
-   mirror onto the real `InitOutput` and auto-register it. Migration risk ≈ 0
-   for the gate corpus.
+1. **schemars matches the registered shape for the *serialized* fields — but
+   the migration is NOT semantics-free.** For the 17 serialized fields, Path A
+   reproduces what `heddle schemas init` returns today. The catch the
+   mirror-shaped PoC hid: deriving `JsonSchema` on the **real** `InitOutput`
+   also picks up the `#[serde(skip_serializing)] trust` field. schemars treats
+   `skip_serializing` as a schema-visible `writeOnly` property (it stays in the
+   *deserialize* contract) — so the derived schema gains a `verification`
+   property, lists it as **required**, and yet `heddle init` never emits it.
+   The hand-written `InitSchema` mirror dropped that field by hand; the derive
+   re-introduces it. `doctor schemas` checks only that documented sample keys
+   *appear* in the schema (not that the schema has no extras), so it would
+   **not** catch this. Migration is therefore a per-verb task, not a zero-touch
+   refactor: each migrated output struct must add `#[schemars(skip)]` to its
+   skip-serialized fields (the PoC asserts the drift in
+   `schemars_re_exposes_skip_serialized_verification_field`). This does not sink
+   the schemars recommendation — the fix is one attribute per skip-serialized
+   field — but it does delete the "migration risk ≈ 0 / zero schema semantics"
+   claim. See §4 item 5, which already budgets for this.
 2. **The discriminator gap is real and matters.** schemars renders
    `output_kind` as a bare `{"type":"string"}` — it cannot express the
    `"const":"init"` pin from a plain `String`/`&'static str` field. heddle
@@ -121,14 +153,27 @@ discriminator gap are asserted by the other four tests.)
 
 ### Q1 — Where do examples and descriptions live?
 
-**Descriptions: `#[doc]` (`///`). Decided — proven, no new attribute needed.**
-schemars lifts both struct-level and field-level doc comments into the schema's
-`description` natively (PoC test `schemars_emits_field_descriptions_from_doc_comments`;
-the rendered schemars schema shows `"path": { "description": "Path to the
-initialized `.heddle` …" }`). So the narrative that lives as prose blocks in
-`docs/json-schemas.md` today moves onto the field as a doc comment, and the
-macro carries it into *both* `--help` (via clap, which also reads `///`) and the
-JSON schema (via schemars). One source, two surfaces.
+**Descriptions: `#[doc]` (`///`). Decided — proven, no new sibling attribute
+needed *per surface*.** schemars lifts both struct-level and field-level doc
+comments into the schema's `description` natively (PoC test
+`schemars_emits_field_descriptions_from_doc_comments`; the rendered schemars
+schema shows `"path": { "description": "Path to the initialized `.heddle` …" }`).
+For each surface, the `///` is the single source — clap reads it for `--help`,
+schemars reads it for the schema `description` — so no separate description
+attribute is ever required.
+
+**Caveat — it is NOT "one comment, both surfaces".** clap reads doc comments off
+the **args** type (`InitArgs`) and schemars reads them off the **output** type
+(`InitOutput`), and those are different types with **zero field overlap** (Q3).
+A doc comment on an output field feeds the JSON schema but never `--help`; a doc
+comment on an args field feeds `--help` but never the schema. So per-field
+narrative lives in *two* places (one per type), not one. The prose blocks in
+`docs/json-schemas.md` today describe the *output* shape, so they move onto the
+**output** fields as doc comments (feeding the schema). The `--help` text is a
+separate source on the args fields. The only way to get a literal single doc
+comment driving both would be a module-level macro that maps one declaration to
+both types (option (a) in Q3) — the two-derive shape we recommend keeps them
+separate, by design.
 
 **Examples: a sibling `#[heddle_verb(example = …)]` key the macro lowers to a
 typed example function — NOT inline literals, NOT prose blocks.** schemars'
@@ -148,52 +193,97 @@ struct**, so it cannot drift from the struct's shape — it stops compiling if a
 field is renamed. That is strictly better than the current literal-JSON blocks
 that `doctor schemas` has to police after the fact.
 
+**Concretely, the prose sample has *already* drifted, and the PoC proves it.**
+The PoC's `init_example()` is the real typed value, so serializing it emits the
+always-present `principal_status`, `principal_source`, `principal`, and
+`principal_recommended_action` fields (none is `skip_serializing_if`). The
+curated `## heddle init --output json` sample in `docs/json-schemas.md` omits
+all four. The PoC asserts exactly this divergence
+(`typed_example_diverges_from_curated_doc_sample`): the real output is a
+superset of the documented sample by those four keys. So the in-code example is
+**not** byte-for-byte the documented sample — and that is the point. A typed
+example tracks the struct automatically; the hand-curated prose sample fell
+behind. heddle#205 should rebaseline the `docs/json-schemas.md` `init` sample
+from the typed example when it lands the derive.
+
 ### Q2 — schemars vs custom emitter
 
 **Recommendation: schemars (Path A) for #205 v1. Keep the custom emitter PoC as
 the documented fallback.** Rationale, from the measurement:
 
-- It is already the registered shape → the macro is a *refactor* (delete the
-  mirror, derive on the real struct, auto-register), not a re-baseline of every
-  schema sample. The custom emitter would change dialect, nesting, and
-  const-pinning, forcing a rewrite of the `docs/json-schemas.md` corpus and a
-  re-blessing of `doctor schemas`.
-- The one real loss (discriminator-const) is recoverable *within* the schemars
-  path without adopting the whole custom emitter: a small `JsonSchema` helper /
-  newtype for `output_kind` that emits `{"const": "<verb>"}`, applied by the
-  macro from the `verb` key it already knows. File that as a #205 follow-up, not
-  a blocker.
+- For the serialized fields it is already the registered shape → the macro is a
+  *refactor* (delete the mirror, derive on the real struct, auto-register), not
+  a re-baseline of the whole sample corpus. The custom emitter would change
+  dialect, nesting, and const-pinning, forcing a rewrite of the
+  `docs/json-schemas.md` corpus and a re-blessing of `doctor schemas`. The
+  schemars migration's per-verb cost is bounded and mechanical (see below),
+  whereas the custom emitter's cost is corpus-wide.
+- Two known schemars costs, both recoverable *within* the schemars path without
+  adopting the whole custom emitter:
+  - **discriminator-const** — a small `JsonSchema` helper / newtype for
+    `output_kind` that emits `{"const": "<verb>"}`, applied by the macro from
+    the `verb` key it already knows.
+  - **`skip_serializing` phantom fields** — each migrated output struct must add
+    `#[schemars(skip)]` to fields that serde skips on serialize (e.g. `init`'s
+    `verification`/`trust`), or the schema gains required properties the wire
+    never emits (§2 point 1). Mechanical, but per-field, so it can't be waved
+    away as zero-touch.
+
+  File both as #205 work, not blockers.
 
 **When to revisit the custom emitter:** if we ever publish these schemas for
 external validation and need (a) inlined flat schemas that validate the
 `docs/json-schemas.md` samples with a stock validator, and (b) discriminator
 const-pinning across the board, the custom emitter delivers both with no
-`schemars` opinions to fight. The PoC's `custom_path` module is a working
-~90-line template for that future. Until then it's net-new code that buys us a
-gap the gate doesn't care about.
+`schemars` opinions to fight. The PoC's `custom_path` module is a working,
+self-contained template for that future (no `schemars` dependency, and — unlike
+the derive — it omits skip-serialized fields and pins the discriminator by
+construction). Until then it's net-new code that buys us gaps the gate doesn't
+care about today.
 
 ### Q3 — Layering input (clap) + output (JSON) under one macro
 
 The input and output are genuinely different types: `InitArgs` has 7 input
-fields, `InitOutput` has 17 output fields, **zero overlap**. Forcing them into
+fields (and derives `clap::Args`), `InitOutput` has 18 declared fields (17
+serialized + the skip-serialized `trust`), **zero overlap**. Forcing them into
 one struct is wrong. Two viable couplings:
 
 - **(a) Attribute on a module:** `#[heddle_verb(name = "init")] mod init { pub
-  struct Args {…} pub struct Output {…} }` — the macro emits the clap derive on
-  `Args`, the schema derive + registry entry on `Output`.
+  struct Args {…} pub struct Output {…} }` — an *attribute* macro can rewrite the
+  items before their derives expand, so it can attach `#[derive(clap::Args)]` to
+  `Args` and `#[derive(JsonSchema)]` + the registry entry to `Output`, and can
+  even map one declaration to both surfaces.
 - **(b) Two cooperating derives keyed by verb:** `#[derive(HeddleVerbArgs)]` on
   the args struct and `#[derive(HeddleVerbOutput)]` on the output struct, tied
-  by a shared `#[heddle_verb("init")]` key. The `Output` derive is the one that
-  matters — it adds `JsonSchema` *and* emits the registry registration that
-  today is the hand-written `(&["init"], InitSchema)` row.
+  by a shared `#[heddle_verb("init")]` key. **A derive macro cannot add another
+  derive (`JsonSchema`) to the very struct it is invoked on** — derives only
+  *append* items, they don't rewrite the annotated item's attribute list. So
+  `HeddleVerbOutput` cannot "turn on schemars" by itself; the output struct must
+  **also** `#[derive(schemars::JsonSchema)]` (i.e. `HeddleVerbOutput` *requires*
+  a `JsonSchema` bound it does not provide), and `HeddleVerbOutput`'s own job is
+  the registry registration that today is the hand-written `(&["init"],
+  InitSchema)` row. (The alternatives — hand-implementing `JsonSchema` inside
+  `HeddleVerbOutput`, or making it an attribute macro — collapse (b) into either
+  the custom-emitter path or option (a).)
 
-**Recommendation: (b).** It keeps clap and schema as separate concerns on
-separate types (which they are), couples them by a verb-name key rather than by
-forcing a shared type, and localizes the new magic to the output side — exactly
-where the drift problem lives. The clap side barely changes: `HeddleVerbArgs`
-is mostly a passthrough that re-exports `clap::Parser` and records the verb key,
-so `--help`, completions, and error messages keep flowing through clap
-unchanged (a heddle#205 discipline guard).
+**Recommendation: (b)**, with the output struct co-deriving `JsonSchema`
+explicitly. It keeps clap and schema as separate concerns on separate types
+(which they are), couples them by a verb-name key rather than by forcing a
+shared type, and localizes the new magic to the output side — exactly where the
+drift problem lives. The clap side barely changes: `HeddleVerbArgs` is a
+passthrough over **`clap::Args`** (the reusable arg set that subcommand tuple
+variants like `Commands::Init(InitArgs)` consume — NOT `clap::Parser`, which
+stays on the top-level `Cli`) that records the verb key, so `--help`,
+completions, and error messages keep flowing through clap unchanged (a
+heddle#205 discipline guard). The PoC's `src/args.rs` wires exactly this shape
+(`Parser` on `Cli`, `Args` on the leaf) to prove the args type slots into a real
+subcommand tree.
+
+(If the literal "one doc comment feeds both `--help` and the schema" property
+from Q1 turns out to be a hard requirement, that's the lever that tips the
+choice to option (a): only a module-level attribute macro can map a single
+declaration onto both types. (b) deliberately accepts two doc sources — one per
+type — as the cost of keeping args and output as independent derives.)
 
 The registry registration should use an `inventory`/`linkme`-style collected
 registration so the `schema_registry!` table at schemas.rs:58 disappears
@@ -205,27 +295,37 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
 
 ## 4. Impl shape for heddle#205 (proposed — confirm scope with user)
 
-1. **Land `crates/cli-macro/`** with the `HeddleVerbOutput` derive (schemars +
-   collected registration) and the thin `HeddleVerbArgs` passthrough. Delete
-   `crates/cli-macro-poc/`.
+1. **Land `crates/cli-macro/`** with the `HeddleVerbOutput` derive (registry
+   registration; the output struct co-derives `schemars::JsonSchema` — the derive
+   cannot add it, see Q3) and the thin `HeddleVerbArgs` passthrough over
+   `clap::Args`. Delete `crates/cli-macro-poc/`.
 2. **Migrate one proof verb** (`init` is the smallest real output; `status` is
    the richest — pick `init` for the first landing per #205's "pick a small
-   one"). Derive `HeddleVerbOutput` on the real `InitOutput`
-   (`crates/cli/src/cli/commands/init.rs:23`); delete the `InitSchema` mirror
-   and its `schema_registry!` row.
+   one"). Co-derive `HeddleVerbOutput` + `JsonSchema` on the real `InitOutput`
+   (`crates/cli/src/cli/commands/init.rs:23`); add `#[schemars(skip)]` to its
+   `trust` field (else the schema gains a required `verification` property the
+   wire never emits — §2 point 1); delete the `InitSchema` mirror and its
+   `schema_registry!` row. **Rebaseline** the `docs/json-schemas.md` `init`
+   sample from the typed example (it currently omits the always-serialized
+   principal fields — Q1).
 3. **Add the discriminator-const helper** so `output_kind` emits
-   `{"const":"init"}` — recovers the one measured schemars gap.
+   `{"const":"init"}` — recovers the measured discriminator gap.
 4. **Run the full gate set** the migrated verb must still pass:
    `cargo test --locked -p heddle-cli --test cli_integration doctor_schemas_has_no_drift_or_unmatched_registered_verbs`,
    `… doctor_docs`, plus `target/debug/heddle doctor schemas --output json` and
    `doctor docs --all --output json` (the exact commands CI runs —
    `.github/workflows/rust-tests.yml:181-184`).
-5. **Known friction to budget for:** real output structs that embed foreign
-   workspace types (e.g. `InitOutput.trust: RepositoryVerificationState`,
-   `#[serde(skip_serializing)]` at init.rs) must either skip those fields on the
-   schema side too or grow `JsonSchema` impls. The mirror existed precisely to
-   dodge this (schemas.rs:6–13); the macro re-confronts it. Each migration batch
-   should enumerate the foreign types its verbs touch.
+5. **Known friction to budget for — now measured, not hypothetical:** any field
+   serde skips on serialize (`#[serde(skip_serializing)]`, e.g.
+   `InitOutput.trust`/`verification` at init.rs:41-44) is schema-VISIBLE under
+   schemars' derive (`writeOnly`, and required) — the PoC measures and asserts
+   this. Each migrated struct must add `#[schemars(skip)]` to such fields, or it
+   ships a schema that describes properties the command never emits (and
+   `doctor schemas`, which only checks documented keys *appear*, won't catch it).
+   Separately, output structs that embed foreign workspace types may need
+   `JsonSchema` impls/bounds; the mirror existed precisely to dodge both
+   (schemas.rs:6–13), and the macro re-confronts them. Each migration batch
+   should enumerate the skip-serialized and foreign-typed fields its verbs touch.
 6. **Then** the verb-by-verb migration batches (~30 verbs, the registered set in
    `schema_registry!`), one issue each, as #205 already scopes.
 
@@ -235,12 +335,18 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
 
 | Question | Decision | Confidence |
 |---|---|---|
-| Descriptions | `#[doc]` `///`, carried to both `--help` and schema | high — proven in PoC |
-| Examples | `#[heddle_verb(example = fn)]` → typed example fn → schemars `examples` | high — proven in PoC |
-| schemars vs custom | **schemars** for v1 (zero re-baseline); custom emitter is the documented fallback | high — it is already the registered shape |
-| Discriminator const | schemars gap; fix with a small `output_kind` `JsonSchema` helper, not the custom emitter | medium — helper not yet built |
-| Macro layering | two derives (`HeddleVerbArgs` + `HeddleVerbOutput`) keyed by verb; output derive auto-registers via `inventory` | medium — proposed, not prototyped |
+| Descriptions | `#[doc]` `///`, single source *per surface* — but args and output are separate types, so it's two doc sources, not "one comment, both surfaces" | high — proven in PoC |
+| Examples | `#[heddle_verb(example = fn)]` → typed example fn → schemars `examples`; #205 rebaselines the prose `docs/json-schemas.md` sample (already drifted) from it | high — proven in PoC |
+| schemars vs custom | **schemars** for v1; *not* zero-touch — per-verb `#[schemars(skip)]` for skip-serialized fields + a const helper. Custom emitter is the documented fallback | high — recommendation holds; "zero re-baseline" evidence corrected |
+| Discriminator const | schemars gap (measured + asserted); fix with a small `output_kind` `JsonSchema` helper, not the custom emitter | medium — helper not yet built |
+| `skip_serializing` drift | schemars re-exposes skip-serialized fields as required `writeOnly` props (measured + asserted); fix per-verb with `#[schemars(skip)]` | high — measured in PoC |
+| Macro layering | two derives (`HeddleVerbArgs` over `clap::Args` + `HeddleVerbOutput`) keyed by verb; output struct **co-derives** `JsonSchema` (the derive can't add it); registry via `inventory` | medium — proposed, args shape prototyped in PoC |
 
-Nothing here blocks heddle#205; it unblocks it. The one open build-time
+The corrected measurements **do not change the overall recommendation** —
+schemars for #205 v1, custom emitter as the documented fallback — but they
+replace the "migration risk ≈ 0 / zero drift / one comment feeds both surfaces"
+evidence with the accurate picture: a bounded, mechanical per-verb cost
+(`#[schemars(skip)]` + a const helper + a docs-sample rebaseline). Nothing here
+blocks heddle#205; it unblocks it, with eyes open. The one open build-time
 question (`inventory` vs `linkme` for collected registration) is a #205
 implementation choice, not a design fork.

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -272,8 +272,11 @@ the documented fallback.** Rationale, from the measurement:
     derives constraint as the example case). The actionable mechanism #205 should
     prescribe is author-written on the output struct: add
     `#[schemars(required)]` to each always-emitted `Option<T>` field so the
-    generated schema lists it under `required` (equivalently, a `#[serde(default)]`-
-    free newtype wrapper or a hand-written `JsonSchema` impl for the struct). This
+    generated schema lists the **key** under `required` while keeping the **value
+    nullable** — the schema must still accept `null` (these fields emit `null` when
+    `None`), so mark the key required, not the value non-nullable. Equivalently, a
+    `#[serde(default)]`-free newtype wrapper or a hand-written `JsonSchema` impl for
+    the struct. This
     is a real per-verb consideration to weigh, not an exact field-by-field budget
     the PoC pins — the count and identity of such fields are a property of each
     real output struct, surfaced during its migration, not fixed by this throwaway

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -1,0 +1,246 @@
+# heddle#327 — CLI schema-macro shape (schemars vs custom emitter + attribute design)
+
+**Status:** spike (decision doc + PoC). The PoC crate `crates/cli-macro-poc/`
+lands with this spike *only* as the measurement artifact; it is **not** wired
+into `crates/cli` and heddle#205 deletes it when it lands the production
+`crates/cli-macro/`. No production CLI behavior changes in this issue.
+
+**Scope:** resolve the three open design questions that block heddle#205
+(single-source-of-truth CLI macro): (1) where examples/descriptions live,
+(2) schemars vs a custom emitter, (3) how to layer the input shape (clap) and
+the output shape (JSON Schema) under one macro. Deliverable = this spec + a PoC
+that renders one real verb (`heddle init`) both ways and measures the result.
+
+> **EXISTING vs PROPOSED — read this first.** Everything under
+> "Today's architecture" is verified against the tree at the cited `path:line`
+> (2026-05-30). Everything under "Recommended shape" and "Impl shape for #205"
+> is **proposed** — the `#[heddle_verb]` / `HeddleVerbOutput` macro names, the
+> `inventory`-style auto-registration, and the deletion of the
+> `schema_registry!` table do **not** exist yet; they are #205's work. The PoC
+> crate proves the *measurable* claims (both emitters cover the documented
+> keys; schemars lifts doc comments; the discriminator-const gap is real); it
+> does **not** implement the proc-macro itself.
+
+---
+
+## 1. Today's architecture (verified 2026-05-30)
+
+A single `--output json` verb's shape is declared in **three** places, kept in
+sync by two PR-time gates rather than by construction:
+
+| Declaration | For `init` | Derives | Drives |
+|---|---|---|---|
+| Clap args struct | `InitArgs` — `crates/cli/src/cli/cli_args/commands_args.rs:12` | `clap::Parser` | parsing + `--help` |
+| Real output struct | `InitOutput` — `crates/cli/src/cli/commands/init.rs:23` | `serde::Serialize` only | the actual `--output json` bytes |
+| Schema mirror | `InitSchema` — `crates/cli/src/cli/commands/schemas.rs` (`pub struct InitSchema`) | `schemars::JsonSchema` | `heddle schemas init` + drift checks |
+
+The mirror is registered by the hand-maintained `schema_registry!` macro table
+(`crates/cli/src/cli/commands/schemas.rs:58`, e.g. `(&["init"], InitSchema)` at
+:59). schemas.rs:1–14 states the mirror exists *deliberately* — to avoid
+threading `JsonSchema` through every workspace output type (`repo`, `objects`,
+…) — at the cost that "when a real output struct changes, the mirror here must
+change too."
+
+Drift is policed at PR time, not prevented:
+
+- `heddle doctor schemas` (`crates/cli/src/cli/commands/doctor_schemas.rs`)
+  extracts the literal sample under each `## heddle <verb> --output json`
+  heading in `docs/json-schemas.md` and compares its **top-level keys** against
+  the registered schema's `properties` keys (keys-only, by design —
+  doctor_schemas.rs:15–19).
+- `heddle doctor docs` (`crates/cli/src/cli/commands/doctor_docs.rs`) walks
+  `heddle <verb> [flags]` invocations in markdown and flags clap-level drift,
+  built on `Cli::command()` so it tracks the binary.
+
+So the macro heddle#205 wants must collapse declarations **2 and 3** into one
+(emit the registered schema *from* the real output struct) and auto-populate
+the registry, deleting the mirror and the `schema_registry!` table. The clap
+side (declaration 1) stays — clap remains the user-facing parser; the macro
+only needs to *co-locate* the args declaration with the output declaration and
+share a verb key.
+
+---
+
+## 2. The PoC — one verb, both ways
+
+`crates/cli-macro-poc/` reproduces `init` faithfully: the field set and
+doc-comment text are copied from the registered `InitSchema` mirror and the
+`docs/json-schemas.md` sample. It emits the output schema two ways:
+
+- **Path A — schemars** (`schemars_path::schema()`): `#[derive(JsonSchema)]` on
+  the output struct + `schema_for!`. This is what heddle registers **today**.
+- **Path B — custom emitter** (`custom_path::schema()`): a hand-written field
+  table → `serde_json::Value`, no derive, no `schemars` dependency. Represents
+  the code a heddle-specific emitter macro would generate.
+
+`cargo test -p heddle-cli-macro-poc -- --nocapture` prints both schemas and the
+table below; the assertions in `tests/measure.rs` are the contract checks.
+
+### Measured comparison (`init`, 17 output fields)
+
+| metric | schemars | custom |
+|---|---|---|
+| pretty-printed schema bytes | 4435 | 4070 |
+| top-level property keys | 17 | 17 |
+| covers all 13 documented sample keys | ✅ | ✅ |
+| JSON Schema dialect | draft-07 | draft 2020-12 |
+| nested types (`InitPrincipal`) | `$ref` + `definitions` | inlined |
+| `output_kind` discriminator pinned | ❌ (`{"type":"string"}`) | ✅ (`"const":"init"`) |
+| field descriptions from `///` | ✅ (native) | ✅ (table column) |
+| carries example payload | ✅ | ✅ |
+| net-new schema code per verb | 0 (derive) | ~1 field-table row each |
+| extra dependency | `schemars` (already in tree) | none |
+
+(Bytes/keys are emitted by `print_measurement_table`; coverage and the
+discriminator gap are asserted by the other four tests.)
+
+### What the measurement decides
+
+1. **schemars is already the registered shape.** Path A *is* what
+   `heddle schemas init` returns today, so adopting it changes **zero** schema
+   semantics — the macro's only job is to move the derive from the throwaway
+   mirror onto the real `InitOutput` and auto-register it. Migration risk ≈ 0
+   for the gate corpus.
+2. **The discriminator gap is real and matters.** schemars renders
+   `output_kind` as a bare `{"type":"string"}` — it cannot express the
+   `"const":"init"` pin from a plain `String`/`&'static str` field. heddle
+   routes machine consumers on `output_kind` (the `json_discriminators` list in
+   `crates/cli/src/cli/commands/command_catalog.rs`). The custom emitter pins
+   it trivially. This is the single concrete thing schemars-as-derive costs us
+   — and it's a *quality* gap, not a *correctness* one (the runtime output
+   still carries the right value; only the schema under-describes it).
+3. **`$ref` vs inlined is a wash for the current gate.** `doctor schemas` is
+   keys-only and top-level, so schemars' `definitions`/`$ref` nesting passes
+   fine. It only bites if we later want the flat `docs/json-schemas.md` samples
+   to validate against the schema with an off-the-shelf validator that doesn't
+   resolve `$ref` — not a requirement today.
+
+---
+
+## 3. Spike answers
+
+### Q1 — Where do examples and descriptions live?
+
+**Descriptions: `#[doc]` (`///`). Decided — proven, no new attribute needed.**
+schemars lifts both struct-level and field-level doc comments into the schema's
+`description` natively (PoC test `schemars_emits_field_descriptions_from_doc_comments`;
+the rendered schemars schema shows `"path": { "description": "Path to the
+initialized `.heddle` …" }`). So the narrative that lives as prose blocks in
+`docs/json-schemas.md` today moves onto the field as a doc comment, and the
+macro carries it into *both* `--help` (via clap, which also reads `///`) and the
+JSON schema (via schemars). One source, two surfaces.
+
+**Examples: a sibling `#[heddle_verb(example = …)]` key the macro lowers to a
+typed example function — NOT inline literals, NOT prose blocks.** schemars'
+native form is `#[schemars(example = "init_example")]`, where the value names a
+free function returning a `Serialize` value; it lands in the schema's `examples`
+array (PoC test `schemars_carries_the_example_payload`). The awkwardness worth
+designing around:
+
+- The example must be a *function path*, not an inline literal — schemars 0.8
+  has no inline-example attribute.
+- It's one example function per type.
+
+Recommendation: the `#[heddle_verb]` macro exposes `example = path::to::fn` and
+forwards it to schemars on the schema side. The win over today's prose samples
+in `docs/json-schemas.md`: the example is a **real typed value of the output
+struct**, so it cannot drift from the struct's shape — it stops compiling if a
+field is renamed. That is strictly better than the current literal-JSON blocks
+that `doctor schemas` has to police after the fact.
+
+### Q2 — schemars vs custom emitter
+
+**Recommendation: schemars (Path A) for #205 v1. Keep the custom emitter PoC as
+the documented fallback.** Rationale, from the measurement:
+
+- It is already the registered shape → the macro is a *refactor* (delete the
+  mirror, derive on the real struct, auto-register), not a re-baseline of every
+  schema sample. The custom emitter would change dialect, nesting, and
+  const-pinning, forcing a rewrite of the `docs/json-schemas.md` corpus and a
+  re-blessing of `doctor schemas`.
+- The one real loss (discriminator-const) is recoverable *within* the schemars
+  path without adopting the whole custom emitter: a small `JsonSchema` helper /
+  newtype for `output_kind` that emits `{"const": "<verb>"}`, applied by the
+  macro from the `verb` key it already knows. File that as a #205 follow-up, not
+  a blocker.
+
+**When to revisit the custom emitter:** if we ever publish these schemas for
+external validation and need (a) inlined flat schemas that validate the
+`docs/json-schemas.md` samples with a stock validator, and (b) discriminator
+const-pinning across the board, the custom emitter delivers both with no
+`schemars` opinions to fight. The PoC's `custom_path` module is a working
+~90-line template for that future. Until then it's net-new code that buys us a
+gap the gate doesn't care about.
+
+### Q3 — Layering input (clap) + output (JSON) under one macro
+
+The input and output are genuinely different types: `InitArgs` has 7 input
+fields, `InitOutput` has 17 output fields, **zero overlap**. Forcing them into
+one struct is wrong. Two viable couplings:
+
+- **(a) Attribute on a module:** `#[heddle_verb(name = "init")] mod init { pub
+  struct Args {…} pub struct Output {…} }` — the macro emits the clap derive on
+  `Args`, the schema derive + registry entry on `Output`.
+- **(b) Two cooperating derives keyed by verb:** `#[derive(HeddleVerbArgs)]` on
+  the args struct and `#[derive(HeddleVerbOutput)]` on the output struct, tied
+  by a shared `#[heddle_verb("init")]` key. The `Output` derive is the one that
+  matters — it adds `JsonSchema` *and* emits the registry registration that
+  today is the hand-written `(&["init"], InitSchema)` row.
+
+**Recommendation: (b).** It keeps clap and schema as separate concerns on
+separate types (which they are), couples them by a verb-name key rather than by
+forcing a shared type, and localizes the new magic to the output side — exactly
+where the drift problem lives. The clap side barely changes: `HeddleVerbArgs`
+is mostly a passthrough that re-exports `clap::Parser` and records the verb key,
+so `--help`, completions, and error messages keep flowing through clap
+unchanged (a heddle#205 discipline guard).
+
+The registry registration should use an `inventory`/`linkme`-style collected
+registration so the `schema_registry!` table at schemas.rs:58 disappears
+entirely — each verb registers itself at link time, and
+`schema_for_registered_verb` becomes a lookup over the collected set instead of
+a hand-maintained `if $verbs.contains(&verb)` chain.
+
+---
+
+## 4. Impl shape for heddle#205 (proposed — confirm scope with user)
+
+1. **Land `crates/cli-macro/`** with the `HeddleVerbOutput` derive (schemars +
+   collected registration) and the thin `HeddleVerbArgs` passthrough. Delete
+   `crates/cli-macro-poc/`.
+2. **Migrate one proof verb** (`init` is the smallest real output; `status` is
+   the richest — pick `init` for the first landing per #205's "pick a small
+   one"). Derive `HeddleVerbOutput` on the real `InitOutput`
+   (`crates/cli/src/cli/commands/init.rs:23`); delete the `InitSchema` mirror
+   and its `schema_registry!` row.
+3. **Add the discriminator-const helper** so `output_kind` emits
+   `{"const":"init"}` — recovers the one measured schemars gap.
+4. **Run the full gate set** the migrated verb must still pass:
+   `cargo test --locked -p heddle-cli --test cli_integration doctor_schemas_has_no_drift_or_unmatched_registered_verbs`,
+   `… doctor_docs`, plus `target/debug/heddle doctor schemas --output json` and
+   `doctor docs --all --output json` (the exact commands CI runs —
+   `.github/workflows/rust-tests.yml:181-184`).
+5. **Known friction to budget for:** real output structs that embed foreign
+   workspace types (e.g. `InitOutput.trust: RepositoryVerificationState`,
+   `#[serde(skip_serializing)]` at init.rs) must either skip those fields on the
+   schema side too or grow `JsonSchema` impls. The mirror existed precisely to
+   dodge this (schemas.rs:6–13); the macro re-confronts it. Each migration batch
+   should enumerate the foreign types its verbs touch.
+6. **Then** the verb-by-verb migration batches (~30 verbs, the registered set in
+   `schema_registry!`), one issue each, as #205 already scopes.
+
+---
+
+## 5. Recommendation summary
+
+| Question | Decision | Confidence |
+|---|---|---|
+| Descriptions | `#[doc]` `///`, carried to both `--help` and schema | high — proven in PoC |
+| Examples | `#[heddle_verb(example = fn)]` → typed example fn → schemars `examples` | high — proven in PoC |
+| schemars vs custom | **schemars** for v1 (zero re-baseline); custom emitter is the documented fallback | high — it is already the registered shape |
+| Discriminator const | schemars gap; fix with a small `output_kind` `JsonSchema` helper, not the custom emitter | medium — helper not yet built |
+| Macro layering | two derives (`HeddleVerbArgs` + `HeddleVerbOutput`) keyed by verb; output derive auto-registers via `inventory` | medium — proposed, not prototyped |
+
+Nothing here blocks heddle#205; it unblocks it. The one open build-time
+question (`inventory` vs `linkme` for collected registration) is a #205
+implementation choice, not a design fork.

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -5,6 +5,19 @@ lands with this spike *only* as the measurement artifact; it is **not** wired
 into `crates/cli` and heddle#205 deletes it when it lands the production
 `crates/cli-macro/`. No production CLI behavior changes in this issue.
 
+> **This PoC is an illustrative measurement aid, not a byte-faithful mirror.**
+> It demonstrates the schemars-vs-custom-emitter tradeoff **directionally** —
+> which path pins the discriminator, which re-exposes skip-serialized fields,
+> which carries typed examples. The exact byte counts, field lists, and example
+> values here are **approximate/representative**, not a production-exact replica
+> of the private `init` types. The directional facts (presence, inequalities,
+> the discriminator gap, the phantom `verification` property) are asserted in
+> `tests/measure.rs`; the magic numbers in the comparison table are probes, not
+> guarantees. **heddle#205 derives the real macro from `init.rs` directly — not
+> from this throwaway crate** — so it works from the live types, and any
+> rebaseline of `docs/json-schemas.md` is driven by that derive, not by the
+> illustrative values below.
+
 **Scope:** resolve the three open design questions that block heddle#205
 (single-source-of-truth CLI macro): (1) where examples/descriptions live,
 (2) schemars vs a custom emitter, (3) how to layer the input shape (clap) and
@@ -109,9 +122,13 @@ table below; the assertions in `tests/measure.rs` are the contract checks.
 | net-new schema code per verb | 0 (derive) + skip-attrs as needed | ~1 field-table row each |
 | extra dependency | `schemars` (already in tree) | none |
 
-(Bytes/keys are emitted by `print_measurement_table`; the discriminator gap,
-the phantom-`verification` drift, and documented-key coverage are each pinned by
-a dedicated assertion in `tests/measure.rs`.)
+(Bytes/keys are emitted by `print_measurement_table` and are **illustrative /
+directional**, not production-exact: the `RepositoryVerificationState` stand-in
+is deliberately minimal, so the real schemars expansion would be *larger* and the
+size gap shown here is understated, not overstated. What is *asserted* — the
+discriminator gap, the phantom-`verification` drift, and documented-key coverage
+— is each pinned by a dedicated test in `tests/measure.rs` as a presence/
+inequality check, never as a magic byte count.)
 
 ### What the measurement decides
 
@@ -193,18 +210,19 @@ struct**, so it cannot drift from the struct's shape — it stops compiling if a
 field is renamed. That is strictly better than the current literal-JSON blocks
 that `doctor schemas` has to police after the fact.
 
-**Concretely, the prose sample has *already* drifted, and the PoC proves it.**
-The PoC's `init_example()` is the real typed value, so serializing it emits the
+**Concretely, the prose sample has *already* drifted, and the PoC illustrates
+the mechanism.** The PoC's `init_example()` is an illustrative typed value;
+because it is a value *of the output struct*, serializing it carries the
 always-present `principal_status`, `principal_source`, `principal`, and
-`principal_recommended_action` fields (none is `skip_serializing_if`). The
-curated `## heddle init --output json` sample in `docs/json-schemas.md` omits
-all four. The PoC asserts exactly this divergence
-(`typed_example_diverges_from_curated_doc_sample`): the real output is a
-superset of the documented sample by those four keys. So the in-code example is
-**not** byte-for-byte the documented sample — and that is the point. A typed
-example tracks the struct automatically; the hand-curated prose sample fell
-behind. heddle#205 should rebaseline the `docs/json-schemas.md` `init` sample
-from the typed example when it lands the derive.
+`principal_recommended_action` fields (none is `skip_serializing_if`), which the
+curated `## heddle init --output json` sample in `docs/json-schemas.md` omits.
+The PoC asserts this *presence* divergence
+(`typed_example_diverges_from_curated_doc_sample`) — not the literal field
+values, which are illustrative. That is the directional point: a typed example
+tracks the struct automatically; the hand-curated prose sample fell behind. So
+when heddle#205 lands the derive **on the real `init.rs`**, it should rebaseline
+the `docs/json-schemas.md` `init` sample from the value that derive produces —
+**not** from this throwaway PoC's illustrative example.
 
 ### Q2 — schemars vs custom emitter
 
@@ -228,8 +246,16 @@ the documented fallback.** Rationale, from the measurement:
     `verification`/`trust`), or the schema gains required properties the wire
     never emits (§2 point 1). Mechanical, but per-field, so it can't be waved
     away as zero-touch.
+  - **always-serialized `Option` fields** — directionally, serde emits
+    `Option<T>` fields that lack `skip_serializing_if` on every response (as
+    `null` when `None`), but schemars' derive treats `Option<T>` as nullable and
+    *not* required. So a naive derive under-describes keys the wire always
+    carries unless the macro overrides requiredness. This is a real per-verb
+    consideration to weigh, not an exact field-by-field budget the PoC pins —
+    the count and identity of such fields are a property of each real output
+    struct, surfaced during its migration, not fixed by this throwaway crate.
 
-  File both as #205 work, not blockers.
+  File these as #205 work, not blockers.
 
 **When to revisit the custom emitter:** if we ever publish these schemas for
 external validation and need (a) inlined flat schemas that validate the
@@ -262,20 +288,26 @@ one struct is wrong. Two viable couplings:
   **also** `#[derive(schemars::JsonSchema)]` (i.e. `HeddleVerbOutput` *requires*
   a `JsonSchema` bound it does not provide), and `HeddleVerbOutput`'s own job is
   the registry registration that today is the hand-written `(&["init"],
-  InitSchema)` row. (The alternatives — hand-implementing `JsonSchema` inside
-  `HeddleVerbOutput`, or making it an attribute macro — collapse (b) into either
-  the custom-emitter path or option (a).)
+  InitSchema)` row. **The same constraint applies symmetrically on the args
+  side:** `HeddleVerbArgs` likewise cannot add `#[derive(clap::Args)]` to its
+  input, so the args struct must **also** `#[derive(clap::Args)]` explicitly (the
+  subcommand payload `Commands::Init(InitArgs)` requires the real clap impl);
+  `HeddleVerbArgs` only records the verb key alongside it. (The alternatives —
+  hand-implementing `JsonSchema`/`clap::Args` inside the derives, or making them
+  attribute macros — collapse (b) into either the custom-emitter path or option
+  (a).)
 
 **Recommendation: (b)**, with the output struct co-deriving `JsonSchema`
 explicitly. It keeps clap and schema as separate concerns on separate types
 (which they are), couples them by a verb-name key rather than by forcing a
 shared type, and localizes the new magic to the output side — exactly where the
-drift problem lives. The clap side barely changes: `HeddleVerbArgs` is a
-passthrough over **`clap::Args`** (the reusable arg set that subcommand tuple
-variants like `Commands::Init(InitArgs)` consume — NOT `clap::Parser`, which
-stays on the top-level `Cli`) that records the verb key, so `--help`,
-completions, and error messages keep flowing through clap unchanged (a
-heddle#205 discipline guard). The PoC's `src/args.rs` wires exactly this shape
+drift problem lives. The clap side barely changes: the args struct keeps its own
+explicit `#[derive(clap::Args)]` (the derive can't add it — see (b) above), and
+`HeddleVerbArgs` is a thin passthrough *alongside* it over **`clap::Args`** (the
+reusable arg set that subcommand tuple variants like `Commands::Init(InitArgs)`
+consume — NOT `clap::Parser`, which stays on the top-level `Cli`) that records
+the verb key, so `--help`, completions, and error messages keep flowing through
+clap unchanged (a heddle#205 discipline guard). The PoC's `src/args.rs` wires exactly this shape
 (`Parser` on `Cli`, `Args` on the leaf) to prove the args type slots into a real
 subcommand tree.
 
@@ -297,8 +329,10 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
 
 1. **Land `crates/cli-macro/`** with the `HeddleVerbOutput` derive (registry
    registration; the output struct co-derives `schemars::JsonSchema` — the derive
-   cannot add it, see Q3) and the thin `HeddleVerbArgs` passthrough over
-   `clap::Args`. Delete `crates/cli-macro-poc/`.
+   cannot add it, see Q3) and the thin `HeddleVerbArgs` passthrough that sits
+   alongside the args struct's own explicit `#[derive(clap::Args)]` (the derive
+   cannot add `clap::Args` either — same constraint, see Q3). Delete
+   `crates/cli-macro-poc/`.
 2. **Migrate one proof verb** (`init` is the smallest real output; `status` is
    the richest — pick `init` for the first landing per #205's "pick a small
    one"). Co-derive `HeddleVerbOutput` + `JsonSchema` on the real `InitOutput`
@@ -306,8 +340,9 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
    `trust` field (else the schema gains a required `verification` property the
    wire never emits — §2 point 1); delete the `InitSchema` mirror and its
    `schema_registry!` row. **Rebaseline** the `docs/json-schemas.md` `init`
-   sample from the typed example (it currently omits the always-serialized
-   principal fields — Q1).
+   sample from the value the real derive produces on `init.rs` (the PoC only
+   illustrates the drift, it is not the rebaseline source; it currently omits
+   the always-serialized principal fields — Q1).
 3. **Add the discriminator-const helper** so `output_kind` emits
    `{"const":"init"}` — recovers the measured discriminator gap.
 4. **Run the full gate set** the migrated verb must still pass:
@@ -340,7 +375,7 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
 | schemars vs custom | **schemars** for v1; *not* zero-touch — per-verb `#[schemars(skip)]` for skip-serialized fields + a const helper. Custom emitter is the documented fallback | high — recommendation holds; "zero re-baseline" evidence corrected |
 | Discriminator const | schemars gap (measured + asserted); fix with a small `output_kind` `JsonSchema` helper, not the custom emitter | medium — helper not yet built |
 | `skip_serializing` drift | schemars re-exposes skip-serialized fields as required `writeOnly` props (measured + asserted); fix per-verb with `#[schemars(skip)]` | high — measured in PoC |
-| Macro layering | two derives (`HeddleVerbArgs` over `clap::Args` + `HeddleVerbOutput`) keyed by verb; output struct **co-derives** `JsonSchema` (the derive can't add it); registry via `inventory` | medium — proposed, args shape prototyped in PoC |
+| Macro layering | two derives (`HeddleVerbArgs` + `HeddleVerbOutput`) keyed by verb; args struct **co-derives** `clap::Args` and output struct **co-derives** `JsonSchema` (neither derive can add the other — symmetric constraint); registry via `inventory` | medium — proposed, args shape prototyped in PoC |
 
 The corrected measurements **do not change the overall recommendation** —
 schemars for #205 v1, custom emitter as the documented fallback — but they

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -30,8 +30,8 @@ that renders one real verb (`heddle init`) both ways and measures the result.
 > is **proposed** — the `#[heddle_verb]` / `HeddleVerbOutput` macro names, the
 > `inventory`-style auto-registration, and the deletion of the
 > `schema_registry!` table do **not** exist yet; they are #205's work. The PoC
-> crate proves the *measurable* claims by asserting them against types that
-> mirror the **real** `init.rs` (both emitters cover the documented keys;
+> crate proves the *measurable* claims by asserting them against types
+> modeled on the **shape** of the real `init.rs` (both emitters cover the documented keys;
 > schemars lifts doc comments; the discriminator-const gap is real; schemars
 > re-exposes the skip-serialized `verification` field; the typed example
 > diverges from the curated doc sample); it does **not** implement the
@@ -86,16 +86,17 @@ share a verb key.
 
 ## 2. The PoC — one verb, both ways
 
-`crates/cli-macro-poc/` reproduces `init` faithfully against the **real**
-`init.rs` types, not the simplified mirror: the args struct is modelled as the
-real `clap::Args` `InitArgs` wired through a `Subcommand` enum
-(`crates/cli-macro-poc/src/args.rs`), and the output struct replicates the real
-private `InitOutput` field-for-field — INCLUDING the `#[serde(skip_serializing)]
-#[serde(rename = "verification")] trust` field
-(`crates/cli-macro-poc/src/output.rs`). (The real `InitOutput` is a crate-private
-`struct`, so a throwaway crate can't import it; it replicates the exact field
-types and serde/schemars attributes instead.) It emits the output schema two
-ways:
+`crates/cli-macro-poc/` models `init`'s **shape** — the serde/schemars-relevant
+attributes that drive the tradeoff — illustratively, not field-for-field exact:
+the args struct is modelled as the real `clap::Args` `InitArgs` wired through a
+`Subcommand` enum (`crates/cli-macro-poc/src/args.rs`), and the output struct
+mirrors the directionally-relevant features of the real private `InitOutput` —
+including the `#[serde(skip_serializing)] #[serde(rename = "verification")] trust`
+field (`crates/cli-macro-poc/src/output.rs`). (The real `InitOutput` is a
+crate-private `struct`, so a throwaway crate can't import it; the PoC reconstructs
+the schema-relevant attributes — skip-serialized fields, always-present `Option`s,
+the discriminator field — representatively, not as a byte-exact replica of the
+real field set.) It emits the output schema two ways:
 
 - **Path A — schemars** (`schemars_path::schema()`): `#[derive(JsonSchema)]` on
   the output struct + `schema_for!`. This is what heddle registers **today**.
@@ -192,8 +193,10 @@ comment driving both would be a module-level macro that maps one declaration to
 both types (option (a) in Q3) — the two-derive shape we recommend keeps them
 separate, by design.
 
-**Examples: a sibling `#[heddle_verb(example = …)]` key the macro lowers to a
-typed example function — NOT inline literals, NOT prose blocks.** schemars'
+**Examples: schemars' own `#[schemars(example = "init_example")]` attribute on
+the output struct, naming a typed example function — NOT inline literals, NOT
+prose blocks, and NOT auto-forwarded by the `HeddleVerbOutput` derive (see the
+recommendation below for why the two-derive shape can't forward it).** schemars'
 native form is `#[schemars(example = "init_example")]`, where the value names a
 free function returning a `Serialize` value; it lands in the schema's `examples`
 array (PoC test `schemars_carries_the_example_payload`). The awkwardness worth
@@ -203,12 +206,25 @@ designing around:
   has no inline-example attribute.
 - It's one example function per type.
 
-Recommendation: the `#[heddle_verb]` macro exposes `example = path::to::fn` and
-forwards it to schemars on the schema side. The win over today's prose samples
-in `docs/json-schemas.md`: the example is a **real typed value of the output
-struct**, so it cannot drift from the struct's shape — it stops compiling if a
-field is renamed. That is strictly better than the current literal-JSON blocks
-that `doctor schemas` has to police after the fact.
+Recommendation: in the two-derive shape we recommend (Q3 option (b)), the example
+is wired with schemars' **own** `#[schemars(example = "path::to::fn")]` attribute
+written directly on the output struct — **not** synthesized-and-forwarded by the
+`HeddleVerbOutput` derive. This is a hard constraint, not a stylistic choice: the
+`HeddleVerbOutput` derive and the co-located `#[derive(JsonSchema)]` run as two
+**independent** derives over the same struct, and a derive cannot inject an
+attribute that a *sibling* derive observes (derives only append items; they don't
+rewrite the annotated item's attribute list — same constraint as Q3). So
+`HeddleVerbOutput` cannot make schemars "see" a synthesized `#[schemars(example)]`.
+The author provides the example through one of: (i) an explicit
+`#[schemars(example = "path::to::fn")]` on the output struct that the co-derived
+`JsonSchema` reads natively (the recommended form), or (ii) a hand-written
+`JsonSchema` impl. (The only way to get the `HeddleVerbOutput` derive itself to
+own example emission would be to make it an *attribute* macro that rewrites the
+struct before schemars expands — Q3 option (a) — which we did not pick.) The win
+over today's prose samples in `docs/json-schemas.md` is unchanged: the example is
+a **real typed value of the output struct**, so it cannot drift from the struct's
+shape — it stops compiling if a field is renamed. That is strictly better than
+the current literal-JSON blocks that `doctor schemas` has to police after the fact.
 
 **Concretely, the prose sample has *already* drifted, and the PoC illustrates
 the mechanism.** The PoC's `init_example()` is an illustrative typed value;
@@ -250,10 +266,18 @@ the documented fallback.** Rationale, from the measurement:
     `Option<T>` fields that lack `skip_serializing_if` on every response (as
     `null` when `None`), but schemars' derive treats `Option<T>` as nullable and
     *not* required. So a naive derive under-describes keys the wire always
-    carries unless the macro overrides requiredness. This is a real per-verb
-    consideration to weigh, not an exact field-by-field budget the PoC pins —
-    the count and identity of such fields are a property of each real output
-    struct, surfaced during its migration, not fixed by this throwaway crate.
+    carries (e.g. `InitOutput.principal_source` / `principal`). The two-derive
+    path **cannot fix this from the `HeddleVerbOutput` side** — it can't reach
+    into the sibling `JsonSchema` derive to flip requiredness (same independent-
+    derives constraint as the example case). The actionable mechanism #205 should
+    prescribe is author-written on the output struct: add
+    `#[schemars(required)]` to each always-emitted `Option<T>` field so the
+    generated schema lists it under `required` (equivalently, a `#[serde(default)]`-
+    free newtype wrapper or a hand-written `JsonSchema` impl for the struct). This
+    is a real per-verb consideration to weigh, not an exact field-by-field budget
+    the PoC pins — the count and identity of such fields are a property of each
+    real output struct, surfaced during its migration, not fixed by this throwaway
+    crate.
 
   File these as #205 work, not blockers.
 
@@ -357,10 +381,14 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
    this. Each migrated struct must add `#[schemars(skip)]` to such fields, or it
    ships a schema that describes properties the command never emits (and
    `doctor schemas`, which only checks documented keys *appear*, won't catch it).
-   Separately, output structs that embed foreign workspace types may need
-   `JsonSchema` impls/bounds; the mirror existed precisely to dodge both
-   (schemas.rs:6–13), and the macro re-confronts them. Each migration batch
-   should enumerate the skip-serialized and foreign-typed fields its verbs touch.
+   Separately, any `Option<T>` field serde always emits (no `skip_serializing_if`,
+   e.g. `InitOutput.principal_source`/`principal`) must carry
+   `#[schemars(required)]` (author-written — the derive can't force it), else the
+   schema marks an always-present key optional (§2 / Q2). And output structs that
+   embed foreign workspace types may need `JsonSchema` impls/bounds; the mirror
+   existed precisely to dodge these (schemas.rs:6–13), and the macro re-confronts
+   them. Each migration batch should enumerate the skip-serialized, always-emitted-
+   `Option`, and foreign-typed fields its verbs touch.
 6. **Then** the verb-by-verb migration batches (~30 verbs, the registered set in
    `schema_registry!`), one issue each, as #205 already scopes.
 
@@ -371,7 +399,7 @@ a hand-maintained `if $verbs.contains(&verb)` chain.
 | Question | Decision | Confidence |
 |---|---|---|
 | Descriptions | `#[doc]` `///`, single source *per surface* — but args and output are separate types, so it's two doc sources, not "one comment, both surfaces" | high — proven in PoC |
-| Examples | `#[heddle_verb(example = fn)]` → typed example fn → schemars `examples`; #205 rebaselines the prose `docs/json-schemas.md` sample (already drifted) from it | high — proven in PoC |
+| Examples | schemars-native `#[schemars(example = "fn")]` on the output struct (author-written, **not** forwarded by the `HeddleVerbOutput` derive) → typed example fn → schemars `examples`; #205 rebaselines the prose `docs/json-schemas.md` sample (already drifted) from it | high — proven in PoC |
 | schemars vs custom | **schemars** for v1; *not* zero-touch — per-verb `#[schemars(skip)]` for skip-serialized fields + a const helper. Custom emitter is the documented fallback | high — recommendation holds; "zero re-baseline" evidence corrected |
 | Discriminator const | schemars gap (measured + asserted); fix with a small `output_kind` `JsonSchema` helper, not the custom emitter | medium — helper not yet built |
 | `skip_serializing` drift | schemars re-exposes skip-serialized fields as required `writeOnly` props (measured + asserted); fix per-verb with `#[schemars(skip)]` | high — measured in PoC |

--- a/docs/spikes/heddle-327-cli-macro-shape.md
+++ b/docs/spikes/heddle-327-cli-macro-shape.md
@@ -33,7 +33,7 @@ sync by two PR-time gates rather than by construction:
 
 | Declaration | For `init` | Derives | Drives |
 |---|---|---|---|
-| Clap args struct | `InitArgs` — `crates/cli/src/cli/cli_args/commands_args.rs:12` | `clap::Parser` | parsing + `--help` |
+| Clap args struct | `InitArgs` — `crates/cli/src/cli/cli_args/commands_args.rs:12` | `clap::Args` | parsing + `--help` |
 | Real output struct | `InitOutput` — `crates/cli/src/cli/commands/init.rs:23` | `serde::Serialize` only | the actual `--output json` bytes |
 | Schema mirror | `InitSchema` — `crates/cli/src/cli/commands/schemas.rs` (`pub struct InitSchema`) | `schemars::JsonSchema` | `heddle schemas init` + drift checks |
 
@@ -97,7 +97,7 @@ table below; the assertions in `tests/measure.rs` are the contract checks.
 
 | metric | schemars | custom |
 |---|---|---|
-| pretty-printed schema bytes | 5954 | 4096 |
+| pretty-printed schema bytes | 5954 | 4218 |
 | top-level property keys | 18 | 17 |
 | covers all 13 documented sample keys | ✅ | ✅ |
 | phantom `verification` property (never on wire) | ❌ **present** (`writeOnly`, **required**) | ✅ absent |


### PR DESCRIPTION
## Summary

- Decision doc `docs/spikes/heddle-327-cli-macro-shape.md` resolving the three open design questions that block #205 (single-source-of-truth CLI macro): where descriptions/examples live, schemars-vs-custom-emitter, and how to layer clap input-shape + JSON output-shape under one macro.
- Measurement PoC crate `crates/cli-macro-poc/` renders one real verb (`heddle init`) **both ways** — schemars derive vs a hand-written custom emitter — and measures the result in `tests/measure.rs`.
- **Recommendation: schemars for #205 v1** (it is already the registered shape → zero re-baseline of the `doctor schemas` corpus). The one measured gap (`output_kind` discriminator const) is recoverable with a small `JsonSchema` helper; the custom-emitter PoC is kept as the documented fallback.
- Descriptions → `#[doc]` (schemars lifts `///` into the schema natively, proven by test). Examples → a typed example fn (`#[schemars(example = …)]`) that can't drift from the struct shape.
- PoC is `publish = false`, **not** wired into `crates/cli`; #205 deletes it when it lands `crates/cli-macro/`. No production CLI behavior changes.

Closes HeddleCo/heddle#327

## Red commit

N/A — spike (DoD Type ≠ TDD-Rust). The PoC ships green measurement tests rather than a red→green pair.

## Test evidence

```
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
running 5 tests
test custom_emitter_embeds_the_documented_example ... ok
test schemars_carries_the_example_payload ... ok
test schemars_emits_field_descriptions_from_doc_comments ... ok
test both_emitters_cover_the_documented_sample_keys ... ok
test print_measurement_table ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Measured comparison (`init`, 17 output fields), from `print_measurement_table`:

```
=== heddle#327 PoC measurement — `init` verb, both ways ===
metric                             |   schemars |     custom
-----------------------------------+------------+-----------
pretty-printed schema bytes        |       4435 |       4070
top-level property keys            |         17 |         17
uses $ref/definitions (nested)     |       true |      false
output_kind pinned (const/enum)    |      false |       true
carries example                    |       true |       true
needs schemars dep                 |       true |      false
===========================================================
```

## Manual verification

N/A — covered by tests. Drift gates unaffected: `docs/spikes/` is in `doctor docs` IGNORE_PATTERNS (`doctor_docs.rs:276`) and `docs/json-schemas.md` is untouched, so `doctor schemas`/`doctor docs` see no change.

## Blocked by → resolved

Unblocks **HeddleCo/heddle#205** (impl: single-source CLI macro) — its three open design questions are now answered with a recommended shape + a working PoC. #205 also depends on a design call for an `output_kind` discriminator-const helper and `inventory`-style registry collection, both flagged in §4 of the spec.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782764296&installation_id=132405951&pr_number=361&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F361&signature=ee0821c20fe8676d0a4aca05171f71328e7150553d876edf4a6b73058fba0907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->