### PR TITLE
heddle#354: land the AtomicMutation primitive (impl-a) + read/write chokepoints

### DIFF
--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -79,3 +79,27 @@ jobs:
 
       - name: Assert no `get_tree(...)?.unwrap_or_default()` regressions
         run: bash scripts/check-no-silent-default-tree-load.sh
+
+  no-publish-first-snapshot:
+    name: no cross-crate publish-first snapshot (heddle#354 r8)
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # Workspace-wide `syn` AST walker (heddle-devtools subcommand): a
+      # snapshot must record its `OpRecord::Snapshot` before publishing
+      # the paired ref. Closes the cross-crate coverage hole the
+      # refs-internal r7 conformance left.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: asserter-${{ runner.os }}
+          cache-on-failure: true
+
+      - name: Build asserter binary
+        run: cargo build -p heddle-devtools --quiet
+
+      - name: Assert no cross-crate publish-first snapshot regressions
+        run: bash scripts/check-snapshot-atomicity.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,6 +3165,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -6,7 +6,8 @@ use std::time::Instant;
 
 use anyhow::Result;
 use objects::object::State;
-use refs::Head;
+use oplog::OpRecord;
+use refs::{Head, RefExpectation, RefUpdate};
 use repo::Repository;
 use serde::Serialize;
 
@@ -95,22 +96,40 @@ pub fn cmd_collapse(
         eprintln!("Writing collapsed state {}...", new_state.change_id.short());
     }
 
-    // Update HEAD to point to the new state
-    match repo.refs().read_head()? {
-        Head::Attached { ref thread } => {
-            repo.refs().set_thread(thread, &new_state.change_id)?;
-        }
-        Head::Detached { .. } => {
-            repo.refs().write_head(&Head::Detached {
-                state: new_state.change_id,
-            })?;
-        }
-    }
+    // Build the published ref batch + its matching `Collapse` record, then
+    // publish record-first through the write chokepoint (heddle#330 §2.2): the
+    // record is the commit point and the ref publish is a post-commit
+    // materialization, replacing the prior publish-then-record order. The
+    // `Collapse` record names the published ref (a thread when HEAD was
+    // attached, or a detached HEAD at the collapse result).
+    let (ref_updates, published_thread): (Vec<RefUpdate>, Option<String>) =
+        match repo.refs().read_head()? {
+            Head::Attached { ref thread } => (
+                vec![RefUpdate::Thread {
+                    name: thread.clone(),
+                    expected: RefExpectation::Any,
+                    new: Some(new_state.change_id),
+                }],
+                Some(thread.to_string()),
+            ),
+            Head::Detached { .. } => (
+                vec![RefUpdate::Head {
+                    expected: RefExpectation::Any,
+                    new: Head::Detached {
+                        state: new_state.change_id,
+                    },
+                }],
+                None,
+            ),
+        };
 
-    // Record in oplog
     let source_ids: Vec<_> = resolved_states.iter().map(|s| s.change_id).collect();
-    repo.oplog()
-        .record_collapse(&source_ids, &new_state.change_id)?;
+    let collapse_record = OpRecord::Collapse {
+        sources: source_ids,
+        result: new_state.change_id,
+        thread: published_thread,
+    };
+    repo.commit_and_publish(vec![collapse_record], &ref_updates)?;
 
     let output = CollapseOutput {
         change_id: new_state.change_id.short(),

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -4,6 +4,7 @@
 use objects::store::ObjectStore;
 use anyhow::Result;
 use objects::object::{State, ThreadName};
+use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
 use repo::Repository;
 use serde::Serialize;
@@ -65,34 +66,54 @@ pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result
         new_state = new_state.with_intent(format!("Fork from {}", source_state.change_id.short()));
     }
 
-    // Store the new state
+    // Store the new state (orphan until a ref points at it).
     repo.store().put_state(&new_state)?;
 
-    // If a name was provided, create a new thread
-    if let Some(ref track_name) = name {
+    // Build the atomic ref batch + its matching `Fork` record, then publish
+    // record-first through the write chokepoint (heddle#330 §2.2): the oplog
+    // record is the commit point (phase 4) and the ref publish is a post-commit
+    // materialization (phase 5), so a crash between them leaves a re-derivable
+    // ref — never a reader-visible ref with no undo record (the prior
+    // publish-then-record order). The `Fork` record carries the published ref
+    // identity and the corrected `from = source_state` argument order (r15).
+    let (ref_updates, fork_record) = if let Some(ref track_name) = name {
         let tn = ThreadName::new(track_name.as_str());
-        let updates = vec![
-            RefUpdate::Thread {
-                name: tn.clone(),
-                expected: RefExpectation::Missing,
-                new: Some(new_state.change_id),
+        (
+            vec![
+                RefUpdate::Thread {
+                    name: tn.clone(),
+                    expected: RefExpectation::Missing,
+                    new: Some(new_state.change_id),
+                },
+                RefUpdate::Head {
+                    expected: RefExpectation::Any,
+                    new: Head::Attached { thread: tn },
+                },
+            ],
+            OpRecord::Fork {
+                from: source_state.change_id,
+                new_state: new_state.change_id,
+                thread: Some(track_name.clone()),
+                head: None,
             },
-            RefUpdate::Head {
-                expected: RefExpectation::Any,
-                new: Head::Attached { thread: tn },
-            },
-        ];
-        repo.refs().update_refs(&updates)?;
+        )
     } else {
-        // Detach HEAD to point to the new state
-        repo.refs().write_head(&Head::Detached {
-            state: new_state.change_id,
-        })?;
-    }
-
-    // Record in oplog
-    repo.oplog()
-        .record_fork(&new_state.change_id, &source_state.change_id)?;
+        (
+            vec![RefUpdate::Head {
+                expected: RefExpectation::Any,
+                new: Head::Detached {
+                    state: new_state.change_id,
+                },
+            }],
+            OpRecord::Fork {
+                from: source_state.change_id,
+                new_state: new_state.change_id,
+                thread: None,
+                head: Some(new_state.change_id),
+            },
+        )
+    };
+    repo.commit_and_publish(vec![fork_record], &ref_updates)?;
 
     let output = ForkOutput {
         output_kind: "fork",

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -1438,7 +1438,29 @@ fn merge_op_targets_state(op: &OpRecord, state: &ChangeId) -> bool {
             state: checkpoint_state,
             ..
         } => checkpoint_state == state,
-        _ => false,
+        // These records don't advance HEAD/thread to the merge state the merge
+        // flow tracks (legacy V1 `FastForward` carries no post-target id).
+        // Enumerated explicitly (no wildcard) so a new state-advancing variant
+        // must be considered as a possible merge target here (heddle#354 r9).
+        OpRecord::ThreadCreate { .. }
+        | OpRecord::ThreadCreateV2 { .. }
+        | OpRecord::ThreadDelete { .. }
+        | OpRecord::ThreadUpdate { .. }
+        | OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::MarkerCreate { .. }
+        | OpRecord::MarkerDelete { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::FastForward { .. }
+        | OpRecord::GitCheckpoint { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => false,
     }
 }
 

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -225,16 +225,41 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                         OpRecord::FastForward { .. }
                         | OpRecord::FastForwardV2 { .. }
                         | OpRecord::Goto { .. } => pending_advances.push(advance),
-                        other if for_abort => {
-                            let _ = other;
-                            continue;
-                        }
-                        other => {
+                        // Anything else would land in the committed batch
+                        // verbatim and pollute undo/redo with records the
+                        // rebase never produced. Abort silently drops them (the
+                        // buffered FF history is discarded on rewind); the
+                        // strict loader rejects. Enumerated explicitly (no
+                        // wildcard) so a new FF-style variant must be decided
+                        // here rather than silently rejected (heddle#354 r9).
+                        OpRecord::Snapshot { .. }
+                        | OpRecord::ThreadCreate { .. }
+                        | OpRecord::ThreadCreateV2 { .. }
+                        | OpRecord::ThreadDelete { .. }
+                        | OpRecord::ThreadUpdate { .. }
+                        | OpRecord::Fork { .. }
+                        | OpRecord::Collapse { .. }
+                        | OpRecord::MarkerCreate { .. }
+                        | OpRecord::MarkerDelete { .. }
+                        | OpRecord::Checkpoint { .. }
+                        | OpRecord::TransactionAbort { .. }
+                        | OpRecord::EphemeralThreadCollapse { .. }
+                        | OpRecord::ConflictResolved { .. }
+                        | OpRecord::TransactionCommit { .. }
+                        | OpRecord::Redact { .. }
+                        | OpRecord::Purge { .. }
+                        | OpRecord::GitCheckpoint { .. }
+                        | OpRecord::RemoteThreadUpdate { .. }
+                        | OpRecord::RemoteThreadDelete { .. }
+                        | OpRecord::UndoRecoveryUpdate { .. } => {
+                            if for_abort {
+                                continue;
+                            }
                             return Err(anyhow!(RecoveryAdvice::rebase_state_corrupted(
                                 "Unexpected pending_advance variant in rebase state",
                                 format!(
                                     "{} — only FastForward/FastForwardV2/Goto are accepted",
-                                    other.description()
+                                    advance.description()
                                 ),
                             )));
                         }

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -243,7 +243,31 @@ pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
                         timestamp: format_ts(entry.timestamp),
                     });
                 }
-                _ => {}
+                // Not surfaced in the retro summary (includes `Collapse` when
+                // `--include-merges` is off). Enumerated explicitly (no
+                // wildcard) so a new `OpRecord` variant must be considered for
+                // the retro rollup instead of silently vanishing from it
+                // (heddle#354 r9).
+                OpRecord::Goto { .. }
+                | OpRecord::ThreadCreate { .. }
+                | OpRecord::ThreadCreateV2 { .. }
+                | OpRecord::ThreadDelete { .. }
+                | OpRecord::ThreadUpdate { .. }
+                | OpRecord::Fork { .. }
+                | OpRecord::Collapse { .. }
+                | OpRecord::MarkerDelete { .. }
+                | OpRecord::TransactionAbort { .. }
+                | OpRecord::EphemeralThreadCollapse { .. }
+                | OpRecord::ConflictResolved { .. }
+                | OpRecord::TransactionCommit { .. }
+                | OpRecord::Redact { .. }
+                | OpRecord::Purge { .. }
+                | OpRecord::FastForward { .. }
+                | OpRecord::FastForwardV2 { .. }
+                | OpRecord::GitCheckpoint { .. }
+                | OpRecord::RemoteThreadUpdate { .. }
+                | OpRecord::RemoteThreadDelete { .. }
+                | OpRecord::UndoRecoveryUpdate { .. } => {}
             }
         }
     }
@@ -320,7 +344,30 @@ fn find_recent_turn_ts(repo: &Repository) -> Result<Option<DateTime<Utc>>> {
                 | OpRecord::Checkpoint {
                     state: new_state, ..
                 } => *new_state,
-                _ => continue,
+                // Only capture-style records carry a turn-boundary intent.
+                // Enumerated explicitly (no wildcard) so a future
+                // intent-carrying variant is considered here (heddle#354 r9).
+                OpRecord::Goto { .. }
+                | OpRecord::ThreadCreate { .. }
+                | OpRecord::ThreadCreateV2 { .. }
+                | OpRecord::ThreadDelete { .. }
+                | OpRecord::ThreadUpdate { .. }
+                | OpRecord::Fork { .. }
+                | OpRecord::Collapse { .. }
+                | OpRecord::MarkerCreate { .. }
+                | OpRecord::MarkerDelete { .. }
+                | OpRecord::TransactionAbort { .. }
+                | OpRecord::EphemeralThreadCollapse { .. }
+                | OpRecord::ConflictResolved { .. }
+                | OpRecord::TransactionCommit { .. }
+                | OpRecord::Redact { .. }
+                | OpRecord::Purge { .. }
+                | OpRecord::FastForward { .. }
+                | OpRecord::FastForwardV2 { .. }
+                | OpRecord::GitCheckpoint { .. }
+                | OpRecord::RemoteThreadUpdate { .. }
+                | OpRecord::RemoteThreadDelete { .. }
+                | OpRecord::UndoRecoveryUpdate { .. } => continue,
             };
             if let Some(state) = repo.store().get_state(&new_state)?
                 && let Some(intent) = state.intent.as_deref()

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -633,7 +633,29 @@ fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::MarkerDelete { state, .. } => vec![*state],
         OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
         OpRecord::FastForwardV2 { pre_target_id, .. } => vec![*pre_target_id],
-        _ => Vec::new(),
+        // No prior state to load: the inverse is a no-op, touches only
+        // sidecars / Git OIDs, or is irreversible. Enumerated explicitly (no
+        // wildcard) so a new state-carrying variant must declare what its undo
+        // needs to load, instead of silently skipping the reachability check
+        // (heddle#354 r9).
+        OpRecord::Snapshot { prev_head: None, .. }
+        | OpRecord::Goto { prev_head: None, .. }
+        | OpRecord::ThreadCreate { .. }
+        | OpRecord::ThreadCreateV2 { .. }
+        | OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::MarkerCreate { .. }
+        | OpRecord::Checkpoint { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::GitCheckpoint { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
     }
 }
 
@@ -690,7 +712,28 @@ fn states_required_for_redo(op: &OpRecord) -> Vec<ChangeId> {
         OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
         OpRecord::MarkerCreate { state, .. } => vec![*state],
         OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
-        _ => Vec::new(),
+        // No post-state to load at redo time: the redo is a no-op, deletes a
+        // ref, touches only sidecars / Git OIDs, or (legacy V1 `FastForward`)
+        // re-resolves `source_thread → tip` through its own error path.
+        // Enumerated explicitly (no wildcard) so a new state-carrying variant
+        // must declare its redo target instead of silently skipping the
+        // reachability check (heddle#354 r9).
+        OpRecord::ThreadDelete { .. }
+        | OpRecord::MarkerDelete { .. }
+        | OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::Checkpoint { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::FastForward { .. }
+        | OpRecord::GitCheckpoint { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
     }
 }
 
@@ -742,7 +785,31 @@ fn ensure_redaction_undo_safe(
                     state: *state,
                     path: path.clone(),
                 }),
-                _ => {}
+                // This preflight only concerns redaction bookkeeping; every
+                // other record is irrelevant to undo safety. Enumerated
+                // explicitly (no wildcard) so a future redaction-adjacent
+                // variant must be classified here (heddle#354 r9).
+                OpRecord::Snapshot { .. }
+                | OpRecord::Goto { .. }
+                | OpRecord::ThreadCreate { .. }
+                | OpRecord::ThreadCreateV2 { .. }
+                | OpRecord::ThreadDelete { .. }
+                | OpRecord::ThreadUpdate { .. }
+                | OpRecord::Fork { .. }
+                | OpRecord::Collapse { .. }
+                | OpRecord::MarkerCreate { .. }
+                | OpRecord::MarkerDelete { .. }
+                | OpRecord::Checkpoint { .. }
+                | OpRecord::TransactionAbort { .. }
+                | OpRecord::EphemeralThreadCollapse { .. }
+                | OpRecord::ConflictResolved { .. }
+                | OpRecord::TransactionCommit { .. }
+                | OpRecord::FastForward { .. }
+                | OpRecord::FastForwardV2 { .. }
+                | OpRecord::GitCheckpoint { .. }
+                | OpRecord::RemoteThreadUpdate { .. }
+                | OpRecord::RemoteThreadDelete { .. }
+                | OpRecord::UndoRecoveryUpdate { .. } => {}
             }
         }
     }
@@ -843,7 +910,31 @@ fn ensure_redaction_redo_supported(batches: &[OpBatch]) -> Result<()> {
             match &entry.operation {
                 OpRecord::Redact { .. } => blocking.push((entry.id, "Redact")),
                 OpRecord::Purge { .. } => blocking.push((entry.id, "Purge")),
-                _ => {}
+                // Only Redact/Purge lack a faithful redo path; every other
+                // record redoes normally. Enumerated explicitly (no wildcard)
+                // so a future variant without a redo path must be classified
+                // here (heddle#354 r9).
+                OpRecord::Snapshot { .. }
+                | OpRecord::Goto { .. }
+                | OpRecord::ThreadCreate { .. }
+                | OpRecord::ThreadCreateV2 { .. }
+                | OpRecord::ThreadDelete { .. }
+                | OpRecord::ThreadUpdate { .. }
+                | OpRecord::Fork { .. }
+                | OpRecord::Collapse { .. }
+                | OpRecord::MarkerCreate { .. }
+                | OpRecord::MarkerDelete { .. }
+                | OpRecord::Checkpoint { .. }
+                | OpRecord::TransactionAbort { .. }
+                | OpRecord::EphemeralThreadCollapse { .. }
+                | OpRecord::ConflictResolved { .. }
+                | OpRecord::TransactionCommit { .. }
+                | OpRecord::FastForward { .. }
+                | OpRecord::FastForwardV2 { .. }
+                | OpRecord::GitCheckpoint { .. }
+                | OpRecord::RemoteThreadUpdate { .. }
+                | OpRecord::RemoteThreadDelete { .. }
+                | OpRecord::UndoRecoveryUpdate { .. } => {}
             }
         }
     }
@@ -899,7 +990,31 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
             // same worktree-orphan hazard on undo.
             let name = match &entry.operation {
                 OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => name,
-                _ => continue,
+                // Only thread creates carry the worktree-orphan hazard on undo;
+                // every other record is irrelevant to this preflight.
+                // Enumerated explicitly (no wildcard) so a future
+                // worktree-creating variant must be classified (heddle#354 r9).
+                OpRecord::Snapshot { .. }
+                | OpRecord::Goto { .. }
+                | OpRecord::ThreadDelete { .. }
+                | OpRecord::ThreadUpdate { .. }
+                | OpRecord::Fork { .. }
+                | OpRecord::Collapse { .. }
+                | OpRecord::MarkerCreate { .. }
+                | OpRecord::MarkerDelete { .. }
+                | OpRecord::Checkpoint { .. }
+                | OpRecord::TransactionAbort { .. }
+                | OpRecord::EphemeralThreadCollapse { .. }
+                | OpRecord::ConflictResolved { .. }
+                | OpRecord::TransactionCommit { .. }
+                | OpRecord::Redact { .. }
+                | OpRecord::Purge { .. }
+                | OpRecord::FastForward { .. }
+                | OpRecord::FastForwardV2 { .. }
+                | OpRecord::GitCheckpoint { .. }
+                | OpRecord::RemoteThreadUpdate { .. }
+                | OpRecord::RemoteThreadDelete { .. }
+                | OpRecord::UndoRecoveryUpdate { .. } => continue,
             };
             let Some(record) = manager.find_by_thread(name)? else {
                 continue;

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -249,7 +249,33 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         } => {
             apply_git_checkpoint_undo(repo, branch, previous_git_oid.as_deref(), new_git_oid)?;
         }
-        _ => {}
+        // No undo inverse: these records don't move a ref the undo chain
+        // restores, or their reversal is irreversible / handled outside the
+        // oplog replay. Enumerated explicitly (no wildcard) so a new
+        // `OpRecord` variant is a COMPILE error here until its undo behavior
+        // is decided (heddle#354 r9):
+        //   - Fork / Collapse: structural ops; HEAD/thread restoration is
+        //     driven by the surrounding records in the same batch.
+        //   - Checkpoint: addressable save, goto-reachable; nothing to invert.
+        //   - TransactionAbort / TransactionCommit / ConflictResolved: forensic
+        //     / audit records, no ref to restore.
+        //   - EphemeralThreadCollapse: TTL retirement of a thread pointer; the
+        //     states stay addressable and the pointer is not resurrected here.
+        //   - Purge: irreversible by design (bytes physically removed) — the
+        //     undo preflight (`ensure_redaction_undo_safe`) refuses earlier.
+        //   - RemoteThreadUpdate / RemoteThreadDelete / UndoRecoveryUpdate:
+        //     reconcile-class bookkeeping refs, outside the user undo chain.
+        OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::Checkpoint { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => {}
     }
 
     Ok(())
@@ -400,7 +426,33 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             })?;
             apply_ff_redo(repo, source_thread, target_thread, &source_tip)?;
         }
-        _ => {}
+        // No redo replay: these records don't re-advance a ref redo touches, or
+        // they are refused upstream. Enumerated explicitly (no wildcard) so a
+        // new `OpRecord` variant is a COMPILE error here until its redo
+        // behavior is decided (heddle#354 r9):
+        //   - Fork / Collapse: structural ops; redo is driven by the
+        //     surrounding records in the same batch.
+        //   - Checkpoint: addressable save, goto-reachable; nothing to replay.
+        //   - Redact: redo is refused upstream by `ensure_redaction_redo_supported`
+        //     (the OpRecord doesn't carry the full Redaction needed to recreate
+        //     it); reaching here is a no-op.
+        //   - Purge: irreversible by design; also refused upstream.
+        //   - TransactionAbort / TransactionCommit / ConflictResolved /
+        //     EphemeralThreadCollapse: forensic / TTL records, no ref to replay.
+        //   - RemoteThreadUpdate / RemoteThreadDelete / UndoRecoveryUpdate:
+        //     reconcile-class bookkeeping refs, outside the user redo chain.
+        OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::Checkpoint { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => {}
     }
 
     Ok(())

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -73,22 +73,21 @@ const INTENT_DISPLAY_WIDTH: usize = 50;
 /// concern (use `heddle log` for full history).
 const MAX_TAIL_WINDOW: usize = 100_000;
 
-/// Entry kinds the user can pass to `--filter`. Names match the
-/// `kind` field emitted in JSON mode so a `--filter snapshot` pipes
-/// cleanly into `--output json` for downstream tooling.
-const FILTER_KINDS: &[&str] = &[
-    "snapshot",
-    "goto",
-    "thread_create",
-    "thread_delete",
-    "thread_update",
-    "fork",
-    "collapse",
-    "marker_create",
-    "marker_delete",
-    "merge", // alias for thread_update on a merge target — see kind_for
-    "fast_forward",
-];
+/// Entry kinds the user can pass to `--filter`. Names match the `kind` field
+/// emitted in JSON mode (which is `OpRecord::verb()`) so a `--filter snapshot`
+/// pipes cleanly into `--output json` for downstream tooling.
+///
+/// Derived from the oplog verb catalog (the single source of truth) plus the
+/// `merge` UX alias — never a hand-maintained list, so every emitted kind
+/// (including any future `OpRecord` variant) is a valid filter the moment it
+/// joins the catalog, instead of being rejected as "unknown" (heddle#354 r9,
+/// cid 3330304668). `merge` is the only entry that is not a literal verb: it
+/// aliases `thread_update` on a merge target (see [`Renderer::passes_filter`]).
+fn valid_filter_kinds() -> Vec<&'static str> {
+    let mut kinds = OpRecord::verbs(true);
+    kinds.push("merge");
+    kinds
+}
 
 /// Top-level entry point. Threading-wise:
 ///
@@ -206,13 +205,14 @@ fn parse_filter(spec: Option<&str>) -> Result<Option<Vec<String>>> {
     if kinds.is_empty() {
         return Ok(None);
     }
+    let valid = valid_filter_kinds();
     for kind in &kinds {
-        if !FILTER_KINDS.contains(&kind.as_str()) {
+        if !valid.contains(&kind.as_str()) {
             return Err(anyhow!(RecoveryAdvice::invalid_usage(
                 "watch_filter_invalid",
                 format!(
                     "unknown event kind in --filter: {kind:?} (valid: {})",
-                    FILTER_KINDS.join(", ")
+                    valid.join(", ")
                 ),
                 "Use one of the valid watch event kinds, or omit `--filter`.",
                 "heddle watch --filter snapshot",
@@ -439,33 +439,12 @@ fn state_lookup(
     (state.intent.clone(), state.confidence, actor)
 }
 
-/// Resolve an `OpRecord` to the user-facing kind label. The labels
-/// match `--filter` keywords and the JSON `kind` field; keep them in
-/// sync with `FILTER_KINDS`.
+/// Resolve an `OpRecord` to the user-facing kind label — the snake-case
+/// `OpRecord::verb()` from the oplog catalog, which is also the JSON `kind`
+/// field and the `--filter` keyword. Single source of truth: a new variant
+/// gets its label from the catalog automatically (heddle#354 r9).
 fn kind_for(op: &OpRecord) -> String {
-    match op {
-        OpRecord::Snapshot { .. } => "snapshot".into(),
-        OpRecord::Goto { .. } => "goto".into(),
-        OpRecord::ThreadCreate { .. } | OpRecord::ThreadCreateV2 { .. } => "thread_create".into(),
-        OpRecord::ThreadDelete { .. } => "thread_delete".into(),
-        OpRecord::ThreadUpdate { .. } => "thread_update".into(),
-        OpRecord::Fork { .. } => "fork".into(),
-        OpRecord::Collapse { .. } => "collapse".into(),
-        OpRecord::MarkerCreate { .. } => "marker_create".into(),
-        OpRecord::MarkerDelete { .. } => "marker_delete".into(),
-        OpRecord::Checkpoint { .. } => "checkpoint".into(),
-        OpRecord::TransactionAbort { .. } => "transaction_abort".into(),
-        OpRecord::TransactionCommit { .. } => "transaction_commit".into(),
-        OpRecord::EphemeralThreadCollapse { .. } => "ephemeral_thread_collapse".into(),
-        OpRecord::ConflictResolved { .. } => "conflict_resolved".into(),
-        OpRecord::Redact { .. } => "redact".into(),
-        OpRecord::Purge { .. } => "purge".into(),
-        OpRecord::FastForward { .. } | OpRecord::FastForwardV2 { .. } => "fast_forward".into(),
-        OpRecord::GitCheckpoint { .. } => "git_checkpoint".into(),
-        OpRecord::RemoteThreadUpdate { .. } => "remote_thread_update".into(),
-        OpRecord::RemoteThreadDelete { .. } => "remote_thread_delete".into(),
-        OpRecord::UndoRecoveryUpdate { .. } => "undo_recovery_update".into(),
-    }
+    op.verb().to_string()
 }
 
 /// Best-effort thread/lane identifier for the columnar layout. Falls
@@ -795,6 +774,28 @@ mod tests {
         let parsed = parse_filter(Some("snapshot,merge")).unwrap().unwrap();
         assert_eq!(parsed, vec!["snapshot", "merge"]);
         assert!(parse_filter(Some("not_a_real_kind")).is_err());
+    }
+
+    #[test]
+    fn filter_accepts_newer_emitted_kinds() {
+        // Non-vacuous for cid 3330304668: these kinds are emitted by
+        // `OpRecord::verb()` but were absent from the old hand-maintained
+        // FILTER_KINDS list, so `--filter remote_thread_update` was wrongly
+        // rejected as "unknown". The derived list now accepts every real kind.
+        for kind in [
+            "remote_thread_update",
+            "remote_thread_delete",
+            "transaction_commit",
+            "redact",
+            "purge",
+            "git_checkpoint",
+            "undo_recovery_update",
+        ] {
+            assert!(
+                parse_filter(Some(kind)).is_ok(),
+                "filter kind {kind:?} must be accepted (it is a real emitted kind)"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -462,6 +462,9 @@ fn kind_for(op: &OpRecord) -> String {
         OpRecord::Purge { .. } => "purge".into(),
         OpRecord::FastForward { .. } | OpRecord::FastForwardV2 { .. } => "fast_forward".into(),
         OpRecord::GitCheckpoint { .. } => "git_checkpoint".into(),
+        OpRecord::RemoteThreadUpdate { .. } => "remote_thread_update".into(),
+        OpRecord::RemoteThreadDelete { .. } => "remote_thread_delete".into(),
+        OpRecord::UndoRecoveryUpdate { .. } => "undo_recovery_update".into(),
     }
 }
 
@@ -483,6 +486,8 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         OpRecord::FastForward { target_thread, .. }
         | OpRecord::FastForwardV2 { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
+        OpRecord::RemoteThreadUpdate { thread, .. }
+        | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -490,6 +495,7 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Redact { .. }
+        | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::Purge { .. } => None,
     }
 }
@@ -514,6 +520,9 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::GitCheckpoint { state, .. } => Some(*state),
         OpRecord::EphemeralThreadCollapse { final_state, .. } => Some(*final_state),
         OpRecord::Redact { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. }
+        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
@@ -975,10 +984,13 @@ mod tests {
             OpRecord::Fork {
                 from: cid,
                 new_state: cid,
+                thread: None,
+                head: None,
             },
             OpRecord::Collapse {
                 sources: vec![cid],
                 result: cid,
+                thread: None,
             },
             OpRecord::MarkerCreate {
                 name: "m".into(),

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1130,8 +1130,30 @@ fn op_targets_merge_state(op: &OpRecord, merge_state: &str) -> bool {
         OpRecord::FastForwardV2 { post_target_id, .. } => {
             change_id_matches_display(post_target_id, merge_state)
         }
-        OpRecord::FastForward { .. } => false,
-        _ => false,
+        // These records don't advance HEAD/thread to a merge target the ship
+        // flow tracks (legacy V1 `FastForward` re-resolves at apply time and
+        // carries no post-target id). Enumerated explicitly (no wildcard) so a
+        // new state-advancing variant must be considered as a possible merge
+        // target here (heddle#354 r9).
+        OpRecord::FastForward { .. }
+        | OpRecord::ThreadCreate { .. }
+        | OpRecord::ThreadCreateV2 { .. }
+        | OpRecord::ThreadDelete { .. }
+        | OpRecord::ThreadUpdate { .. }
+        | OpRecord::Fork { .. }
+        | OpRecord::Collapse { .. }
+        | OpRecord::MarkerCreate { .. }
+        | OpRecord::MarkerDelete { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::EphemeralThreadCollapse { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. }
+        | OpRecord::GitCheckpoint { .. }
+        | OpRecord::RemoteThreadUpdate { .. }
+        | OpRecord::RemoteThreadDelete { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => false,
     }
 }
 

--- a/crates/daemon/src/grpc_local_impl/operation_log_query.rs
+++ b/crates/daemon/src/grpc_local_impl/operation_log_query.rs
@@ -43,25 +43,6 @@ fn parse_unix_secs(secs: i64) -> Option<chrono::DateTime<chrono::Utc>> {
     chrono::Utc.timestamp_opt(secs, 0).single()
 }
 
-/// Default verbs included when `include_checkpoints` is `false` and the
-/// caller didn't supply an explicit verb filter. Mirrors the snake-case
-/// names used by the index, which in turn mirror the `OpRecord` variants
-/// minus `Checkpoint`.
-const DEFAULT_NON_CHECKPOINT_VERBS: &[&str] = &[
-    "snapshot",
-    "goto",
-    "thread_create",
-    "thread_delete",
-    "thread_update",
-    "fork",
-    "collapse",
-    "marker_create",
-    "marker_delete",
-    "transaction_abort",
-    "ephemeral_thread_collapse",
-    "conflict_resolved",
-];
-
 /// Query is an operator-facing inspection command, so it should answer from
 /// the live oplog even before the rebuildable index sidecar has been warmed.
 /// Keep the scan bounded; long-tail history can use the index once populated.
@@ -79,12 +60,11 @@ fn build_query(req: &QueryOperationsRequest) -> OperationLogQuery {
         limit: (req.limit > 0).then_some(req.limit as usize),
     };
     if !req.include_checkpoints && q.verbs.is_none() {
-        q.verbs = Some(
-            DEFAULT_NON_CHECKPOINT_VERBS
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect(),
-        );
+        // Derived from the oplog verb catalog (the single source of truth), not
+        // a hand-maintained list — so a new `OpRecord` variant is surfaced by
+        // default the moment it joins the catalog, instead of being silently
+        // dropped from the default query (heddle#354 r9, cid 3330304663).
+        q.verbs = Some(OpRecord::verbs(false).iter().map(|s| s.to_string()).collect());
     }
     q
 }
@@ -151,11 +131,10 @@ fn query_oplog_fallback(
 }
 
 fn indexed_from_oplog_entry(entry: &OpEntry) -> IndexedOperation {
-    let verb = verb_for(&entry.operation);
     IndexedOperation {
         seq: entry.id,
         timestamp_secs: entry.timestamp.timestamp(),
-        verb: verb.to_string(),
+        verb: entry.operation.verb().to_string(),
         actor_email: entry.actor.email.clone(),
         operation_id: entry.operation_id,
         thread: thread_for(&entry.operation),
@@ -203,32 +182,6 @@ fn indexed_operation_matches(hit: &IndexedOperation, query: &OperationLogQuery) 
         return false;
     }
     true
-}
-
-fn verb_for(op: &OpRecord) -> &'static str {
-    match op {
-        OpRecord::Snapshot { .. } => "snapshot",
-        OpRecord::Goto { .. } => "goto",
-        OpRecord::ThreadCreate { .. } | OpRecord::ThreadCreateV2 { .. } => "thread_create",
-        OpRecord::ThreadDelete { .. } => "thread_delete",
-        OpRecord::ThreadUpdate { .. } => "thread_update",
-        OpRecord::Fork { .. } => "fork",
-        OpRecord::Collapse { .. } => "collapse",
-        OpRecord::MarkerCreate { .. } => "marker_create",
-        OpRecord::MarkerDelete { .. } => "marker_delete",
-        OpRecord::Checkpoint { .. } => "checkpoint",
-        OpRecord::TransactionAbort { .. } => "transaction_abort",
-        OpRecord::TransactionCommit { .. } => "transaction_commit",
-        OpRecord::EphemeralThreadCollapse { .. } => "ephemeral_thread_collapse",
-        OpRecord::ConflictResolved { .. } => "conflict_resolved",
-        OpRecord::Redact { .. } => "redact",
-        OpRecord::Purge { .. } => "purge",
-        OpRecord::FastForward { .. } | OpRecord::FastForwardV2 { .. } => "fast_forward",
-        OpRecord::GitCheckpoint { .. } => "git_checkpoint",
-        OpRecord::RemoteThreadUpdate { .. } => "remote_thread_update",
-        OpRecord::RemoteThreadDelete { .. } => "remote_thread_delete",
-        OpRecord::UndoRecoveryUpdate { .. } => "undo_recovery_update",
-    }
 }
 
 fn thread_for(op: &OpRecord) -> Option<String> {
@@ -424,6 +377,35 @@ mod tests {
             .into_inner();
         assert_eq!(resp.hits.len(), 1);
         assert_eq!(resp.hits[0].verb, "snapshot");
+    }
+
+    #[tokio::test]
+    async fn default_query_includes_newer_non_checkpoint_verbs() {
+        // Non-vacuous for cid 3330304663: `transaction_commit` was missing from
+        // the old hand-maintained default list, so it was silently dropped from
+        // the default (non-checkpoint) view. Now the default is derived from the
+        // oplog catalog, so it surfaces.
+        let (_t, svc) = fresh_service();
+        write_oplog_record(
+            &svc,
+            OpRecord::TransactionCommit {
+                transaction_id: "tx-1".into(),
+                op_count: 3,
+            },
+        );
+
+        let req = QueryOperationsRequest {
+            include_checkpoints: false,
+            ..Default::default()
+        };
+        let resp = svc
+            .query_operations(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.hits.len(), 1, "newer non-checkpoint verb must not be dropped");
+        assert_eq!(resp.hits[0].verb, "transaction_commit");
     }
 
     #[tokio::test]

--- a/crates/daemon/src/grpc_local_impl/operation_log_query.rs
+++ b/crates/daemon/src/grpc_local_impl/operation_log_query.rs
@@ -225,6 +225,9 @@ fn verb_for(op: &OpRecord) -> &'static str {
         OpRecord::Purge { .. } => "purge",
         OpRecord::FastForward { .. } | OpRecord::FastForwardV2 { .. } => "fast_forward",
         OpRecord::GitCheckpoint { .. } => "git_checkpoint",
+        OpRecord::RemoteThreadUpdate { .. } => "remote_thread_update",
+        OpRecord::RemoteThreadDelete { .. } => "remote_thread_delete",
+        OpRecord::UndoRecoveryUpdate { .. } => "undo_recovery_update",
     }
 }
 
@@ -243,6 +246,8 @@ fn thread_for(op: &OpRecord) -> Option<String> {
         OpRecord::FastForward { target_thread, .. }
         | OpRecord::FastForwardV2 { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
+        OpRecord::RemoteThreadUpdate { thread, .. }
+        | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -250,6 +255,7 @@ fn thread_for(op: &OpRecord) -> Option<String> {
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Redact { .. }
+        | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::Purge { .. } => None,
     }
 }
@@ -271,6 +277,9 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::GitCheckpoint { state, .. } => Some(*state),
         OpRecord::EphemeralThreadCollapse { final_state, .. } => Some(*final_state),
         OpRecord::Redact { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. }
+        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }

--- a/crates/devtools/src/check_oprecord_exhaustiveness.rs
+++ b/crates/devtools/src/check_oprecord_exhaustiveness.rs
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Workspace-wide AST asserter for the **non-exhaustive `OpRecord` consumer**
+//! bug class (heddle#354 r9).
+//!
+//! ## The bug class
+//!
+//! Every consumer that `match`es over the `OpRecord` variant set (or a future
+//! emitted-kind enum like `OpKind`) must handle new variants **exhaustively**.
+//! A bare `_ => …` wildcard arm silently swallows any variant added later —
+//! the reconciler folds it as a no-op, undo/redo skips it, the op-log query
+//! drops it from the default view. Each round of review kept finding the *next*
+//! consumer that missed the *previous* round's new variant (a drip). The fix is
+//! structural: no production `match` over `OpRecord`/`OpKind` may use a
+//! catch-all arm, so `rustc`'s own exhaustiveness check fails the build the
+//! moment a variant is added until every consumer is updated.
+//!
+//! Predicates that genuinely want a default (`matches!(op, OpRecord::X { .. })`,
+//! `op.verb()`) are fine: `matches!` expands to a macro (not an `ExprMatch` in
+//! the source AST) and `verb()`/`is_checkpoint_verb()` are exhaustive matches in
+//! the oplog catalog. Only a literal `match` expression with an unguarded
+//! catch-all arm over a target enum is a hit.
+//!
+//! ## Why an AST asserter (vs. trusting rustc alone)
+//!
+//! `rustc` exhaustiveness only bites a match that has *no* wildcard. A single
+//! `_ => {}` re-opens the whole class and compiles cleanly forever. This gate
+//! fails CI if any production consumer reintroduces a wildcard over a target
+//! enum, so the rustc teeth can never be filed off. A planted wildcard (see the
+//! tests) proves the analyzer is non-vacuous.
+//!
+//! The env-var contract mirrors the sibling asserters:
+//! `HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS` (colon-separated, default
+//! `crates`) and `HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST` (semicolon-separated
+//! `path:line`; empty disables, unset uses the built-in default — currently
+//! empty, because there are no legitimate exceptions).
+
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use syn::{
+    Attribute, ExprMatch, ImplItemFn, ItemFn, ItemMod, Meta, Pat, spanned::Spanned, visit::Visit,
+};
+use walkdir::WalkDir;
+
+const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+
+/// Enums whose `match` consumers must be exhaustive. `OpKind` is listed
+/// proactively so a future emitted-kind enum is covered the day it lands.
+const TARGET_ENUMS: &[&str] = &["OpRecord", "OpKind"];
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(arg) = args.first() {
+        bail!(
+            "check-oprecord-exhaustiveness: unexpected argument '{arg}' (configured via env vars: \
+HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS, HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST)"
+        );
+    }
+
+    check(&read_search_dirs(), &read_allowlist())
+}
+
+/// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
+/// findings, and `bail!` if any non-allowlisted wildcard arm over a target enum
+/// remains. `run()` is the thin env-reading wrapper around this.
+fn check(search_dirs: &[PathBuf], allowlist: &[String]) -> Result<()> {
+    let mut hits: Vec<Hit> = Vec::new();
+    let mut files_scanned = 0usize;
+    for dir in search_dirs {
+        scan_dir(dir, &mut hits, &mut files_scanned)
+            .with_context(|| format!("scan {}", dir.display()))?;
+    }
+
+    let mut failed = 0usize;
+    for hit in &hits {
+        let key = format!("{}:{}", hit.path.display(), hit.line);
+        if allowlist.iter().any(|entry| entry == &key) {
+            println!("ok: exempt: {key} — {}", hit.snippet.trim());
+            continue;
+        }
+        eprintln!(
+            "::error::non-exhaustive {} match at {key}: a wildcard arm (`{}`) silently swallows \
+unhandled variants — {}",
+            hit.enum_name,
+            hit.arm,
+            hit.snippet.trim()
+        );
+        failed += 1;
+    }
+
+    if failed > 0 {
+        eprintln!(
+            "\n::error::Found {failed} non-exhaustive match(es) over a target enum ({}). A \
+production `match` over these enums must name every variant (group no-op variants in an explicit \
+`A | B | C => {{}}` arm), so adding a variant is a COMPILE error until every consumer is updated — \
+that is what closes the \"new variant not propagated to every consumer\" class. Replace the \
+catch-all `_ =>` arm with explicit per-variant arms.\n\
+\n\
+If a site is a legitimate exception, add a `path:line` entry (of the wildcard arm) to \
+HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST with a one-line justification.",
+            TARGET_ENUMS.join("/")
+        );
+        bail!("asserter failed");
+    }
+
+    println!(
+        "asserter clean: every production match over {} is exhaustive ({files_scanned} file(s) \
+scanned)",
+        TARGET_ENUMS.join("/")
+    );
+    Ok(())
+}
+
+fn read_search_dirs() -> Vec<PathBuf> {
+    match env::var("HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS") {
+        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
+        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
+    }
+}
+
+fn read_allowlist() -> Vec<String> {
+    match env::var("HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST") {
+        Ok(value) if value.is_empty() => Vec::new(),
+        Ok(value) => value.split(';').map(str::to_string).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Debug)]
+struct Hit {
+    path: PathBuf,
+    line: usize,
+    enum_name: String,
+    arm: String,
+    snippet: String,
+}
+
+fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in WalkDir::new(dir).follow_links(false) {
+        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("rs") {
+            continue;
+        }
+        if is_test_path(path) {
+            continue;
+        }
+        let source =
+            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        *files_scanned += 1;
+        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+        let lines: Vec<&str> = source.lines().collect();
+        let mut visitor = Finder {
+            path: path.to_path_buf(),
+            lines: &lines,
+            hits,
+        };
+        visitor.visit_file(&file);
+    }
+    Ok(())
+}
+
+/// Skip test code: tests legitimately plant wildcard arms (this asserter's own
+/// tests do). Mirrors the sibling asserter — a `tests/` path segment, a
+/// `*_tests.rs` / `tests.rs` file, and inline `#[cfg(test)]` items (handled in
+/// the visitor).
+fn is_test_path(path: &Path) -> bool {
+    for component in path.components() {
+        if component.as_os_str() == "tests" {
+            return true;
+        }
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .map(|name| name.ends_with("_tests.rs") || name == "tests.rs")
+        .unwrap_or(false)
+}
+
+/// True iff the item carries a `#[cfg(test)]` attribute (directly, or nested in
+/// an `all(...)` / `any(...)` predicate).
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    fn meta_mentions_test(meta: &Meta) -> bool {
+        match meta {
+            Meta::Path(path) => path.is_ident("test"),
+            Meta::List(list) if list.path.is_ident("cfg") => {
+                list.tokens.to_string().contains("test")
+            }
+            Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
+                list.tokens.to_string().contains("test")
+            }
+            _ => false,
+        }
+    }
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta))
+}
+
+struct Finder<'a> {
+    path: PathBuf,
+    lines: &'a [&'a str],
+    hits: &'a mut Vec<Hit>,
+}
+
+impl<'ast> Visit<'ast> for Finder<'_> {
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_expr_match(&mut self, node: &'ast ExprMatch) {
+        if let Some(enum_name) = matched_target_enum(node) {
+            for arm in &node.arms {
+                // A guarded arm (`_ if cond =>`) does not make the match
+                // exhaustive on its own, so it is not a silent-swallow: other
+                // arms must still cover the variants. Only an UNGUARDED
+                // catch-all swallows unhandled variants.
+                if arm.guard.is_none() && pat_is_catch_all(&arm.pat) {
+                    let line = arm.pat.span().start().line;
+                    let snippet = self
+                        .lines
+                        .get(line.saturating_sub(1))
+                        .copied()
+                        .unwrap_or("")
+                        .to_string();
+                    self.hits.push(Hit {
+                        path: self.path.clone(),
+                        line,
+                        enum_name: enum_name.clone(),
+                        arm: pat_text(&arm.pat),
+                        snippet,
+                    });
+                }
+            }
+        }
+        // Recurse so nested matches (and matches inside the arms) are checked.
+        syn::visit::visit_expr_match(self, node);
+    }
+}
+
+/// If any arm pattern names a `TARGET_ENUMS` variant, the match is "over" that
+/// enum — return its name. Catches `OpRecord::Snapshot { .. }`,
+/// `OpRecord::Fork(..)`, and or-patterns / refs / parens thereof.
+fn matched_target_enum(node: &ExprMatch) -> Option<String> {
+    node.arms
+        .iter()
+        .find_map(|arm| pat_target_enum(&arm.pat))
+}
+
+fn pat_target_enum(pat: &Pat) -> Option<String> {
+    let path = match pat {
+        Pat::Path(p) => Some(&p.path),
+        Pat::TupleStruct(ts) => Some(&ts.path),
+        Pat::Struct(s) => Some(&s.path),
+        Pat::Or(or) => return or.cases.iter().find_map(pat_target_enum),
+        Pat::Paren(p) => return pat_target_enum(&p.pat),
+        Pat::Reference(r) => return pat_target_enum(&r.pat),
+        _ => None,
+    }?;
+    let first = path.segments.first()?.ident.to_string();
+    TARGET_ENUMS
+        .iter()
+        .find(|name| **name == first)
+        .map(|name| (*name).to_string())
+}
+
+/// True iff this arm pattern catches every remaining value: a `_` wildcard or a
+/// bare lowercase binding (`other => …`), including inside or-patterns / parens
+/// / references. An uppercase bare ident is treated as a (unit) variant/const,
+/// not a catch-all, so we do not misclassify it.
+fn pat_is_catch_all(pat: &Pat) -> bool {
+    match pat {
+        Pat::Wild(_) => true,
+        Pat::Ident(p) => p.subpat.is_none() && is_binding_ident(&p.ident.to_string()),
+        Pat::Or(or) => or.cases.iter().any(pat_is_catch_all),
+        Pat::Paren(p) => pat_is_catch_all(&p.pat),
+        Pat::Reference(r) => pat_is_catch_all(&r.pat),
+        _ => false,
+    }
+}
+
+/// A binding identifier (catch-all) starts with `_` or a lowercase letter;
+/// variants/consts conventionally start uppercase.
+fn is_binding_ident(ident: &str) -> bool {
+    ident
+        .chars()
+        .next()
+        .is_some_and(|c| c == '_' || c.is_lowercase())
+}
+
+/// A short human description of the catch-all arm for the error message.
+/// Deliberately avoids a token-stream pretty-printer (no `quote` dependency);
+/// the snippet line carries the full context.
+fn pat_text(pat: &Pat) -> String {
+    match pat {
+        Pat::Wild(_) => "_".to_string(),
+        Pat::Ident(p) => p.ident.to_string(),
+        Pat::Or(or) => or
+            .cases
+            .iter()
+            .map(pat_text)
+            .collect::<Vec<_>>()
+            .join(" | "),
+        Pat::Paren(p) => pat_text(&p.pat),
+        Pat::Reference(r) => format!("&{}", pat_text(&r.pat)),
+        _ => "<catch-all>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn scan_source(src: &str) -> Vec<Hit> {
+        let file = syn::parse_file(src).expect("parse");
+        let lines: Vec<&str> = src.lines().collect();
+        let mut hits = Vec::new();
+        let mut v = Finder {
+            path: PathBuf::from("test.rs"),
+            lines: &lines,
+            hits: &mut hits,
+        };
+        v.visit_file(&file);
+        hits
+    }
+
+    #[test]
+    fn flags_wildcard_arm_over_oprecord() {
+        let hits = scan_source(
+            "fn f(op: &OpRecord) { match op { \
+                OpRecord::Snapshot { .. } => a(), \
+                _ => {} \
+            } }",
+        );
+        assert_eq!(hits.len(), 1, "wildcard over OpRecord must be flagged");
+        assert_eq!(hits[0].enum_name, "OpRecord");
+    }
+
+    #[test]
+    fn flags_bare_binding_catch_all() {
+        let hits = scan_source(
+            "fn f(op: &OpRecord) -> u8 { match op { \
+                OpRecord::Goto { .. } => 1, \
+                other => g(other), \
+            } }",
+        );
+        assert_eq!(hits.len(), 1, "bare binding catch-all must be flagged");
+    }
+
+    #[test]
+    fn flags_wildcard_inside_or_pattern() {
+        let hits = scan_source(
+            "fn f(op: &OpRecord) { match op { \
+                OpRecord::Snapshot { .. } | _ => {} \
+            } }",
+        );
+        assert_eq!(hits.len(), 1, "wildcard inside an or-pattern must be flagged");
+    }
+
+    #[test]
+    fn flags_o_p_kind_match_too() {
+        let hits = scan_source(
+            "fn f(k: OpKind) { match k { OpKind::Snapshot => a(), _ => {} } }",
+        );
+        assert_eq!(hits.len(), 1, "OpKind is also a target enum");
+        assert_eq!(hits[0].enum_name, "OpKind");
+    }
+
+    #[test]
+    fn ignores_exhaustive_match() {
+        let hits = scan_source(
+            "fn f(op: &OpRecord) { match op { \
+                OpRecord::Snapshot { .. } => a(), \
+                OpRecord::Goto { .. } | OpRecord::Fork { .. } => b(), \
+            } }",
+        );
+        assert!(hits.is_empty(), "an exhaustive match must not be flagged");
+    }
+
+    #[test]
+    fn ignores_guarded_catch_all() {
+        // A guarded arm does not make the match exhaustive by itself; the other
+        // arms still have to cover the variants, so rustc keeps the teeth.
+        let hits = scan_source(
+            "fn f(op: &OpRecord) { match op { \
+                OpRecord::Snapshot { .. } => a(), \
+                _ if cond() => b(), \
+                OpRecord::Goto { .. } => c(), \
+            } }",
+        );
+        assert!(hits.is_empty(), "a guarded catch-all is not a silent swallow");
+    }
+
+    #[test]
+    fn ignores_wildcard_over_non_target_enum() {
+        // A `match` over a string/other enum legitimately uses `_`.
+        let hits = scan_source(
+            "fn f(kind: &str) -> u8 { match kind { \"snapshot\" => 1, _ => 0 } }",
+        );
+        assert!(hits.is_empty(), "non-target matches keep their wildcard");
+    }
+
+    #[test]
+    fn ignores_matches_macro() {
+        // `matches!` expands to a macro, not an `ExprMatch`, so its internal
+        // `_ => false` is invisible to the source AST — the idiomatic predicate
+        // stays allowed.
+        let hits = scan_source(
+            "fn f(op: &OpRecord) -> bool { matches!(op, OpRecord::Snapshot { .. }) }",
+        );
+        assert!(hits.is_empty(), "matches! predicate must not be flagged");
+    }
+
+    #[test]
+    fn ignores_inline_cfg_test_module() {
+        let hits = scan_source(
+            "fn prod() {} \
+             #[cfg(test)] mod tests { \
+                fn t(op: &OpRecord) { match op { OpRecord::Snapshot { .. } => a(), _ => {} } } \
+             }",
+        );
+        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+    }
+
+    const PLANTED: &str = "fn f(op: &OpRecord) { match op { \
+            OpRecord::Snapshot { .. } => a(), \
+            _ => {} \
+        } }";
+
+    #[test]
+    fn check_bails_on_planted_site_and_exempts_via_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bypass.rs"), PLANTED).unwrap();
+        let dirs = vec![dir.path().to_path_buf()];
+
+        // No allowlist → the planted wildcard fails the gate (non-vacuous).
+        assert!(
+            check(&dirs, &[]).is_err(),
+            "a planted wildcard over OpRecord must fail the check"
+        );
+
+        // Allowlisting the wildcard arm's line exempts it (the `_ =>` is line 1).
+        let key = format!("{}:1", dir.path().join("bypass.rs").display());
+        assert!(
+            check(&dirs, &[key]).is_ok(),
+            "an allowlisted site must pass the check"
+        );
+    }
+
+    #[test]
+    fn check_passes_on_clean_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("clean.rs"),
+            "fn f(op: &OpRecord) { match op { \
+                OpRecord::Snapshot { .. } => a(), \
+                OpRecord::Goto { .. } => b(), \
+            } }",
+        )
+        .unwrap();
+        assert!(check(&[dir.path().to_path_buf()], &[]).is_ok());
+    }
+
+    /// Enforcement test: scan the REAL workspace tree with the built-in (empty)
+    /// allowlist and assert clean. This makes the gate fail CI under
+    /// `cargo test --workspace` if a non-exhaustive `OpRecord`/`OpKind` match is
+    /// introduced in production code.
+    #[test]
+    fn production_tree_oprecord_matches_are_exhaustive() {
+        let crates_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("devtools crate dir has a parent (the crates/ dir)")
+            .to_path_buf();
+        let mut hits = Vec::new();
+        let mut scanned = 0usize;
+        scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
+        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            hits.is_empty(),
+            "non-exhaustive OpRecord/OpKind match(es) found: {:?}",
+            hits.iter()
+                .map(|h| format!("{}:{} ({} arm `{}`)", h.path.display(), h.line, h.enum_name, h.arm))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/devtools/src/check_snapshot_atomicity.rs
+++ b/crates/devtools/src/check_snapshot_atomicity.rs
@@ -305,15 +305,67 @@ struct CallCollector {
     /// A snapshot record append (`oplog.record_snapshot(...)` or the free-fn
     /// `record_snapshot_in_oplog(...)` wrapper) is present.
     has_snapshot_record: bool,
+    /// Local bindings that alias a refs handle (`let r = &self.refs;`,
+    /// `let refs = self.inner.repo.refs();`). A publish method invoked on one of
+    /// these names is a publish too — closes the aliased-handle blind spot
+    /// where a bypass routed through a local escaped the analyzer (heddle#354
+    /// r9, cid 3330304661). Over-approximating across sibling scopes is the safe
+    /// direction for an atomicity gate (better to flag than to miss).
+    refs_aliases: std::collections::HashSet<String>,
+}
+
+impl CallCollector {
+    /// True iff `expr` resolves to a refs handle: a `.refs` field, a `.refs()`
+    /// accessor, or a local bound to one of those (tracked in `refs_aliases`).
+    /// Peels `&`/`?`/paren/group/await wrappers so an aliased or borrowed handle
+    /// is seen the same as a direct one.
+    fn expr_is_refs_handle(&self, expr: &Expr) -> bool {
+        let mut cur = expr;
+        loop {
+            match cur {
+                Expr::Field(field) => {
+                    return matches!(&field.member, syn::Member::Named(ident) if ident == "refs");
+                }
+                Expr::MethodCall(mc) => return mc.method == "refs",
+                Expr::Path(p) => {
+                    return p
+                        .path
+                        .get_ident()
+                        .is_some_and(|id| self.refs_aliases.contains(&id.to_string()));
+                }
+                Expr::Reference(r) => cur = &r.expr,
+                Expr::Try(t) => cur = &t.expr,
+                Expr::Paren(p) => cur = &p.expr,
+                Expr::Group(g) => cur = &g.expr,
+                Expr::Await(a) => cur = &a.base,
+                _ => return false,
+            }
+        }
+    }
 }
 
 impl<'ast> Visit<'ast> for CallCollector {
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        // `let <ident> = <refs handle>;` registers `<ident>` as an alias, so a
+        // later `<ident>.set_thread(...)` is recognized as a publish. Handles
+        // alias-of-alias chains (`let b = a;`) because `expr_is_refs_handle`
+        // also accepts a path that is already a known alias.
+        if let Some(init) = &node.init
+            && self.expr_is_refs_handle(&init.expr)
+            && let syn::Pat::Ident(pat_ident) = &node.pat
+            && pat_ident.subpat.is_none()
+        {
+            self.refs_aliases.insert(pat_ident.ident.to_string());
+        }
+        syn::visit::visit_local(self, node);
+    }
+
     fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
         let method = node.method.to_string();
         if method == "record_snapshot" {
             self.has_snapshot_record = true;
         } else if PUBLISH_METHODS.contains(&method.as_str())
-            && receiver_is_refs_handle(&node.receiver)
+            && self.expr_is_refs_handle(&node.receiver)
         {
             self.publishes
                 .push((method, node.method.span().start().line));
@@ -331,27 +383,6 @@ impl<'ast> Visit<'ast> for CallCollector {
             self.has_snapshot_record = true;
         }
         syn::visit::visit_expr_call(self, node);
-    }
-}
-
-/// True iff the immediate receiver of a publish method call is a `refs` handle:
-/// a `.refs` field (`self.refs.set_thread(...)`) or a `.refs()` accessor call
-/// (`self.inner.repo.refs().set_thread(...)`). Peels `?`/paren/group/await that
-/// can sit between.
-fn receiver_is_refs_handle(expr: &Expr) -> bool {
-    let mut cur = expr;
-    loop {
-        match cur {
-            Expr::Field(field) => {
-                return matches!(&field.member, syn::Member::Named(ident) if ident == "refs");
-            }
-            Expr::MethodCall(mc) => return mc.method == "refs",
-            Expr::Try(t) => cur = &t.expr,
-            Expr::Paren(p) => cur = &p.expr,
-            Expr::Group(g) => cur = &g.expr,
-            Expr::Await(a) => cur = &a.base,
-            _ => return false,
-        }
     }
 }
 
@@ -400,6 +431,50 @@ mod tests {
         );
         assert_eq!(hits.len(), 1, "planted cross-crate bypass must be flagged");
         assert_eq!(hits[0].method, "set_thread");
+    }
+
+    #[test]
+    fn flags_publish_via_aliased_refs_handle() {
+        // A bypass routed through a local alias of the refs handle must still
+        // be flagged (heddle#354 r9, cid 3330304661) — an aliased handle was a
+        // blind spot the gate missed.
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                let r = &self.refs; \
+                r.set_thread(&t, &id)?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1, "publish via aliased refs handle must be flagged");
+        assert_eq!(hits[0].method, "set_thread");
+    }
+
+    #[test]
+    fn flags_publish_via_accessor_alias_chain() {
+        // Alias of a `.refs()` accessor, then an alias-of-alias chain.
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                let a = self.inner.repo.refs(); \
+                let b = a; \
+                b.write_head(&Head::Detached { state })?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1, "publish via aliased accessor handle must be flagged");
+        assert_eq!(hits[0].method, "write_head");
+    }
+
+    #[test]
+    fn ignores_non_refs_alias() {
+        // A local bound to a non-refs value must NOT be treated as a refs alias.
+        let hits = scan_source(
+            "fn f(&self) -> Result<()> { \
+                let r = &self.cache; \
+                r.set_thread(&t, &id)?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert!(hits.is_empty(), "a non-refs local must not be a refs alias");
     }
 
     #[test]

--- a/crates/devtools/src/check_snapshot_atomicity.rs
+++ b/crates/devtools/src/check_snapshot_atomicity.rs
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Workspace-wide AST asserter for the **cross-crate publish-first snapshot**
+//! bug class (heddle#354 r8).
+//!
+//! ## The bug class
+//!
+//! A snapshot must commit its `OpRecord::Snapshot` **before** it publishes the
+//! paired ref (record-first), so the reconciler's authoritative `Snapshot` fold
+//! (newest committed record wins) can never resurrect a stale snapshot over a
+//! newer concurrent write. The pre-r8 shape was the opposite — publish first,
+//! record second:
+//!
+//! ```ignore
+//! self.refs.set_thread(&thread, &state.change_id)?;   // PUBLISH (phase 5)
+//! self.oplog.record_snapshot(...)?;                    // RECORD  (phase 4)
+//! ```
+//!
+//! ## Why this asserter exists (the coverage hole r7 left)
+//!
+//! r7 added a conformance check INSIDE the `refs` crate
+//! (`write_read_conformance`). It guards the refs-internal raw writers, but it
+//! is blind to **cross-crate** callers: `crates/repo/src/repository_snapshot.rs`
+//! and `crates/mount/src/core.rs` both called `refs.set_thread(...)` /
+//! `refs.write_head(...)` directly, ahead of the snapshot record, and the
+//! refs-only walk never saw them. This asserter walks the ENTIRE workspace and
+//! fails CI if any production function co-locates a raw refs-publish with a
+//! snapshot-record append — they must go through the record-first chokepoint
+//! (`Repository::commit_snapshot_atomic` → `commit_and_publish`) instead.
+//!
+//! A function that uses `commit_snapshot_atomic` has NEITHER a raw publish NOR a
+//! raw `record_snapshot`, so it drops out cleanly; re-introducing the
+//! publish-first shape brings it back and fails the gate. A planted cross-crate
+//! bypass (see the tests) proves the analyzer is non-vacuous.
+//!
+//! ## Scope
+//!
+//! This closes the SNAPSHOT publish-first class across crates. The broader
+//! AtomicMutation call-site migration (the other publish-first verbs — marker,
+//! thread, goto, fast-forward — which the reconciler handles via canonical-wins
+//! HEAD folds or which are tracked for the deferred migration) is intentionally
+//! out of scope here; the record-class allowlist below is the extension point as
+//! that migration lands. Detection is by snapshot record class precisely so this
+//! gate does not flag the deferred verbs.
+//!
+//! The env-var contract mirrors the sibling tree-load asserter:
+//! `HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS` (colon-separated, default `crates`)
+//! and `HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST` (semicolon-separated `path:line`;
+//! empty disables, unset uses the built-in default — currently empty, because
+//! the two known sites are fixed, not exempted).
+
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use syn::{Attribute, Expr, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
+use walkdir::WalkDir;
+
+const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+
+/// Raw ref-publish methods reachable on a `refs` handle across crates. A call to
+/// any of these on a `.refs` / `.refs()` receiver is a "publish". Deliberately
+/// excludes `commit_and_publish` (the record-first chokepoint — the fix).
+const PUBLISH_METHODS: &[&str] = &[
+    "set_thread",
+    "set_thread_cas",
+    "write_head",
+    "write_head_cas",
+    "set_marker_cas",
+    "create_marker",
+    "delete_thread",
+    "delete_thread_cas",
+    "delete_marker",
+    "delete_marker_cas",
+    "set_remote_thread",
+    "delete_remote_thread",
+    "set_undo_recovery",
+    "update_refs",
+];
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(arg) = args.first() {
+        bail!(
+            "check-snapshot-atomicity: unexpected argument '{arg}' (configured via env vars: \
+HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS, HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST)"
+        );
+    }
+
+    check(&read_search_dirs(), &read_allowlist())
+}
+
+/// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
+/// findings, and `bail!` if any non-allowlisted publish-first snapshot remains.
+/// `run()` is the thin env-reading wrapper around this.
+fn check(search_dirs: &[PathBuf], allowlist: &[String]) -> Result<()> {
+    let mut hits: Vec<Hit> = Vec::new();
+    let mut files_scanned = 0usize;
+    for dir in search_dirs {
+        scan_dir(dir, &mut hits, &mut files_scanned)
+            .with_context(|| format!("scan {}", dir.display()))?;
+    }
+
+    let mut failed = 0usize;
+    for hit in &hits {
+        let key = format!("{}:{}", hit.path.display(), hit.line);
+        if allowlist.iter().any(|entry| entry == &key) {
+            println!("ok: exempt: {key} — {}", hit.snippet.trim());
+            continue;
+        }
+        eprintln!(
+            "::error::publish-first snapshot at {key}: `{}` is published in the same function \
+that appends an `OpRecord::Snapshot` — {}",
+            hit.method,
+            hit.snippet.trim()
+        );
+        failed += 1;
+    }
+
+    if failed > 0 {
+        eprintln!(
+            "\n::error::Found {failed} cross-crate publish-first snapshot site(s). A snapshot must \
+commit its `OpRecord::Snapshot` BEFORE publishing the paired ref (record-first), so the \
+reconciler's authoritative `Snapshot` fold cannot resurrect a stale snapshot over a newer \
+concurrent write. Route the ref write + record through `Repository::commit_snapshot_atomic` \
+(which uses the record-first `commit_and_publish` chokepoint) instead of calling \
+`refs.set_thread`/`refs.write_head` next to `oplog.record_snapshot`.\n\
+\n\
+If a site is a legitimate exception, add a `path:line` entry (of the publish call) to \
+HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST with a one-line justification."
+        );
+        bail!("asserter failed");
+    }
+
+    println!(
+        "asserter clean: no cross-crate publish-first snapshot sites in production code \
+({files_scanned} file(s) scanned)"
+    );
+    Ok(())
+}
+
+fn read_search_dirs() -> Vec<PathBuf> {
+    match env::var("HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS") {
+        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
+        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
+    }
+}
+
+fn read_allowlist() -> Vec<String> {
+    match env::var("HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST") {
+        Ok(value) if value.is_empty() => Vec::new(),
+        Ok(value) => value.split(';').map(str::to_string).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Debug)]
+struct Hit {
+    path: PathBuf,
+    line: usize,
+    method: String,
+    snippet: String,
+}
+
+fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in WalkDir::new(dir).follow_links(false) {
+        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("rs") {
+            continue;
+        }
+        if is_test_path(path) {
+            continue;
+        }
+        let source =
+            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        *files_scanned += 1;
+        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+        let lines: Vec<&str> = source.lines().collect();
+        let mut visitor = Finder {
+            path: path.to_path_buf(),
+            lines: &lines,
+            hits,
+        };
+        visitor.visit_file(&file);
+    }
+    Ok(())
+}
+
+/// Tests legitimately exercise the bug class (they drive `set_thread` +
+/// `record_snapshot` directly to simulate crashes/races) — skip them. Three
+/// shapes: integration tests under a `tests/` segment, unit-test files named
+/// `*_tests.rs`, and submodule test files named exactly `tests.rs` (e.g.
+/// `crates/repo/src/atomic/tests.rs`). Inline `#[cfg(test)] mod tests { ... }`
+/// blocks inside a production file are skipped separately, at the AST level
+/// (see `is_cfg_test`), because their `#[cfg(test)]` gate lives in the same file.
+fn is_test_path(path: &Path) -> bool {
+    for component in path.components() {
+        if component.as_os_str() == "tests" {
+            return true;
+        }
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .map(|name| name.ends_with("_tests.rs") || name == "tests.rs")
+        .unwrap_or(false)
+}
+
+/// True iff the item carries a `#[cfg(test)]` attribute (directly, or nested in
+/// an `all(...)` / `any(...)` predicate) — a test-only module that must not be
+/// held to the production no-publish-first invariant.
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    fn meta_mentions_test(meta: &Meta) -> bool {
+        match meta {
+            Meta::Path(path) => path.is_ident("test"),
+            Meta::List(list) if list.path.is_ident("cfg") => list.tokens.to_string().contains("test"),
+            Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
+                list.tokens.to_string().contains("test")
+            }
+            _ => false,
+        }
+    }
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta)
+    })
+}
+
+struct Finder<'a> {
+    path: PathBuf,
+    lines: &'a [&'a str],
+    hits: &'a mut Vec<Hit>,
+}
+
+impl Finder<'_> {
+    /// Evaluate one function body: if it both publishes a ref AND appends a
+    /// snapshot record, every publish call in it is a hit. The `body` is the
+    /// whole fn block, visited recursively (closures included — the snapshot
+    /// path historically wrapped its work in an IIFE), so a publish nested in a
+    /// closure is still attributed to the enclosing function.
+    fn evaluate_fn(&mut self, body: &syn::Block) {
+        let mut collector = CallCollector::default();
+        collector.visit_block(body);
+        if collector.publishes.is_empty() || !collector.has_snapshot_record {
+            return;
+        }
+        for (method, line) in collector.publishes {
+            let snippet = self
+                .lines
+                .get(line.saturating_sub(1))
+                .copied()
+                .unwrap_or("")
+                .to_string();
+            self.hits.push(Hit {
+                path: self.path.clone(),
+                line,
+                method,
+                snippet,
+            });
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Finder<'_> {
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        // Skip inline `#[cfg(test)] mod tests { ... }` blocks: test code drives
+        // the publish-first shape on purpose to exercise reconcile/recovery.
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        // Evaluate this fn; nested fns are captured by the recursive collector,
+        // so we do NOT descend the Finder again (avoids double-attribution).
+        self.evaluate_fn(&node.block);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        self.evaluate_fn(&node.block);
+    }
+}
+
+/// Collects, within one function body, the raw ref-publish calls and whether a
+/// snapshot-record append is present. Recurses through closures and blocks (the
+/// syn default), so it sees calls wherever they sit in the body.
+#[derive(Default)]
+struct CallCollector {
+    /// `(method_name, line)` for each raw `refs`-publish call.
+    publishes: Vec<(String, usize)>,
+    /// A snapshot record append (`oplog.record_snapshot(...)` or the free-fn
+    /// `record_snapshot_in_oplog(...)` wrapper) is present.
+    has_snapshot_record: bool,
+}
+
+impl<'ast> Visit<'ast> for CallCollector {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if method == "record_snapshot" {
+            self.has_snapshot_record = true;
+        } else if PUBLISH_METHODS.contains(&method.as_str())
+            && receiver_is_refs_handle(&node.receiver)
+        {
+            self.publishes
+                .push((method, node.method.span().start().line));
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let Expr::Path(p) = node.func.as_ref()
+            && p.path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "record_snapshot_in_oplog")
+        {
+            self.has_snapshot_record = true;
+        }
+        syn::visit::visit_expr_call(self, node);
+    }
+}
+
+/// True iff the immediate receiver of a publish method call is a `refs` handle:
+/// a `.refs` field (`self.refs.set_thread(...)`) or a `.refs()` accessor call
+/// (`self.inner.repo.refs().set_thread(...)`). Peels `?`/paren/group/await that
+/// can sit between.
+fn receiver_is_refs_handle(expr: &Expr) -> bool {
+    let mut cur = expr;
+    loop {
+        match cur {
+            Expr::Field(field) => {
+                return matches!(&field.member, syn::Member::Named(ident) if ident == "refs");
+            }
+            Expr::MethodCall(mc) => return mc.method == "refs",
+            Expr::Try(t) => cur = &t.expr,
+            Expr::Paren(p) => cur = &p.expr,
+            Expr::Group(g) => cur = &g.expr,
+            Expr::Await(a) => cur = &a.base,
+            _ => return false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn scan_source(src: &str) -> Vec<Hit> {
+        let file = syn::parse_file(src).expect("parse");
+        let lines: Vec<&str> = src.lines().collect();
+        let mut hits = Vec::new();
+        let mut v = Finder {
+            path: PathBuf::from("test.rs"),
+            lines: &lines,
+            hits: &mut hits,
+        };
+        v.visit_file(&file);
+        hits
+    }
+
+    #[test]
+    fn flags_publish_then_snapshot_record_same_fn() {
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                self.refs.set_thread(&t, &id)?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].method, "set_thread");
+    }
+
+    /// The cross-crate planted bypass the task calls for: a repo/mount-style
+    /// caller writing a ref before recording a snapshot. Uses the `.refs()`
+    /// accessor and the `record_snapshot_in_oplog` free-fn wrapper — both must be
+    /// caught, proving the analyzer is non-vacuous beyond the refs crate.
+    #[test]
+    fn flags_planted_cross_crate_bypass_accessor_and_free_fn() {
+        let hits = scan_source(
+            "fn capture(&self) -> Result<()> { \
+                self.inner.repo.refs().set_thread(&served, &change_id)?; \
+                repo::snapshot_metadata::record_snapshot_in_oplog(&self.inner.repo, &change_id, p, th)?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1, "planted cross-crate bypass must be flagged");
+        assert_eq!(hits[0].method, "set_thread");
+    }
+
+    #[test]
+    fn flags_detached_write_head_with_snapshot_record() {
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                self.refs.write_head(&Head::Detached { state })?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].method, "write_head");
+    }
+
+    #[test]
+    fn flags_publish_inside_closure() {
+        // The snapshot path historically wrapped its body in an IIFE; a publish
+        // nested in a closure must still be attributed to the enclosing fn.
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                let r = (|| -> Result<()> { \
+                    self.refs.set_thread(&t, &id)?; \
+                    self.oplog.record_snapshot(&id, p, th, s)?; \
+                    Ok(()) })(); \
+                r }",
+        );
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn ignores_record_first_via_commit_and_publish() {
+        // The fix shape: a single chokepoint call, no raw publish, no raw
+        // record_snapshot — must NOT be flagged.
+        let hits = scan_source(
+            "fn cap(&self) -> Result<()> { \
+                self.commit_snapshot_atomic(&id, prev, thread)?; \
+                Ok(()) }",
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_publish_without_snapshot_record() {
+        // A pure publish (e.g. `seed_default_thread`, git-overlay HEAD sync) has
+        // no paired snapshot record — not a snapshot-atomicity hazard.
+        let hits = scan_source(
+            "fn seed(&self) -> Result<()> { self.refs.set_thread(&main, &id)?; Ok(()) }",
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_snapshot_record_without_publish() {
+        // The committer/oplog side records without a co-located raw publish.
+        let hits = scan_source(
+            "fn rec(&self) -> Result<()> { self.oplog.record_snapshot(&id, p, th, s)?; Ok(()) }",
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_refs_receiver() {
+        // `set_thread`-named method on a non-refs receiver is not a ref publish.
+        let hits = scan_source(
+            "fn f(&self) -> Result<()> { \
+                self.cache.set_thread(&t, &id)?; \
+                self.oplog.record_snapshot(&id, p, th, s)?; \
+                Ok(()) }",
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn ignores_inline_cfg_test_module() {
+        // Test code drives the publish-first shape on purpose (to exercise
+        // reconcile/recovery), so an inline `#[cfg(test)] mod tests` must be
+        // skipped even when it lives in a production-named file.
+        let hits = scan_source(
+            "fn prod() {} \
+             #[cfg(test)] \
+             mod tests { \
+                fn race() { \
+                    self.refs.set_thread(&t, &id).unwrap(); \
+                    self.oplog.record_snapshot(&id, p, th, s).unwrap(); \
+                } \
+             }",
+        );
+        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+    }
+
+    #[test]
+    fn ignores_string_literal() {
+        let hits = scan_source(
+            "fn f() { let s = \"self.refs.set_thread(x); record_snapshot(y)\"; let _ = s; }",
+        );
+        assert!(hits.is_empty());
+    }
+
+    const PLANTED: &str = "fn cap(&self) -> Result<()> { \
+            self.refs.set_thread(&t, &id)?; \
+            self.oplog.record_snapshot(&id, p, th, s)?; \
+            Ok(()) }";
+
+    #[test]
+    fn check_bails_on_planted_site_and_exempts_via_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bypass.rs"), PLANTED).unwrap();
+        let dirs = vec![dir.path().to_path_buf()];
+
+        // No allowlist → the planted publish-first site fails the gate.
+        assert!(
+            check(&dirs, &[]).is_err(),
+            "a planted publish-first site must fail the check"
+        );
+
+        // Allowlisting the publish line exempts it (the publish is on line 1).
+        let key = format!("{}:1", dir.path().join("bypass.rs").display());
+        assert!(
+            check(&dirs, &[key]).is_ok(),
+            "an allowlisted site must pass the check"
+        );
+    }
+
+    #[test]
+    fn check_passes_on_clean_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("clean.rs"),
+            "fn cap(&self) -> Result<()> { self.commit_snapshot_atomic(&id, p, t)?; Ok(()) }",
+        )
+        .unwrap();
+        assert!(check(&[dir.path().to_path_buf()], &[]).is_ok());
+    }
+
+    /// Enforcement test: scan the REAL workspace tree with the built-in (empty)
+    /// allowlist and assert clean. This is what makes the gate fail CI under
+    /// `cargo test --workspace` if a publish-first snapshot site is introduced.
+    #[test]
+    fn production_tree_has_no_publish_first_snapshot() {
+        let crates_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("devtools crate dir has a parent (the crates/ dir)")
+            .to_path_buf();
+        let mut hits = Vec::new();
+        let mut scanned = 0usize;
+        scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
+        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            hits.is_empty(),
+            "cross-crate publish-first snapshot site(s) found: {:?}",
+            hits.iter()
+                .map(|h| format!("{}:{} ({})", h.path.display(), h.line, h.method))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 
 mod check_no_silent_default_tree_load;
+mod check_snapshot_atomicity;
 mod fuse_dispatch_bench;
 
 fn main() -> Result<()> {
@@ -19,6 +20,7 @@ fn main() -> Result<()> {
         Some("check-no-silent-default-tree-load") => {
             check_no_silent_default_tree_load::run(args.collect())
         }
+        Some("check-snapshot-atomicity") => check_snapshot_atomicity::run(args.collect()),
         Some("fuse-dispatch-bench") => fuse_dispatch_bench::run(args.collect()),
         Some(command) => bail!("unknown command '{command}'"),
         None => bail!("expected a command (for example: web-proto)"),

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 
 mod check_no_silent_default_tree_load;
+mod check_oprecord_exhaustiveness;
 mod check_snapshot_atomicity;
 mod fuse_dispatch_bench;
 
@@ -21,6 +22,9 @@ fn main() -> Result<()> {
             check_no_silent_default_tree_load::run(args.collect())
         }
         Some("check-snapshot-atomicity") => check_snapshot_atomicity::run(args.collect()),
+        Some("check-oprecord-exhaustiveness") => {
+            check_oprecord_exhaustiveness::run(args.collect())
+        }
         Some("fuse-dispatch-bench") => fuse_dispatch_bench::run(args.collect()),
         Some(command) => bail!("unknown command '{command}'"),
         None => bail!("expected a command (for example: web-proto)"),

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -73,7 +73,7 @@ use objects::{
     store::{AnyStore, ObjectStore},
 };
 use oplog::OpLog;
-use refs::{Head, RefManager};
+use refs::RefManager;
 use repo::Repository;
 use tracing::{debug, instrument, warn};
 
@@ -3958,46 +3958,26 @@ impl ContentAddressedMount {
         state = state.with_confidence(self.inner.repo.config().defaults.confidence);
         self.store().put_state(&state).map_err(MountError::Store)?;
 
-        // Step 3: advance the thread's HEAD. We respect whatever
-        // head the repo currently has (Attached vs Detached): mounts
-        // are always created against a thread name, so we walk the
-        // attached path, but be defensive and fall back to setting
-        // the named thread directly if HEAD is detached.
+        // Step 3 + 3a unified: advance the served thread and record the
+        // `OpRecord::Snapshot` **record-first** through the write chokepoint
+        // (heddle#354 r8). The pre-r8 path published the thread ref FIRST and
+        // recorded SECOND — the same cross-crate publish-first snapshot class as
+        // `repository_snapshot.rs`. Because the reconciler folds a `Snapshot`
+        // record authoritatively, a late snapshot record carrying a stale thread
+        // value could clobber a newer concurrent write. Routing through
+        // `commit_snapshot_atomic` makes the record commit before the publish,
+        // so the newest committed record is the newest write.
+        //
+        // A mount always serves one specific thread, so the snapshot always
+        // advances `self.inner.thread` — HEAD being attached elsewhere (or
+        // detached) does not change which ref the mount advances.
         let change_id = state.change_id;
         let prev_head_change_id = state_snapshot.change_id;
-        match self.inner.repo.head_ref().map_err(MountError::Store)? {
-            Head::Attached { thread } if thread == self.inner.thread => {
-                self.inner
-                    .repo
-                    .refs()
-                    .set_thread(&thread, &change_id)
-                    .map_err(MountError::Store)?;
-            }
-            _ => {
-                // Always update the named thread, even if HEAD is
-                // pointed elsewhere. The mount serves a specific
-                // thread; that's what should advance.
-                self.inner
-                    .repo
-                    .refs()
-                    .set_thread(&objects::object::ThreadName::from(self.inner.thread.as_str()), &change_id)
-                    .map_err(MountError::Store)?;
-            }
-        }
-
-        // Step 3a: record the snapshot in the oplog. Mirrors what
-        // `repository_snapshot.rs` does after a worktree-walk
-        // capture and what `cmd_snapshot` relies on for `heddle
-        // undo` / `heddle log`. We pass `prev_head` so the entry
-        // captures the parent-state edge for traversal.
-        if let Err(err) = repo::snapshot_metadata::record_snapshot_in_oplog(
-            &self.inner.repo,
-            &change_id,
-            Some(&prev_head_change_id),
-            Some(&self.inner.thread),
-        ) {
-            warn!(?err, "oplog record_snapshot from mount capture failed");
-        }
+        let served_thread = objects::object::ThreadName::from(self.inner.thread.as_str());
+        self.inner
+            .repo
+            .commit_snapshot_atomic(&change_id, Some(prev_head_change_id), Some(&served_thread))
+            .map_err(MountError::Store)?;
 
         // Step 3b: refresh the active thread record's metadata
         // (changed paths, heavy-impact paths, freshness, etc).

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -222,19 +222,91 @@ pub trait OpLogBackend: Send + Sync {
         )
     }
 
-    fn record_fork(&self, from: &ChangeId, new_state: &ChangeId) -> Result<u64> {
+    /// Record a fork. `from` is the source state, `new_state` the fork
+    /// result (correct argument order — heddle#330 r15 fixed the
+    /// `cmd_fork` call site that passed these reversed). `thread`/`head`
+    /// name the published ref so crash-replay can re-materialize it.
+    fn record_fork(
+        &self,
+        from: &ChangeId,
+        new_state: &ChangeId,
+        thread: Option<&str>,
+        head: Option<&ChangeId>,
+    ) -> Result<u64> {
         let ids = self.record_batch(vec![OpRecord::Fork {
             from: *from,
             new_state: *new_state,
+            thread: thread.map(str::to_string),
+            head: head.copied(),
         }])?;
         Ok(ids[0])
     }
 
-    fn record_collapse(&self, sources: &[ChangeId], result: &ChangeId) -> Result<u64> {
+    /// Record a collapse. `thread` names the published ref (`Some(name)`
+    /// for a thread ref, `None` for a detached HEAD at `result`).
+    fn record_collapse(
+        &self,
+        sources: &[ChangeId],
+        result: &ChangeId,
+        thread: Option<&str>,
+    ) -> Result<u64> {
         let ids = self.record_batch(vec![OpRecord::Collapse {
             sources: sources.to_vec(),
             result: *result,
+            thread: thread.map(str::to_string),
         }])?;
+        Ok(ids[0])
+    }
+
+    /// Record a remote-thread publish (heddle#330 r9).
+    fn record_remote_thread_update(
+        &self,
+        remote: &str,
+        thread: &str,
+        state: &ChangeId,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::RemoteThreadUpdate {
+                remote: remote.to_string(),
+                thread: thread.to_string(),
+                state: *state,
+            }],
+            scope,
+        )?;
+        Ok(ids[0])
+    }
+
+    /// Record a remote-thread deletion (heddle#330 r9).
+    fn record_remote_thread_delete(
+        &self,
+        remote: &str,
+        thread: &str,
+        state: &ChangeId,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::RemoteThreadDelete {
+                remote: remote.to_string(),
+                thread: thread.to_string(),
+                state: *state,
+            }],
+            scope,
+        )?;
+        Ok(ids[0])
+    }
+
+    /// Record an undo-recovery pointer publish (heddle#330 r9). Local
+    /// (per-checkout) ref, so `scope` carries `op_scope()`.
+    fn record_undo_recovery_update(
+        &self,
+        state: &ChangeId,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::UndoRecoveryUpdate { state: *state }],
+            scope,
+        )?;
         Ok(ids[0])
     }
 

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -226,35 +226,52 @@ pub trait OpLogBackend: Send + Sync {
     /// result (correct argument order — heddle#330 r15 fixed the
     /// `cmd_fork` call site that passed these reversed). `thread`/`head`
     /// name the published ref so crash-replay can re-materialize it.
+    ///
+    /// `scope` MUST be the writer's `op_scope` for a HEAD-moving fork
+    /// (heddle#354 r7, cid 3329765074): the read chokepoint reconciles the
+    /// `Local` HEAD class scoped to `op_scope`, so an unscoped record would be
+    /// invisible to the fold and a crash before HEAD-publish would strand it.
     fn record_fork(
         &self,
         from: &ChangeId,
         new_state: &ChangeId,
         thread: Option<&str>,
         head: Option<&ChangeId>,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        let ids = self.record_batch(vec![OpRecord::Fork {
-            from: *from,
-            new_state: *new_state,
-            thread: thread.map(str::to_string),
-            head: head.copied(),
-        }])?;
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::Fork {
+                from: *from,
+                new_state: *new_state,
+                thread: thread.map(str::to_string),
+                head: head.copied(),
+            }],
+            scope,
+        )?;
         Ok(ids[0])
     }
 
     /// Record a collapse. `thread` names the published ref (`Some(name)`
     /// for a thread ref, `None` for a detached HEAD at `result`).
+    ///
+    /// `scope` MUST be the writer's `op_scope` for a detached (HEAD-moving)
+    /// collapse (heddle#354 r7, cid 3329765074), for the same reason as
+    /// [`record_fork`](Self::record_fork).
     fn record_collapse(
         &self,
         sources: &[ChangeId],
         result: &ChangeId,
         thread: Option<&str>,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        let ids = self.record_batch(vec![OpRecord::Collapse {
-            sources: sources.to_vec(),
-            result: *result,
-            thread: thread.map(str::to_string),
-        }])?;
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::Collapse {
+                sources: sources.to_vec(),
+                result: *result,
+                thread: thread.map(str::to_string),
+            }],
+            scope,
+        )?;
         Ok(ids[0])
     }
 

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -124,6 +124,19 @@ impl OpLog {
         Ok(guard)
     }
 
+    /// Force this handle's in-memory cache to reload from disk, so it observes
+    /// commits written through a DIFFERENT `OpLog` handle of the same file —
+    /// e.g. the refs write chokepoint's committer, which appends via its own
+    /// fresh handle (the `refs`→`repo` seam). Without this, a long-lived handle
+    /// (the mount/daemon's `repo.oplog()`) keeps a stale cache after a
+    /// `commit_and_publish` and a same-process `recent()` would miss the just
+    /// committed batch (heddle#354 r8). Same staleness class as the
+    /// cross-process case the reconciler already refreshes for (cid 3329711888).
+    pub fn refresh_cache(&self) -> Result<()> {
+        let _guard = self.refresh_cached()?;
+        Ok(())
+    }
+
     /// Get the last operation entry.
     pub fn last(&self) -> Result<Option<OpEntry>> {
         let guard = self.load_cached()?;

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -392,6 +392,53 @@ impl OpLog {
         }
     }
 
+    /// The non-marker records of the batch that committed `transaction_id`
+    /// (heddle#354 r5, cid 3329631075) — i.e. the batch whose `TransactionCommit`
+    /// marker carries that id, minus the marker itself. A crash-retry that
+    /// dedup-hits an already-committed transaction uses these to reconstruct the
+    /// ORIGINAL committed identity, instead of returning this run's freshly
+    /// (re-)generated value, which may diverge from what was actually persisted.
+    ///
+    /// Unbounded scan, matching the dedup domain of
+    /// [`record_batch_exactly_once`](Self::record_batch_exactly_once). Returns an
+    /// empty vec if no batch committed that id, or if the batch held only its
+    /// marker.
+    pub fn committed_batch_records(&self, transaction_id: &str) -> Result<Vec<OpRecord>> {
+        let guard = self.load_cached()?;
+        let packed = guard.as_ref().unwrap();
+
+        let Some(commit_entry) = packed.entries.iter().find(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::TransactionCommit { transaction_id: id, .. }
+                    if id == transaction_id
+            )
+        }) else {
+            return Ok(Vec::new());
+        };
+        let batch_id = if commit_entry.batch_id == 0 {
+            commit_entry.id
+        } else {
+            commit_entry.batch_id
+        };
+
+        let records = packed
+            .entries
+            .iter()
+            .filter(|entry| {
+                let bid = if entry.batch_id == 0 {
+                    entry.id
+                } else {
+                    entry.batch_id
+                };
+                bid == batch_id
+            })
+            .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+            .map(|entry| entry.operation.clone())
+            .collect();
+        Ok(records)
+    }
+
     pub(super) fn record_single_scoped(
         &self,
         operation: OpRecord,

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -319,6 +319,79 @@ impl OpLog {
         Ok(Some(ids))
     }
 
+    /// Append a transaction batch **exactly once**, deduplicated by an
+    /// **unbounded** scan over the entire committed history for a
+    /// matching `OpRecord::TransactionCommit { transaction_id }` marker —
+    /// the linearization point for the atomic-mutation primitive
+    /// (heddle#330 §2.2).
+    ///
+    /// Unlike [`OpLog::record_batch_scoped_if_no_transaction`], which scans
+    /// only a caller-supplied recent window and concedes that "ageing past
+    /// it duplicates the batch", this is exact-once at **any** retry timing
+    /// — including a delayed crash-retry after an arbitrary number of
+    /// intervening commits — because the lookup domain is the whole log.
+    /// The scan and the append are held under the same oplog write lock, so
+    /// two concurrent retriers serialize and exactly one wins.
+    ///
+    /// `operations` must already carry the `TransactionCommit` marker whose
+    /// `transaction_id` matches the `transaction_id` argument. Returns
+    /// `Ok(None)` when the transaction was already committed by a prior
+    /// (possibly long-ago) run.
+    pub fn record_batch_exactly_once(
+        &self,
+        operations: Vec<OpRecord>,
+        scope: Option<&str>,
+        transaction_id: &str,
+    ) -> Result<Option<Vec<u64>>> {
+        if operations.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        let _lock = self.write_lock()?;
+        let mut packed = self.load_fresh()?;
+
+        // Unbounded scan over the ENTIRE committed history — not a window.
+        let already_committed = packed.entries.iter().any(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::TransactionCommit { transaction_id: id, .. }
+                    if id == transaction_id
+            )
+        });
+        if already_committed {
+            return Ok(None);
+        }
+
+        let start_id = packed.head_id + 1;
+        let timestamp = Utc::now();
+        let scope_owned = scope.map(str::to_string);
+        let new_entries =
+            Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
+        let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
+
+        packed.append(new_entries);
+        packed.save()?;
+        *self.cached.lock().unwrap() = Some(packed);
+
+        Ok(Some(ids))
+    }
+
+    /// Current oplog generation — the monotonic `head_id`
+    /// (`packed_oplog.rs` leading field). Reads only the **fixed-size header**
+    /// from disk (not the whole log), so it is the cheap O(1) gate the per-read
+    /// reconciliation needs (heddle#330 §2.2): a long-held handle observes a
+    /// concurrent commit's advance, and the no-lag hot path is one header read +
+    /// one integer compare against a cached watermark — no tail scan. Returns 0
+    /// when the oplog file does not exist yet.
+    pub fn head_id(&self) -> Result<u64> {
+        match PackedOpLog::read_head_id(&self.oplog_path()) {
+            Ok(id) => Ok(id),
+            // Treat a not-yet-created oplog as generation 0.
+            Err(_) if !self.oplog_path().exists() => Ok(0),
+            Err(e) => Err(e),
+        }
+    }
+
     pub(super) fn record_single_scoped(
         &self,
         operation: OpRecord,

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -113,6 +113,17 @@ impl OpLog {
         Ok(guard)
     }
 
+    /// Force a fresh disk load into the cache, returning the refreshed guard.
+    /// Read paths that must observe a CROSS-PROCESS commit use this instead of
+    /// [`load_cached`]: a long-lived handle's already-populated cache is a stale
+    /// view that would miss a batch another process wrote (heddle#354 r6, cid
+    /// 3329711888).
+    fn refresh_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLog>>> {
+        let mut guard = self.cached.lock().unwrap();
+        *guard = Some(self.load_fresh()?);
+        Ok(guard)
+    }
+
     /// Get the last operation entry.
     pub fn last(&self) -> Result<Option<OpEntry>> {
         let guard = self.load_cached()?;
@@ -404,7 +415,13 @@ impl OpLog {
     /// empty vec if no batch committed that id, or if the batch held only its
     /// marker.
     pub fn committed_batch_records(&self, transaction_id: &str) -> Result<Vec<OpRecord>> {
-        let guard = self.load_cached()?;
+        // Refresh, don't trust the cache: this is only ever reached on a dedup
+        // hit, which may be CROSS-PROCESS — another process committed the batch
+        // while this long-lived handle's cache stayed stale. A cached read would
+        // fail to find the batch and reconstruct a miss (heddle#354 r6, cid
+        // 3329711888). The committed batch is durable and append-only, so a
+        // lock-free fresh read observes it consistently.
+        let guard = self.refresh_cached()?;
         let packed = guard.as_ref().unwrap();
 
         let Some(commit_entry) = packed.entries.iter().find(|entry| {

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -109,19 +109,36 @@ impl OpLog {
         )
     }
 
-    /// Record a fork operation.
-    pub fn record_fork(&self, from: &ChangeId, new_state: &ChangeId) -> Result<u64> {
+    /// Record a fork operation. `from` is the source state, `new_state`
+    /// the fork result; `thread`/`head` name the published ref so
+    /// crash-replay can re-materialize it (heddle#330).
+    pub fn record_fork(
+        &self,
+        from: &ChangeId,
+        new_state: &ChangeId,
+        thread: Option<&str>,
+        head: Option<&ChangeId>,
+    ) -> Result<u64> {
         self.record_single(OpRecord::Fork {
             from: *from,
             new_state: *new_state,
+            thread: thread.map(str::to_string),
+            head: head.copied(),
         })
     }
 
-    /// Record a collapse operation.
-    pub fn record_collapse(&self, sources: &[ChangeId], result: &ChangeId) -> Result<u64> {
+    /// Record a collapse operation. `thread` names the published ref
+    /// (`Some` thread name, or `None` for a detached HEAD at `result`).
+    pub fn record_collapse(
+        &self,
+        sources: &[ChangeId],
+        result: &ChangeId,
+        thread: Option<&str>,
+    ) -> Result<u64> {
         self.record_single(OpRecord::Collapse {
             sources: sources.to_vec(),
             result: *result,
+            thread: thread.map(str::to_string),
         })
     }
 

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -112,34 +112,57 @@ impl OpLog {
     /// Record a fork operation. `from` is the source state, `new_state`
     /// the fork result; `thread`/`head` name the published ref so
     /// crash-replay can re-materialize it (heddle#330).
+    ///
+    /// `scope` MUST be the writer's `op_scope` whenever the fork moves HEAD
+    /// (heddle#354 r7, cid 3329765074): a fork that detaches HEAD (`head =
+    /// Some`) — or attaches it to a new thread — is a `Local`-class HEAD-mover,
+    /// and the read chokepoint reconciles `Local` refs scoped to `op_scope`. An
+    /// UNSCOPED fork record (the prior `record_single`) is invisible to that
+    /// scoped fold, so a crash between commit and HEAD-publish would strand an
+    /// unreconcilable record. Routing through `record_single_scoped` makes the
+    /// helper-recorded fork reconcile like every other committed record.
     pub fn record_fork(
         &self,
         from: &ChangeId,
         new_state: &ChangeId,
         thread: Option<&str>,
         head: Option<&ChangeId>,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        self.record_single(OpRecord::Fork {
-            from: *from,
-            new_state: *new_state,
-            thread: thread.map(str::to_string),
-            head: head.copied(),
-        })
+        self.record_single_scoped(
+            OpRecord::Fork {
+                from: *from,
+                new_state: *new_state,
+                thread: thread.map(str::to_string),
+                head: head.copied(),
+            },
+            scope,
+        )
     }
 
     /// Record a collapse operation. `thread` names the published ref
     /// (`Some` thread name, or `None` for a detached HEAD at `result`).
+    ///
+    /// As with [`record_fork`](Self::record_fork), `scope` MUST be the writer's
+    /// `op_scope`: a detached collapse (`thread = None`) moves HEAD, a
+    /// `Local`-class ref reconciled scoped to `op_scope` (heddle#354 r7, cid
+    /// 3329765074). Recorded via `record_single_scoped` so the HEAD-moving
+    /// record reconciles under the same scope the write chokepoint uses.
     pub fn record_collapse(
         &self,
         sources: &[ChangeId],
         result: &ChangeId,
         thread: Option<&str>,
+        scope: Option<&str>,
     ) -> Result<u64> {
-        self.record_single(OpRecord::Collapse {
-            sources: sources.to_vec(),
-            result: *result,
-            thread: thread.map(str::to_string),
-        })
+        self.record_single_scoped(
+            OpRecord::Collapse {
+                sources: sources.to_vec(),
+                result: *result,
+                thread: thread.map(str::to_string),
+            },
+            scope,
+        )
     }
 
     /// Record a marker creation.

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -5,7 +5,7 @@ use std::{
     thread,
 };
 
-use objects::object::ChangeId;
+use objects::object::{ChangeId, ContentHash};
 use tempfile::TempDir;
 
 use super::oplog_backend::OpLogBackend;
@@ -303,6 +303,369 @@ fn record_batch_exactly_once_dedups_past_any_window() {
         )
         .unwrap();
     assert!(other.is_some(), "a different transaction id must commit");
+}
+
+/// rmp-serde round-trips every `OpRecord` variant — the on-disk encoding
+/// the oplog actually uses. Asserts the variant survives encode→decode
+/// unchanged (catches a reordered/inserted discriminant) and that
+/// `description()` produces a non-empty line for each. The new heddle#330
+/// tail variants (`RemoteThreadUpdate` / `RemoteThreadDelete` /
+/// `UndoRecoveryUpdate`) and the Fork/Collapse published-ref retrofit are
+/// the load-bearing cases.
+#[test]
+fn op_record_variants_roundtrip_and_describe() {
+    let st = ChangeId::from_bytes([3u8; 16]);
+    let st2 = ChangeId::from_bytes([5u8; 16]);
+    let blob = ContentHash::from_bytes([7u8; 32]);
+    let redaction = ContentHash::from_bytes([9u8; 32]);
+
+    let records = vec![
+        OpRecord::Snapshot {
+            new_state: st,
+            prev_head: Some(st2),
+            thread: Some("main".into()),
+        },
+        OpRecord::Snapshot {
+            new_state: st,
+            prev_head: None,
+            thread: None,
+        },
+        OpRecord::Goto {
+            target: st,
+            prev_head: Some(st2),
+        },
+        OpRecord::ThreadCreate {
+            name: "feat".into(),
+            state: st,
+        },
+        OpRecord::ThreadDelete {
+            name: "feat".into(),
+            state: st,
+        },
+        OpRecord::ThreadUpdate {
+            name: "feat".into(),
+            old_state: st2,
+            new_state: st,
+        },
+        // Fork retrofit: both published-ref shapes (attached thread / detached head).
+        OpRecord::Fork {
+            from: st2,
+            new_state: st,
+            thread: Some("topic".into()),
+            head: None,
+        },
+        OpRecord::Fork {
+            from: st2,
+            new_state: st,
+            thread: None,
+            head: Some(st),
+        },
+        // Collapse retrofit: published thread ref / detached head.
+        OpRecord::Collapse {
+            sources: vec![st, st2],
+            result: st,
+            thread: Some("trunk".into()),
+        },
+        OpRecord::Collapse {
+            sources: vec![st],
+            result: st2,
+            thread: None,
+        },
+        OpRecord::MarkerCreate {
+            name: "v1".into(),
+            state: st,
+        },
+        OpRecord::MarkerDelete {
+            name: "v1".into(),
+            state: st,
+        },
+        OpRecord::Checkpoint {
+            parent: Some(st2),
+            state: st,
+            thread: Some("agent".into()),
+        },
+        OpRecord::Checkpoint {
+            parent: None,
+            state: st,
+            thread: None,
+        },
+        OpRecord::TransactionAbort {
+            transaction_id: "tx".into(),
+            reason: "conflict".into(),
+        },
+        OpRecord::EphemeralThreadCollapse {
+            thread: "scratch".into(),
+            final_state: st,
+        },
+        OpRecord::ConflictResolved {
+            conflict_id: "c1".into(),
+            resolution: "ours".into(),
+        },
+        OpRecord::TransactionCommit {
+            transaction_id: "tx".into(),
+            op_count: 3,
+        },
+        OpRecord::Redact {
+            redaction_id: redaction,
+            blob,
+            state: st,
+            path: "secret.txt".into(),
+        },
+        OpRecord::Purge {
+            redaction_id: redaction,
+            blob,
+        },
+        OpRecord::FastForward {
+            source_thread: "topic".into(),
+            target_thread: "main".into(),
+            pre_target_id: st2,
+        },
+        OpRecord::FastForwardV2 {
+            source_thread: "topic".into(),
+            target_thread: "main".into(),
+            pre_target_id: st2,
+            post_target_id: st,
+        },
+        OpRecord::ThreadCreateV2 {
+            name: "feat".into(),
+            state: st,
+            manager_snapshot: Some(vec![1, 2, 3]),
+        },
+        OpRecord::GitCheckpoint {
+            branch: "main".into(),
+            state: st,
+            previous_git_oid: Some("abc".into()),
+            new_git_oid: "def".into(),
+        },
+        OpRecord::GitCheckpoint {
+            branch: "main".into(),
+            state: st,
+            previous_git_oid: None,
+            new_git_oid: "def".into(),
+        },
+        // heddle#330 r9 tail variants.
+        OpRecord::RemoteThreadUpdate {
+            remote: "origin".into(),
+            thread: "main".into(),
+            state: st,
+        },
+        OpRecord::RemoteThreadDelete {
+            remote: "origin".into(),
+            thread: "main".into(),
+            state: st,
+        },
+        OpRecord::UndoRecoveryUpdate { state: st },
+    ];
+
+    for rec in &records {
+        assert!(
+            !rec.description().is_empty(),
+            "description must be non-empty for {rec:?}"
+        );
+        let bytes = rmp_serde::to_vec(rec).expect("encode");
+        let back: OpRecord = rmp_serde::from_slice(&bytes).expect("decode");
+        // Re-encode the decoded value; identical bytes ⇒ structural round-trip.
+        let bytes2 = rmp_serde::to_vec(&back).expect("re-encode");
+        assert_eq!(bytes, bytes2, "round-trip mismatch for {rec:?}");
+        assert_eq!(back.description(), rec.description());
+    }
+}
+
+/// The Fork/Collapse published-ref fields default to `None` when absent —
+/// pre-retrofit records (encoded without `thread`/`head`) must still
+/// deserialize via `#[serde(default)]`. Round-trip the retrofit fields and
+/// assert they survive.
+#[test]
+fn fork_collapse_published_ref_fields_roundtrip() {
+    let from = ChangeId::from_bytes([1u8; 16]);
+    let new_state = ChangeId::from_bytes([2u8; 16]);
+
+    let fork = OpRecord::Fork {
+        from,
+        new_state,
+        thread: Some("published".into()),
+        head: Some(new_state),
+    };
+    let back: OpRecord = rmp_serde::from_slice(&rmp_serde::to_vec(&fork).unwrap()).unwrap();
+    match back {
+        OpRecord::Fork {
+            from: f,
+            new_state: n,
+            thread,
+            head,
+        } => {
+            assert_eq!(f, from);
+            assert_eq!(n, new_state);
+            assert_eq!(thread.as_deref(), Some("published"));
+            assert_eq!(head, Some(new_state));
+        }
+        other => panic!("expected Fork, got {other:?}"),
+    }
+
+    let collapse = OpRecord::Collapse {
+        sources: vec![from, new_state],
+        result: new_state,
+        thread: Some("trunk".into()),
+    };
+    let back: OpRecord = rmp_serde::from_slice(&rmp_serde::to_vec(&collapse).unwrap()).unwrap();
+    match back {
+        OpRecord::Collapse {
+            sources,
+            result,
+            thread,
+        } => {
+            assert_eq!(sources, vec![from, new_state]);
+            assert_eq!(result, new_state);
+            assert_eq!(thread.as_deref(), Some("trunk"));
+        }
+        other => panic!("expected Collapse, got {other:?}"),
+    }
+}
+
+/// Exercises every recording method on `OpLog` (the `oplog_records.rs`
+/// surface) and reads the persisted variant back. Confirms `record_fork`
+/// writes its args in the documented order (`from = source`) and that the
+/// published-ref fields land on the stored record.
+#[test]
+fn record_methods_persist_expected_variants() {
+    let (_temp, oplog) = create_oplog();
+    let from = ChangeId::generate();
+    let result = ChangeId::generate();
+    let blob = ContentHash::from_bytes([7u8; 32]);
+    let redaction = ContentHash::from_bytes([9u8; 32]);
+
+    oplog.record_goto(&result, Some(&from), Some("lane")).unwrap();
+    oplog
+        .record_thread_create("feat", &result, Some(vec![9, 8, 7]), Some("lane"))
+        .unwrap();
+    oplog.record_thread_delete("legacy", &result, None).unwrap();
+    let rename_ids = oplog
+        .record_thread_rename("old", "new", &result, Some("lane"))
+        .unwrap();
+    assert_eq!(rename_ids.len(), 2);
+    oplog
+        .record_fork(&from, &result, Some("topic"), None)
+        .unwrap();
+    oplog
+        .record_collapse(&[from, result], &result, Some("trunk"))
+        .unwrap();
+    oplog.record_marker_create("v1", &result).unwrap();
+    oplog.record_marker_delete("v1", &result).unwrap();
+    oplog
+        .record_redact(&redaction, &blob, &result, "secret.txt", Some("lane"))
+        .unwrap();
+    oplog.record_purge(&redaction, &blob, Some("lane")).unwrap();
+    oplog
+        .record_fast_forward("topic", "main", &from, &result, Some("lane"))
+        .unwrap();
+
+    // record_fork must store `from` as the source state, not the result.
+    let entries = oplog.recent(64).unwrap();
+    let fork = entries
+        .iter()
+        .find_map(|e| match &e.operation {
+            OpRecord::Fork {
+                from: f,
+                new_state,
+                thread,
+                head,
+            } => Some((*f, *new_state, thread.clone(), *head)),
+            _ => None,
+        })
+        .expect("a Fork record was written");
+    assert_eq!(fork.0, from, "record_fork's `from` must be the source state");
+    assert_eq!(fork.1, result);
+    assert_eq!(fork.2.as_deref(), Some("topic"));
+    assert_eq!(fork.3, None);
+
+    // A ThreadCreate is always emitted as the V2 variant with the snapshot.
+    let created = entries.iter().find_map(|e| match &e.operation {
+        OpRecord::ThreadCreateV2 {
+            name,
+            manager_snapshot,
+            ..
+        } if name == "feat" => Some(manager_snapshot.clone()),
+        _ => None,
+    });
+    assert_eq!(created, Some(Some(vec![9u8, 8, 7])));
+
+    // The fast-forward always lands as the V2 variant carrying post_target_id.
+    assert!(entries.iter().any(|e| matches!(
+        &e.operation,
+        OpRecord::FastForwardV2 { post_target_id, .. } if *post_target_id == result
+    )));
+}
+
+/// `head_id()` reads the fixed-size header generation gate: 0 before any
+/// write (and for a not-yet-created log), then the last appended id.
+#[test]
+fn head_id_tracks_generation() {
+    let temp = TempDir::new().unwrap();
+    let heddle_dir = temp.path().join(".heddle");
+    std::fs::create_dir_all(&heddle_dir).unwrap();
+    let oplog = OpLog::new_unattributed(&heddle_dir);
+
+    // Not-yet-initialized oplog reads as generation 0.
+    assert_eq!(oplog.head_id().unwrap(), 0);
+
+    oplog.init().unwrap();
+    assert_eq!(oplog.head_id().unwrap(), 0);
+
+    oplog
+        .record_snapshot(&ChangeId::generate(), None, None, Some("lane"))
+        .unwrap();
+    assert_eq!(oplog.head_id().unwrap(), 1);
+
+    let ids = oplog
+        .record_batch(vec![
+            OpRecord::MarkerCreate {
+                name: "v1".into(),
+                state: ChangeId::generate(),
+            },
+            OpRecord::MarkerDelete {
+                name: "v1".into(),
+                state: ChangeId::generate(),
+            },
+        ])
+        .unwrap();
+    assert_eq!(oplog.head_id().unwrap(), *ids.last().unwrap());
+}
+
+/// `record_batch_exactly_once` returns `Ok(Some(empty))` for an empty op
+/// list without writing, and commits two *distinct* transaction ids
+/// independently (the no-collision path).
+#[test]
+fn record_batch_exactly_once_empty_and_distinct_ids() {
+    let (_temp, oplog) = create_oplog();
+
+    let empty = oplog
+        .record_batch_exactly_once(Vec::new(), Some("lane"), "tx-empty")
+        .unwrap();
+    assert_eq!(empty, Some(Vec::new()));
+    assert_eq!(oplog.head_id().unwrap(), 0, "empty commit writes nothing");
+
+    let a = oplog
+        .record_batch_exactly_once(
+            vec![OpRecord::TransactionCommit {
+                transaction_id: "tx-a".into(),
+                op_count: 1,
+            }],
+            Some("lane"),
+            "tx-a",
+        )
+        .unwrap();
+    let b = oplog
+        .record_batch_exactly_once(
+            vec![OpRecord::TransactionCommit {
+                transaction_id: "tx-b".into(),
+                op_count: 1,
+            }],
+            Some("lane"),
+            "tx-b",
+        )
+        .unwrap();
+    assert!(a.is_some() && b.is_some());
+    assert_ne!(a, b, "distinct transaction ids commit independently");
 }
 
 /// Covers the **default** (non-atomic) `record_batch_scoped_if_no_transaction`

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -633,10 +633,10 @@ fn record_methods_persist_expected_variants() {
         .unwrap();
     assert_eq!(rename_ids.len(), 2);
     oplog
-        .record_fork(&from, &result, Some("topic"), None)
+        .record_fork(&from, &result, Some("topic"), None, None)
         .unwrap();
     oplog
-        .record_collapse(&[from, result], &result, Some("trunk"))
+        .record_collapse(&[from, result], &result, Some("trunk"), None)
         .unwrap();
     oplog.record_marker_create("v1", &result).unwrap();
     oplog.record_marker_delete("v1", &result).unwrap();
@@ -922,10 +922,10 @@ mod default_backend {
             .unwrap();
         assert_eq!(rename_ids.len(), 2, "rename emits create + delete");
         backend
-            .record_fork(&from, &cid, Some("topic"), Some(&cid))
+            .record_fork(&from, &cid, Some("topic"), Some(&cid), Some("s"))
             .unwrap();
         backend
-            .record_collapse(&[from, cid], &cid, Some("trunk"))
+            .record_collapse(&[from, cid], &cid, Some("trunk"), Some("s"))
             .unwrap();
         backend
             .record_remote_thread_update("origin", "rt", &cid, Some("s"))

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -793,4 +793,103 @@ mod default_backend {
         .unwrap();
         assert!(second.is_none());
     }
+
+    /// The `record_*` convenience wrappers on `OpLogBackend` are *default*
+    /// trait methods. On `OpLog` they are shadowed by the inherent
+    /// `oplog_records.rs` methods, so a backend that does NOT redefine them
+    /// (the `MemOpLog` mock, like the Postgres backend) is the only way to
+    /// drive the default bodies. Calls each through the trait and asserts the
+    /// expected variant landed in a recorded batch.
+    #[test]
+    fn default_record_wrappers_emit_expected_variants() {
+        use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName};
+
+        let backend = MemOpLog::default();
+        let from = ChangeId::from_bytes([1u8; 16]);
+        let cid = ChangeId::from_bytes([2u8; 16]);
+        let blob = ContentHash::from_bytes([7u8; 32]);
+        let redaction = ContentHash::from_bytes([9u8; 32]);
+
+        // `record_batch` default delegates to `record_batch_scoped(_, None)`.
+        backend
+            .record_batch(vec![OpRecord::Goto {
+                target: cid,
+                prev_head: Some(from),
+            }])
+            .unwrap();
+
+        backend
+            .record_snapshot(&cid, Some(&from), Some("thread"), Some("s"))
+            .unwrap();
+        backend.record_goto(&cid, Some(&from), Some("s")).unwrap();
+        backend
+            .record_thread_create(&ThreadName::new("ft"), &cid, Some(vec![1, 2, 3]), Some("s"))
+            .unwrap();
+        backend
+            .record_thread_delete(&ThreadName::new("ft"), &cid, Some("s"))
+            .unwrap();
+        let rename_ids = backend
+            .record_thread_rename(&ThreadName::new("old"), &ThreadName::new("new"), &cid, Some("s"))
+            .unwrap();
+        assert_eq!(rename_ids.len(), 2, "rename emits create + delete");
+        backend
+            .record_fork(&from, &cid, Some("topic"), Some(&cid))
+            .unwrap();
+        backend
+            .record_collapse(&[from, cid], &cid, Some("trunk"))
+            .unwrap();
+        backend
+            .record_remote_thread_update("origin", "rt", &cid, Some("s"))
+            .unwrap();
+        backend
+            .record_remote_thread_delete("origin", "rt", &cid, Some("s"))
+            .unwrap();
+        backend.record_undo_recovery_update(&cid, Some("s")).unwrap();
+        backend
+            .record_marker_create(&MarkerName::new("v1"), &cid)
+            .unwrap();
+        backend
+            .record_marker_delete(&MarkerName::new("v1"), &cid)
+            .unwrap();
+        backend
+            .record_redact(&redaction, &blob, &cid, "secret.txt", Some("s"))
+            .unwrap();
+        backend.record_purge(&redaction, &blob, Some("s")).unwrap();
+        backend
+            .record_fast_forward(&ThreadName::new("topic"), &ThreadName::new("main"), &from, &cid, Some("s"))
+            .unwrap();
+
+        // `coalesce_batches` default is fail-closed.
+        assert!(
+            backend.coalesce_batches(1, 2).is_err(),
+            "default coalesce must refuse"
+        );
+
+        // Every wrapper appended through `record_batch_scoped`; spot-check the
+        // distinctive published-ref variants made it into the recorded batches.
+        let batches = pollster::block_on(backend.recent_batches(256)).unwrap();
+        let ops: Vec<&OpRecord> = batches
+            .iter()
+            .flat_map(|b| b.entries.iter().map(|e| &e.operation))
+            .collect();
+        assert!(ops.iter().any(|o| matches!(
+            o,
+            OpRecord::Fork { from: f, new_state, thread, head }
+                if *f == from && *new_state == cid && thread.as_deref() == Some("topic") && *head == Some(cid)
+        )));
+        assert!(ops.iter().any(|o| matches!(
+            o,
+            OpRecord::ThreadCreateV2 { name, manager_snapshot, .. }
+                if name == "ft" && manager_snapshot.as_deref() == Some(&[1u8, 2, 3][..])
+        )));
+        assert!(ops.iter().any(|o| matches!(
+            o,
+            OpRecord::RemoteThreadUpdate { remote, thread, .. } if remote == "origin" && thread == "rt"
+        )));
+        assert!(ops.iter().any(|o| matches!(o, OpRecord::UndoRecoveryUpdate { .. })));
+        assert!(ops.iter().any(|o| matches!(
+            o,
+            OpRecord::FastForwardV2 { post_target_id, .. } if *post_target_id == cid
+        )));
+    }
 }

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -256,6 +256,55 @@ fn test_oplogbackend_trait_async_methods_dispatch() {
     assert!(dup.is_none());
 }
 
+/// The unbounded `record_batch_exactly_once` dedups a retry even after far
+/// more intervening commits than any fixed window — the property
+/// `record_batch_scoped_if_no_transaction`'s window cannot give
+/// (heddle#330 §2.2 "Idempotency of the commit").
+#[test]
+fn record_batch_exactly_once_dedups_past_any_window() {
+    let (_temp, oplog) = create_oplog();
+    let commit_ops = || {
+        vec![OpRecord::TransactionCommit {
+            transaction_id: "tx-delayed".to_string(),
+            op_count: 0,
+        }]
+    };
+
+    // First commit lands.
+    let first = oplog
+        .record_batch_exactly_once(commit_ops(), Some("lane"), "tx-delayed")
+        .unwrap();
+    assert!(first.is_some(), "first commit must append");
+
+    // Bury it under 200 unrelated batches — far past any plausible
+    // recent-window the bounded helper would scan.
+    for _ in 0..200 {
+        oplog
+            .record_snapshot(&ChangeId::generate(), None, None, Some("lane"))
+            .unwrap();
+    }
+
+    // A delayed retry still finds the original commit and refuses to
+    // double-append — exact-once regardless of how much aged out.
+    let retry = oplog
+        .record_batch_exactly_once(commit_ops(), Some("lane"), "tx-delayed")
+        .unwrap();
+    assert!(retry.is_none(), "delayed retry must dedup to None");
+
+    // A distinct transaction id still commits.
+    let other = oplog
+        .record_batch_exactly_once(
+            vec![OpRecord::TransactionCommit {
+                transaction_id: "tx-other".to_string(),
+                op_count: 0,
+            }],
+            Some("lane"),
+            "tx-other",
+        )
+        .unwrap();
+    assert!(other.is_some(), "a different transaction id must commit");
+}
+
 /// Covers the **default** (non-atomic) `record_batch_scoped_if_no_transaction`
 /// on the trait. `OpLog` overrides it, so a backend that keeps the default
 /// is the only way to exercise that fallback body.

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -305,6 +305,95 @@ fn record_batch_exactly_once_dedups_past_any_window() {
     assert!(other.is_some(), "a different transaction id must commit");
 }
 
+/// Finding 1 (heddle#354 r6, cid 3329711888) — the dedup-hit output
+/// reconstruction reads a FRESH oplog, not a long-lived handle's stale cache.
+/// Process A commits tx T; process B (a separate handle whose cache was
+/// populated *before* T) replays T: the commit dedups to `None` AND
+/// `committed_batch_records` recovers the batch A actually committed via a
+/// refresh — not an empty stale-cache miss.
+#[test]
+fn committed_batch_records_refreshes_for_cross_process_dedup_hit() {
+    let temp = TempDir::new().unwrap();
+    let heddle_dir = temp.path().join(".heddle");
+    std::fs::create_dir_all(&heddle_dir).unwrap();
+
+    // Two independent handles on the same on-disk oplog — two "processes",
+    // each with its own in-memory cache.
+    let proc_a = OpLog::new_unattributed(&heddle_dir);
+    let proc_b = OpLog::new_unattributed(&heddle_dir);
+    proc_a.init().unwrap();
+
+    // B reads first, populating its cache with the pre-T (empty) state.
+    let before = proc_b.recent(10).unwrap();
+    assert!(
+        before.iter().all(|e| !matches!(
+            &e.operation,
+            OpRecord::TransactionCommit { transaction_id, .. } if transaction_id == "tx-shared"
+        )),
+        "precondition: B's cache must not yet contain the shared tx"
+    );
+
+    // A commits the transaction with a distinguishable Snapshot payload.
+    let committed_state = ChangeId::generate();
+    let appended = proc_a
+        .record_batch_exactly_once(
+            vec![
+                OpRecord::Snapshot {
+                    new_state: committed_state,
+                    prev_head: None,
+                    thread: None,
+                },
+                OpRecord::TransactionCommit {
+                    transaction_id: "tx-shared".into(),
+                    op_count: 1,
+                },
+            ],
+            Some("lane"),
+            "tx-shared",
+        )
+        .unwrap();
+    assert!(appended.is_some(), "A's commit must append");
+
+    // B replays the same transaction id: a cross-process dedup hit. B's
+    // regenerated Snapshot id differs from A's, so a stale reconstruction
+    // would diverge even if it found anything.
+    let replay = proc_b
+        .record_batch_exactly_once(
+            vec![
+                OpRecord::Snapshot {
+                    new_state: ChangeId::generate(),
+                    prev_head: None,
+                    thread: None,
+                },
+                OpRecord::TransactionCommit {
+                    transaction_id: "tx-shared".into(),
+                    op_count: 1,
+                },
+            ],
+            Some("lane"),
+            "tx-shared",
+        )
+        .unwrap();
+    assert!(replay.is_none(), "cross-process replay must dedup to None");
+
+    // The reconstruction must read the FRESH oplog and recover A's record,
+    // even though B's cache predates A's commit. Pre-fix (stale `load_cached`)
+    // this returned an empty vec.
+    let prior = proc_b.committed_batch_records("tx-shared").unwrap();
+    let recovered: Vec<_> = prior
+        .iter()
+        .filter_map(|op| match op {
+            OpRecord::Snapshot { new_state, .. } => Some(*new_state),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        recovered,
+        vec![committed_state],
+        "B reconstructs the batch A committed (via refresh), not a stale miss"
+    );
+}
+
 /// rmp-serde round-trips every `OpRecord` variant — the on-disk encoding
 /// the oplog actually uses. Asserts the variant survives encode→decode
 /// unchanged (catches a reordered/inserted discriminant) and that

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -408,6 +408,95 @@ impl OpRecord {
     }
 }
 
+/// Single source of truth for the oplog verb vocabulary (heddle#354 r9).
+///
+/// Every emitted "kind" string — the daemon op-log index verbs, the
+/// `heddle watch --filter` keywords, the `heddle log` verb filter — derives
+/// from this one catalog, so the verb set can never drift away from the
+/// `OpRecord` variant set. The generated [`OpRecord::verb`] /
+/// [`OpRecord::is_checkpoint_verb`] are **exhaustive** matches: adding an
+/// `OpRecord` variant is a COMPILE error until it is named here, and the
+/// derived [`OpRecord::verbs`] / [`OP_VERB_CATALOG`] pick it up automatically.
+/// This closes the "a new variant is added but not propagated to every
+/// consumer" class for the verb-vocabulary consumers — they no longer keep
+/// hand-maintained string lists that silently fall out of sync.
+macro_rules! op_verb_catalog {
+    ( $( $variant:ident => ($verb:literal, checkpoint = $ckpt:literal) ),+ $(,)? ) => {
+        impl OpRecord {
+            /// The stable snake-case verb for this record's variant. Exhaustive
+            /// match — a new `OpRecord` variant fails to compile until it has a
+            /// verb here. Verbs are shared across variants that fold to one
+            /// concept (e.g. `ThreadCreate`/`ThreadCreateV2` → `thread_create`).
+            pub fn verb(&self) -> &'static str {
+                match self {
+                    $( OpRecord::$variant { .. } => $verb, )+
+                }
+            }
+
+            /// True iff this is the agent-style [`OpRecord::Checkpoint`] that
+            /// `heddle log --no-checkpoints` (the human default) and the daemon
+            /// op-log query hide. New variants surface by default — only the
+            /// catalog entries flagged `checkpoint = true` are hidden.
+            pub fn is_checkpoint_verb(&self) -> bool {
+                match self {
+                    $( OpRecord::$variant { .. } => $ckpt, )+
+                }
+            }
+        }
+
+        /// Every `(verb, is_checkpoint)` pair the vocabulary contains, in
+        /// variant-declaration order. Generated from the same catalog as
+        /// [`OpRecord::verb`], so it tracks the variant set with no drift. A
+        /// verb shared by several variants appears once per variant; dedup at
+        /// the use site (see [`OpRecord::verbs`]).
+        pub const OP_VERB_CATALOG: &[(&str, bool)] = &[ $( ($verb, $ckpt) ),+ ];
+    };
+}
+
+op_verb_catalog! {
+    Snapshot => ("snapshot", checkpoint = false),
+    Goto => ("goto", checkpoint = false),
+    ThreadCreate => ("thread_create", checkpoint = false),
+    ThreadDelete => ("thread_delete", checkpoint = false),
+    ThreadUpdate => ("thread_update", checkpoint = false),
+    Fork => ("fork", checkpoint = false),
+    Collapse => ("collapse", checkpoint = false),
+    MarkerCreate => ("marker_create", checkpoint = false),
+    MarkerDelete => ("marker_delete", checkpoint = false),
+    Checkpoint => ("checkpoint", checkpoint = true),
+    TransactionAbort => ("transaction_abort", checkpoint = false),
+    EphemeralThreadCollapse => ("ephemeral_thread_collapse", checkpoint = false),
+    ConflictResolved => ("conflict_resolved", checkpoint = false),
+    TransactionCommit => ("transaction_commit", checkpoint = false),
+    Redact => ("redact", checkpoint = false),
+    Purge => ("purge", checkpoint = false),
+    FastForward => ("fast_forward", checkpoint = false),
+    FastForwardV2 => ("fast_forward", checkpoint = false),
+    ThreadCreateV2 => ("thread_create", checkpoint = false),
+    GitCheckpoint => ("git_checkpoint", checkpoint = false),
+    RemoteThreadUpdate => ("remote_thread_update", checkpoint = false),
+    RemoteThreadDelete => ("remote_thread_delete", checkpoint = false),
+    UndoRecoveryUpdate => ("undo_recovery_update", checkpoint = false),
+}
+
+impl OpRecord {
+    /// The deduped verb vocabulary. With `include_checkpoints == false` the
+    /// agent `checkpoint` verb is dropped (the `heddle log` human default and
+    /// the daemon op-log query's default filter); every other verb — including
+    /// any future variant — is surfaced. Derived from [`OP_VERB_CATALOG`], so a
+    /// new variant joins the vocabulary the moment it has a catalog entry, with
+    /// no hand-maintained list to forget. Order follows variant declaration.
+    pub fn verbs(include_checkpoints: bool) -> Vec<&'static str> {
+        let mut out: Vec<&'static str> = Vec::new();
+        for &(verb, is_checkpoint) in OP_VERB_CATALOG {
+            if (include_checkpoints || !is_checkpoint) && !out.contains(&verb) {
+                out.push(verb);
+            }
+        }
+        out
+    }
+}
+
 /// Entry in the operation log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpEntry {
@@ -446,4 +535,206 @@ pub struct OpBatch {
     pub id: u64,
     /// Operations in the batch.
     pub entries: Vec<OpEntry>,
+}
+
+#[cfg(test)]
+mod verb_catalog_tests {
+    use super::*;
+    use objects::object::{ChangeId, ContentHash};
+
+    fn cid() -> ChangeId {
+        ChangeId::from_bytes([7; 16])
+    }
+
+    fn hash() -> ContentHash {
+        ContentHash::from_bytes([3; 32])
+    }
+
+    /// One representative of every `OpRecord` variant. The match is exhaustive,
+    /// so adding a variant forces a new arm here — and the assertions below then
+    /// prove the new variant has a non-empty verb that is present in the
+    /// catalog, i.e. the vocabulary cannot silently drop it.
+    fn one_per_variant() -> Vec<OpRecord> {
+        let sample = OpRecord::Snapshot {
+            new_state: cid(),
+            prev_head: None,
+            thread: None,
+        };
+        // Exhaustiveness anchor: this match has no wildcard, so a new variant
+        // breaks the build until it is added to `all` below too.
+        match &sample {
+            OpRecord::Snapshot { .. }
+            | OpRecord::Goto { .. }
+            | OpRecord::ThreadCreate { .. }
+            | OpRecord::ThreadDelete { .. }
+            | OpRecord::ThreadUpdate { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::FastForwardV2 { .. }
+            | OpRecord::ThreadCreateV2 { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => {}
+        }
+        vec![
+            sample,
+            OpRecord::Goto {
+                target: cid(),
+                prev_head: None,
+            },
+            OpRecord::ThreadCreate {
+                name: "t".into(),
+                state: cid(),
+            },
+            OpRecord::ThreadDelete {
+                name: "t".into(),
+                state: cid(),
+            },
+            OpRecord::ThreadUpdate {
+                name: "t".into(),
+                old_state: cid(),
+                new_state: cid(),
+            },
+            OpRecord::Fork {
+                from: cid(),
+                new_state: cid(),
+                thread: None,
+                head: None,
+            },
+            OpRecord::Collapse {
+                sources: vec![cid()],
+                result: cid(),
+                thread: None,
+            },
+            OpRecord::MarkerCreate {
+                name: "m".into(),
+                state: cid(),
+            },
+            OpRecord::MarkerDelete {
+                name: "m".into(),
+                state: cid(),
+            },
+            OpRecord::Checkpoint {
+                parent: None,
+                state: cid(),
+                thread: None,
+            },
+            OpRecord::TransactionAbort {
+                transaction_id: "tx".into(),
+                reason: "r".into(),
+            },
+            OpRecord::EphemeralThreadCollapse {
+                thread: "t".into(),
+                final_state: cid(),
+            },
+            OpRecord::ConflictResolved {
+                conflict_id: "c".into(),
+                resolution: "r".into(),
+            },
+            OpRecord::TransactionCommit {
+                transaction_id: "tx".into(),
+                op_count: 1,
+            },
+            OpRecord::Redact {
+                redaction_id: hash(),
+                blob: hash(),
+                state: cid(),
+                path: "p".into(),
+            },
+            OpRecord::Purge {
+                redaction_id: hash(),
+                blob: hash(),
+            },
+            OpRecord::FastForward {
+                source_thread: "s".into(),
+                target_thread: "t".into(),
+                pre_target_id: cid(),
+            },
+            OpRecord::FastForwardV2 {
+                source_thread: "s".into(),
+                target_thread: "t".into(),
+                pre_target_id: cid(),
+                post_target_id: cid(),
+            },
+            OpRecord::ThreadCreateV2 {
+                name: "t".into(),
+                state: cid(),
+                manager_snapshot: None,
+            },
+            OpRecord::GitCheckpoint {
+                branch: "main".into(),
+                state: cid(),
+                previous_git_oid: None,
+                new_git_oid: "oid".into(),
+            },
+            OpRecord::RemoteThreadUpdate {
+                remote: "origin".into(),
+                thread: "t".into(),
+                state: cid(),
+            },
+            OpRecord::RemoteThreadDelete {
+                remote: "origin".into(),
+                thread: "t".into(),
+                state: cid(),
+            },
+            OpRecord::UndoRecoveryUpdate { state: cid() },
+        ]
+    }
+
+    #[test]
+    fn every_variant_has_a_catalog_verb() {
+        for op in one_per_variant() {
+            let verb = op.verb();
+            assert!(!verb.is_empty(), "empty verb for {op:?}");
+            assert!(
+                OP_VERB_CATALOG.iter().any(|(v, _)| *v == verb),
+                "verb {verb:?} for {op:?} missing from OP_VERB_CATALOG"
+            );
+        }
+    }
+
+    #[test]
+    fn only_checkpoint_is_checkpoint_verb() {
+        for op in one_per_variant() {
+            let expected = matches!(op, OpRecord::Checkpoint { .. });
+            assert_eq!(op.is_checkpoint_verb(), expected, "checkpoint flag for {op:?}");
+        }
+    }
+
+    #[test]
+    fn verbs_excludes_checkpoint_by_default_and_dedups() {
+        let with = OpRecord::verbs(true);
+        let without = OpRecord::verbs(false);
+        assert!(with.contains(&"checkpoint"));
+        assert!(!without.contains(&"checkpoint"));
+        // git_checkpoint is NOT the agent checkpoint — it must survive the
+        // no-checkpoints default.
+        assert!(without.contains(&"git_checkpoint"));
+        // Verbs shared by multiple variants appear once.
+        assert_eq!(with.iter().filter(|v| **v == "thread_create").count(), 1);
+        assert_eq!(with.iter().filter(|v| **v == "fast_forward").count(), 1);
+        // Newer tail variants are surfaced by default (the drift the catalog closes).
+        for v in [
+            "transaction_commit",
+            "redact",
+            "purge",
+            "fast_forward",
+            "remote_thread_update",
+            "remote_thread_delete",
+            "undo_recovery_update",
+        ] {
+            assert!(without.contains(&v), "{v} missing from default verb set");
+        }
+    }
 }

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -36,11 +36,32 @@ pub enum OpRecord {
         new_state: ChangeId,
     },
     /// Fork operation.
-    Fork { from: ChangeId, new_state: ChangeId },
-    /// Collapse operation.
+    ///
+    /// `from` is the source state forked from; `new_state` is the fork
+    /// result. `thread`/`head` name the ref the fork *published* so a
+    /// crash-replay (oplog committed, ref not yet materialized) can
+    /// re-derive which ref to publish (heddle#330 write chokepoint):
+    /// `thread = Some(name)` when the fork attached HEAD to a new thread,
+    /// `head = Some(state)` when it detached HEAD at the fork result.
+    /// These published-ref fields — not the `from`/`new_state` positional
+    /// pair — are the authoritative replay/materialization target.
+    Fork {
+        from: ChangeId,
+        new_state: ChangeId,
+        #[serde(default)]
+        thread: Option<String>,
+        #[serde(default)]
+        head: Option<ChangeId>,
+    },
+    /// Collapse operation. `thread` names the published ref: `Some(name)`
+    /// when the collapse published a thread ref, `None` when it published
+    /// a detached HEAD at `result` (heddle#330 write chokepoint — the
+    /// published-ref discriminant replay needs to materialize the ref).
     Collapse {
         sources: Vec<ChangeId>,
         result: ChangeId,
+        #[serde(default)]
+        thread: Option<String>,
     },
     /// Marker creation.
     MarkerCreate { name: String, state: ChangeId },
@@ -226,6 +247,30 @@ pub enum OpRecord {
         previous_git_oid: Option<String>,
         new_git_oid: String,
     },
+    /// A remote-thread ref was published (heddle#330 r9). Before this
+    /// variant `set_remote_thread` wrote the ref directly with no
+    /// committed record, so reconciliation of the remote-thread class
+    /// folded an empty tail. Recording the publish makes that
+    /// reconciliation non-vacuous and lets crash-replay re-materialize
+    /// the ref from its newest in-scope record.
+    RemoteThreadUpdate {
+        remote: String,
+        thread: String,
+        state: ChangeId,
+    },
+    /// A remote-thread ref was deleted (heddle#330 r9). Folded like a
+    /// `MarkerDelete`: drops the name from the reconciled remote-thread
+    /// set. `state` is the value at delete time (forensic context).
+    RemoteThreadDelete {
+        remote: String,
+        thread: String,
+        state: ChangeId,
+    },
+    /// The heddle-internal pre-undo recovery pointer was set (heddle#330
+    /// r9). A single rolling ORIG_HEAD-style pointer with no delete path,
+    /// so one update variant suffices. Local (per-checkout) ref —
+    /// reconciles within its own `op_scope`.
+    UndoRecoveryUpdate { state: ChangeId },
 }
 
 impl OpRecord {
@@ -345,6 +390,19 @@ impl OpRecord {
                     previous_git_oid.as_deref().unwrap_or("(none)"),
                     new_git_oid
                 )
+            }
+            OpRecord::RemoteThreadUpdate {
+                remote,
+                thread,
+                state,
+            } => {
+                format!("update remote thread {}/{} -> {}", remote, thread, state.short())
+            }
+            OpRecord::RemoteThreadDelete { remote, thread, .. } => {
+                format!("delete remote thread {}/{}", remote, thread)
+            }
+            OpRecord::UndoRecoveryUpdate { state } => {
+                format!("set undo-recovery -> {}", state.short())
             }
         }
     }

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -41,6 +41,24 @@ impl PackedOpLog {
         Self::parse(&bytes, path.to_path_buf())
     }
 
+    /// Read only the `head_id` from the fixed-size header — the cheap O(1)
+    /// generation gate (heddle#330). Layout: MAGIC(8) + VERSION(4) +
+    /// entry_count(8) + head_id(8); `head_id` is at byte offset 20.
+    pub(crate) fn read_head_id(path: &Path) -> Result<u64> {
+        use std::io::Read;
+        let mut file = std::fs::File::open(path)?;
+        let mut header = [0u8; 28];
+        file.read_exact(&mut header)?;
+        if &header[0..8] != MAGIC {
+            return Err(HeddleError::InvalidObject(
+                "invalid oplog magic".to_string(),
+            ));
+        }
+        let mut head_id_bytes = [0u8; 8];
+        head_id_bytes.copy_from_slice(&header[20..28]);
+        Ok(u64::from_le_bytes(head_id_bytes))
+    }
+
     pub(crate) fn save(&self) -> Result<()> {
         let bytes = self.serialize()?;
         write_file_atomic(&self.path, &bytes)?;

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -44,6 +44,12 @@ impl PackedOpLog {
     /// Read only the `head_id` from the fixed-size header — the cheap O(1)
     /// generation gate (heddle#330). Layout: MAGIC(8) + VERSION(4) +
     /// entry_count(8) + head_id(8); `head_id` is at byte offset 20.
+    ///
+    /// Validates BOTH the magic AND the version: the fast path must reject the
+    /// same headers the full [`parse`](Self::parse) would (heddle#354 r6, cid
+    /// 3329711891). Otherwise a right-magic / unsupported-version file yields a
+    /// generation and lets a reconciled read take the `tip == watermark`
+    /// shortcut, silently trusting a format the parser would refuse.
     pub(crate) fn read_head_id(path: &Path) -> Result<u64> {
         use std::io::Read;
         let mut file = std::fs::File::open(path)?;
@@ -53,6 +59,14 @@ impl PackedOpLog {
             return Err(HeddleError::InvalidObject(
                 "invalid oplog magic".to_string(),
             ));
+        }
+        let mut version_bytes = [0u8; 4];
+        version_bytes.copy_from_slice(&header[8..12]);
+        let version = u32::from_le_bytes(version_bytes);
+        if version != VERSION {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {version}"
+            )));
         }
         let mut head_id_bytes = [0u8; 8];
         head_id_bytes.copy_from_slice(&header[20..28]);
@@ -413,6 +427,37 @@ mod tests {
         assert_eq!(loaded.entries[0].id, 1);
         assert_eq!(loaded.entries[1].id, 2);
         assert_eq!(loaded.entries[0].scope.as_deref(), Some("lane-a"));
+    }
+
+    /// Finding 2 (heddle#354 r6, cid 3329711891) — the fast-path header read
+    /// rejects an unsupported version just as the full parser does, so a
+    /// right-magic / wrong-version file can never yield a silently-trusted
+    /// generation.
+    #[test]
+    fn read_head_id_rejects_unsupported_version() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let mut log = PackedOpLog::new(path.clone());
+        log.append(vec![make_entry(1, Some("lane"))]);
+        log.head_id = 1;
+        log.save().unwrap();
+
+        // A valid file's fast-path read succeeds.
+        assert_eq!(PackedOpLog::read_head_id(&path).unwrap(), 1);
+
+        // Bump the version field (bytes 8..12) to a forward-incompatible value,
+        // leaving the magic intact.
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[8..12].copy_from_slice(&(VERSION + 1).to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let err = PackedOpLog::read_head_id(&path).unwrap_err();
+        assert!(
+            matches!(&err, HeddleError::InvalidObject(message) if message.contains("unsupported oplog version")),
+            "fast path must reject an unsupported version, got: {err:?}"
+        );
+        // And the full parser agrees — the two paths stay in lockstep.
+        assert!(PackedOpLog::load(&path).is_err());
     }
 
     #[test]

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -16,6 +16,7 @@ rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/refs/src/refs/backend.rs
+++ b/crates/refs/src/refs/backend.rs
@@ -112,7 +112,7 @@ mod tests {
     use objects::object::{ChangeId, MarkerName, ThreadName};
 
     use super::CoreRefBackend;
-    use crate::refs::{Head, RefExpectation, RefUpdate};
+    use crate::refs::{Head, RefBackend, RefExpectation, RefUpdate};
 
     /// In-memory backend that does **not** override `resolve`, so the
     /// trait's default `resolve` (the only non-Pg, non-`RefManager`
@@ -231,6 +231,56 @@ mod tests {
             Ok(())
         }
         // `resolve` deliberately left unimplemented — exercises the default.
+    }
+
+    /// Implements only the required remote methods, leaving
+    /// `commit_and_publish` (and the other maintenance methods) on the trait
+    /// default — the exerciser for the default `commit_and_publish` fail-closed
+    /// path.
+    impl RefBackend for MemRefBackend {
+        fn get_remote_thread(
+            &self,
+            _remote: &str,
+            _thread: &ThreadName,
+        ) -> Result<Option<ChangeId>, HeddleError> {
+            Ok(None)
+        }
+        fn set_remote_thread(
+            &self,
+            _remote: &str,
+            _thread: &ThreadName,
+            _state: &ChangeId,
+        ) -> Result<(), HeddleError> {
+            Ok(())
+        }
+        fn delete_remote_thread(
+            &self,
+            _remote: &str,
+            _thread: &ThreadName,
+        ) -> Result<Option<ChangeId>, HeddleError> {
+            Ok(None)
+        }
+        fn list_remotes(&self) -> Result<Vec<String>, HeddleError> {
+            Ok(Vec::new())
+        }
+        fn list_remote_threads(&self, _remote: &str) -> Result<Vec<ThreadName>, HeddleError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// The default `commit_and_publish` (no record committer) must fail closed
+    /// when handed records (heddle#354 r9, cid 3330304656): committed data can
+    /// never be silently dropped while the ref batch is published anyway. A
+    /// record-free publish still succeeds.
+    #[test]
+    fn default_commit_and_publish_fails_closed_on_records() {
+        let backend = MemRefBackend::default();
+        assert!(
+            RefBackend::commit_and_publish(&backend, &[vec![1u8, 2, 3]], &[], None).is_err(),
+            "records with no committer must fail closed, not be silently dropped"
+        );
+        RefBackend::commit_and_publish(&backend, &[], &[], None)
+            .expect("a record-free publish has nothing to lose and must succeed");
     }
 
     #[test]

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -8,6 +8,7 @@ pub mod operation_index;
 mod packed_model;
 mod packed_refs;
 mod ref_backend;
+mod reconcile;
 mod ref_summary_index;
 mod refs_head;
 mod refs_manager;
@@ -39,6 +40,9 @@ pub use packed_model::PackedRefsModel;
 #[cfg(feature = "postgres")]
 pub use pg_refs::PgRefBackend;
 pub use ref_backend::RefBackend;
+pub use reconcile::{
+    Loaded, LoadRequest, RefClass, RefCommitter, RefReconciler, ReconcileOutcome,
+};
 pub use ref_summary_index::RefSummaryIndexInspection;
 pub use refs_manager::{RefManager, UNDO_RECOVERY_HANDLE};
 pub use reftable_model::{ReftableError, ReftableModel};

--- a/crates/refs/src/refs/reconcile.rs
+++ b/crates/refs/src/refs/reconcile.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The read-chokepoint reconciler seam (heddle#330 §2.2 "Reader model").
+//!
+//! All ten `RefManager` read methods funnel through `reconciled_load`, which
+//! reconciles the raw-loaded ref value against the committed oplog tail. The
+//! oplog lives in the `oplog` crate, which `refs` must NOT depend on, so the
+//! fold is behind a [`RefReconciler`] trait **defined here** (over `refs`-owned
+//! types) whose concrete oplog-backed impl is injected from the `repo`/`oplog`
+//! layer via [`RefManager::with_reconciler`](super::RefManager::with_reconciler)
+//! — the same dependency-inversion the write side uses.
+
+use objects::{
+    error::Result,
+    object::{ChangeId, MarkerName, ThreadName},
+};
+
+use super::{Head, RefUpdate};
+
+/// Whether a ref class reconciles within this checkout's `op_scope` (local) or
+/// globally across all lanes (shared) — heddle#330 §2.2 r10.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefClass {
+    /// `HEAD` + undo-recovery: live beside the per-worktree HEAD pointer, so a
+    /// read folds only this worktree's lane (never lifting a sibling's HEAD).
+    Local,
+    /// thread, marker, remote-thread: one shared file per ref, so a read folds
+    /// the full committed tail across all lanes (never missing a co-tenant's
+    /// committed-but-unpublished write).
+    Shared,
+}
+
+/// Which ref (or set of refs) a logical read wants. The single discriminator
+/// `reconciled_load` dispatches on — a point read's raw sub-step reads one ref;
+/// a list read's reads the summary set.
+#[derive(Clone, Debug)]
+pub enum LoadRequest {
+    Head,
+    Thread(ThreadName),
+    Marker(MarkerName),
+    UndoRecovery,
+    RemoteThread { remote: String, thread: ThreadName },
+    ThreadList,
+    MarkerList,
+    RemoteList,
+    RemoteThreadList { remote: String },
+}
+
+impl LoadRequest {
+    /// The ref class — local refs reconcile within `op_scope`, shared refs
+    /// globally (heddle#330 §2.2 r10).
+    pub fn ref_class(&self) -> RefClass {
+        match self {
+            LoadRequest::Head | LoadRequest::UndoRecovery => RefClass::Local,
+            _ => RefClass::Shared,
+        }
+    }
+}
+
+/// The raw-loaded (and, after reconciliation, authoritative) value for a
+/// [`LoadRequest`]. The variant matches the request shape.
+#[derive(Clone, Debug)]
+pub enum Loaded {
+    Head(Head),
+    Point(Option<ChangeId>),
+    ThreadList(Vec<ThreadName>),
+    MarkerList(Vec<MarkerName>),
+    RemoteList(Vec<String>),
+    RemoteThreadList(Vec<ThreadName>),
+}
+
+/// The result of a reconcile: the authoritative value for the request plus the
+/// re-materialization set for **every** ref the lagged batches touched (lazily
+/// re-published so the canonical cache catches up batch-atomically — heddle#330
+/// §2.2 r8). The watermark may advance only after every ref of the class is
+/// materialized, never after a partial single-ref reconcile.
+///
+/// `republish` carries the thread/marker/HEAD refs (expressible as
+/// [`RefUpdate`]); `remote_updates` and `undo_recovery` carry the two classes
+/// without a `RefUpdate` variant.
+pub struct ReconcileOutcome {
+    pub loaded: Loaded,
+    pub republish: Vec<RefUpdate>,
+    /// `(remote, thread, Some(state) | None == delete)` materializations.
+    pub remote_updates: Vec<(String, ThreadName, Option<ChangeId>)>,
+    /// New undo-recovery pointer to materialize, if a lagged batch set it.
+    pub undo_recovery: Option<ChangeId>,
+}
+
+/// The write-side dual of [`RefReconciler`] (heddle#330 §2.2 "The write
+/// chokepoint"): commits the caller's ref-carrying oplog record batch (phase 4)
+/// before the canonical publish (phase 5), so no ref is published without a
+/// preceding replayable record. The records cross the seam as opaque
+/// rmp-serde-encoded bytes, so `refs` names no `oplog` type; the impl (in
+/// `repo`) decodes and appends them. Injected via
+/// [`RefManager::with_committer`](super::RefManager::with_committer).
+pub trait RefCommitter: Send + Sync {
+    /// Append the (opaque-encoded) ref-carrying `OpRecord` batch under the
+    /// oplog write lock — phase 4, the commit point.
+    fn commit_records(&self, encoded_records: &[Vec<u8>], scope: Option<&str>) -> Result<()>;
+}
+
+/// The oplog-backed fold, injected into `RefManager` from the `repo`/`oplog`
+/// layer. Defined in `refs` over `refs`-owned types so `refs` keeps no `oplog`
+/// dependency; the impl (which names `OpRecord`) lives in `repo`.
+pub trait RefReconciler: Send + Sync {
+    /// Current oplog generation — the monotonic `head_id`. The cheap O(1) gate:
+    /// a read whose class watermark equals this returns the raw value with no
+    /// tail scan.
+    fn generation(&self) -> u64;
+
+    /// Fold the committed oplog tail (scoped by the request's ref class) into
+    /// `raw`, returning the authoritative value + the re-materialization set for
+    /// **every** ref the lagged batches touched (batch-atomic). Only the
+    /// committed entries newer than `since` (the class watermark) are folded, so
+    /// the scan is bounded to what actually lags — never the whole history. Only
+    /// invoked when the class watermark lags `generation()`.
+    fn reconcile(&self, req: &LoadRequest, raw: Loaded, since: u64) -> Result<ReconcileOutcome>;
+}

--- a/crates/refs/src/refs/reconcile.rs
+++ b/crates/refs/src/refs/reconcile.rs
@@ -106,7 +106,13 @@ pub trait RefReconciler: Send + Sync {
     /// Current oplog generation — the monotonic `head_id`. The cheap O(1) gate:
     /// a read whose class watermark equals this returns the raw value with no
     /// tail scan.
-    fn generation(&self) -> u64;
+    ///
+    /// Returns `Err` when the generation cannot be read (a truncated/corrupt/
+    /// unreadable oplog header) — it MUST NOT report a fallback generation
+    /// (cid 3329631081): a header error silently reported as generation 0 makes
+    /// a logical read skip every committed record, data-loss masquerading as an
+    /// empty oplog. The reconciled read fails loudly instead.
+    fn generation(&self) -> Result<u64>;
 
     /// Fold the committed oplog tail (scoped by the request's ref class) into
     /// `raw`, returning the authoritative value + the re-materialization set for

--- a/crates/refs/src/refs/ref_backend.rs
+++ b/crates/refs/src/refs/ref_backend.rs
@@ -31,13 +31,28 @@ pub trait RefBackend: CoreRefBackend<Error = HeddleError> {
     /// committer override it. (`PgRefBackend`'s single-tx co-commit needs the
     /// server's shared-pool wiring, which is out of this tree; it keeps the
     /// default until that lands.)
+    ///
+    /// **Fail closed (heddle#354 r9, cid 3330304656).** A backend with no
+    /// record committer MUST NOT publish the ref batch while silently dropping
+    /// the records it was handed — committed data must never be lost. A
+    /// record-free publish has nothing to lose and stays on the plain path; a
+    /// publish carrying records is refused with an error so the caller learns
+    /// the records would have vanished, rather than discovering it after the
+    /// fact via a reconcile that folds an empty tail.
     fn commit_and_publish(
         &self,
         encoded_records: &[Vec<u8>],
         ref_updates: &[RefUpdate],
         scope: Option<&str>,
     ) -> Result<()> {
-        let _ = (encoded_records, scope);
+        let _ = scope;
+        if !encoded_records.is_empty() {
+            return Err(HeddleError::Config(format!(
+                "commit_and_publish was handed {} record(s) on a backend with no record \
+                 committer; refusing to publish and silently drop committed data",
+                encoded_records.len()
+            )));
+        }
         self.update_refs(ref_updates)
     }
 

--- a/crates/refs/src/refs/ref_backend.rs
+++ b/crates/refs/src/refs/ref_backend.rs
@@ -9,7 +9,7 @@ use objects::{
     object::{ChangeId, ThreadName},
 };
 
-use super::{backend::CoreRefBackend, RefSummaryIndexInspection};
+use super::{backend::CoreRefBackend, RefSummaryIndexInspection, RefUpdate};
 
 /// Backend-agnostic interface for reading and writing repository references.
 pub trait RefBackend: CoreRefBackend<Error = HeddleError> {
@@ -18,6 +18,28 @@ pub trait RefBackend: CoreRefBackend<Error = HeddleError> {
     fn delete_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<ChangeId>>;
     fn list_remotes(&self) -> Result<Vec<String>>;
     fn list_remote_threads(&self, remote: &str) -> Result<Vec<ThreadName>>;
+
+    /// The write chokepoint (heddle#330 §2.2 r18): append the caller-supplied
+    /// ref-carrying record batch (phase 4, opaque rmp-serde `OpRecord` bytes so
+    /// `refs` names no `oplog` type) before publishing the atomic ref batch
+    /// (phase 5), record-before-publish. The seam is **per backend**: the file
+    /// backend (`RefManager`) earns atomicity by oplog-append-then-publish +
+    /// per-read reconciliation; the Postgres backend would co-commit the record
+    /// row and ref/head rows in one SQL transaction (native ACID).
+    ///
+    /// The default publishes **without** a record — backends with an injected
+    /// committer override it. (`PgRefBackend`'s single-tx co-commit needs the
+    /// server's shared-pool wiring, which is out of this tree; it keeps the
+    /// default until that lands.)
+    fn commit_and_publish(
+        &self,
+        encoded_records: &[Vec<u8>],
+        ref_updates: &[RefUpdate],
+        scope: Option<&str>,
+    ) -> Result<()> {
+        let _ = (encoded_records, scope);
+        self.update_refs(ref_updates)
+    }
 
     fn inspect_ref_summary_index(&self) -> Result<RefSummaryIndexInspection> {
         Ok(RefSummaryIndexInspection::absent())

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -2,8 +2,8 @@
 //! Reference manager: threads, markers, HEAD, and packed refs.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use objects::{
     error::{HeddleError, Result},
@@ -12,10 +12,13 @@ use objects::{
 };
 
 use super::{
-    backend::CoreRefBackend, format_change_id_text, packed_refs::PackedRefs,
+    Head, RefExpectation, RefUpdate,
+    backend::CoreRefBackend,
+    format_change_id_text,
+    packed_refs::PackedRefs,
+    reconcile::{LoadRequest, Loaded, RefClass, RefCommitter, RefReconciler},
     ref_backend::RefBackend,
-    reconcile::{Loaded, LoadRequest, RefClass, RefCommitter, RefReconciler},
-    resolve_refspec, Head, RefExpectation, RefUpdate,
+    resolve_refspec,
 };
 use crate::fs_atomic::sync_directory;
 
@@ -95,7 +98,8 @@ impl RefManager {
     /// record yet.
     pub fn with_reconciler(mut self, reconciler: Arc<dyn RefReconciler>) -> Self {
         let generation = reconciler.generation();
-        self.cached_local_generation.store(generation, Ordering::Release);
+        self.cached_local_generation
+            .store(generation, Ordering::Release);
         self.cached_shared_generation
             .store(generation, Ordering::Release);
         self.reconciler = Some(reconciler);
@@ -138,10 +142,11 @@ impl RefManager {
         self.validate_commit_publish(ref_updates, &lock, || {
             // Phase 4 — the commit point: append the ref-carrying records only
             // after phase-3 validation has passed, under the held refs lock.
+            let committed_for_reconcile = self.committer.is_some() && !encoded_records.is_empty();
             if let Some(committer) = self.committer.as_ref() {
                 committer.commit_records(encoded_records, scope)?;
             }
-            Ok(())
+            Ok(committed_for_reconcile)
         })
     }
 
@@ -209,8 +214,11 @@ impl RefManager {
                         to_publish.push(update.clone());
                     }
                 }
-                // HEAD is not reconstructed from the oplog (see the `Fold` doc).
-                RefUpdate::Head { .. } => {}
+                RefUpdate::Head { new, .. } => {
+                    if self.read_head_state()?.head != *new {
+                        to_publish.push(update.clone());
+                    }
+                }
             }
         }
         if !to_publish.is_empty() {

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -18,6 +18,7 @@ use super::{
     packed_refs::PackedRefs,
     reconcile::{LoadRequest, Loaded, RefClass, RefCommitter, RefReconciler},
     ref_backend::RefBackend,
+    refs_storage::RefsLock,
     resolve_refspec,
 };
 use crate::fs_atomic::sync_directory;
@@ -97,7 +98,11 @@ impl RefManager {
     /// refs from old records in the un-migrated tree, where deletes do not all
     /// record yet.
     pub fn with_reconciler(mut self, reconciler: Arc<dyn RefReconciler>) -> Self {
-        let generation = reconciler.generation();
+        // Seed both watermarks to the current generation. On a header read error
+        // (cid 3329631081) seed `WATERMARK_UNSET` rather than swallowing it as a
+        // generation — the next [`reconciled_load`] re-reads `generation()` and
+        // propagates the error loudly instead of trusting a fabricated value.
+        let generation = reconciler.generation().unwrap_or(WATERMARK_UNSET);
         self.cached_local_generation
             .store(generation, Ordering::Release);
         self.cached_shared_generation
@@ -157,32 +162,163 @@ impl RefManager {
     /// from inside here — the maintenance path `pack_refs` is the one allowlisted
     /// non-logical caller. With no reconciler this is the plain raw load.
     fn reconciled_load(&self, req: LoadRequest) -> Result<Loaded> {
+        let Some(reconciler) = self.reconciler.as_ref() else {
+            return self.raw_load(&req);
+        };
+
+        let watermark = match req.ref_class() {
+            RefClass::Local => &self.cached_local_generation,
+            RefClass::Shared => &self.cached_shared_generation,
+        };
+
+        // Cheap O(1) gate: when this class's watermark already equals the oplog
+        // tip, every committed record of the class is materialized into
+        // canonical ⇒ the raw read is authoritative ⇒ no lock, no tail scan.
+        // A `generation()` error propagates (cid 3329631081) — never silently
+        // treated as generation 0.
+        let tip = reconciler.generation()?;
+        if tip == watermark.load(Ordering::Acquire) {
+            return self.raw_load(&req);
+        }
+
+        // Lag: the fold AND the lazy re-publish must be atomic w.r.t. a
+        // concurrent `commit_and_publish` (cid 3329631077). Take the publish
+        // lock FIRST, then re-read tip + raw and fold UNDER the lock — so a
+        // concurrent publish that lands a newer value cannot interpose between
+        // the fold and the materialize. The fold sees the newest committed
+        // record (highest id wins), so materialization never republishes a stale
+        // value over a freshly-published newer one.
+        let lock = self.lock_refs()?;
+        let tip = reconciler.generation()?;
+        let cached = watermark.load(Ordering::Acquire);
         let raw = self.raw_load(&req)?;
+        if tip == cached {
+            // A concurrent reconcile materialized the lag while we waited for the
+            // lock; the freshly-read canonical is now authoritative.
+            return Ok(raw);
+        }
+
+        // The reconcile is batch-atomic — it returns the re-materialization set
+        // for every ref the lagged batches touched, which we publish (under the
+        // held lock) so the watermark can advance without leaving a batch sibling
+        // stale.
+        let since = if cached == WATERMARK_UNSET { 0 } else { cached };
+        let outcome = reconciler.reconcile(&req, raw, since)?;
+        self.materialize(&outcome, &lock)?;
+        watermark.store(tip, Ordering::Release);
+        // Persist the advanced watermark so a future process seeds from this
+        // last-clean point and folds only the genuine crash tail above it, never
+        // re-deriving long-since-deleted refs from ancient records (cid
+        // 3329631074). Best-effort: a write failure only costs extra folding next
+        // open, never correctness.
+        let _ = self.persist_reconcile_watermark(&lock);
+        Ok(outcome.loaded)
+    }
+
+    /// Fold the committed-but-unpublished oplog tail over the raw value WITHOUT
+    /// taking the refs lock — the caller already holds it (phase-3 validation in
+    /// [`plan_ref_updates`](Self::plan_ref_updates)). Closes the stale-validation
+    /// gap (cid 3329631079): a `Missing`/CAS expectation, and the publish base,
+    /// are computed from the reconciled state — never a pre-lock raw read that a
+    /// crash-left committed-but-unpublished record has made stale. The same O(1)
+    /// gate applies: with the watermark current, the raw value is authoritative.
+    pub(super) fn reconciled_value_under_lock(&self, req: &LoadRequest) -> Result<Loaded> {
+        let raw = self.raw_load(req)?;
         let Some(reconciler) = self.reconciler.as_ref() else {
             return Ok(raw);
         };
-
-        let tip = reconciler.generation();
+        let tip = reconciler.generation()?;
         let watermark = match req.ref_class() {
             RefClass::Local => &self.cached_local_generation,
             RefClass::Shared => &self.cached_shared_generation,
         };
         let cached = watermark.load(Ordering::Acquire);
         if tip == cached {
-            // No commit affecting this class since the last full materialization
-            // ⇒ the canonical cache is current ⇒ no tail scan, no write.
             return Ok(raw);
         }
-
-        // Lag possible: fold the committed tail newer than the watermark. The
-        // reconcile is batch-atomic — it returns the re-materialization set for
-        // every ref the lagged batches touched, which we publish so the
-        // watermark can advance without leaving a batch sibling stale.
         let since = if cached == WATERMARK_UNSET { 0 } else { cached };
-        let outcome = reconciler.reconcile(&req, raw, since)?;
-        self.materialize(&outcome)?;
-        watermark.store(tip, Ordering::Release);
-        Ok(outcome.loaded)
+        Ok(reconciler.reconcile(req, raw, since)?.loaded)
+    }
+
+    /// Seed the per-read watermarks from the persisted last-clean point
+    /// (heddle#354 r5, cid 3329631074), so a fresh handle recovers a prior
+    /// process's committed-but-unpublished crash tail.
+    ///
+    /// A `RefManager` seeds its in-memory watermarks at the current generation
+    /// ([`with_reconciler`](Self::with_reconciler)) — so the per-read gate, on a
+    /// fresh process, would never fold a record committed *before* this handle
+    /// opened, and a cross-process crash (phase-4 committed, phase-5 publish
+    /// never ran) would be silently lost. The fix is NOT an eager open-time fold
+    /// (that would re-derive long-since-deleted refs from ancient records, since
+    /// the un-migrated delete paths do not all record yet): it is a **persisted
+    /// watermark**. Reads advance and persist it past every materialized record,
+    /// so on open the seed sits at the last point canonical was known-consistent;
+    /// the per-read reconcile then folds only `(seed, tip]` — the genuine crash
+    /// tail — and never the ancient records below the seed.
+    ///
+    /// When no watermark has been persisted yet (a fresh repo, or a repo from
+    /// before this version), seed conservatively at the current generation and
+    /// write the file, so the next process has a real last-clean point.
+    pub fn init_reconcile_watermark(&self) -> Result<()> {
+        if self.reconciler.is_none() {
+            return Ok(());
+        }
+        match self.read_persisted_reconcile_watermark()? {
+            Some((local, shared)) => {
+                self.cached_local_generation.store(local, Ordering::Release);
+                self.cached_shared_generation
+                    .store(shared, Ordering::Release);
+            }
+            None => {
+                let lock = self.lock_refs()?;
+                self.persist_reconcile_watermark(&lock)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Path of the per-worktree persisted reconcile watermark, beside `HEAD`
+    /// and `UNDO_RECOVERY` (the local watermark is per-`op_scope`; the shared
+    /// watermark is persisted per-worktree too — a conservative lower bound just
+    /// means more folding, never a missed record).
+    fn reconcile_watermark_path(&self) -> PathBuf {
+        self.head_path()
+            .parent()
+            .map(|dir| dir.join("RECONCILE_WATERMARK"))
+            .unwrap_or_else(|| self.root.join("RECONCILE_WATERMARK"))
+    }
+
+    /// Read the persisted `(local, shared)` watermark, or `None` when absent /
+    /// unparseable (treated as "no last-clean point yet").
+    fn read_persisted_reconcile_watermark(&self) -> Result<Option<(u64, u64)>> {
+        let Some(contents) = self.read_optional_string(&self.reconcile_watermark_path())? else {
+            return Ok(None);
+        };
+        let mut parts = contents.split_whitespace();
+        match (
+            parts.next().and_then(|s| s.parse::<u64>().ok()),
+            parts.next().and_then(|s| s.parse::<u64>().ok()),
+        ) {
+            (Some(local), Some(shared)) => Ok(Some((local, shared))),
+            _ => Ok(None),
+        }
+    }
+
+    /// Persist the current in-memory `(local, shared)` watermark under the held
+    /// refs lock. Called after a read advances a watermark, and at open when no
+    /// file exists yet.
+    fn persist_reconcile_watermark(&self, _lock: &RefsLock) -> Result<()> {
+        let local = self.cached_local_generation.load(Ordering::Acquire);
+        let shared = self.cached_shared_generation.load(Ordering::Acquire);
+        // A still-unset watermark (no reconciler, or seeded UNSET on a header
+        // error) is not a meaningful last-clean point — skip it.
+        if local == WATERMARK_UNSET || shared == WATERMARK_UNSET {
+            return Ok(());
+        }
+        self.write_string(
+            &self.reconcile_watermark_path(),
+            &format!("{} {}\n", local, shared),
+        )
     }
 
     /// Lazily re-publish (phase-5 materialization) the refs a reconcile found
@@ -200,37 +336,26 @@ impl RefManager {
     /// rewritten; a write equal to the canonical is skipped as a no-op. (The
     /// rare un-migrated case where an unrecorded direct write raced in *after*
     /// the commit is the residual the writers' record-first migration closes.)
-    fn materialize(&self, outcome: &super::reconcile::ReconcileOutcome) -> Result<()> {
-        let mut to_publish = Vec::new();
-        for update in &outcome.republish {
-            match update {
-                RefUpdate::Thread { name, new, .. } => {
-                    if self.raw_get_thread(name)? != *new {
-                        to_publish.push(update.clone());
-                    }
-                }
-                RefUpdate::Marker { name, new, .. } => {
-                    if self.raw_get_marker(name)? != *new {
-                        to_publish.push(update.clone());
-                    }
-                }
-                RefUpdate::Head { new, .. } => {
-                    if self.read_head_state()?.head != *new {
-                        to_publish.push(update.clone());
-                    }
-                }
-            }
-        }
-        if !to_publish.is_empty() {
-            let lock = self.lock_refs()?;
-            self.update_refs_with_lock(&to_publish, &lock)?;
+    fn materialize(
+        &self,
+        outcome: &super::reconcile::ReconcileOutcome,
+        lock: &RefsLock,
+    ) -> Result<()> {
+        // The whole materialization runs under the caller's single held lock so
+        // the fold that produced `outcome` and these re-publishes are one atomic
+        // unit vs a concurrent publish (cid 3329631077). The publish values are
+        // the authoritative folded values; the no-op skip is against the current
+        // canonical, computed inside `plan_materialization`.
+        let plans = self.plan_materialization(&outcome.republish)?;
+        if !plans.is_empty() {
+            self.publish_ref_plans(plans, lock)?;
         }
         for (remote, thread, value) in &outcome.remote_updates {
             if self.raw_get_remote_thread(remote, thread)? != *value {
                 match value {
-                    Some(state) => self.set_remote_thread_raw(remote, thread, state)?,
+                    Some(state) => self.set_remote_thread_locked(remote, thread, state, lock)?,
                     None => {
-                        self.delete_remote_thread_raw(remote, thread)?;
+                        self.delete_remote_thread_locked(remote, thread, lock)?;
                     }
                 }
             }
@@ -242,7 +367,7 @@ impl RefManager {
                 UNDO_RECOVERY_HANDLE,
             )?;
             if current.as_ref() != Some(state) {
-                self.set_undo_recovery_raw(state)?;
+                self.set_undo_recovery_locked(state, lock)?;
             }
         }
         Ok(())
@@ -518,7 +643,14 @@ impl RefManager {
     /// phase-5 materialization sub-step (used by both the public setter and the
     /// reconciler's lazy re-publish).
     fn set_undo_recovery_raw(&self, state: &ChangeId) -> Result<()> {
-        let _lock = self.lock_refs()?;
+        let lock = self.lock_refs()?;
+        self.set_undo_recovery_locked(state, &lock)
+    }
+
+    /// The lock-free core of [`set_undo_recovery_raw`](Self::set_undo_recovery_raw):
+    /// the caller already holds the refs lock (e.g. the reconciler's
+    /// materialization runs the whole fold + re-publish under one lock).
+    fn set_undo_recovery_locked(&self, state: &ChangeId, _lock: &RefsLock) -> Result<()> {
         self.write_string(
             &self.undo_recovery_path(),
             &super::format_change_id_text(state),
@@ -561,7 +693,19 @@ impl RefManager {
         thread: &ThreadName,
         state: &ChangeId,
     ) -> Result<()> {
-        let _lock = self.lock_refs()?;
+        let lock = self.lock_refs()?;
+        self.set_remote_thread_locked(remote, thread, state, &lock)
+    }
+
+    /// The lock-free core of [`set_remote_thread_raw`](Self::set_remote_thread_raw):
+    /// the caller already holds the refs lock.
+    fn set_remote_thread_locked(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+        state: &ChangeId,
+        lock: &RefsLock,
+    ) -> Result<()> {
         let path = self.remote_thread_path(remote, thread)?;
         let content = format_change_id_text(state);
         let parent = path.parent().ok_or_else(|| {
@@ -572,7 +716,7 @@ impl RefManager {
         })?;
         std::fs::create_dir_all(parent)?;
         self.write_string(&path, &content)?;
-        if self.rebuild_ref_summary_index_with_lock(&_lock).is_err() {
+        if self.rebuild_ref_summary_index_with_lock(lock).is_err() {
             self.invalidate_ref_summary_index();
         }
         Ok(())
@@ -592,7 +736,18 @@ impl RefManager {
         remote: &str,
         thread: &ThreadName,
     ) -> Result<Option<ChangeId>> {
-        let _lock = self.lock_refs()?;
+        let lock = self.lock_refs()?;
+        self.delete_remote_thread_locked(remote, thread, &lock)
+    }
+
+    /// The lock-free core of [`delete_remote_thread_raw`](Self::delete_remote_thread_raw):
+    /// the caller already holds the refs lock.
+    fn delete_remote_thread_locked(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+        lock: &RefsLock,
+    ) -> Result<Option<ChangeId>> {
         let state = self.raw_get_remote_thread(remote, thread)?;
         if state.is_some() {
             let path = self.remote_thread_path(remote, thread)?;
@@ -602,7 +757,7 @@ impl RefManager {
                 Err(e) => return Err(HeddleError::from(e)),
             }
         }
-        if self.rebuild_ref_summary_index_with_lock(&_lock).is_err() {
+        if self.rebuild_ref_summary_index_with_lock(lock).is_err() {
             self.invalidate_ref_summary_index();
         }
         Ok(state)

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -2,6 +2,8 @@
 //! Reference manager: threads, markers, HEAD, and packed refs.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use objects::{
     error::{HeddleError, Result},
@@ -11,9 +13,15 @@ use objects::{
 
 use super::{
     backend::CoreRefBackend, format_change_id_text, packed_refs::PackedRefs,
-    ref_backend::RefBackend, resolve_refspec, Head, RefExpectation, RefUpdate,
+    ref_backend::RefBackend,
+    reconcile::{Loaded, LoadRequest, RefClass, RefCommitter, RefReconciler},
+    resolve_refspec, Head, RefExpectation, RefUpdate,
 };
 use crate::fs_atomic::sync_directory;
+
+/// Sentinel meaning "no batch has been reconciled yet" — distinct from a real
+/// `head_id` so the first read after a reconciler is injected always reconciles.
+const WATERMARK_UNSET: u64 = u64::MAX;
 
 /// Well-known refspec that resolves the heddle-internal pre-undo recovery
 /// pointer (so `heddle goto .undo-recovery` works). It is UNSHADOWABLE by any
@@ -37,6 +45,20 @@ pub const UNDO_RECOVERY_HANDLE: &str = ".undo-recovery";
 pub struct RefManager {
     pub(crate) root: PathBuf,
     pub(crate) local_head: Option<PathBuf>,
+    /// Oplog-backed reconciler (heddle#330 read chokepoint). `None` for the
+    /// bootstrap/test path — then `reconciled_load` returns the plain cache,
+    /// behaviourally identical to the pre-chokepoint code.
+    reconciler: Option<Arc<dyn RefReconciler>>,
+    /// Oplog-backed committer (heddle#330 write chokepoint). `None` for the
+    /// bootstrap/test path — then `commit_and_publish` publishes without a
+    /// record, like the pre-chokepoint code.
+    committer: Option<Arc<dyn RefCommitter>>,
+    /// Watermark of fully-materialized **local**-class batches (HEAD,
+    /// undo-recovery) — `op_scope`-scoped. `WATERMARK_UNSET` until first reconcile.
+    cached_local_generation: AtomicU64,
+    /// Watermark of fully-materialized **shared**-class batches (thread, marker,
+    /// remote-thread) — global across lanes.
+    cached_shared_generation: AtomicU64,
 }
 
 impl RefManager {
@@ -44,12 +66,234 @@ impl RefManager {
         Self {
             root: heddle_dir.as_ref().to_path_buf(),
             local_head: None,
+            reconciler: None,
+            committer: None,
+            cached_local_generation: AtomicU64::new(WATERMARK_UNSET),
+            cached_shared_generation: AtomicU64::new(WATERMARK_UNSET),
         }
     }
 
     pub fn with_local_head(mut self, path: PathBuf) -> Self {
         self.local_head = Some(path);
         self
+    }
+
+    /// Inject the oplog-backed reconciler (heddle#330 §2.2). Once set, every
+    /// logical read funnels through [`RefManager::reconciled_load`] and
+    /// reconciles against the committed oplog tail. Mirrors the
+    /// [`with_local_head`](Self::with_local_head) builder shape.
+    ///
+    /// The class watermarks are seeded to the **current** generation: this
+    /// handle trusts the already-published canonical cache as of open and
+    /// reconciles only commits made *after* it — the load-bearing long-held
+    /// handle cell (the daemon's `Arc<Repository>`, cid 3328112197) an
+    /// open-time-only pass cannot reach. (Catching a *pre-open* crash lag is the
+    /// job of the optional `Repository::open` eager pass, deferred here as the
+    /// spike's stated optimization, not the guarantee.) Seeding to the current
+    /// generation also keeps reconciliation from re-deriving long-since-deleted
+    /// refs from old records in the un-migrated tree, where deletes do not all
+    /// record yet.
+    pub fn with_reconciler(mut self, reconciler: Arc<dyn RefReconciler>) -> Self {
+        let generation = reconciler.generation();
+        self.cached_local_generation.store(generation, Ordering::Release);
+        self.cached_shared_generation
+            .store(generation, Ordering::Release);
+        self.reconciler = Some(reconciler);
+        self
+    }
+
+    /// Inject the oplog-backed committer (heddle#330 §2.2 write chokepoint).
+    /// Once set, [`commit_and_publish`](Self::commit_and_publish) appends the
+    /// caller's ref-carrying records before publishing the ref batch.
+    pub fn with_committer(mut self, committer: Arc<dyn RefCommitter>) -> Self {
+        self.committer = Some(committer);
+        self
+    }
+
+    /// THE write chokepoint (heddle#330 §2.2): commit the caller-supplied
+    /// ref-carrying record batch (phase 4) **before** publishing the atomic ref
+    /// batch (phase 5), record-before-publish, the whole batch published as one
+    /// unit. `encoded_records` are opaque rmp-serde `OpRecord` bytes (so `refs`
+    /// names no `oplog` type). The bare publish (temp→rename, via
+    /// `update_refs_with_lock`) is reachable through this seam, never with a ref
+    /// published ahead of its record. With no committer it degrades to a plain
+    /// publish (bootstrap).
+    pub fn commit_and_publish(
+        &self,
+        encoded_records: &[Vec<u8>],
+        ref_updates: &[RefUpdate],
+        scope: Option<&str>,
+    ) -> Result<()> {
+        // Phase 4 — the commit point: append every ref-carrying record first.
+        if let Some(committer) = self.committer.as_ref() {
+            committer.commit_records(encoded_records, scope)?;
+        }
+        // Phase 5 — publish the atomic ref batch as one unit (raw publish).
+        if !ref_updates.is_empty() {
+            let lock = self.lock_refs()?;
+            self.update_refs_with_lock(ref_updates, &lock)?;
+        }
+        Ok(())
+    }
+
+    /// THE read chokepoint (heddle#330 §2.2): the sole path for a **logical
+    /// read** to obtain ref data. The raw loaders
+    /// (`read_change_id_at`/`read_head_state`/`try_read_ref_summary_index`/
+    /// `*_from_storage`/`PackedRefs::load`) are reached from a logical read only
+    /// from inside here — the maintenance path `pack_refs` is the one allowlisted
+    /// non-logical caller. With no reconciler this is the plain raw load.
+    fn reconciled_load(&self, req: LoadRequest) -> Result<Loaded> {
+        let raw = self.raw_load(&req)?;
+        let Some(reconciler) = self.reconciler.as_ref() else {
+            return Ok(raw);
+        };
+
+        let tip = reconciler.generation();
+        let watermark = match req.ref_class() {
+            RefClass::Local => &self.cached_local_generation,
+            RefClass::Shared => &self.cached_shared_generation,
+        };
+        let cached = watermark.load(Ordering::Acquire);
+        if tip == cached {
+            // No commit affecting this class since the last full materialization
+            // ⇒ the canonical cache is current ⇒ no tail scan, no write.
+            return Ok(raw);
+        }
+
+        // Lag possible: fold the committed tail newer than the watermark. The
+        // reconcile is batch-atomic — it returns the re-materialization set for
+        // every ref the lagged batches touched, which we publish so the
+        // watermark can advance without leaving a batch sibling stale.
+        let since = if cached == WATERMARK_UNSET { 0 } else { cached };
+        let outcome = reconciler.reconcile(&req, raw, since)?;
+        self.materialize(&outcome)?;
+        watermark.store(tip, Ordering::Release);
+        Ok(outcome.loaded)
+    }
+
+    /// Lazily re-publish (phase-5 materialization) the refs a reconcile found
+    /// committed-but-unpublished — the records already exist, so this writes
+    /// canonical only (never the oplog).
+    ///
+    /// **Fill-if-absent (non-destructive):** only refs whose canonical value is
+    /// *missing* are materialized. In the un-migrated tree many ref writes do
+    /// not yet record an oplog entry, so a present canonical may be newer than
+    /// the fold; overwriting it would regress the ref. So we only fill genuine
+    /// gaps (the committed-but-never-published crash-replay case) and never
+    /// clobber a present canonical.
+    fn materialize(&self, outcome: &super::reconcile::ReconcileOutcome) -> Result<()> {
+        let mut to_publish = Vec::new();
+        for update in &outcome.republish {
+            match update {
+                RefUpdate::Thread {
+                    name,
+                    new: Some(_),
+                    ..
+                } if self.raw_get_thread(name)?.is_none() => to_publish.push(update.clone()),
+                RefUpdate::Marker {
+                    name,
+                    new: Some(_),
+                    ..
+                } if self.raw_get_marker(name)?.is_none() => to_publish.push(update.clone()),
+                _ => {}
+            }
+        }
+        if !to_publish.is_empty() {
+            let lock = self.lock_refs()?;
+            self.update_refs_with_lock(&to_publish, &lock)?;
+        }
+        for (remote, thread, value) in &outcome.remote_updates {
+            if let Some(state) = value
+                && self.raw_get_remote_thread(remote, thread)?.is_none()
+            {
+                self.set_remote_thread_raw(remote, thread, state)?;
+            }
+        }
+        if let Some(state) = &outcome.undo_recovery {
+            let current = self.read_change_id_at(
+                &self.undo_recovery_path(),
+                "undo recovery",
+                UNDO_RECOVERY_HANDLE,
+            )?;
+            if current.is_none() {
+                self.set_undo_recovery_raw(state)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Request-scoped raw read — the private sub-step `reconciled_load` calls.
+    /// Each arm touches exactly one raw loader for a point read (no whole-set
+    /// scan on the hot path).
+    fn raw_load(&self, req: &LoadRequest) -> Result<Loaded> {
+        Ok(match req {
+            LoadRequest::Head => Loaded::Head(self.read_head_state()?.head),
+            LoadRequest::Thread(name) => Loaded::Point(self.raw_get_thread(name)?),
+            LoadRequest::Marker(name) => Loaded::Point(self.raw_get_marker(name)?),
+            LoadRequest::UndoRecovery => Loaded::Point(self.read_change_id_at(
+                &self.undo_recovery_path(),
+                "undo recovery",
+                UNDO_RECOVERY_HANDLE,
+            )?),
+            LoadRequest::RemoteThread { remote, thread } => {
+                Loaded::Point(self.raw_get_remote_thread(remote, thread)?)
+            }
+            LoadRequest::ThreadList => Loaded::ThreadList(self.raw_list_threads()?),
+            LoadRequest::MarkerList => Loaded::MarkerList(self.raw_list_markers()?),
+            LoadRequest::RemoteList => Loaded::RemoteList(self.raw_list_remotes()?),
+            LoadRequest::RemoteThreadList { remote } => {
+                Loaded::RemoteThreadList(self.raw_list_remote_threads(remote)?)
+            }
+        })
+    }
+
+    fn raw_get_thread(&self, name: &ThreadName) -> Result<Option<ChangeId>> {
+        let path = self.thread_path(name)?;
+        if let Some(id) = self.read_change_id_at(&path, "thread", name)? {
+            return Ok(Some(id));
+        }
+        Ok(PackedRefs::load(&self.packed_refs_path())?.get_thread(name))
+    }
+
+    fn raw_get_marker(&self, name: &MarkerName) -> Result<Option<ChangeId>> {
+        let path = self.marker_path(name)?;
+        if let Some(id) = self.read_change_id_at(&path, "marker", name)? {
+            return Ok(Some(id));
+        }
+        Ok(PackedRefs::load(&self.packed_refs_path())?.get_marker(name))
+    }
+
+    fn raw_get_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<ChangeId>> {
+        let path = self.remote_thread_path(remote, thread)?;
+        self.read_change_id_at(&path, "remote thread", &format!("{}/{}", remote, thread))
+    }
+
+    fn raw_list_threads(&self) -> Result<Vec<ThreadName>> {
+        if let Some(summary) = self.try_read_ref_summary_index() {
+            return Ok(summary.thread_names());
+        }
+        self.list_threads_from_storage()
+    }
+
+    fn raw_list_markers(&self) -> Result<Vec<MarkerName>> {
+        if let Some(summary) = self.try_read_ref_summary_index() {
+            return Ok(summary.marker_names());
+        }
+        self.list_markers_from_storage()
+    }
+
+    fn raw_list_remotes(&self) -> Result<Vec<String>> {
+        if let Some(summary) = self.try_read_ref_summary_index() {
+            return Ok(summary.remote_names());
+        }
+        self.list_remotes_from_storage()
+    }
+
+    fn raw_list_remote_threads(&self, remote: &str) -> Result<Vec<ThreadName>> {
+        if let Some(summary) = self.try_read_ref_summary_index() {
+            return Ok(summary.remote_thread_names(remote));
+        }
+        self.list_remote_threads_from_storage(remote)
     }
 
     pub fn init(&self) -> Result<()> {
@@ -112,7 +356,10 @@ impl RefManager {
     }
 
     pub fn read_head(&self) -> Result<Head> {
-        self.read_head_state().map(|state| state.head)
+        match self.reconciled_load(LoadRequest::Head)? {
+            Loaded::Head(head) => Ok(head),
+            _ => unreachable!("Head request yields Head"),
+        }
     }
 
     pub fn write_head(&self, head: &Head) -> Result<()> {
@@ -127,11 +374,10 @@ impl RefManager {
     }
 
     pub fn get_thread(&self, name: &ThreadName) -> Result<Option<ChangeId>> {
-        let path = self.thread_path(name)?;
-        if let Some(id) = self.read_change_id_at(&path, "thread", name)? {
-            return Ok(Some(id));
+        match self.reconciled_load(LoadRequest::Thread(name.clone()))? {
+            Loaded::Point(id) => Ok(id),
+            _ => unreachable!("Thread request yields Point"),
         }
-        Ok(PackedRefs::load(&self.packed_refs_path())?.get_thread(name))
     }
 
     pub fn set_thread(&self, name: &ThreadName, state: &ChangeId) -> Result<()> {
@@ -176,18 +422,17 @@ impl RefManager {
     }
 
     pub fn list_threads(&self) -> Result<Vec<ThreadName>> {
-        if let Some(summary) = self.try_read_ref_summary_index() {
-            return Ok(summary.thread_names());
+        match self.reconciled_load(LoadRequest::ThreadList)? {
+            Loaded::ThreadList(names) => Ok(names),
+            _ => unreachable!("ThreadList request yields ThreadList"),
         }
-        self.list_threads_from_storage()
     }
 
     pub fn get_marker(&self, name: &MarkerName) -> Result<Option<ChangeId>> {
-        let path = self.marker_path(name)?;
-        if let Some(id) = self.read_change_id_at(&path, "marker", name)? {
-            return Ok(Some(id));
+        match self.reconciled_load(LoadRequest::Marker(name.clone()))? {
+            Loaded::Point(id) => Ok(id),
+            _ => unreachable!("Marker request yields Point"),
         }
-        Ok(PackedRefs::load(&self.packed_refs_path())?.get_marker(name))
     }
 
     pub fn create_marker(&self, name: &MarkerName, state: &ChangeId) -> Result<()> {
@@ -228,10 +473,10 @@ impl RefManager {
     }
 
     pub fn list_markers(&self) -> Result<Vec<MarkerName>> {
-        if let Some(summary) = self.try_read_ref_summary_index() {
-            return Ok(summary.marker_names());
+        match self.reconciled_load(LoadRequest::MarkerList)? {
+            Loaded::MarkerList(names) => Ok(names),
+            _ => unreachable!("MarkerList request yields MarkerList"),
         }
-        self.list_markers_from_storage()
     }
 
     /// Record the heddle-internal pre-undo recovery pointer (ORIG_HEAD-style:
@@ -240,6 +485,13 @@ impl RefManager {
     /// undo inverses — can never collide with it. See
     /// [`UNDO_RECOVERY_HANDLE`] for the resolution handle.
     pub fn set_undo_recovery(&self, state: &ChangeId) -> Result<()> {
+        self.set_undo_recovery_raw(state)
+    }
+
+    /// The raw canonical write for undo-recovery, with no oplog append — the
+    /// phase-5 materialization sub-step (used by both the public setter and the
+    /// reconciler's lazy re-publish).
+    fn set_undo_recovery_raw(&self, state: &ChangeId) -> Result<()> {
         let _lock = self.lock_refs()?;
         self.write_string(
             &self.undo_recovery_path(),
@@ -250,15 +502,34 @@ impl RefManager {
     /// Read the heddle-internal pre-undo recovery pointer, if one has been
     /// recorded. Returns `None` when no undo has run in this repo.
     pub fn get_undo_recovery(&self) -> Result<Option<ChangeId>> {
-        self.read_change_id_at(&self.undo_recovery_path(), "undo recovery", UNDO_RECOVERY_HANDLE)
+        match self.reconciled_load(LoadRequest::UndoRecovery)? {
+            Loaded::Point(id) => Ok(id),
+            _ => unreachable!("UndoRecovery request yields Point"),
+        }
     }
 
     pub fn get_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<ChangeId>> {
-        let path = self.remote_thread_path(remote, thread)?;
-        self.read_change_id_at(&path, "remote thread", &format!("{}/{}", remote, thread))
+        match self.reconciled_load(LoadRequest::RemoteThread {
+            remote: remote.to_string(),
+            thread: thread.clone(),
+        })? {
+            Loaded::Point(id) => Ok(id),
+            _ => unreachable!("RemoteThread request yields Point"),
+        }
     }
 
     pub fn set_remote_thread(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+        state: &ChangeId,
+    ) -> Result<()> {
+        self.set_remote_thread_raw(remote, thread, state)
+    }
+
+    /// The raw canonical write for a remote-thread ref, with no oplog append —
+    /// the phase-5 materialization sub-step.
+    fn set_remote_thread_raw(
         &self,
         remote: &str,
         thread: &ThreadName,
@@ -286,8 +557,17 @@ impl RefManager {
         remote: &str,
         thread: &ThreadName,
     ) -> Result<Option<ChangeId>> {
+        self.delete_remote_thread_raw(remote, thread)
+    }
+
+    /// The raw canonical delete for a remote-thread ref, with no oplog append.
+    fn delete_remote_thread_raw(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+    ) -> Result<Option<ChangeId>> {
         let _lock = self.lock_refs()?;
-        let state = self.get_remote_thread(remote, thread)?;
+        let state = self.raw_get_remote_thread(remote, thread)?;
         if state.is_some() {
             let path = self.remote_thread_path(remote, thread)?;
             match std::fs::remove_file(&path) {
@@ -303,17 +583,19 @@ impl RefManager {
     }
 
     pub fn list_remotes(&self) -> Result<Vec<String>> {
-        if let Some(summary) = self.try_read_ref_summary_index() {
-            return Ok(summary.remote_names());
+        match self.reconciled_load(LoadRequest::RemoteList)? {
+            Loaded::RemoteList(names) => Ok(names),
+            _ => unreachable!("RemoteList request yields RemoteList"),
         }
-        self.list_remotes_from_storage()
     }
 
     pub fn list_remote_threads(&self, remote: &str) -> Result<Vec<ThreadName>> {
-        if let Some(summary) = self.try_read_ref_summary_index() {
-            return Ok(summary.remote_thread_names(remote));
+        match self.reconciled_load(LoadRequest::RemoteThreadList {
+            remote: remote.to_string(),
+        })? {
+            Loaded::RemoteThreadList(names) => Ok(names),
+            _ => unreachable!("RemoteThreadList request yields RemoteThreadList"),
         }
-        self.list_remote_threads_from_storage(remote)
     }
 
     pub fn update_refs(&self, updates: &[RefUpdate]) -> Result<()> {
@@ -469,6 +751,14 @@ impl RefBackend for RefManager {
     }
     fn list_remote_threads(&self, remote: &str) -> Result<Vec<ThreadName>> {
         RefManager::list_remote_threads(self, remote)
+    }
+    fn commit_and_publish(
+        &self,
+        encoded_records: &[Vec<u8>],
+        ref_updates: &[RefUpdate],
+        scope: Option<&str>,
+    ) -> Result<()> {
+        RefManager::commit_and_publish(self, encoded_records, ref_updates, scope)
     }
     fn inspect_ref_summary_index(&self) -> Result<super::RefSummaryIndexInspection> {
         RefManager::inspect_ref_summary_index(self)

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -166,6 +166,17 @@ impl RefManager {
                     self.committer.is_some() && !encoded_records.is_empty();
                 if let Some(committer) = self.committer.as_ref() {
                     committer.commit_records(encoded_records, scope)?;
+                } else if !encoded_records.is_empty() {
+                    // Fail closed (heddle#354 r9, cid 3330304656): no committer
+                    // is wired but records were handed in. Publishing the refs
+                    // here would silently drop them — committed data must never
+                    // be lost. The bootstrap/no-committer path only legitimately
+                    // runs with an empty record batch.
+                    return Err(HeddleError::Config(format!(
+                        "commit_and_publish was handed {} record(s) but this RefManager has no \
+                         committer; refusing to publish and silently drop committed data",
+                        encoded_records.len()
+                    )));
                 }
                 Ok(committed_for_reconcile)
             })

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -118,22 +118,31 @@ impl RefManager {
     /// `update_refs_with_lock`) is reachable through this seam, never with a ref
     /// published ahead of its record. With no committer it degrades to a plain
     /// publish (bootstrap).
+    ///
+    /// **Invariant (cid 3329490978 / 3329490984): the oplog record and the ref
+    /// publish commit together under the refs lock; a record exists iff its
+    /// publish succeeded, and concurrent publishes to the same ref serialize
+    /// record-and-publish as a unit.** The refs lock is taken FIRST, the ref
+    /// expectations are validated (phase 3) BEFORE the record is appended (phase
+    /// 4), and the publish (phase 5) follows under the same lock — so a failed
+    /// expectation never leaks a record, and two concurrent callers can never
+    /// append in one order and publish in another. (For `PgRefBackend` the single
+    /// `pool.begin()…commit()` gives the same atomicity natively.)
     pub fn commit_and_publish(
         &self,
         encoded_records: &[Vec<u8>],
         ref_updates: &[RefUpdate],
         scope: Option<&str>,
     ) -> Result<()> {
-        // Phase 4 — the commit point: append every ref-carrying record first.
-        if let Some(committer) = self.committer.as_ref() {
-            committer.commit_records(encoded_records, scope)?;
-        }
-        // Phase 5 — publish the atomic ref batch as one unit (raw publish).
-        if !ref_updates.is_empty() {
-            let lock = self.lock_refs()?;
-            self.update_refs_with_lock(ref_updates, &lock)?;
-        }
-        Ok(())
+        let lock = self.lock_refs()?;
+        self.validate_commit_publish(ref_updates, &lock, || {
+            // Phase 4 — the commit point: append the ref-carrying records only
+            // after phase-3 validation has passed, under the held refs lock.
+            if let Some(committer) = self.committer.as_ref() {
+                committer.commit_records(encoded_records, scope)?;
+            }
+            Ok(())
+        })
     }
 
     /// THE read chokepoint (heddle#330 §2.2): the sole path for a **logical
@@ -175,27 +184,33 @@ impl RefManager {
     /// committed-but-unpublished — the records already exist, so this writes
     /// canonical only (never the oplog).
     ///
-    /// **Fill-if-absent (non-destructive):** only refs whose canonical value is
-    /// *missing* are materialized. In the un-migrated tree many ref writes do
-    /// not yet record an oplog entry, so a present canonical may be newer than
-    /// the fold; overwriting it would regress the ref. So we only fill genuine
-    /// gaps (the committed-but-never-published crash-replay case) and never
-    /// clobber a present canonical.
+    /// **Authoritative-apply (cid 3329490981):** a committed record past the
+    /// class watermark is authoritative over the live canonical, so a folded
+    /// value is materialized when it CREATES a missing ref *or* UPDATES a stale
+    /// present one (the crash-replayed update-to-existing case) — not
+    /// fill-if-absent, which silently dropped a committed update to an
+    /// already-existing ref. The folded set only ever holds refs touched by
+    /// commits newer than the watermark, so applying it respects the
+    /// two-watermark scoping and a ref with no recent committed record is never
+    /// rewritten; a write equal to the canonical is skipped as a no-op. (The
+    /// rare un-migrated case where an unrecorded direct write raced in *after*
+    /// the commit is the residual the writers' record-first migration closes.)
     fn materialize(&self, outcome: &super::reconcile::ReconcileOutcome) -> Result<()> {
         let mut to_publish = Vec::new();
         for update in &outcome.republish {
             match update {
-                RefUpdate::Thread {
-                    name,
-                    new: Some(_),
-                    ..
-                } if self.raw_get_thread(name)?.is_none() => to_publish.push(update.clone()),
-                RefUpdate::Marker {
-                    name,
-                    new: Some(_),
-                    ..
-                } if self.raw_get_marker(name)?.is_none() => to_publish.push(update.clone()),
-                _ => {}
+                RefUpdate::Thread { name, new, .. } => {
+                    if self.raw_get_thread(name)? != *new {
+                        to_publish.push(update.clone());
+                    }
+                }
+                RefUpdate::Marker { name, new, .. } => {
+                    if self.raw_get_marker(name)? != *new {
+                        to_publish.push(update.clone());
+                    }
+                }
+                // HEAD is not reconstructed from the oplog (see the `Fold` doc).
+                RefUpdate::Head { .. } => {}
             }
         }
         if !to_publish.is_empty() {
@@ -203,10 +218,13 @@ impl RefManager {
             self.update_refs_with_lock(&to_publish, &lock)?;
         }
         for (remote, thread, value) in &outcome.remote_updates {
-            if let Some(state) = value
-                && self.raw_get_remote_thread(remote, thread)?.is_none()
-            {
-                self.set_remote_thread_raw(remote, thread, state)?;
+            if self.raw_get_remote_thread(remote, thread)? != *value {
+                match value {
+                    Some(state) => self.set_remote_thread_raw(remote, thread, state)?,
+                    None => {
+                        self.delete_remote_thread_raw(remote, thread)?;
+                    }
+                }
             }
         }
         if let Some(state) = &outcome.undo_recovery {
@@ -215,7 +233,7 @@ impl RefManager {
                 "undo recovery",
                 UNDO_RECOVERY_HANDLE,
             )?;
-            if current.is_none() {
+            if current.as_ref() != Some(state) {
                 self.set_undo_recovery_raw(state)?;
             }
         }

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -131,21 +131,24 @@ impl RefManager {
         self
     }
 
-    /// THE write chokepoint (heddle#330 §2.2): commit the caller-supplied
-    /// ref-carrying record batch (phase 4) **before** publishing the atomic ref
-    /// batch (phase 5), record-before-publish, the whole batch published as one
-    /// unit. `encoded_records` are opaque rmp-serde `OpRecord` bytes (so `refs`
-    /// names no `oplog` type). The bare publish (temp→rename, via
-    /// `update_refs_with_lock`) is reachable through this seam, never with a ref
-    /// published ahead of its record. With no committer it degrades to a plain
-    /// publish (bootstrap).
+    /// The atomic-write entry of THE write chokepoint (heddle#330 §2.2): commit
+    /// the caller-supplied ref-carrying record batch (phase 4) **before**
+    /// publishing the atomic ref batch (phase 5), record-before-publish, the
+    /// whole batch published as one unit. `encoded_records` are opaque rmp-serde
+    /// `OpRecord` bytes (so `refs` names no `oplog` type). The bare publish
+    /// (temp→rename, via `update_refs_with_lock`) is reachable through this seam,
+    /// never with a ref published ahead of its record. With no committer it
+    /// degrades to a plain publish (bootstrap).
     ///
     /// **Invariant (cid 3329490978 / 3329490984): the oplog record and the ref
     /// publish commit together under the refs lock; a record exists iff its
     /// publish succeeded, and concurrent publishes to the same ref serialize
-    /// record-and-publish as a unit.** The refs lock is taken FIRST, the ref
-    /// expectations are validated (phase 3) BEFORE the record is appended (phase
-    /// 4), and the publish (phase 5) follows under the same lock — so a failed
+    /// record-and-publish as a unit.** Routed through
+    /// [`write_chokepoint`](Self::write_chokepoint), which takes the refs lock
+    /// FIRST and materializes the committed-but-unpublished tail of every class
+    /// BEFORE the body runs; the ref expectations are then validated (phase 3)
+    /// against that reconciled state, BEFORE the record is appended (phase 4),
+    /// and the publish (phase 5) follows under the same lock — so a failed
     /// expectation never leaks a record, and two concurrent callers can never
     /// append in one order and publish in another. (For `PgRefBackend` the single
     /// `pool.begin()…commit()` gives the same atomicity natively.)
@@ -155,16 +158,147 @@ impl RefManager {
         ref_updates: &[RefUpdate],
         scope: Option<&str>,
     ) -> Result<()> {
-        let lock = self.lock_refs()?;
-        self.validate_commit_publish(ref_updates, &lock, || {
-            // Phase 4 — the commit point: append the ref-carrying records only
-            // after phase-3 validation has passed, under the held refs lock.
-            let committed_for_reconcile = self.committer.is_some() && !encoded_records.is_empty();
-            if let Some(committer) = self.committer.as_ref() {
-                committer.commit_records(encoded_records, scope)?;
-            }
-            Ok(committed_for_reconcile)
+        self.write_chokepoint(|lock| {
+            self.validate_commit_publish(ref_updates, lock, || {
+                // Phase 4 — the commit point: append the ref-carrying records
+                // only after phase-3 validation has passed, under the held lock.
+                let committed_for_reconcile =
+                    self.committer.is_some() && !encoded_records.is_empty();
+                if let Some(committer) = self.committer.as_ref() {
+                    committer.commit_records(encoded_records, scope)?;
+                }
+                Ok(committed_for_reconcile)
+            })
         })
+    }
+
+    /// THE write chokepoint (heddle#354 r7): the SOLE path by which any ref
+    /// write reaches the backend. Under ONE held publish lock it
+    ///
+    /// 1. reconciles AND materializes the committed-but-unpublished tail of
+    ///    BOTH ref classes ([`materialize_committed_tail`](Self::materialize_committed_tail)),
+    ///    advancing+persisting each class watermark to the current oplog tip, and
+    /// 2. runs the caller's `body` (validate → commit → publish) against the
+    ///    now-materialized canonical state.
+    ///
+    /// Materializing FIRST is what closes the lost-/clobbered-record class (cid
+    /// 3329765073): a non-atomic [`update_refs`](Self::update_refs) — or any
+    /// remote-thread / undo-recovery setter — used to fold the committed tail
+    /// only for *validation* and discard it, so the canonical never caught up
+    /// and a later read could re-fold an ancient record over the just-written
+    /// value. Now every write first persists the committed tail and advances the
+    /// watermark to the tip, so the write lands on a fully-reconciled canonical
+    /// and no later read re-folds across it.
+    ///
+    /// **No-bypass invariant.** The raw backend writers (`publish_ref_plans`,
+    /// `set_remote_thread_locked`, `delete_remote_thread_locked`,
+    /// `set_undo_recovery_locked`) are private and reached ONLY from a
+    /// chokepoint `body` or from [`materialize`](Self::materialize) (which itself
+    /// runs only here and on the read chokepoint). A source-level conformance
+    /// check (`write_read_conformance` in the refs tests) fails CI if any other
+    /// path calls a raw writer, so a path-by-path allowlist cannot silently
+    /// re-open the class.
+    fn write_chokepoint<T>(&self, body: impl FnOnce(&RefsLock) -> Result<T>) -> Result<T> {
+        let lock = self.lock_refs()?;
+        self.materialize_committed_tail(&lock)?;
+        body(&lock)
+    }
+
+    /// Reconcile + materialize the committed-but-unpublished tail of BOTH ref
+    /// classes under the held lock — the first step of every write
+    /// ([`write_chokepoint`](Self::write_chokepoint)). The O(1) gate
+    /// (watermark == tip) skips a class with no lag, so on the hot path this is
+    /// two `generation()` header reads and no fold.
+    fn materialize_committed_tail(&self, lock: &RefsLock) -> Result<()> {
+        self.materialize_class(RefClass::Local, lock)?;
+        self.materialize_class(RefClass::Shared, lock)?;
+        Ok(())
+    }
+
+    /// Materialize one class's committed tail under the held lock — the
+    /// class-scoped form of [`reconciled_load`](Self::reconciled_load)'s lag
+    /// branch, driven by a lightweight probe request of the class (the
+    /// materialization set covers EVERY ref the lagged batches touched and does
+    /// not depend on the specific request — only on the class + fold). No-op
+    /// when the class is not lagging or no reconciler is injected.
+    fn materialize_class(&self, class: RefClass, lock: &RefsLock) -> Result<()> {
+        let Some(reconciler) = self.reconciler.as_ref() else {
+            return Ok(());
+        };
+        let watermark = self.class_watermark(class);
+        let tip = reconciler.generation()?;
+        if tip == watermark.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        // Re-read the persisted (possibly sibling-advanced) last-clean point
+        // before folding, so a long-lived handle never re-derives a record a
+        // sibling already materialized past (cid 3329765075).
+        self.refresh_persisted_watermark(class, lock)?;
+        let cached = watermark.load(Ordering::Acquire);
+        if tip == cached {
+            return Ok(());
+        }
+        let req = Self::class_probe(class);
+        let raw = self.raw_load(&req)?;
+        let since = if cached == WATERMARK_UNSET { 0 } else { cached };
+        let outcome = reconciler.reconcile(&req, raw, since)?;
+        self.materialize(&outcome, lock)?;
+        watermark.store(tip, Ordering::Release);
+        let _ = self.persist_reconcile_watermark(lock);
+        Ok(())
+    }
+
+    /// The per-read class watermark atomic.
+    fn class_watermark(&self, class: RefClass) -> &AtomicU64 {
+        match class {
+            RefClass::Local => &self.cached_local_generation,
+            RefClass::Shared => &self.cached_shared_generation,
+        }
+    }
+
+    /// A lightweight probe request of `class` to drive a class-wide reconcile.
+    /// The materialization set (`republish` / `remote_updates` / `undo_recovery`)
+    /// is class-derived, not request-derived, so any request of the class yields
+    /// the full set; the projected `loaded` value is discarded by the caller.
+    fn class_probe(class: RefClass) -> LoadRequest {
+        match class {
+            RefClass::Local => LoadRequest::Head,
+            RefClass::Shared => LoadRequest::MarkerList,
+        }
+    }
+
+    /// Advance the in-memory class watermark to the persisted last-clean point
+    /// when a sibling worktree (or a prior read) has advanced it past our
+    /// in-memory value (heddle#354 r7, cid 3329765075). The persisted watermark
+    /// is a known-materialized point, so adopting it is always safe and
+    /// ADVANCE-ONLY — it never regresses what this handle already materialized.
+    ///
+    /// This is what makes a long-lived handle behave like a fresh open: rather
+    /// than re-folding from a value frozen at open, each reconcile re-reads the
+    /// CURRENT shared (or local) last-clean point and folds only what genuinely
+    /// lags above it. Called under the held lock so the load→store is serialized
+    /// with every other watermark writer.
+    fn refresh_persisted_watermark(&self, class: RefClass, _lock: &RefsLock) -> Result<()> {
+        let path = match class {
+            RefClass::Local => self.reconcile_watermark_local_path(),
+            RefClass::Shared => self.reconcile_watermark_shared_path(),
+        };
+        let Some(persisted) = self.read_single_watermark(&path)? else {
+            return Ok(());
+        };
+        let watermark = self.class_watermark(class);
+        let cached = watermark.load(Ordering::Acquire);
+        // The `UNSET` sentinel is `u64::MAX`, so a plain `max` would keep it;
+        // adopt the persisted value outright in that case.
+        let next = if cached == WATERMARK_UNSET {
+            persisted
+        } else {
+            cached.max(persisted)
+        };
+        if next != cached {
+            watermark.store(next, Ordering::Release);
+        }
+        Ok(())
     }
 
     /// THE read chokepoint (heddle#330 §2.2): the sole path for a **logical
@@ -202,6 +336,13 @@ impl RefManager {
         // value over a freshly-published newer one.
         let lock = self.lock_refs()?;
         let tip = reconciler.generation()?;
+        // Re-read the CURRENT persisted watermark (heddle#354 r7, cid 3329765075):
+        // a long-lived handle's in-memory watermark is frozen at open, so a
+        // sibling worktree that advanced the shared last-clean point past it
+        // would otherwise be re-folded from the stale frozen value. Refreshing
+        // here makes a long-lived handle fold from the same floor a fresh open
+        // would — re-deriving only what genuinely lags above the current point.
+        self.refresh_persisted_watermark(req.ref_class(), &lock)?;
         let cached = watermark.load(Ordering::Acquire);
         let raw = self.raw_load(&req)?;
         if tip == cached {
@@ -685,12 +826,14 @@ impl RefManager {
         self.set_undo_recovery_raw(state)
     }
 
-    /// The raw canonical write for undo-recovery, with no oplog append — the
-    /// phase-5 materialization sub-step (used by both the public setter and the
-    /// reconciler's lazy re-publish).
+    /// The undo-recovery write entry of the write chokepoint: materialize the
+    /// committed tail FIRST, then write canonical under the held lock. Has no
+    /// oplog append of its own (undo-recovery is recorded via the atomic
+    /// `commit_and_publish` path); routing it through
+    /// [`write_chokepoint`](Self::write_chokepoint) keeps it from bypassing
+    /// reconciliation (heddle#354 r7).
     fn set_undo_recovery_raw(&self, state: &ChangeId) -> Result<()> {
-        let lock = self.lock_refs()?;
-        self.set_undo_recovery_locked(state, &lock)
+        self.write_chokepoint(|lock| self.set_undo_recovery_locked(state, lock))
     }
 
     /// The lock-free core of [`set_undo_recovery_raw`](Self::set_undo_recovery_raw):
@@ -731,16 +874,16 @@ impl RefManager {
         self.set_remote_thread_raw(remote, thread, state)
     }
 
-    /// The raw canonical write for a remote-thread ref, with no oplog append —
-    /// the phase-5 materialization sub-step.
+    /// The remote-thread write entry of the write chokepoint: materialize the
+    /// committed tail FIRST, then write canonical under the held lock
+    /// (heddle#354 r7), so a remote-thread setter cannot bypass reconciliation.
     fn set_remote_thread_raw(
         &self,
         remote: &str,
         thread: &ThreadName,
         state: &ChangeId,
     ) -> Result<()> {
-        let lock = self.lock_refs()?;
-        self.set_remote_thread_locked(remote, thread, state, &lock)
+        self.write_chokepoint(|lock| self.set_remote_thread_locked(remote, thread, state, lock))
     }
 
     /// The lock-free core of [`set_remote_thread_raw`](Self::set_remote_thread_raw):
@@ -776,14 +919,15 @@ impl RefManager {
         self.delete_remote_thread_raw(remote, thread)
     }
 
-    /// The raw canonical delete for a remote-thread ref, with no oplog append.
+    /// The remote-thread delete entry of the write chokepoint: materialize the
+    /// committed tail FIRST, then delete canonical under the held lock
+    /// (heddle#354 r7), so a remote-thread delete cannot bypass reconciliation.
     fn delete_remote_thread_raw(
         &self,
         remote: &str,
         thread: &ThreadName,
     ) -> Result<Option<ChangeId>> {
-        let lock = self.lock_refs()?;
-        self.delete_remote_thread_locked(remote, thread, &lock)
+        self.write_chokepoint(|lock| self.delete_remote_thread_locked(remote, thread, lock))
     }
 
     /// The lock-free core of [`delete_remote_thread_raw`](Self::delete_remote_thread_raw):
@@ -829,8 +973,13 @@ impl RefManager {
         if updates.is_empty() {
             return Ok(());
         }
-        let lock = self.lock_refs()?;
-        self.update_refs_with_lock(updates, &lock)
+        // The non-atomic write path funnels through the same chokepoint as the
+        // atomic one: materialize the committed tail FIRST, then validate +
+        // publish under the held lock (heddle#354 r7). Validating + writing
+        // against the reconciled-and-materialized canonical is what stops a
+        // non-atomic write from losing a committed record or being re-folded
+        // over by an ancient one (cid 3329765073).
+        self.write_chokepoint(|lock| self.update_refs_with_lock(updates, lock))
     }
 
     pub fn resolve(&self, refspec: &str) -> Result<Option<ChangeId>> {

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -27,6 +27,18 @@ use crate::fs_atomic::sync_directory;
 /// `head_id` so the first read after a reconciler is injected always reconciles.
 const WATERMARK_UNSET: u64 = u64::MAX;
 
+/// Per-worktree persisted **local**-class watermark (HEAD + undo-recovery),
+/// stored beside the per-checkout `HEAD`. Local refs are worktree-private, so
+/// each checkout tracks its own.
+const RECONCILE_WATERMARK_LOCAL: &str = "RECONCILE_WATERMARK_LOCAL";
+
+/// Persisted **shared**-class watermark (thread / marker / remote-thread),
+/// stored in the SHARED Heddle dir so every sibling worktree advances and seeds
+/// from the SAME value (heddle#354 r6, cid 3329711893). A per-worktree shared
+/// watermark let a checkout opened with a lagging file re-fold a shared create a
+/// sibling had already processed/published — resurrecting it cross-worktree.
+const RECONCILE_WATERMARK_SHARED: &str = "RECONCILE_WATERMARK_SHARED";
+
 /// Well-known refspec that resolves the heddle-internal pre-undo recovery
 /// pointer (so `heddle goto .undo-recovery` works). It is UNSHADOWABLE by any
 /// user marker or thread, in BOTH directions (heddle#305 r3):
@@ -259,66 +271,100 @@ impl RefManager {
     /// When no watermark has been persisted yet (a fresh repo, or a repo from
     /// before this version), seed conservatively at the current generation and
     /// write the file, so the next process has a real last-clean point.
+    ///
+    /// The two classes seed from SEPARATE files: the local watermark from the
+    /// per-worktree file, the shared watermark from the shared-dir file (cid
+    /// 3329711893). A sibling worktree that already advanced the shared
+    /// watermark publishes it to the shared file, so this checkout seeds at that
+    /// shared last-clean point and never re-folds a shared create the sibling
+    /// already processed.
     pub fn init_reconcile_watermark(&self) -> Result<()> {
         if self.reconciler.is_none() {
             return Ok(());
         }
-        match self.read_persisted_reconcile_watermark()? {
-            Some((local, shared)) => {
-                self.cached_local_generation.store(local, Ordering::Release);
-                self.cached_shared_generation
-                    .store(shared, Ordering::Release);
-            }
-            None => {
-                let lock = self.lock_refs()?;
-                self.persist_reconcile_watermark(&lock)?;
-            }
+        let (local, shared) = self.read_persisted_reconcile_watermark()?;
+        if let Some(local) = local {
+            self.cached_local_generation.store(local, Ordering::Release);
+        }
+        if let Some(shared) = shared {
+            self.cached_shared_generation
+                .store(shared, Ordering::Release);
+        }
+        // Any class with no persisted last-clean point yet (fresh repo, or a
+        // repo from before this version) keeps the current-generation seed from
+        // `with_reconciler` and gets written, so the next process has a real
+        // last-clean point.
+        if local.is_none() || shared.is_none() {
+            let lock = self.lock_refs()?;
+            self.persist_reconcile_watermark(&lock)?;
         }
         Ok(())
     }
 
-    /// Path of the per-worktree persisted reconcile watermark, beside `HEAD`
-    /// and `UNDO_RECOVERY` (the local watermark is per-`op_scope`; the shared
-    /// watermark is persisted per-worktree too — a conservative lower bound just
-    /// means more folding, never a missed record).
-    fn reconcile_watermark_path(&self) -> PathBuf {
+    /// Per-worktree LOCAL watermark file (HEAD + undo-recovery), beside the
+    /// per-checkout `HEAD` and `UNDO_RECOVERY` — local refs are worktree-private.
+    fn reconcile_watermark_local_path(&self) -> PathBuf {
         self.head_path()
             .parent()
-            .map(|dir| dir.join("RECONCILE_WATERMARK"))
-            .unwrap_or_else(|| self.root.join("RECONCILE_WATERMARK"))
+            .map(|dir| dir.join(RECONCILE_WATERMARK_LOCAL))
+            .unwrap_or_else(|| self.root.join(RECONCILE_WATERMARK_LOCAL))
     }
 
-    /// Read the persisted `(local, shared)` watermark, or `None` when absent /
-    /// unparseable (treated as "no last-clean point yet").
-    fn read_persisted_reconcile_watermark(&self) -> Result<Option<(u64, u64)>> {
-        let Some(contents) = self.read_optional_string(&self.reconcile_watermark_path())? else {
+    /// SHARED watermark file (thread / marker / remote-thread), in the SHARED
+    /// Heddle dir (`self.root`, objectstore-pointed). Every sibling worktree
+    /// resolves the SAME path, so a shared create one worktree advances past is
+    /// never re-folded by another (cid 3329711893). Mirrors `refs/`, which lives
+    /// under the same shared root and whose `LOCK` already serializes writers.
+    fn reconcile_watermark_shared_path(&self) -> PathBuf {
+        self.root.join(RECONCILE_WATERMARK_SHARED)
+    }
+
+    /// Read the persisted `(local, shared)` watermark from their two scope
+    /// files; each component is `None` when absent / unparseable ("no last-clean
+    /// point yet" for that class).
+    fn read_persisted_reconcile_watermark(&self) -> Result<(Option<u64>, Option<u64>)> {
+        let local = self.read_single_watermark(&self.reconcile_watermark_local_path())?;
+        let shared = self.read_single_watermark(&self.reconcile_watermark_shared_path())?;
+        Ok((local, shared))
+    }
+
+    /// Read a single `u64` watermark from `path`, or `None` when absent /
+    /// unparseable.
+    fn read_single_watermark(&self, path: &Path) -> Result<Option<u64>> {
+        let Some(contents) = self.read_optional_string(path)? else {
             return Ok(None);
         };
-        let mut parts = contents.split_whitespace();
-        match (
-            parts.next().and_then(|s| s.parse::<u64>().ok()),
-            parts.next().and_then(|s| s.parse::<u64>().ok()),
-        ) {
-            (Some(local), Some(shared)) => Ok(Some((local, shared))),
-            _ => Ok(None),
-        }
+        Ok(contents
+            .split_whitespace()
+            .next()
+            .and_then(|s| s.parse::<u64>().ok()))
     }
 
-    /// Persist the current in-memory `(local, shared)` watermark under the held
-    /// refs lock. Called after a read advances a watermark, and at open when no
-    /// file exists yet.
+    /// Persist the current in-memory local + shared watermarks, each to its own
+    /// scope file, under the held refs lock. Called after a read advances a
+    /// watermark, and at open when a file does not exist yet.
     fn persist_reconcile_watermark(&self, _lock: &RefsLock) -> Result<()> {
         let local = self.cached_local_generation.load(Ordering::Acquire);
         let shared = self.cached_shared_generation.load(Ordering::Acquire);
-        // A still-unset watermark (no reconciler, or seeded UNSET on a header
-        // error) is not a meaningful last-clean point — skip it.
-        if local == WATERMARK_UNSET || shared == WATERMARK_UNSET {
+        self.persist_watermark_file(&self.reconcile_watermark_local_path(), local)?;
+        self.persist_watermark_file(&self.reconcile_watermark_shared_path(), shared)?;
+        Ok(())
+    }
+
+    /// Write `value` to a watermark file ADVANCE-ONLY: never below what is
+    /// already on disk. The shared file is written by concurrent sibling
+    /// worktrees (serialized by the shared refs `LOCK`); a checkout whose
+    /// in-memory shared watermark lags a sibling's published value must not
+    /// regress the file when it persists after a local-only read (cid
+    /// 3329711893). A still-`UNSET` watermark (no reconciler, or seeded UNSET on
+    /// a header error) is not a meaningful last-clean point — skip it.
+    fn persist_watermark_file(&self, path: &Path, value: u64) -> Result<()> {
+        if value == WATERMARK_UNSET {
             return Ok(());
         }
-        self.write_string(
-            &self.reconcile_watermark_path(),
-            &format!("{} {}\n", local, shared),
-        )
+        let on_disk = self.read_single_watermark(path)?.unwrap_or(0);
+        let next = value.max(on_disk);
+        self.write_string(path, &format!("{next}\n"))
     }
 
     /// Lazily re-publish (phase-5 materialization) the refs a reconcile found

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -571,8 +571,8 @@ mod chokepoint {
     }
 
     impl RefReconciler for FakeReconciler {
-        fn generation(&self) -> u64 {
-            self.generation.load(Ordering::Acquire)
+        fn generation(&self) -> Result<u64> {
+            Ok(self.generation.load(Ordering::Acquire))
         }
         fn reconcile(&self, req: &LoadRequest, raw: Loaded, _since: u64) -> Result<ReconcileOutcome> {
             self.calls.fetch_add(1, Ordering::AcqRel);

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -651,21 +651,32 @@ mod chokepoint {
         assert_eq!(calls.load(Ordering::Acquire), 0, "hot path must not reconcile");
     }
 
-    /// The lag path drives `materialize`'s fill-if-absent branches: an absent
-    /// thread + marker + remote-thread + undo-recovery are all published, a
-    /// already-present thread is left untouched, and a `None` remote update and
-    /// the watermark advance are exercised. A second read then takes the hot
-    /// path because the watermark caught up to the (unchanged) generation.
+    /// The lag path drives `materialize`'s authoritative-apply branches: an
+    /// absent thread + marker + remote-thread + undo-recovery are all published
+    /// (create), a present-but-STALE thread is overwritten with the committed
+    /// value (the cid 3329490981 update-to-existing case), a present thread whose
+    /// committed value equals the canonical is a no-op skip, and a `None` remote
+    /// update + the watermark advance are exercised. A second read then takes the
+    /// hot path because the watermark caught up to the (unchanged) generation.
     #[test]
-    fn reconciled_load_lag_path_materializes_absent_refs_only() {
+    fn reconciled_load_lag_path_materializes_committed_values() {
         let (_t, dir) = manager();
 
-        // Pre-publish a present thread so its republish is skipped (fill-if-absent
-        // must not clobber a present canonical).
+        // `present` is pre-published with the same value the fold carries ⇒ skip.
         let present_state = ChangeId::generate();
+        // `stale` is pre-published with an OLD value; the fold carries a newer
+        // committed value ⇒ it must be overwritten (authoritative-apply).
+        let stale_old = ChangeId::generate();
+        let stale_new = ChangeId::generate();
         let absent_state = ChangeId::generate();
         let marker_state = ChangeId::generate();
         let remote_state = ChangeId::generate();
+        // A present-but-stale remote thread (overwrite) + a present remote thread
+        // the fold deleted (remove) + a stale undo-recovery pointer (overwrite).
+        let remote_stale_old = ChangeId::generate();
+        let remote_stale_new = ChangeId::generate();
+        let remote_doomed = ChangeId::generate();
+        let undo_old = ChangeId::generate();
         let undo_state = ChangeId::generate();
 
         let calls = Arc::new(AtomicU64::new(0));
@@ -678,11 +689,16 @@ mod chokepoint {
                     new: Some(present_state),
                 },
                 RefUpdate::Thread {
+                    name: ThreadName::new("stale"),
+                    expected: RefExpectation::Any,
+                    new: Some(stale_new),
+                },
+                RefUpdate::Thread {
                     name: ThreadName::new("absent"),
                     expected: RefExpectation::Any,
                     new: Some(absent_state),
                 },
-                // `new: None` arm — not a fill candidate.
+                // `new: None` arm — canonical absent ⇒ no-op (nothing to delete).
                 RefUpdate::Thread {
                     name: ThreadName::new("deleted"),
                     expected: RefExpectation::Any,
@@ -696,16 +712,24 @@ mod chokepoint {
             ],
             remote_updates: vec![
                 ("origin".to_string(), ThreadName::new("rt"), Some(remote_state)),
-                // `None` value — skipped.
+                // `None` value, canonical absent — skipped.
                 ("origin".to_string(), ThreadName::new("gone"), None),
+                // Present-but-stale remote thread ⇒ overwritten with committed value.
+                ("origin".to_string(), ThreadName::new("rt_stale"), Some(remote_stale_new)),
+                // Present remote thread the fold deleted ⇒ removed.
+                ("origin".to_string(), ThreadName::new("rt_doomed"), None),
             ],
             undo_recovery: Some(undo_state),
             calls: Arc::clone(&calls),
         });
         let refs = RefManager::new(&dir).with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
         refs.init().unwrap();
-        // Publish the present thread AFTER injection (raw write, bypasses chokepoint).
+        // Publish present + stale AFTER injection (raw writes, bypass chokepoint).
         refs.set_thread(&ThreadName::new("present"), &present_state).unwrap();
+        refs.set_thread(&ThreadName::new("stale"), &stale_old).unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_stale"), &remote_stale_old).unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_doomed"), &remote_doomed).unwrap();
+        refs.set_undo_recovery(&undo_old).unwrap();
 
         // Bump generation so the next read lags ⇒ reconcile + materialize run.
         reconciler.generation.store(2, Ordering::Release);
@@ -714,16 +738,34 @@ mod chokepoint {
         assert_eq!(got, Some(absent_state), "reconciled value is surfaced");
         assert_eq!(calls.load(Ordering::Acquire), 1, "lag path reconciles once");
 
-        // The absent refs were materialized; the present one is unchanged.
+        // The absent refs were materialized; the present (same-value) one is a
+        // no-op; the stale present one is overwritten with the committed value.
         assert_eq!(
             refs.get_thread(&ThreadName::new("present")).unwrap(),
             Some(present_state)
+        );
+        assert_eq!(
+            refs.get_thread(&ThreadName::new("stale")).unwrap(),
+            Some(stale_new),
+            "a stale present ref must be overwritten with the committed value"
         );
         assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
         assert_eq!(
             refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
             Some(remote_state)
         );
+        // The stale remote thread is overwritten; the doomed one is removed.
+        assert_eq!(
+            refs.get_remote_thread("origin", &ThreadName::new("rt_stale")).unwrap(),
+            Some(remote_stale_new),
+            "a stale present remote thread must be overwritten with the committed value"
+        );
+        assert_eq!(
+            refs.get_remote_thread("origin", &ThreadName::new("rt_doomed")).unwrap(),
+            None,
+            "a committed delete must remove a present remote thread"
+        );
+        // The stale undo-recovery pointer is overwritten with the committed value.
         assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo_state));
 
         // Second read: watermark now == generation (2) ⇒ hot path, no new reconcile.

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -886,4 +886,307 @@ mod chokepoint {
         let _ = RefBackend::rebuild_ref_summary_index(&refs).unwrap();
         RefBackend::cleanup_stale_temps(&refs);
     }
+
+    /// heddle#354 r7 (cid 3329765075) — a long-lived handle re-reads the CURRENT
+    /// persisted (shared) watermark on each reconcile, so a sibling worktree's
+    /// advance stops it re-folding records the sibling already materialized.
+    /// Two contrasting cases on a handle whose in-memory watermark is frozen at
+    /// its open value (5) while a sibling advanced the oplog tip to 10:
+    ///
+    /// * **A** — the sibling never persisted the advance: the handle still folds
+    ///   the lag (the frozen-at-open behaviour, unchanged).
+    /// * **B** — THE FIX: the sibling persisted the shared watermark to the tip;
+    ///   the handle re-reads it and does NOT re-fold. Pre-r7 (no refresh) this
+    ///   would fold from the frozen 5 and re-derive the sibling's work.
+    #[test]
+    fn long_lived_handle_refreshes_persisted_shared_watermark() {
+        // Case A — no persisted advance ⇒ the lag is folded.
+        let (_ta, dir_a) = manager();
+        let calls_a = Arc::new(AtomicU64::new(0));
+        let recon_a = Arc::new(FakeReconciler {
+            generation: AtomicU64::new(5),
+            republish: Vec::new(),
+            remote_updates: Vec::new(),
+            undo_recovery: None,
+            calls: Arc::clone(&calls_a),
+        });
+        let refs_a =
+            RefManager::new(&dir_a).with_reconciler(Arc::clone(&recon_a) as Arc<dyn RefReconciler>);
+        refs_a.init().unwrap();
+        // A sibling advanced the oplog tip to 10 but never persisted the shared
+        // watermark; this handle's in-memory watermark stays frozen at 5.
+        recon_a.generation.store(10, Ordering::Release);
+        let _ = refs_a.get_marker(&MarkerName::new("any")).unwrap();
+        assert_eq!(
+            calls_a.load(Ordering::Acquire),
+            1,
+            "no persisted advance ⇒ the lag is folded"
+        );
+
+        // Case B — the sibling persisted the shared watermark to the tip; the
+        // long-lived handle re-reads it and does NOT re-fold.
+        let (_tb, dir_b) = manager();
+        let calls_b = Arc::new(AtomicU64::new(0));
+        let recon_b = Arc::new(FakeReconciler {
+            generation: AtomicU64::new(5),
+            republish: Vec::new(),
+            remote_updates: Vec::new(),
+            undo_recovery: None,
+            calls: Arc::clone(&calls_b),
+        });
+        let refs_b =
+            RefManager::new(&dir_b).with_reconciler(Arc::clone(&recon_b) as Arc<dyn RefReconciler>);
+        refs_b.init().unwrap();
+        recon_b.generation.store(10, Ordering::Release);
+        // The sibling's persisted SHARED last-clean point (the shared-dir file).
+        std::fs::write(dir_b.join("RECONCILE_WATERMARK_SHARED"), "10\n").unwrap();
+        let _ = refs_b.get_marker(&MarkerName::new("any")).unwrap();
+        assert_eq!(
+            calls_b.load(Ordering::Acquire),
+            0,
+            "a long-lived handle must re-read the sibling-advanced shared \
+             watermark and NOT re-fold (frozen-at-open would re-fold here)"
+        );
+    }
+}
+
+/// heddle#354 r7 — source-level conformance checks (the point of the
+/// close-the-class round): they FAIL CI if any path bypasses the read/write
+/// chokepoints. They walk the PRODUCTION source of `refs_manager.rs` +
+/// `refs_transactions.rs`, partition it into per-function chunks, and assert the
+/// no-bypass invariants:
+///
+/// * every raw backend WRITER is reached only from the chokepoint body or
+///   `materialize` (so no write reaches the backend without first
+///   reconciling+materializing under the lock);
+/// * the per-request raw-loader funnel `raw_load` is reached only from the read
+///   chokepoint (so no logical read bypasses `reconciled_load`);
+/// * every public writer/reader funnels through the respective chokepoint; and
+/// * the read chokepoint re-reads the persisted watermark each reconcile.
+///
+/// A planted-bypass fixture proves the analyzer is non-vacuous.
+mod write_read_conformance {
+    use std::collections::BTreeSet;
+
+    const MANAGER_SRC: &str = include_str!("refs_manager.rs");
+    const TXNS_SRC: &str = include_str!("refs_transactions.rs");
+
+    /// Everything before the in-file `#[cfg(test)]` module — the invariant is
+    /// enforced on production code only, never on the tests' own scaffolding.
+    fn production(src: &str) -> &str {
+        src.split("#[cfg(test)]").next().unwrap()
+    }
+
+    /// The function name a declaration line introduces, if any (`pub fn x(`,
+    /// `pub(super) fn x(`, `async fn x(`, `fn x<T>(`, …). `None` otherwise.
+    fn parse_fn_name(trimmed: &str) -> Option<String> {
+        let idx = trimmed.find("fn ")?;
+        let before = &trimmed[..idx];
+        if !(before.is_empty() || before.ends_with(' ')) {
+            return None;
+        }
+        let rest = &trimmed[idx + 3..];
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            return None;
+        }
+        let after = rest[name.len()..].trim_start();
+        (after.starts_with('(') || after.starts_with('<')).then_some(name)
+    }
+
+    /// Partition source into `(fn_name, body_text)` chunks: a new chunk starts at
+    /// each function declaration and runs until the next one. Comment lines never
+    /// start a chunk. Sufficient for "which fn contains this call" without brace
+    /// counting, since every method here is a 4-space-indented `impl` item.
+    fn fn_chunks(src: &str) -> Vec<(String, String)> {
+        let mut chunks = Vec::new();
+        let mut name = "<prologue>".to_string();
+        let mut body = String::new();
+        for line in production(src).lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("//")
+                && let Some(decl) = parse_fn_name(trimmed)
+            {
+                chunks.push((std::mem::take(&mut name), std::mem::take(&mut body)));
+                name = decl;
+            }
+            body.push_str(line);
+            body.push('\n');
+        }
+        chunks.push((name, body));
+        chunks
+    }
+
+    /// The set of function names whose body contains a call `.callee(`.
+    fn callers_of(srcs: &[&str], callee: &str) -> BTreeSet<String> {
+        let pat = format!(".{callee}(");
+        let mut out = BTreeSet::new();
+        for src in srcs {
+            for (name, body) in fn_chunks(src) {
+                if body.contains(&pat) {
+                    out.insert(name);
+                }
+            }
+        }
+        out
+    }
+
+    /// The body of the FIRST function named `name` (the inherent `impl
+    /// RefManager` definition precedes the trait-delegation `impl`s).
+    fn first_body(srcs: &[&str], name: &str) -> String {
+        for src in srcs {
+            for (fname, body) in fn_chunks(src) {
+                if fname == name {
+                    return body;
+                }
+            }
+        }
+        panic!("function `{name}` not found in sources");
+    }
+
+    fn strays(callers: &BTreeSet<String>, allow: &[&str]) -> Vec<String> {
+        let allow: BTreeSet<String> = allow.iter().map(|s| s.to_string()).collect();
+        callers.difference(&allow).cloned().collect()
+    }
+
+    fn assert_only(callers: &BTreeSet<String>, allow: &[&str], primitive: &str) {
+        let strays = strays(callers, allow);
+        assert!(
+            strays.is_empty(),
+            "chokepoint bypass: `{primitive}` is reached from {strays:?}, outside the \
+             allowlist {allow:?} — route the write through `write_chokepoint` (or the \
+             read through `reconciled_load`) instead of calling the raw primitive"
+        );
+    }
+
+    /// WRITE no-bypass: every raw backend writer is reached only from a
+    /// chokepoint body or from `materialize` (the read/write catch-up).
+    #[test]
+    fn raw_writers_are_reached_only_through_the_chokepoint() {
+        let srcs = [MANAGER_SRC, TXNS_SRC];
+        assert_only(
+            &callers_of(&srcs, "publish_ref_plans"),
+            &[
+                "materialize",
+                "update_refs_with_lock",
+                "validate_commit_publish",
+            ],
+            "publish_ref_plans",
+        );
+        assert_only(
+            &callers_of(&srcs, "set_remote_thread_locked"),
+            &["materialize", "set_remote_thread_raw"],
+            "set_remote_thread_locked",
+        );
+        assert_only(
+            &callers_of(&srcs, "delete_remote_thread_locked"),
+            &["materialize", "delete_remote_thread_raw"],
+            "delete_remote_thread_locked",
+        );
+        assert_only(
+            &callers_of(&srcs, "set_undo_recovery_locked"),
+            &["materialize", "set_undo_recovery_raw"],
+            "set_undo_recovery_locked",
+        );
+    }
+
+    /// READ no-bypass: the per-request raw-loader funnel `raw_load` is reached
+    /// only from the read chokepoint and the write-side reconcile catch-up.
+    #[test]
+    fn raw_load_is_reached_only_through_the_read_chokepoint() {
+        assert_only(
+            &callers_of(&[MANAGER_SRC], "raw_load"),
+            &[
+                "reconciled_load",
+                "reconciled_value_under_lock",
+                "materialize_class",
+            ],
+            "raw_load",
+        );
+    }
+
+    /// Every public ref WRITER funnels through `write_chokepoint`.
+    #[test]
+    fn public_writers_funnel_through_write_chokepoint() {
+        for writer in [
+            "update_refs",
+            "commit_and_publish",
+            "set_undo_recovery_raw",
+            "set_remote_thread_raw",
+            "delete_remote_thread_raw",
+        ] {
+            assert!(
+                first_body(&[MANAGER_SRC], writer).contains("write_chokepoint("),
+                "write bypass: `{writer}` must route through `write_chokepoint`"
+            );
+        }
+    }
+
+    /// Every public ref READER funnels through `reconciled_load` and never calls
+    /// a raw loader directly.
+    #[test]
+    fn public_readers_funnel_through_reconciled_load() {
+        for reader in [
+            "read_head",
+            "get_thread",
+            "get_marker",
+            "get_undo_recovery",
+            "get_remote_thread",
+            "list_threads",
+            "list_markers",
+            "list_remotes",
+            "list_remote_threads",
+        ] {
+            let body = first_body(&[MANAGER_SRC], reader);
+            assert!(
+                body.contains("reconciled_load("),
+                "read bypass: `{reader}` must funnel through `reconciled_load`"
+            );
+            for raw in [".raw_load(", ".raw_get_", ".read_head_state(", ".raw_list_"] {
+                assert!(
+                    !body.contains(raw),
+                    "read bypass: `{reader}` calls a raw loader (`{raw}`) directly"
+                );
+            }
+        }
+    }
+
+    /// The read chokepoint re-reads the persisted watermark each reconcile, so a
+    /// long-lived handle never folds from a frozen-at-open value (cid 3329765075).
+    #[test]
+    fn read_chokepoint_refreshes_watermark_fresh() {
+        assert!(
+            first_body(&[MANAGER_SRC], "reconciled_load")
+                .contains("refresh_persisted_watermark("),
+            "the read chokepoint must re-read the persisted watermark each reconcile"
+        );
+    }
+
+    /// The analyzer has TEETH: a planted bypass (a function calling a raw writer
+    /// outside the allowlist) is both detected by `callers_of` AND surfaced as a
+    /// stray by the allowlist check — proving the conformance checks above are
+    /// non-vacuous and would fail if such a function existed in production.
+    #[test]
+    fn analyzer_detects_a_planted_bypass() {
+        let fixture = "\
+    fn legit(&self, lock: &RefsLock) -> Result<()> {
+        self.materialize(outcome, lock)
+    }
+    fn sneaky_bypass(&self, lock: &RefsLock) -> Result<()> {
+        self.publish_ref_plans(plans, lock)
+    }
+";
+        let callers = callers_of(&[fixture], "publish_ref_plans");
+        assert!(
+            callers.contains("sneaky_bypass"),
+            "analyzer must flag a planted raw-writer bypass"
+        );
+        assert!(
+            strays(&callers, &["materialize"]).contains(&"sneaky_bypass".to_string()),
+            "the allowlist check must surface the planted bypass as a stray (non-vacuous)"
+        );
+    }
 }

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -856,6 +856,49 @@ mod chokepoint {
         assert_eq!(plain.get_thread(&ThreadName::new("feature")).unwrap(), None);
     }
 
+    /// heddle#354 r10 (cid 3330632443): when phase-5 publish fails AFTER the
+    /// record durably committed, the operation has already linearized — the arm
+    /// LOGS the swallowed publish error (operator visibility) and still returns
+    /// `Ok(())`. Returning `Err` here would falsely report failure for a
+    /// successful op; reconciliation materializes the committed effect later.
+    #[test]
+    #[cfg(unix)]
+    fn publish_failure_after_commit_logs_and_returns_ok() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_t, dir) = manager();
+        let refs = RefManager::new(&dir);
+        refs.init().unwrap();
+
+        // Read-only threads dir makes the phase-5 temp write fail, while the
+        // phase-3 read of the still-missing ref (which needs no write perm)
+        // succeeds — isolating a publish-after-commit failure.
+        let threads_dir = refs.threads_dir();
+        let original = std::fs::metadata(&threads_dir).unwrap().permissions().mode();
+        std::fs::set_permissions(&threads_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let lock = refs.lock_refs().unwrap();
+        let updates = vec![RefUpdate::Thread {
+            name: ThreadName::new("feature"),
+            expected: RefExpectation::Missing,
+            new: Some(ChangeId::generate()),
+        }];
+        // commit() reports the record durably committed (committed_for_reconcile);
+        // publish then fails. Behavior must be Ok(()), not Err.
+        let result = refs.validate_commit_publish(&updates, &lock, || Ok(true));
+
+        std::fs::set_permissions(&threads_dir, std::fs::Permissions::from_mode(original)).unwrap();
+        drop(lock);
+
+        assert!(
+            result.is_ok(),
+            "a publish failure after a durable commit linearized the op: must return Ok(()), not Err"
+        );
+        // The ref was NOT published (publish failed) — reconciliation will
+        // materialize the committed effect on the next read.
+        assert_eq!(refs.get_thread(&ThreadName::new("feature")).unwrap(), None);
+    }
+
     /// The remote-thread raw read/write/delete + list paths and `pack_refs`,
     /// `resolve`, and the `RefBackend`/`CoreRefBackend` trait delegations.
     #[test]

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -827,6 +827,35 @@ mod chokepoint {
         assert_eq!(plain.get_marker(&MarkerName::new("v2")).unwrap(), Some(other));
     }
 
+    /// Fail closed (heddle#354 r9, cid 3330304656): a `commit_and_publish` with
+    /// records but NO committer must error and publish NOTHING — committed data
+    /// can never be silently dropped while the ref is published anyway.
+    #[test]
+    fn commit_and_publish_without_committer_fails_closed_on_records() {
+        let (_t, dir) = manager();
+        let plain = RefManager::new(&dir);
+        plain.init().unwrap();
+
+        let state = ChangeId::generate();
+        let result = plain.commit_and_publish(
+            &[vec![1u8, 2, 3]],
+            &[RefUpdate::Thread {
+                name: ThreadName::new("feature"),
+                expected: RefExpectation::Missing,
+                new: Some(state),
+            }],
+            None,
+        );
+
+        // Errors rather than silently dropping the record...
+        assert!(
+            result.is_err(),
+            "records with no committer must fail closed, not drop silently"
+        );
+        // ...and the ref was NOT published (no half-applied write).
+        assert_eq!(plain.get_thread(&ThreadName::new("feature")).unwrap(), None);
+    }
+
     /// The remote-thread raw read/write/delete + list paths and `pack_refs`,
     /// `resolve`, and the `RefBackend`/`CoreRefBackend` trait delegations.
     #[test]

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -529,3 +529,319 @@ fn undo_recovery_is_scoped_per_checkout_on_shared_ref_root() {
     assert_eq!(refs_a.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(state_a));
     assert_eq!(refs_b.resolve(UNDO_RECOVERY_HANDLE).unwrap(), Some(state_b));
 }
+
+// ---- Read/write chokepoint coverage (heddle#330 §2.2) ----
+//
+// These drive `RefManager`'s reconciler/committer seams directly via injected
+// test doubles, exercising `reconciled_load`'s hot path + lag path,
+// `materialize`'s fill-if-absent branches, and `commit_and_publish`'s
+// record-before-publish ordering — without the `repo`/`oplog` layer.
+
+mod chokepoint {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use objects::error::Result;
+    use objects::object::{ChangeId, MarkerName, ThreadName};
+    use tempfile::TempDir;
+
+    use super::super::{
+        Loaded, LoadRequest, RefCommitter, RefManager, RefReconciler, ReconcileOutcome,
+        RefExpectation, RefUpdate,
+    };
+
+    fn manager() -> (TempDir, std::path::PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let heddle_dir = temp.path().join(".heddle");
+        std::fs::create_dir_all(&heddle_dir).unwrap();
+        let refs = RefManager::new(&heddle_dir);
+        refs.init().unwrap();
+        (temp, heddle_dir)
+    }
+
+    /// A reconciler whose generation is bumpable after injection (so the
+    /// watermark, seeded at inject time, lags and the reconcile path runs), and
+    /// whose `reconcile` returns a caller-configured materialization set.
+    struct FakeReconciler {
+        generation: AtomicU64,
+        republish: Vec<RefUpdate>,
+        remote_updates: Vec<(String, ThreadName, Option<ChangeId>)>,
+        undo_recovery: Option<ChangeId>,
+        calls: Arc<AtomicU64>,
+    }
+
+    impl RefReconciler for FakeReconciler {
+        fn generation(&self) -> u64 {
+            self.generation.load(Ordering::Acquire)
+        }
+        fn reconcile(&self, req: &LoadRequest, raw: Loaded, _since: u64) -> Result<ReconcileOutcome> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            // Project the request's authoritative value out of the configured
+            // materialization set (mirrors the real reconciler's per-request fold).
+            let loaded = match req {
+                LoadRequest::Thread(name) => self
+                    .republish
+                    .iter()
+                    .find_map(|u| match u {
+                        RefUpdate::Thread { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        _ => None,
+                    })
+                    .unwrap_or(raw),
+                LoadRequest::Marker(name) => self
+                    .republish
+                    .iter()
+                    .find_map(|u| match u {
+                        RefUpdate::Marker { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        _ => None,
+                    })
+                    .unwrap_or(raw),
+                LoadRequest::UndoRecovery => Loaded::Point(self.undo_recovery),
+                LoadRequest::RemoteThread { remote, thread } => self
+                    .remote_updates
+                    .iter()
+                    .find_map(|(r, t, v)| (r == remote && t == thread).then_some(Loaded::Point(*v)))
+                    .unwrap_or(raw),
+                _ => raw,
+            };
+            Ok(ReconcileOutcome {
+                loaded,
+                republish: self.republish.clone(),
+                remote_updates: self.remote_updates.clone(),
+                undo_recovery: self.undo_recovery,
+            })
+        }
+    }
+
+    type CommitCall = (Vec<Vec<u8>>, Option<String>);
+
+    struct FakeCommitter {
+        seen: Mutex<Vec<CommitCall>>,
+    }
+
+    impl RefCommitter for FakeCommitter {
+        fn commit_records(&self, encoded_records: &[Vec<u8>], scope: Option<&str>) -> Result<()> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push((encoded_records.to_vec(), scope.map(str::to_string)));
+            Ok(())
+        }
+    }
+
+    /// The hot path: when the class watermark equals the reconciler generation,
+    /// the raw value is returned with no reconcile call (no tail scan, no write).
+    #[test]
+    fn reconciled_load_hot_path_skips_reconcile_when_generation_unchanged() {
+        let (_t, dir) = manager();
+        let calls = Arc::new(AtomicU64::new(0));
+        let reconciler = Arc::new(FakeReconciler {
+            generation: AtomicU64::new(7),
+            republish: Vec::new(),
+            remote_updates: Vec::new(),
+            undo_recovery: None,
+            calls: Arc::clone(&calls),
+        });
+        // `with_reconciler` seeds both watermarks to generation()==7.
+        let refs = RefManager::new(&dir).with_reconciler(reconciler);
+        refs.init().unwrap();
+
+        // Generation still 7 ⇒ tip == cached ⇒ reconcile is never invoked.
+        let got = refs.get_thread(&ThreadName::new("absent")).unwrap();
+        assert_eq!(got, None);
+        assert_eq!(calls.load(Ordering::Acquire), 0, "hot path must not reconcile");
+    }
+
+    /// The lag path drives `materialize`'s fill-if-absent branches: an absent
+    /// thread + marker + remote-thread + undo-recovery are all published, a
+    /// already-present thread is left untouched, and a `None` remote update and
+    /// the watermark advance are exercised. A second read then takes the hot
+    /// path because the watermark caught up to the (unchanged) generation.
+    #[test]
+    fn reconciled_load_lag_path_materializes_absent_refs_only() {
+        let (_t, dir) = manager();
+
+        // Pre-publish a present thread so its republish is skipped (fill-if-absent
+        // must not clobber a present canonical).
+        let present_state = ChangeId::generate();
+        let absent_state = ChangeId::generate();
+        let marker_state = ChangeId::generate();
+        let remote_state = ChangeId::generate();
+        let undo_state = ChangeId::generate();
+
+        let calls = Arc::new(AtomicU64::new(0));
+        let reconciler = Arc::new(FakeReconciler {
+            generation: AtomicU64::new(1),
+            republish: vec![
+                RefUpdate::Thread {
+                    name: ThreadName::new("present"),
+                    expected: RefExpectation::Any,
+                    new: Some(present_state),
+                },
+                RefUpdate::Thread {
+                    name: ThreadName::new("absent"),
+                    expected: RefExpectation::Any,
+                    new: Some(absent_state),
+                },
+                // `new: None` arm — not a fill candidate.
+                RefUpdate::Thread {
+                    name: ThreadName::new("deleted"),
+                    expected: RefExpectation::Any,
+                    new: None,
+                },
+                RefUpdate::Marker {
+                    name: MarkerName::new("mk"),
+                    expected: RefExpectation::Any,
+                    new: Some(marker_state),
+                },
+            ],
+            remote_updates: vec![
+                ("origin".to_string(), ThreadName::new("rt"), Some(remote_state)),
+                // `None` value — skipped.
+                ("origin".to_string(), ThreadName::new("gone"), None),
+            ],
+            undo_recovery: Some(undo_state),
+            calls: Arc::clone(&calls),
+        });
+        let refs = RefManager::new(&dir).with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
+        refs.init().unwrap();
+        // Publish the present thread AFTER injection (raw write, bypasses chokepoint).
+        refs.set_thread(&ThreadName::new("present"), &present_state).unwrap();
+
+        // Bump generation so the next read lags ⇒ reconcile + materialize run.
+        reconciler.generation.store(2, Ordering::Release);
+
+        let got = refs.get_thread(&ThreadName::new("absent")).unwrap();
+        assert_eq!(got, Some(absent_state), "reconciled value is surfaced");
+        assert_eq!(calls.load(Ordering::Acquire), 1, "lag path reconciles once");
+
+        // The absent refs were materialized; the present one is unchanged.
+        assert_eq!(
+            refs.get_thread(&ThreadName::new("present")).unwrap(),
+            Some(present_state)
+        );
+        assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
+        assert_eq!(
+            refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
+            Some(remote_state)
+        );
+        assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo_state));
+
+        // Second read: watermark now == generation (2) ⇒ hot path, no new reconcile.
+        let before = calls.load(Ordering::Acquire);
+        let _ = refs.get_thread(&ThreadName::new("absent")).unwrap();
+        assert_eq!(calls.load(Ordering::Acquire), before, "watermark caught up ⇒ hot path");
+    }
+
+    /// `commit_and_publish` appends the ref-carrying records (phase 4) before
+    /// publishing the ref batch (phase 5), and degrades to a plain publish when
+    /// no committer is injected.
+    #[test]
+    fn commit_and_publish_records_before_it_publishes() {
+        let (_t, dir) = manager();
+        let committer = Arc::new(FakeCommitter {
+            seen: Mutex::new(Vec::new()),
+        });
+        let refs = RefManager::new(&dir).with_committer(Arc::clone(&committer) as Arc<dyn RefCommitter>);
+        refs.init().unwrap();
+
+        let state = ChangeId::generate();
+        let records = vec![vec![1u8, 2, 3]];
+        let updates = vec![RefUpdate::Thread {
+            name: ThreadName::new("feature"),
+            expected: RefExpectation::Missing,
+            new: Some(state),
+        }];
+        refs.commit_and_publish(&records, &updates, Some("lane")).unwrap();
+
+        // The committer saw the records (phase 4) and the ref published (phase 5).
+        let seen = committer.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, records);
+        assert_eq!(seen[0].1.as_deref(), Some("lane"));
+        drop(seen);
+        assert_eq!(
+            refs.get_thread(&ThreadName::new("feature")).unwrap(),
+            Some(state)
+        );
+
+        // No-committer path: a plain publish (no records) still publishes, and
+        // an empty ref batch is a no-op.
+        let (_t2, dir2) = manager();
+        let plain = RefManager::new(&dir2);
+        plain.init().unwrap();
+        plain.commit_and_publish(&[], &[], None).unwrap();
+        let other = ChangeId::generate();
+        plain
+            .commit_and_publish(
+                &[],
+                &[RefUpdate::Marker {
+                    name: MarkerName::new("v2"),
+                    expected: RefExpectation::Missing,
+                    new: Some(other),
+                }],
+                None,
+            )
+            .unwrap();
+        assert_eq!(plain.get_marker(&MarkerName::new("v2")).unwrap(), Some(other));
+    }
+
+    /// The remote-thread raw read/write/delete + list paths and `pack_refs`,
+    /// `resolve`, and the `RefBackend`/`CoreRefBackend` trait delegations.
+    #[test]
+    fn remote_threads_pack_and_trait_delegations() {
+        use super::super::{CoreRefBackend, RefBackend};
+
+        let (_t, dir) = manager();
+        let refs = RefManager::new(&dir);
+        refs.init().unwrap();
+
+        let s1 = ChangeId::generate();
+        let s2 = ChangeId::generate();
+        // RefBackend trait surface for remotes.
+        RefBackend::set_remote_thread(&refs, "origin", &ThreadName::new("rt1"), &s1).unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt2"), &s2).unwrap();
+        assert_eq!(
+            RefBackend::get_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap(),
+            Some(s1)
+        );
+        assert!(RefBackend::list_remotes(&refs).unwrap().contains(&"origin".to_string()));
+        let mut rts = RefBackend::list_remote_threads(&refs, "origin").unwrap();
+        rts.sort();
+        assert_eq!(rts.len(), 2);
+        let removed = RefBackend::delete_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap();
+        assert_eq!(removed, Some(s1));
+        // Deleting an absent remote thread returns None.
+        assert_eq!(
+            refs.delete_remote_thread("origin", &ThreadName::new("nope")).unwrap(),
+            None
+        );
+
+        // Threads + markers + pack_refs (packs loose refs into packed-refs).
+        let t = ChangeId::generate();
+        let m = ChangeId::generate();
+        refs.set_thread(&ThreadName::new("main2"), &t).unwrap();
+        refs.create_marker(&MarkerName::new("rel"), &m).unwrap();
+        RefBackend::pack_refs(&refs).unwrap();
+        assert_eq!(refs.get_thread(&ThreadName::new("main2")).unwrap(), Some(t));
+        assert_eq!(refs.get_marker(&MarkerName::new("rel")).unwrap(), Some(m));
+
+        // resolve() funnels through read_head/get_thread/get_marker/undo.
+        assert_eq!(refs.resolve("main2").unwrap(), Some(t));
+        assert_eq!(refs.resolve("rel").unwrap(), Some(m));
+
+        // CoreRefBackend async + sync delegations.
+        let got = pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main2"))).unwrap();
+        assert_eq!(got, Some(t));
+        let gm = pollster::block_on(CoreRefBackend::get_marker(&refs, &MarkerName::new("rel"))).unwrap();
+        assert_eq!(gm, Some(m));
+        assert!(CoreRefBackend::list_threads(&refs).unwrap().contains(&ThreadName::new("main2")));
+        assert!(CoreRefBackend::list_markers(&refs).unwrap().contains(&MarkerName::new("rel")));
+        let r = pollster::block_on(CoreRefBackend::resolve(&refs, "main2")).unwrap();
+        assert_eq!(r, Some(t));
+
+        // Maintenance trait methods.
+        let _ = RefBackend::inspect_ref_summary_index(&refs).unwrap();
+        let _ = RefBackend::rebuild_ref_summary_index(&refs).unwrap();
+        RefBackend::cleanup_stale_temps(&refs);
+    }
+}

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -103,8 +103,38 @@ impl RefManager {
     pub(super) fn update_refs_with_lock(
         &self,
         updates: &[RefUpdate],
-        _lock: &RefsLock,
+        lock: &RefsLock,
     ) -> Result<()> {
+        let plans = self.plan_ref_updates(updates)?;
+        self.publish_ref_plans(plans, lock)
+    }
+
+    /// Validate + commit + publish as one atomic unit under the held refs lock
+    /// (heddle#330 §2.2 write chokepoint, cid 3329490978 / 3329490984).
+    ///
+    /// Phase 3 plans and validates every update against the on-disk value
+    /// **first** (writing nothing), so a CAS-expectation failure returns `Err`
+    /// before `commit` runs — the oplog record is never appended for a mutation
+    /// that will not publish (no validation-failure leak). `commit` (phase 4)
+    /// then runs, immediately followed by the phase-5 publish, all while the
+    /// caller holds the refs lock — so concurrent callers serialize the
+    /// record-and-publish as a single unit (no record/publish order divergence).
+    pub(super) fn validate_commit_publish(
+        &self,
+        updates: &[RefUpdate],
+        lock: &RefsLock,
+        commit: impl FnOnce() -> Result<()>,
+    ) -> Result<()> {
+        let plans = self.plan_ref_updates(updates)?;
+        commit()?;
+        self.publish_ref_plans(plans, lock)
+    }
+
+    /// Phase 3 (heddle#330 §2.2): plan + validate every update against the
+    /// current on-disk value, rejecting CAS conflicts and duplicate targets up
+    /// front. Pure validation — touches no canonical ref and no temp file, so a
+    /// failed expectation returns `Err` before anything is staged or committed.
+    fn plan_ref_updates(&self, updates: &[RefUpdate]) -> Result<Vec<RefUpdatePlan>> {
         let mut seen = HashSet::new();
         let mut plans = Vec::new();
 
@@ -216,6 +246,15 @@ impl RefManager {
             }
         }
 
+        Ok(plans)
+    }
+
+    /// Phase 5 (heddle#330 §2.2): stage each update into a temp file, rename the
+    /// temps into their canonical paths (the publish), apply packed-ref removals,
+    /// and rebuild the summary index. On any apply error the reverse-order
+    /// `rollback_updates` restores prior contents. Called only after
+    /// [`plan_ref_updates`](Self::plan_ref_updates) has validated the batch.
+    fn publish_ref_plans(&self, mut plans: Vec<RefUpdatePlan>, _lock: &RefsLock) -> Result<()> {
         for plan in &mut plans {
             if let Some(ref content) = plan.new_content {
                 let temp_path = self.write_string_temp(&plan.path, content)?;

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -9,7 +9,7 @@ use objects::{
 };
 
 use super::{
-    format_change_id_text,
+    RefManager, RefUpdate, format_change_id_text,
     packed_refs::PackedRefs,
     parse_change_id_text,
     refs_storage::RefsLock,
@@ -17,7 +17,6 @@ use super::{
         describe_change_id, describe_expectation_change_id, describe_expectation_head,
         describe_head, matches_expectation,
     },
-    RefManager, RefUpdate,
 };
 use crate::fs_atomic::sync_directory;
 
@@ -109,25 +108,30 @@ impl RefManager {
         self.publish_ref_plans(plans, lock)
     }
 
-    /// Validate + commit + publish as one atomic unit under the held refs lock
-    /// (heddle#330 §2.2 write chokepoint, cid 3329490978 / 3329490984).
+    /// Validate + commit + publish under the held refs lock (heddle#330 §2.2
+    /// write chokepoint, cid 3329490978 / 3329490984).
     ///
     /// Phase 3 plans and validates every update against the on-disk value
     /// **first** (writing nothing), so a CAS-expectation failure returns `Err`
     /// before `commit` runs — the oplog record is never appended for a mutation
     /// that will not publish (no validation-failure leak). `commit` (phase 4)
-    /// then runs, immediately followed by the phase-5 publish, all while the
-    /// caller holds the refs lock — so concurrent callers serialize the
-    /// record-and-publish as a single unit (no record/publish order divergence).
+    /// then runs, immediately followed by the phase-5 publish. If phase 5
+    /// fails after a ref-carrying record was durably committed, the operation
+    /// has already linearized; return success and let reconciliation materialize
+    /// the committed effect on the next read.
     pub(super) fn validate_commit_publish(
         &self,
         updates: &[RefUpdate],
         lock: &RefsLock,
-        commit: impl FnOnce() -> Result<()>,
+        commit: impl FnOnce() -> Result<bool>,
     ) -> Result<()> {
         let plans = self.plan_ref_updates(updates)?;
-        commit()?;
-        self.publish_ref_plans(plans, lock)
+        let committed_for_reconcile = commit()?;
+        match self.publish_ref_plans(plans, lock) {
+            Ok(()) => Ok(()),
+            Err(_err) if committed_for_reconcile => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 
     /// Phase 3 (heddle#330 §2.2): plan + validate every update against the
@@ -364,8 +368,13 @@ impl RefManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use objects::object::MarkerName;
     use tempfile::TempDir;
 
+    use super::super::reconcile::{LoadRequest, Loaded, ReconcileOutcome, RefReconciler};
     use super::*;
 
     fn create_ref_manager() -> (TempDir, RefManager) {
@@ -412,6 +421,87 @@ mod tests {
         assert!(
             !thread_path.exists(),
             "rollback should restore packed refs, not leave a loose recovery ref"
+        );
+    }
+
+    struct OneMarkerReconciler {
+        generation: Arc<AtomicU64>,
+        name: MarkerName,
+        state: ChangeId,
+    }
+
+    impl RefReconciler for OneMarkerReconciler {
+        fn generation(&self) -> u64 {
+            self.generation.load(Ordering::Acquire)
+        }
+
+        fn reconcile(
+            &self,
+            req: &LoadRequest,
+            raw: Loaded,
+            _since: u64,
+        ) -> Result<ReconcileOutcome> {
+            let loaded = match req {
+                LoadRequest::Marker(name) if name == &self.name => Loaded::Point(Some(self.state)),
+                _ => raw,
+            };
+            Ok(ReconcileOutcome {
+                loaded,
+                republish: vec![RefUpdate::Marker {
+                    name: self.name.clone(),
+                    expected: super::super::RefExpectation::Any,
+                    new: Some(self.state),
+                }],
+                remote_updates: Vec::new(),
+                undo_recovery: None,
+            })
+        }
+    }
+
+    #[test]
+    fn post_commit_publish_failure_is_deferred_success() {
+        let (temp, plain_refs) = create_ref_manager();
+        let generation = Arc::new(AtomicU64::new(0));
+        let good = MarkerName::new("good");
+        let bad = MarkerName::new("bad");
+        let committed_state = ChangeId::generate();
+        let refs = RefManager::new(temp.path().join(".heddle")).with_reconciler(Arc::new(
+            OneMarkerReconciler {
+                generation: Arc::clone(&generation),
+                name: good.clone(),
+                state: committed_state,
+            },
+        ));
+
+        let updates = vec![
+            RefUpdate::Marker {
+                name: good.clone(),
+                expected: super::super::RefExpectation::Missing,
+                new: Some(committed_state),
+            },
+            RefUpdate::Marker {
+                name: bad.clone(),
+                expected: super::super::RefExpectation::Missing,
+                new: Some(ChangeId::generate()),
+            },
+        ];
+        let lock = refs.lock_refs().unwrap();
+        let result = refs.validate_commit_publish(&updates, &lock, || {
+            generation.store(1, Ordering::Release);
+            std::fs::create_dir(plain_refs.marker_path(bad.as_str()).unwrap()).unwrap();
+            Ok(true)
+        });
+        drop(lock);
+
+        assert!(
+            result.is_ok(),
+            "phase-5 failure after durable commit must not report mutation failure"
+        );
+        std::fs::remove_dir_all(plain_refs.marker_path(bad.as_str()).unwrap()).unwrap();
+        assert_eq!(
+            refs.get_marker(&good).unwrap(),
+            Some(committed_state),
+            "the next read must materialize the committed effect"
         );
     }
 }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -118,8 +118,9 @@ impl RefManager {
     /// that will not publish (no validation-failure leak). `commit` (phase 4)
     /// then runs, immediately followed by the phase-5 publish. If phase 5
     /// fails after a ref-carrying record was durably committed, the operation
-    /// has already linearized; return success and let reconciliation materialize
-    /// the committed effect on the next read.
+    /// has already linearized; log the swallowed publish error (warn) for
+    /// operator visibility, then return success and let reconciliation
+    /// materialize the committed effect on the next read.
     pub(super) fn validate_commit_publish(
         &self,
         updates: &[RefUpdate],
@@ -130,7 +131,14 @@ impl RefManager {
         let committed_for_reconcile = commit()?;
         match self.publish_ref_plans(plans, lock) {
             Ok(()) => Ok(()),
-            Err(_err) if committed_for_reconcile => Ok(()),
+            Err(err) if committed_for_reconcile => {
+                tracing::warn!(
+                    error = %err,
+                    "ref publish failed after the record committed; the operation \
+                     linearized and reconciliation will materialize it on the next read"
+                );
+                Ok(())
+            }
             Err(err) => Err(err),
         }
     }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -12,6 +12,7 @@ use super::{
     RefManager, RefUpdate, format_change_id_text,
     packed_refs::PackedRefs,
     parse_change_id_text,
+    reconcile::{LoadRequest, Loaded},
     refs_storage::RefsLock,
     refs_types::{
         describe_change_id, describe_expectation_change_id, describe_expectation_head,
@@ -25,7 +26,7 @@ enum PackedRemove {
     Marker(String),
 }
 
-struct RefUpdatePlan {
+pub(super) struct RefUpdatePlan {
     path: PathBuf,
     new_content: Option<String>,
     previous_content: Option<String>,
@@ -135,9 +136,20 @@ impl RefManager {
     }
 
     /// Phase 3 (heddle#330 §2.2): plan + validate every update against the
-    /// current on-disk value, rejecting CAS conflicts and duplicate targets up
-    /// front. Pure validation — touches no canonical ref and no temp file, so a
-    /// failed expectation returns `Err` before anything is staged or committed.
+    /// **reconciled** current value, rejecting CAS conflicts and duplicate
+    /// targets up front. Pure validation — touches no canonical ref and no temp
+    /// file, so a failed expectation returns `Err` before anything is staged or
+    /// committed.
+    ///
+    /// **Validation + publish base come from the under-lock reconciled state, not
+    /// a pre-lock raw disk read (heddle#354 r5, cid 3329631079).** Because a
+    /// committed-but-unpublished record can leave the on-disk ref stale (a crash
+    /// between phase 4 and phase 5, or a co-tenant lane's lagging publish), a
+    /// `Missing`/CAS expectation checked against raw disk would validate against
+    /// the wrong value. The caller already holds the refs lock, so
+    /// [`reconciled_value_under_lock`](RefManager::reconciled_value_under_lock)
+    /// folds the committed tail without re-locking; the fold→validate→publish
+    /// sequence is therefore one atomic unit under the single held lock.
     fn plan_ref_updates(&self, updates: &[RefUpdate]) -> Result<Vec<RefUpdatePlan>> {
         let mut seen = HashSet::new();
         let mut plans = Vec::new();
@@ -149,7 +161,7 @@ impl RefManager {
                     expected,
                     new,
                 } => {
-                    let (path, current, effective_prev) =
+                    let (path, _raw_current, _raw_prev) =
                         self.read_track_with_packed_fallback(name)?;
                     if !seen.insert(path.clone()) {
                         return Err(HeddleError::Conflict(format!(
@@ -158,6 +170,12 @@ impl RefManager {
                         )));
                     }
 
+                    let current = match self
+                        .reconciled_value_under_lock(&LoadRequest::Thread(name.clone()))?
+                    {
+                        Loaded::Point(id) => id,
+                        _ => unreachable!("Thread request yields Point"),
+                    };
                     if !matches_expectation(expected, current.as_ref(), current.is_some()) {
                         return Err(HeddleError::Conflict(format!(
                             "thread {} expected {}, found {}",
@@ -168,6 +186,7 @@ impl RefManager {
                     }
 
                     let new_content = new.as_ref().map(format_change_id_text);
+                    let previous_content = current.as_ref().map(format_change_id_text);
                     let packed_remove = if new.is_none() && current.is_some() {
                         Some(PackedRemove::Thread(name.to_string()))
                     } else {
@@ -176,7 +195,7 @@ impl RefManager {
                     plans.push(RefUpdatePlan {
                         path,
                         new_content,
-                        previous_content: effective_prev,
+                        previous_content,
                         description: format!("thread {}", name),
                         temp_path: None,
                         packed_remove,
@@ -195,9 +214,12 @@ impl RefManager {
                         )));
                     }
 
-                    let (current, effective_prev) =
-                        self.read_marker_with_packed_fallback(&path, name)?;
-
+                    let current = match self
+                        .reconciled_value_under_lock(&LoadRequest::Marker(name.clone()))?
+                    {
+                        Loaded::Point(id) => id,
+                        _ => unreachable!("Marker request yields Point"),
+                    };
                     if !matches_expectation(expected, current.as_ref(), current.is_some()) {
                         return Err(HeddleError::Conflict(format!(
                             "marker {} expected {}, found {}",
@@ -208,6 +230,7 @@ impl RefManager {
                     }
 
                     let new_content = new.as_ref().map(format_change_id_text);
+                    let previous_content = current.as_ref().map(format_change_id_text);
                     let packed_remove = if new.is_none() && current.is_some() {
                         Some(PackedRemove::Marker(name.to_string()))
                     } else {
@@ -216,21 +239,29 @@ impl RefManager {
                     plans.push(RefUpdatePlan {
                         path,
                         new_content,
-                        previous_content: effective_prev,
+                        previous_content,
                         description: format!("marker {}", name),
                         temp_path: None,
                         packed_remove,
                     });
                 }
                 RefUpdate::Head { expected, new } => {
-                    let state = self.read_head_state()?;
-                    let current_desc = if state.exists {
-                        describe_head(&state.head)
+                    let raw_state = self.read_head_state()?;
+                    let reconciled_head = match self.reconciled_value_under_lock(&LoadRequest::Head)?
+                    {
+                        Loaded::Head(head) => head,
+                        _ => unreachable!("Head request yields Head"),
+                    };
+                    // HEAD "exists" if its file is present OR a committed record
+                    // reconstructs a value the stale on-disk HEAD does not reflect.
+                    let exists = raw_state.exists || reconciled_head != raw_state.head;
+                    let current_desc = if exists {
+                        describe_head(&reconciled_head)
                     } else {
                         "missing".to_string()
                     };
 
-                    if !matches_expectation(expected, Some(&state.head), state.exists) {
+                    if !matches_expectation(expected, Some(&reconciled_head), exists) {
                         return Err(HeddleError::Conflict(format!(
                             "HEAD expected {}, found {}",
                             describe_expectation_head(expected),
@@ -238,10 +269,19 @@ impl RefManager {
                         )));
                     }
 
+                    // Publish base from the reconciled HEAD: when a committed
+                    // record reconstructs a value the raw HEAD lags, a rollback
+                    // restores that authoritative value, not the stale disk one.
+                    let previous_content = if reconciled_head == raw_state.head {
+                        raw_state.raw
+                    } else {
+                        Some(reconciled_head.to_text())
+                    };
+
                     plans.push(RefUpdatePlan {
                         path: self.head_path(),
                         new_content: Some(new.to_text()),
-                        previous_content: state.raw,
+                        previous_content,
                         description: "HEAD".to_string(),
                         temp_path: None,
                         packed_remove: None,
@@ -253,12 +293,92 @@ impl RefManager {
         Ok(plans)
     }
 
+    /// Build the publish plans for the reconciler's lazy re-materialization set
+    /// (heddle#354 r5). Unlike [`plan_ref_updates`](Self::plan_ref_updates) this
+    /// does NOT re-reconcile or validate: the `republish` values are already the
+    /// authoritative under-lock fold (computed by the caller before the lock was
+    /// taken stale-free), so re-folding here would be redundant and could double-
+    /// count the reconciler's call budget. Each entry is skipped when the current
+    /// canonical already equals the folded value (no-op), and the publish base is
+    /// the current canonical (so a failed publish rolls back to exactly what was
+    /// on disk).
+    pub(super) fn plan_materialization(
+        &self,
+        republish: &[RefUpdate],
+    ) -> Result<Vec<RefUpdatePlan>> {
+        let mut plans = Vec::new();
+        for update in republish {
+            match update {
+                RefUpdate::Thread { name, new, .. } => {
+                    let (path, current, effective_prev) =
+                        self.read_track_with_packed_fallback(name)?;
+                    if current == *new {
+                        continue;
+                    }
+                    let packed_remove = if new.is_none() && current.is_some() {
+                        Some(PackedRemove::Thread(name.to_string()))
+                    } else {
+                        None
+                    };
+                    plans.push(RefUpdatePlan {
+                        path,
+                        new_content: new.as_ref().map(format_change_id_text),
+                        previous_content: effective_prev,
+                        description: format!("thread {}", name),
+                        temp_path: None,
+                        packed_remove,
+                    });
+                }
+                RefUpdate::Marker { name, new, .. } => {
+                    let path = self.marker_path(name)?;
+                    let (current, effective_prev) =
+                        self.read_marker_with_packed_fallback(&path, name)?;
+                    if current == *new {
+                        continue;
+                    }
+                    let packed_remove = if new.is_none() && current.is_some() {
+                        Some(PackedRemove::Marker(name.to_string()))
+                    } else {
+                        None
+                    };
+                    plans.push(RefUpdatePlan {
+                        path,
+                        new_content: new.as_ref().map(format_change_id_text),
+                        previous_content: effective_prev,
+                        description: format!("marker {}", name),
+                        temp_path: None,
+                        packed_remove,
+                    });
+                }
+                RefUpdate::Head { new, .. } => {
+                    let state = self.read_head_state()?;
+                    if state.exists && state.head == *new {
+                        continue;
+                    }
+                    plans.push(RefUpdatePlan {
+                        path: self.head_path(),
+                        new_content: Some(new.to_text()),
+                        previous_content: state.raw,
+                        description: "HEAD".to_string(),
+                        temp_path: None,
+                        packed_remove: None,
+                    });
+                }
+            }
+        }
+        Ok(plans)
+    }
+
     /// Phase 5 (heddle#330 §2.2): stage each update into a temp file, rename the
     /// temps into their canonical paths (the publish), apply packed-ref removals,
     /// and rebuild the summary index. On any apply error the reverse-order
     /// `rollback_updates` restores prior contents. Called only after
     /// [`plan_ref_updates`](Self::plan_ref_updates) has validated the batch.
-    fn publish_ref_plans(&self, mut plans: Vec<RefUpdatePlan>, _lock: &RefsLock) -> Result<()> {
+    pub(super) fn publish_ref_plans(
+        &self,
+        mut plans: Vec<RefUpdatePlan>,
+        _lock: &RefsLock,
+    ) -> Result<()> {
         for plan in &mut plans {
             if let Some(ref content) = plan.new_content {
                 let temp_path = self.write_string_temp(&plan.path, content)?;
@@ -431,8 +551,8 @@ mod tests {
     }
 
     impl RefReconciler for OneMarkerReconciler {
-        fn generation(&self) -> u64 {
-            self.generation.load(Ordering::Acquire)
+        fn generation(&self) -> Result<u64> {
+            Ok(self.generation.load(Ordering::Acquire))
         }
 
         fn reconcile(

--- a/crates/repo/src/atomic/committer.rs
+++ b/crates/repo/src/atomic/committer.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The oplog-backed [`RefCommitter`] (heddle#330 write chokepoint).
+//!
+//! The write-side dual of [`OplogRefReconciler`](super::OplogRefReconciler):
+//! decodes the opaque `OpRecord` batch handed across the `refs`→`repo` seam and
+//! appends it to the file oplog (phase 4) before `RefManager` publishes the ref
+//! batch (phase 5). Defined in `repo` (which names `OpRecord`) and injected into
+//! `RefManager`, so `refs` keeps no `oplog` dependency.
+
+use std::path::{Path, PathBuf};
+
+use objects::error::{HeddleError, Result};
+use objects::object::Principal;
+use oplog::{OpLog, OpRecord};
+use refs::RefCommitter;
+
+/// Appends ref-carrying records to the file oplog as the phase-4 commit point.
+pub struct OplogRefCommitter {
+    heddle_dir: PathBuf,
+    principal: Principal,
+}
+
+impl OplogRefCommitter {
+    pub fn new(heddle_dir: &Path, principal: Principal) -> Self {
+        Self {
+            heddle_dir: heddle_dir.to_path_buf(),
+            principal,
+        }
+    }
+}
+
+impl RefCommitter for OplogRefCommitter {
+    fn commit_records(&self, encoded_records: &[Vec<u8>], scope: Option<&str>) -> Result<()> {
+        if encoded_records.is_empty() {
+            return Ok(());
+        }
+        let records = encoded_records
+            .iter()
+            .map(|bytes| {
+                rmp_serde::from_slice::<OpRecord>(bytes)
+                    .map_err(|e| HeddleError::Serialization(e.to_string()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // Fresh handle so the append reloads the current log under the write
+        // lock; preserves the configured principal for attribution.
+        let oplog = OpLog::new(&self.heddle_dir, self.principal.clone());
+        oplog.record_batch_scoped(records, scope)?;
+        Ok(())
+    }
+}

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The generic executor (heddle#330 §2.1).
+//!
+//! [`execute`] is the single entry point that enforces the commit point and
+//! the reverse-order rewind exactly once. Monomorphized per mutation type —
+//! zero vtable. The bound `M: AtomicMutation` makes "register an atomic op
+//! without a `rewind`" a compile error.
+
+use objects::error::Result;
+
+use super::traits::{AtomicMutation, StagedCommit};
+use super::tx::Tx;
+use crate::Repository;
+
+/// Run a mutation as one all-or-nothing transaction.
+///
+/// 1. Stage every reversible effect (`apply`), registering inverses on the
+///    ledger. A pre-commit `Err` (or a panic — caught by `Tx::drop`) unwinds
+///    the ledger in reverse order and the oplog is never touched.
+/// 2. Reach the single commit point: append the staged records + a
+///    `TransactionCommit` marker, deduplicated by the unbounded
+///    `transaction_id` index (exact-once at any retry timing).
+///
+/// On commit failure the staged effects are rewound too, so the call is
+/// all-or-nothing.
+pub fn execute<'a, M>(repo: &'a Repository, mut m: M) -> Result<M::Output>
+where
+    M: AtomicMutation + 'a,
+{
+    let mut tx = Tx::root(repo);
+
+    let staged = match m.apply(&mut tx) {
+        Ok(staged) => staged,
+        Err(e) => {
+            // Reverse-order unwind of whatever `apply` staged before failing.
+            let _ = tx.rewind_all();
+            return Err(e);
+        }
+    };
+
+    let StagedCommit { output, oplog } = staged;
+
+    // Register the top mutation's whole-op rewind (a no-op for mutations that
+    // registered granular inverses). Moves `m` into the ledger closure; on a
+    // successful commit it is never invoked and drops with the ledger.
+    let ledger = tx.ledger_view();
+    tx.on_rewind(move || m.rewind(&ledger));
+
+    match tx.commit(oplog) {
+        Ok(()) => Ok(output),
+        Err(e) => {
+            let _ = tx.rewind_all();
+            Err(e)
+        }
+    }
+}

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -49,14 +49,27 @@ where
 
     match tx.commit(oplog) {
         Ok(CommitOutcome::Committed) => Ok(output),
-        Ok(CommitOutcome::AlreadyCommitted) => match tx.rewind_all() {
-            Ok(()) => Ok(output),
-            Err(rewind_err) => Err(HeddleError::Conflict(format!(
-                "transaction {} was already committed, but replay rewind failed: {}",
-                tx.transaction_id(),
-                rewind_err
-            ))),
-        },
+        Ok(CommitOutcome::AlreadyCommitted(prior_records)) => {
+            // Dedup hit: this run's `output` may diverge from what was actually
+            // committed (e.g. a regenerated `ChangeId`), so reconstruct the
+            // originally-committed identity from the prior batch (cid 3329631075).
+            // Reconstruct BEFORE rewinding — `rewind_all` runs the whole-op
+            // rewind, which takes the mutation out of its cell.
+            let reconstructed = mutation
+                .borrow()
+                .as_ref()
+                .expect("root mutation present before replay rewind")
+                .reconstruct_committed_output(&prior_records, output);
+            match (reconstructed, tx.rewind_all()) {
+                (Ok(committed_output), Ok(())) => Ok(committed_output),
+                (Ok(_), Err(rewind_err)) => Err(HeddleError::Conflict(format!(
+                    "transaction {} was already committed, but replay rewind failed: {}",
+                    tx.transaction_id(),
+                    rewind_err
+                ))),
+                (Err(reconstruct_err), _) => Err(reconstruct_err),
+            }
+        }
         Err(e) => rewind_error(&mut tx, e),
     }
 }

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -27,12 +27,23 @@ pub fn execute<'a, M>(repo: &'a Repository, mut m: M) -> Result<M::Output>
 where
     M: AtomicMutation + 'a,
 {
-    let mut tx = Tx::root(repo);
+    // The stable idempotency key, supplied by the mutation (cid 3329490982);
+    // identical across retries so a crash-retry deduplicates instead of
+    // double-applying.
+    let mut tx = Tx::root(repo, m.transaction_id());
 
     let staged = match m.apply(&mut tx) {
         Ok(staged) => staged,
         Err(e) => {
-            // Reverse-order unwind of whatever `apply` staged before failing.
+            // The whole-op rewind must run on the apply-`Err` path too, or a
+            // mutation that uses it (rather than granular `on_rewind` inverses)
+            // would leak the state its `apply` staged before failing (cid
+            // 3329490979). Register it exactly as the commit-failure path below,
+            // then unwind: the granular ledger AND the whole-op rewind run
+            // together (one is a no-op per the one-mechanism-per-mutation
+            // contract), so zero staged state survives a failed `apply`.
+            let ledger = tx.ledger_view();
+            tx.on_rewind(move || m.rewind(&ledger));
             let _ = tx.rewind_all();
             return Err(e);
         }

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -6,10 +6,10 @@
 //! zero vtable. The bound `M: AtomicMutation` makes "register an atomic op
 //! without a `rewind`" a compile error.
 
-use objects::error::Result;
+use objects::error::{HeddleError, Result};
 
 use super::traits::{AtomicMutation, StagedCommit};
-use super::tx::Tx;
+use super::tx::{CommitOutcome, Tx};
 use crate::Repository;
 
 /// Run a mutation as one all-or-nothing transaction.
@@ -23,7 +23,7 @@ use crate::Repository;
 ///
 /// On commit failure the staged effects are rewound too, so the call is
 /// all-or-nothing.
-pub fn execute<'a, M>(repo: &'a Repository, mut m: M) -> Result<M::Output>
+pub fn execute<'a, M>(repo: &'a Repository, m: M) -> Result<M::Output>
 where
     M: AtomicMutation + 'a,
 {
@@ -31,37 +31,42 @@ where
     // identical across retries so a crash-retry deduplicates instead of
     // double-applying.
     let mut tx = Tx::root(repo, m.transaction_id());
+    let mutation = tx.enroll_whole_op(m);
 
-    let staged = match m.apply(&mut tx) {
+    let staged = {
+        let mut guard = mutation.borrow_mut();
+        guard
+            .as_mut()
+            .expect("root mutation must be present during apply")
+            .apply(&mut tx)
+    };
+    let staged = match staged {
         Ok(staged) => staged,
-        Err(e) => {
-            // The whole-op rewind must run on the apply-`Err` path too, or a
-            // mutation that uses it (rather than granular `on_rewind` inverses)
-            // would leak the state its `apply` staged before failing (cid
-            // 3329490979). Register it exactly as the commit-failure path below,
-            // then unwind: the granular ledger AND the whole-op rewind run
-            // together (one is a no-op per the one-mechanism-per-mutation
-            // contract), so zero staged state survives a failed `apply`.
-            let ledger = tx.ledger_view();
-            tx.on_rewind(move || m.rewind(&ledger));
-            let _ = tx.rewind_all();
-            return Err(e);
-        }
+        Err(e) => return rewind_error(&mut tx, e),
     };
 
     let StagedCommit { output, oplog } = staged;
 
-    // Register the top mutation's whole-op rewind (a no-op for mutations that
-    // registered granular inverses). Moves `m` into the ledger closure; on a
-    // successful commit it is never invoked and drops with the ledger.
-    let ledger = tx.ledger_view();
-    tx.on_rewind(move || m.rewind(&ledger));
-
     match tx.commit(oplog) {
-        Ok(()) => Ok(output),
-        Err(e) => {
-            let _ = tx.rewind_all();
-            Err(e)
-        }
+        Ok(CommitOutcome::Committed) => Ok(output),
+        Ok(CommitOutcome::AlreadyCommitted) => match tx.rewind_all() {
+            Ok(()) => Ok(output),
+            Err(rewind_err) => Err(HeddleError::Conflict(format!(
+                "transaction {} was already committed, but replay rewind failed: {}",
+                tx.transaction_id(),
+                rewind_err
+            ))),
+        },
+        Err(e) => rewind_error(&mut tx, e),
+    }
+}
+
+fn rewind_error<T>(tx: &mut Tx<'_>, original: HeddleError) -> Result<T> {
+    match tx.rewind_all() {
+        Ok(()) => Err(original),
+        Err(rewind_err) => Err(HeddleError::Conflict(format!(
+            "transaction failed: {}; rewind failed: {}",
+            original, rewind_err
+        ))),
     }
 }

--- a/crates/repo/src/atomic/mod.rs
+++ b/crates/repo/src/atomic/mod.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The atomic-mutation primitive (heddle#330 impl-a).
+//!
+//! A heddle-native primitive that makes "multi-step mutation with a forgotten
+//! or mis-ordered cleanup" structurally unrepresentable. The primitive is a
+//! [`trait`](AtomicMutation) each mutation implements plus a generic
+//! [`execute`] that enforces the commit point and the reverse-order rewind
+//! exactly once.
+//!
+//! Design (see `docs/spikes/heddle-330-atomic-mutation-primitive.md`):
+//! - **The oplog append is the SOLE commit point** ([`Tx::commit`]). Refs are a
+//!   post-commit materialized view; a mutation is committed iff its
+//!   `TransactionCommit` marker is durable, deduplicated by the **unbounded
+//!   indexed `transaction_id`** lookup (`OpLog::record_batch_exactly_once`).
+//! - **Nesting = enroll-into-outermost (savepoint) by default**
+//!   ([`Tx::enroll`]); eager-commit only for cross-process-visible effects
+//!   ([`Tx::enroll_eager`] + [`EagerMutation`]). The savepoint/eager split is
+//!   enforced at the **type** level (a compile error, no runtime const).
+//! - **Panic-safety:** explicit `Result` plumbing is primary; [`Tx`]'s `Drop`
+//!   is an abort-only backstop that never half-commits.
+//! - **`dyn`-free public surface:** `execute`/`enroll` are monomorphized; the
+//!   ledger boxes *closures* internally, never `dyn AtomicMutation`.
+
+mod committer;
+mod execute;
+mod reconciler;
+mod traits;
+mod tx;
+
+#[cfg(test)]
+mod tests;
+
+pub use committer::OplogRefCommitter;
+pub use execute::execute;
+pub use reconciler::OplogRefReconciler;
+pub use traits::{AtomicMutation, Compensator, EagerMutation, SavepointMutation, StagedCommit};
+pub use tx::{RewindLedger, Tx};

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -51,20 +51,22 @@ impl OplogRefReconciler {
 /// `B`. The last HEAD-mover in id order wins; every earlier mover is masked.
 ///
 /// The two republish modes differ by the latest mover's commit ordering:
-/// - [`HeadFold::Republish`] — `Fork`/`Collapse` are emitted by the atomic
-///   write chokepoint, which commits the oplog record (phase 4) BEFORE
-///   publishing HEAD (phase 5). A crash in between leaves the record committed
-///   but HEAD unpublished, so reconstruct from the record and republish to
-///   recover it (the `crash_replay_reconstructs_committed_head_update` case).
-/// - [`HeadFold::Canonical`] — `Goto`, detached `Snapshot`/`Checkpoint`, and
-///   `FastForward` write HEAD DIRECTLY *before* recording (`repository_goto.rs`
-///   `:160`, `repository_snapshot.rs` `:246`, `ff_record.rs`). Canonical
-///   therefore already reflects the move; worse, an unrecorded follow-up write
-///   (e.g. `fast_forward_attached`'s re-attach to a thread) may have superseded
-///   it. Defer to canonical — republishing the record's intermediate target
-///   here would clobber a newer, legitimately-published HEAD. Reaching this
-///   mode still MASKS an earlier `Republish`, which is what stops the stale
-///   Fork from resurrecting.
+/// - [`HeadFold::Republish`] — `Fork`/`Collapse` AND the detached `Snapshot`
+///   are emitted by the atomic write chokepoint, which commits the oplog record
+///   (phase 4) BEFORE publishing HEAD (phase 5). A crash in between leaves the
+///   record committed but HEAD unpublished, so reconstruct from the record and
+///   republish to recover it (the
+///   `crash_replay_reconstructs_committed_head_update` case). The detached
+///   snapshot joined this set in heddle#354 r8 when its publish moved
+///   record-first through `commit_and_publish`.
+/// - [`HeadFold::Canonical`] — `Goto`, detached `Checkpoint`, and `FastForward`
+///   write HEAD DIRECTLY *before* recording (`repository_goto.rs` `:160`,
+///   `ff_record.rs`). Canonical therefore already reflects the move; worse, an
+///   unrecorded follow-up write (e.g. `fast_forward_attached`'s re-attach to a
+///   thread) may have superseded it. Defer to canonical — republishing the
+///   record's intermediate target here would clobber a newer,
+///   legitimately-published HEAD. Reaching this mode still MASKS an earlier
+///   `Republish`, which is what stops the stale Fork from resurrecting.
 ///
 /// Invariant: HEAD reconciliation considers EVERY HEAD-moving record shape, not
 /// a Fork/Collapse allowlist. A publish-first mover defers to canonical (never
@@ -76,11 +78,12 @@ enum HeadFold {
     /// No HEAD-moving record in the window — canonical is authoritative.
     #[default]
     Untouched,
-    /// Latest mover is a record-first atomic publish (Fork/Collapse):
-    /// reconstruct and republish to recover a crash-lost HEAD publish.
+    /// Latest mover is a record-first atomic publish (Fork / Collapse /
+    /// detached Snapshot): reconstruct and republish to recover a crash-lost
+    /// HEAD publish.
     Republish(Head),
     /// Latest mover is a publish-first direct write (Goto / detached
-    /// Snapshot / detached Checkpoint / FastForward): canonical wins.
+    /// Checkpoint / FastForward): canonical wins.
     Canonical,
 }
 
@@ -103,12 +106,20 @@ impl Fold {
                 Some(name) => {
                     // Attached snapshot advances the thread; HEAD stays
                     // `Attached{name}` (identity unchanged), so it is not a
-                    // HEAD-mover.
+                    // HEAD-mover. Now record-first (commit_and_publish,
+                    // heddle#354 r8), so a later record IS the later write —
+                    // the authoritative thread fold can no longer be clobbered
+                    // by a stale snapshot appended after a concurrent write.
                     self.threads.insert(name.clone(), Some(*new_state));
                 }
-                // Detached snapshot writes `Head::Detached` directly before
-                // recording (repository_snapshot.rs:246) — publish-first.
-                None => self.head = HeadFold::Canonical,
+                // Detached snapshot is record-first as of heddle#354 r8
+                // (commit_and_publish appends the `Snapshot` record before
+                // publishing HEAD). A crash between phase-4 commit and phase-5
+                // publish must therefore reconstruct HEAD = Detached{new_state}
+                // from the record — the symmetric recovery to Fork/Collapse.
+                None => {
+                    self.head = HeadFold::Republish(Head::Detached { state: *new_state });
+                }
             },
             OpRecord::ThreadCreate { name, state }
             | OpRecord::ThreadUpdate {
@@ -275,14 +286,36 @@ impl OplogRefReconciler {
                 }
             }
             RefClass::Local => {
-                // Only a record-first mover (Fork/Collapse) republishes a
-                // reconstructed HEAD; a publish-first mover defers to canonical
-                // (`HeadFold::Canonical`) so it never clobbers a newer HEAD.
+                // Only a record-first mover (Fork / Collapse / detached
+                // Snapshot) republishes a reconstructed HEAD; a publish-first
+                // mover defers to canonical (`HeadFold::Canonical`) so it never
+                // clobbers a newer HEAD.
                 if let HeadFold::Republish(head) = &fold.head {
                     republish.push(RefUpdate::Head {
                         expected: RefExpectation::Any,
                         new: head.clone(),
                     });
+                    // Cross-class recovery atomicity (heddle#354 r8, cid
+                    // 3330183592): a record-first HEAD mover that ATTACHES to a
+                    // thread (named-fork / collapse-into-thread) created or
+                    // advanced that thread in the SAME committed record. The
+                    // thread lives in the Shared class with its own watermark,
+                    // so a Local-only reconcile would republish HEAD =
+                    // Attached(topic) yet leave `topic` unmaterialized —
+                    // advancing the Local watermark over a HEAD that points at a
+                    // missing ref. Materialize the paired thread HERE, under the
+                    // same lock and before the Local watermark advances, so HEAD
+                    // and its target land atomically. (A detached-HEAD mover has
+                    // no paired thread, so this is a no-op for it.)
+                    if let Head::Attached { thread } = head
+                        && let Some(value) = fold.threads.get(thread.as_str())
+                    {
+                        republish.push(RefUpdate::Thread {
+                            name: thread.clone(),
+                            expected: RefExpectation::Any,
+                            new: *value,
+                        });
+                    }
                 }
                 undo_recovery = fold.undo_recovery;
             }

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The oplog-backed [`RefReconciler`] (heddle#330 read chokepoint).
+//!
+//! Defined here, in the `repo`/`oplog` layer that sees both crates, and injected
+//! into `RefManager` via `with_reconciler` — so `refs` names no `oplog` type
+//! (dependency inversion). It folds the committed oplog tail (scoped by ref
+//! class) to re-derive the authoritative ref value when the canonical cache
+//! lags a committed-but-unpublished write.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use objects::error::Result;
+use objects::object::{ChangeId, MarkerName, ThreadName};
+use oplog::{OpLog, OpRecord};
+use refs::{
+    Loaded, LoadRequest, RefClass, RefExpectation, RefReconciler, ReconcileOutcome, RefUpdate,
+};
+
+/// Reads the file oplog from disk (path-based, so a long-held handle observes
+/// concurrent commits) and folds it into ref values.
+///
+/// Holds the heddle dir rather than a cached `OpLog` so each reconcile reads a
+/// **fresh** view — the writes that produced the lag came through a *different*
+/// `OpLog` handle (the repository's), so a cached reader would miss them.
+pub struct OplogRefReconciler {
+    heddle_dir: PathBuf,
+    op_scope: String,
+}
+
+impl OplogRefReconciler {
+    pub fn new(heddle_dir: &Path, op_scope: String) -> Self {
+        Self {
+            heddle_dir: heddle_dir.to_path_buf(),
+            op_scope,
+        }
+    }
+
+    fn oplog(&self) -> OpLog {
+        OpLog::new_unattributed(&self.heddle_dir)
+    }
+}
+
+/// The folded state of one ref class, replayed from committed entries.
+///
+/// HEAD is intentionally **not** reconstructed here: the pre-existing
+/// `Snapshot`/`Goto` records do not unambiguously encode HEAD attach/detach, so
+/// folding them would corrupt HEAD reads (e.g. a fast-forward that must preserve
+/// HEAD's attachment). HEAD is local and written directly by every publish, so
+/// the canonical HEAD stays authoritative; reconstructing it from the oplog
+/// needs the records to carry the post-HEAD state — a follow-up. `read_head`
+/// still funnels through the chokepoint; it simply returns the raw canonical.
+#[derive(Default)]
+struct Fold {
+    threads: BTreeMap<String, Option<ChangeId>>,
+    markers: BTreeMap<String, Option<ChangeId>>,
+    remotes: BTreeMap<(String, String), Option<ChangeId>>,
+    undo_recovery: Option<ChangeId>,
+}
+
+impl Fold {
+    fn apply(&mut self, op: &OpRecord) {
+        match op {
+            OpRecord::Snapshot {
+                new_state, thread, ..
+            } => {
+                if let Some(name) = thread {
+                    self.threads.insert(name.clone(), Some(*new_state));
+                }
+            }
+            OpRecord::ThreadCreate { name, state }
+            | OpRecord::ThreadUpdate {
+                name,
+                new_state: state,
+                ..
+            } => {
+                self.threads.insert(name.clone(), Some(*state));
+            }
+            OpRecord::ThreadCreateV2 { name, state, .. } => {
+                self.threads.insert(name.clone(), Some(*state));
+            }
+            OpRecord::ThreadDelete { name, .. } => {
+                self.threads.insert(name.clone(), None);
+            }
+            OpRecord::Fork {
+                new_state, thread, ..
+            } => {
+                if let Some(name) = thread {
+                    self.threads.insert(name.clone(), Some(*new_state));
+                }
+            }
+            OpRecord::Collapse {
+                result, thread, ..
+            } => {
+                if let Some(name) = thread {
+                    self.threads.insert(name.clone(), Some(*result));
+                }
+            }
+            OpRecord::MarkerCreate { name, state } => {
+                self.markers.insert(name.clone(), Some(*state));
+            }
+            OpRecord::MarkerDelete { name, .. } => {
+                self.markers.insert(name.clone(), None);
+            }
+            OpRecord::Checkpoint { state, thread, .. } => {
+                if let Some(name) = thread {
+                    self.threads.insert(name.clone(), Some(*state));
+                }
+            }
+            OpRecord::FastForwardV2 {
+                target_thread,
+                post_target_id,
+                ..
+            } => {
+                self.threads
+                    .insert(target_thread.clone(), Some(*post_target_id));
+            }
+            OpRecord::EphemeralThreadCollapse { thread, .. } => {
+                self.threads.insert(thread.clone(), None);
+            }
+            OpRecord::RemoteThreadUpdate {
+                remote,
+                thread,
+                state,
+            } => {
+                self.remotes
+                    .insert((remote.clone(), thread.clone()), Some(*state));
+            }
+            OpRecord::RemoteThreadDelete { remote, thread, .. } => {
+                self.remotes.insert((remote.clone(), thread.clone()), None);
+            }
+            OpRecord::UndoRecoveryUpdate { state } => {
+                self.undo_recovery = Some(*state);
+            }
+            // HEAD-only / non-thread-publishing records contribute nothing to
+            // the thread/marker/remote/undo materialization the reconciler does
+            // (HEAD itself is not reconstructed — see the `Fold` doc).
+            OpRecord::Goto { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::GitCheckpoint { .. } => {}
+        }
+    }
+}
+
+impl RefReconciler for OplogRefReconciler {
+    fn generation(&self) -> u64 {
+        self.oplog().head_id().unwrap_or(0)
+    }
+
+    fn reconcile(&self, req: &LoadRequest, raw: Loaded, since: u64) -> Result<ReconcileOutcome> {
+        let class = req.ref_class();
+        let scope = match class {
+            RefClass::Local => Some(self.op_scope.as_str()),
+            RefClass::Shared => None,
+        };
+
+        // Replay committed (non-undone) entries newer than the watermark, in id
+        // order, so the fold reflects the newest committed target per ref.
+        let batches = self.oplog().recent_batches_scoped(usize::MAX, scope)?;
+        let mut entries: Vec<_> = batches
+            .into_iter()
+            .flat_map(|b| b.entries)
+            .filter(|e| !e.undone && e.id > since)
+            .collect();
+        entries.sort_by_key(|e| e.id);
+
+        let mut fold = Fold::default();
+        for entry in &entries {
+            fold.apply(&entry.operation);
+        }
+
+        let mut republish = Vec::new();
+        let mut remote_updates = Vec::new();
+        let mut undo_recovery = None;
+
+        match class {
+            RefClass::Shared => {
+                for (name, value) in &fold.threads {
+                    republish.push(RefUpdate::Thread {
+                        name: ThreadName::new(name),
+                        expected: RefExpectation::Any,
+                        new: *value,
+                    });
+                }
+                for (name, value) in &fold.markers {
+                    republish.push(RefUpdate::Marker {
+                        name: MarkerName::new(name),
+                        expected: RefExpectation::Any,
+                        new: *value,
+                    });
+                }
+                for ((remote, thread), value) in &fold.remotes {
+                    remote_updates.push((remote.clone(), ThreadName::new(thread), *value));
+                }
+            }
+            RefClass::Local => {
+                // HEAD is not reconstructed (see `Fold` doc); only undo-recovery
+                // reconciles in the local class.
+                undo_recovery = fold.undo_recovery;
+            }
+        }
+
+        let loaded = reconciled_value(req, &raw, &fold);
+
+        Ok(ReconcileOutcome {
+            loaded,
+            republish,
+            remote_updates,
+            undo_recovery,
+        })
+    }
+}
+
+/// Project the authoritative value for the specific request out of the fold,
+/// **filling only when the canonical cache is absent**. In the un-migrated tree
+/// many ref writes do not yet record an oplog entry, so the canonical value can
+/// be *newer* than the oplog fold; trusting a present canonical (and only
+/// re-deriving a genuinely-missing one — the committed-but-unpublished
+/// crash-replay case) keeps reconciliation non-destructive. The committed-but-
+/// stale-present lag (a rarer crash shape) is left to the writers' eventual
+/// record-first migration.
+fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
+    match req {
+        // HEAD is not reconstructed from the oplog (see `Fold` doc); the
+        // canonical HEAD is authoritative.
+        LoadRequest::Head => raw.clone(),
+        LoadRequest::UndoRecovery => fill_point(raw, fold.undo_recovery.map(Some)),
+        LoadRequest::Thread(name) => fill_point(raw, fold.threads.get(name.as_str()).copied()),
+        LoadRequest::Marker(name) => fill_point(raw, fold.markers.get(name.as_str()).copied()),
+        LoadRequest::RemoteThread { remote, thread } => fill_point(
+            raw,
+            fold.remotes.get(&(remote.clone(), thread.to_string())).copied(),
+        ),
+        LoadRequest::ThreadList => Loaded::ThreadList(
+            merge_list(raw_thread_names(raw), &fold.threads)
+                .into_iter()
+                .map(|n| ThreadName::new(&n))
+                .collect(),
+        ),
+        LoadRequest::MarkerList => Loaded::MarkerList(
+            merge_list(raw_marker_names(raw), &fold.markers)
+                .into_iter()
+                .map(|n| MarkerName::new(&n))
+                .collect(),
+        ),
+        LoadRequest::RemoteList => {
+            // A remote is present if it has any non-deleted thread.
+            let mut names: Vec<String> = match raw {
+                Loaded::RemoteList(names) => names.clone(),
+                _ => Vec::new(),
+            };
+            for ((remote, _thread), value) in &fold.remotes {
+                if value.is_some() && !names.contains(remote) {
+                    names.push(remote.clone());
+                }
+            }
+            names.sort();
+            names.dedup();
+            Loaded::RemoteList(names)
+        }
+        LoadRequest::RemoteThreadList { remote } => {
+            let base: Vec<ThreadName> = match raw {
+                Loaded::RemoteThreadList(names) => names.clone(),
+                _ => Vec::new(),
+            };
+            let mut set: BTreeMap<String, ()> =
+                base.into_iter().map(|n| (n.to_string(), ())).collect();
+            for ((r, thread), value) in &fold.remotes {
+                if r == remote && value.is_some() {
+                    set.insert(thread.clone(), ());
+                }
+            }
+            Loaded::RemoteThreadList(set.into_keys().map(|n| ThreadName::new(&n)).collect())
+        }
+    }
+}
+
+/// Fill-if-absent for a point read: trust a present canonical value; only when
+/// the canonical is missing do we adopt the fold's committed target.
+/// `folded` is `Some(Some(state))` / `Some(None)` (touched: set/deleted) or
+/// `None` (untouched by the lagged batches).
+fn fill_point(raw: &Loaded, folded: Option<Option<ChangeId>>) -> Loaded {
+    match raw {
+        Loaded::Point(Some(_)) => raw.clone(),
+        _ => match folded {
+            Some(value) => Loaded::Point(value),
+            None => raw.clone(),
+        },
+    }
+}
+
+fn raw_thread_names(raw: &Loaded) -> Vec<String> {
+    match raw {
+        Loaded::ThreadList(names) => names.iter().map(|n| n.to_string()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn raw_marker_names(raw: &Loaded) -> Vec<String> {
+    match raw {
+        Loaded::MarkerList(names) => names.iter().map(|n| n.to_string()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Add the fold's committed-but-unpublished names to the raw list (union).
+/// Additive only — a fold *delete* never removes a name the canonical still
+/// lists, since in the un-migrated tree that name may have been re-created by a
+/// not-yet-recorded raw write (fill-if-absent, see [`fill_point`]).
+fn merge_list(base: Vec<String>, changes: &BTreeMap<String, Option<ChangeId>>) -> Vec<String> {
+    let mut set: BTreeMap<String, ()> = base.into_iter().map(|n| (n, ())).collect();
+    for (name, value) in changes {
+        if value.is_some() {
+            set.insert(name.clone(), ());
+        }
+    }
+    set.into_keys().collect()
+}

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -220,21 +220,18 @@ impl Fold {
     }
 }
 
-impl RefReconciler for OplogRefReconciler {
-    fn generation(&self) -> u64 {
-        self.oplog().head_id().unwrap_or(0)
-    }
+/// The re-materialization set a folded window implies for one ref class:
+/// (`republish` thread/marker/HEAD updates, `remote_updates`, `undo_recovery`).
+type ClassMaterialization = (
+    Vec<RefUpdate>,
+    Vec<(String, ThreadName, Option<ChangeId>)>,
+    Option<ChangeId>,
+);
 
-    fn reconcile(&self, req: &LoadRequest, raw: Loaded, since: u64) -> Result<ReconcileOutcome> {
-        let class = req.ref_class();
-        let scope = match class {
-            RefClass::Local => Some(self.op_scope.as_str()),
-            RefClass::Shared => None,
-        };
-
-        // Replay committed (non-undone) entries newer than the watermark, in id
-        // order, so the fold reflects the newest committed target per ref.
-        let batches = self.oplog().recent_batches_scoped(usize::MAX, scope)?;
+impl OplogRefReconciler {
+    /// Fold the committed entries of `batches` newer than `since` into a
+    /// [`Fold`], in id order so the newest committed target per ref wins.
+    fn fold_batches(&self, batches: Vec<oplog::OpBatch>, since: u64) -> Fold {
         let mut entries: Vec<_> = batches
             .into_iter()
             .flat_map(|b| b.entries)
@@ -246,7 +243,13 @@ impl RefReconciler for OplogRefReconciler {
         for entry in &entries {
             fold.apply(&entry.operation);
         }
+        fold
+    }
 
+    /// The re-materialization set a folded window implies for `class`: thread /
+    /// marker / remote-thread for shared; reconstructed HEAD + undo-recovery for
+    /// local.
+    fn class_materialization(class: RefClass, fold: &Fold) -> ClassMaterialization {
         let mut republish = Vec::new();
         let mut remote_updates = Vec::new();
         let mut undo_recovery = None;
@@ -285,6 +288,32 @@ impl RefReconciler for OplogRefReconciler {
             }
         }
 
+        (republish, remote_updates, undo_recovery)
+    }
+}
+
+impl RefReconciler for OplogRefReconciler {
+    fn generation(&self) -> Result<u64> {
+        // Propagate a header read error (cid 3329631081): never report a
+        // truncated/corrupt/unreadable header as generation 0, which would make
+        // logical reads silently skip committed records. `head_id` itself maps a
+        // not-yet-created oplog to 0; only a genuine read failure surfaces here.
+        self.oplog().head_id()
+    }
+
+    fn reconcile(&self, req: &LoadRequest, raw: Loaded, since: u64) -> Result<ReconcileOutcome> {
+        let class = req.ref_class();
+        let scope = match class {
+            RefClass::Local => Some(self.op_scope.as_str()),
+            RefClass::Shared => None,
+        };
+
+        // Replay committed (non-undone) entries newer than the watermark, in id
+        // order, so the fold reflects the newest committed target per ref.
+        let batches = self.oplog().recent_batches_scoped(usize::MAX, scope)?;
+        let fold = self.fold_batches(batches, since);
+
+        let (republish, remote_updates, undo_recovery) = Self::class_materialization(class, &fold);
         let loaded = reconciled_value(req, &raw, &fold, &self.heddle_dir)?;
 
         Ok(ReconcileOutcome {

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -51,14 +51,19 @@ impl OplogRefReconciler {
 /// `B`. The last HEAD-mover in id order wins; every earlier mover is masked.
 ///
 /// The two republish modes differ by the latest mover's commit ordering:
-/// - [`HeadFold::Republish`] — `Fork`/`Collapse` AND the detached `Snapshot`
-///   are emitted by the atomic write chokepoint, which commits the oplog record
-///   (phase 4) BEFORE publishing HEAD (phase 5). A crash in between leaves the
-///   record committed but HEAD unpublished, so reconstruct from the record and
-///   republish to recover it (the
-///   `crash_replay_reconstructs_committed_head_update` case). The detached
-///   snapshot joined this set in heddle#354 r8 when its publish moved
-///   record-first through `commit_and_publish`.
+/// - [`HeadFold::Republish`] — the HEAD-moving records emitted by the atomic
+///   write chokepoint, which commits the oplog record (phase 4) BEFORE
+///   publishing HEAD (phase 5). A crash in between leaves the record committed
+///   but HEAD unpublished, so reconstruct from the record and republish to
+///   recover it (the `crash_replay_reconstructs_committed_head_update` case).
+///   This set is the *HEAD-moving* shapes only: a named `Fork` (creates a
+///   thread and attaches HEAD to it), a detached `Fork`/`Collapse`/`Snapshot`
+///   (publishes a detached HEAD). An ATTACHED `Collapse` or `Snapshot` is NOT
+///   here — it only advances the thread it is already attached to, so HEAD's
+///   identity is unchanged and canonical already reflects it (the attached
+///   collapse was wrongly republishing `Attached` until heddle#354 r9, cid
+///   3330304665). The detached snapshot joined this set in heddle#354 r8 when
+///   its publish moved record-first through `commit_and_publish`.
 /// - [`HeadFold::Canonical`] — `Goto`, detached `Checkpoint`, and `FastForward`
 ///   write HEAD DIRECTLY *before* recording (`repository_goto.rs` `:160`,
 ///   `ff_record.rs`). Canonical therefore already reflects the move; worse, an
@@ -156,16 +161,26 @@ impl Fold {
                     self.head = HeadFold::Republish(Head::Detached { state: *head });
                 }
             }
-            OpRecord::Collapse { result, thread, .. } => {
-                if let Some(name) = thread {
+            OpRecord::Collapse { result, thread, .. } => match thread {
+                // Attached collapse advances the thread; HEAD stays
+                // `Attached{name}` (identity unchanged), so it is NOT a
+                // HEAD-mover — mirror the attached `Snapshot` arm. The collapse
+                // command publishes ONLY the thread ref when HEAD is attached
+                // (it never re-attaches HEAD), so canonical HEAD is already
+                // correct and republishing `Attached` here moved HEAD when it
+                // should stay attached (heddle#354 r9, cid 3330304665). The
+                // thread ref is recovered via the Shared-class fold below.
+                Some(name) => {
                     self.threads.insert(name.clone(), Some(*result));
-                    self.head = HeadFold::Republish(Head::Attached {
-                        thread: ThreadName::new(name),
-                    });
-                } else {
+                }
+                // Detached collapse publishes HEAD record-first (the command
+                // emits `RefUpdate::Head` Detached): reconstruct it so a
+                // phase-4-committed / phase-5-unpublished collapse is recovered
+                // (symmetric with the detached `Snapshot` / `Fork` arms).
+                None => {
                     self.head = HeadFold::Republish(Head::Detached { state: *result });
                 }
-            }
+            },
             OpRecord::MarkerCreate { name, state } => {
                 self.markers.insert(name.clone(), Some(*state));
             }

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -42,14 +42,52 @@ impl OplogRefReconciler {
     }
 }
 
-/// The folded state of one ref class, replayed from committed entries.
+/// What the folded window implies for canonical HEAD (the `Local` class).
 ///
-/// HEAD is reconstructed only from records that now carry the published HEAD
-/// identity (`Fork` and `Collapse`). Older records that do not identify the
-/// post-HEAD shape remain non-authoritative for HEAD.
+/// HEAD reconciliation folds the **latest HEAD-moving record of ANY shape** in
+/// the window — a per-shape allowlist (Fork/Collapse only) re-opens the
+/// stale-HEAD clobber (heddle#354 r4): a `goto B` recorded *after* a `Fork A`
+/// would be ignored, so a reconcile would resurrect the stale `A` over the live
+/// `B`. The last HEAD-mover in id order wins; every earlier mover is masked.
+///
+/// The two republish modes differ by the latest mover's commit ordering:
+/// - [`HeadFold::Republish`] — `Fork`/`Collapse` are emitted by the atomic
+///   write chokepoint, which commits the oplog record (phase 4) BEFORE
+///   publishing HEAD (phase 5). A crash in between leaves the record committed
+///   but HEAD unpublished, so reconstruct from the record and republish to
+///   recover it (the `crash_replay_reconstructs_committed_head_update` case).
+/// - [`HeadFold::Canonical`] — `Goto`, detached `Snapshot`/`Checkpoint`, and
+///   `FastForward` write HEAD DIRECTLY *before* recording (`repository_goto.rs`
+///   `:160`, `repository_snapshot.rs` `:246`, `ff_record.rs`). Canonical
+///   therefore already reflects the move; worse, an unrecorded follow-up write
+///   (e.g. `fast_forward_attached`'s re-attach to a thread) may have superseded
+///   it. Defer to canonical — republishing the record's intermediate target
+///   here would clobber a newer, legitimately-published HEAD. Reaching this
+///   mode still MASKS an earlier `Republish`, which is what stops the stale
+///   Fork from resurrecting.
+///
+/// Invariant: HEAD reconciliation considers EVERY HEAD-moving record shape, not
+/// a Fork/Collapse allowlist. A publish-first mover defers to canonical (never
+/// republishing its possibly-stale target over a newer HEAD); a record-first
+/// mover reconstructs. Reintroducing a per-shape allowlist re-opens the
+/// stale-HEAD clobber class.
+#[derive(Default)]
+enum HeadFold {
+    /// No HEAD-moving record in the window — canonical is authoritative.
+    #[default]
+    Untouched,
+    /// Latest mover is a record-first atomic publish (Fork/Collapse):
+    /// reconstruct and republish to recover a crash-lost HEAD publish.
+    Republish(Head),
+    /// Latest mover is a publish-first direct write (Goto / detached
+    /// Snapshot / detached Checkpoint / FastForward): canonical wins.
+    Canonical,
+}
+
+/// The folded state of one ref class, replayed from committed entries.
 #[derive(Default)]
 struct Fold {
-    head: Option<Head>,
+    head: HeadFold,
     threads: BTreeMap<String, Option<ChangeId>>,
     markers: BTreeMap<String, Option<ChangeId>>,
     remotes: BTreeMap<(String, String), Option<ChangeId>>,
@@ -61,11 +99,17 @@ impl Fold {
         match op {
             OpRecord::Snapshot {
                 new_state, thread, ..
-            } => {
-                if let Some(name) = thread {
+            } => match thread {
+                Some(name) => {
+                    // Attached snapshot advances the thread; HEAD stays
+                    // `Attached{name}` (identity unchanged), so it is not a
+                    // HEAD-mover.
                     self.threads.insert(name.clone(), Some(*new_state));
                 }
-            }
+                // Detached snapshot writes `Head::Detached` directly before
+                // recording (repository_snapshot.rs:246) — publish-first.
+                None => self.head = HeadFold::Canonical,
+            },
             OpRecord::ThreadCreate { name, state }
             | OpRecord::ThreadUpdate {
                 name,
@@ -83,9 +127,14 @@ impl Fold {
             OpRecord::Fork {
                 new_state, thread, ..
             } => {
+                // Record-first atomic publish: reconstruct the published HEAD so
+                // a phase-4-committed/phase-5-unpublished fork is recovered. A
+                // fork that publishes neither a thread nor a detached HEAD
+                // (`thread = None, head = None`) moves no ref, so it leaves the
+                // fold's HEAD untouched (it must not mask a later/earlier mover).
                 if let Some(name) = thread {
                     self.threads.insert(name.clone(), Some(*new_state));
-                    self.head = Some(Head::Attached {
+                    self.head = HeadFold::Republish(Head::Attached {
                         thread: ThreadName::new(name),
                     });
                 }
@@ -93,17 +142,17 @@ impl Fold {
                     head: Some(head), ..
                 } = op
                 {
-                    self.head = Some(Head::Detached { state: *head });
+                    self.head = HeadFold::Republish(Head::Detached { state: *head });
                 }
             }
             OpRecord::Collapse { result, thread, .. } => {
                 if let Some(name) = thread {
                     self.threads.insert(name.clone(), Some(*result));
-                    self.head = Some(Head::Attached {
+                    self.head = HeadFold::Republish(Head::Attached {
                         thread: ThreadName::new(name),
                     });
                 } else {
-                    self.head = Some(Head::Detached { state: *result });
+                    self.head = HeadFold::Republish(Head::Detached { state: *result });
                 }
             }
             OpRecord::MarkerCreate { name, state } => {
@@ -112,18 +161,26 @@ impl Fold {
             OpRecord::MarkerDelete { name, .. } => {
                 self.markers.insert(name.clone(), None);
             }
-            OpRecord::Checkpoint { state, thread, .. } => {
-                if let Some(name) = thread {
+            OpRecord::Checkpoint { state, thread, .. } => match thread {
+                Some(name) => {
                     self.threads.insert(name.clone(), Some(*state));
                 }
-            }
+                // Detached checkpoint moves HEAD via a publish-first direct
+                // write (symmetric with the detached `Snapshot` arm).
+                None => self.head = HeadFold::Canonical,
+            },
             OpRecord::FastForwardV2 {
                 target_thread,
                 post_target_id,
                 ..
             } => {
+                // The forward FF (`fast_forward_attached_without_record`) writes
+                // HEAD directly before recording — publish-first, so canonical
+                // wins for HEAD. The target thread ref also advances and IS
+                // reconstructable from the record.
                 self.threads
                     .insert(target_thread.clone(), Some(*post_target_id));
+                self.head = HeadFold::Canonical;
             }
             OpRecord::EphemeralThreadCollapse { thread, .. } => {
                 self.threads.insert(thread.clone(), None);
@@ -142,11 +199,18 @@ impl Fold {
             OpRecord::UndoRecoveryUpdate { state } => {
                 self.undo_recovery = Some(*state);
             }
-            // HEAD-only records that do not encode the post-HEAD shape
-            // contribute nothing to materialization.
-            OpRecord::Goto { .. }
-            | OpRecord::FastForward { .. }
-            | OpRecord::TransactionAbort { .. }
+            // Publish-first HEAD moves: `goto` writes `Head::Detached` directly
+            // before recording (repository_goto.rs:160); legacy V1 `FastForward`
+            // likewise moved HEAD via a direct write. Canonical already reflects
+            // them (and may carry a newer unrecorded re-attach), so defer — while
+            // masking any earlier `Republish` so a stale Fork cannot resurrect.
+            OpRecord::Goto { .. } | OpRecord::FastForward { .. } => {
+                self.head = HeadFold::Canonical;
+            }
+            // Records that do not move canonical HEAD: transaction markers,
+            // conflict resolution, redaction bookkeeping, and the Git-overlay
+            // checkpoint leave HEAD where it is.
+            OpRecord::TransactionAbort { .. }
             | OpRecord::TransactionCommit { .. }
             | OpRecord::ConflictResolved { .. }
             | OpRecord::Redact { .. }
@@ -208,7 +272,10 @@ impl RefReconciler for OplogRefReconciler {
                 }
             }
             RefClass::Local => {
-                if let Some(head) = &fold.head {
+                // Only a record-first mover (Fork/Collapse) republishes a
+                // reconstructed HEAD; a publish-first mover defers to canonical
+                // (`HeadFold::Canonical`) so it never clobbers a newer HEAD.
+                if let HeadFold::Republish(head) = &fold.head {
                     republish.push(RefUpdate::Head {
                         expected: RefExpectation::Any,
                         new: head.clone(),
@@ -245,8 +312,10 @@ fn reconciled_value(
 ) -> Result<Loaded> {
     Ok(match req {
         LoadRequest::Head => match &fold.head {
-            Some(head) => Loaded::Head(head.clone()),
-            None => raw.clone(),
+            HeadFold::Republish(head) => Loaded::Head(head.clone()),
+            // A publish-first mover (or no mover at all) leaves canonical
+            // authoritative — return the raw HEAD, never a stale reconstruction.
+            HeadFold::Canonical | HeadFold::Untouched => raw.clone(),
         },
         LoadRequest::UndoRecovery => fill_point(raw, fold.undo_recovery.map(Some)),
         LoadRequest::Thread(name) => fill_point(raw, fold.threads.get(name.as_str()).copied()),

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -14,7 +14,8 @@ use objects::error::Result;
 use objects::object::{ChangeId, MarkerName, ThreadName};
 use oplog::{OpLog, OpRecord};
 use refs::{
-    Loaded, LoadRequest, RefClass, RefExpectation, RefReconciler, ReconcileOutcome, RefUpdate,
+    Head, LoadRequest, Loaded, ReconcileOutcome, RefClass, RefExpectation, RefManager,
+    RefReconciler, RefUpdate,
 };
 
 /// Reads the file oplog from disk (path-based, so a long-held handle observes
@@ -43,15 +44,12 @@ impl OplogRefReconciler {
 
 /// The folded state of one ref class, replayed from committed entries.
 ///
-/// HEAD is intentionally **not** reconstructed here: the pre-existing
-/// `Snapshot`/`Goto` records do not unambiguously encode HEAD attach/detach, so
-/// folding them would corrupt HEAD reads (e.g. a fast-forward that must preserve
-/// HEAD's attachment). HEAD is local and written directly by every publish, so
-/// the canonical HEAD stays authoritative; reconstructing it from the oplog
-/// needs the records to carry the post-HEAD state — a follow-up. `read_head`
-/// still funnels through the chokepoint; it simply returns the raw canonical.
+/// HEAD is reconstructed only from records that now carry the published HEAD
+/// identity (`Fork` and `Collapse`). Older records that do not identify the
+/// post-HEAD shape remain non-authoritative for HEAD.
 #[derive(Default)]
 struct Fold {
+    head: Option<Head>,
     threads: BTreeMap<String, Option<ChangeId>>,
     markers: BTreeMap<String, Option<ChangeId>>,
     remotes: BTreeMap<(String, String), Option<ChangeId>>,
@@ -87,13 +85,25 @@ impl Fold {
             } => {
                 if let Some(name) = thread {
                     self.threads.insert(name.clone(), Some(*new_state));
+                    self.head = Some(Head::Attached {
+                        thread: ThreadName::new(name),
+                    });
+                }
+                if let OpRecord::Fork {
+                    head: Some(head), ..
+                } = op
+                {
+                    self.head = Some(Head::Detached { state: *head });
                 }
             }
-            OpRecord::Collapse {
-                result, thread, ..
-            } => {
+            OpRecord::Collapse { result, thread, .. } => {
                 if let Some(name) = thread {
                     self.threads.insert(name.clone(), Some(*result));
+                    self.head = Some(Head::Attached {
+                        thread: ThreadName::new(name),
+                    });
+                } else {
+                    self.head = Some(Head::Detached { state: *result });
                 }
             }
             OpRecord::MarkerCreate { name, state } => {
@@ -132,9 +142,8 @@ impl Fold {
             OpRecord::UndoRecoveryUpdate { state } => {
                 self.undo_recovery = Some(*state);
             }
-            // HEAD-only / non-thread-publishing records contribute nothing to
-            // the thread/marker/remote/undo materialization the reconciler does
-            // (HEAD itself is not reconstructed — see the `Fold` doc).
+            // HEAD-only records that do not encode the post-HEAD shape
+            // contribute nothing to materialization.
             OpRecord::Goto { .. }
             | OpRecord::FastForward { .. }
             | OpRecord::TransactionAbort { .. }
@@ -199,13 +208,17 @@ impl RefReconciler for OplogRefReconciler {
                 }
             }
             RefClass::Local => {
-                // HEAD is not reconstructed (see `Fold` doc); only undo-recovery
-                // reconciles in the local class.
+                if let Some(head) = &fold.head {
+                    republish.push(RefUpdate::Head {
+                        expected: RefExpectation::Any,
+                        new: head.clone(),
+                    });
+                }
                 undo_recovery = fold.undo_recovery;
             }
         }
 
-        let loaded = reconciled_value(req, &raw, &fold);
+        let loaded = reconciled_value(req, &raw, &fold, &self.heddle_dir)?;
 
         Ok(ReconcileOutcome {
             loaded,
@@ -224,17 +237,25 @@ impl RefReconciler for OplogRefReconciler {
 /// crash-replayed `cmd_collapse` update-to-existing-`main` case). The fold only
 /// holds refs touched by commits newer than the watermark, so a ref with no
 /// recent committed record keeps its canonical value untouched.
-fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
-    match req {
-        // HEAD is not reconstructed from the oplog (see `Fold` doc); the
-        // canonical HEAD is authoritative.
-        LoadRequest::Head => raw.clone(),
+fn reconciled_value(
+    req: &LoadRequest,
+    raw: &Loaded,
+    fold: &Fold,
+    heddle_dir: &Path,
+) -> Result<Loaded> {
+    Ok(match req {
+        LoadRequest::Head => match &fold.head {
+            Some(head) => Loaded::Head(head.clone()),
+            None => raw.clone(),
+        },
         LoadRequest::UndoRecovery => fill_point(raw, fold.undo_recovery.map(Some)),
         LoadRequest::Thread(name) => fill_point(raw, fold.threads.get(name.as_str()).copied()),
         LoadRequest::Marker(name) => fill_point(raw, fold.markers.get(name.as_str()).copied()),
         LoadRequest::RemoteThread { remote, thread } => fill_point(
             raw,
-            fold.remotes.get(&(remote.clone(), thread.to_string())).copied(),
+            fold.remotes
+                .get(&(remote.clone(), thread.to_string()))
+                .copied(),
         ),
         LoadRequest::ThreadList => Loaded::ThreadList(
             merge_list(raw_thread_names(raw), &fold.threads)
@@ -248,21 +269,7 @@ fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
                 .map(|n| MarkerName::new(&n))
                 .collect(),
         ),
-        LoadRequest::RemoteList => {
-            // A remote is present if it has any non-deleted thread.
-            let mut names: Vec<String> = match raw {
-                Loaded::RemoteList(names) => names.clone(),
-                _ => Vec::new(),
-            };
-            for ((remote, _thread), value) in &fold.remotes {
-                if value.is_some() && !names.contains(remote) {
-                    names.push(remote.clone());
-                }
-            }
-            names.sort();
-            names.dedup();
-            Loaded::RemoteList(names)
-        }
+        LoadRequest::RemoteList => remote_list_value(raw, fold, heddle_dir)?,
         LoadRequest::RemoteThreadList { remote } => {
             let base: Vec<ThreadName> = match raw {
                 Loaded::RemoteThreadList(names) => names.clone(),
@@ -271,13 +278,17 @@ fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
             let mut set: BTreeMap<String, ()> =
                 base.into_iter().map(|n| (n.to_string(), ())).collect();
             for ((r, thread), value) in &fold.remotes {
-                if r == remote && value.is_some() {
-                    set.insert(thread.clone(), ());
+                if r == remote {
+                    if value.is_some() {
+                        set.insert(thread.clone(), ());
+                    } else {
+                        set.remove(thread);
+                    }
                 }
             }
             Loaded::RemoteThreadList(set.into_keys().map(|n| ThreadName::new(&n)).collect())
         }
-    }
+    })
 }
 
 /// Authoritative point read: a committed record past the watermark wins over
@@ -306,16 +317,54 @@ fn raw_marker_names(raw: &Loaded) -> Vec<String> {
     }
 }
 
-/// Add the fold's committed-but-unpublished names to the raw list (union).
-/// Additive only — a fold *delete* never removes a name the canonical still
-/// lists, since in the un-migrated tree that name may have been re-created by a
-/// not-yet-recorded raw write (fill-if-absent, see [`fill_point`]).
+/// Apply the fold's committed effect to a raw list: set inserts the name and
+/// delete removes it. The fold only contains records newer than the class
+/// watermark, so its touched refs are authoritative over the canonical view.
 fn merge_list(base: Vec<String>, changes: &BTreeMap<String, Option<ChangeId>>) -> Vec<String> {
     let mut set: BTreeMap<String, ()> = base.into_iter().map(|n| (n, ())).collect();
     for (name, value) in changes {
         if value.is_some() {
             set.insert(name.clone(), ());
+        } else {
+            set.remove(name);
         }
     }
     set.into_keys().collect()
+}
+
+fn remote_list_value(raw: &Loaded, fold: &Fold, heddle_dir: &Path) -> Result<Loaded> {
+    let mut remotes: BTreeMap<String, ()> = match raw {
+        Loaded::RemoteList(names) => names.iter().cloned().map(|n| (n, ())).collect(),
+        _ => BTreeMap::new(),
+    };
+    for ((remote, _thread), value) in &fold.remotes {
+        if value.is_some() {
+            remotes.insert(remote.clone(), ());
+        } else {
+            remotes.entry(remote.clone()).or_insert(());
+        }
+    }
+
+    let raw_refs = RefManager::new(heddle_dir);
+    let mut present = Vec::new();
+    for remote in remotes.into_keys() {
+        let mut threads: BTreeMap<String, ()> = raw_refs
+            .list_remote_threads(&remote)?
+            .into_iter()
+            .map(|name| (name.to_string(), ()))
+            .collect();
+        for ((r, thread), value) in &fold.remotes {
+            if r == &remote {
+                if value.is_some() {
+                    threads.insert(thread.clone(), ());
+                } else {
+                    threads.remove(thread);
+                }
+            }
+        }
+        if !threads.is_empty() {
+            present.push(remote);
+        }
+    }
+    Ok(Loaded::RemoteList(present))
 }

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -216,14 +216,14 @@ impl RefReconciler for OplogRefReconciler {
     }
 }
 
-/// Project the authoritative value for the specific request out of the fold,
-/// **filling only when the canonical cache is absent**. In the un-migrated tree
-/// many ref writes do not yet record an oplog entry, so the canonical value can
-/// be *newer* than the oplog fold; trusting a present canonical (and only
-/// re-deriving a genuinely-missing one — the committed-but-unpublished
-/// crash-replay case) keeps reconciliation non-destructive. The committed-but-
-/// stale-present lag (a rarer crash shape) is left to the writers' eventual
-/// record-first migration.
+/// Project the authoritative value for the specific request out of the fold.
+/// A committed record past the class watermark is **authoritative** over the
+/// live canonical, so a folded value wins whether it CREATES a missing ref or
+/// UPDATES a stale present one (cid 3329490981) — not fill-if-absent, which
+/// silently dropped a committed update to an already-existing ref (the
+/// crash-replayed `cmd_collapse` update-to-existing-`main` case). The fold only
+/// holds refs touched by commits newer than the watermark, so a ref with no
+/// recent committed record keeps its canonical value untouched.
 fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
     match req {
         // HEAD is not reconstructed from the oplog (see `Fold` doc); the
@@ -280,17 +280,15 @@ fn reconciled_value(req: &LoadRequest, raw: &Loaded, fold: &Fold) -> Loaded {
     }
 }
 
-/// Fill-if-absent for a point read: trust a present canonical value; only when
-/// the canonical is missing do we adopt the fold's committed target.
-/// `folded` is `Some(Some(state))` / `Some(None)` (touched: set/deleted) or
-/// `None` (untouched by the lagged batches).
+/// Authoritative point read: a committed record past the watermark wins over
+/// the live canonical, so whenever the lagged batches *touched* this ref we
+/// adopt the folded target — set or delete, present canonical or not (cid
+/// 3329490981). `folded` is `Some(Some(state))` / `Some(None)` (touched:
+/// set/deleted) or `None` (untouched by the lagged batches ⇒ keep canonical).
 fn fill_point(raw: &Loaded, folded: Option<Option<ChangeId>>) -> Loaded {
-    match raw {
-        Loaded::Point(Some(_)) => raw.clone(),
-        _ => match folded {
-            Some(value) => Loaded::Point(value),
-            None => raw.clone(),
-        },
+    match folded {
+        Some(value) => Loaded::Point(value),
+        None => raw.clone(),
     }
 }
 

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1762,11 +1762,15 @@ fn named_fork_recovery_materializes_head_and_paired_thread() {
     );
 }
 
-/// Cross-class recovery atomicity — the collapse analogue: a collapse that
-/// attaches HEAD to `topic` must, on a LOCAL-class read, recover HEAD AND the
-/// paired thread together.
+/// Attached collapse is NOT a HEAD-mover (heddle#354 r9, cid 3330304665). The
+/// collapse command, when HEAD is attached, publishes ONLY the thread ref and
+/// never re-attaches HEAD — so a crash-replayed attached collapse must advance
+/// the thread but leave HEAD where it is. Republishing `Attached(<named>)`
+/// moved HEAD when it should stay put. Non-vacuous: the record names a thread
+/// (`topic`) different from the attached one (`main`), so the pre-fix code
+/// republished HEAD = Attached(topic) and this assertion failed.
 #[test]
-fn collapse_recovery_materializes_head_and_paired_thread() {
+fn attached_collapse_advances_thread_without_moving_head() {
     let (_t, repo) = test_repo();
     let scope = repo.op_scope();
     let base = ChangeId::generate();
@@ -1779,25 +1783,52 @@ fn collapse_recovery_materializes_head_and_paired_thread() {
         })
         .unwrap();
 
-    // Phase 4 only: a collapse into thread `topic` (HEAD = Attached(topic)).
+    // Phase 4 only: an attached collapse naming thread `topic`.
     let result = ChangeId::generate();
     repo.oplog()
         .record_collapse(&[base], &result, Some("topic"), Some(&scope))
         .unwrap();
 
+    // HEAD must stay Attached(main): the attached collapse advances the thread,
+    // it does NOT move/republish HEAD.
     assert_eq!(
         repo.refs().read_head().unwrap(),
         Head::Attached {
-            thread: ThreadName::new("topic")
+            thread: ThreadName::new("main")
         },
-        "collapse recovery must republish HEAD = Attached(topic)"
+        "attached collapse must NOT republish/move HEAD"
     );
 
-    let raw = RefManager::new(repo.heddle_dir());
+    // The named thread still advances (Shared-class fold materializes it).
     assert_eq!(
-        raw.get_thread(&ThreadName::new("topic")).unwrap(),
+        repo.refs().get_thread(&ThreadName::new("topic")).unwrap(),
         Some(result),
-        "the paired thread must be materialized atomically with the recovered HEAD"
+        "attached collapse must still advance the thread it published"
+    );
+}
+
+/// Detached collapse DOES republish HEAD: the command emits `RefUpdate::Head`
+/// Detached record-first, so a phase-4-committed / phase-5-unpublished collapse
+/// recovers HEAD = Detached(result). The counterpart to the attached case above.
+#[test]
+fn detached_collapse_republishes_detached_head() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: base })
+        .unwrap();
+
+    // Phase 4 only: a detached collapse (thread = None).
+    let result = ChangeId::generate();
+    repo.oplog()
+        .record_collapse(&[base], &result, None, Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: result },
+        "detached collapse must republish HEAD = Detached(result)"
     );
 }
 

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1347,3 +1347,273 @@ fn crash_replay_reconstructs_committed_head_update() {
         "a committed HEAD publish must be reconstructed after phase-4 crash"
     );
 }
+
+// ---- HEAD-class closure (heddle#354 r4) ----
+//
+// HEAD reconciliation must fold the LATEST HEAD-moving record of ANY shape, not
+// a Fork/Collapse allowlist. A publish-first mover (Goto / FastForward /
+// detached Snapshot) that lands AFTER an atomic Fork must mask the fork so the
+// reconcile cannot resurrect the fork's stale HEAD over the live canonical.
+// Each test below records a Fork (whose reconstruction a Fork/Collapse-only
+// allowlist would republish) then a later mover, on a handle whose watermark
+// predates the fork, and asserts HEAD is the later (canonical) value.
+
+/// Fork-then-goto: a `goto` recorded after a `Fork` must win. The goto writes
+/// canonical HEAD directly (publish-first) before recording; the reconcile must
+/// defer to that canonical, never republish the stale fork target.
+#[test]
+fn fork_then_goto_reconcile_yields_goto_target_not_stale_fork() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    // An atomic Fork committed (phase 4) a published HEAD = Detached{fork_a}.
+    let fork_a = ChangeId::generate();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Fork {
+                from: base,
+                new_state: fork_a,
+                thread: None,
+                head: Some(fork_a),
+            }],
+            Some(&scope),
+        )
+        .unwrap();
+
+    // `goto goto_b` then writes canonical HEAD = Detached{goto_b} DIRECTLY
+    // (publish-first) and records a `Goto`. The direct write is the canonical
+    // the reconciler reads; the record masks the older Fork.
+    let goto_b = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: goto_b })
+        .unwrap();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Goto {
+                target: goto_b,
+                prev_head: Some(fork_a),
+            }],
+            Some(&scope),
+        )
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: goto_b },
+        "a goto recorded after a fork must win — the stale fork must not resurrect"
+    );
+}
+
+/// FastForward-after-Fork: a fast-forward re-attaches HEAD and writes it
+/// directly before recording `FastForwardV2`. The reconcile must defer to the
+/// re-attached canonical HEAD, not the stale fork. (This is the exact
+/// stale-HEAD clobber a Fork/Collapse-only allowlist re-opens: `FastForwardV2`
+/// is publish-first, so the fork's reconstruction must be masked.)
+#[test]
+fn fast_forward_after_fork_reconcile_defers_to_reattached_head() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    let fork_a = ChangeId::generate();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Fork {
+                from: base,
+                new_state: fork_a,
+                thread: None,
+                head: Some(fork_a),
+            }],
+            Some(&scope),
+        )
+        .unwrap();
+
+    // A fast-forward advances "main" to ff_target and re-attaches HEAD
+    // (`fast_forward_attached`): canonical HEAD = Attached{main}, written
+    // directly before the FastForwardV2 record.
+    let ff_target = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &ff_target)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+    repo.oplog()
+        .record_fast_forward("src", "main", &base, &ff_target, Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Attached {
+            thread: ThreadName::new("main")
+        },
+        "a fast-forward after a fork must defer to the re-attached canonical HEAD, not resurrect the fork"
+    );
+}
+
+/// Detached-Snapshot-after-Fork: a detached snapshot writes HEAD = Detached
+/// directly before recording. The reconcile must yield the snapshot's HEAD, not
+/// the stale fork.
+#[test]
+fn detached_snapshot_after_fork_reconcile_yields_snapshot_head() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    let fork_a = ChangeId::generate();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Fork {
+                from: base,
+                new_state: fork_a,
+                thread: None,
+                head: Some(fork_a),
+            }],
+            Some(&scope),
+        )
+        .unwrap();
+
+    // A detached snapshot writes HEAD = Detached{snap_b} directly, then records.
+    let snap_b = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: snap_b })
+        .unwrap();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Snapshot {
+                new_state: snap_b,
+                prev_head: Some(fork_a),
+                thread: None,
+            }],
+            Some(&scope),
+        )
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: snap_b },
+        "a detached snapshot after a fork must win — the stale fork must not resurrect"
+    );
+}
+
+// ---- Eager one-mechanism guard (heddle#354 r4) ----
+
+/// An eager mutation that OVERRIDES `rewind` (sets `rewound`) and whose
+/// `commit_eager` returns a compensator (sets `compensated`). The one-mechanism
+/// guard must run ONLY the compensator on outer rollback — never the overridden
+/// whole-op rewind, which would double-undo.
+struct EagerOverrideRewind {
+    compensated: Rc<RefCell<bool>>,
+    rewound: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for EagerOverrideRewind {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "eager-override-rewind".to_string()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        Ok(StagedCommit::pure(()))
+    }
+
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        *self.rewound.borrow_mut() = true;
+        Ok(())
+    }
+}
+
+impl EagerMutation for EagerOverrideRewind {
+    fn commit_eager(&mut self, _tx: &mut Tx<'_>) -> Result<Compensator> {
+        let compensated = Rc::clone(&self.compensated);
+        Ok(Compensator::new(move || {
+            *compensated.borrow_mut() = true;
+            Ok(())
+        }))
+    }
+}
+
+struct EagerOverrideThenFail {
+    compensated: Rc<RefCell<bool>>,
+    rewound: Rc<RefCell<bool>>,
+    log: Rc<RefCell<Vec<u32>>>,
+}
+
+impl AtomicMutation for EagerOverrideThenFail {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "eager-override-then-fail".to_string()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        tx.enroll_eager(EagerOverrideRewind {
+            compensated: Rc::clone(&self.compensated),
+            rewound: Rc::clone(&self.rewound),
+        })?;
+        tx.enroll(Leg {
+            id: 1,
+            fail: true,
+            log: Rc::clone(&self.log),
+        })?;
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+/// The one-mechanism guard: an `EagerMutation` that overrides `rewind` must not
+/// double-undo. After `commit_eager` succeeds, the pre-registered whole-op
+/// rewind is taken out of play, so an outer rollback runs ONLY the compensator.
+#[test]
+fn eager_override_rewind_does_not_double_undo() {
+    let (_t, repo) = test_repo();
+    let compensated = Rc::new(RefCell::new(false));
+    let rewound = Rc::new(RefCell::new(false));
+    let log = Rc::new(RefCell::new(Vec::new()));
+
+    let result = execute(
+        &repo,
+        EagerOverrideThenFail {
+            compensated: Rc::clone(&compensated),
+            rewound: Rc::clone(&rewound),
+            log: Rc::clone(&log),
+        },
+    );
+
+    assert!(result.is_err(), "the composite must fail");
+    assert!(
+        *compensated.borrow(),
+        "the eager compensator must run on outer rollback"
+    );
+    assert!(
+        !*rewound.borrow(),
+        "the overridden whole-op rewind must NOT run for an eager mutation (no double-undo)"
+    );
+}

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1523,6 +1523,284 @@ fn detached_snapshot_after_fork_reconcile_yields_snapshot_head() {
     );
 }
 
+// ---- Snapshot record-first close-the-class (heddle#354 r8) ----
+//
+// The snapshot path now commits its `OpRecord::Snapshot` BEFORE publishing the
+// paired ref (record-first via `commit_snapshot_atomic` →
+// `commit_and_publish`). These tests pin the two properties that makes that
+// safe: (1) a detached snapshot's HEAD is reconstructable from its record after
+// a phase-4-committed / phase-5-unpublished crash, and (2) the reconciler's
+// authoritative `Snapshot` fold yields the NEWEST committed value, so a snapshot
+// can never clobber a newer concurrent write. (The cross-crate conformance that
+// FORCES the production reorder lives in `heddle-devtools`
+// `check-snapshot-atomicity`.)
+
+/// Detached snapshot is record-first as of r8: a crash between the record
+/// commit (phase 4) and the HEAD publish (phase 5) must be recovered by
+/// reconstructing `Head::Detached{new_state}` from the committed record. Before
+/// r8 the detached `Snapshot` fold deferred to canonical (`HeadFold::Canonical`),
+/// which — now that the publish is record-first — would LOSE the snapshot's HEAD
+/// move. This test fails under the pre-r8 `Canonical` arm and passes under the
+/// `Republish` arm.
+#[test]
+fn detached_snapshot_record_first_crash_recovery_reconstructs_head() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    // Phase 4 only: a detached snapshot committed its record, the phase-5 HEAD
+    // publish never ran (canonical HEAD is still `Attached{main}`).
+    let snap = ChangeId::generate();
+    repo.oplog()
+        .record_snapshot(&snap, Some(&base), None, Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: snap },
+        "a record-first detached snapshot's HEAD must be reconstructed after a phase-5 crash"
+    );
+}
+
+/// Snapshot-vs-newer-write race (attached): A's snapshot commits its record at a
+/// LOWER oplog id than B's later thread write. Because the snapshot is now
+/// record-first, the snapshot's record reflects when A actually committed, so
+/// B's newer record (higher id) wins under the reconciler's id-ordered
+/// authoritative fold — the stale snapshot value must NOT clobber it. (A
+/// publish-first snapshot would have recorded AFTER B, inverting the ids and
+/// resurrecting the stale snapshot.)
+#[test]
+fn snapshot_does_not_clobber_newer_committed_thread_write_attached() {
+    let (temp, repo) = test_repo();
+    let scope = repo.op_scope();
+    let s0 = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("feature"), &s0)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("feature"),
+        })
+        .unwrap();
+
+    // A's snapshot (record-first) advances `feature` = sA at the lower id.
+    let sa = ChangeId::generate();
+    repo.oplog()
+        .record_snapshot(&sa, Some(&s0), Some("feature"), Some(&scope))
+        .unwrap();
+    // B advances `feature` = sB and records (record-first) at the higher id.
+    let sb = ChangeId::generate();
+    repo.oplog()
+        .record_thread_create("feature", &sb, None, Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("feature")).unwrap(),
+        Some(sb),
+        "the newest committed write (B) must win; the older snapshot (A) must not clobber it"
+    );
+
+    // The reconcile materialized the canonical too: a raw, reconciler-free
+    // handle reads the newest committed value.
+    let raw = RefManager::new(repo.heddle_dir());
+    assert_eq!(
+        raw.get_thread(&ThreadName::new("feature")).unwrap(),
+        Some(sb),
+        "the newest committed value must be materialized to the canonical ref"
+    );
+    drop(temp);
+}
+
+/// Snapshot-vs-newer-write race (detached): a later detached snapshot (higher
+/// id) wins over an earlier one. Both are record-first `Republish(Detached)`
+/// movers, so the id-ordered fold takes the newest.
+#[test]
+fn snapshot_does_not_clobber_newer_committed_write_detached() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: base })
+        .unwrap();
+
+    let sa = ChangeId::generate();
+    repo.oplog()
+        .record_snapshot(&sa, Some(&base), None, Some(&scope))
+        .unwrap();
+    let sb = ChangeId::generate();
+    repo.oplog()
+        .record_snapshot(&sb, Some(&sa), None, Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: sb },
+        "the newest committed detached snapshot must win"
+    );
+}
+
+/// `commit_snapshot_atomic` (attached): records an `OpRecord::Snapshot` AND
+/// publishes the thread ref through the record-first chokepoint, atomically.
+#[test]
+fn commit_snapshot_atomic_attached_records_and_publishes() {
+    let (_t, repo) = test_repo();
+    let s0 = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("feature"), &s0)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("feature"),
+        })
+        .unwrap();
+
+    let sa = ChangeId::generate();
+    repo.commit_snapshot_atomic(&sa, Some(s0), Some(&ThreadName::new("feature")))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("feature")).unwrap(),
+        Some(sa),
+        "the snapshot must publish the thread ref"
+    );
+    let has_snap = repo.oplog().recent(16).unwrap().into_iter().any(|e| {
+        matches!(
+            &e.operation,
+            OpRecord::Snapshot { new_state, thread: Some(t), .. } if *new_state == sa && t == "feature"
+        )
+    });
+    assert!(
+        has_snap,
+        "commit_snapshot_atomic must append the paired OpRecord::Snapshot"
+    );
+}
+
+/// `commit_snapshot_atomic` (detached): records an `OpRecord::Snapshot` with no
+/// thread AND republishes a detached HEAD, atomically.
+#[test]
+fn commit_snapshot_atomic_detached_records_and_publishes() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: base })
+        .unwrap();
+
+    let sb = ChangeId::generate();
+    repo.commit_snapshot_atomic(&sb, Some(base), None).unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: sb },
+        "the detached snapshot must publish HEAD = Detached{{new_state}}"
+    );
+    let has_snap = repo.oplog().recent(16).unwrap().into_iter().any(|e| {
+        matches!(
+            &e.operation,
+            OpRecord::Snapshot { new_state, thread: None, .. } if *new_state == sb
+        )
+    });
+    assert!(
+        has_snap,
+        "commit_snapshot_atomic must append the paired detached OpRecord::Snapshot"
+    );
+}
+
+/// Cross-class recovery atomicity (heddle#354 r8, cid 3330183592): a named fork
+/// committed (phase 4) a new thread `topic` AND HEAD = Attached(topic), but the
+/// phase-5 publish never ran. A LOCAL-class read (HEAD) must recover BOTH HEAD
+/// and the paired thread under one lock, before the Local watermark advances —
+/// so HEAD = Attached(topic) is never observable with `topic` missing. Without
+/// the cross-class fix the Local reconcile republishes only HEAD and advances
+/// its watermark while `topic` is still unmaterialized, which a raw read of
+/// `topic` exposes.
+#[test]
+fn named_fork_recovery_materializes_head_and_paired_thread() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    // Phase 4 only: the fork's record is committed (thread `topic` + HEAD =
+    // Attached(topic)); no phase-5 publish ran.
+    let forked = ChangeId::generate();
+    repo.oplog()
+        .record_fork(&base, &forked, Some("topic"), None, Some(&scope))
+        .unwrap();
+
+    // A LOCAL-class read recovers HEAD.
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Attached {
+            thread: ThreadName::new("topic")
+        },
+        "named-fork recovery must republish HEAD = Attached(topic)"
+    );
+
+    // RAW read (no reconciler): the paired thread must already be on disk after
+    // the Local reconcile — materialized atomically with the recovered HEAD, not
+    // deferred to a later Shared read.
+    let raw = RefManager::new(repo.heddle_dir());
+    assert_eq!(
+        raw.get_thread(&ThreadName::new("topic")).unwrap(),
+        Some(forked),
+        "the paired thread must be materialized atomically with the recovered HEAD"
+    );
+}
+
+/// Cross-class recovery atomicity — the collapse analogue: a collapse that
+/// attaches HEAD to `topic` must, on a LOCAL-class read, recover HEAD AND the
+/// paired thread together.
+#[test]
+fn collapse_recovery_materializes_head_and_paired_thread() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    // Phase 4 only: a collapse into thread `topic` (HEAD = Attached(topic)).
+    let result = ChangeId::generate();
+    repo.oplog()
+        .record_collapse(&[base], &result, Some("topic"), Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Attached {
+            thread: ThreadName::new("topic")
+        },
+        "collapse recovery must republish HEAD = Attached(topic)"
+    );
+
+    let raw = RefManager::new(repo.heddle_dir());
+    assert_eq!(
+        raw.get_thread(&ThreadName::new("topic")).unwrap(),
+        Some(result),
+        "the paired thread must be materialized atomically with the recovered HEAD"
+    );
+}
+
 // ---- Eager one-mechanism guard (heddle#354 r4) ----
 
 /// An eager mutation that OVERRIDES `rewind` (sets `rewound`) and whose

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -432,3 +432,184 @@ fn write_chokepoint_records_before_publishing() {
         Some(state)
     );
 }
+
+/// The `Tx` accessors and the rewind ledger's error-handling paths: the
+/// getters, the first-error-wins/suppress-the-rest rewind, the committed
+/// early-return on a double commit, and the `Drop` backstop logging a rewind
+/// failure instead of panicking.
+#[test]
+fn tx_accessors_and_rewind_error_paths() {
+    let (_t, repo) = test_repo();
+
+    // Accessors.
+    let mut tx = Tx::root(&repo);
+    assert_eq!(tx.depth(), 0);
+    assert_eq!(tx.scope(), repo.op_scope());
+    assert!(!tx.transaction_id().is_empty());
+    let _ = tx.repo();
+    let ledger = tx.ledger_view();
+    assert_eq!(ledger.depth, 0);
+    assert_eq!(ledger.scope, repo.op_scope());
+
+    // Two failing inverses: LIFO order ⇒ the last-pushed runs first and its
+    // error is surfaced; the earlier one's error is attempted then suppressed.
+    tx.on_rewind(|| Err(HeddleError::Config("second".to_string())));
+    tx.on_rewind(|| Err(HeddleError::Config("first".to_string())));
+    let err = tx.rewind_all().unwrap_err();
+    assert!(
+        matches!(err, HeddleError::Config(m) if m == "first"),
+        "the first rewind error (LIFO) must be the one returned"
+    );
+
+    // A second commit after a successful one is a no-op (committed guard).
+    let mut tx2 = Tx::root(&repo);
+    tx2.commit(vec![OpRecord::Snapshot {
+        new_state: ChangeId::generate(),
+        prev_head: None,
+        thread: None,
+    }])
+    .unwrap();
+    tx2.commit(vec![OpRecord::Snapshot {
+        new_state: ChangeId::generate(),
+        prev_head: None,
+        thread: None,
+    }])
+    .unwrap();
+    // Only one TransactionCommit landed despite two commit calls.
+    let commits = repo
+        .oplog()
+        .recent(64)
+        .unwrap()
+        .into_iter()
+        .filter(|e| matches!(e.operation, OpRecord::TransactionCommit { .. }))
+        .count();
+    assert_eq!(commits, 1, "the committed guard suppresses the second commit");
+
+    // Drop backstop: an uncommitted Tx whose inverse fails logs (never panics).
+    {
+        let mut tx3 = Tx::root(&repo);
+        tx3.on_rewind(|| Err(HeddleError::Config("drop-time".to_string())));
+        // tx3 dropped here without commit ⇒ Drop runs rewind_all, gets Err, logs.
+    }
+}
+
+/// Drives the reconciler's fold over every published-ref-bearing `OpRecord`
+/// shape so each `Fold::apply` arm and each list/remote projection runs. The
+/// canonical refs are never published (only the records committed), so a read
+/// reconciles the folded value — exercising the read chokepoint end to end.
+#[test]
+fn reconcile_folds_every_record_shape() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let op = repo.oplog();
+
+    let v1 = ChangeId::generate();
+    let v1b = ChangeId::generate();
+    let v2 = ChangeId::generate();
+    let coll = ChangeId::generate();
+    let ckpt = ChangeId::generate();
+    let ff = ChangeId::generate();
+    let mk = ChangeId::generate();
+    let remote = ChangeId::generate();
+    let undo = ChangeId::generate();
+
+    // Legacy read-back-only variants (V1 create + update).
+    op.record_batch(vec![OpRecord::ThreadCreate {
+        name: "t_v1".to_string(),
+        state: v1,
+    }])
+    .unwrap();
+    op.record_batch(vec![OpRecord::ThreadUpdate {
+        name: "t_v1".to_string(),
+        old_state: v1,
+        new_state: v1b,
+    }])
+    .unwrap();
+    // V2 create + a delete (folds to None).
+    op.record_thread_create("t_v2", &v2, None, None).unwrap();
+    op.record_batch(vec![OpRecord::ThreadDelete {
+        name: "t_del".to_string(),
+        state: v2,
+    }])
+    .unwrap();
+    // Collapse with a thread, and one detaching HEAD (thread = None arm).
+    op.record_collapse(&[v1, v1b], &coll, Some("t_coll")).unwrap();
+    op.record_batch(vec![OpRecord::Collapse {
+        sources: vec![v1],
+        result: coll,
+        thread: None,
+    }])
+    .unwrap();
+    // Checkpoint with a thread, and one without (thread = None arm).
+    op.record_batch(vec![OpRecord::Checkpoint {
+        parent: Some(v1),
+        state: ckpt,
+        thread: Some("t_ckpt".to_string()),
+    }])
+    .unwrap();
+    op.record_batch(vec![OpRecord::Checkpoint {
+        parent: None,
+        state: ckpt,
+        thread: None,
+    }])
+    .unwrap();
+    // Fast-forward (V2) folds target_thread → post_target_id.
+    op.record_fast_forward("t_src", "t_ff", &v1, &ff, None).unwrap();
+    // Fork that publishes no ref (thread = None arm).
+    op.record_batch(vec![OpRecord::Fork {
+        from: v1,
+        new_state: v1b,
+        thread: None,
+        head: None,
+    }])
+    .unwrap();
+    // Ephemeral collapse retires its thread pointer (folds to None).
+    op.record_batch(vec![OpRecord::EphemeralThreadCollapse {
+        thread: "t_eph".to_string(),
+        final_state: v1,
+    }])
+    .unwrap();
+    // Marker create + delete; remote update + delete; undo-recovery (local).
+    op.record_marker_create("mk2", &mk).unwrap();
+    op.record_batch(vec![OpRecord::MarkerDelete {
+        name: "mk_del".to_string(),
+        state: mk,
+    }])
+    .unwrap();
+    op.record_remote_thread_update("origin", "rt2", &remote, None)
+        .unwrap();
+    op.record_remote_thread_delete("origin", "rt_del", &remote, None)
+        .unwrap();
+    op.record_undo_recovery_update(&undo, Some(&scope)).unwrap();
+
+    let refs = repo.refs();
+
+    // Point reads fold + fill the absent canonical (fill_point set arm).
+    assert_eq!(refs.get_thread(&ThreadName::new("t_coll")).unwrap(), Some(coll));
+    assert_eq!(refs.get_thread(&ThreadName::new("t_ckpt")).unwrap(), Some(ckpt));
+    assert_eq!(refs.get_thread(&ThreadName::new("t_ff")).unwrap(), Some(ff));
+    assert_eq!(refs.get_thread(&ThreadName::new("t_v1")).unwrap(), Some(v1b));
+    assert_eq!(refs.get_thread(&ThreadName::new("t_v2")).unwrap(), Some(v2));
+    assert_eq!(refs.get_marker(&MarkerName::new("mk2")).unwrap(), Some(mk));
+    assert_eq!(
+        refs.get_remote_thread("origin", &ThreadName::new("rt2")).unwrap(),
+        Some(remote)
+    );
+    assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo));
+
+    // A deleted ref folds to None and is not filled.
+    assert_eq!(refs.get_thread(&ThreadName::new("t_del")).unwrap(), None);
+
+    // List reads exercise the ThreadList/MarkerList/RemoteList/RemoteThreadList
+    // projection arms (merge_list union + remote presence filter).
+    let threads = refs.list_threads().unwrap();
+    assert!(threads.contains(&ThreadName::new("t_coll")));
+    assert!(threads.contains(&ThreadName::new("t_ff")));
+    assert!(refs.list_markers().unwrap().contains(&MarkerName::new("mk2")));
+    let remotes = refs.list_remotes().unwrap();
+    assert!(remotes.contains(&"origin".to_string()));
+    let remote_threads = refs.list_remote_threads("origin").unwrap();
+    assert!(remote_threads.contains(&ThreadName::new("rt2")));
+    // The deleted remote thread is absent from the projection.
+    assert!(!remote_threads.contains(&ThreadName::new("rt_del")));
+}

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1617,3 +1617,354 @@ fn eager_override_rewind_does_not_double_undo() {
         "the overridden whole-op rewind must NOT run for an eager mutation (no double-undo)"
     );
 }
+
+// ---- heddle#354 r5 — reconcile-consistency closures ----
+
+/// Finding B (cid 3329631074) — cross-process pre-open recovery via the
+/// persisted reconcile watermark. A prior process durably commits a Fork's
+/// phase-4 record naming "explore" but crashes before phase-5 publishes the
+/// canonical ref; the handle is dropped without advancing the watermark past
+/// that record. A FRESH handle seeds its per-read watermark from the PERSISTED
+/// last-clean point (below the unpublished record), so its next read folds
+/// `(seed, tip]` — the crash tail — and recovers the committed mutation, instead
+/// of seeding at tip and silently losing it cross-process.
+#[test]
+fn persisted_watermark_recovers_cross_process_crash_tail() {
+    let temp = TempDir::new().unwrap();
+    let base = ChangeId::generate();
+    let forked = ChangeId::generate();
+    {
+        let repo = Repository::init_default(temp.path()).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("main"), &base)
+            .unwrap();
+        // "Prior process": phase-4 commit only (Fork naming "explore"), no
+        // phase-5 publish, then the handle drops.
+        repo.oplog()
+            .record_fork(&base, &forked, Some("explore"), None)
+            .unwrap();
+    }
+
+    // Fresh process: a brand-new handle whose watermark seeds at the current
+    // generation (past the unpublished record). The open-time pass recovers it.
+    let reopened = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        reopened
+            .refs()
+            .get_thread(&ThreadName::new("explore"))
+            .unwrap(),
+        Some(forked),
+        "a prior process's committed-but-unpublished ref must materialize on fresh open"
+    );
+
+    // It was materialized to canonical: a second fresh open reads it the same.
+    let reread = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        reread
+            .refs()
+            .get_thread(&ThreadName::new("explore"))
+            .unwrap(),
+        Some(forked)
+    );
+}
+
+/// Finding B safety — the persisted watermark must NOT resurrect a ref deleted
+/// via an UNRECORDED path (the un-migrated delete the record-first retrofit has
+/// not yet reached). A thread is created (recorded + published) and a read
+/// advances + persists the watermark past it; the thread is then deleted
+/// directly, appending NO oplog record. A fresh handle seeds from the persisted
+/// watermark (at/above the create), so its read does not re-fold the stale
+/// create — the thread stays deleted. (An eager open-time fold of the tail, by
+/// contrast, WOULD resurrect it — the reason this fix is a persisted watermark,
+/// not an eager pass.)
+#[test]
+fn persisted_watermark_does_not_resurrect_unrecorded_delete() {
+    let temp = TempDir::new().unwrap();
+    let state = ChangeId::generate();
+    {
+        let repo = Repository::init_default(temp.path()).unwrap();
+        // Create through the chokepoint (records + publishes).
+        repo.commit_and_publish(
+            vec![OpRecord::ThreadCreateV2 {
+                name: "fcn".to_string(),
+                state,
+                manager_snapshot: None,
+            }],
+            &[RefUpdate::Thread {
+                name: ThreadName::new("fcn"),
+                expected: RefExpectation::Missing,
+                new: Some(state),
+            }],
+        )
+        .unwrap();
+        // A read advances + persists the watermark past the create.
+        assert_eq!(
+            repo.refs().get_thread(&ThreadName::new("fcn")).unwrap(),
+            Some(state)
+        );
+        // Delete directly — NO oplog record (the un-migrated delete path).
+        repo.refs().delete_thread(&ThreadName::new("fcn")).unwrap();
+    }
+
+    // Fresh process: seeding from the persisted watermark (≥ the create's
+    // generation) means the read does not fold the stale create ⇒ no resurrect.
+    let reopened = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        reopened.refs().get_thread(&ThreadName::new("fcn")).unwrap(),
+        None,
+        "a ref deleted via an unrecorded path must not be resurrected on reopen"
+    );
+}
+
+/// Class A (cid 3329631079) — a `Missing`/CAS expectation is validated against
+/// the RECONCILED state, not a stale on-disk read. A committed-but-unpublished
+/// Fork record creates "explore" (canonical still absent); a later
+/// `commit_and_publish` with a `Missing` expectation on "explore" must FAIL,
+/// because under the lock the reconciled value shows it already exists.
+#[test]
+fn commit_and_publish_validates_against_reconciled_not_stale_disk() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    let committed = ChangeId::generate();
+
+    // Phase-4 only: "explore" is committed-but-unpublished (canonical absent).
+    repo.oplog()
+        .record_fork(&base, &committed, Some("explore"), None)
+        .unwrap();
+
+    // A Missing expectation must fail: the reconciled state shows "explore"
+    // exists even though the raw on-disk ref is absent.
+    let result = repo.commit_and_publish(
+        vec![OpRecord::Fork {
+            from: base,
+            new_state: ChangeId::generate(),
+            thread: Some("explore".to_string()),
+            head: None,
+        }],
+        &[RefUpdate::Thread {
+            name: ThreadName::new("explore"),
+            expected: RefExpectation::Missing,
+            new: Some(ChangeId::generate()),
+        }],
+    );
+    assert!(
+        result.is_err(),
+        "a Missing expectation must fail against a committed-but-unpublished value (reconciled, not stale disk)"
+    );
+
+    // A CAS to the COMMITTED value (not the absent on-disk value) must succeed.
+    let next = ChangeId::generate();
+    repo.commit_and_publish(
+        vec![OpRecord::Fork {
+            from: committed,
+            new_state: next,
+            thread: Some("explore".to_string()),
+            head: None,
+        }],
+        &[RefUpdate::Thread {
+            name: ThreadName::new("explore"),
+            expected: RefExpectation::Value(committed),
+            new: Some(next),
+        }],
+    )
+    .expect("a CAS against the reconciled committed value must succeed");
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("explore")).unwrap(),
+        Some(next)
+    );
+}
+
+/// Class A (cid 3329631077) — the fold→publish TOCTOU. A lagging reader folds
+/// while a writer concurrently publishes a NEWER value; the reader's lazy
+/// re-publish must never clobber the writer's newer publish with a stale folded
+/// value. The fold now runs UNDER the publish lock, so it serializes with the
+/// writer's commit-and-publish and always observes the newest committed record.
+/// Stress loop: each iteration reaches the same end state — the published
+/// canonical equals the newest committed Fork record — never an older value.
+#[test]
+fn lagging_reader_never_clobbers_concurrent_publish() {
+    for _ in 0..25 {
+        let temp = TempDir::new().unwrap();
+        let base = ChangeId::generate();
+        {
+            let repo = Repository::init_default(temp.path()).unwrap();
+            repo.refs()
+                .set_thread(&ThreadName::new("main"), &base)
+                .unwrap();
+            // A committed-but-unpublished OLD value a lagging reader would fold.
+            repo.oplog()
+                .record_fork(&base, &ChangeId::generate(), Some("main"), None)
+                .unwrap();
+        }
+        let path = temp.path().to_path_buf();
+        let v_new = ChangeId::generate();
+
+        std::thread::scope(|s| {
+            let p_r = path.clone();
+            s.spawn(move || {
+                let reader = Repository::open(&p_r).unwrap();
+                for _ in 0..40 {
+                    let _ = reader.refs().get_thread(&ThreadName::new("main"));
+                }
+            });
+            let p_w = path.clone();
+            s.spawn(move || {
+                let writer = Repository::open(&p_w).unwrap();
+                let _ = writer.commit_and_publish(
+                    vec![OpRecord::Fork {
+                        from: base,
+                        new_state: v_new,
+                        thread: Some("main".to_string()),
+                        head: None,
+                    }],
+                    &[RefUpdate::Thread {
+                        name: ThreadName::new("main"),
+                        expected: RefExpectation::Any,
+                        new: Some(v_new),
+                    }],
+                );
+            });
+        });
+
+        // The published canonical must equal the newest committed Fork record
+        // for "main" — the reader's materialize never republished a stale value.
+        let reader = Repository::open(temp.path()).unwrap();
+        let published = reader.refs().get_thread(&ThreadName::new("main")).unwrap();
+        let newest = reader
+            .oplog()
+            .recent(64)
+            .unwrap()
+            .into_iter()
+            .filter(|e| matches!(&e.operation, OpRecord::Fork { thread: Some(t), .. } if t == "main"))
+            .max_by_key(|e| e.id)
+            .map(|e| match e.operation {
+                OpRecord::Fork { new_state, .. } => new_state,
+                _ => unreachable!(),
+            });
+        assert_eq!(
+            published, newest,
+            "a lagging reader's materialize must not clobber the newest committed publish"
+        );
+    }
+}
+
+/// A mutation that REGENERATES its `ChangeId` output on every `apply` run, and
+/// reconstructs the committed identity from the deduped record on a dedup hit.
+struct RegeneratesChangeId {
+    key: String,
+    fresh_ids: Rc<RefCell<Vec<ChangeId>>>,
+}
+
+impl AtomicMutation for RegeneratesChangeId {
+    type Output = ChangeId;
+
+    fn transaction_id(&self) -> String {
+        self.key.clone()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<ChangeId>> {
+        // A fresh, NON-deterministic output each run — a crash-retry's value
+        // would diverge from the originally-committed one.
+        let fresh = ChangeId::generate();
+        self.fresh_ids.borrow_mut().push(fresh);
+        Ok(StagedCommit::new(
+            fresh,
+            vec![OpRecord::Snapshot {
+                new_state: fresh,
+                prev_head: None,
+                thread: None,
+            }],
+        ))
+    }
+
+    fn reconstruct_committed_output(
+        &self,
+        committed_records: &[OpRecord],
+        _this_run: ChangeId,
+    ) -> Result<ChangeId> {
+        for op in committed_records {
+            if let OpRecord::Snapshot { new_state, .. } = op {
+                return Ok(*new_state);
+            }
+        }
+        Err(HeddleError::Config(
+            "no committed snapshot to reconstruct from".to_string(),
+        ))
+    }
+}
+
+/// Finding C (cid 3329631075) — a dedup-hit replay returns the ORIGINALLY
+/// committed output, not this run's freshly regenerated value. The replay's
+/// `apply` mints a *different* ChangeId; `execute` must reconstruct the
+/// committed identity from the deduped record and return that.
+#[test]
+fn dedup_hit_returns_prior_committed_output_not_replays_fresh_one() {
+    let (_t, repo) = test_repo();
+    let fresh_ids = Rc::new(RefCell::new(Vec::new()));
+    let key = "regenerating-op".to_string();
+
+    let first = execute(
+        &repo,
+        RegeneratesChangeId {
+            key: key.clone(),
+            fresh_ids: Rc::clone(&fresh_ids),
+        },
+    )
+    .unwrap();
+
+    let second = execute(
+        &repo,
+        RegeneratesChangeId {
+            key,
+            fresh_ids: Rc::clone(&fresh_ids),
+        },
+    )
+    .unwrap();
+
+    let minted = fresh_ids.borrow();
+    assert_eq!(minted.len(), 2, "both runs minted a fresh id");
+    assert_ne!(
+        minted[0], minted[1],
+        "the replay regenerated a DIFFERENT id (non-vacuous)"
+    );
+    assert_eq!(
+        first, minted[0],
+        "the first run returns its committed id"
+    );
+    assert_eq!(
+        second, minted[0],
+        "the dedup-hit replay returns the ORIGINALLY committed id, not its own fresh one"
+    );
+    assert_ne!(
+        second, minted[1],
+        "the replay must NOT return the value it freshly regenerated"
+    );
+}
+
+/// Finding D (cid 3329631081) — a truncated/corrupt oplog header must FAIL a
+/// reconciled read loudly, never silently report generation 0 (which would make
+/// the read skip every committed record, data-loss masquerading as an empty
+/// oplog).
+#[test]
+fn corrupt_oplog_header_fails_reconciled_read_loudly() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+
+    // Clobber the oplog magic so the header read fails on an EXISTING file.
+    let oplog_path = repo.heddle_dir().join("oplog").join("oplog.bin");
+    let mut bytes = std::fs::read(&oplog_path).unwrap();
+    assert!(bytes.len() >= 8, "oplog file must have a header");
+    for b in bytes.iter_mut().take(8) {
+        *b = 0xFF;
+    }
+    std::fs::write(&oplog_path, &bytes).unwrap();
+
+    let result = repo.refs().get_thread(&ThreadName::new("main"));
+    assert!(
+        result.is_err(),
+        "a corrupt oplog header must fail the reconciled read, not default to generation 0"
+    );
+}

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -11,7 +11,10 @@ use oplog::{OpLogBackend, OpRecord};
 use refs::{Head, RefExpectation, RefUpdate};
 use tempfile::TempDir;
 
-use super::{execute, AtomicMutation, Compensator, EagerMutation, SavepointMutation, StagedCommit, Tx};
+use super::{
+    execute, AtomicMutation, Compensator, EagerMutation, RewindLedger, SavepointMutation,
+    StagedCommit, Tx,
+};
 use crate::Repository;
 
 fn test_repo() -> (TempDir, Repository) {
@@ -30,6 +33,10 @@ struct Leg {
 
 impl AtomicMutation for Leg {
     type Output = ();
+
+    fn transaction_id(&self) -> String {
+        format!("leg-{}", self.id)
+    }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let id = self.id;
@@ -54,6 +61,10 @@ struct FailingComposite {
 
 impl AtomicMutation for FailingComposite {
     type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "failing-composite".to_string()
+    }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll(Leg {
@@ -110,6 +121,10 @@ struct Panicker {
 impl AtomicMutation for Panicker {
     type Output = ();
 
+    fn transaction_id(&self) -> String {
+        "panicker".to_string()
+    }
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let log = Rc::clone(&self.log);
         tx.on_rewind(move || {
@@ -155,6 +170,10 @@ struct Recorder {
 
 impl AtomicMutation for Recorder {
     type Output = u32;
+
+    fn transaction_id(&self) -> String {
+        format!("recorder-{}", self.state.to_string_full())
+    }
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
         Ok(StagedCommit::new(
@@ -204,6 +223,10 @@ struct Reserve {
 impl AtomicMutation for Reserve {
     type Output = ();
 
+    fn transaction_id(&self) -> String {
+        "reserve".to_string()
+    }
+
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         Ok(StagedCommit::pure(()))
     }
@@ -230,6 +253,10 @@ struct EagerThenFail {
 
 impl AtomicMutation for EagerThenFail {
     type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "eager-then-fail".to_string()
+    }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll_eager(Reserve {
@@ -442,10 +469,10 @@ fn tx_accessors_and_rewind_error_paths() {
     let (_t, repo) = test_repo();
 
     // Accessors.
-    let mut tx = Tx::root(&repo);
+    let mut tx = Tx::root(&repo, "accessor-tx".to_string());
     assert_eq!(tx.depth(), 0);
     assert_eq!(tx.scope(), repo.op_scope());
-    assert!(!tx.transaction_id().is_empty());
+    assert_eq!(tx.transaction_id(), "accessor-tx");
     let _ = tx.repo();
     let ledger = tx.ledger_view();
     assert_eq!(ledger.depth, 0);
@@ -462,7 +489,7 @@ fn tx_accessors_and_rewind_error_paths() {
     );
 
     // A second commit after a successful one is a no-op (committed guard).
-    let mut tx2 = Tx::root(&repo);
+    let mut tx2 = Tx::root(&repo, "double-commit-tx".to_string());
     tx2.commit(vec![OpRecord::Snapshot {
         new_state: ChangeId::generate(),
         prev_head: None,
@@ -487,7 +514,7 @@ fn tx_accessors_and_rewind_error_paths() {
 
     // Drop backstop: an uncommitted Tx whose inverse fails logs (never panics).
     {
-        let mut tx3 = Tx::root(&repo);
+        let mut tx3 = Tx::root(&repo, "drop-backstop-tx".to_string());
         tx3.on_rewind(|| Err(HeddleError::Config("drop-time".to_string())));
         // tx3 dropped here without commit ⇒ Drop runs rewind_all, gets Err, logs.
     }
@@ -612,4 +639,285 @@ fn reconcile_folds_every_record_shape() {
     assert!(remote_threads.contains(&ThreadName::new("rt2")));
     // The deleted remote thread is absent from the projection.
     assert!(!remote_threads.contains(&ThreadName::new("rt_del")));
+}
+
+// ---- New correctness regressions (heddle#354 r2 Codex findings) ----
+
+/// A whole-op-rewind mutation (no granular `on_rewind` inverses): it stages
+/// state in `apply`, then fails. Its `rewind` — not a ledger inverse — is the
+/// only thing that can undo the staged state.
+struct StageThenFail {
+    staged: Rc<RefCell<bool>>,
+    rewound: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for StageThenFail {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "stage-then-fail".to_string()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        // Stage state, relying on the whole-op `rewind` (NOT a granular inverse)
+        // to undo it — then fail.
+        *self.staged.borrow_mut() = true;
+        Err(HeddleError::Config("apply failed after staging".to_string()))
+    }
+
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        *self.staged.borrow_mut() = false;
+        *self.rewound.borrow_mut() = true;
+        Ok(())
+    }
+}
+
+/// The whole-op rewind must run on the `apply`-returns-`Err` path, not only
+/// after a successful `apply` (cid 3329490979). Otherwise a mutation that stages
+/// state then fails leaks it: the granular ledger is empty, and the whole-op
+/// `rewind` was historically registered only post-apply.
+#[test]
+fn whole_op_rewind_runs_on_apply_err() {
+    let (_t, repo) = test_repo();
+    let staged = Rc::new(RefCell::new(false));
+    let rewound = Rc::new(RefCell::new(false));
+
+    let result = execute(&repo, StageThenFail {
+        staged: Rc::clone(&staged),
+        rewound: Rc::clone(&rewound),
+    });
+
+    assert!(result.is_err(), "the mutation must fail");
+    assert!(
+        *rewound.borrow(),
+        "the whole-op rewind must run on the apply-Err path"
+    );
+    assert!(
+        !*staged.borrow(),
+        "a failing apply must leave zero staged state"
+    );
+}
+
+/// A mutation with a STABLE idempotency key derived from a field, staging one
+/// oplog record. Two instances with the same key model the same logical op
+/// being re-run after a crash.
+struct StableKeyed {
+    key: String,
+    state: ChangeId,
+    applied: Rc<RefCell<u32>>,
+}
+
+impl AtomicMutation for StableKeyed {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        self.key.clone()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        *self.applied.borrow_mut() += 1;
+        Ok(StagedCommit::new((), vec![OpRecord::Snapshot {
+            new_state: self.state,
+            prev_head: None,
+            thread: None,
+        }]))
+    }
+}
+
+/// A crash-retry of the same logical op presents the SAME stable
+/// `transaction_id`, so the unbounded dedup scan finds the prior commit and the
+/// second run is a no-op at the commit point — exactly-once (cid 3329490982).
+/// With a freshly-minted-per-`execute` id the retry would commit a second time.
+#[test]
+fn stable_transaction_id_dedupes_crash_retry() {
+    let (_t, repo) = test_repo();
+    let applied = Rc::new(RefCell::new(0u32));
+    let state = ChangeId::generate();
+    let key = "logical-op-42".to_string();
+
+    // First run commits.
+    execute(&repo, StableKeyed {
+        key: key.clone(),
+        state,
+        applied: Rc::clone(&applied),
+    })
+    .unwrap();
+    // The crash-retry: identical stable key ⇒ the commit deduplicates.
+    execute(&repo, StableKeyed {
+        key: key.clone(),
+        state,
+        applied: Rc::clone(&applied),
+    })
+    .unwrap();
+
+    let recent = repo.oplog().recent(64).unwrap();
+    let commits = recent
+        .iter()
+        .filter(|e| matches!(
+            &e.operation,
+            OpRecord::TransactionCommit { transaction_id, .. } if transaction_id == &key
+        ))
+        .count();
+    assert_eq!(
+        commits, 1,
+        "a replayed op with a stable id must commit exactly once"
+    );
+    let snapshots = recent
+        .iter()
+        .filter(|e| matches!(
+            &e.operation,
+            OpRecord::Snapshot { new_state, .. } if *new_state == state
+        ))
+        .count();
+    assert_eq!(snapshots, 1, "the staged record must not be double-applied");
+}
+
+/// A ref-expectation failure under `commit_and_publish` must append NO oplog
+/// record (cid 3329490978): validation (phase 3) precedes the record append
+/// (phase 4), so a record never exists for a mutation that did not publish.
+#[test]
+fn validation_failure_appends_no_record() {
+    let (_t, repo) = test_repo();
+    let existing = ChangeId::generate();
+
+    // Publish "dup" with a backing record through the chokepoint.
+    repo.commit_and_publish(
+        vec![OpRecord::ThreadCreateV2 {
+            name: "dup".to_string(),
+            state: existing,
+            manager_snapshot: None,
+        }],
+        &[RefUpdate::Thread {
+            name: ThreadName::new("dup"),
+            expected: RefExpectation::Missing,
+            new: Some(existing),
+        }],
+    )
+    .unwrap();
+
+    // A second publish whose ref expectation FAILS: `Missing`, but "dup" exists.
+    let leaked = ChangeId::generate();
+    let result = repo.commit_and_publish(
+        vec![OpRecord::Fork {
+            from: existing,
+            new_state: leaked,
+            thread: Some("dup".to_string()),
+            head: None,
+        }],
+        &[RefUpdate::Thread {
+            name: ThreadName::new("dup"),
+            expected: RefExpectation::Missing,
+            new: Some(leaked),
+        }],
+    );
+    assert!(
+        result.is_err(),
+        "a Missing expectation must fail when the thread already exists"
+    );
+
+    // The Fork record must NOT have been appended — validation precedes commit.
+    let recent = repo.oplog().recent(64).unwrap();
+    assert!(
+        !recent.iter().any(|e| matches!(
+            &e.operation,
+            OpRecord::Fork { new_state, .. } if *new_state == leaked
+        )),
+        "no oplog record may be appended when ref-expectation validation fails"
+    );
+}
+
+/// Concurrent `commit_and_publish` to the same ref (permissive `Any`
+/// expectations) must not let the record order diverge from the publish order
+/// (cid 3329490984): the record append and the ref publish happen as one unit
+/// under the refs lock, so the last-committed record for a ref is always the one
+/// whose value is published. A fresh handle (watermark seeded to the current
+/// generation) reads the RAW published canonical, which must equal the
+/// last-committed Fork record's value.
+#[test]
+fn concurrent_commit_and_publish_serializes_record_and_publish() {
+    for _ in 0..10 {
+        let temp = TempDir::new().unwrap();
+        {
+            let repo = Repository::init_default(temp.path()).unwrap();
+            let base = ChangeId::generate();
+            repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+        }
+        let va = ChangeId::generate();
+        let vb = ChangeId::generate();
+        let path = temp.path().to_path_buf();
+
+        std::thread::scope(|s| {
+            for v in [va, vb] {
+                let p = path.clone();
+                s.spawn(move || {
+                    let repo = Repository::open(&p).unwrap();
+                    let _ = repo.commit_and_publish(
+                        vec![OpRecord::Fork {
+                            from: v,
+                            new_state: v,
+                            thread: Some("main".to_string()),
+                            head: None,
+                        }],
+                        &[RefUpdate::Thread {
+                            name: ThreadName::new("main"),
+                            expected: RefExpectation::Any,
+                            new: Some(v),
+                        }],
+                    );
+                });
+            }
+        });
+
+        let reader = Repository::open(temp.path()).unwrap();
+        let published = reader.refs().get_thread(&ThreadName::new("main")).unwrap();
+        let last_fork = reader
+            .oplog()
+            .recent(64)
+            .unwrap()
+            .into_iter()
+            .filter(|e| matches!(
+                &e.operation,
+                OpRecord::Fork { thread: Some(t), .. } if t == "main"
+            ))
+            .max_by_key(|e| e.id)
+            .map(|e| match e.operation {
+                OpRecord::Fork { new_state, .. } => new_state,
+                _ => unreachable!(),
+            });
+
+        assert_eq!(
+            published, last_fork,
+            "the published ref must equal the last-committed record's value (no interleave)"
+        );
+    }
+}
+
+/// A crash-interrupted UPDATE to an ALREADY-EXISTING ref (cid 3329490981):
+/// `cmd_collapse` on attached "main" records the `Collapse` (phase 4) then
+/// crashes before publishing main's new value (phase 5). On recovery "main"
+/// already exists, so the prior fill-if-absent rule kept the STALE value — the
+/// committed update must now win.
+#[test]
+fn crash_replay_reconciles_update_to_existing_ref() {
+    let (temp, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+
+    // Phase 4 only: record a Collapse updating "main", with no phase-5 publish.
+    let result = ChangeId::generate();
+    repo.oplog().record_collapse(&[base], &result, Some("main")).unwrap();
+
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
+        Some(result),
+        "a crash-replayed UPDATE to an existing ref must materialize the committed value"
+    );
+
+    // The read materialized the canonical too: a fresh handle reads it raw.
+    let reader = Repository::open(temp.path()).unwrap();
+    assert_eq!(
+        reader.refs().get_thread(&ThreadName::new("main")).unwrap(),
+        Some(result),
+        "the committed update must be materialized to the canonical ref"
+    );
 }

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -2,7 +2,7 @@
 //! Unit tests for the atomic-mutation primitive (heddle#330 §7 item 1).
 
 use std::cell::RefCell;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
@@ -12,8 +12,8 @@ use refs::{Head, RefExpectation, RefUpdate};
 use tempfile::TempDir;
 
 use super::{
-    execute, AtomicMutation, Compensator, EagerMutation, RewindLedger, SavepointMutation,
-    StagedCommit, Tx,
+    AtomicMutation, Compensator, EagerMutation, RewindLedger, SavepointMutation, StagedCommit, Tx,
+    execute,
 };
 use crate::Repository;
 
@@ -93,9 +93,12 @@ fn reverse_order_rewind_on_failure() {
     let (_t, repo) = test_repo();
     let log = Rc::new(RefCell::new(Vec::new()));
 
-    let result = execute(&repo, FailingComposite {
-        log: Rc::clone(&log),
-    });
+    let result = execute(
+        &repo,
+        FailingComposite {
+            log: Rc::clone(&log),
+        },
+    );
 
     assert!(result.is_err(), "the composite must fail");
     assert_eq!(
@@ -135,6 +138,33 @@ impl AtomicMutation for Panicker {
     }
 }
 
+/// A whole-op-rewind mutation whose `apply` panics after staging state. It
+/// registers no granular inverse, so only the pre-enrolled whole-op rewind can
+/// clean it up during `Tx::drop`.
+struct WholeOpPanicker {
+    staged: Rc<RefCell<bool>>,
+    rewound: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for WholeOpPanicker {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "whole-op-panicker".to_string()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        *self.staged.borrow_mut() = true;
+        panic!("apply panicked after whole-op staging");
+    }
+
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        *self.staged.borrow_mut() = false;
+        *self.rewound.borrow_mut() = true;
+        Ok(())
+    }
+}
+
 /// The `Drop` backstop (heddle#330 §4): a panic that unwinds through `apply`
 /// still runs the reverse-order rewind and never commits.
 #[test]
@@ -143,9 +173,12 @@ fn panic_unwind_runs_drop_backstop() {
     let log = Rc::new(RefCell::new(Vec::new()));
 
     let caught = catch_unwind(AssertUnwindSafe(|| {
-        let _ = execute(&repo, Panicker {
-            log: Rc::clone(&log),
-        });
+        let _ = execute(
+            &repo,
+            Panicker {
+                log: Rc::clone(&log),
+            },
+        );
     }));
 
     assert!(caught.is_err(), "the panic must propagate past execute");
@@ -160,6 +193,80 @@ fn panic_unwind_runs_drop_backstop() {
             .iter()
             .any(|e| matches!(e.operation, OpRecord::TransactionCommit { .. })),
         "a panicked transaction must not commit"
+    );
+}
+
+#[test]
+fn whole_op_rewind_runs_on_apply_panic() {
+    let (_t, repo) = test_repo();
+    let staged = Rc::new(RefCell::new(false));
+    let rewound = Rc::new(RefCell::new(false));
+
+    let caught = catch_unwind(AssertUnwindSafe(|| {
+        let _ = execute(
+            &repo,
+            WholeOpPanicker {
+                staged: Rc::clone(&staged),
+                rewound: Rc::clone(&rewound),
+            },
+        );
+    }));
+
+    assert!(caught.is_err(), "the panic must propagate past execute");
+    assert!(
+        *rewound.borrow(),
+        "the pre-enrolled whole-op rewind must run during panic unwind"
+    );
+    assert!(
+        !*staged.borrow(),
+        "a panicking apply must leave zero whole-op staged state"
+    );
+}
+
+struct CommitFailsRewindFails;
+
+impl AtomicMutation for CommitFailsRewindFails {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "commit-fails-rewind-fails".to_string()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        let oplog_path = tx.repo().heddle_dir().join("oplog").join("oplog.bin");
+        if oplog_path.exists() {
+            std::fs::remove_file(&oplog_path)?;
+        }
+        std::fs::create_dir(&oplog_path)?;
+        Ok(StagedCommit::new(
+            (),
+            vec![OpRecord::Snapshot {
+                new_state: ChangeId::generate(),
+                prev_head: None,
+                thread: None,
+            }],
+        ))
+    }
+
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        Err(HeddleError::Config("rewind failed too".to_string()))
+    }
+}
+
+#[test]
+fn commit_failure_surfaces_rewind_failure_too() {
+    let (_t, repo) = test_repo();
+
+    let err = execute(&repo, CommitFailsRewindFails).unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("transaction failed"),
+        "the original commit failure must be preserved: {message}"
+    );
+    assert!(
+        message.contains("rewind failed too"),
+        "the rewind failure must be surfaced with the original error: {message}"
     );
 }
 
@@ -284,11 +391,14 @@ fn eager_compensator_runs_on_outer_rollback() {
     let cancelled = Rc::new(RefCell::new(false));
     let log = Rc::new(RefCell::new(Vec::new()));
 
-    let result = execute(&repo, EagerThenFail {
-        reserved: Rc::clone(&reserved),
-        cancelled: Rc::clone(&cancelled),
-        log: Rc::clone(&log),
-    });
+    let result = execute(
+        &repo,
+        EagerThenFail {
+            reserved: Rc::clone(&reserved),
+            cancelled: Rc::clone(&cancelled),
+            log: Rc::clone(&log),
+        },
+    );
 
     assert!(result.is_err(), "the composite must fail");
     assert!(*reserved.borrow(), "the eager effect must have run");
@@ -309,7 +419,9 @@ fn eager_compensator_runs_on_outer_rollback() {
 fn crash_replay_reconciles_on_long_held_handle() {
     let (_t, repo) = test_repo();
     let base = ChangeId::generate();
-    repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
 
     // Phase 4 only: append the Fork record naming the published thread, with no
     // phase-5 canonical publish of "explore".
@@ -338,7 +450,10 @@ fn crash_replay_reconciles_a_concurrent_commit() {
     let temp = TempDir::new().unwrap();
     let reader = Repository::init_default(temp.path()).unwrap();
     let base = ChangeId::generate();
-    reader.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+    reader
+        .refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
 
     // A second handle stands in for a concurrent process committing a fork's
     // phase-4 record without publishing the ref.
@@ -352,7 +467,10 @@ fn crash_replay_reconciles_a_concurrent_commit() {
     // The reader handle — opened before the commit, never re-opened —
     // reconciles the unpublished ref on its next read.
     assert_eq!(
-        reader.refs().get_thread(&ThreadName::new("explore")).unwrap(),
+        reader
+            .refs()
+            .get_thread(&ThreadName::new("explore"))
+            .unwrap(),
         Some(forked),
         "a pre-opened handle must reconcile a concurrent committed-but-unpublished ref"
     );
@@ -373,7 +491,9 @@ fn all_ten_readers_reconcile() {
         .record_fork(&ChangeId::generate(), &thread_state, Some("ft"), None)
         .unwrap();
     let marker_state = ChangeId::generate();
-    repo.oplog().record_marker_create("mk", &marker_state).unwrap();
+    repo.oplog()
+        .record_marker_create("mk", &marker_state)
+        .unwrap();
     let remote_state = ChangeId::generate();
     repo.oplog()
         .record_remote_thread_update("origin", "rt", &remote_state, None)
@@ -397,20 +517,36 @@ fn all_ten_readers_reconcile() {
             thread: ThreadName::new("main")
         }
     );
-    assert_eq!(refs.get_thread(&ThreadName::new("ft")).unwrap(), Some(thread_state));
-    assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("ft")).unwrap(),
+        Some(thread_state)
+    );
+    assert_eq!(
+        refs.get_marker(&MarkerName::new("mk")).unwrap(),
+        Some(marker_state)
+    );
     assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo_state));
     assert_eq!(
-        refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
+        refs.get_remote_thread("origin", &ThreadName::new("rt"))
+            .unwrap(),
         Some(remote_state)
     );
-    assert!(refs.list_threads().unwrap().contains(&ThreadName::new("ft")));
-    assert!(refs.list_markers().unwrap().contains(&MarkerName::new("mk")));
+    assert!(
+        refs.list_threads()
+            .unwrap()
+            .contains(&ThreadName::new("ft"))
+    );
+    assert!(
+        refs.list_markers()
+            .unwrap()
+            .contains(&MarkerName::new("mk"))
+    );
     assert!(refs.list_remotes().unwrap().contains(&"origin".to_string()));
-    assert!(refs
-        .list_remote_threads("origin")
-        .unwrap()
-        .contains(&ThreadName::new("rt")));
+    assert!(
+        refs.list_remote_threads("origin")
+            .unwrap()
+            .contains(&ThreadName::new("rt"))
+    );
     assert_eq!(refs.resolve("ft").unwrap(), Some(thread_state));
 }
 
@@ -510,7 +646,10 @@ fn tx_accessors_and_rewind_error_paths() {
         .into_iter()
         .filter(|e| matches!(e.operation, OpRecord::TransactionCommit { .. }))
         .count();
-    assert_eq!(commits, 1, "the committed guard suppresses the second commit");
+    assert_eq!(
+        commits, 1,
+        "the committed guard suppresses the second commit"
+    );
 
     // Drop backstop: an uncommitted Tx whose inverse fails logs (never panics).
     {
@@ -560,7 +699,8 @@ fn reconcile_folds_every_record_shape() {
     }])
     .unwrap();
     // Collapse with a thread, and one detaching HEAD (thread = None arm).
-    op.record_collapse(&[v1, v1b], &coll, Some("t_coll")).unwrap();
+    op.record_collapse(&[v1, v1b], &coll, Some("t_coll"))
+        .unwrap();
     op.record_batch(vec![OpRecord::Collapse {
         sources: vec![v1],
         result: coll,
@@ -581,7 +721,8 @@ fn reconcile_folds_every_record_shape() {
     }])
     .unwrap();
     // Fast-forward (V2) folds target_thread → post_target_id.
-    op.record_fast_forward("t_src", "t_ff", &v1, &ff, None).unwrap();
+    op.record_fast_forward("t_src", "t_ff", &v1, &ff, None)
+        .unwrap();
     // Fork that publishes no ref (thread = None arm).
     op.record_batch(vec![OpRecord::Fork {
         from: v1,
@@ -612,14 +753,24 @@ fn reconcile_folds_every_record_shape() {
     let refs = repo.refs();
 
     // Point reads fold + fill the absent canonical (fill_point set arm).
-    assert_eq!(refs.get_thread(&ThreadName::new("t_coll")).unwrap(), Some(coll));
-    assert_eq!(refs.get_thread(&ThreadName::new("t_ckpt")).unwrap(), Some(ckpt));
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("t_coll")).unwrap(),
+        Some(coll)
+    );
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("t_ckpt")).unwrap(),
+        Some(ckpt)
+    );
     assert_eq!(refs.get_thread(&ThreadName::new("t_ff")).unwrap(), Some(ff));
-    assert_eq!(refs.get_thread(&ThreadName::new("t_v1")).unwrap(), Some(v1b));
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("t_v1")).unwrap(),
+        Some(v1b)
+    );
     assert_eq!(refs.get_thread(&ThreadName::new("t_v2")).unwrap(), Some(v2));
     assert_eq!(refs.get_marker(&MarkerName::new("mk2")).unwrap(), Some(mk));
     assert_eq!(
-        refs.get_remote_thread("origin", &ThreadName::new("rt2")).unwrap(),
+        refs.get_remote_thread("origin", &ThreadName::new("rt2"))
+            .unwrap(),
         Some(remote)
     );
     assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo));
@@ -632,7 +783,11 @@ fn reconcile_folds_every_record_shape() {
     let threads = refs.list_threads().unwrap();
     assert!(threads.contains(&ThreadName::new("t_coll")));
     assert!(threads.contains(&ThreadName::new("t_ff")));
-    assert!(refs.list_markers().unwrap().contains(&MarkerName::new("mk2")));
+    assert!(
+        refs.list_markers()
+            .unwrap()
+            .contains(&MarkerName::new("mk2"))
+    );
     let remotes = refs.list_remotes().unwrap();
     assert!(remotes.contains(&"origin".to_string()));
     let remote_threads = refs.list_remote_threads("origin").unwrap();
@@ -662,7 +817,9 @@ impl AtomicMutation for StageThenFail {
         // Stage state, relying on the whole-op `rewind` (NOT a granular inverse)
         // to undo it — then fail.
         *self.staged.borrow_mut() = true;
-        Err(HeddleError::Config("apply failed after staging".to_string()))
+        Err(HeddleError::Config(
+            "apply failed after staging".to_string(),
+        ))
     }
 
     fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
@@ -671,6 +828,8 @@ impl AtomicMutation for StageThenFail {
         Ok(())
     }
 }
+
+impl SavepointMutation for StageThenFail {}
 
 /// The whole-op rewind must run on the `apply`-returns-`Err` path, not only
 /// after a successful `apply` (cid 3329490979). Otherwise a mutation that stages
@@ -682,10 +841,13 @@ fn whole_op_rewind_runs_on_apply_err() {
     let staged = Rc::new(RefCell::new(false));
     let rewound = Rc::new(RefCell::new(false));
 
-    let result = execute(&repo, StageThenFail {
-        staged: Rc::clone(&staged),
-        rewound: Rc::clone(&rewound),
-    });
+    let result = execute(
+        &repo,
+        StageThenFail {
+            staged: Rc::clone(&staged),
+            rewound: Rc::clone(&rewound),
+        },
+    );
 
     assert!(result.is_err(), "the mutation must fail");
     assert!(
@@ -695,6 +857,52 @@ fn whole_op_rewind_runs_on_apply_err() {
     assert!(
         !*staged.borrow(),
         "a failing apply must leave zero staged state"
+    );
+}
+
+struct EnrollStageThenFail {
+    staged: Rc<RefCell<bool>>,
+    rewound: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for EnrollStageThenFail {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "enroll-stage-then-fail".to_string()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        tx.enroll(StageThenFail {
+            staged: Rc::clone(&self.staged),
+            rewound: Rc::clone(&self.rewound),
+        })?;
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+#[test]
+fn savepoint_whole_op_rewind_runs_on_apply_err() {
+    let (_t, repo) = test_repo();
+    let staged = Rc::new(RefCell::new(false));
+    let rewound = Rc::new(RefCell::new(false));
+
+    let result = execute(
+        &repo,
+        EnrollStageThenFail {
+            staged: Rc::clone(&staged),
+            rewound: Rc::clone(&rewound),
+        },
+    );
+
+    assert!(result.is_err(), "the savepoint child must fail");
+    assert!(
+        *rewound.borrow(),
+        "savepoint enrollment must pre-register the child's whole-op rewind"
+    );
+    assert!(
+        !*staged.borrow(),
+        "a failing savepoint apply must leave zero staged state"
     );
 }
 
@@ -716,11 +924,14 @@ impl AtomicMutation for StableKeyed {
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         *self.applied.borrow_mut() += 1;
-        Ok(StagedCommit::new((), vec![OpRecord::Snapshot {
-            new_state: self.state,
-            prev_head: None,
-            thread: None,
-        }]))
+        Ok(StagedCommit::new(
+            (),
+            vec![OpRecord::Snapshot {
+                new_state: self.state,
+                prev_head: None,
+                thread: None,
+            }],
+        ))
     }
 }
 
@@ -736,27 +947,35 @@ fn stable_transaction_id_dedupes_crash_retry() {
     let key = "logical-op-42".to_string();
 
     // First run commits.
-    execute(&repo, StableKeyed {
-        key: key.clone(),
-        state,
-        applied: Rc::clone(&applied),
-    })
+    execute(
+        &repo,
+        StableKeyed {
+            key: key.clone(),
+            state,
+            applied: Rc::clone(&applied),
+        },
+    )
     .unwrap();
     // The crash-retry: identical stable key ⇒ the commit deduplicates.
-    execute(&repo, StableKeyed {
-        key: key.clone(),
-        state,
-        applied: Rc::clone(&applied),
-    })
+    execute(
+        &repo,
+        StableKeyed {
+            key: key.clone(),
+            state,
+            applied: Rc::clone(&applied),
+        },
+    )
     .unwrap();
 
     let recent = repo.oplog().recent(64).unwrap();
     let commits = recent
         .iter()
-        .filter(|e| matches!(
-            &e.operation,
-            OpRecord::TransactionCommit { transaction_id, .. } if transaction_id == &key
-        ))
+        .filter(|e| {
+            matches!(
+                &e.operation,
+                OpRecord::TransactionCommit { transaction_id, .. } if transaction_id == &key
+            )
+        })
         .count();
     assert_eq!(
         commits, 1,
@@ -764,12 +983,77 @@ fn stable_transaction_id_dedupes_crash_retry() {
     );
     let snapshots = recent
         .iter()
-        .filter(|e| matches!(
-            &e.operation,
-            OpRecord::Snapshot { new_state, .. } if *new_state == state
-        ))
+        .filter(|e| {
+            matches!(
+                &e.operation,
+                OpRecord::Snapshot { new_state, .. } if *new_state == state
+            )
+        })
         .count();
     assert_eq!(snapshots, 1, "the staged record must not be double-applied");
+}
+
+struct ReplayStages {
+    key: String,
+    staged_count: Rc<RefCell<u32>>,
+}
+
+impl AtomicMutation for ReplayStages {
+    type Output = u32;
+
+    fn transaction_id(&self) -> String {
+        self.key.clone()
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
+        *self.staged_count.borrow_mut() += 1;
+        Ok(StagedCommit::new(
+            7,
+            vec![OpRecord::Snapshot {
+                new_state: ChangeId::generate(),
+                prev_head: None,
+                thread: None,
+            }],
+        ))
+    }
+
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        *self.staged_count.borrow_mut() -= 1;
+        Ok(())
+    }
+}
+
+#[test]
+fn exact_once_replay_compensates_this_runs_staging() {
+    let (_t, repo) = test_repo();
+    let staged_count = Rc::new(RefCell::new(0u32));
+    let key = "stable-replay-with-staging".to_string();
+
+    let first = execute(
+        &repo,
+        ReplayStages {
+            key: key.clone(),
+            staged_count: Rc::clone(&staged_count),
+        },
+    )
+    .unwrap();
+    assert_eq!(first, 7);
+    assert_eq!(*staged_count.borrow(), 1);
+
+    let second = execute(
+        &repo,
+        ReplayStages {
+            key,
+            staged_count: Rc::clone(&staged_count),
+        },
+    )
+    .unwrap();
+    assert_eq!(second, 7);
+    assert_eq!(
+        *staged_count.borrow(),
+        1,
+        "a dedup-hit replay must rewind the staging performed by this run"
+    );
 }
 
 /// A ref-expectation failure under `commit_and_publish` must append NO oplog
@@ -840,7 +1124,9 @@ fn concurrent_commit_and_publish_serializes_record_and_publish() {
         {
             let repo = Repository::init_default(temp.path()).unwrap();
             let base = ChangeId::generate();
-            repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+            repo.refs()
+                .set_thread(&ThreadName::new("main"), &base)
+                .unwrap();
         }
         let va = ChangeId::generate();
         let vb = ChangeId::generate();
@@ -875,10 +1161,12 @@ fn concurrent_commit_and_publish_serializes_record_and_publish() {
             .recent(64)
             .unwrap()
             .into_iter()
-            .filter(|e| matches!(
-                &e.operation,
-                OpRecord::Fork { thread: Some(t), .. } if t == "main"
-            ))
+            .filter(|e| {
+                matches!(
+                    &e.operation,
+                    OpRecord::Fork { thread: Some(t), .. } if t == "main"
+                )
+            })
             .max_by_key(|e| e.id)
             .map(|e| match e.operation {
                 OpRecord::Fork { new_state, .. } => new_state,
@@ -901,11 +1189,15 @@ fn concurrent_commit_and_publish_serializes_record_and_publish() {
 fn crash_replay_reconciles_update_to_existing_ref() {
     let (temp, repo) = test_repo();
     let base = ChangeId::generate();
-    repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
 
     // Phase 4 only: record a Collapse updating "main", with no phase-5 publish.
     let result = ChangeId::generate();
-    repo.oplog().record_collapse(&[base], &result, Some("main")).unwrap();
+    repo.oplog()
+        .record_collapse(&[base], &result, Some("main"))
+        .unwrap();
 
     assert_eq!(
         repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
@@ -919,5 +1211,139 @@ fn crash_replay_reconciles_update_to_existing_ref() {
         reader.refs().get_thread(&ThreadName::new("main")).unwrap(),
         Some(result),
         "the committed update must be materialized to the canonical ref"
+    );
+}
+
+#[test]
+fn crash_replay_reconciles_delete_in_point_and_list_reads() {
+    let (_t, repo) = test_repo();
+    let state = ChangeId::generate();
+    let deleted = ThreadName::new("deleted");
+    repo.refs().set_thread(&deleted, &state).unwrap();
+
+    repo.oplog()
+        .record_batch(vec![OpRecord::ThreadDelete {
+            name: deleted.to_string(),
+            state,
+        }])
+        .unwrap();
+
+    assert!(
+        !repo.refs().list_threads().unwrap().contains(&deleted),
+        "a committed-but-unpublished delete must be absent from list reads"
+    );
+    assert_eq!(
+        repo.refs().get_thread(&deleted).unwrap(),
+        None,
+        "a committed-but-unpublished delete must win for point reads"
+    );
+}
+
+#[test]
+fn crash_replay_reconciles_marker_delete_in_list_reads() {
+    let (_t, repo) = test_repo();
+    let state = ChangeId::generate();
+    let deleted = MarkerName::new("deleted-marker");
+    repo.refs().create_marker(&deleted, &state).unwrap();
+
+    repo.oplog()
+        .record_batch(vec![OpRecord::MarkerDelete {
+            name: deleted.to_string(),
+            state,
+        }])
+        .unwrap();
+
+    assert!(
+        !repo.refs().list_markers().unwrap().contains(&deleted),
+        "a committed-but-unpublished marker delete must be absent from list reads"
+    );
+    assert_eq!(
+        repo.refs().get_marker(&deleted).unwrap(),
+        None,
+        "a committed-but-unpublished marker delete must win for point reads"
+    );
+}
+
+#[test]
+fn crash_replay_reconciles_remote_thread_create_and_delete_in_lists() {
+    let (_t, repo) = test_repo();
+    let original = ChangeId::generate();
+    let replacement = ChangeId::generate();
+    let deleted = ThreadName::new("deleted-remote");
+    let created = ThreadName::new("created-remote");
+    repo.refs()
+        .set_remote_thread("origin", &deleted, &original)
+        .unwrap();
+
+    repo.oplog()
+        .record_remote_thread_delete("origin", deleted.as_ref(), &original, None)
+        .unwrap();
+    repo.oplog()
+        .record_remote_thread_update("upstream", created.as_ref(), &replacement, None)
+        .unwrap();
+
+    let remotes = repo.refs().list_remotes().unwrap();
+    assert!(
+        !remotes.contains(&"origin".to_string()),
+        "a remote with only a committed-but-unpublished deleted thread must be absent"
+    );
+    assert!(
+        remotes.contains(&"upstream".to_string()),
+        "a remote with a committed-but-unpublished created thread must be present"
+    );
+
+    let origin_threads = repo.refs().list_remote_threads("origin").unwrap();
+    assert!(
+        !origin_threads.contains(&deleted),
+        "a committed-but-unpublished remote-thread delete must be absent from list reads"
+    );
+    let upstream_threads = repo.refs().list_remote_threads("upstream").unwrap();
+    assert!(
+        upstream_threads.contains(&created),
+        "a committed-but-unpublished remote-thread create must be present in list reads"
+    );
+
+    assert_eq!(
+        repo.refs().get_remote_thread("origin", &deleted).unwrap(),
+        None,
+        "a committed-but-unpublished remote-thread delete must win for point reads"
+    );
+    assert_eq!(
+        repo.refs().get_remote_thread("upstream", &created).unwrap(),
+        Some(replacement),
+        "a committed-but-unpublished remote-thread create must win for point reads"
+    );
+}
+
+#[test]
+fn crash_replay_reconstructs_committed_head_update() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: ThreadName::new("main"),
+        })
+        .unwrap();
+
+    let detached = ChangeId::generate();
+    repo.oplog()
+        .record_batch_scoped(
+            vec![OpRecord::Fork {
+                from: base,
+                new_state: detached,
+                thread: None,
+                head: Some(detached),
+            }],
+            Some(&repo.op_scope()),
+        )
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: detached },
+        "a committed HEAD publish must be reconstructed after phase-4 crash"
     );
 }

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1716,6 +1716,85 @@ fn persisted_watermark_does_not_resurrect_unrecorded_delete() {
     );
 }
 
+/// Finding 3 (cid 3329711893) — the SHARED-class reconcile watermark is shared
+/// across sibling worktrees, not per-worktree. Worktree B persists a shared
+/// watermark at a low generation; worktree A then records+publishes a shared
+/// (thread) create and a read advances the SHARED watermark past it; the create
+/// is deleted via an unrecorded path. When B reopens, it seeds its shared
+/// watermark from the SHARED file (which A advanced), so it does NOT re-fold and
+/// resurrect the create — even though B's own per-worktree state is behind. With
+/// a per-worktree shared watermark (the bug), B would seed below the create and
+/// resurrect it.
+#[test]
+fn shared_watermark_is_cross_worktree_no_resurrect() {
+    let main_holder = TempDir::new().unwrap();
+    let main = Repository::init_default(main_holder.path()).unwrap();
+    let shared_heddle = main.heddle_dir().to_path_buf();
+
+    // Two sibling worktrees pointing at the same shared store.
+    let wt_holder = TempDir::new().unwrap();
+    let wt_a = wt_holder.path().join("a");
+    let wt_b = wt_holder.path().join("b");
+    Repository::init_worktree(&wt_a, &shared_heddle).unwrap();
+    Repository::init_worktree(&wt_b, &shared_heddle).unwrap();
+
+    // B opens early and reads a shared ref, persisting its shared watermark at
+    // the current (pre-create) generation — the "behind" per-worktree state.
+    {
+        let repo_b = Repository::open(&wt_b).unwrap();
+        let _ = repo_b.refs().get_thread(&ThreadName::new("not-yet")).unwrap();
+    }
+
+    // A records + publishes a shared-ref create, then a read advances + persists
+    // the SHARED watermark past it.
+    let created = ChangeId::generate();
+    {
+        let repo_a = Repository::open(&wt_a).unwrap();
+        repo_a
+            .commit_and_publish(
+                vec![OpRecord::ThreadCreateV2 {
+                    name: "shared-thread".to_string(),
+                    state: created,
+                    manager_snapshot: None,
+                }],
+                &[RefUpdate::Thread {
+                    name: ThreadName::new("shared-thread"),
+                    expected: RefExpectation::Missing,
+                    new: Some(created),
+                }],
+            )
+            .unwrap();
+        assert_eq!(
+            repo_a
+                .refs()
+                .get_thread(&ThreadName::new("shared-thread"))
+                .unwrap(),
+            Some(created)
+        );
+        // Delete via the unrecorded path (no oplog record): canonical gone, the
+        // create record still sits in the tail.
+        repo_a
+            .refs()
+            .delete_thread(&ThreadName::new("shared-thread"))
+            .unwrap();
+    }
+
+    // B reopens: its per-worktree state is behind the create, but it seeds the
+    // SHARED watermark from the shared file A advanced, so the read does not
+    // re-fold the stale create. A per-worktree shared watermark would resurrect
+    // it here.
+    let repo_b = Repository::open(&wt_b).unwrap();
+    assert_eq!(
+        repo_b
+            .refs()
+            .get_thread(&ThreadName::new("shared-thread"))
+            .unwrap(),
+        None,
+        "a shared create another worktree processed past the shared watermark \
+         must not be re-folded/resurrected by a sibling worktree"
+    );
+}
+
 /// Class A (cid 3329631079) — a `Missing`/CAS expectation is validated against
 /// the RECONCILED state, not a stale on-disk read. A committed-but-unpublished
 /// Fork record creates "explore" (canonical still absent); a later
@@ -1966,5 +2045,35 @@ fn corrupt_oplog_header_fails_reconciled_read_loudly() {
     assert!(
         result.is_err(),
         "a corrupt oplog header must fail the reconciled read, not default to generation 0"
+    );
+}
+
+/// Finding 2 (cid 3329711891) — a right-magic / unsupported-version oplog must
+/// FAIL a reconciled read, not yield a silently-trusted generation that lets
+/// the `tip == watermark` fast path skip the full parser (which would reject
+/// the version). Sibling of Finding D extended from corrupt-magic to
+/// wrong-version.
+#[test]
+fn unsupported_oplog_version_fails_reconciled_read_loudly() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base)
+        .unwrap();
+
+    // Bump the version field (bytes 8..12) to a forward-incompatible value on
+    // an EXISTING file, leaving the magic intact.
+    let oplog_path = repo.heddle_dir().join("oplog").join("oplog.bin");
+    let mut bytes = std::fs::read(&oplog_path).unwrap();
+    assert!(bytes.len() >= 12, "oplog file must have magic + version");
+    // Any value distinct from the current on-disk version is unsupported.
+    let current = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    bytes[8..12].copy_from_slice(&current.wrapping_add(1).to_le_bytes());
+    std::fs::write(&oplog_path, &bytes).unwrap();
+
+    let result = repo.refs().get_thread(&ThreadName::new("main"));
+    assert!(
+        result.is_err(),
+        "an unsupported oplog version must fail the reconciled read, not be silently trusted via the fast path"
     );
 }

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use objects::error::{HeddleError, Result};
 use objects::object::{ChangeId, MarkerName, ThreadName};
 use oplog::{OpLogBackend, OpRecord};
-use refs::{Head, RefExpectation, RefUpdate};
+use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
 
 use super::{
@@ -427,7 +427,7 @@ fn crash_replay_reconciles_on_long_held_handle() {
     // phase-5 canonical publish of "explore".
     let forked = ChangeId::generate();
     repo.oplog()
-        .record_fork(&base, &forked, Some("explore"), None)
+        .record_fork(&base, &forked, Some("explore"), None, None)
         .unwrap();
 
     // The canonical "explore" ref was never written, yet the long-held handle
@@ -461,7 +461,7 @@ fn crash_replay_reconciles_a_concurrent_commit() {
     let forked = ChangeId::generate();
     committer
         .oplog()
-        .record_fork(&base, &forked, Some("explore"), None)
+        .record_fork(&base, &forked, Some("explore"), None, None)
         .unwrap();
 
     // The reader handle — opened before the commit, never re-opened —
@@ -488,7 +488,7 @@ fn all_ten_readers_reconcile() {
     // Shared classes — committed records, canonical refs unpublished.
     let thread_state = ChangeId::generate();
     repo.oplog()
-        .record_fork(&ChangeId::generate(), &thread_state, Some("ft"), None)
+        .record_fork(&ChangeId::generate(), &thread_state, Some("ft"), None, None)
         .unwrap();
     let marker_state = ChangeId::generate();
     repo.oplog()
@@ -699,7 +699,7 @@ fn reconcile_folds_every_record_shape() {
     }])
     .unwrap();
     // Collapse with a thread, and one detaching HEAD (thread = None arm).
-    op.record_collapse(&[v1, v1b], &coll, Some("t_coll"))
+    op.record_collapse(&[v1, v1b], &coll, Some("t_coll"), None)
         .unwrap();
     op.record_batch(vec![OpRecord::Collapse {
         sources: vec![v1],
@@ -1196,7 +1196,7 @@ fn crash_replay_reconciles_update_to_existing_ref() {
     // Phase 4 only: record a Collapse updating "main", with no phase-5 publish.
     let result = ChangeId::generate();
     repo.oplog()
-        .record_collapse(&[base], &result, Some("main"))
+        .record_collapse(&[base], &result, Some("main"), None)
         .unwrap();
 
     assert_eq!(
@@ -1641,7 +1641,7 @@ fn persisted_watermark_recovers_cross_process_crash_tail() {
         // "Prior process": phase-4 commit only (Fork naming "explore"), no
         // phase-5 publish, then the handle drops.
         repo.oplog()
-            .record_fork(&base, &forked, Some("explore"), None)
+            .record_fork(&base, &forked, Some("explore"), None, None)
             .unwrap();
     }
 
@@ -1795,6 +1795,160 @@ fn shared_watermark_is_cross_worktree_no_resurrect() {
     );
 }
 
+// ---- heddle#354 r7 — close-the-class (unified write chokepoint + scoped forks) ----
+
+/// cid 3329765073 — a NON-ATOMIC `update_refs`-class write funnels through the
+/// same write chokepoint as the atomic path, which materializes the committed
+/// tail FIRST. So a committed-but-unpublished record is persisted to canonical
+/// by the write, not discarded. Pre-r7 the non-atomic path folded the tail only
+/// for validation and threw the `ReconcileOutcome` away, leaving the record
+/// unmaterialized (and re-foldable over the very write that should have
+/// superseded it).
+#[test]
+fn non_atomic_write_materializes_committed_tail() {
+    let (_t, repo) = test_repo();
+    let v_new = ChangeId::generate();
+    // Phase-4 only: a committed-but-unpublished thread "x" (canonical absent,
+    // watermark behind).
+    repo.oplog()
+        .record_batch(vec![OpRecord::ThreadCreateV2 {
+            name: "x".to_string(),
+            state: v_new,
+            manager_snapshot: None,
+        }])
+        .unwrap();
+
+    // A no-reconciler view reads RAW canonical: "x" is not yet materialized.
+    assert_eq!(
+        RefManager::new(repo.heddle_dir())
+            .get_thread(&ThreadName::new("x"))
+            .unwrap(),
+        None,
+        "precondition: the committed record is not yet materialized to canonical"
+    );
+
+    // A NON-ATOMIC write to a DIFFERENT ref runs the write chokepoint, which
+    // materializes the committed tail before publishing.
+    let y = ChangeId::generate();
+    repo.refs().set_thread(&ThreadName::new("y"), &y).unwrap();
+
+    // The committed "x" is now in canonical — observable WITHOUT reconciliation.
+    // Pre-r7 the non-atomic write discarded the reconcile outcome and "x" stayed
+    // absent until a reconciling read happened to fold it.
+    assert_eq!(
+        RefManager::new(repo.heddle_dir())
+            .get_thread(&ThreadName::new("x"))
+            .unwrap(),
+        Some(v_new),
+        "a non-atomic write must materialize the committed tail (no lost records)"
+    );
+}
+
+/// cid 3329765073, the clobber face — a non-atomic delete of a ref whose
+/// committed-but-unpublished record would otherwise be re-folded over the
+/// delete. The write chokepoint materializes + advances the watermark to the
+/// tip, so the delete lands on a fully-reconciled canonical and no later read
+/// re-derives the deleted value. Pre-r7 the watermark stayed behind and the
+/// next read re-folded the create, resurrecting the deleted ref.
+#[test]
+fn non_atomic_delete_is_not_clobbered_by_a_committed_record() {
+    let (_t, repo) = test_repo();
+    let v_old = ChangeId::generate();
+    let v_new = ChangeId::generate();
+    // Publish "x"=v_old (no record), then commit (don't publish) "x"=v_new.
+    repo.refs()
+        .set_thread(&ThreadName::new("x"), &v_old)
+        .unwrap();
+    repo.oplog()
+        .record_batch(vec![OpRecord::ThreadUpdate {
+            name: "x".to_string(),
+            old_state: v_old,
+            new_state: v_new,
+        }])
+        .unwrap();
+
+    // Non-atomic delete via `update_refs` (no preceding reconciling read).
+    repo.refs()
+        .update_refs(&[RefUpdate::Thread {
+            name: ThreadName::new("x"),
+            expected: RefExpectation::Any,
+            new: None,
+        }])
+        .unwrap();
+
+    // The delete is preserved: a read does NOT re-fold the committed update.
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("x")).unwrap(),
+        None,
+        "a non-atomic delete must not be clobbered by re-folding a committed record"
+    );
+}
+
+/// cid 3329765074 — a HEAD-moving fork recorded via the `record_fork` HELPER is
+/// SCOPED to `op_scope`, so the read chokepoint's `Local`-class (scoped) fold
+/// reconciles it. Covers BOTH a detached fork (`head = Some`) and an attached
+/// fork (`thread = Some`, which also moves HEAD), plus the contrast that an
+/// UNSCOPED helper-recorded fork is invisible to the scoped fold (the pre-r7
+/// `record_single` bug — proving the scope is load-bearing).
+#[test]
+fn helper_recorded_head_moving_fork_is_scoped_and_reconciles() {
+    // Detached fork, scoped → HEAD reconciles.
+    let (_t1, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    let forked = ChangeId::generate();
+    repo.oplog()
+        .record_fork(&base, &forked, None, Some(&forked), Some(&scope))
+        .unwrap();
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: forked },
+        "a scoped helper-recorded detached fork must reconcile HEAD"
+    );
+
+    // Attached fork, scoped → HEAD reconciles to the new thread AND the thread
+    // ref reconciles.
+    let (_t2, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    let forked = ChangeId::generate();
+    repo.oplog()
+        .record_fork(&base, &forked, Some("topic"), None, Some(&scope))
+        .unwrap();
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("topic")).unwrap(),
+        Some(forked),
+        "a scoped helper-recorded attached fork must reconcile the thread ref"
+    );
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Attached {
+            thread: ThreadName::new("topic")
+        },
+        "a scoped helper-recorded attached fork must reconcile HEAD to the new thread"
+    );
+
+    // Contrast: an UNSCOPED detached fork is invisible to the scoped Local fold,
+    // so HEAD is NOT reconstructed (the pre-r7 bug — scope is load-bearing).
+    let (_t3, repo) = test_repo();
+    let base = ChangeId::generate();
+    let head_before = repo.refs().read_head().unwrap();
+    repo.oplog()
+        .record_fork(
+            &base,
+            &ChangeId::generate(),
+            None,
+            Some(&ChangeId::generate()),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        head_before,
+        "an unscoped detached fork must NOT reconcile HEAD (scope is load-bearing)"
+    );
+}
+
 /// Class A (cid 3329631079) — a `Missing`/CAS expectation is validated against
 /// the RECONCILED state, not a stale on-disk read. A committed-but-unpublished
 /// Fork record creates "explore" (canonical still absent); a later
@@ -1808,7 +1962,7 @@ fn commit_and_publish_validates_against_reconciled_not_stale_disk() {
 
     // Phase-4 only: "explore" is committed-but-unpublished (canonical absent).
     repo.oplog()
-        .record_fork(&base, &committed, Some("explore"), None)
+        .record_fork(&base, &committed, Some("explore"), None, None)
         .unwrap();
 
     // A Missing expectation must fail: the reconciled state shows "explore"
@@ -1872,7 +2026,7 @@ fn lagging_reader_never_clobbers_concurrent_publish() {
                 .unwrap();
             // A committed-but-unpublished OLD value a lagging reader would fold.
             repo.oplog()
-                .record_fork(&base, &ChangeId::generate(), Some("main"), None)
+                .record_fork(&base, &ChangeId::generate(), Some("main"), None, None)
                 .unwrap();
         }
         let path = temp.path().to_path_buf();

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Unit tests for the atomic-mutation primitive (heddle#330 §7 item 1).
+
+use std::cell::RefCell;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::rc::Rc;
+
+use objects::error::{HeddleError, Result};
+use objects::object::{ChangeId, MarkerName, ThreadName};
+use oplog::{OpLogBackend, OpRecord};
+use refs::{Head, RefExpectation, RefUpdate};
+use tempfile::TempDir;
+
+use super::{execute, AtomicMutation, Compensator, EagerMutation, SavepointMutation, StagedCommit, Tx};
+use crate::Repository;
+
+fn test_repo() -> (TempDir, Repository) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    (temp, repo)
+}
+
+/// A savepoint leg that records its id when its inverse runs, and can be made
+/// to fail mid-apply (after registering its inverse).
+struct Leg {
+    id: u32,
+    fail: bool,
+    log: Rc<RefCell<Vec<u32>>>,
+}
+
+impl AtomicMutation for Leg {
+    type Output = ();
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        let id = self.id;
+        let log = Rc::clone(&self.log);
+        tx.on_rewind(move || {
+            log.borrow_mut().push(id);
+            Ok(())
+        });
+        if self.fail {
+            return Err(HeddleError::Config(format!("leg {id} failed")));
+        }
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+impl SavepointMutation for Leg {}
+
+/// A composite that enrolls three legs; the third fails.
+struct FailingComposite {
+    log: Rc<RefCell<Vec<u32>>>,
+}
+
+impl AtomicMutation for FailingComposite {
+    type Output = ();
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        tx.enroll(Leg {
+            id: 1,
+            fail: false,
+            log: Rc::clone(&self.log),
+        })?;
+        tx.enroll(Leg {
+            id: 2,
+            fail: false,
+            log: Rc::clone(&self.log),
+        })?;
+        tx.enroll(Leg {
+            id: 3,
+            fail: true,
+            log: Rc::clone(&self.log),
+        })?;
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+/// Mirrors `refs_transactions.rs:341-377`: a mid-apply failure unwinds the
+/// already-staged legs in strict reverse (LIFO) order, and nothing commits.
+#[test]
+fn reverse_order_rewind_on_failure() {
+    let (_t, repo) = test_repo();
+    let log = Rc::new(RefCell::new(Vec::new()));
+
+    let result = execute(&repo, FailingComposite {
+        log: Rc::clone(&log),
+    });
+
+    assert!(result.is_err(), "the composite must fail");
+    assert_eq!(
+        *log.borrow(),
+        vec![3, 2, 1],
+        "inverses must run in reverse enroll order"
+    );
+    // Nothing committed: no TransactionCommit in the oplog.
+    let recent = repo.oplog().recent(64).unwrap();
+    assert!(
+        !recent
+            .iter()
+            .any(|e| matches!(e.operation, OpRecord::TransactionCommit { .. })),
+        "a failed transaction must not commit"
+    );
+}
+
+/// A mutation whose `apply` panics after staging an effect.
+struct Panicker {
+    log: Rc<RefCell<Vec<u32>>>,
+}
+
+impl AtomicMutation for Panicker {
+    type Output = ();
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        let log = Rc::clone(&self.log);
+        tx.on_rewind(move || {
+            log.borrow_mut().push(99);
+            Ok(())
+        });
+        panic!("apply blew up");
+    }
+}
+
+/// The `Drop` backstop (heddle#330 §4): a panic that unwinds through `apply`
+/// still runs the reverse-order rewind and never commits.
+#[test]
+fn panic_unwind_runs_drop_backstop() {
+    let (_t, repo) = test_repo();
+    let log = Rc::new(RefCell::new(Vec::new()));
+
+    let caught = catch_unwind(AssertUnwindSafe(|| {
+        let _ = execute(&repo, Panicker {
+            log: Rc::clone(&log),
+        });
+    }));
+
+    assert!(caught.is_err(), "the panic must propagate past execute");
+    assert_eq!(
+        *log.borrow(),
+        vec![99],
+        "Tx::drop must rewind the staged effect on panic-unwind"
+    );
+    let recent = repo.oplog().recent(64).unwrap();
+    assert!(
+        !recent
+            .iter()
+            .any(|e| matches!(e.operation, OpRecord::TransactionCommit { .. })),
+        "a panicked transaction must not commit"
+    );
+}
+
+/// A leaf mutation that stages one oplog record and surfaces a value.
+struct Recorder {
+    state: ChangeId,
+}
+
+impl AtomicMutation for Recorder {
+    type Output = u32;
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
+        Ok(StagedCommit::new(
+            42,
+            vec![OpRecord::Snapshot {
+                new_state: self.state,
+                prev_head: None,
+                thread: None,
+            }],
+        ))
+    }
+}
+
+/// The happy path: `execute` surfaces the output and the commit point appends
+/// the staged record plus a `TransactionCommit` marker, in one batch.
+#[test]
+fn execute_commits_at_the_oplog() {
+    let (_t, repo) = test_repo();
+    let state = ChangeId::generate();
+
+    let out = execute(&repo, Recorder { state }).unwrap();
+    assert_eq!(out, 42);
+
+    let recent = repo.oplog().recent(8).unwrap();
+    assert!(
+        recent.iter().any(|e| matches!(
+            &e.operation,
+            OpRecord::Snapshot { new_state, .. } if *new_state == state
+        )),
+        "the staged snapshot record must be committed"
+    );
+    assert!(
+        recent
+            .iter()
+            .any(|e| matches!(e.operation, OpRecord::TransactionCommit { .. })),
+        "the commit point must append a TransactionCommit marker"
+    );
+}
+
+/// An eager sub-op: the effect lands in `commit_eager`, which returns the
+/// compensator. (The op-id reserve exemplar, §3.2/§5.4.)
+struct Reserve {
+    reserved: Rc<RefCell<bool>>,
+    cancelled: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for Reserve {
+    type Output = ();
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+impl EagerMutation for Reserve {
+    fn commit_eager(&mut self, _tx: &mut Tx<'_>) -> Result<Compensator> {
+        *self.reserved.borrow_mut() = true;
+        let cancelled = Rc::clone(&self.cancelled);
+        Ok(Compensator::new(move || {
+            *cancelled.borrow_mut() = true;
+            Ok(())
+        }))
+    }
+}
+
+/// A composite that eagerly reserves, then fails — so the eager compensator
+/// must run on the outer rollback.
+struct EagerThenFail {
+    reserved: Rc<RefCell<bool>>,
+    cancelled: Rc<RefCell<bool>>,
+    log: Rc<RefCell<Vec<u32>>>,
+}
+
+impl AtomicMutation for EagerThenFail {
+    type Output = ();
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        tx.enroll_eager(Reserve {
+            reserved: Rc::clone(&self.reserved),
+            cancelled: Rc::clone(&self.cancelled),
+        })?;
+        tx.enroll(Leg {
+            id: 1,
+            fail: true,
+            log: Rc::clone(&self.log),
+        })?;
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+/// The eager-commit exception (heddle#330 §3.2): an eagerly-committed sub-op's
+/// compensator runs when the outer transaction later fails, so a leaked
+/// reservation is unrepresentable. The savepoint/eager split is enforced at the
+/// type level — `tx.enroll(Reserve { .. })` would not compile (`Reserve` is not
+/// a `SavepointMutation`), so `enroll_eager` is the only path.
+#[test]
+fn eager_compensator_runs_on_outer_rollback() {
+    let (_t, repo) = test_repo();
+    let reserved = Rc::new(RefCell::new(false));
+    let cancelled = Rc::new(RefCell::new(false));
+    let log = Rc::new(RefCell::new(Vec::new()));
+
+    let result = execute(&repo, EagerThenFail {
+        reserved: Rc::clone(&reserved),
+        cancelled: Rc::clone(&cancelled),
+        log: Rc::clone(&log),
+    });
+
+    assert!(result.is_err(), "the composite must fail");
+    assert!(*reserved.borrow(), "the eager effect must have run");
+    assert!(
+        *cancelled.borrow(),
+        "the eager compensator must run on outer rollback"
+    );
+}
+
+// ---- Read-chokepoint reconciliation (heddle#330 §2.2) ----
+
+/// Crash-replay (heddle#330 §2.4): a fork interrupted between phase 4 (oplog
+/// record committed) and phase 5 (ref publish) leaves a committed-but-
+/// unpublished thread ref. A read on the **long-held handle** that opened
+/// BEFORE the record — the daemon cell an open-time-only pass cannot reach (cid
+/// 3328112197) — must reconcile to the committed target.
+#[test]
+fn crash_replay_reconciles_on_long_held_handle() {
+    let (_t, repo) = test_repo();
+    let base = ChangeId::generate();
+    repo.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+
+    // Phase 4 only: append the Fork record naming the published thread, with no
+    // phase-5 canonical publish of "explore".
+    let forked = ChangeId::generate();
+    repo.oplog()
+        .record_fork(&base, &forked, Some("explore"), None)
+        .unwrap();
+
+    // The canonical "explore" ref was never written, yet the long-held handle
+    // reconciles per-read (not per-open) to the committed value.
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("explore")).unwrap(),
+        Some(forked),
+        "long-held handle must reconcile a committed-but-unpublished ref"
+    );
+}
+
+/// Crash-replay across reader shapes that share a backend: a handle opened
+/// *before* a concurrent committer's fork phase-4 (another process / a second
+/// `Arc<Repository>`) reconciles it on its next read, without re-opening — the
+/// shared-oplog daemon cell. (A handle opened *after* a prior process's crash
+/// relies on the deferred `Repository::open` eager pass, the spike's stated
+/// optimization, so it is not asserted here.)
+#[test]
+fn crash_replay_reconciles_a_concurrent_commit() {
+    let temp = TempDir::new().unwrap();
+    let reader = Repository::init_default(temp.path()).unwrap();
+    let base = ChangeId::generate();
+    reader.refs().set_thread(&ThreadName::new("main"), &base).unwrap();
+
+    // A second handle stands in for a concurrent process committing a fork's
+    // phase-4 record without publishing the ref.
+    let committer = Repository::open(temp.path()).unwrap();
+    let forked = ChangeId::generate();
+    committer
+        .oplog()
+        .record_fork(&base, &forked, Some("explore"), None)
+        .unwrap();
+
+    // The reader handle — opened before the commit, never re-opened —
+    // reconciles the unpublished ref on its next read.
+    assert_eq!(
+        reader.refs().get_thread(&ThreadName::new("explore")).unwrap(),
+        Some(forked),
+        "a pre-opened handle must reconcile a concurrent committed-but-unpublished ref"
+    );
+}
+
+/// All ten `RefManager` read methods funnel through `reconciled_load` and so
+/// reconcile non-vacuously — including the r9 remote-thread / undo-recovery
+/// classes that previously had no committed records (heddle#330 §2.2). Each
+/// read below resolves a committed-but-unpublished value of its class.
+#[test]
+fn all_ten_readers_reconcile() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+
+    // Shared classes — committed records, canonical refs unpublished.
+    let thread_state = ChangeId::generate();
+    repo.oplog()
+        .record_fork(&ChangeId::generate(), &thread_state, Some("ft"), None)
+        .unwrap();
+    let marker_state = ChangeId::generate();
+    repo.oplog().record_marker_create("mk", &marker_state).unwrap();
+    let remote_state = ChangeId::generate();
+    repo.oplog()
+        .record_remote_thread_update("origin", "rt", &remote_state, None)
+        .unwrap();
+
+    // Local class — undo-recovery reconciles within this checkout's lane.
+    let undo_state = ChangeId::generate();
+    repo.oplog()
+        .record_undo_recovery_update(&undo_state, Some(&scope))
+        .unwrap();
+
+    let refs = repo.refs();
+    // 1 read_head, 2 get_thread, 3 get_marker, 4 get_undo_recovery,
+    // 5 get_remote_thread, 6 list_threads, 7 list_markers, 8 list_remotes,
+    // 9 list_remote_threads, 10 resolve. read_head funnels through the
+    // chokepoint but returns the authoritative canonical HEAD (not
+    // reconstructed from the oplog in impl-a) — here the seeded "main".
+    assert_eq!(
+        refs.read_head().unwrap(),
+        Head::Attached {
+            thread: ThreadName::new("main")
+        }
+    );
+    assert_eq!(refs.get_thread(&ThreadName::new("ft")).unwrap(), Some(thread_state));
+    assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
+    assert_eq!(refs.get_undo_recovery().unwrap(), Some(undo_state));
+    assert_eq!(
+        refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
+        Some(remote_state)
+    );
+    assert!(refs.list_threads().unwrap().contains(&ThreadName::new("ft")));
+    assert!(refs.list_markers().unwrap().contains(&MarkerName::new("mk")));
+    assert!(refs.list_remotes().unwrap().contains(&"origin".to_string()));
+    assert!(refs
+        .list_remote_threads("origin")
+        .unwrap()
+        .contains(&ThreadName::new("rt")));
+    assert_eq!(refs.resolve("ft").unwrap(), Some(thread_state));
+}
+
+// ---- Write-chokepoint conformance (heddle#330 §2.2) ----
+
+/// `commit_and_publish` records before it publishes (heddle#330 §2.2): a
+/// published ref always has a preceding, ref-carrying committed record. Proven
+/// by reopening (a fresh oplog read) and asserting the published thread has its
+/// backing record durable.
+#[test]
+fn write_chokepoint_records_before_publishing() {
+    let temp = TempDir::new().unwrap();
+    let state = ChangeId::generate();
+    {
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let record = OpRecord::ThreadCreateV2 {
+            name: "feature".to_string(),
+            state,
+            manager_snapshot: None,
+        };
+        let updates = vec![RefUpdate::Thread {
+            name: ThreadName::new("feature"),
+            expected: RefExpectation::Missing,
+            new: Some(state),
+        }];
+        repo.commit_and_publish(vec![record], &updates).unwrap();
+        // The ref is published on this handle.
+        assert_eq!(
+            repo.refs().get_thread(&ThreadName::new("feature")).unwrap(),
+            Some(state)
+        );
+    }
+
+    // Reopen for a fresh oplog view: the published ref has a backing record.
+    let repo = Repository::open(temp.path()).unwrap();
+    let recent = repo.oplog().recent(32).unwrap();
+    assert!(
+        recent.iter().any(|e| matches!(
+            &e.operation,
+            OpRecord::ThreadCreateV2 { name, .. } if name == "feature"
+        )),
+        "every published ref must have a preceding ref-carrying record"
+    );
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("feature")).unwrap(),
+        Some(state)
+    );
+}

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The `AtomicMutation` trait family (heddle#330 §2.1, §3.3).
+//!
+//! A single all-or-nothing mutation implements [`AtomicMutation`]; the
+//! generic [`execute`](super::execute) enforces the commit point and the
+//! reverse-order rewind exactly once. Composition stays **`dyn`-free** on the
+//! public surface — `execute`/`enroll` are monomorphized per mutation type and
+//! no mutation is ever invoked through a vtable.
+
+use objects::error::Result;
+use oplog::OpRecord;
+
+use super::tx::{RewindLedger, Tx};
+
+/// What `apply` returns: the value to surface to the caller plus the oplog
+/// record(s) the executor appends **at the commit point**. The mutation never
+/// appends to the oplog itself; it hands the records to the executor so the
+/// append happens once, last (heddle#330 §2.2 phase 4).
+pub struct StagedCommit<T> {
+    /// The value produced on a committed run (e.g. the new `ChangeId`).
+    pub output: T,
+    /// Records to append at the single commit point. A composite mutation
+    /// merges its enrolled children's records into this vector so the whole
+    /// nest commits in one batch.
+    pub oplog: Vec<OpRecord>,
+}
+
+impl<T> StagedCommit<T> {
+    pub fn new(output: T, oplog: Vec<OpRecord>) -> Self {
+        Self { output, oplog }
+    }
+
+    /// A staged commit that contributes no oplog records of its own.
+    pub fn pure(output: T) -> Self {
+        Self {
+            output,
+            oplog: Vec::new(),
+        }
+    }
+}
+
+/// A single all-or-nothing mutation.
+///
+/// Implementors supply the staged forward work (`apply`) and their own
+/// idempotent rewind. `apply` performs only **staged, not-yet-visible** side
+/// effects — object-store puts (orphan until referenced), FS temp writes, ref
+/// temp writes — and registers each effect's inverse on the transaction via
+/// [`Tx::on_rewind`]. It MUST NOT publish a canonical ref or append to the
+/// oplog; both happen at/after the executor's single commit step.
+pub trait AtomicMutation {
+    /// The value produced on a committed run.
+    type Output;
+
+    /// Forward, staged, fallible side effects. Every effect performed here
+    /// MUST be paired with an inverse registered via [`Tx::on_rewind`] (the
+    /// granular ledger), OR be undone wholesale by [`AtomicMutation::rewind`].
+    /// Use one mechanism per mutation, not both.
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>>;
+
+    /// Undo whatever THIS mutation's `apply` staged. Called in reverse order
+    /// on any pre-commit failure or panic-unwind. MUST be idempotent (may run
+    /// after a partial apply) and MUST undo ONLY what this invocation created,
+    /// never pre-existing user state (the #302 r4 lesson). The default is a
+    /// no-op for mutations that register their undo via [`Tx::on_rewind`].
+    fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Opt-in marker for a **savepoint-enrollable** mutation: its staged effects
+/// are invisible to other readers until the outer commit publishes them, so it
+/// may defer to the outermost commit (heddle#330 §3.1).
+///
+/// There is deliberately **no** blanket `impl<M: AtomicMutation>
+/// SavepointMutation for M` — a mutation opts in explicitly, so a mutation that
+/// is *only* an [`EagerMutation`] does NOT satisfy the [`Tx::enroll`] bound and
+/// cannot be enrolled as a savepoint. This is the type-level half of the
+/// compile-error guarantee (§3.3).
+pub trait SavepointMutation: AtomicMutation {}
+
+/// An **eager** mutation: its forward effect is cross-process-visible the
+/// instant it runs (the #251 op-id reserve exemplar, §3.2), so it must commit
+/// eagerly AND hand back a [`Compensator`]. The eager effect lives in
+/// [`commit_eager`](EagerMutation::commit_eager), never in `apply` — the method
+/// performs the effect and *returns* the compensator, so "perform the eager
+/// effect" and "produce the compensator" are one call. The method is required,
+/// so an eager mutation with no compensator cannot implement the trait at all
+/// (§3.3).
+pub trait EagerMutation: AtomicMutation {
+    /// Run the eager, cross-process-visible effect (e.g. `store.reserve`) and
+    /// return the compensator the outer `Tx` stores. Separate from `rewind`
+    /// because an eager leg's undo is a *forward* compensating action
+    /// (cancel/release), not a staged-state rollback.
+    fn commit_eager(&mut self, tx: &mut Tx<'_>) -> Result<Compensator>;
+}
+
+/// The compensating action for an eagerly-committed sub-op. Run in reverse
+/// order with the rest of the rewind ledger if the outer transaction fails.
+///
+/// Boxes a `'static` closure (eager compensators capture `Arc`-shared stores,
+/// e.g. `store.cancel(op_id)`), kept opaque so callers cannot inspect or skip
+/// it — the only way to obtain one is from
+/// [`EagerMutation::commit_eager`].
+pub struct Compensator(Box<dyn FnOnce() -> Result<()> + 'static>);
+
+impl Compensator {
+    pub fn new(f: impl FnOnce() -> Result<()> + 'static) -> Self {
+        Self(Box::new(f))
+    }
+
+    pub(super) fn into_fn(self) -> Box<dyn FnOnce() -> Result<()> + 'static> {
+        self.0
+    }
+}

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -51,6 +51,19 @@ pub trait AtomicMutation {
     /// The value produced on a committed run.
     type Output;
 
+    /// A **stable** idempotency key for this logical operation — identical
+    /// across retries of the *same* op (heddle#330 §2.2 "Idempotency of the
+    /// commit", cid 3329490982). It MUST be derived deterministically from the
+    /// operation's identity (its inputs / op-id), NEVER minted fresh per
+    /// [`execute`](super::execute): a crash after the commit append but before
+    /// the caller observes success is re-run by the caller, and a freshly-minted
+    /// key would miss the unbounded dedup scan and double-apply. With a stable
+    /// key the replayed op presents the same id, the dedup lookup finds the
+    /// prior commit, and the second run is a no-op. Required (no default), so the
+    /// "minted fresh" footgun is unrepresentable. Only the *root* mutation's key
+    /// is used — an enrolled child never reaches the commit point.
+    fn transaction_id(&self) -> String;
+
     /// Forward, staged, fallible side effects. Every effect performed here
     /// MUST be paired with an inverse registered via [`Tx::on_rewind`] (the
     /// granular ledger), OR be undone wholesale by [`AtomicMutation::rewind`].

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -78,6 +78,28 @@ pub trait AtomicMutation {
     fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
         Ok(())
     }
+
+    /// Reconstruct the output the ORIGINAL committed run produced, from the
+    /// deduped committed record batch (heddle#354 r5, cid 3329631075). Called
+    /// ONLY on a crash-retry that dedup-hits an already-committed
+    /// `transaction_id`: this run re-ran `apply` and may have produced a
+    /// *different* output than what was persisted — e.g. a freshly generated
+    /// `ChangeId` — so returning this run's value would hand the caller an
+    /// identity that does not match the committed record. Derive the committed
+    /// identity from `committed_records` (the prior batch, marker stripped).
+    ///
+    /// The default returns this run's output unchanged, correct when the output
+    /// is deterministic from the mutation's inputs (the common case). A mutation
+    /// whose output is generated non-deterministically MUST override this to read
+    /// the committed identity out of `committed_records`.
+    fn reconstruct_committed_output(
+        &self,
+        committed_records: &[OpRecord],
+        this_run: Self::Output,
+    ) -> Result<Self::Output> {
+        let _ = committed_records;
+        Ok(this_run)
+    }
 }
 
 /// Opt-in marker for a **savepoint-enrollable** mutation: its staged effects

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -184,6 +184,17 @@ impl<'a> Tx<'a> {
             }
         };
         self.ledger.push(compensator.into_fn());
+        // One-mechanism contract (heddle#354 r4): an eager mutation's undo is its
+        // `Compensator` (returned by `commit_eager`), NEVER the whole-op
+        // `rewind`. `enroll_whole_op` above registered the whole-op rewind only
+        // to clean up a FAILED `apply`/`commit_eager` (the early returns reach
+        // it via the shared ledger). Now that `commit_eager` has succeeded and
+        // the compensator owns the undo, take the mutation out of its cell so
+        // that pre-registered whole-op rewind closure finds `None` and is a
+        // guaranteed no-op. Without this, an `EagerMutation` that overrode
+        // `rewind` would run BOTH the override AND the compensator on an outer
+        // rollback — a double-undo.
+        let _ = mutation.borrow_mut().take();
         self.depth -= 1;
         Ok(staged.output)
     }

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -7,6 +7,9 @@
 //! only the outermost [`execute`](super::execute) reaches `commit`. The ledger
 //! is a LIFO stack of inverse closures, popped in reverse on any unwind.
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use objects::error::{HeddleError, Result};
 use oplog::OpRecord;
 
@@ -20,6 +23,8 @@ use crate::Repository;
 /// entry N" uniformly. The `'a` bound lets a closure borrow the `Repository`
 /// (e.g. to restore a ref) for the lifetime of the transaction.
 type RewindFn<'a> = Box<dyn FnOnce() -> Result<()> + 'a>;
+
+pub(crate) type EnrolledMutation<M> = Rc<RefCell<Option<M>>>;
 
 /// The ledger snapshot handed to [`AtomicMutation::rewind`](super::AtomicMutation::rewind).
 /// Carries the per-transaction scope + depth captured at apply time; a mutation
@@ -98,22 +103,44 @@ impl<'a> Tx<'a> {
         self.ledger.push(Box::new(f));
     }
 
+    pub(crate) fn enroll_whole_op<M>(&mut self, m: M) -> EnrolledMutation<M>
+    where
+        M: super::AtomicMutation + 'a,
+    {
+        let mutation = Rc::new(RefCell::new(Some(m)));
+        let rewind_mutation = Rc::clone(&mutation);
+        let ledger = self.ledger_view();
+        self.on_rewind(move || {
+            let Some(mut mutation) = rewind_mutation.borrow_mut().take() else {
+                return Ok(());
+            };
+            mutation.rewind(&ledger)
+        });
+        mutation
+    }
+
     /// Savepoint enroll — bounded to [`SavepointMutation`] (§3.3). Runs only
     /// `apply` (staged, reversible) against the *same* ledger, then registers
     /// the child's `rewind` so an outer failure unwinds it. An
     /// `EagerMutation`-only mutation fails this bound at compile time.
-    pub fn enroll<M>(&mut self, mut m: M) -> Result<StagedCommit<M::Output>>
+    pub fn enroll<M>(&mut self, m: M) -> Result<StagedCommit<M::Output>>
     where
         M: SavepointMutation + 'a,
     {
         self.depth += 1;
-        // On apply error, any granular inverses the child already pushed stay
-        // on the ledger and run when the root unwinds.
-        let staged = m.apply(self)?;
-        let ledger = self.ledger_view();
-        self.on_rewind(move || m.rewind(&ledger));
+        let mutation = self.enroll_whole_op(m);
+        // On apply error or panic, the child's whole-op rewind is already on
+        // the shared ledger, so the root unwind compensates both granular and
+        // whole-op savepoint staging uniformly.
+        let staged = {
+            let mut guard = mutation.borrow_mut();
+            guard
+                .as_mut()
+                .expect("enrolled mutation must be present during apply")
+                .apply(self)
+        };
         self.depth -= 1;
-        Ok(staged)
+        staged
     }
 
     /// Eager enroll — bounded to [`EagerMutation`], whose sole method *returns*
@@ -122,13 +149,40 @@ impl<'a> Tx<'a> {
     /// compensator is guaranteed to exist because the bound requires the method
     /// that produces it — enrolling an eager op without a compensator does not
     /// compile (§3.3).
-    pub fn enroll_eager<M>(&mut self, mut m: M) -> Result<M::Output>
+    pub fn enroll_eager<M>(&mut self, m: M) -> Result<M::Output>
     where
         M: EagerMutation + 'a,
     {
         self.depth += 1;
-        let staged = m.apply(self)?;
-        let compensator = m.commit_eager(self)?;
+        let mutation = self.enroll_whole_op(m);
+        let staged = {
+            let mut guard = mutation.borrow_mut();
+            guard
+                .as_mut()
+                .expect("enrolled mutation must be present during apply")
+                .apply(self)
+        };
+        let staged = match staged {
+            Ok(staged) => staged,
+            Err(err) => {
+                self.depth -= 1;
+                return Err(err);
+            }
+        };
+        let compensator = {
+            let mut guard = mutation.borrow_mut();
+            guard
+                .as_mut()
+                .expect("enrolled mutation must be present during eager commit")
+                .commit_eager(self)
+        };
+        let compensator = match compensator {
+            Ok(compensator) => compensator,
+            Err(err) => {
+                self.depth -= 1;
+                return Err(err);
+            }
+        };
         self.ledger.push(compensator.into_fn());
         self.depth -= 1;
         Ok(staged.output)
@@ -146,22 +200,26 @@ impl<'a> Tx<'a> {
     /// the **unbounded indexed `transaction_id`** lookup — so a crash-retry at
     /// any later time is exact-once. After this returns `Ok`, the transaction
     /// is committed and `Drop` becomes a no-op.
-    pub(crate) fn commit(&mut self, mut records: Vec<OpRecord>) -> Result<()> {
+    pub(crate) fn commit(&mut self, mut records: Vec<OpRecord>) -> Result<CommitOutcome> {
         if self.committed {
-            return Ok(());
+            return Ok(CommitOutcome::Committed);
         }
         let op_count = records.len() as u32;
         records.push(OpRecord::TransactionCommit {
             transaction_id: self.transaction_id.clone(),
             op_count,
         });
-        self.repo.oplog().record_batch_exactly_once(
+        let outcome = self.repo.oplog().record_batch_exactly_once(
             records,
             Some(&self.scope),
             &self.transaction_id,
         )?;
-        self.committed = true;
-        Ok(())
+        if outcome.is_some() {
+            self.committed = true;
+            Ok(CommitOutcome::Committed)
+        } else {
+            Ok(CommitOutcome::AlreadyCommitted)
+        }
     }
 
     /// Walk the ledger in reverse (LIFO) order, running every inverse. Drains
@@ -183,6 +241,12 @@ impl<'a> Tx<'a> {
             None => Ok(()),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CommitOutcome {
+    Committed,
+    AlreadyCommitted,
 }
 
 impl Drop for Tx<'_> {

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The transaction context `Tx` + the reverse-order rewind ledger
+//! (heddle#330 §3.1, §4).
+//!
+//! `Tx` threads through every `apply` in a nest. Inner mutations enroll into
+//! the *same* `Tx` (savepoint default) rather than committing independently;
+//! only the outermost [`execute`](super::execute) reaches `commit`. The ledger
+//! is a LIFO stack of inverse closures, popped in reverse on any unwind.
+
+use objects::error::{HeddleError, Result};
+use objects::object::ChangeId;
+use oplog::OpRecord;
+
+use super::traits::{EagerMutation, SavepointMutation, StagedCommit};
+use crate::Repository;
+
+/// One entry in the rewind ledger: a boxed inverse closure. Boxing a *closure*
+/// is an implementation detail of the ledger — it is **not** `dyn
+/// AtomicMutation`. The public composition surface (`enroll::<Inner>`) is fully
+/// static/monomorphized; this is just how the executor stores "the work to undo
+/// entry N" uniformly. The `'a` bound lets a closure borrow the `Repository`
+/// (e.g. to restore a ref) for the lifetime of the transaction.
+type RewindFn<'a> = Box<dyn FnOnce() -> Result<()> + 'a>;
+
+/// The ledger snapshot handed to [`AtomicMutation::rewind`](super::AtomicMutation::rewind).
+/// Carries the per-transaction scope + depth captured at apply time; a mutation
+/// keeps whatever else it needs in its own fields.
+#[derive(Clone, Debug)]
+pub struct RewindLedger {
+    /// The checkout lane (`Repository::op_scope`) the transaction recorded
+    /// under (heddle#330 §1.5).
+    pub scope: String,
+    /// Nesting depth at which the mutation was enrolled.
+    pub depth: u32,
+}
+
+/// The transaction context threaded through a mutation nest.
+///
+/// Holds the `Repository` handle, the checkout `scope`, the idempotency
+/// `transaction_id`, the nesting `depth`, and the reverse-order rewind ledger.
+/// Bound to the file-backed [`Repository`] (the local CLI path the primitive
+/// targets in impl-a); the hosted/Postgres path uses its own gRPC handlers.
+pub struct Tx<'a> {
+    repo: &'a Repository,
+    scope: String,
+    transaction_id: String,
+    depth: u32,
+    ledger: Vec<RewindFn<'a>>,
+    committed: bool,
+}
+
+impl<'a> Tx<'a> {
+    /// Build the root transaction: depth 0, a fresh ledger, a fresh
+    /// idempotency key, scoped to this checkout's lane.
+    pub(crate) fn root(repo: &'a Repository) -> Self {
+        Self {
+            repo,
+            scope: repo.op_scope(),
+            transaction_id: ChangeId::generate().to_string_full(),
+            depth: 0,
+            ledger: Vec::new(),
+            committed: false,
+        }
+    }
+
+    /// The repository handle this transaction operates on.
+    pub fn repo(&self) -> &'a Repository {
+        self.repo
+    }
+
+    /// The checkout lane (`op_scope`) every record in this transaction is
+    /// keyed under, so a sibling checkout's executor never unwinds this one.
+    pub fn scope(&self) -> &str {
+        &self.scope
+    }
+
+    /// The idempotency key — the same id used for the `TransactionCommit`
+    /// marker and (eventually) the on-disk sentinel (§3.4).
+    pub fn transaction_id(&self) -> &str {
+        &self.transaction_id
+    }
+
+    /// Current nesting depth.
+    pub fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    /// Register an inverse for an effect just staged. Closures run in reverse
+    /// (LIFO) order on unwind. The closure may borrow the `Repository`.
+    pub fn on_rewind<F>(&mut self, f: F)
+    where
+        F: FnOnce() -> Result<()> + 'a,
+    {
+        self.ledger.push(Box::new(f));
+    }
+
+    /// Savepoint enroll — bounded to [`SavepointMutation`] (§3.3). Runs only
+    /// `apply` (staged, reversible) against the *same* ledger, then registers
+    /// the child's `rewind` so an outer failure unwinds it. An
+    /// `EagerMutation`-only mutation fails this bound at compile time.
+    pub fn enroll<M>(&mut self, mut m: M) -> Result<StagedCommit<M::Output>>
+    where
+        M: SavepointMutation + 'a,
+    {
+        self.depth += 1;
+        // On apply error, any granular inverses the child already pushed stay
+        // on the ledger and run when the root unwinds.
+        let staged = m.apply(self)?;
+        let ledger = self.ledger_view();
+        self.on_rewind(move || m.rewind(&ledger));
+        self.depth -= 1;
+        Ok(staged)
+    }
+
+    /// Eager enroll — bounded to [`EagerMutation`], whose sole method *returns*
+    /// the [`Compensator`](super::Compensator). Stages via `apply`, runs
+    /// `commit_eager`, and registers the returned compensator atomically. The
+    /// compensator is guaranteed to exist because the bound requires the method
+    /// that produces it — enrolling an eager op without a compensator does not
+    /// compile (§3.3).
+    pub fn enroll_eager<M>(&mut self, mut m: M) -> Result<M::Output>
+    where
+        M: EagerMutation + 'a,
+    {
+        self.depth += 1;
+        let staged = m.apply(self)?;
+        let compensator = m.commit_eager(self)?;
+        self.ledger.push(compensator.into_fn());
+        self.depth -= 1;
+        Ok(staged.output)
+    }
+
+    pub(crate) fn ledger_view(&self) -> RewindLedger {
+        RewindLedger {
+            scope: self.scope.clone(),
+            depth: self.depth,
+        }
+    }
+
+    /// THE commit point (heddle#330 §2.2 phase 4): append the accumulated
+    /// records plus a `TransactionCommit` marker as one batch, deduplicated by
+    /// the **unbounded indexed `transaction_id`** lookup — so a crash-retry at
+    /// any later time is exact-once. After this returns `Ok`, the transaction
+    /// is committed and `Drop` becomes a no-op.
+    pub(crate) fn commit(&mut self, mut records: Vec<OpRecord>) -> Result<()> {
+        if self.committed {
+            return Ok(());
+        }
+        let op_count = records.len() as u32;
+        records.push(OpRecord::TransactionCommit {
+            transaction_id: self.transaction_id.clone(),
+            op_count,
+        });
+        self.repo.oplog().record_batch_exactly_once(
+            records,
+            Some(&self.scope),
+            &self.transaction_id,
+        )?;
+        self.committed = true;
+        Ok(())
+    }
+
+    /// Walk the ledger in reverse (LIFO) order, running every inverse. Drains
+    /// the ledger so a second call (e.g. from `Drop`) is a no-op. Surfaces the
+    /// first rewind error after attempting every entry.
+    pub(crate) fn rewind_all(&mut self) -> Result<()> {
+        let mut first_err: Option<HeddleError> = None;
+        while let Some(f) = self.ledger.pop() {
+            if let Err(e) = f() {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                } else {
+                    tracing::error!(error = %e, "additional Tx rewind failure (suppressed)");
+                }
+            }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for Tx<'_> {
+    /// Backstop for the panic path (heddle#330 §4): a `Tx` dropped **without**
+    /// having reached `commit` (a panic unwound through `apply`) is by
+    /// construction pre-commit, so the safe action is always to rewind the
+    /// staged effects — never to half-commit. It NEVER appends to the oplog.
+    /// Logs (does not panic) on a rewind error to avoid a double-panic abort.
+    fn drop(&mut self) {
+        if !self.committed
+            && let Err(e) = self.rewind_all()
+        {
+            tracing::error!(
+                error = %e,
+                "Tx Drop rewind failed; staged effects may persist as orphans \
+                 (gc-collectable) — see transaction sentinel for recovery"
+            );
+        }
+    }
+}

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -229,7 +229,14 @@ impl<'a> Tx<'a> {
             self.committed = true;
             Ok(CommitOutcome::Committed)
         } else {
-            Ok(CommitOutcome::AlreadyCommitted)
+            // Dedup hit: a prior (possibly cross-process) run already committed
+            // this transaction. Carry its records back so the executor can
+            // reconstruct the originally-committed output (cid 3329631075).
+            let prior = self
+                .repo
+                .oplog()
+                .committed_batch_records(&self.transaction_id)?;
+            Ok(CommitOutcome::AlreadyCommitted(prior))
         }
     }
 
@@ -254,10 +261,13 @@ impl<'a> Tx<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub(crate) enum CommitOutcome {
     Committed,
-    AlreadyCommitted,
+    /// The transaction was already committed by a prior run; carries that
+    /// committed batch's records (marker stripped) so the executor can
+    /// reconstruct the originally-committed output (cid 3329631075).
+    AlreadyCommitted(Vec<OpRecord>),
 }
 
 impl Drop for Tx<'_> {

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -8,7 +8,6 @@
 //! is a LIFO stack of inverse closures, popped in reverse on any unwind.
 
 use objects::error::{HeddleError, Result};
-use objects::object::ChangeId;
 use oplog::OpRecord;
 
 use super::traits::{EagerMutation, SavepointMutation, StagedCommit};
@@ -50,13 +49,18 @@ pub struct Tx<'a> {
 }
 
 impl<'a> Tx<'a> {
-    /// Build the root transaction: depth 0, a fresh ledger, a fresh
-    /// idempotency key, scoped to this checkout's lane.
-    pub(crate) fn root(repo: &'a Repository) -> Self {
+    /// Build the root transaction: depth 0, a fresh ledger, scoped to this
+    /// checkout's lane, keyed by the caller-supplied **stable** idempotency
+    /// `transaction_id` (heddle#330 §2.2, cid 3329490982). The id must be the
+    /// same across retries of the same logical op — see
+    /// [`AtomicMutation::transaction_id`](super::AtomicMutation::transaction_id)
+    /// — so a crash-retry deduplicates against the prior commit instead of
+    /// minting a new key and double-applying.
+    pub(crate) fn root(repo: &'a Repository, transaction_id: String) -> Self {
         Self {
             repo,
             scope: repo.op_scope(),
-            transaction_id: ChangeId::generate().to_string_full(),
+            transaction_id,
             depth: 0,
             ledger: Vec::new(),
             committed: false,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -78,7 +78,7 @@ pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,
-    compute_heavy_impact_paths, format_confidence, record_snapshot_in_oplog,
+    compute_heavy_impact_paths, format_confidence,
     refresh_active_thread_metadata, refresh_thread_freshness, summarize_confidence,
     summarize_verification, update_thread_state_from_state,
 };

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -7,6 +7,7 @@ compile_error!(
      See crates/repo/Cargo.toml."
 );
 
+pub mod atomic;
 pub mod daemon;
 mod ephemeral_thread;
 mod fsmonitor;

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -78,7 +78,7 @@ use objects::{
 };
 use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
-use refs::{Head, RefBackend, RefManager};
+use refs::{Head, RefBackend, RefManager, RefUpdate};
 
 use crate::git_worktree_status::GitWorktreeEntryState;
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
@@ -351,6 +351,16 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
 /// those are bound to the default `AnyStore` flavor and live in
 /// [`Repository::run_open_hooks`], which the config-driven [`Repository::open`]
 /// invokes after `open_raw`.
+/// The per-worktree checkout lane (heddle#330 §1.5). Free function so the
+/// reconciler can be wired at construction (before a `Repository` exists)
+/// using the same computation as [`Repository::op_scope`].
+pub(crate) fn compute_op_scope(root: &Path) -> String {
+    let local_head = root.join(".heddle").join("HEAD");
+    let canonical = local_head.canonicalize().unwrap_or(local_head);
+    let digest = blake3::hash(canonical.to_string_lossy().as_bytes());
+    format!("wt-{}", &digest.to_hex().as_str()[..16])
+}
+
 impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
     fn open_raw(
         root: PathBuf,
@@ -364,8 +374,18 @@ impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
             .as_ref()
             .map(|p| objects::object::Principal::new(&p.name, &p.email))
             .unwrap_or_else(|| objects::object::Principal::new("<unknown>", ""));
-        let oplog = OpLog::new(&heddle_dir, actor);
+        let oplog = OpLog::new(&heddle_dir, actor.clone());
         let shallow = ShallowInfo::load(&heddle_dir)?;
+        // Inject the oplog-backed read + write chokepoints (heddle#330 §2.2):
+        // every logical read reconciles against the committed oplog tail, and
+        // `commit_and_publish` appends a ref-carrying record before publishing.
+        let reconciler = std::sync::Arc::new(crate::atomic::OplogRefReconciler::new(
+            &heddle_dir,
+            compute_op_scope(&root),
+        ));
+        let committer =
+            std::sync::Arc::new(crate::atomic::OplogRefCommitter::new(&heddle_dir, actor));
+        let refs = refs.with_reconciler(reconciler).with_committer(committer);
         Ok(Self::from_parts(
             root, heddle_dir, store, refs, oplog, config, shallow,
         ))
@@ -526,6 +546,19 @@ impl Repository {
         refs.write_head(&Head::Attached {
             thread: ThreadName::from("main"),
         })?;
+
+        // Inject the oplog-backed read + write chokepoints (heddle#330 §2.2) —
+        // same as `open_raw`, so a freshly-init'd handle reconciles and
+        // record-commits too.
+        let reconciler = std::sync::Arc::new(crate::atomic::OplogRefReconciler::new(
+            &heddle_dir,
+            compute_op_scope(&root),
+        ));
+        let committer = std::sync::Arc::new(crate::atomic::OplogRefCommitter::new(
+            &heddle_dir,
+            objects::object::Principal::new("<unknown>", ""),
+        ));
+        let refs = refs.with_reconciler(reconciler).with_committer(committer);
 
         let capability = repository_capability_for_root(&root);
         Ok(Self {
@@ -1647,10 +1680,30 @@ impl Repository {
         //     shared-oplog setups
         //   * opaque on disk — the user's home directory and username
         //     never end up serialized into oplog entries
-        let local_head = self.root.join(".heddle").join("HEAD");
-        let canonical = local_head.canonicalize().unwrap_or(local_head);
-        let digest = blake3::hash(canonical.to_string_lossy().as_bytes());
-        format!("wt-{}", &digest.to_hex().as_str()[..16])
+        compute_op_scope(&self.root)
+    }
+
+    /// The write chokepoint (heddle#330 §2.2): commit the ref-carrying
+    /// `OpRecord` batch (phase 4) **before** publishing the atomic `ref_updates`
+    /// batch (phase 5), record-before-publish. Encodes the records opaquely and
+    /// routes through [`RefBackend::commit_and_publish`] so the backend's seam
+    /// enforces the ordering — the file backend appends-then-publishes, a
+    /// Postgres backend would co-commit in one SQL transaction. Replaces the
+    /// publish-then-record order that left a reader-visible ref with no undo
+    /// record (the fork/collapse bug).
+    pub fn commit_and_publish(
+        &self,
+        records: Vec<OpRecord>,
+        ref_updates: &[RefUpdate],
+    ) -> Result<()> {
+        let encoded = records
+            .iter()
+            .map(|record| {
+                rmp_serde::to_vec(record).map_err(|e| HeddleError::Serialization(e.to_string()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let scope = self.op_scope();
+        self.refs.commit_and_publish(&encoded, ref_updates, Some(&scope))
     }
 
     pub fn repo_config(&self) -> &RepoConfig {

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -78,7 +78,7 @@ use objects::{
 };
 use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
-use refs::{Head, RefBackend, RefManager, RefUpdate};
+use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
 
 use crate::git_worktree_status::GitWorktreeEntryState;
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
@@ -1712,7 +1712,57 @@ impl Repository {
             })
             .collect::<Result<Vec<_>>>()?;
         let scope = self.op_scope();
-        self.refs.commit_and_publish(&encoded, ref_updates, Some(&scope))
+        let result = self.refs.commit_and_publish(&encoded, ref_updates, Some(&scope));
+        // The committer appended through a fresh `OpLog` handle (the `refs`→`repo`
+        // seam), so this repository's own cached oplog handle is now stale.
+        // Refresh it so a same-process read via `self.oplog()` observes the
+        // just-committed records — the long-lived mount/daemon handle would
+        // otherwise miss them (heddle#354 r8). Best-effort: a refresh failure
+        // only costs a stale cache until the next disk reload, never correctness.
+        let _ = self.oplog.refresh_cache();
+        result
+    }
+
+    /// Atomically commit a snapshot's `OpRecord::Snapshot` and its paired ref
+    /// publish through the write chokepoint, **record-first** (heddle#354 r8).
+    ///
+    /// The pre-r8 snapshot path published the ref FIRST (`refs.set_thread` /
+    /// `refs.write_head`) and recorded SECOND. Because the reconciler folds a
+    /// `Snapshot` record authoritatively (newest committed record wins), a late
+    /// snapshot record carrying a stale thread value could clobber a newer
+    /// concurrent write that had already recorded. Routing every snapshot ref
+    /// write through this single chokepoint makes the record the unit of
+    /// ordering: the newest committed record IS the newest write, so the
+    /// authoritative fold can no longer resurrect a stale snapshot.
+    ///
+    /// `thread = Some(name)` advances that thread (HEAD stays attached);
+    /// `thread = None` republishes a detached HEAD. The detached case is now
+    /// record-first too, so a phase-4-committed / phase-5-unpublished crash is
+    /// recovered by the reconciler reconstructing `Head::Detached{new_state}`
+    /// (see `atomic::reconciler`'s detached-`Snapshot` arm).
+    pub fn commit_snapshot_atomic(
+        &self,
+        new_state: &ChangeId,
+        prev_head: Option<ChangeId>,
+        thread: Option<&ThreadName>,
+    ) -> Result<()> {
+        let record = OpRecord::Snapshot {
+            new_state: *new_state,
+            prev_head,
+            thread: thread.map(|name| name.to_string()),
+        };
+        let ref_update = match thread {
+            Some(name) => RefUpdate::Thread {
+                name: name.clone(),
+                expected: RefExpectation::Any,
+                new: Some(*new_state),
+            },
+            None => RefUpdate::Head {
+                expected: RefExpectation::Any,
+                new: Head::Detached { state: *new_state },
+            },
+        };
+        self.commit_and_publish(vec![record], &[ref_update])
     }
 
     pub fn repo_config(&self) -> &RepoConfig {

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -386,6 +386,11 @@ impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
         let committer =
             std::sync::Arc::new(crate::atomic::OplogRefCommitter::new(&heddle_dir, actor));
         let refs = refs.with_reconciler(reconciler).with_committer(committer);
+        // Seed the per-read watermark from the persisted last-clean point
+        // (heddle#354 r5, cid 3329631074) so a fresh handle folds — and recovers
+        // — a prior process's committed-but-unpublished crash tail on its next
+        // read, without re-deriving long-since-deleted refs from ancient records.
+        refs.init_reconcile_watermark()?;
         Ok(Self::from_parts(
             root, heddle_dir, store, refs, oplog, config, shallow,
         ))
@@ -559,6 +564,10 @@ impl Repository {
             objects::object::Principal::new("<unknown>", ""),
         ));
         let refs = refs.with_reconciler(reconciler).with_committer(committer);
+        // Establish the persisted reconcile watermark at init (heddle#354 r5,
+        // cid 3329631074) so subsequent processes seed from a real last-clean
+        // point — parity with `open_raw`.
+        refs.init_reconcile_watermark()?;
 
         let capability = repository_capability_for_root(&root);
         Ok(Self {

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -238,23 +238,11 @@ impl Repository {
                 Head::Detached { .. } => None,
             };
 
-            match head {
-                Head::Attached { thread } => {
-                    self.refs.set_thread(&thread, &state.change_id)?;
-                }
-                Head::Detached { .. } => {
-                    self.refs.write_head(&Head::Detached {
-                        state: state.change_id,
-                    })?;
-                }
-            }
-
-            self.oplog.record_snapshot(
-                &state.change_id,
-                prev_head.as_ref(),
-                thread.as_deref(),
-                Some(&self.op_scope()),
-            )?;
+            // Record-first through the write chokepoint (heddle#354 r8): the
+            // `OpRecord::Snapshot` commits before the thread/HEAD publish, so a
+            // late snapshot record can no longer clobber a newer concurrent
+            // write under the reconciler's authoritative fold.
+            self.commit_snapshot_atomic(&state.change_id, prev_head, thread.as_ref())?;
 
             // Refresh the thread manifest when capturing inside a
             // materialized-thread worktree: bump `state_id` + `tree_hash`
@@ -410,23 +398,8 @@ impl Repository {
                 Head::Detached { .. } => None,
             };
 
-            match head {
-                Head::Attached { thread } => {
-                    self.refs.set_thread(&thread, &state.change_id)?;
-                }
-                Head::Detached { .. } => {
-                    self.refs.write_head(&Head::Detached {
-                        state: state.change_id,
-                    })?;
-                }
-            }
-
-            self.oplog.record_snapshot(
-                &state.change_id,
-                prev_head.as_ref(),
-                thread.as_deref(),
-                Some(&self.op_scope()),
-            )?;
+            // Record-first through the write chokepoint (heddle#354 r8).
+            self.commit_snapshot_atomic(&state.change_id, prev_head, thread.as_ref())?;
 
             Ok(SnapshotExecution {
                 state,
@@ -507,23 +480,8 @@ impl Repository {
             Head::Detached { .. } => None,
         };
 
-        match head {
-            Head::Attached { thread } => {
-                self.refs.set_thread(&thread, &state.change_id)?;
-            }
-            Head::Detached { .. } => {
-                self.refs.write_head(&Head::Detached {
-                    state: state.change_id,
-                })?;
-            }
-        }
-
-        self.oplog.record_snapshot(
-            &state.change_id,
-            Some(&first_parent),
-            thread.as_deref(),
-            Some(&self.op_scope()),
-        )?;
+        // Record-first through the write chokepoint (heddle#354 r8).
+        self.commit_snapshot_atomic(&state.change_id, Some(first_parent), thread.as_ref())?;
 
         Ok(state)
     }

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -309,19 +309,6 @@ fn is_public_api_path(path: &str) -> bool {
         || path.ends_with("/public.rs")
 }
 
-/// Record this snapshot in the oplog, mirroring the worktree-snapshot
-/// path. The mount-side `capture()` calls this after planting the
-/// new state and updating the thread ref.
-pub fn record_snapshot_in_oplog(
-    repo: &Repository,
-    new_state: &ChangeId,
-    prev_head: Option<&ChangeId>,
-    thread: Option<&str>,
-) -> Result<u64, HeddleError> {
-    repo.oplog()
-        .record_snapshot(new_state, prev_head, thread, Some(&repo.op_scope()))
-}
-
 /// Translate `ChangeId` short-strings into `ChangeId`s if the thread
 /// references one. `Repository::resolve_state` already handles the
 /// alias forms; this just flattens the option for callers.

--- a/scripts/check-snapshot-atomicity.sh
+++ b/scripts/check-snapshot-atomicity.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Asserter for the cross-crate publish-first snapshot bug class
+# (heddle#354 r8). A `syn`-based AST walker living in `heddle-devtools`
+# walks the WHOLE workspace and fails CI if any production function
+# co-locates a raw refs-publish (`refs.set_thread` / `refs.write_head`
+# / etc.) with a snapshot-record append (`oplog.record_snapshot` or the
+# `record_snapshot_in_oplog` wrapper).
+#
+# The bug class:
+#   self.refs.set_thread(&thread, &state.change_id)?;  // PUBLISH (phase 5)
+#   self.oplog.record_snapshot(...)?;                   // RECORD  (phase 4)
+# A snapshot published its ref BEFORE recording its `OpRecord::Snapshot`.
+# Because the reconciler folds a `Snapshot` record authoritatively
+# (newest committed record wins), a late snapshot record carrying a
+# stale thread value could clobber a newer concurrent write. The fix is
+# `Repository::commit_snapshot_atomic(...)`, which commits the record
+# BEFORE publishing the ref via the record-first `commit_and_publish`
+# chokepoint.
+#
+# This complements the refs-crate-internal `write_read_conformance`
+# check (heddle#354 r7): that one guards the refs-internal raw writers
+# but is blind to cross-crate callers. This one walks every crate, so a
+# publish-first snapshot in `repo`, `mount`, or any future caller fails
+# CI (the coverage hole r7 left).
+#
+# Driving knobs (consumed by the binary):
+#   HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS — colon-separated dirs
+#                                           (default: `crates`)
+#   HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST   — semicolon-separated
+#                                           `path:line` entries (of the
+#                                           publish call); empty string
+#                                           disables, unset uses the
+#                                           built-in default.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Default allowlist for production code: EMPTY. The two known sites
+# (crates/repo/src/repository_snapshot.rs, crates/mount/src/core.rs)
+# were fixed to route through `commit_snapshot_atomic`, not exempted.
+DEFAULT_ALLOWLIST=""
+
+if [[ -z "${HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST+set}" ]]; then
+  export HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST="$DEFAULT_ALLOWLIST"
+fi
+
+# Build the binary up front so its first-run output doesn't interleave
+# with the asserter's stdout. Quiet on success; cargo's own diagnostics
+# still go through if the build fails.
+(
+  cd "$WORKSPACE_ROOT"
+  cargo build -p heddle-devtools --quiet
+)
+
+exec cargo run -p heddle-devtools --quiet --manifest-path "$WORKSPACE_ROOT/Cargo.toml" -- \
+  check-snapshot-atomicity


### PR DESCRIPTION
## Summary

Lands the foundational atomic-mutation primitive from the [#330 spike](../blob/main/docs/spikes/heddle-330-atomic-mutation-primitive.md) (§7 item 1), **in the `repo` crate** (new `crates/repo/src/atomic/` module — **no new crate**, per owner decision). Closes #354.

- **Core primitive** (`crates/repo/src/atomic/`): `AtomicMutation`/`SavepointMutation`/`EagerMutation` traits, `Tx`, generic `execute`, the reverse-order rewind ledger + `Drop` backstop, `StagedCommit`/`Compensator`. dyn-free public surface; the savepoint/eager split is a **compile-time** type-level guarantee (no `COMMIT_KIND` const, no release-eliding `debug_assert!`).
- **Commit point**: the oplog append is the sole commit, deduplicated by a new **unbounded indexed `transaction_id`** lookup (`OpLog::record_batch_exactly_once`) — exact-once at *any* retry timing, not the window-bounded helper.
- **Read chokepoint**: one internal `reconciled_load` that **all 10** `RefManager` read methods funnel through, reconciling against the committed oplog tail via a `refs`-defined `RefReconciler` trait injected from `repo` — so **`refs` keeps no `oplog` dep** (verified). Ref-class-scoped (local=`op_scope`, shared=global), **two watermarks** seeded to the open-time generation (the load-bearing long-held-handle cell, cid 3328112197). Reconciliation is **fill-if-absent** so the un-migrated tree's not-yet-recorded writes are never regressed.
- **Write chokepoint**: `commit_and_publish` as a **`RefBackend`-trait method** (record-before-publish) with a `refs`-defined `RefCommitter` injected from `repo`; the raw temp→rename publish is its sub-step. `cmd_fork`/`cmd_collapse` routed through it — fixing the publish-then-record order **and** the reversed `record_fork` argument order (r15).
- **Oplog format** (pre-1.0 clean break, **no migration shim**): new `RemoteThreadUpdate`/`RemoteThreadDelete`/`UndoRecoveryUpdate` tail variants; `Fork`/`Collapse` extended **in place** to carry the published ref identity.

### Staged within the epic (not in this PR)
- Full 46-site write routing + the **Postgres single-tx co-commit** (the server's shared-pool wiring is outside this tree; `PgRefBackend` keeps the publish-only default).
- The optional `Repository::open` eager pass for *pre-open* crash lag (the spike's stated optimization, not the guarantee) — and full HEAD reconstruction (current `Snapshot`/`Goto` records don't carry post-HEAD state; the canonical HEAD stays authoritative).

## Test plan (red→green evidence)

All in `crates/repo/src/atomic/tests.rs` + `crates/oplog/src/oplog/oplog_tests.rs`:
- [x] reverse-order rewind on mid-apply failure (LIFO `[3,2,1]`)
- [x] panic-unwind runs the `Drop` backstop; never commits
- [x] `execute` commits the staged record + `TransactionCommit` marker
- [x] eager compensator runs on outer rollback (type-level split enforced)
- [x] delayed-retry exact-once **past** a 200-batch window (unbounded dedup)
- [x] all-10-reader reconciliation of committed-but-unpublished refs
- [x] write-chokepoint: a published ref always has a preceding ref-carrying record
- [x] crash-replay across reader shapes: long-held handle + concurrent commit
- [x] `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `check-no-silent-default-tree-load.sh` clean; `doctor docs --all` no issues; `doctor schemas` no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782769902&installation_id=132405951&pr_number=362&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F362&signature=399452e2050b882ebe89ec00fb4710bd3e0375c3a82735e44ee10e41d8e7c7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->