### PR TITLE
chore: scrub real personal name/email from example & test data

### DIFF
--- a/.agents/redaction-primitive.md
+++ b/.agents/redaction-primitive.md
@@ -70,7 +70,7 @@ pub enum OpKind {
 Materialization path (the place where `Repository::read_file` builds a working file from a state's tree) checks for an outstanding `Redaction` on the blob hash before returning bytes. If redacted, return a stub:
 
 ```
-# this file was redacted on 2026-05-10T14:33Z by anan@heddle.sh
+# this file was redacted on 2026-05-10T14:33Z by grace@example.com
 # reason: leaked credential
 # redaction: hd-r4d4c7e0 (signed)
 ```

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -414,8 +414,8 @@ fn truncate(s: &str, max_len: usize) -> String {
 
 /// Fit an attribution string (`Name <email>`) into `max_len` characters
 /// without losing semantic information. The default truncation cuts
-/// `"Luke Thorne <the.thorne48@gmail.com>"` to `"Luke Thorne <the..."` —
-/// which keeps the noise (`<the...`) and drops the signal (the actual
+/// `"Ada Lovelace <ada@really.long.example.com>"` to `"Ada Lovelace <ada..."` —
+/// which keeps the noise (`<ada...`) and drops the signal (the actual
 /// name and email host). Strategy:
 ///
 /// 1. If the full string fits, return it.

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -11560,8 +11560,8 @@ fn default_undo_text_hides_batches_and_checkpoint_ids_until_verbose() {
 
 #[test]
 fn blame_drops_email_when_attribution_overflows_column() {
-    // `Luke Thorne <the.thorne48@gmail.com>` blew the 20-char column,
-    // truncating to `Luke Thorne <the...` — keeping the noise and
+    // `Ada Lovelace <ada@really.long.example.com>` blew the 20-char column,
+    // truncating to `Ada Lovelace <ada...` — keeping the noise and
     // dropping the signal. The fit_author helper drops the email
     // entirely when the name alone fits the column.
     let temp = TempDir::new().unwrap();

--- a/crates/objects/src/object/redaction.rs
+++ b/crates/objects/src/object/redaction.rs
@@ -205,8 +205,8 @@ mod tests {
 
     fn principal() -> Principal {
         Principal {
-            name: "Anan".into(),
-            email: "anan@heddle.sh".into(),
+            name: "Grace Hopper".into(),
+            email: "grace@example.com".into(),
         }
     }
 
@@ -280,8 +280,8 @@ mod tests {
         // The stub is the ONLY thing readers see for redacted files. It
         // must carry every field a reviewer would want: who, when, why,
         // and whether the bytes are still recoverable.
-        assert!(stub.contains("Anan"));
-        assert!(stub.contains("anan@heddle.sh"));
+        assert!(stub.contains("Grace Hopper"));
+        assert!(stub.contains("grace@example.com"));
         assert!(stub.contains("leaked credential"));
         assert!(stub.contains("# redacted-at:"));
         assert!(stub.contains("# redaction:"));

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -789,8 +789,8 @@ mod tests {
 
     fn sample_principal() -> Principal {
         Principal {
-            name: "Anan".into(),
-            email: "anan@heddle.sh".into(),
+            name: "Grace Hopper".into(),
+            email: "grace@example.com".into(),
         }
     }
 


### PR DESCRIPTION
## Summary
heddle is public; a privacy scan turned up a **real personal name + Gmail** and a personal-looking redaction principal embedded as example/test data. This replaces them with synthetic placeholders. **Comment/test-data only — no behavior change.**

- `Luke Thorne <the.thorne48@gmail.com>` → `Ada Lovelace <ada@really.long.example.com>` (the fixture the same test already uses): `crates/cli/src/cli/commands/blame.rs` (doc comment) + `crates/cli/tests/cli_integration/oss_cli_polish.rs` (test comment).
- `Anan <anan@heddle.sh>` → `Grace Hopper <grace@example.com>` (RFC 2606 reserved domain): redaction test principals in `crates/objects/src/object/redaction.rs` (fixture + assertions kept in sync) and `crates/repo/src/repository_redaction.rs`, plus the `.agents/redaction-primitive.md` stub example.

Synthetic role addresses already in the tree (`auditor@heddle.sh`, `tester@heddle.sh`) were left as-is — not personal data.

## Note
This removes the PII from the working tree going forward; it still exists in prior git history. Purging history would need a separate, destructive `filter-repo` + force-push and is out of scope here.

## Test plan
- [ ] `cargo test --workspace` (redaction tests assert on the new placeholder strings)
- [ ] clippy clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782842346&installation_id=132405951&pr_number=376&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F376&signature=5a7403a72ac114a01141eb078d02a60e79309b9e34987539c4c25f215f2d7bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->