### PR TITLE
heddle#355: migrate undo/redo to the AtomicMutation primitive (impl-b)

### DIFF
--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -1039,14 +1039,18 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
                 | OpRecord::RemoteThreadDelete { .. }
                 | OpRecord::UndoRecoveryUpdate { .. } => continue,
             };
-            let Some(record) = manager.find_by_thread(name)? else {
-                continue;
-            };
-            let Some(path) = record.materialized_path.as_ref() else {
-                continue;
-            };
-            if path.exists() {
-                blocking.push((entry.id, name.clone(), path.clone()));
+            // The `ThreadCreate` inverse converges the name to EMPTY — it removes
+            // EVERY record filed under the name, not just the `find_by_thread`
+            // winner. So the preflight must check the FULL same-name set: a
+            // non-winner duplicate with a live `materialized_path` would otherwise
+            // pass this gate and have its worktree orphaned by the converge.
+            for record in manager.snapshot_records(name)? {
+                let Some(path) = record.materialized_path.as_ref() else {
+                    continue;
+                };
+                if path.exists() {
+                    blocking.push((entry.id, name.clone(), path.clone()));
+                }
             }
         }
     }
@@ -1085,4 +1089,124 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
         first_drop_command.clone(),
         vec![first_drop_command, "heddle undo --list".to_string()],
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn record(
+        id: &str,
+        thread: &str,
+        materialized: Option<std::path::PathBuf>,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> repo::Thread {
+        repo::Thread {
+            id: id.to_string(),
+            thread: thread.to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode: repo::ThreadMode::Solid,
+            state: repo::ThreadState::Active,
+            base_state: "base".to_string(),
+            base_root: "root".to_string(),
+            current_state: Some("base".to_string()),
+            merged_state: None,
+            task: None,
+            execution_path: std::path::PathBuf::from("/work/exec"),
+            materialized_path: materialized,
+            changed_paths: vec![],
+            impact_categories: vec![],
+            heavy_impact_paths: vec![],
+            promotion_suggested: false,
+            freshness: repo::ThreadFreshness::Current,
+            verification_summary: repo::ThreadVerificationSummary::default(),
+            confidence_summary: repo::ThreadConfidenceSummary::default(),
+            integration_policy_result: repo::ThreadIntegrationPolicy::default(),
+            created_at: chrono::Utc::now(),
+            updated_at,
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        }
+    }
+
+    /// The worktree-safety preflight must check EVERY record the `ThreadCreate`
+    /// inverse will remove — the converge empties the WHOLE same-name set — not
+    /// just the `find_by_thread` winner (cid 3331603138). A non-winner duplicate
+    /// with a LIVE materialized worktree, sitting behind a winner whose path no
+    /// longer exists, must still trip the refusal; otherwise the converge orphans
+    /// that live worktree. Fails against the winner-only check (the winner's path
+    /// is gone, so it passed) and passes against the set-aware check.
+    #[test]
+    fn worktree_undo_safe_checks_full_same_name_set_not_just_winner() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // A live worktree directory for the NON-winner duplicate.
+        let live_worktree = temp.path().join("live-worktree");
+        std::fs::create_dir_all(&live_worktree).unwrap();
+
+        let now = chrono::Utc::now();
+        // Winner (newer `updated_at`) — its materialized path does NOT exist, so a
+        // winner-only check would not block.
+        let winner = record(
+            "rec-winner",
+            "feature/x",
+            Some(temp.path().join("gone-worktree")),
+            now,
+        );
+        manager.save(&winner).unwrap();
+        // Non-winner duplicate (older) — its materialized path EXISTS on disk.
+        let dup = record(
+            "rec-dup",
+            "feature/x",
+            Some(live_worktree.clone()),
+            now - chrono::Duration::seconds(60),
+        );
+        manager.save(&dup).unwrap();
+
+        // Sanity: the winner-only view would NOT block — the winner is selected and
+        // its path is gone.
+        let winner_seen = manager.find_by_thread("feature/x").unwrap().unwrap();
+        assert_eq!(winner_seen.id, "rec-winner");
+        assert!(!winner_seen.materialized_path.unwrap().exists());
+
+        // Record a `ThreadCreateV2` for the name; its undo converges the name to
+        // empty, removing BOTH same-name records.
+        std::fs::write(temp.path().join("f.txt"), "x").unwrap();
+        let state = repo.snapshot(Some("s".to_string()), None).unwrap().change_id;
+        let scope = repo.op_scope();
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::ThreadCreateV2 {
+                    name: "feature/x".to_string(),
+                    state,
+                    manager_snapshot: None,
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        assert!(
+            batches.iter().any(|b| b.entries.iter().any(|e| matches!(
+                &e.operation,
+                OpRecord::ThreadCreateV2 { name, .. } if name == "feature/x"
+            ))),
+            "the recorded ThreadCreateV2 is the undoable batch"
+        );
+
+        let result = ensure_thread_worktree_undo_safe(&repo, &batches);
+        assert!(
+            result.is_err(),
+            "the live non-winner duplicate worktree must trip the refusal"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains(&live_worktree.display().to_string()),
+            "the refusal names the live non-winner worktree path: {msg}"
+        );
+    }
 }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -15,7 +15,8 @@ use super::{
     command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     undo_apply::{
-        RedoOp, UndoOp, preflight_redo_batches, preflight_undo_batches, undo_redo_transaction_id,
+        RedoOp, UndoOp, acquire_undo_redo_lock, preflight_redo_batches, preflight_undo_batches,
+        undo_redo_transaction_id,
     },
     worktree_safety::ensure_worktree_clean,
 };
@@ -106,15 +107,14 @@ pub fn cmd_undo(
 
     if list {
         let scope = repo.op_scope();
-        // Drop record-less commit sentinels (an `undo`/`redo`'s marker-only
-        // batch) so they never pollute the history view — they carry no
-        // user-facing operation. See `OpBatch::is_transaction_marker_only`.
+        // Count only user-facing batches toward `depth`, dropping the record-less
+        // commit sentinels (an `undo`/`redo`'s marker-only batch) BEFORE the
+        // limit applies. Filtering after a fixed-count fetch made `--depth 1`
+        // return empty whenever the latest op was itself an undo/redo, whose
+        // marker is the newest batch (heddle#355 cid 3330867777).
         let batches: Vec<OpBatch> = repo
             .oplog()
-            .recent_batches_scoped(depth, Some(&scope))?
-            .into_iter()
-            .filter(|batch| !batch.is_transaction_marker_only())
-            .collect();
+            .recent_user_batches_scoped(depth, Some(&scope))?;
         let output = OpListOutput {
             output_kind: "undo_list",
             batches: batches.iter().map(build_batch_output).collect(),
@@ -135,6 +135,12 @@ pub fn cmd_undo(
 
         return Ok(());
     }
+
+    // Serialize the whole select→apply→commit against concurrent undo/redo so two
+    // invocations can't collide on the generation-derived transaction id (see
+    // `acquire_undo_redo_lock`; heddle#355 cid 3330867776). Held until the
+    // command returns, covering the `--preview` short-circuit and the commit.
+    let _undo_redo_lock = acquire_undo_redo_lock(&repo)?;
 
     let scope = repo.op_scope();
     let batches = repo.oplog().undo_batches_scoped(steps, Some(&scope))?;
@@ -269,6 +275,10 @@ pub fn cmd_undo(
 
 pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+
+    // Serialize against concurrent undo/redo (mirror of `cmd_undo`; heddle#355
+    // cid 3330867776).
+    let _undo_redo_lock = acquire_undo_redo_lock(&repo)?;
 
     let scope = repo.op_scope();
     let batches = repo.oplog().redo_batches_scoped(steps, Some(&scope))?;

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -15,7 +15,7 @@ use super::{
     command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     undo_apply::{
-        apply_redo_batch, apply_undo_batch, preflight_redo_batches, preflight_undo_batches,
+        RedoOp, UndoOp, preflight_redo_batches, preflight_undo_batches, undo_redo_transaction_id,
     },
     worktree_safety::ensure_worktree_clean,
 };
@@ -106,7 +106,15 @@ pub fn cmd_undo(
 
     if list {
         let scope = repo.op_scope();
-        let batches = repo.oplog().recent_batches_scoped(depth, Some(&scope))?;
+        // Drop record-less commit sentinels (an `undo`/`redo`'s marker-only
+        // batch) so they never pollute the history view — they carry no
+        // user-facing operation. See `OpBatch::is_transaction_marker_only`.
+        let batches: Vec<OpBatch> = repo
+            .oplog()
+            .recent_batches_scoped(depth, Some(&scope))?
+            .into_iter()
+            .filter(|batch| !batch.is_transaction_marker_only())
+            .collect();
         let output = OpListOutput {
             output_kind: "undo_list",
             batches: batches.iter().map(build_batch_output).collect(),
@@ -192,17 +200,21 @@ pub fn cmd_undo(
     //
     // heddle#305 r2: this is written to a heddle-INTERNAL ref, not a user
     // marker — see UNDO_RECOVERY_MARKER. Keeping it out of `refs/markers/`
-    // means the `MarkerDelete` undo inverse below can never collide with it.
+    // means the `MarkerDelete` undo inverse can never collide with it.
+    //
+    // heddle#355: the recovery-ref write and every batch's worktree rewrite +
+    // mark-undone now run inside ONE atomic transaction (`UndoOp`), so a
+    // failure mid-undo rewinds every applied step back to the pre-undo state
+    // instead of leaving the repo half-rewound. The preflights above still run
+    // outside the transaction (their structured refusals are unchanged).
     let recovery_state = repo.head()?;
-    if let Some(state) = recovery_state {
-        repo.refs().set_undo_recovery(&state)?;
-    }
-
-    let mut updated_batches = Vec::with_capacity(batches.len());
-    for batch in batches {
-        apply_undo_batch(&repo, &batch)?;
-        updated_batches.push(repo.oplog().mark_batch_undone(&batch)?);
-    }
+    let generation = repo.oplog().head_id()?;
+    let transaction_id = undo_redo_transaction_id("undo", &scope, generation, &batches);
+    let updated_batches = repo::atomic::execute(
+        &repo,
+        UndoOp::new(batches, recovery_state, transaction_id),
+    )
+    .map_err(|e| anyhow!(e))?;
 
     let post_undo_repo = Repository::open(repo.root())?;
     let post_undo_trust = build_repository_verification_state(&post_undo_repo);
@@ -312,11 +324,12 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     ensure_worktree_clean(&repo, "redo")?;
     preflight_redo_batches(&repo, &batches)?;
 
-    let mut updated_batches = Vec::with_capacity(batches.len());
-    for batch in batches {
-        apply_redo_batch(&repo, &batch)?;
-        updated_batches.push(repo.oplog().mark_batch_redone(&batch)?);
-    }
+    // heddle#355: replay + mark-redone run as ONE atomic transaction so a
+    // failure mid-redo rewinds every applied step (mirror of `cmd_undo`).
+    let generation = repo.oplog().head_id()?;
+    let transaction_id = undo_redo_transaction_id("redo", &scope, generation, &batches);
+    let updated_batches =
+        repo::atomic::execute(&repo, RedoOp::new(batches, transaction_id)).map_err(|e| anyhow!(e))?;
 
     let post_redo_trust = build_repository_verification_state(&repo);
     let recommended_action = ActionFields::from_action(&post_redo_trust.recommended_action);

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -16,6 +16,7 @@ use gix::{
     },
 };
 use objects::error::{HeddleError, Result as HeddleResult};
+use objects::lock::{RepoLock, WriteLockGuard};
 use objects::object::{ChangeId, MarkerName, ThreadName};
 use oplog::{OpBatch, OpEntry, OpRecord};
 use refs::Head;
@@ -948,10 +949,12 @@ fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<
 // canonical mutations (ref writes, `goto` worktree material, thread-record and
 // git-mirror state, and the in-place `mark_batch_undone` flag flip) and append
 // NO new domain oplog record — they navigate states that already exist. So:
-//   * Each sub-op stages its effect and registers its inverse via the granular
-//     `Tx::on_rewind` ledger (the inverse of "undo entry E" is "redo entry E",
-//     and vice-versa; both are absolute SET operations, so the inverse restores
-//     the pre-step state regardless of how far a failed step got).
+//   * Each sub-op stages its effect through the forward-first `Tx::step`
+//     combinator, which registers the inverse on the granular ledger ONLY after
+//     the forward succeeds (the inverse of "undo entry E" is "redo entry E", and
+//     vice-versa; both are absolute SET operations, so the inverse restores the
+//     pre-step state regardless of how far a failed step got — and a forward
+//     that fails registers no inverse at all).
 //   * The parent NESTS the sub-ops via `Tx::enroll` (savepoint enrollment) —
 //     the recovery-ref child then one child per batch — so a child that stages
 //     then fails rewinds the child AND unwinds the parent through the shared
@@ -976,7 +979,7 @@ fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<
 //      batches undone, so a retry re-derives a different batch set) and
 //      unnecessary (re-applying an undo is idempotent) for this op.
 //   2. SAVEPOINT SEMANTICS. The children use the savepoint ENROLLMENT mechanism
-//      (`enroll` + `on_rewind`) for its apply+ledger-rewind shape, but their
+//      (`enroll` + `step`) for its apply+ledger-rewind shape, but their
 //      effects are direct canonical writes (visible immediately), not the
 //      invisible-until-commit staging `SavepointMutation` describes. This adds
 //      FAILURE atomicity (rewind), not concurrent-reader isolation — matching
@@ -1001,6 +1004,29 @@ fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<
 /// foresee — whose rewind has already restored the pre-operation state.
 fn apply_error(err: anyhow::Error) -> HeddleError {
     HeddleError::Conflict(format!("{err:#}"))
+}
+
+/// Acquire the per-repository undo/redo serialization lock, held across the
+/// whole `select batches → preflight → apply → commit` critical section.
+///
+/// Two concurrent `heddle undo` (or `redo`) invocations that both read the same
+/// oplog generation derive the SAME generation-based [`undo_redo_transaction_id`];
+/// the second then dedup-hits `AlreadyCommitted` inside the executor and
+/// `rewind_all`s its own replay — silently reverting the first invocation while
+/// returning success (heddle#355 cid 3330867776). Serializing the critical
+/// section forces the second invocation to (re-)select its batches only AFTER
+/// the first has committed, so it observes the already-undone batch and cleanly
+/// undoes the next op (or finds nothing to do) — never colliding on the key.
+/// Crash-retry of the same logical op is unaffected: a retry re-selects against
+/// the post-commit generation and idempotently re-derives the correct batch set.
+///
+/// Uses a dedicated `locks/undo-redo.lock`, NOT the repo-wide `repo.lock`: the
+/// apply path calls `goto`, which itself takes `repo.lock`, so reusing it here
+/// would self-deadlock on the non-reentrant exclusive `flock`.
+pub(super) fn acquire_undo_redo_lock(repo: &Repository) -> Result<WriteLockGuard> {
+    RepoLock::at(repo.heddle_dir().join("locks/undo-redo.lock"))
+        .write()
+        .map_err(|e| anyhow!("failed to acquire undo/redo serialization lock: {e}"))
 }
 
 /// Build the stable-per-transaction idempotency key. Derived from the oplog
@@ -1042,11 +1068,16 @@ impl AtomicMutation for StageUndoRecovery {
         // Reconciled read of the prior pointer so the inverse restores exactly
         // what was there (never a raw-ref bypass).
         let prior = repo.refs().get_undo_recovery()?;
-        tx.on_rewind(move || match prior {
-            Some(prior) => repo.refs().set_undo_recovery(&prior),
-            None => repo.refs().clear_undo_recovery(),
-        });
-        repo.refs().set_undo_recovery(&state)?;
+        // Forward-first via `Tx::step`: the restore inverse is registered ONLY
+        // after the pointer is actually overwritten, so a failed write leaves
+        // the pre-existing recovery pointer untouched on rollback.
+        tx.step(
+            || repo.refs().set_undo_recovery(&state),
+            move || match prior {
+                Some(prior) => repo.refs().set_undo_recovery(&prior),
+                None => repo.refs().clear_undo_recovery(),
+            },
+        )?;
         Ok(StagedCommit::pure(()))
     }
 }
@@ -1094,8 +1125,14 @@ impl AtomicMutation for ApplyUndoBatch {
         let repo = tx.repo();
         for (applied, entry) in self.batch.entries.iter().rev().enumerate() {
             let redo_entry = entry.clone();
-            tx.on_rewind(move || apply_redo_entry(repo, &redo_entry).map_err(apply_error));
-            apply_undo_entry(repo, entry).map_err(apply_error)?;
+            // Forward-first: `apply_undo_entry` runs, and only on success is its
+            // `apply_redo_entry` inverse registered. A failed undo entry leaves
+            // the ledger empty for it, so the rollback never redoes an undo that
+            // didn't happen (heddle#355 cid 3330867774).
+            tx.step(
+                || apply_undo_entry(repo, entry).map_err(apply_error),
+                move || apply_redo_entry(repo, &redo_entry).map_err(apply_error),
+            )?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1106,8 +1143,10 @@ impl AtomicMutation for ApplyUndoBatch {
             let _ = applied;
         }
         let batch_for_redo = self.batch.clone();
-        tx.on_rewind(move || repo.oplog().mark_batch_redone(&batch_for_redo).map(|_| ()));
-        let updated = repo.oplog().mark_batch_undone(&self.batch)?;
+        let updated = tx.step(
+            || repo.oplog().mark_batch_undone(&self.batch),
+            move || repo.oplog().mark_batch_redone(&batch_for_redo).map(|_| ()),
+        )?;
         Ok(StagedCommit::pure(updated))
     }
 }
@@ -1152,8 +1191,13 @@ impl AtomicMutation for ApplyRedoBatch {
         let repo = tx.repo();
         for (applied, entry) in self.batch.entries.iter().enumerate() {
             let undo_entry = entry.clone();
-            tx.on_rewind(move || apply_undo_entry(repo, &undo_entry).map_err(apply_error));
-            apply_redo_entry(repo, entry).map_err(apply_error)?;
+            // Forward-first mirror of `ApplyUndoBatch`: register the
+            // `apply_undo_entry` inverse only after `apply_redo_entry` succeeds
+            // (heddle#355 cid 3330867775).
+            tx.step(
+                || apply_redo_entry(repo, entry).map_err(apply_error),
+                move || apply_undo_entry(repo, &undo_entry).map_err(apply_error),
+            )?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1164,8 +1208,10 @@ impl AtomicMutation for ApplyRedoBatch {
             let _ = applied;
         }
         let batch_for_undo = self.batch.clone();
-        tx.on_rewind(move || repo.oplog().mark_batch_undone(&batch_for_undo).map(|_| ()));
-        let updated = repo.oplog().mark_batch_redone(&self.batch)?;
+        let updated = tx.step(
+            || repo.oplog().mark_batch_redone(&self.batch),
+            move || repo.oplog().mark_batch_undone(&batch_for_undo).map(|_| ()),
+        )?;
         Ok(StagedCommit::pure(updated))
     }
 }
@@ -1524,5 +1570,205 @@ mod atomic_tests {
         repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid)).unwrap();
         assert_eq!(repo.head().unwrap(), Some(s2), "redo restored the s2 tip");
         assert!(temp.path().join("b.txt").exists(), "s2 file restored by redo");
+    }
+
+    /// The undo/redo serialization lock is mutually exclusive: while one holder
+    /// has it, a second writer on the same lock file is blocked; once released it
+    /// is acquirable again (heddle#355 cid 3330867776).
+    #[test]
+    fn undo_redo_lock_is_exclusive() {
+        let (_temp, repo, _s1, _s2) = repo_with_two_snapshots();
+        let lock_path = repo.heddle_dir().join("locks/undo-redo.lock");
+
+        let guard = acquire_undo_redo_lock(&repo).unwrap();
+        let contended = RepoLock::at(lock_path.clone()).try_write().unwrap();
+        assert!(
+            contended.is_none(),
+            "a second writer must be blocked while the lock is held"
+        );
+
+        drop(guard);
+        let reacquired = RepoLock::at(lock_path).try_write().unwrap();
+        assert!(
+            reacquired.is_some(),
+            "the lock is acquirable again after the holder releases it"
+        );
+    }
+
+    /// The serialized outcome the lock guarantees: a second undo invocation that
+    /// (re-)selects its batches only AFTER the first has committed sees the
+    /// already-undone batch and targets the PRECEDING op instead — it never
+    /// re-selects the batch the first undid, so the two can't derive the same
+    /// generation-keyed transaction id and the second can't dedup-hit and
+    /// self-revert the first (heddle#355 cid 3330867776).
+    #[test]
+    fn serialized_second_undo_selects_a_different_batch() {
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        // Invocation 1, under the lock: undo the newest batch (s2).
+        let first_ids: Vec<u64> = {
+            let _lock = acquire_undo_redo_lock(&repo).unwrap();
+            let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+            let ids = batches.iter().map(|b| b.id).collect();
+            let recovery = repo.head().unwrap();
+            let generation = repo.oplog().head_id().unwrap();
+            let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+            repo::atomic::execute(&repo, UndoOp::new(batches, recovery, txid)).unwrap();
+            ids
+        };
+        assert_eq!(repo.head().unwrap(), Some(s1), "first undo reverted to s1");
+
+        // Invocation 2, under the lock (after 1 released + committed): the s2
+        // batch is now undone, so re-selection returns the preceding s1 batch.
+        let _lock = acquire_undo_redo_lock(&repo).unwrap();
+        let second = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let second_ids: Vec<u64> = second.iter().map(|b| b.id).collect();
+        assert!(!second_ids.is_empty(), "a preceding op is still undoable");
+        assert_ne!(
+            second_ids, first_ids,
+            "the serialized second undo must not re-select the batch the first already undid"
+        );
+    }
+
+    /// `undo --list --depth N` returns N *user-facing* batches even when the
+    /// newest batch is an undo/redo's record-less commit marker (heddle#355 cid
+    /// 3330867777). After undoing s2, `recent_batches_scoped(1)` surfaces only
+    /// the marker sentinel; `recent_user_batches_scoped(1)` skips it and returns
+    /// the preceding real op (the s1 snapshot).
+    #[test]
+    fn list_depth_one_returns_preceding_user_op_past_commit_marker() {
+        let (_temp, repo, _s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        // Undo s2 — this appends a marker-only `TransactionCommit` batch that is
+        // now the newest batch in the log.
+        let recovery_head = repo.head().unwrap();
+        let undo_batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &undo_batches);
+        repo::atomic::execute(&repo, UndoOp::new(undo_batches, recovery_head, txid)).unwrap();
+
+        // The fixed-count fetch surfaces only the commit marker for depth 1...
+        let raw = repo.oplog().recent_batches_scoped(1, Some(&scope)).unwrap();
+        assert_eq!(raw.len(), 1);
+        assert!(
+            raw[0].is_transaction_marker_only(),
+            "the newest batch is the undo's commit marker"
+        );
+
+        // ...while the user-facing query skips it and returns the real op.
+        let user = repo
+            .oplog()
+            .recent_user_batches_scoped(1, Some(&scope))
+            .unwrap();
+        assert_eq!(user.len(), 1, "depth 1 returns exactly one user-facing batch");
+        assert!(
+            !user[0].is_transaction_marker_only(),
+            "the returned batch is a real op, not the marker sentinel"
+        );
+        assert!(
+            user[0]
+                .entries
+                .iter()
+                .any(|e| matches!(e.operation, OpRecord::Snapshot { .. })),
+            "it is the preceding s1 snapshot"
+        );
+    }
+
+    /// Compensator class, undo direction (heddle#355 cid 3330867774). Undoing a
+    /// `MarkerDelete` recreates the marker (`create_marker`). When that forward
+    /// FAILS because a marker of the same name already exists (a pre-existing
+    /// ref), the migration onto `Tx::step` guarantees NO `delete_marker` inverse
+    /// was registered — so the rollback leaves the pre-existing marker intact.
+    /// Pre-`step` (register-then-forward) the inverse ran on rollback and deleted
+    /// the pre-existing marker.
+    #[test]
+    fn undo_marker_delete_forward_failure_keeps_preexisting_marker() {
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        let marker = MarkerName::new("keep");
+
+        // A `MarkerDelete` batch becomes the newest undoable op; undoing it will
+        // attempt `create_marker("keep", s1)`.
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::MarkerDelete {
+                    name: "keep".to_string(),
+                    state: s1,
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+
+        // Plant a pre-existing marker of the same name — the undo's
+        // `create_marker` will now collide and fail.
+        repo.refs().create_marker(&marker, &s1).unwrap();
+
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        assert!(
+            matches!(
+                batches[0].entries[0].operation,
+                OpRecord::MarkerDelete { .. }
+            ),
+            "the newest undoable batch is the MarkerDelete"
+        );
+        let recovery_head = repo.head().unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        let result = repo::atomic::execute(&repo, UndoOp::new(batches, recovery_head, txid));
+
+        assert!(result.is_err(), "the colliding create_marker must fail the undo");
+        assert_eq!(
+            repo.refs().get_marker(&marker).unwrap(),
+            Some(s1),
+            "the pre-existing marker survives the rolled-back undo (no delete inverse ran)"
+        );
+    }
+
+    /// Compensator class, redo direction (heddle#355 cid 3330867775). Redoing a
+    /// `MarkerCreate` re-runs `create_marker`. A collision with a pre-existing
+    /// marker must NOT delete it on rollback — the mirror of the undo case.
+    #[test]
+    fn redo_marker_create_forward_failure_keeps_preexisting_marker() {
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        let marker = MarkerName::new("keep");
+
+        // Record a `MarkerCreate`, then mark it undone so it is REDOABLE; redoing
+        // it will attempt `create_marker("keep", s1)`.
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::MarkerCreate {
+                    name: "keep".to_string(),
+                    state: s1,
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+        let created = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        repo.oplog().mark_batch_undone(&created[0]).unwrap();
+
+        // Plant the pre-existing colliding marker.
+        repo.refs().create_marker(&marker, &s1).unwrap();
+
+        let redo_batches = repo.oplog().redo_batches_scoped(1, Some(&scope)).unwrap();
+        assert!(
+            matches!(
+                redo_batches[0].entries[0].operation,
+                OpRecord::MarkerCreate { .. }
+            ),
+            "the redoable batch is the MarkerCreate"
+        );
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("redo", &scope, generation, &redo_batches);
+        let result = repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid));
+
+        assert!(result.is_err(), "the colliding create_marker must fail the redo");
+        assert_eq!(
+            repo.refs().get_marker(&marker).unwrap(),
+            Some(s1),
+            "the pre-existing marker survives the rolled-back redo (no delete inverse ran)"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -380,32 +380,23 @@ impl<'a> EntrySteps<'_, 'a> {
         )
     }
 
-    /// Persist a mutated ThreadManager record; inverse restores the record's
-    /// prior persisted form (or removes it if there was none). NON-atomic:
-    /// `ThreadManager::save` writes the record file AND the workspace file, so a
-    /// failure on the second write leaves the first applied — the capture
-    /// snapshots both prior forms and the restore rewrites/removes them.
+    /// Persist a mutated ThreadManager record; inverse converges the persisted
+    /// state for the thread back to its prior form (or removes it if there was
+    /// none). NON-atomic: `ThreadManager::save` writes the record file AND the
+    /// workspace file, so a failure on the second write leaves the first applied.
+    /// The restore routes through [`ThreadManager::restore_to_snapshot`], which
+    /// drops EVERY record under the thread name except `prev` — so a replacement
+    /// save that wrote a NEW-id, newer-timestamped record cannot leak past
+    /// rollback regardless of whether its id is known here.
     fn save_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
         let repo = self.repo();
         let manager = ThreadManager::new(repo.heddle_dir());
-        let prev = manager.find_by_thread(&record.thread)?;
-        let new_id = record.id.clone();
+        let name = record.thread.clone();
+        let prev = manager.find_by_thread(&name)?;
         self.step_nonatomic(
             || Ok(prev),
             move |prev| {
-                let manager = ThreadManager::new(repo.heddle_dir());
-                match prev {
-                    Some(prev) => {
-                        // A replacement save wrote the record under a new id; the
-                        // newer record + its workspace file must be removed so
-                        // `find_by_thread` sees only `prev` after rollback.
-                        if prev.id != new_id {
-                            manager.delete(&new_id)?;
-                        }
-                        manager.save(&prev)
-                    }
-                    None => manager.delete(&new_id),
-                }
+                ThreadManager::new(repo.heddle_dir()).restore_to_snapshot(&name, prev.as_ref())
             },
             move || ThreadManager::new(repo.heddle_dir()).save(&record),
         )
@@ -424,11 +415,16 @@ impl<'a> EntrySteps<'_, 'a> {
         )
     }
 
-    /// Restore a ThreadManager record from a redo snapshot; inverse restores the
-    /// prior persisted form (or removes the restored record if there was none).
-    /// A snapshot that fails to decode is a non-fatal warning (pre-migration
-    /// parity). NON-atomic for the same record-file + workspace-file reason as
-    /// [`save_thread_record`](Self::save_thread_record).
+    /// Restore a ThreadManager record from a redo snapshot; inverse converges the
+    /// persisted state for the thread back to its prior form (or empties it if
+    /// there was none). A snapshot that fails to decode is a non-fatal warning
+    /// (pre-migration parity). NON-atomic for the same record-file +
+    /// workspace-file reason as [`save_thread_record`](Self::save_thread_record).
+    /// The forward (`restore_thread_record_from_snapshot`) writes a record under
+    /// an id buried in the opaque snapshot bytes — possibly different from
+    /// `prev`'s and with a fresher timestamp. Routing the restore through
+    /// [`ThreadManager::restore_to_snapshot`] drops that snapshot-id record on
+    /// rollback without ever needing to know its id.
     fn restore_thread_record(&mut self, name: &str, bytes: &[u8]) -> HeddleResult<()> {
         let repo = self.repo();
         let manager = ThreadManager::new(repo.heddle_dir());
@@ -439,14 +435,8 @@ impl<'a> EntrySteps<'_, 'a> {
         self.step_nonatomic(
             || Ok(prev),
             move |prev| {
-                let manager = ThreadManager::new(repo.heddle_dir());
-                match prev {
-                    Some(prev) => manager.save(&prev),
-                    None => match manager.find_by_thread(&restore_name)? {
-                        Some(record) => manager.delete(&record.id),
-                        None => Ok(()),
-                    },
-                }
+                ThreadManager::new(repo.heddle_dir())
+                    .restore_to_snapshot(&restore_name, prev.as_ref())
             },
             move || {
                 let manager = ThreadManager::new(repo.heddle_dir());
@@ -2786,6 +2776,98 @@ mod atomic_tests {
             manager.find_by_thread("main").unwrap().is_none(),
             "no record survives for a rolled-back create save"
         );
+    }
+
+    /// Test-only deferred mutation that restores ONE thread record from a redo
+    /// snapshot through the `EntrySteps` applier — exercises the real
+    /// `restore_thread_record` (`step_nonatomic`) capture-restore path, the redo
+    /// arm whose forward writes a record under a snapshot-buried id.
+    struct RestoreSnapshotOnly {
+        name: String,
+        bytes: Vec<u8>,
+    }
+
+    impl AtomicMutation for RestoreSnapshotOnly {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            "test-restore-snapshot-only".to_string()
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+            let mut steps = EntrySteps::new(tx);
+            steps.restore_thread_record(&self.name, &self.bytes)?;
+            Ok(StagedCommit::pure(()))
+        }
+    }
+
+    impl DeferredMutation for RestoreSnapshotOnly {}
+
+    /// The redo-snapshot sibling of `..._restores_replacement_save_...`: the redo
+    /// of a `ThreadCreateV2` restores the record from an opaque snapshot whose
+    /// record id is NOT known to the applier. The forward writes that snapshot-id
+    /// record (newer timestamp); on rollback the converge must drop it so
+    /// `find_by_thread` returns ONLY the prior record. A re-save-only restore
+    /// (the pre-r6 redo arm) left the snapshot-id record and `find_by_thread`
+    /// returned the leak — this test fails against that arm and passes against the
+    /// `restore_to_snapshot` converge.
+    #[test]
+    fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // R0: the prior persisted record for thread "main".
+        let mut r0 = sample_main_thread("current-A", "/work/A");
+        r0.id = "thread-main-v1".to_string();
+        r0.updated_at = chrono::Utc::now();
+        manager.save(&r0).unwrap();
+
+        // Build a redo snapshot of a DIFFERENT-id, NEWER record (what the redo
+        // forward writes). Save it, snapshot it, then remove it so only the prior
+        // record remains at capture time.
+        let mut snap_rec = r0.clone();
+        snap_rec.id = "thread-main-v2".to_string();
+        snap_rec.current_state = Some("current-B".to_string());
+        snap_rec.updated_at = r0.updated_at + chrono::Duration::seconds(60);
+        manager.save(&snap_rec).unwrap();
+        let snapshot = manager.snapshot_thread_record("main").unwrap().unwrap();
+        manager.delete("thread-main-v2").unwrap();
+        assert_eq!(
+            manager.list().unwrap().len(),
+            1,
+            "precondition: only the prior record exists at capture time"
+        );
+
+        let result = with_nonatomic_forward_fault(0, || {
+            repo::atomic::execute(
+                &repo,
+                RestoreSnapshotOnly {
+                    name: "main".to_string(),
+                    bytes: snapshot,
+                },
+            )
+        });
+        assert!(
+            result.is_err(),
+            "the injected restore fault must fail the op"
+        );
+
+        assert!(
+            manager.load("thread-main-v2").unwrap().is_none(),
+            "the leaked snapshot-id record must be deleted on rollback"
+        );
+        assert_eq!(
+            manager.list().unwrap().len(),
+            1,
+            "only the prior record survives, no leaked newer record"
+        );
+        let restored = manager.find_by_thread("main").unwrap().unwrap();
+        assert_eq!(
+            restored.id, "thread-main-v1",
+            "find_by_thread returns ONLY prev"
+        );
+        assert_eq!(restored.current_state.as_deref(), Some("current-A"));
     }
 
     /// Undoing a `Redact` removes the per-blob sidecar (re-exposing the blob). If

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -395,7 +395,15 @@ impl<'a> EntrySteps<'_, 'a> {
             move |prev| {
                 let manager = ThreadManager::new(repo.heddle_dir());
                 match prev {
-                    Some(prev) => manager.save(&prev),
+                    Some(prev) => {
+                        // A replacement save wrote the record under a new id; the
+                        // newer record + its workspace file must be removed so
+                        // `find_by_thread` sees only `prev` after rollback.
+                        if prev.id != new_id {
+                            manager.delete(&new_id)?;
+                        }
+                        manager.save(&prev)
+                    }
                     None => manager.delete(&new_id),
                 }
             },
@@ -2704,6 +2712,79 @@ mod atomic_tests {
             restored.materialized_path,
             Some(PathBuf::from("/work/A")),
             "the workspace half (materialized_path) was restored to R0"
+        );
+    }
+
+    /// A "replacement save" persists the thread under a NEW record id (the prior
+    /// record had a different id). `find_by_thread` selects among ALL records with
+    /// that thread name, so if a later failure rolls the save back, the restore
+    /// must delete the newly-written `new_id` record + its workspace file — not
+    /// just re-save `prev`. Otherwise the leaked newer record stays visible and
+    /// record-backed commands observe the rolled-back-away state. A re-save-only
+    /// restore leaves two records for "main" and `find_by_thread` returns the leak.
+    #[test]
+    fn step_nonatomic_restores_replacement_save_deleting_leaked_new_record() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // R0: the prior persisted record for thread "main".
+        let mut r0 = sample_main_thread("current-A", "/work/A");
+        r0.id = "thread-main-v1".to_string();
+        r0.updated_at = chrono::Utc::now();
+        manager.save(&r0).unwrap();
+
+        // R1: the replacement save — SAME thread, DIFFERENT record id, and a later
+        // `updated_at` so a leaked R1 would win `find_by_thread`'s max-by-updated.
+        let mut r1 = r0.clone();
+        r1.id = "thread-main-v2".to_string();
+        r1.current_state = Some("current-B".to_string());
+        r1.updated_at = r0.updated_at + chrono::Duration::seconds(60);
+
+        let result = with_nonatomic_forward_fault(0, || {
+            repo::atomic::execute(&repo, SaveOnly { record: r1 })
+        });
+        assert!(result.is_err(), "the injected save fault must fail the op");
+
+        assert!(
+            manager.load("thread-main-v2").unwrap().is_none(),
+            "the leaked new_id record must be deleted on rollback"
+        );
+        let remaining = manager.list().unwrap();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only the prior record survives for the thread, no leaked newer record"
+        );
+        let restored = manager.find_by_thread("main").unwrap().unwrap();
+        assert_eq!(restored.id, "thread-main-v1", "find_by_thread returns ONLY prev");
+        assert_eq!(restored.current_state.as_deref(), Some("current-A"));
+    }
+
+    /// A "create save" persists a thread with NO prior record. On rollback the
+    /// restore must delete the created record + its workspace file so nothing is
+    /// left for the thread.
+    #[test]
+    fn step_nonatomic_create_save_rollback_removes_created_record() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        let mut created = sample_main_thread("current-A", "/work/A");
+        created.id = "thread-main-new".to_string();
+
+        let result = with_nonatomic_forward_fault(0, || {
+            repo::atomic::execute(&repo, SaveOnly { record: created })
+        });
+        assert!(result.is_err(), "the injected save fault must fail the op");
+
+        assert!(
+            manager.load("thread-main-new").unwrap().is_none(),
+            "the created record must be removed on rollback"
+        );
+        assert!(
+            manager.find_by_thread("main").unwrap().is_none(),
+            "no record survives for a rolled-back create save"
         );
     }
 

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -1493,13 +1493,33 @@ fn change_contains(repo: &Repository, ancestor: &ChangeId, descendant: &ChangeId
     graph.is_ancestor(ancestor, descendant).unwrap_or(false)
 }
 
-/// Remove the ThreadManager record matching `thread_name`. No-op when no
-/// record exists. Used by the `ThreadCreate` inverse to keep refs and
-/// record-store state in lockstep (cross-thread undo contract rule 4).
+/// Remove EVERY ThreadManager record filed under `thread_name`, converging the
+/// name to empty. No-op when none exist. Used by the `ThreadCreate` inverse to
+/// keep refs and record-store state in lockstep (cross-thread undo contract
+/// rule 4). Converging to empty — rather than deleting only the
+/// `find_by_thread` winner — is what closes the duplicate class the converge
+/// primitive tolerates: if multiple records are filed under the name, deleting
+/// just the `max_by_key(updated_at)` winner leaves the older same-name records
+/// as phantoms after the thread ref is gone, and `find_by_thread` would then
+/// surface a thread whose ref no longer exists. Each record is deleted via its
+/// own `delete_thread_record` (a `step_nonatomic` whose inverse re-saves that
+/// exact record), so a later transaction failure rolls back ALL of them, not
+/// just the winner — preserving the per-record rollback granularity invariant.
+///
+/// RESIDUAL: the `list()` snapshot → per-record-delete sequence has a narrow
+/// window vs a concurrent NON-undo writer (a `thread start` racing an in-flight
+/// undo). That window is a pre-existing property of the thread store (plain
+/// thread commands already race each other identically) and is not introduced
+/// by this migration; the per-effect `step_nonatomic` ledger model cannot hold
+/// a file lock across a whole multi-step entry.
 fn remove_thread_manager_record(steps: &mut EntrySteps, thread_name: &str) -> HeddleResult<()> {
     let manager = ThreadManager::new(steps.repo().heddle_dir());
-    if let Some(thread) = manager.find_by_thread(thread_name)? {
-        steps.delete_thread_record(thread)?;
+    for record in manager
+        .list()?
+        .into_iter()
+        .filter(|t| t.thread == thread_name)
+    {
+        steps.delete_thread_record(record)?;
     }
     Ok(())
 }
@@ -2868,6 +2888,116 @@ mod atomic_tests {
             "find_by_thread returns ONLY prev"
         );
         assert_eq!(restored.current_state.as_deref(), Some("current-A"));
+    }
+
+    /// Test-only deferred mutation that runs `remove_thread_manager_record` — the
+    /// `ThreadCreate`/`ThreadCreateV2` inverse — through the `EntrySteps` applier,
+    /// so its per-record `delete_thread_record` (`step_nonatomic`) granularity and
+    /// rollback can be exercised in isolation.
+    struct RemoveRecordOnly {
+        name: String,
+    }
+
+    impl AtomicMutation for RemoveRecordOnly {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            "test-remove-record-only".to_string()
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+            let mut steps = EntrySteps::new(tx);
+            remove_thread_manager_record(&mut steps, &self.name)?;
+            Ok(StagedCommit::pure(()))
+        }
+    }
+
+    impl DeferredMutation for RemoveRecordOnly {}
+
+    /// The created-thread inverse converges the name to EMPTY: when the store holds
+    /// MULTIPLE records under the name (the duplicate class the converge tolerates),
+    /// undoing the `ThreadCreate` must drop EVERY same-name record, not just the
+    /// `find_by_thread` winner. The pre-fix arm deleted only the winner, leaving the
+    /// older duplicate as a phantom whose thread ref is gone — this test fails
+    /// against that arm (the older record survives) and passes against converge-to-
+    /// empty.
+    #[test]
+    fn remove_thread_manager_record_converges_name_to_empty() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // Two records under "main": a winner (newer) + an older duplicate.
+        let mut winner = sample_main_thread("current-A", "/work/A");
+        winner.id = "rec-winner".to_string();
+        winner.updated_at = chrono::Utc::now();
+        manager.save(&winner).unwrap();
+        let mut older = sample_main_thread("current-B", "/work/B");
+        older.id = "rec-older".to_string();
+        older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
+        manager.save(&older).unwrap();
+        assert_eq!(manager.list().unwrap().len(), 2, "precondition: two records");
+
+        repo::atomic::execute(&repo, RemoveRecordOnly { name: "main".to_string() }).unwrap();
+
+        assert!(
+            manager.find_by_thread("main").unwrap().is_none(),
+            "converge-to-empty: no record survives under the name"
+        );
+        assert!(
+            manager.list().unwrap().iter().all(|t| t.thread != "main"),
+            "EVERY same-name record removed, not just the find_by_thread winner"
+        );
+    }
+
+    /// Per-record rollback granularity for the converge-to-empty inverse: when a
+    /// LATER step in the same transaction fails after BOTH same-name records were
+    /// deleted, the rollback must re-save ALL of them (each `delete_thread_record`
+    /// is its own `step_nonatomic` with its own re-save inverse), not just the
+    /// winner. Arming the fault at the 2nd `step_nonatomic` also proves the inverse
+    /// issues a delete PER record: pre-fix there is only ONE delete (winner only),
+    /// so the index-1 fault never trips and the op wrongly succeeds.
+    #[test]
+    fn remove_thread_manager_record_rollback_resaves_all_records() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        let mut winner = sample_main_thread("current-A", "/work/A");
+        winner.id = "rec-winner".to_string();
+        winner.updated_at = chrono::Utc::now();
+        manager.save(&winner).unwrap();
+        let mut older = sample_main_thread("current-B", "/work/B");
+        older.id = "rec-older".to_string();
+        older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
+        manager.save(&older).unwrap();
+
+        // Fault the 2nd per-record delete's forward: both records get deleted, then
+        // the op fails — the rollback must re-save BOTH via their per-record
+        // inverses. (Two records ⇒ two `step_nonatomic` deletes; index 1 is the
+        // last one.)
+        let result = with_nonatomic_forward_fault(1, || {
+            repo::atomic::execute(&repo, RemoveRecordOnly { name: "main".to_string() })
+        });
+        assert!(result.is_err(), "the injected forward fault must fail the op");
+
+        let remaining = manager.list().unwrap();
+        assert_eq!(
+            remaining.len(),
+            2,
+            "rollback re-saved ALL same-name records, not just the winner"
+        );
+        let ids: std::collections::HashSet<_> =
+            remaining.iter().map(|t| t.id.clone()).collect();
+        assert!(
+            ids.contains("rec-winner") && ids.contains("rec-older"),
+            "both the winner and the older duplicate were restored"
+        );
+        assert_eq!(
+            manager.find_by_thread("main").unwrap().unwrap().id,
+            "rec-winner",
+            "find_by_thread still selects the newer winner after rollback"
+        );
     }
 
     /// Undoing a `Redact` removes the per-blob sidecar (re-exposing the blob). If

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -380,76 +380,88 @@ impl<'a> EntrySteps<'_, 'a> {
         )
     }
 
-    /// Persist a mutated ThreadManager record; inverse converges the persisted
-    /// state for the thread back to its prior form (or removes it if there was
-    /// none). NON-atomic: `ThreadManager::save` writes the record file AND the
-    /// workspace file, so a failure on the second write leaves the first applied.
-    /// The restore routes through [`ThreadManager::restore_to_snapshot`], which
-    /// drops EVERY record under the thread name except `prev` — so a replacement
-    /// save that wrote a NEW-id, newer-timestamped record cannot leak past
-    /// rollback regardless of whether its id is known here.
-    fn save_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
+    /// The SOLE way the undo/redo applier mutates a thread's persisted record
+    /// set: converge the records filed under `name` to exactly `desired`, as ONE
+    /// `step_nonatomic`. Capture snapshots the FULL prior same-name set
+    /// ([`ThreadManager::snapshot_records`]); the inverse converges back to it;
+    /// the forward converges to `desired`. Both directions run through
+    /// [`ThreadManager::converge_records`] — the lone lock-atomic record-set
+    /// mutation point — so no entry-apply path can mutate a thread's record set
+    /// except through it.
+    ///
+    /// GRANULARITY. One whole-set capture→converge inverse REPLACES the prior
+    /// per-record `step_nonatomic` inverses. Correct, not a regression: per-record
+    /// granularity existed to unwind a NON-atomic forward that could fail partway
+    /// (the r3/r4 `save`/`delete` loop). `converge_records` is lock-atomic /
+    /// all-or-nothing, so a single converge-back-to-prior fully reverses it.
+    fn converge_thread_records(&mut self, name: &str, desired: Vec<Thread>) -> HeddleResult<()> {
         let repo = self.repo();
-        let manager = ThreadManager::new(repo.heddle_dir());
-        let name = record.thread.clone();
-        let prev = manager.find_by_thread(&name)?;
-        self.step_nonatomic(
-            || Ok(prev),
-            move |prev| {
-                ThreadManager::new(repo.heddle_dir()).restore_to_snapshot(&name, prev.as_ref())
-            },
-            move || ThreadManager::new(repo.heddle_dir()).save(&record),
-        )
-    }
-
-    /// Delete a ThreadManager record; inverse re-saves it. NON-atomic:
-    /// `ThreadManager::delete` removes the record file AND the workspace file,
-    /// so the inverse re-saves the captured record wholesale.
-    fn delete_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
-        let repo = self.repo();
-        let id = record.id.clone();
-        self.step_nonatomic(
-            || Ok(record),
-            move |record| ThreadManager::new(repo.heddle_dir()).save(&record),
-            move || ThreadManager::new(repo.heddle_dir()).delete(&id),
-        )
-    }
-
-    /// Restore a ThreadManager record from a redo snapshot; inverse converges the
-    /// persisted state for the thread back to its prior form (or empties it if
-    /// there was none). A snapshot that fails to decode is a non-fatal warning
-    /// (pre-migration parity). NON-atomic for the same record-file +
-    /// workspace-file reason as [`save_thread_record`](Self::save_thread_record).
-    /// The forward (`restore_thread_record_from_snapshot`) writes a record under
-    /// an id buried in the opaque snapshot bytes — possibly different from
-    /// `prev`'s and with a fresher timestamp. Routing the restore through
-    /// [`ThreadManager::restore_to_snapshot`] drops that snapshot-id record on
-    /// rollback without ever needing to know its id.
-    fn restore_thread_record(&mut self, name: &str, bytes: &[u8]) -> HeddleResult<()> {
-        let repo = self.repo();
-        let manager = ThreadManager::new(repo.heddle_dir());
-        let prev = manager.find_by_thread(name)?;
-        let bytes = bytes.to_vec();
         let forward_name = name.to_string();
         let restore_name = name.to_string();
+        let prior = ThreadManager::new(repo.heddle_dir()).snapshot_records(name)?;
         self.step_nonatomic(
-            || Ok(prev),
-            move |prev| {
-                ThreadManager::new(repo.heddle_dir())
-                    .restore_to_snapshot(&restore_name, prev.as_ref())
+            || Ok(prior),
+            move |prior| {
+                ThreadManager::new(repo.heddle_dir()).converge_records(&restore_name, &prior)
+            },
+            move || {
+                ThreadManager::new(repo.heddle_dir()).converge_records(&forward_name, &desired)
+            },
+        )
+    }
+
+    /// Persist a mutated ThreadManager record as the SOLE record under its thread
+    /// name (single-record postcondition). Routes through
+    /// [`converge_thread_records`](Self::converge_thread_records) with
+    /// `desired = [record]`, so a replacement save that would write a NEW-id,
+    /// newer-timestamped record cannot leave a duplicate behind, and rollback
+    /// converges back to the captured prior set regardless of any leaked id.
+    fn save_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
+        let name = record.thread.clone();
+        self.converge_thread_records(&name, vec![record])
+    }
+
+    /// Restore a ThreadManager record from a redo snapshot as the SOLE record
+    /// under its thread name. Capture = the full prior same-name set; inverse =
+    /// converge back to it; forward = DECODE the opaque snapshot bytes and
+    /// [`converge_records`](ThreadManager::converge_records) the name to the single
+    /// restored record — NOT a raw save, so a pre-existing duplicate cannot
+    /// survive (cid 3331603135) and the success path has the same single-record
+    /// postcondition as the rollback converge. A snapshot that fails to decode is
+    /// a non-fatal warning that writes nothing — the on-disk set stays the
+    /// captured prior set (a no-op converge), preserving the pre-migration
+    /// ref-only fallback.
+    fn restore_thread_record(&mut self, name: &str, bytes: &[u8]) -> HeddleResult<()> {
+        let repo = self.repo();
+        let forward_name = name.to_string();
+        let restore_name = name.to_string();
+        let warn_name = name.to_string();
+        let bytes = bytes.to_vec();
+        let prior = ThreadManager::new(repo.heddle_dir()).snapshot_records(name)?;
+        self.step_nonatomic(
+            || Ok(prior),
+            move |prior| {
+                ThreadManager::new(repo.heddle_dir()).converge_records(&restore_name, &prior)
             },
             move || {
                 let manager = ThreadManager::new(repo.heddle_dir());
-                if let Err(e) = manager.restore_thread_record_from_snapshot(&bytes) {
-                    eprintln!(
-                        "warning: redo of `ThreadCreate` for '{}' restored the ref but failed to \
-                         decode the ThreadManager record snapshot ({}). Record-backed commands \
-                         (`thread cd`, delegate) may degrade on this thread — run `heddle thread \
-                         start {}` to recreate the record.",
-                        forward_name, e, forward_name
-                    );
+                match manager.decode_thread_record_snapshot(&bytes) {
+                    Ok(restored) => {
+                        manager.converge_records(&forward_name, std::slice::from_ref(&restored))
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: redo of `ThreadCreate` for '{}' restored the ref but failed \
+                             to decode the ThreadManager record snapshot ({}). Record-backed \
+                             commands (`thread cd`, delegate) may degrade on this thread — run \
+                             `heddle thread start {}` to recreate the record.",
+                            warn_name, e, warn_name
+                        );
+                        // Write nothing: the on-disk set is unchanged (== the
+                        // captured prior set), i.e. a no-op converge.
+                        Ok(())
+                    }
                 }
-                Ok(())
             },
         )
     }
@@ -1494,34 +1506,22 @@ fn change_contains(repo: &Repository, ancestor: &ChangeId, descendant: &ChangeId
 }
 
 /// Remove EVERY ThreadManager record filed under `thread_name`, converging the
-/// name to empty. No-op when none exist. Used by the `ThreadCreate` inverse to
-/// keep refs and record-store state in lockstep (cross-thread undo contract
-/// rule 4). Converging to empty — rather than deleting only the
-/// `find_by_thread` winner — is what closes the duplicate class the converge
-/// primitive tolerates: if multiple records are filed under the name, deleting
-/// just the `max_by_key(updated_at)` winner leaves the older same-name records
-/// as phantoms after the thread ref is gone, and `find_by_thread` would then
-/// surface a thread whose ref no longer exists. Each record is deleted via its
-/// own `delete_thread_record` (a `step_nonatomic` whose inverse re-saves that
-/// exact record), so a later transaction failure rolls back ALL of them, not
-/// just the winner — preserving the per-record rollback granularity invariant.
+/// name to EMPTY as ONE lock-atomic `step_nonatomic` (cid 3331603131). Used by
+/// the `ThreadCreate`/`ThreadCreateV2` inverse to keep refs and record-store
+/// state in lockstep (cross-thread undo contract rule 4).
 ///
-/// RESIDUAL: the `list()` snapshot → per-record-delete sequence has a narrow
-/// window vs a concurrent NON-undo writer (a `thread start` racing an in-flight
-/// undo). That window is a pre-existing property of the thread store (plain
-/// thread commands already race each other identically) and is not introduced
-/// by this migration; the per-effect `step_nonatomic` ledger model cannot hold
-/// a file lock across a whole multi-step entry.
+/// Converging to empty under a SINGLE write lock via
+/// [`ThreadManager::converge_records`] — rather than taking an unlocked `list()`
+/// snapshot and deleting each record separately — is what closes the duplicate
+/// class: a same-name writer that lands between the snapshot and the deletes can
+/// no longer survive the converge (the old per-record loop had exactly that
+/// window). Deleting the FULL same-name set (not just the `find_by_thread`
+/// winner) also stops an older duplicate from being left as a phantom after the
+/// thread ref is gone. The inverse re-converges to the full captured prior set,
+/// so a later transaction failure restores ALL same-name records, not just the
+/// winner.
 fn remove_thread_manager_record(steps: &mut EntrySteps, thread_name: &str) -> HeddleResult<()> {
-    let manager = ThreadManager::new(steps.repo().heddle_dir());
-    for record in manager
-        .list()?
-        .into_iter()
-        .filter(|t| t.thread == thread_name)
-    {
-        steps.delete_thread_record(record)?;
-    }
-    Ok(())
+    steps.converge_thread_records(thread_name, Vec::new())
 }
 
 // ---- Atomic undo/redo (heddle#355 impl-b) ----
@@ -2830,7 +2830,7 @@ mod atomic_tests {
     /// `find_by_thread` returns ONLY the prior record. A re-save-only restore
     /// (the pre-r6 redo arm) left the snapshot-id record and `find_by_thread`
     /// returned the leak — this test fails against that arm and passes against the
-    /// `restore_to_snapshot` converge.
+    /// `converge_records` restore.
     #[test]
     fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
         let temp = TempDir::new().unwrap();
@@ -2890,10 +2890,77 @@ mod atomic_tests {
         assert_eq!(restored.current_state.as_deref(), Some("current-A"));
     }
 
+    /// SUCCESS-path postcondition of the redo `ThreadCreateV2` restore (cid
+    /// 3331603135): when a pre-existing DUPLICATE is already filed under the name,
+    /// redoing the create restores the snapshot AND leaves ONLY the restored
+    /// record — the success path has the same single-record postcondition as the
+    /// rollback converge. The pre-r8 arm `save`d the decoded record without
+    /// removing the duplicate, so two records survived and `find_by_thread`
+    /// (max-by-updated) returned the newer duplicate, not the restored record —
+    /// this test fails against that arm and passes against decode→converge.
+    #[test]
+    fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // The record the redo snapshot will restore (older timestamp).
+        let mut to_restore = sample_main_thread("current-restored", "/work/R");
+        to_restore.id = "rec-restored".to_string();
+        to_restore.updated_at = chrono::Utc::now();
+        manager.save(&to_restore).unwrap();
+        let snapshot = manager.snapshot_thread_record("main").unwrap().unwrap();
+        manager.delete("rec-restored").unwrap();
+
+        // A pre-existing DUPLICATE under the same name with a NEWER timestamp, so
+        // a raw-save redo would leave it winning `find_by_thread`.
+        let mut dup = sample_main_thread("current-dup", "/work/D");
+        dup.id = "rec-dup".to_string();
+        dup.updated_at = to_restore.updated_at + chrono::Duration::seconds(60);
+        manager.save(&dup).unwrap();
+        assert_eq!(
+            manager.list().unwrap().iter().filter(|t| t.thread == "main").count(),
+            1,
+            "precondition: only the duplicate is filed at redo time"
+        );
+
+        // Redo restores the snapshot — SUCCESS path (no fault).
+        repo::atomic::execute(
+            &repo,
+            RestoreSnapshotOnly {
+                name: "main".to_string(),
+                bytes: snapshot,
+            },
+        )
+        .unwrap();
+
+        let under_name: Vec<_> = manager
+            .list()
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.thread == "main")
+            .collect();
+        assert_eq!(
+            under_name.len(),
+            1,
+            "ONLY the restored record remains — the duplicate is converged away"
+        );
+        assert_eq!(under_name[0].id, "rec-restored");
+        assert_eq!(
+            manager.find_by_thread("main").unwrap().unwrap().id,
+            "rec-restored",
+            "find_by_thread returns the restored record, not the leaked duplicate"
+        );
+        assert!(
+            manager.load("rec-dup").unwrap().is_none(),
+            "the pre-existing duplicate record file is gone"
+        );
+    }
+
     /// Test-only deferred mutation that runs `remove_thread_manager_record` — the
     /// `ThreadCreate`/`ThreadCreateV2` inverse — through the `EntrySteps` applier,
-    /// so its per-record `delete_thread_record` (`step_nonatomic`) granularity and
-    /// rollback can be exercised in isolation.
+    /// so its single lock-atomic `converge_records`-to-empty step and the
+    /// converge-back-to-prior rollback can be exercised in isolation.
     struct RemoveRecordOnly {
         name: String,
     }
@@ -2950,13 +3017,13 @@ mod atomic_tests {
         );
     }
 
-    /// Per-record rollback granularity for the converge-to-empty inverse: when a
-    /// LATER step in the same transaction fails after BOTH same-name records were
-    /// deleted, the rollback must re-save ALL of them (each `delete_thread_record`
-    /// is its own `step_nonatomic` with its own re-save inverse), not just the
-    /// winner. Arming the fault at the 2nd `step_nonatomic` also proves the inverse
-    /// issues a delete PER record: pre-fix there is only ONE delete (winner only),
-    /// so the index-1 fault never trips and the op wrongly succeeds.
+    /// Rollback of the converge-to-empty inverse: the single `step_nonatomic`
+    /// converge runs its forward (deleting BOTH same-name records under one write
+    /// lock) and then fails — the converge-back-to-prior inverse, registered
+    /// BEFORE the forward, must restore the FULL captured prior set (both
+    /// records), not just the `find_by_thread` winner. Arming the fault at the
+    /// converge step (index 0) proves the whole-set capture-restore reverses a
+    /// lock-atomic all-or-nothing forward in one inverse.
     #[test]
     fn remove_thread_manager_record_rollback_resaves_all_records() {
         let temp = TempDir::new().unwrap();
@@ -2972,11 +3039,10 @@ mod atomic_tests {
         older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
         manager.save(&older).unwrap();
 
-        // Fault the 2nd per-record delete's forward: both records get deleted, then
-        // the op fails — the rollback must re-save BOTH via their per-record
-        // inverses. (Two records ⇒ two `step_nonatomic` deletes; index 1 is the
-        // last one.)
-        let result = with_nonatomic_forward_fault(1, || {
+        // Fault the converge forward: it empties the name (both records deleted
+        // under one lock), then the op fails — the inverse must re-converge to the
+        // full captured prior set, restoring BOTH records.
+        let result = with_nonatomic_forward_fault(0, || {
             repo::atomic::execute(&repo, RemoveRecordOnly { name: "main".to_string() })
         });
         assert!(result.is_err(), "the injected forward fault must fail the op");
@@ -2985,7 +3051,7 @@ mod atomic_tests {
         assert_eq!(
             remaining.len(),
             2,
-            "rollback re-saved ALL same-name records, not just the winner"
+            "rollback re-converged to ALL same-name records, not just the winner"
         );
         let ids: std::collections::HashSet<_> =
             remaining.iter().map(|t| t.id.clone()).collect();

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -15,30 +15,18 @@ use gix::{
         transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
     },
 };
+use objects::error::{HeddleError, Result as HeddleResult};
 use objects::object::{ChangeId, MarkerName, ThreadName};
 use oplog::{OpBatch, OpEntry, OpRecord};
 use refs::Head;
 use repo::{
     CommitGraphIndex, Repository, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
     ThreadState, refresh_thread_freshness,
+    atomic::{AtomicMutation, SavepointMutation, StagedCommit, Tx},
 };
 
 use super::{advice::RecoveryAdvice, thread_cmd::thread_not_found_advice};
 use crate::bridge::git_core::{open_repo as open_git_repo, set_reference};
-
-pub(super) fn apply_undo_batch(repo: &Repository, batch: &OpBatch) -> Result<()> {
-    for entry in batch.entries.iter().rev() {
-        apply_undo_entry(repo, entry)?;
-    }
-    Ok(())
-}
-
-pub(super) fn apply_redo_batch(repo: &Repository, batch: &OpBatch) -> Result<()> {
-    for entry in &batch.entries {
-        apply_redo_entry(repo, entry)?;
-    }
-    Ok(())
-}
 
 pub(super) fn preflight_undo_batches(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
     if !batches_have_git_checkpoint(batches) {
@@ -946,4 +934,595 @@ fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<
         manager.delete(&thread.id)?;
     }
     Ok(())
+}
+
+// ---- Atomic undo/redo (heddle#355 impl-b) ----
+//
+// `undo`/`redo` are migrated to the `AtomicMutation` primitive so the whole
+// operation is all-or-nothing: a failure anywhere mid-apply rewinds every
+// already-applied step back to the exact pre-operation state instead of
+// leaving the repo half-rewound (the spike §5.1 hazard — batch N fails after
+// batches `0..N` were applied AND marked undone, with no rollback).
+//
+// SHAPE. `undo`/`redo` perform direct, immediately-visible, **idempotent**
+// canonical mutations (ref writes, `goto` worktree material, thread-record and
+// git-mirror state, and the in-place `mark_batch_undone` flag flip) and append
+// NO new domain oplog record — they navigate states that already exist. So:
+//   * Each sub-op stages its effect and registers its inverse via the granular
+//     `Tx::on_rewind` ledger (the inverse of "undo entry E" is "redo entry E",
+//     and vice-versa; both are absolute SET operations, so the inverse restores
+//     the pre-step state regardless of how far a failed step got).
+//   * The parent NESTS the sub-ops via `Tx::enroll` (savepoint enrollment) —
+//     the recovery-ref child then one child per batch — so a child that stages
+//     then fails rewinds the child AND unwinds the parent through the shared
+//     ledger. This is the nesting path the migration exists to validate.
+//   * The commit point is the executor's lone `TransactionCommit` marker over
+//     an EMPTY domain batch (`StagedCommit::pure`). `OpBatch::is_transaction_
+//     marker_only` keeps that record-less commit sentinel out of the undo/redo
+//     eligibility scans and the `undo --list` view.
+//
+// TWO VALIDATION NOTES (see the PR description) — neither blocks the migration,
+// both are properties of mapping a self-mutating, immediately-visible op onto
+// the primitive:
+//   1. IDEMPOTENCY KEY. `undo`/`redo` have no unique content identity (they
+//      revisit existing states), so a key derived from "operation identity"
+//      (batch ids + head) COLLIDES on the legitimate `undo → redo → undo`
+//      toggle, and the primitive's dedup-then-`rewind_all` on a hit would
+//      silently REVERT the second undo. The key is therefore derived from the
+//      oplog GENERATION (`head_id`) at command start — unique per committed
+//      transaction (every undo/redo appends a marker that bumps the
+//      generation), so the dedup branch is never taken. The crash-retry dedup
+//      the trait optimizes for is both unreachable (a committed undo marks its
+//      batches undone, so a retry re-derives a different batch set) and
+//      unnecessary (re-applying an undo is idempotent) for this op.
+//   2. SAVEPOINT SEMANTICS. The children use the savepoint ENROLLMENT mechanism
+//      (`enroll` + `on_rewind`) for its apply+ledger-rewind shape, but their
+//      effects are direct canonical writes (visible immediately), not the
+//      invisible-until-commit staging `SavepointMutation` describes. This adds
+//      FAILURE atomicity (rewind), not concurrent-reader isolation — matching
+//      the pre-migration concurrency semantics, where undo already published
+//      refs batch-by-batch.
+//
+// EXACTNESS SCOPE. The rewind restores the exact pre-operation state for `undo`
+// of any batch count and for single-batch `redo` (the `-n 1` default). A
+// MULTI-batch `redo -n N>1` replays batches newest-first with absolute `goto`s
+// (pre-existing forward behavior this migration preserves), so the per-entry
+// inverses do not compose back to the exact pre-redo head — a mid-redo fault
+// there rewinds to a consistent intermediate state, not the precise pre-redo
+// tip. Still strictly safer than the pre-migration path, which had no rollback
+// at all. Fixing it would mean reordering redo replay (a forward-behavior
+// change) — out of scope for the atomicity migration.
+
+/// Convert an `anyhow` error raised by an undo/redo apply helper into the
+/// `HeddleError` the primitive's `Result` requires. The structured
+/// `RecoveryAdvice` refusals are produced by the command-level preflights
+/// (which run BEFORE `execute`), so a wrapped message here only ever surfaces a
+/// genuinely-unexpected mid-apply failure — one the preflights could not
+/// foresee — whose rewind has already restored the pre-operation state.
+fn apply_error(err: anyhow::Error) -> HeddleError {
+    HeddleError::Conflict(format!("{err:#}"))
+}
+
+/// Build the stable-per-transaction idempotency key. Derived from the oplog
+/// `generation` (read at command start) rather than the batch contents — see
+/// the "IDEMPOTENCY KEY" note above for why a content-derived key is unsafe for
+/// a self-mutating op.
+pub(super) fn undo_redo_transaction_id(
+    action: &str,
+    scope: &str,
+    generation: u64,
+    batches: &[OpBatch],
+) -> String {
+    let ids: Vec<String> = batches.iter().map(|batch| batch.id.to_string()).collect();
+    format!("{action}:{scope}:gen{generation}:[{}]", ids.join(","))
+}
+
+/// Savepoint child: preserve the pre-undo HEAD into the heddle-internal
+/// recovery pointer (the heddle#305 `ORIG_HEAD`-style ref), registering its
+/// restore as the inverse so an outer failure puts the prior pointer back
+/// (or clears it, on the first-ever undo).
+struct StageUndoRecovery {
+    head: Option<ChangeId>,
+}
+
+impl AtomicMutation for StageUndoRecovery {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        // Enrolled children never reach the commit point; only the root's id is
+        // used. A constant is sufficient and never minted fresh.
+        "undo:stage-recovery".to_string()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+        let Some(state) = self.head else {
+            return Ok(StagedCommit::pure(()));
+        };
+        let repo = tx.repo();
+        // Reconciled read of the prior pointer so the inverse restores exactly
+        // what was there (never a raw-ref bypass).
+        let prior = repo.refs().get_undo_recovery()?;
+        tx.on_rewind(move || match prior {
+            Some(prior) => repo.refs().set_undo_recovery(&prior),
+            None => repo.refs().clear_undo_recovery(),
+        });
+        repo.refs().set_undo_recovery(&state)?;
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+impl SavepointMutation for StageUndoRecovery {}
+
+/// Savepoint child: undo one batch. Each entry's inverse (`apply_redo_entry`)
+/// is registered on the shared ledger BEFORE its `apply_undo_entry` runs, so a
+/// mid-batch failure rewinds exactly the entries already touched; the
+/// `mark_batch_undone` flip is paired with its `mark_batch_redone` inverse.
+struct ApplyUndoBatch {
+    batch: OpBatch,
+    /// Test seam: when `Some(n)`, fail immediately after undoing `n` entries,
+    /// to exercise the mid-batch rewind path. Always `None` in production.
+    #[cfg(test)]
+    fail_after_entries: Option<usize>,
+}
+
+impl ApplyUndoBatch {
+    fn new(batch: OpBatch) -> Self {
+        Self {
+            batch,
+            #[cfg(test)]
+            fail_after_entries: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn failing_after(batch: OpBatch, entries: usize) -> Self {
+        Self {
+            batch,
+            fail_after_entries: Some(entries),
+        }
+    }
+}
+
+impl AtomicMutation for ApplyUndoBatch {
+    type Output = OpBatch;
+
+    fn transaction_id(&self) -> String {
+        format!("undo:batch:{}", self.batch.id)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
+        let repo = tx.repo();
+        for (applied, entry) in self.batch.entries.iter().rev().enumerate() {
+            let redo_entry = entry.clone();
+            tx.on_rewind(move || apply_redo_entry(repo, &redo_entry).map_err(apply_error));
+            apply_undo_entry(repo, entry).map_err(apply_error)?;
+            #[cfg(test)]
+            if self.fail_after_entries == Some(applied + 1) {
+                return Err(HeddleError::Conflict(
+                    "injected mid-undo fault".to_string(),
+                ));
+            }
+            #[cfg(not(test))]
+            let _ = applied;
+        }
+        let batch_for_redo = self.batch.clone();
+        tx.on_rewind(move || repo.oplog().mark_batch_redone(&batch_for_redo).map(|_| ()));
+        let updated = repo.oplog().mark_batch_undone(&self.batch)?;
+        Ok(StagedCommit::pure(updated))
+    }
+}
+
+impl SavepointMutation for ApplyUndoBatch {}
+
+/// Savepoint child: redo one batch — the mirror of [`ApplyUndoBatch`]. Entries
+/// replay in forward order; each inverse is `apply_undo_entry`, and the
+/// `mark_batch_redone` flip pairs with `mark_batch_undone`.
+struct ApplyRedoBatch {
+    batch: OpBatch,
+    #[cfg(test)]
+    fail_after_entries: Option<usize>,
+}
+
+impl ApplyRedoBatch {
+    fn new(batch: OpBatch) -> Self {
+        Self {
+            batch,
+            #[cfg(test)]
+            fail_after_entries: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn failing_after(batch: OpBatch, entries: usize) -> Self {
+        Self {
+            batch,
+            fail_after_entries: Some(entries),
+        }
+    }
+}
+
+impl AtomicMutation for ApplyRedoBatch {
+    type Output = OpBatch;
+
+    fn transaction_id(&self) -> String {
+        format!("redo:batch:{}", self.batch.id)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
+        let repo = tx.repo();
+        for (applied, entry) in self.batch.entries.iter().enumerate() {
+            let undo_entry = entry.clone();
+            tx.on_rewind(move || apply_undo_entry(repo, &undo_entry).map_err(apply_error));
+            apply_redo_entry(repo, entry).map_err(apply_error)?;
+            #[cfg(test)]
+            if self.fail_after_entries == Some(applied + 1) {
+                return Err(HeddleError::Conflict(
+                    "injected mid-redo fault".to_string(),
+                ));
+            }
+            #[cfg(not(test))]
+            let _ = applied;
+        }
+        let batch_for_undo = self.batch.clone();
+        tx.on_rewind(move || repo.oplog().mark_batch_undone(&batch_for_undo).map(|_| ()));
+        let updated = repo.oplog().mark_batch_redone(&self.batch)?;
+        Ok(StagedCommit::pure(updated))
+    }
+}
+
+impl SavepointMutation for ApplyRedoBatch {}
+
+/// Root composite for `heddle undo`: stage the recovery pointer, then nest one
+/// [`ApplyUndoBatch`] per batch. Returns the updated (undone) batches for the
+/// command's output. Appends no domain record — the executor's commit marker
+/// is the sole commit point.
+pub(super) struct UndoOp {
+    batches: Vec<OpBatch>,
+    recovery_head: Option<ChangeId>,
+    transaction_id: String,
+}
+
+impl UndoOp {
+    pub(super) fn new(
+        batches: Vec<OpBatch>,
+        recovery_head: Option<ChangeId>,
+        transaction_id: String,
+    ) -> Self {
+        Self {
+            batches,
+            recovery_head,
+            transaction_id,
+        }
+    }
+}
+
+impl AtomicMutation for UndoOp {
+    type Output = Vec<OpBatch>;
+
+    fn transaction_id(&self) -> String {
+        self.transaction_id.clone()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<OpBatch>>> {
+        tx.enroll(StageUndoRecovery {
+            head: self.recovery_head,
+        })?;
+        let mut updated = Vec::with_capacity(self.batches.len());
+        for batch in &self.batches {
+            let staged = tx.enroll(ApplyUndoBatch::new(batch.clone()))?;
+            updated.push(staged.output);
+        }
+        Ok(StagedCommit::pure(updated))
+    }
+}
+
+/// Root composite for `heddle redo`: nest one [`ApplyRedoBatch`] per batch. No
+/// recovery child (redo restores the pre-undo state the recovery pointer was
+/// captured against).
+pub(super) struct RedoOp {
+    batches: Vec<OpBatch>,
+    transaction_id: String,
+}
+
+impl RedoOp {
+    pub(super) fn new(batches: Vec<OpBatch>, transaction_id: String) -> Self {
+        Self {
+            batches,
+            transaction_id,
+        }
+    }
+}
+
+impl AtomicMutation for RedoOp {
+    type Output = Vec<OpBatch>;
+
+    fn transaction_id(&self) -> String {
+        self.transaction_id.clone()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<OpBatch>>> {
+        let mut updated = Vec::with_capacity(self.batches.len());
+        for batch in &self.batches {
+            let staged = tx.enroll(ApplyRedoBatch::new(batch.clone()))?;
+            updated.push(staged.output);
+        }
+        Ok(StagedCommit::pure(updated))
+    }
+}
+
+#[cfg(test)]
+mod atomic_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Init a repo and create two snapshots on `main`. The worktree at `s2`
+    /// holds both `a.txt` (from `s1`) and `b.txt` (from `s2`); `s1` holds only
+    /// `a.txt`; the initial state holds neither. Returns the repo + temp dir +
+    /// the two states.
+    fn repo_with_two_snapshots() -> (TempDir, Repository, ChangeId, ChangeId) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+        let s1 = repo.snapshot(Some("s1".to_string()), None).unwrap();
+        std::fs::write(temp.path().join("b.txt"), "b").unwrap();
+        let s2 = repo.snapshot(Some("s2".to_string()), None).unwrap();
+        (temp, repo, s1.change_id, s2.change_id)
+    }
+
+    #[test]
+    fn apply_error_wraps_anyhow_into_conflict() {
+        let wrapped = apply_error(anyhow!("boom"));
+        assert!(
+            matches!(&wrapped, HeddleError::Conflict(message) if message.contains("boom")),
+            "an apply-helper error must surface as a HeddleError::Conflict carrying the message"
+        );
+    }
+
+    fn commit_marker_count(repo: &Repository) -> usize {
+        repo.oplog()
+            .recent(256)
+            .unwrap()
+            .iter()
+            .filter(|entry| matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+            .count()
+    }
+
+    fn main_thread(repo: &Repository) -> Option<ChangeId> {
+        repo.refs().get_thread(&ThreadName::new("main")).unwrap()
+    }
+
+    /// Test-only parent mirroring [`UndoOp`] but injecting a fault: the LAST
+    /// enrolled batch child fails after undoing `fail_after` of its entries.
+    /// Reuses the REAL [`StageUndoRecovery`] + [`ApplyUndoBatch`] children, so
+    /// it exercises the real compensators + nesting + rewind path.
+    struct FaultyUndo {
+        batches: Vec<OpBatch>,
+        recovery_head: Option<ChangeId>,
+        fail_after: usize,
+    }
+
+    impl AtomicMutation for FaultyUndo {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            "test-undo-fault".to_string()
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+            tx.enroll(StageUndoRecovery {
+                head: self.recovery_head,
+            })?;
+            let last = self.batches.len() - 1;
+            for (i, batch) in self.batches.iter().enumerate() {
+                if i == last {
+                    tx.enroll(ApplyUndoBatch::failing_after(batch.clone(), self.fail_after))?;
+                } else {
+                    tx.enroll(ApplyUndoBatch::new(batch.clone()))?;
+                }
+            }
+            Ok(StagedCommit::pure(()))
+        }
+    }
+
+    /// Test-only parent mirroring [`RedoOp`] with an injected fault on the last
+    /// enrolled batch child.
+    struct FaultyRedo {
+        batches: Vec<OpBatch>,
+        fail_after: usize,
+    }
+
+    impl AtomicMutation for FaultyRedo {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            "test-redo-fault".to_string()
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+            let last = self.batches.len() - 1;
+            for (i, batch) in self.batches.iter().enumerate() {
+                if i == last {
+                    tx.enroll(ApplyRedoBatch::failing_after(batch.clone(), self.fail_after))?;
+                } else {
+                    tx.enroll(ApplyRedoBatch::new(batch.clone()))?;
+                }
+            }
+            Ok(StagedCommit::pure(()))
+        }
+    }
+
+    /// Behavioral parity: a clean atomic `UndoOp` reverts the worktree, HEAD,
+    /// and thread ref, marks the batch undone, captures the recovery pointer,
+    /// and commits exactly one marker — same observable result as the
+    /// pre-migration sequential path.
+    #[test]
+    fn atomic_undo_success_reverts_and_records_recovery() {
+        let (temp, repo, s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        let recovery_head = repo.head().unwrap();
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        let updated = repo::atomic::execute(&repo, UndoOp::new(batches, recovery_head, txid)).unwrap();
+
+        assert_eq!(updated.len(), 1);
+        assert!(updated[0].entries.iter().all(|e| e.undone));
+        assert_eq!(repo.head().unwrap(), Some(s1), "HEAD reverted to s1");
+        assert_eq!(main_thread(&repo), Some(s1));
+        assert!(temp.path().join("a.txt").exists(), "s1 file kept");
+        assert!(!temp.path().join("b.txt").exists(), "s2 file reverted");
+        assert_eq!(
+            repo.refs().get_undo_recovery().unwrap(),
+            Some(s2),
+            "recovery pointer pins the pre-undo tip"
+        );
+        assert_eq!(commit_marker_count(&repo), 1, "exactly one commit marker");
+    }
+
+    /// Fault-injection: a failure mid-undo (after the first batch is fully
+    /// applied, partway into the second) rewinds EVERY applied step back to the
+    /// exact pre-operation state — no partial ref / oplog / worktree leak.
+    #[test]
+    fn fault_mid_undo_rewinds_to_pre_operation_state() {
+        let (temp, repo, _s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        let pre_head = repo.head().unwrap();
+        assert_eq!(pre_head, Some(s2));
+        let pre_main = main_thread(&repo);
+        assert_eq!(repo.refs().get_undo_recovery().unwrap(), None);
+        let pre_markers = commit_marker_count(&repo);
+
+        let batches = repo.oplog().undo_batches_scoped(2, Some(&scope)).unwrap();
+        assert_eq!(batches.len(), 2, "two snapshots are undoable");
+        let result = repo::atomic::execute(
+            &repo,
+            FaultyUndo {
+                batches,
+                recovery_head: pre_head,
+                fail_after: 1,
+            },
+        );
+        assert!(result.is_err(), "the injected fault must fail the undo");
+
+        // Exact pre-operation state restored across every dimension.
+        assert_eq!(repo.head().unwrap(), Some(s2), "HEAD rewound to pre-undo tip");
+        assert_eq!(main_thread(&repo), pre_main, "main ref rewound");
+        assert!(temp.path().join("a.txt").exists(), "s1 file restored");
+        assert!(temp.path().join("b.txt").exists(), "s2 file restored");
+        assert_eq!(
+            repo.oplog()
+                .undo_batches_scoped(2, Some(&scope))
+                .unwrap()
+                .len(),
+            2,
+            "no batch left marked undone"
+        );
+        assert_eq!(
+            repo.refs().get_undo_recovery().unwrap(),
+            None,
+            "recovery pointer cleared by rewind (it had no prior value)"
+        );
+        assert_eq!(
+            commit_marker_count(&repo),
+            pre_markers,
+            "a failed transaction commits no marker"
+        );
+    }
+
+    /// Fault-injection: a failure mid-redo rewinds the replay back to the
+    /// fully-undone pre-redo state — no partial effect leaks.
+    #[test]
+    fn fault_mid_redo_rewinds_to_pre_operation_state() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+        let _s1 = repo.snapshot(Some("s1".to_string()), None).unwrap();
+        let scope = repo.op_scope();
+
+        // Cleanly undo the single snapshot through the real atomic UndoOp.
+        let recovery_head = repo.head().unwrap();
+        let undo_batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &undo_batches);
+        repo::atomic::execute(&repo, UndoOp::new(undo_batches, recovery_head, txid)).unwrap();
+
+        // Pre-redo state: the initial (pre-s1) state — a.txt gone, one batch
+        // redoable.
+        assert!(!temp.path().join("a.txt").exists(), "undone: a.txt gone");
+        let pre_redo_head = repo.head().unwrap();
+        let pre_redo_main = main_thread(&repo);
+        assert_eq!(
+            repo.oplog()
+                .redo_batches_scoped(1, Some(&scope))
+                .unwrap()
+                .len(),
+            1,
+            "one batch is redoable"
+        );
+        let pre_markers = commit_marker_count(&repo);
+
+        let redo_batches = repo.oplog().redo_batches_scoped(1, Some(&scope)).unwrap();
+        let result = repo::atomic::execute(
+            &repo,
+            FaultyRedo {
+                batches: redo_batches,
+                fail_after: 1,
+            },
+        );
+        assert!(result.is_err(), "the injected fault must fail the redo");
+
+        // Rewound to the fully-undone pre-redo state.
+        assert_eq!(repo.head().unwrap(), pre_redo_head, "HEAD rewound");
+        assert_eq!(main_thread(&repo), pre_redo_main, "main ref rewound");
+        assert!(!temp.path().join("a.txt").exists(), "s1 file not resurrected");
+        assert_eq!(
+            repo.oplog()
+                .redo_batches_scoped(1, Some(&scope))
+                .unwrap()
+                .len(),
+            1,
+            "batch still redoable"
+        );
+        assert_eq!(
+            commit_marker_count(&repo),
+            pre_markers,
+            "a failed transaction commits no marker"
+        );
+    }
+
+    /// A successful round trip via the atomic ops: undo then redo restores the
+    /// original tip, and the marker-only commit batches are excluded from the
+    /// undo/redo eligibility scans (so the round trip terminates instead of
+    /// chasing its own commit sentinels).
+    #[test]
+    fn atomic_undo_redo_round_trip_ignores_commit_markers() {
+        let (temp, repo, s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        // Undo s2.
+        let recovery_head = repo.head().unwrap();
+        let undo_batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &undo_batches);
+        repo::atomic::execute(&repo, UndoOp::new(undo_batches, recovery_head, txid)).unwrap();
+        assert_eq!(repo.head().unwrap(), Some(s1));
+
+        // The undo's commit marker is a record-less batch — not itself undoable.
+        let still_undoable = repo.oplog().undo_batches_scoped(2, Some(&scope)).unwrap();
+        assert_eq!(
+            still_undoable.len(),
+            1,
+            "only the s1 snapshot remains undoable; the commit marker is excluded"
+        );
+
+        // Redo s2.
+        let redo_batches = repo.oplog().redo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("redo", &scope, generation, &redo_batches);
+        repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid)).unwrap();
+        assert_eq!(repo.head().unwrap(), Some(s2), "redo restored the s2 tip");
+        assert!(temp.path().join("b.txt").exists(), "s2 file restored by redo");
+    }
 }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -21,7 +21,7 @@ use objects::object::{ChangeId, MarkerName, ThreadName};
 use oplog::{OpBatch, OpEntry, OpRecord};
 use refs::Head;
 use repo::{
-    CommitGraphIndex, Repository, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
+    CommitGraphIndex, Repository, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
     ThreadState, refresh_thread_freshness,
     atomic::{AtomicMutation, SavepointMutation, StagedCommit, Tx},
 };
@@ -122,7 +122,253 @@ fn ensure_simulated_git_head_is(
     )))
 }
 
-fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
+// ---- Per-effect step toolkit (heddle#355 r3, cid 3330966930 / 3330966931) ----
+//
+// Every externally-visible write inside an undo/redo entry runs through its OWN
+// `Tx::step`, so a failure on the Nth write leaves the prior N-1 inverses on the
+// rewind ledger and the rollback restores the EXACT pre-entry state. No `step`
+// forward performs more than one independently-failable write — the granularity
+// bug a per-ENTRY `step` had: a forward that did write-A (ok) then write-B (err)
+// returned `Err` with no compensator for A, leaving the repo half-rewound.
+//
+// Inverses capture the value the write is about to overwrite (capture-before),
+// so a step restores its own pre-state regardless of how far it got, and the
+// composition restores the whole entry. `goto_without_record` always re-detaches
+// HEAD, so `step_goto`'s inverse restores the full captured `Head` (worktree
+// state AND ref attachment) — otherwise a later re-attach effect would not be
+// undone in LIFO order. Inverses (rollback, best-effort) MAY touch more than one
+// ref; only forwards are held to the one-write rule.
+
+#[cfg(test)]
+thread_local! {
+    /// Test seam: when armed with `Some(n)`, the (n+1)-th per-effect step within
+    /// an entry application returns an injected error WITHOUT running its forward
+    /// — modeling "the (n+1)-th visible write fails after the first n succeeded",
+    /// so the mid-ENTRY rollback path can be asserted. Counts across every
+    /// `entry_step` of the current entry; disarms on trip.
+    static ENTRY_WRITE_FAULT: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+/// Arm the mid-entry write-fault seam for the duration of `body`, clearing it
+/// afterwards so it never leaks into another test on the same thread.
+#[cfg(test)]
+fn with_entry_write_fault<T>(skip_then_fail_at: usize, body: impl FnOnce() -> T) -> T {
+    ENTRY_WRITE_FAULT.with(|f| f.set(Some(skip_then_fail_at)));
+    let out = body();
+    ENTRY_WRITE_FAULT.with(|f| f.set(None));
+    out
+}
+
+/// Run one reversible leaf write of an undo/redo entry as a `Tx::step`. `forward`
+/// performs exactly one externally-visible write; `inverse` restores the state
+/// captured immediately before it. Honors the [`ENTRY_WRITE_FAULT`] test seam.
+fn entry_step<'a, T>(
+    tx: &mut Tx<'a>,
+    forward: impl FnOnce() -> HeddleResult<T>,
+    inverse: impl FnOnce() -> HeddleResult<()> + 'a,
+) -> HeddleResult<T> {
+    #[cfg(test)]
+    {
+        let trip = ENTRY_WRITE_FAULT.with(|f| match f.get() {
+            Some(0) => {
+                f.set(None);
+                true
+            }
+            Some(n) => {
+                f.set(Some(n - 1));
+                false
+            }
+            None => false,
+        });
+        if trip {
+            return Err(HeddleError::Conflict(
+                "injected mid-entry write fault".to_string(),
+            ));
+        }
+    }
+    tx.step(forward, inverse)
+}
+
+/// Step: navigate HEAD + worktree to `target`. Inverse restores the FULL pre-step
+/// HEAD (worktree state AND ref attachment).
+fn step_goto<'a>(tx: &mut Tx<'a>, target: ChangeId) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let prev_head_ref = repo.head_ref()?;
+    let prev_state = repo.head()?;
+    entry_step(
+        tx,
+        move || repo.goto_without_record(&target),
+        move || restore_head(repo, prev_state, &prev_head_ref),
+    )
+}
+
+/// Restore HEAD to a captured worktree `state` + ref attachment: re-materialize
+/// the worktree (if a state was captured), then restore the exact `Head` ref.
+fn restore_head(repo: &Repository, state: Option<ChangeId>, head_ref: &Head) -> HeddleResult<()> {
+    if let Some(state) = state {
+        repo.goto_without_record(&state)?;
+    }
+    repo.refs().write_head(head_ref)
+}
+
+/// Step: write HEAD to `head`; inverse restores the prior HEAD ref.
+fn step_write_head<'a>(tx: &mut Tx<'a>, head: Head) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let prev = repo.head_ref()?;
+    entry_step(
+        tx,
+        move || repo.refs().write_head(&head),
+        move || repo.refs().write_head(&prev),
+    )
+}
+
+/// Step: set thread ref `name` to `state`; inverse restores its prior value (or
+/// deletes it if it had none).
+fn step_set_thread<'a>(tx: &mut Tx<'a>, name: &str, state: ChangeId) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let forward_name = ThreadName::new(name);
+    let prev = repo.refs().get_thread(&forward_name)?;
+    let restore_name = name.to_string();
+    entry_step(
+        tx,
+        move || repo.refs().set_thread(&forward_name, &state),
+        move || {
+            let name = ThreadName::new(restore_name);
+            match prev {
+                Some(prev) => repo.refs().set_thread(&name, &prev),
+                None => repo.refs().delete_thread(&name).map(|_| ()),
+            }
+        },
+    )
+}
+
+/// Step: delete thread ref `name`; inverse restores its prior value.
+fn step_delete_thread<'a>(tx: &mut Tx<'a>, name: &str) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let forward_name = ThreadName::new(name);
+    let prev = repo.refs().get_thread(&forward_name)?;
+    let restore_name = name.to_string();
+    entry_step(
+        tx,
+        move || repo.refs().delete_thread(&forward_name).map(|_| ()),
+        move || match prev {
+            Some(prev) => repo.refs().set_thread(&ThreadName::new(restore_name), &prev),
+            None => Ok(()),
+        },
+    )
+}
+
+/// Step: create marker `name` at `state`; inverse restores its prior value
+/// (delete if it didn't exist). On a name collision the forward fails, so no
+/// inverse is registered and a pre-existing marker survives the rollback.
+fn step_create_marker<'a>(tx: &mut Tx<'a>, name: &str, state: ChangeId) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let forward_name = MarkerName::new(name);
+    let prev = repo.refs().get_marker(&forward_name)?;
+    let restore_name = name.to_string();
+    entry_step(
+        tx,
+        move || repo.refs().create_marker(&forward_name, &state),
+        move || {
+            let name = MarkerName::new(restore_name);
+            match prev {
+                Some(prev) => repo.refs().create_marker(&name, &prev),
+                None => repo.refs().delete_marker(&name).map(|_| ()),
+            }
+        },
+    )
+}
+
+/// Step: delete marker `name`; inverse recreates it at its prior value.
+fn step_delete_marker<'a>(tx: &mut Tx<'a>, name: &str) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let forward_name = MarkerName::new(name);
+    let prev = repo.refs().get_marker(&forward_name)?;
+    let restore_name = name.to_string();
+    entry_step(
+        tx,
+        move || repo.refs().delete_marker(&forward_name).map(|_| ()),
+        move || match prev {
+            Some(prev) => repo.refs().create_marker(&MarkerName::new(restore_name), &prev),
+            None => Ok(()),
+        },
+    )
+}
+
+/// Step: persist a mutated ThreadManager record; inverse restores the record's
+/// prior persisted form (or removes it if there was none).
+fn step_save_thread_record<'a>(tx: &mut Tx<'a>, record: Thread) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let prev = manager.find_by_thread(&record.thread)?;
+    let new_id = record.id.clone();
+    entry_step(
+        tx,
+        move || ThreadManager::new(repo.heddle_dir()).save(&record),
+        move || {
+            let manager = ThreadManager::new(repo.heddle_dir());
+            match prev {
+                Some(prev) => manager.save(&prev),
+                None => manager.delete(&new_id),
+            }
+        },
+    )
+}
+
+/// Step: delete a ThreadManager record; inverse re-saves it.
+fn step_delete_thread_record<'a>(tx: &mut Tx<'a>, record: Thread) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let id = record.id.clone();
+    entry_step(
+        tx,
+        move || ThreadManager::new(repo.heddle_dir()).delete(&id),
+        move || ThreadManager::new(repo.heddle_dir()).save(&record),
+    )
+}
+
+/// Step: restore a ThreadManager record from a redo snapshot; inverse restores
+/// the prior persisted form (or removes the restored record if there was none).
+/// A snapshot that fails to decode is a non-fatal warning (pre-migration parity).
+fn step_restore_thread_record<'a>(
+    tx: &mut Tx<'a>,
+    name: &str,
+    bytes: &[u8],
+) -> HeddleResult<()> {
+    let repo = tx.repo();
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let prev = manager.find_by_thread(name)?;
+    let bytes = bytes.to_vec();
+    let forward_name = name.to_string();
+    let restore_name = name.to_string();
+    entry_step(
+        tx,
+        move || {
+            let manager = ThreadManager::new(repo.heddle_dir());
+            if let Err(e) = manager.restore_thread_record_from_snapshot(&bytes) {
+                eprintln!(
+                    "warning: redo of `ThreadCreate` for '{}' restored the ref but failed to \
+                     decode the ThreadManager record snapshot ({}). Record-backed commands \
+                     (`thread cd`, delegate) may degrade on this thread — run `heddle thread \
+                     start {}` to recreate the record.",
+                    forward_name, e, forward_name
+                );
+            }
+            Ok(())
+        },
+        move || {
+            let manager = ThreadManager::new(repo.heddle_dir());
+            match prev {
+                Some(prev) => manager.save(&prev),
+                None => match manager.find_by_thread(&restore_name)? {
+                    Some(record) => manager.delete(&record.id),
+                    None => Ok(()),
+                },
+            }
+        },
+    )
+}
+
+fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
     match &entry.operation {
         OpRecord::Snapshot {
             prev_head: Some(prev),
@@ -130,21 +376,24 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             new_state,
             ..
         } => {
-            repo.goto_without_record(prev)?;
+            step_goto(tx, *prev)?;
             if let Some(thread) = thread {
-                repo.refs().set_thread(&ThreadName::new(thread.as_str()), prev)?;
-                repo.refs().write_head(&Head::Attached {
-                    thread: ThreadName::new(thread.as_str()),
-                })?;
-                sync_thread_record_state(repo, thread, *prev)?;
-                mark_merged_threads_unintegrated_for_target(repo, thread, new_state, prev)?;
+                step_set_thread(tx, thread.as_str(), *prev)?;
+                step_write_head(
+                    tx,
+                    Head::Attached {
+                        thread: ThreadName::new(thread.as_str()),
+                    },
+                )?;
+                sync_thread_record_state(tx, thread, *prev)?;
+                mark_merged_threads_unintegrated_for_target(tx, thread, new_state, prev)?;
             }
         }
         OpRecord::Goto {
             prev_head: Some(prev),
             ..
         } => {
-            repo.goto_without_record(prev)?;
+            step_goto(tx, *prev)?;
         }
         OpRecord::Snapshot {
             prev_head: None, ..
@@ -153,7 +402,7 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             prev_head: None, ..
         } => {}
         OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
-            delete_thread_safely(repo, &ThreadName::new(name.as_str()))?;
+            delete_thread_safely(tx, &ThreadName::new(name.as_str()))?;
             // Cross-thread contract rule 4 (docs/design/cross-thread-undo.md):
             // the inverse of `ThreadCreate` must also remove the matching
             // ThreadManager record so `heddle thread show` and the record-
@@ -170,21 +419,21 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             // is recorded for redo, so undo can still destroy the live
             // record without losing the data needed to put it back.
             // Matches the FastForward/V2 shared-undo shape.
-            remove_thread_manager_record(repo, name)?;
+            remove_thread_manager_record(tx, name)?;
         }
         OpRecord::ThreadDelete { name, state } => {
-            repo.refs().set_thread(&ThreadName::new(name.as_str()), state)?;
+            step_set_thread(tx, name.as_str(), *state)?;
         }
         OpRecord::ThreadUpdate {
             name, old_state, ..
         } => {
-            repo.refs().set_thread(&ThreadName::new(name.as_str()), old_state)?;
+            step_set_thread(tx, name.as_str(), *old_state)?;
         }
         OpRecord::MarkerCreate { name, .. } => {
-            repo.refs().delete_marker(&MarkerName::new(name.as_str()))?;
+            step_delete_marker(tx, name.as_str())?;
         }
         OpRecord::MarkerDelete { name, state } => {
-            repo.refs().create_marker(&MarkerName::new(name.as_str()), state)?;
+            step_create_marker(tx, name.as_str(), *state)?;
         }
         // Redaction inverse: drop the specific redaction record so
         // subsequent materialize calls restore the original blob
@@ -207,7 +456,12 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             state,
             path,
         } => {
-            repo.remove_redaction(blob, state, path, redaction_id)?;
+            // A single write, and redo of a redaction is refused upstream
+            // (`ensure_redaction_redo_supported`), so there is no inverse to
+            // register — matching the pre-migration no-op redo for this record.
+            tx.repo()
+                .remove_redaction(blob, state, path, redaction_id)
+                .map_err(apply_error)?;
         }
         // Fast-forward merge inverse: restore both HEAD and the target
         // thread ref to the pre-FF tip. The source thread never moved
@@ -228,7 +482,7 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             pre_target_id,
             ..
         } => {
-            apply_ff_undo(repo, source_thread, target_thread, pre_target_id)?;
+            apply_ff_undo(tx, source_thread, target_thread, pre_target_id)?;
         }
         OpRecord::GitCheckpoint {
             branch,
@@ -236,7 +490,7 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             new_git_oid,
             ..
         } => {
-            apply_git_checkpoint_undo(repo, branch, previous_git_oid.as_deref(), new_git_oid)?;
+            apply_git_checkpoint_undo(tx, branch, previous_git_oid.as_deref(), new_git_oid)?;
         }
         // No undo inverse: these records don't move a ref the undo chain
         // restores, or their reversal is irreversible / handled outside the
@@ -271,39 +525,45 @@ fn apply_undo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
 }
 
 fn apply_ff_undo(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     source_thread: &str,
     target_thread: &str,
     pre_target_id: &ChangeId,
-) -> Result<()> {
-    repo.goto_without_record(pre_target_id)?;
-    repo.refs().set_thread(&ThreadName::new(target_thread), pre_target_id)?;
-    repo.refs().write_head(&Head::Attached {
-        thread: ThreadName::new(target_thread),
-    })?;
-    sync_thread_record_state(repo, target_thread, *pre_target_id)?;
-    mark_source_thread_unintegrated(repo, source_thread, pre_target_id)
+) -> HeddleResult<()> {
+    step_goto(tx, *pre_target_id)?;
+    step_set_thread(tx, target_thread, *pre_target_id)?;
+    step_write_head(
+        tx,
+        Head::Attached {
+            thread: ThreadName::new(target_thread),
+        },
+    )?;
+    sync_thread_record_state(tx, target_thread, *pre_target_id)?;
+    mark_source_thread_unintegrated(tx, source_thread, pre_target_id)
 }
 
-fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
+fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
     match &entry.operation {
         OpRecord::Snapshot {
             new_state,
             prev_head,
             thread,
         } => {
-            repo.goto_without_record(new_state)?;
+            step_goto(tx, *new_state)?;
             if let Some(thread) = thread {
-                repo.refs().set_thread(&ThreadName::new(thread.as_str()), new_state)?;
-                repo.refs().write_head(&Head::Attached {
-                    thread: ThreadName::new(thread.as_str()),
-                })?;
-                sync_thread_record_state(repo, thread, *new_state)?;
-                mark_ready_threads_integrated_for_target(repo, thread, new_state, prev_head)?;
+                step_set_thread(tx, thread.as_str(), *new_state)?;
+                step_write_head(
+                    tx,
+                    Head::Attached {
+                        thread: ThreadName::new(thread.as_str()),
+                    },
+                )?;
+                sync_thread_record_state(tx, thread, *new_state)?;
+                mark_ready_threads_integrated_for_target(tx, thread, new_state, prev_head)?;
             }
         }
         OpRecord::Goto { target, .. } => {
-            repo.goto_without_record(target)?;
+            step_goto(tx, *target)?;
         }
         // V1 ThreadCreate redo: ref-only, with a stderr note that the
         // ThreadManager record is not being restored. V1 records were
@@ -316,7 +576,7 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
         // <name>` if they want the record back. V1 ages out as the
         // live oplog window slides forward.
         OpRecord::ThreadCreate { name, state } => {
-            repo.refs().set_thread(&ThreadName::new(name.as_str()), state)?;
+            step_set_thread(tx, name.as_str(), *state)?;
             eprintln!(
                 "warning: redo of legacy V1 `ThreadCreate` for '{}' restores the ref only — \
                  the matching ThreadManager record body was not snapshotted by this oplog entry. \
@@ -339,37 +599,24 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             state,
             manager_snapshot,
         } => {
-            repo.refs().set_thread(&ThreadName::new(name.as_str()), state)?;
+            step_set_thread(tx, name.as_str(), *state)?;
             if let Some(bytes) = manager_snapshot {
-                let manager = ThreadManager::new(repo.heddle_dir());
-                match manager.restore_thread_record_from_snapshot(bytes) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "warning: redo of `ThreadCreate` for '{}' restored the ref but \
-                             failed to decode the ThreadManager record snapshot ({}). \
-                             Record-backed commands (`thread cd`, delegate) may degrade \
-                             on this thread — run `heddle thread start {}` to recreate \
-                             the record.",
-                            name, e, name
-                        );
-                    }
-                }
+                step_restore_thread_record(tx, name, bytes)?;
             }
         }
         OpRecord::ThreadDelete { name, .. } => {
-            delete_thread_safely(repo, &ThreadName::new(name.as_str()))?;
+            delete_thread_safely(tx, &ThreadName::new(name.as_str()))?;
         }
         OpRecord::ThreadUpdate {
             name, new_state, ..
         } => {
-            repo.refs().set_thread(&ThreadName::new(name.as_str()), new_state)?;
+            step_set_thread(tx, name.as_str(), *new_state)?;
         }
         OpRecord::MarkerCreate { name, state } => {
-            repo.refs().create_marker(&MarkerName::new(name.as_str()), state)?;
+            step_create_marker(tx, name.as_str(), *state)?;
         }
         OpRecord::MarkerDelete { name, .. } => {
-            repo.refs().delete_marker(&MarkerName::new(name.as_str()))?;
+            step_delete_marker(tx, name.as_str())?;
         }
         // FF merge redo (V2): replay the *recorded* FF target. We do
         // not re-read `source_thread` — the recorded `post_target_id`
@@ -384,7 +631,7 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             post_target_id,
             ..
         } => {
-            apply_ff_redo(repo, source_thread, target_thread, post_target_id)?;
+            apply_ff_redo(tx, source_thread, target_thread, post_target_id)?;
         }
         OpRecord::GitCheckpoint {
             branch,
@@ -392,7 +639,7 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             new_git_oid,
             ..
         } => {
-            apply_git_checkpoint_redo(repo, branch, previous_git_oid.as_deref(), new_git_oid)?;
+            apply_git_checkpoint_redo(tx, branch, previous_git_oid.as_deref(), new_git_oid)?;
         }
         // FF merge redo (V1, legacy): the r1 implementation didn't
         // record `post_target_id`, so we have to re-resolve
@@ -406,14 +653,18 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
             target_thread,
             ..
         } => {
-            let source_tip = repo.refs().get_thread(&ThreadName::new(source_thread.as_str()))?.ok_or_else(|| {
-                anyhow!(
-                    "cannot redo fast-forward: source thread '{}' no longer exists \
-                     (legacy V1 oplog record; re-run the merge or `heddle gc oplog` to prune)",
-                    source_thread
-                )
-            })?;
-            apply_ff_redo(repo, source_thread, target_thread, &source_tip)?;
+            let source_tip = tx
+                .repo()
+                .refs()
+                .get_thread(&ThreadName::new(source_thread.as_str()))?
+                .ok_or_else(|| {
+                    HeddleError::Conflict(format!(
+                        "cannot redo fast-forward: source thread '{}' no longer exists \
+                         (legacy V1 oplog record; re-run the merge or `heddle gc oplog` to prune)",
+                        source_thread
+                    ))
+                })?;
+            apply_ff_redo(tx, source_thread, target_thread, &source_tip)?;
         }
         // No redo replay: these records don't re-advance a ref redo touches, or
         // they are refused upstream. Enumerated explicitly (no wildcard) so a
@@ -448,97 +699,273 @@ fn apply_redo_entry(repo: &Repository, entry: &OpEntry) -> Result<()> {
 }
 
 fn apply_ff_redo(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     source_thread: &str,
     target_thread: &str,
     post_target_id: &ChangeId,
-) -> Result<()> {
-    repo.goto_without_record(post_target_id)?;
-    repo.refs().set_thread(&ThreadName::new(target_thread), post_target_id)?;
-    repo.refs().write_head(&Head::Attached {
-        thread: ThreadName::new(target_thread),
-    })?;
-    sync_thread_record_state(repo, target_thread, *post_target_id)?;
-    mark_source_thread_integrated(repo, source_thread, post_target_id)
+) -> HeddleResult<()> {
+    step_goto(tx, *post_target_id)?;
+    step_set_thread(tx, target_thread, *post_target_id)?;
+    step_write_head(
+        tx,
+        Head::Attached {
+            thread: ThreadName::new(target_thread),
+        },
+    )?;
+    sync_thread_record_state(tx, target_thread, *post_target_id)?;
+    mark_source_thread_integrated(tx, source_thread, post_target_id)
+}
+
+/// The pre-entry Git state a checkpoint undo/redo entry overwrites, captured
+/// before any write so a partial failure restores it exactly. `git`-side writes
+/// span the checkout repo (HEAD file, branch ref, index) and the heddle mirror
+/// (branch ref), so all four are snapshotted.
+#[derive(Clone)]
+struct GitState {
+    /// Raw `.git/HEAD` of the checkout repo (symref or detached oid line).
+    head_file: Option<String>,
+    /// `refs/heads/{branch}` in the checkout repo.
+    checkout_branch_oid: Option<ObjectId>,
+    /// Resolved checkout HEAD commit — the index is reset back to this.
+    checkout_head_oid: Option<String>,
+    /// `refs/heads/{branch}` in the heddle mirror.
+    mirror_branch_oid: Option<ObjectId>,
+}
+
+fn capture_git_state(repo: &Repository, branch: &str) -> HeddleResult<GitState> {
+    let git = git_checkout_repo(repo).map_err(apply_error)?;
+    let checkout_branch_oid = if branch == "HEAD" {
+        None
+    } else {
+        ref_target_oid(&git, &format!("refs/heads/{branch}")).map_err(apply_error)?
+    };
+    let head_file = fs::read_to_string(git.git_dir().join("HEAD")).ok();
+    let checkout_head_oid = git.head_id().ok().map(|id| id.detach().to_string());
+    let mirror_branch_oid = capture_mirror_oid(repo, branch).map_err(apply_error)?;
+    Ok(GitState {
+        head_file,
+        checkout_branch_oid,
+        checkout_head_oid,
+        mirror_branch_oid,
+    })
+}
+
+/// Restore the checkout + mirror Git state captured in [`GitState`]. Runs only on
+/// the rollback path; absolute SET/DELETE ops, so re-running it (LIFO across the
+/// entry's steps) is idempotent.
+fn restore_git_state(repo: &Repository, branch: &str, state: &GitState) -> HeddleResult<()> {
+    let git = git_checkout_repo(repo).map_err(apply_error)?;
+    if branch != "HEAD" {
+        let ref_name = format!("refs/heads/{branch}");
+        match state.checkout_branch_oid {
+            Some(oid) => set_reference(
+                &git,
+                &ref_name,
+                oid,
+                PreviousValue::Any,
+                "heddle: rollback git checkpoint",
+            )
+            .map_err(|error| apply_error(anyhow!(error)))?,
+            None => delete_ref_if_present(&git, &ref_name).map_err(apply_error)?,
+        }
+    }
+    if let Some(head) = &state.head_file {
+        let head_path = git.git_dir().join("HEAD");
+        fs::write(&head_path, head)?;
+        fsync_file_and_parent(&head_path).map_err(apply_error)?;
+    }
+    if let Some(oid) = &state.checkout_head_oid {
+        let oid = parse_git_oid(oid).map_err(apply_error)?;
+        reset_git_index_to_commit(&git, oid).map_err(apply_error)?;
+    }
+    restore_mirror_oid(repo, branch, state.mirror_branch_oid).map_err(apply_error)?;
+    Ok(())
+}
+
+fn capture_mirror_oid(repo: &Repository, branch: &str) -> Result<Option<ObjectId>> {
+    if branch == "HEAD" {
+        return Ok(None);
+    }
+    let mirror = repo.heddle_dir().join("git");
+    if !mirror.exists() {
+        return Ok(None);
+    }
+    let git = open_git_repo(&mirror)?;
+    ref_target_oid(&git, &format!("refs/heads/{branch}"))
+}
+
+fn restore_mirror_oid(repo: &Repository, branch: &str, oid: Option<ObjectId>) -> Result<()> {
+    if branch == "HEAD" {
+        return Ok(());
+    }
+    let mirror = repo.heddle_dir().join("git");
+    if !mirror.exists() {
+        return Ok(());
+    }
+    let git = open_git_repo(&mirror)?;
+    let ref_name = format!("refs/heads/{branch}");
+    match oid {
+        Some(oid) => set_reference(
+            &git,
+            &ref_name,
+            oid,
+            PreviousValue::Any,
+            "heddle: rollback mirror checkpoint ref",
+        )
+        .map_err(|error| anyhow!(error)),
+        None => delete_ref_if_present(&git, &ref_name),
+    }
+}
+
+fn delete_ref_if_present(git: &gix::Repository, ref_name: &str) -> Result<()> {
+    if ref_target_oid(git, ref_name)?.is_some() {
+        delete_reference_matching(git, ref_name, None)?;
+    }
+    Ok(())
+}
+
+/// Run one checkout-repo Git write as a per-effect step. `forward` performs
+/// exactly one externally-visible write; on a later failure the rollback restores
+/// the captured `snapshot`. A fresh checkout handle is opened per step (cold path).
+fn git_step<'a>(
+    tx: &mut Tx<'a>,
+    repo: &'a Repository,
+    branch: &str,
+    snapshot: &GitState,
+    forward: impl FnOnce() -> Result<()>,
+) -> HeddleResult<()> {
+    let snapshot = snapshot.clone();
+    let branch = branch.to_string();
+    entry_step(
+        tx,
+        move || forward().map_err(apply_error),
+        move || restore_git_state(repo, &branch, &snapshot),
+    )
 }
 
 fn apply_git_checkpoint_undo(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     branch: &str,
     previous_git_oid: Option<&str>,
     new_git_oid: &str,
-) -> Result<()> {
-    ensure_git_head_is(repo, new_git_oid, "undo git checkpoint")?;
-    ensure_git_worktree_clean(repo, "undo git checkpoint")?;
-    let git = git_checkout_repo(repo)?;
-    let new_oid = parse_git_oid(new_git_oid)?;
+) -> HeddleResult<()> {
+    let repo = tx.repo();
+    ensure_git_head_is(repo, new_git_oid, "undo git checkpoint").map_err(apply_error)?;
+    ensure_git_worktree_clean(repo, "undo git checkpoint").map_err(apply_error)?;
+    let snapshot = capture_git_state(repo, branch)?;
+    let new_oid = parse_git_oid(new_git_oid).map_err(apply_error)?;
     match previous_git_oid {
         Some(previous) => {
-            let previous_oid = parse_git_oid(previous)?;
+            let previous_oid = parse_git_oid(previous).map_err(apply_error)?;
             if branch != "HEAD" {
-                let ref_name = format!("refs/heads/{branch}");
-                if ref_target_oid(&git, &ref_name)? != Some(previous_oid) {
-                    attach_git_head_to_branch(&git, branch)?;
-                    set_attached_git_head(
-                        &git,
-                        branch,
-                        previous_oid,
-                        new_oid,
-                        "heddle: undo git checkpoint",
-                    )?;
+                let git = git_checkout_repo(repo).map_err(apply_error)?;
+                if ref_target_oid(&git, &format!("refs/heads/{branch}")).map_err(apply_error)?
+                    != Some(previous_oid)
+                {
+                    git_step(tx, repo, branch, &snapshot, || {
+                        attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
+                    })?;
+                    git_step(tx, repo, branch, &snapshot, || {
+                        set_attached_git_head(
+                            &git_checkout_repo(repo)?,
+                            branch,
+                            previous_oid,
+                            new_oid,
+                            "heddle: undo git checkpoint",
+                        )
+                    })?;
                 }
-                attach_git_head_to_branch(&git, branch)?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
+                })?;
             }
-            reset_git_index_to_commit(&git, previous_oid)?;
-            update_mirror_branch_ref(repo, branch, Some(previous), Some(new_git_oid))?;
+            git_step(tx, repo, branch, &snapshot, || {
+                reset_git_index_to_commit(&git_checkout_repo(repo)?, previous_oid)
+            })?;
+            let previous = previous.to_string();
+            let new_git_oid = new_git_oid.to_string();
+            git_step(tx, repo, branch, &snapshot, || {
+                update_mirror_branch_ref(repo, branch, Some(&previous), Some(&new_git_oid))
+            })?;
         }
         None => {
             if branch != "HEAD" {
-                delete_reference_matching(&git, &format!("refs/heads/{branch}"), Some(new_oid))?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    delete_reference_matching(
+                        &git_checkout_repo(repo)?,
+                        &format!("refs/heads/{branch}"),
+                        Some(new_oid),
+                    )
+                })?;
             }
-            update_mirror_branch_ref(repo, branch, None, Some(new_git_oid))?;
+            let new_git_oid = new_git_oid.to_string();
+            git_step(tx, repo, branch, &snapshot, || {
+                update_mirror_branch_ref(repo, branch, None, Some(&new_git_oid))
+            })?;
         }
     }
     Ok(())
 }
 
 fn apply_git_checkpoint_redo(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     branch: &str,
     previous_git_oid: Option<&str>,
     new_git_oid: &str,
-) -> Result<()> {
+) -> HeddleResult<()> {
+    let repo = tx.repo();
     if let Some(previous) = previous_git_oid {
-        ensure_git_head_is(repo, previous, "redo git checkpoint")?;
+        ensure_git_head_is(repo, previous, "redo git checkpoint").map_err(apply_error)?;
     }
-    let git = git_checkout_repo(repo)?;
-    let new_oid = parse_git_oid(new_git_oid)?;
+    let snapshot = capture_git_state(repo, branch)?;
+    let new_oid = parse_git_oid(new_git_oid).map_err(apply_error)?;
     if branch != "HEAD" {
         match previous_git_oid {
             Some(previous) => {
-                attach_git_head_to_branch(&git, branch)?;
-                set_attached_git_head(
-                    &git,
-                    branch,
-                    new_oid,
-                    parse_git_oid(previous)?,
-                    "heddle: redo git checkpoint",
-                )?;
+                let previous_oid = parse_git_oid(previous).map_err(apply_error)?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
+                })?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    set_attached_git_head(
+                        &git_checkout_repo(repo)?,
+                        branch,
+                        new_oid,
+                        previous_oid,
+                        "heddle: redo git checkpoint",
+                    )
+                })?;
             }
             None => {
-                set_reference(
-                    &git,
-                    &format!("refs/heads/{branch}"),
-                    new_oid,
-                    PreviousValue::Any,
-                    "heddle: redo git checkpoint",
-                )?;
-                attach_git_head_to_branch(&git, branch)?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    set_reference(
+                        &git_checkout_repo(repo)?,
+                        &format!("refs/heads/{branch}"),
+                        new_oid,
+                        PreviousValue::Any,
+                        "heddle: redo git checkpoint",
+                    )
+                    .map_err(|error| anyhow!(error))
+                })?;
+                git_step(tx, repo, branch, &snapshot, || {
+                    attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
+                })?;
             }
         }
     }
-    reset_git_index_to_commit(&git, new_oid)?;
-    update_mirror_branch_ref(repo, branch, Some(new_git_oid), previous_git_oid)?;
+    git_step(tx, repo, branch, &snapshot, || {
+        reset_git_index_to_commit(&git_checkout_repo(repo)?, new_oid)
+    })?;
+    let previous_git_oid = previous_git_oid.map(|previous| previous.to_string());
+    let new_git_oid = new_git_oid.to_string();
+    git_step(tx, repo, branch, &snapshot, || {
+        update_mirror_branch_ref(
+            repo,
+            branch,
+            Some(&new_git_oid),
+            previous_git_oid.as_deref(),
+        )
+    })?;
     Ok(())
 }
 
@@ -765,40 +1192,45 @@ fn fsync_file_and_parent(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn delete_thread_safely(repo: &Repository, name: &ThreadName) -> Result<()> {
+fn delete_thread_safely(tx: &mut Tx<'_>, name: &ThreadName) -> HeddleResult<()> {
+    let repo = tx.repo();
     if let Head::Attached { thread } = repo.head_ref()?
         && thread == *name
     {
-        let state = repo
-            .refs()
-            .get_thread(name)?
-            .ok_or_else(|| anyhow!(thread_not_found_advice(name.as_str(), "delete thread")))?;
-        repo.refs().write_head(&Head::Detached { state })?;
+        let state = repo.refs().get_thread(name)?.ok_or_else(|| {
+            HeddleError::Conflict(
+                thread_not_found_advice(name.as_str(), "delete thread").to_string(),
+            )
+        })?;
+        // Detaching HEAD is its own effect (inverse restores the prior attached
+        // HEAD), separate from the ref deletion below.
+        step_write_head(tx, Head::Detached { state })?;
     }
 
-    repo.refs().delete_thread(name)?;
+    step_delete_thread(tx, name.as_str())?;
     Ok(())
 }
 
 fn sync_thread_record_state(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     thread_name: &str,
     state: objects::object::ChangeId,
-) -> Result<()> {
-    let manager = ThreadManager::new(repo.heddle_dir());
+) -> HeddleResult<()> {
+    let manager = ThreadManager::new(tx.repo().heddle_dir());
     if let Some(mut thread) = manager.find_by_thread(thread_name)? {
         thread.current_state = Some(state.short());
         thread.updated_at = chrono::Utc::now();
-        manager.save(&thread)?;
+        step_save_thread_record(tx, thread)?;
     }
     Ok(())
 }
 
 fn mark_source_thread_unintegrated(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     source_thread: &str,
     target_after_undo: &ChangeId,
-) -> Result<()> {
+) -> HeddleResult<()> {
+    let repo = tx.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     let Some(mut thread) = manager.find_by_thread(source_thread)? else {
         return Ok(());
@@ -829,16 +1261,17 @@ fn mark_source_thread_unintegrated(
         thread.freshness = ThreadFreshness::Current;
     }
     thread.updated_at = chrono::Utc::now();
-    manager.save(&thread)?;
+    step_save_thread_record(tx, thread)?;
     Ok(())
 }
 
 fn mark_merged_threads_unintegrated_for_target(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     target_thread: &str,
     integrated_state: &ChangeId,
     target_after_undo: &ChangeId,
-) -> Result<()> {
+) -> HeddleResult<()> {
+    let repo = tx.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     for thread in manager.list()? {
         if thread.thread == target_thread
@@ -854,17 +1287,20 @@ fn mark_merged_threads_unintegrated_for_target(
             .and_then(|state| repo.resolve_state(state).ok().flatten())
             .is_some_and(|state| state == *integrated_state);
         if points_at_integrated_state {
-            mark_source_thread_unintegrated(repo, &thread.thread, target_after_undo)?;
+            // Each affected record is saved through its own per-effect step, so a
+            // mid-loop failure rolls each one back independently.
+            mark_source_thread_unintegrated(tx, &thread.thread, target_after_undo)?;
         }
     }
     Ok(())
 }
 
 fn mark_source_thread_integrated(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     source_thread: &str,
     target_after_redo: &ChangeId,
-) -> Result<()> {
+) -> HeddleResult<()> {
+    let repo = tx.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     let Some(mut thread) = manager.find_by_thread(source_thread)? else {
         return Ok(());
@@ -889,16 +1325,17 @@ fn mark_source_thread_integrated(
     };
     thread.freshness = ThreadFreshness::Current;
     thread.updated_at = chrono::Utc::now();
-    manager.save(&thread)?;
+    step_save_thread_record(tx, thread)?;
     Ok(())
 }
 
 fn mark_ready_threads_integrated_for_target(
-    repo: &Repository,
+    tx: &mut Tx<'_>,
     target_thread: &str,
     integrated_state: &ChangeId,
     target_before_redo: &Option<ChangeId>,
-) -> Result<()> {
+) -> HeddleResult<()> {
+    let repo = tx.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     for thread in manager.list()? {
         if thread.thread == target_thread
@@ -915,7 +1352,7 @@ fn mark_ready_threads_integrated_for_target(
                 .as_ref()
                 .is_some_and(|before| change_contains(repo, &source_tip, before));
         if newly_integrated {
-            mark_source_thread_integrated(repo, &thread.thread, integrated_state)?;
+            mark_source_thread_integrated(tx, &thread.thread, integrated_state)?;
         }
     }
     Ok(())
@@ -929,10 +1366,10 @@ fn change_contains(repo: &Repository, ancestor: &ChangeId, descendant: &ChangeId
 /// Remove the ThreadManager record matching `thread_name`. No-op when no
 /// record exists. Used by the `ThreadCreate` inverse to keep refs and
 /// record-store state in lockstep (cross-thread undo contract rule 4).
-fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<()> {
-    let manager = ThreadManager::new(repo.heddle_dir());
+fn remove_thread_manager_record(tx: &mut Tx<'_>, thread_name: &str) -> HeddleResult<()> {
+    let manager = ThreadManager::new(tx.repo().heddle_dir());
     if let Some(thread) = manager.find_by_thread(thread_name)? {
-        manager.delete(&thread.id)?;
+        step_delete_thread_record(tx, thread)?;
     }
     Ok(())
 }
@@ -951,10 +1388,15 @@ fn remove_thread_manager_record(repo: &Repository, thread_name: &str) -> Result<
 // NO new domain oplog record — they navigate states that already exist. So:
 //   * Each sub-op stages its effect through the forward-first `Tx::step`
 //     combinator, which registers the inverse on the granular ledger ONLY after
-//     the forward succeeds (the inverse of "undo entry E" is "redo entry E", and
-//     vice-versa; both are absolute SET operations, so the inverse restores the
-//     pre-step state regardless of how far a failed step got — and a forward
-//     that fails registers no inverse at all).
+//     the forward succeeds (a forward that fails registers no inverse at all).
+//     Crucially this is done PER EFFECT: `apply_undo_entry` / `apply_redo_entry`
+//     wrap EACH individual write (`goto`, each ref/marker/thread-record write,
+//     each git write) in its own `step` with that write's capture-before inverse,
+//     so a failure on the Nth write of an entry leaves the prior N-1 inverses on
+//     the ledger and the rollback restores the exact pre-entry state. A whole-
+//     entry `step` (one forward = many writes) would leave a write half-applied
+//     when a LATER write in the same entry failed (heddle#355 cid 3330966930 /
+//     3330966931) — the granularity bug this migration must NOT reintroduce.
 //   * The parent NESTS the sub-ops via `Tx::enroll` (savepoint enrollment) —
 //     the recovery-ref child then one child per batch — so a child that stages
 //     then fails rewinds the child AND unwinds the parent through the shared
@@ -1084,9 +1526,9 @@ impl AtomicMutation for StageUndoRecovery {
 
 impl SavepointMutation for StageUndoRecovery {}
 
-/// Savepoint child: undo one batch. Each entry's inverse (`apply_redo_entry`)
-/// is registered on the shared ledger BEFORE its `apply_undo_entry` runs, so a
-/// mid-batch failure rewinds exactly the entries already touched; the
+/// Savepoint child: undo one batch. `apply_undo_entry` registers a per-EFFECT
+/// inverse for every individual write it performs, so a mid-ENTRY failure rewinds
+/// exactly the writes already applied (not just whole entries); the
 /// `mark_batch_undone` flip is paired with its `mark_batch_redone` inverse.
 struct ApplyUndoBatch {
     batch: OpBatch,
@@ -1124,15 +1566,13 @@ impl AtomicMutation for ApplyUndoBatch {
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
         let repo = tx.repo();
         for (applied, entry) in self.batch.entries.iter().rev().enumerate() {
-            let redo_entry = entry.clone();
-            // Forward-first: `apply_undo_entry` runs, and only on success is its
-            // `apply_redo_entry` inverse registered. A failed undo entry leaves
-            // the ledger empty for it, so the rollback never redoes an undo that
-            // didn't happen (heddle#355 cid 3330867774).
-            tx.step(
-                || apply_undo_entry(repo, entry).map_err(apply_error),
-                move || apply_redo_entry(repo, &redo_entry).map_err(apply_error),
-            )?;
+            // `apply_undo_entry` wraps EACH of its writes in its own `Tx::step`
+            // with that write's specific inverse, so a failure on the Nth write
+            // of the entry leaves the prior N-1 inverses on the ledger and the
+            // rollback restores the exact pre-entry state (heddle#355 cid
+            // 3330966930). No outer per-entry `step` is needed — and a whole-entry
+            // one would reintroduce the granularity bug it once papered over.
+            apply_undo_entry(tx, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1154,8 +1594,8 @@ impl AtomicMutation for ApplyUndoBatch {
 impl SavepointMutation for ApplyUndoBatch {}
 
 /// Savepoint child: redo one batch — the mirror of [`ApplyUndoBatch`]. Entries
-/// replay in forward order; each inverse is `apply_undo_entry`, and the
-/// `mark_batch_redone` flip pairs with `mark_batch_undone`.
+/// replay in forward order; `apply_redo_entry` registers a per-effect inverse for
+/// each write, and the `mark_batch_redone` flip pairs with `mark_batch_undone`.
 struct ApplyRedoBatch {
     batch: OpBatch,
     #[cfg(test)]
@@ -1190,14 +1630,11 @@ impl AtomicMutation for ApplyRedoBatch {
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
         let repo = tx.repo();
         for (applied, entry) in self.batch.entries.iter().enumerate() {
-            let undo_entry = entry.clone();
-            // Forward-first mirror of `ApplyUndoBatch`: register the
-            // `apply_undo_entry` inverse only after `apply_redo_entry` succeeds
-            // (heddle#355 cid 3330867775).
-            tx.step(
-                || apply_redo_entry(repo, entry).map_err(apply_error),
-                move || apply_undo_entry(repo, &undo_entry).map_err(apply_error),
-            )?;
+            // Mirror of `ApplyUndoBatch`: `apply_redo_entry` registers a
+            // per-effect inverse for each of its writes, so a mid-entry redo
+            // failure rolls back per-write to the exact pre-entry state
+            // (heddle#355 cid 3330966931).
+            apply_redo_entry(tx, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1535,6 +1972,230 @@ mod atomic_tests {
             commit_marker_count(&repo),
             pre_markers,
             "a failed transaction commits no marker"
+        );
+    }
+
+    /// Per-effect rollback, UNDO direction (heddle#355 cid 3330966930). A threaded
+    /// `Snapshot` undo performs several writes — `goto` (moves HEAD + worktree),
+    /// then the thread-ref / HEAD / record updates. Injecting a failure on the
+    /// SECOND write, after the goto already moved HEAD + worktree, must roll the
+    /// goto back too, restoring the EXACT pre-entry state. Under the old
+    /// whole-entry `step`, the goto leaked: a forward that failed partway had no
+    /// inverse registered, leaving HEAD/worktree half-rewound.
+    #[test]
+    fn per_effect_rollback_threaded_snapshot_undo() {
+        let (temp, repo, _s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        let pre_head = repo.head().unwrap();
+        assert_eq!(pre_head, Some(s2));
+        let pre_main = main_thread(&repo);
+        let pre_markers = commit_marker_count(&repo);
+        assert_eq!(repo.refs().get_undo_recovery().unwrap(), None);
+
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        // Fail the entry's 2nd per-effect write: the goto (write 1) succeeds and
+        // moves HEAD/worktree, then the thread-ref update (write 2) errors.
+        let result = with_entry_write_fault(1, || {
+            repo::atomic::execute(&repo, UndoOp::new(batches, pre_head, txid))
+        });
+        assert!(result.is_err(), "the injected 2nd-write fault must fail the undo");
+
+        // The goto was rolled back along with everything else.
+        assert_eq!(
+            repo.head().unwrap(),
+            Some(s2),
+            "HEAD goto rolled back to the pre-undo tip"
+        );
+        assert_eq!(main_thread(&repo), pre_main, "main ref unchanged");
+        assert!(temp.path().join("a.txt").exists(), "s1 file present");
+        assert!(
+            temp.path().join("b.txt").exists(),
+            "s2 file restored by the goto rollback (the per-effect inverse ran)"
+        );
+        assert_eq!(
+            repo.oplog()
+                .undo_batches_scoped(1, Some(&scope))
+                .unwrap()
+                .len(),
+            1,
+            "no batch left marked undone"
+        );
+        assert_eq!(
+            repo.refs().get_undo_recovery().unwrap(),
+            None,
+            "recovery pointer cleared by rewind"
+        );
+        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+    }
+
+    /// Per-effect rollback, REDO direction (heddle#355 cid 3330966931). Mirror of
+    /// the undo case: a threaded `Snapshot` redo's `goto` moves HEAD + worktree,
+    /// then the 2nd write fails — the goto must roll back to the fully-undone
+    /// pre-redo state, not leave the s2 worktree material resurrected. The
+    /// `GitCheckpoint` redo Codex named is the same multi-write class, now routed
+    /// through the identical per-effect `entry_step` machinery this exercises.
+    #[test]
+    fn per_effect_rollback_threaded_snapshot_redo() {
+        let (temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        // Cleanly undo s2 so it becomes redoable; pre-redo state is the s1 tip.
+        let recovery_head = repo.head().unwrap();
+        let undo_batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &undo_batches);
+        repo::atomic::execute(&repo, UndoOp::new(undo_batches, recovery_head, txid)).unwrap();
+        assert_eq!(repo.head().unwrap(), Some(s1), "undone to s1");
+        assert!(!temp.path().join("b.txt").exists(), "b.txt gone after undo");
+
+        let pre_redo_head = repo.head().unwrap();
+        let pre_redo_main = main_thread(&repo);
+        let pre_markers = commit_marker_count(&repo);
+
+        let redo_batches = repo.oplog().redo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("redo", &scope, generation, &redo_batches);
+        let result = with_entry_write_fault(1, || {
+            repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid))
+        });
+        assert!(result.is_err(), "the injected 2nd-write fault must fail the redo");
+
+        assert_eq!(
+            repo.head().unwrap(),
+            pre_redo_head,
+            "HEAD goto rolled back to the pre-redo (fully-undone) state"
+        );
+        assert_eq!(main_thread(&repo), pre_redo_main, "main ref unchanged");
+        assert!(temp.path().join("a.txt").exists(), "s1 file present");
+        assert!(
+            !temp.path().join("b.txt").exists(),
+            "s2 file NOT resurrected — the goto's per-effect inverse rolled it back"
+        );
+        assert_eq!(
+            repo.oplog()
+                .redo_batches_scoped(1, Some(&scope))
+                .unwrap()
+                .len(),
+            1,
+            "batch still redoable"
+        );
+        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+    }
+
+    /// Per-effect rollback of marker writes. Undoing a batch whose entries delete
+    /// one marker (`mc`) and re-create another (`md`) registers a per-effect
+    /// inverse for each; a later write failing must restore both markers to their
+    /// exact pre-undo presence (`mc` back, `md` gone again).
+    #[test]
+    fn per_effect_rollback_restores_marker_writes() {
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        // `mc` exists (its MarkerCreate undo = delete_marker, inverse recreate);
+        // `md` does not (its MarkerDelete undo = create_marker, inverse delete).
+        repo.refs().create_marker(&MarkerName::new("mc"), &s1).unwrap();
+        let main_state = main_thread(&repo).unwrap();
+
+        repo.oplog()
+            .record_batch_scoped(
+                vec![
+                    OpRecord::ThreadUpdate {
+                        name: "main".to_string(),
+                        old_state: main_state,
+                        new_state: main_state,
+                    },
+                    OpRecord::MarkerCreate {
+                        name: "mc".to_string(),
+                        state: s1,
+                    },
+                    OpRecord::MarkerDelete {
+                        name: "md".to_string(),
+                        state: s1,
+                    },
+                ],
+                Some(&scope),
+            )
+            .unwrap();
+
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let recovery_head = repo.head().unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        // Undo order (entries.rev()): create `md` [w1], delete `mc` [w2], then the
+        // ThreadUpdate undo's set_thread [w3] — trip at w3 so both marker inverses
+        // are on the ledger.
+        let result = with_entry_write_fault(2, || {
+            repo::atomic::execute(&repo, UndoOp::new(batches, recovery_head, txid))
+        });
+        assert!(result.is_err(), "the injected fault must fail the undo");
+
+        assert_eq!(
+            repo.refs().get_marker(&MarkerName::new("mc")).unwrap(),
+            Some(s1),
+            "mc restored by the delete_marker inverse"
+        );
+        assert_eq!(
+            repo.refs().get_marker(&MarkerName::new("md")).unwrap(),
+            None,
+            "md removed again by the create_marker inverse"
+        );
+    }
+
+    /// Per-effect rollback of thread-ref writes. Undoing a batch that re-creates a
+    /// deleted thread (`new`) and deletes a created thread (`old`) registers a
+    /// per-effect inverse for each; a later write failing must restore both refs.
+    #[test]
+    fn per_effect_rollback_restores_thread_ref_writes() {
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        // `old` exists (its ThreadCreate undo = delete_thread, inverse re-set);
+        // `new` does not (its ThreadDelete undo = set_thread, inverse delete).
+        repo.refs().set_thread(&ThreadName::new("old"), &s1).unwrap();
+        let main_state = main_thread(&repo).unwrap();
+
+        repo.oplog()
+            .record_batch_scoped(
+                vec![
+                    OpRecord::ThreadUpdate {
+                        name: "main".to_string(),
+                        old_state: main_state,
+                        new_state: main_state,
+                    },
+                    OpRecord::ThreadCreate {
+                        name: "old".to_string(),
+                        state: s1,
+                    },
+                    OpRecord::ThreadDelete {
+                        name: "new".to_string(),
+                        state: s1,
+                    },
+                ],
+                Some(&scope),
+            )
+            .unwrap();
+
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let recovery_head = repo.head().unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        // Undo order (entries.rev()): set `new` [w1], delete `old` [w2], then the
+        // ThreadUpdate undo's set_thread [w3] — trip at w3.
+        let result = with_entry_write_fault(2, || {
+            repo::atomic::execute(&repo, UndoOp::new(batches, recovery_head, txid))
+        });
+        assert!(result.is_err(), "the injected fault must fail the undo");
+
+        assert_eq!(
+            repo.refs().get_thread(&ThreadName::new("old")).unwrap(),
+            Some(s1),
+            "old restored by the delete_thread inverse"
+        );
+        assert_eq!(
+            repo.refs().get_thread(&ThreadName::new("new")).unwrap(),
+            None,
+            "new removed again by the set_thread inverse"
         );
     }
 

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -17,13 +17,13 @@ use gix::{
 };
 use objects::error::{HeddleError, Result as HeddleResult};
 use objects::lock::{RepoLock, WriteLockGuard};
-use objects::object::{ChangeId, MarkerName, ThreadName};
+use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName};
 use oplog::{OpBatch, OpEntry, OpRecord};
 use refs::Head;
 use repo::{
     CommitGraphIndex, Repository, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
     ThreadState, refresh_thread_freshness,
-    atomic::{AtomicMutation, SavepointMutation, StagedCommit, Tx},
+    atomic::{AtomicMutation, DeferredMutation, StagedCommit, Tx},
 };
 
 use super::{advice::RecoveryAdvice, thread_cmd::thread_not_found_advice};
@@ -122,35 +122,59 @@ fn ensure_simulated_git_head_is(
     )))
 }
 
-// ---- Per-effect step toolkit (heddle#355 r3, cid 3330966930 / 3330966931) ----
+// ---- The per-effect undo/redo applier (heddle#355 r3/r4) ----
 //
-// Every externally-visible write inside an undo/redo entry runs through its OWN
-// `Tx::step`, so a failure on the Nth write leaves the prior N-1 inverses on the
-// rewind ledger and the rollback restores the EXACT pre-entry state. No `step`
-// forward performs more than one independently-failable write — the granularity
-// bug a per-ENTRY `step` had: a forward that did write-A (ok) then write-B (err)
-// returned `Err` with no compensator for A, leaving the repo half-rewound.
+// `EntrySteps` owns the `&mut Tx` for the lifetime of one undo/redo apply and
+// exposes the domain's reversible writes as NAMED per-effect operations
+// (`goto`, `set_thread`, `save_thread_record`, `remove_redaction_sidecar`, …).
+// Each wraps the correct ledger combinator ONCE, so the entry appliers read as
+// `steps.set_thread(name, state)?` instead of inlining a forward/inverse closure
+// pair at every call site. The domain knowledge (refs, git, thread records,
+// redaction sidecars) lives HERE in the CLI/undo layer, never in the atomic
+// primitive (`crates/repo/src/atomic/`).
 //
-// Inverses capture the value the write is about to overwrite (capture-before),
-// so a step restores its own pre-state regardless of how far it got, and the
-// composition restores the whole entry. `goto_without_record` always re-detaches
-// HEAD, so `step_goto`'s inverse restores the full captured `Head` (worktree
-// state AND ref attachment) — otherwise a later re-attach effect would not be
-// undone in LIFO order. Inverses (rollback, best-effort) MAY touch more than one
-// ref; only forwards are held to the one-write rule.
+// GRANULARITY. Every externally-visible write runs through its OWN combinator
+// call, so a failure on the Nth write leaves the prior N-1 inverses on the
+// rewind ledger and the rollback restores the EXACT pre-entry state. The two
+// combinators guard opposite hazards:
+//
+//   * `step` (forward-first) — for a single all-or-nothing write. Registers its
+//     capture-before inverse only AFTER the forward returns `Ok`, so a forward
+//     that fails registers no inverse for an effect that did not happen (the
+//     register-then-forward footgun, cid 3330867774 / 3330867775).
+//   * `step_nonatomic` (capture-restore) — for a NON-atomic forward (several
+//     internal writes, or a materialization that can fail partway): a `goto`
+//     (worktree materialize + HEAD write), `ThreadManager::save` (record file +
+//     workspace file), or the redaction-sidecar removal (rewrite/delete). It
+//     captures the prior state and registers a restore-to-snapshot inverse
+//     BEFORE running the forward, so a partially-applied (or applied-then-later-
+//     failed) forward is still fully unwound. A plain `step` here would leak the
+//     partial effect, because it registers nothing when the forward returns
+//     `Err`.
+//
+// Inverses (rollback, best-effort) MAY touch more than one ref; only `step`
+// forwards are held to the one-write rule. `step_nonatomic` forwards may be
+// non-atomic by definition — that is the whole point of the second combinator.
 
 #[cfg(test)]
 thread_local! {
     /// Test seam: when armed with `Some(n)`, the (n+1)-th per-effect step within
     /// an entry application returns an injected error WITHOUT running its forward
-    /// — modeling "the (n+1)-th visible write fails after the first n succeeded",
-    /// so the mid-ENTRY rollback path can be asserted. Counts across every
-    /// `entry_step` of the current entry; disarms on trip.
+    /// — modeling "the (n+1)-th visible write fails before it does anything", so
+    /// the mid-ENTRY rollback path can be asserted. Counts across every `step` /
+    /// `step_nonatomic` of the current entry; disarms on trip.
     static ENTRY_WRITE_FAULT: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+    /// Test seam for the NON-atomic forwards: when armed with `Some(n)`, the
+    /// (n+1)-th `step_nonatomic` RUNS its forward (applying its possibly-partial
+    /// effect) and THEN returns an injected error — modeling a composite forward
+    /// that mutated state and then failed. The restore registered BEFORE the
+    /// forward must unwind it. Counts only `step_nonatomic` calls; disarms on
+    /// trip.
+    static NONATOMIC_FORWARD_FAULT: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
-/// Arm the mid-entry write-fault seam for the duration of `body`, clearing it
-/// afterwards so it never leaks into another test on the same thread.
+/// Arm the trip-before mid-entry write-fault seam for the duration of `body`,
+/// clearing it afterwards so it never leaks into another test on the same thread.
 #[cfg(test)]
 fn with_entry_write_fault<T>(skip_then_fail_at: usize, body: impl FnOnce() -> T) -> T {
     ENTRY_WRITE_FAULT.with(|f| f.set(Some(skip_then_fail_at)));
@@ -159,47 +183,33 @@ fn with_entry_write_fault<T>(skip_then_fail_at: usize, body: impl FnOnce() -> T)
     out
 }
 
-/// Run one reversible leaf write of an undo/redo entry as a `Tx::step`. `forward`
-/// performs exactly one externally-visible write; `inverse` restores the state
-/// captured immediately before it. Honors the [`ENTRY_WRITE_FAULT`] test seam.
-fn entry_step<'a, T>(
-    tx: &mut Tx<'a>,
-    forward: impl FnOnce() -> HeddleResult<T>,
-    inverse: impl FnOnce() -> HeddleResult<()> + 'a,
-) -> HeddleResult<T> {
-    #[cfg(test)]
-    {
-        let trip = ENTRY_WRITE_FAULT.with(|f| match f.get() {
-            Some(0) => {
-                f.set(None);
-                true
-            }
-            Some(n) => {
-                f.set(Some(n - 1));
-                false
-            }
-            None => false,
-        });
-        if trip {
-            return Err(HeddleError::Conflict(
-                "injected mid-entry write fault".to_string(),
-            ));
-        }
-    }
-    tx.step(forward, inverse)
+/// Arm the non-atomic forward-partial-failure seam for the duration of `body`:
+/// the `skip_then_fail_at`-th-after `step_nonatomic` forward runs (applying its
+/// effect) then fails, exercising the restore-to-snapshot rollback the second
+/// combinator exists for.
+#[cfg(test)]
+fn with_nonatomic_forward_fault<T>(skip_then_fail_at: usize, body: impl FnOnce() -> T) -> T {
+    NONATOMIC_FORWARD_FAULT.with(|f| f.set(Some(skip_then_fail_at)));
+    let out = body();
+    NONATOMIC_FORWARD_FAULT.with(|f| f.set(None));
+    out
 }
 
-/// Step: navigate HEAD + worktree to `target`. Inverse restores the FULL pre-step
-/// HEAD (worktree state AND ref attachment).
-fn step_goto<'a>(tx: &mut Tx<'a>, target: ChangeId) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let prev_head_ref = repo.head_ref()?;
-    let prev_state = repo.head()?;
-    entry_step(
-        tx,
-        move || repo.goto_without_record(&target),
-        move || restore_head(repo, prev_state, &prev_head_ref),
-    )
+/// Decrement-and-test one of the per-entry fault counters; `true` iff this call
+/// is the armed trip point (the counter disarms on trip).
+#[cfg(test)]
+fn fault_counter_trips(cell: &'static std::thread::LocalKey<std::cell::Cell<Option<usize>>>) -> bool {
+    cell.with(|f| match f.get() {
+        Some(0) => {
+            f.set(None);
+            true
+        }
+        Some(n) => {
+            f.set(Some(n - 1));
+            false
+        }
+        None => false,
+    })
 }
 
 /// Restore HEAD to a captured worktree `state` + ref attachment: re-materialize
@@ -211,164 +221,316 @@ fn restore_head(repo: &Repository, state: Option<ChangeId>, head_ref: &Head) -> 
     repo.refs().write_head(head_ref)
 }
 
-/// Step: write HEAD to `head`; inverse restores the prior HEAD ref.
-fn step_write_head<'a>(tx: &mut Tx<'a>, head: Head) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let prev = repo.head_ref()?;
-    entry_step(
-        tx,
-        move || repo.refs().write_head(&head),
-        move || repo.refs().write_head(&prev),
-    )
+/// Owns the `&mut Tx` for one undo/redo apply and exposes the domain's reversible
+/// writes as named per-effect operations. See the module comment above.
+struct EntrySteps<'tx, 'a> {
+    tx: &'tx mut Tx<'a>,
 }
 
-/// Step: set thread ref `name` to `state`; inverse restores its prior value (or
-/// deletes it if it had none).
-fn step_set_thread<'a>(tx: &mut Tx<'a>, name: &str, state: ChangeId) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let forward_name = ThreadName::new(name);
-    let prev = repo.refs().get_thread(&forward_name)?;
-    let restore_name = name.to_string();
-    entry_step(
-        tx,
-        move || repo.refs().set_thread(&forward_name, &state),
-        move || {
-            let name = ThreadName::new(restore_name);
-            match prev {
-                Some(prev) => repo.refs().set_thread(&name, &prev),
-                None => repo.refs().delete_thread(&name).map(|_| ()),
-            }
-        },
-    )
+impl<'a> EntrySteps<'_, 'a> {
+    fn new<'tx>(tx: &'tx mut Tx<'a>) -> EntrySteps<'tx, 'a> {
+        EntrySteps { tx }
+    }
+
+    fn repo(&self) -> &'a Repository {
+        self.tx.repo()
+    }
+
+    /// One reversible leaf write that is a single all-or-nothing operation:
+    /// forward-first via [`Tx::step`]. Honors the [`ENTRY_WRITE_FAULT`] seam.
+    fn step<T>(
+        &mut self,
+        forward: impl FnOnce() -> HeddleResult<T>,
+        inverse: impl FnOnce() -> HeddleResult<()> + 'a,
+    ) -> HeddleResult<T> {
+        #[cfg(test)]
+        if fault_counter_trips(&ENTRY_WRITE_FAULT) {
+            return Err(HeddleError::Conflict(
+                "injected mid-entry write fault".to_string(),
+            ));
+        }
+        self.tx.step(forward, inverse)
+    }
+
+    /// One reversible write whose `forward` is NOT a single all-or-nothing
+    /// operation: capture-restore via [`Tx::step_nonatomic`], which registers the
+    /// restore-to-snapshot inverse BEFORE running the forward. Honors both the
+    /// trip-before [`ENTRY_WRITE_FAULT`] seam (shared per-entry write counter) and
+    /// the [`NONATOMIC_FORWARD_FAULT`] seam (run-forward-then-fail).
+    fn step_nonatomic<T, S: 'a>(
+        &mut self,
+        capture: impl FnOnce() -> HeddleResult<S>,
+        restore: impl FnOnce(S) -> HeddleResult<()> + 'a,
+        forward: impl FnOnce() -> HeddleResult<T>,
+    ) -> HeddleResult<T> {
+        #[cfg(test)]
+        if fault_counter_trips(&ENTRY_WRITE_FAULT) {
+            return Err(HeddleError::Conflict(
+                "injected mid-entry write fault".to_string(),
+            ));
+        }
+        #[cfg(test)]
+        if fault_counter_trips(&NONATOMIC_FORWARD_FAULT) {
+            // Run the real forward (applying its possibly-partial effect), then
+            // fail — the restore registered BEFORE the forward unwinds it.
+            return self.tx.step_nonatomic(capture, restore, move || {
+                forward()?;
+                Err(HeddleError::Conflict(
+                    "injected non-atomic forward fault".to_string(),
+                ))
+            });
+        }
+        self.tx.step_nonatomic(capture, restore, forward)
+    }
+
+    /// Navigate HEAD + worktree to `target`. NON-atomic: `goto_without_record`
+    /// materializes the worktree and then re-detaches HEAD, so it can fail
+    /// partway. The capture snapshots the FULL pre-step `Head` (worktree state
+    /// AND ref attachment) and the restore re-materializes it, so a partial
+    /// (or later-failed) goto is fully unwound.
+    fn goto(&mut self, target: ChangeId) -> HeddleResult<()> {
+        let repo = self.repo();
+        self.step_nonatomic(
+            move || Ok((repo.head()?, repo.head_ref()?)),
+            move |(prev_state, prev_head_ref)| restore_head(repo, prev_state, &prev_head_ref),
+            move || repo.goto_without_record(&target),
+        )
+    }
+
+    /// Write HEAD to `head`; inverse restores the prior HEAD ref. A single ref
+    /// write — genuinely all-or-nothing.
+    fn write_head(&mut self, head: Head) -> HeddleResult<()> {
+        let repo = self.repo();
+        let prev = repo.head_ref()?;
+        self.step(
+            move || repo.refs().write_head(&head),
+            move || repo.refs().write_head(&prev),
+        )
+    }
+
+    /// Set thread ref `name` to `state`; inverse restores its prior value (or
+    /// deletes it if it had none). A single ref write.
+    fn set_thread(&mut self, name: &str, state: ChangeId) -> HeddleResult<()> {
+        let repo = self.repo();
+        let forward_name = ThreadName::new(name);
+        let prev = repo.refs().get_thread(&forward_name)?;
+        let restore_name = name.to_string();
+        self.step(
+            move || repo.refs().set_thread(&forward_name, &state),
+            move || {
+                let name = ThreadName::new(restore_name);
+                match prev {
+                    Some(prev) => repo.refs().set_thread(&name, &prev),
+                    None => repo.refs().delete_thread(&name).map(|_| ()),
+                }
+            },
+        )
+    }
+
+    /// Delete thread ref `name`; inverse restores its prior value. A single ref
+    /// write.
+    fn delete_thread(&mut self, name: &str) -> HeddleResult<()> {
+        let repo = self.repo();
+        let forward_name = ThreadName::new(name);
+        let prev = repo.refs().get_thread(&forward_name)?;
+        let restore_name = name.to_string();
+        self.step(
+            move || repo.refs().delete_thread(&forward_name).map(|_| ()),
+            move || match prev {
+                Some(prev) => repo.refs().set_thread(&ThreadName::new(restore_name), &prev),
+                None => Ok(()),
+            },
+        )
+    }
+
+    /// Create marker `name` at `state`; inverse restores its prior value (delete
+    /// if it didn't exist). A single ref write — on a name collision the forward
+    /// fails, so no inverse is registered and a pre-existing marker survives the
+    /// rollback.
+    fn create_marker(&mut self, name: &str, state: ChangeId) -> HeddleResult<()> {
+        let repo = self.repo();
+        let forward_name = MarkerName::new(name);
+        let prev = repo.refs().get_marker(&forward_name)?;
+        let restore_name = name.to_string();
+        self.step(
+            move || repo.refs().create_marker(&forward_name, &state),
+            move || {
+                let name = MarkerName::new(restore_name);
+                match prev {
+                    Some(prev) => repo.refs().create_marker(&name, &prev),
+                    None => repo.refs().delete_marker(&name).map(|_| ()),
+                }
+            },
+        )
+    }
+
+    /// Delete marker `name`; inverse recreates it at its prior value. A single
+    /// ref write.
+    fn delete_marker(&mut self, name: &str) -> HeddleResult<()> {
+        let repo = self.repo();
+        let forward_name = MarkerName::new(name);
+        let prev = repo.refs().get_marker(&forward_name)?;
+        let restore_name = name.to_string();
+        self.step(
+            move || repo.refs().delete_marker(&forward_name).map(|_| ()),
+            move || match prev {
+                Some(prev) => repo.refs().create_marker(&MarkerName::new(restore_name), &prev),
+                None => Ok(()),
+            },
+        )
+    }
+
+    /// Persist a mutated ThreadManager record; inverse restores the record's
+    /// prior persisted form (or removes it if there was none). NON-atomic:
+    /// `ThreadManager::save` writes the record file AND the workspace file, so a
+    /// failure on the second write leaves the first applied — the capture
+    /// snapshots both prior forms and the restore rewrites/removes them.
+    fn save_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
+        let repo = self.repo();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let prev = manager.find_by_thread(&record.thread)?;
+        let new_id = record.id.clone();
+        self.step_nonatomic(
+            || Ok(prev),
+            move |prev| {
+                let manager = ThreadManager::new(repo.heddle_dir());
+                match prev {
+                    Some(prev) => manager.save(&prev),
+                    None => manager.delete(&new_id),
+                }
+            },
+            move || ThreadManager::new(repo.heddle_dir()).save(&record),
+        )
+    }
+
+    /// Delete a ThreadManager record; inverse re-saves it. NON-atomic:
+    /// `ThreadManager::delete` removes the record file AND the workspace file,
+    /// so the inverse re-saves the captured record wholesale.
+    fn delete_thread_record(&mut self, record: Thread) -> HeddleResult<()> {
+        let repo = self.repo();
+        let id = record.id.clone();
+        self.step_nonatomic(
+            || Ok(record),
+            move |record| ThreadManager::new(repo.heddle_dir()).save(&record),
+            move || ThreadManager::new(repo.heddle_dir()).delete(&id),
+        )
+    }
+
+    /// Restore a ThreadManager record from a redo snapshot; inverse restores the
+    /// prior persisted form (or removes the restored record if there was none).
+    /// A snapshot that fails to decode is a non-fatal warning (pre-migration
+    /// parity). NON-atomic for the same record-file + workspace-file reason as
+    /// [`save_thread_record`](Self::save_thread_record).
+    fn restore_thread_record(&mut self, name: &str, bytes: &[u8]) -> HeddleResult<()> {
+        let repo = self.repo();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let prev = manager.find_by_thread(name)?;
+        let bytes = bytes.to_vec();
+        let forward_name = name.to_string();
+        let restore_name = name.to_string();
+        self.step_nonatomic(
+            || Ok(prev),
+            move |prev| {
+                let manager = ThreadManager::new(repo.heddle_dir());
+                match prev {
+                    Some(prev) => manager.save(&prev),
+                    None => match manager.find_by_thread(&restore_name)? {
+                        Some(record) => manager.delete(&record.id),
+                        None => Ok(()),
+                    },
+                }
+            },
+            move || {
+                let manager = ThreadManager::new(repo.heddle_dir());
+                if let Err(e) = manager.restore_thread_record_from_snapshot(&bytes) {
+                    eprintln!(
+                        "warning: redo of `ThreadCreate` for '{}' restored the ref but failed to \
+                         decode the ThreadManager record snapshot ({}). Record-backed commands \
+                         (`thread cd`, delegate) may degrade on this thread — run `heddle thread \
+                         start {}` to recreate the record.",
+                        forward_name, e, forward_name
+                    );
+                }
+                Ok(())
+            },
+        )
+    }
+
+    /// Remove a redaction record from its per-blob sidecar. NON-atomic and
+    /// re-exposing: `remove_redaction` rewrites or deletes the sidecar file, so
+    /// the capture snapshots the whole sidecar (bytes or absence) and registers a
+    /// restore-to-snapshot BEFORE the removal — a later transaction failure then
+    /// restores the sidecar and the redacted blob is NOT re-exposed.
+    fn remove_redaction_sidecar(
+        &mut self,
+        blob: ContentHash,
+        state: ChangeId,
+        path: String,
+        redaction_id: ContentHash,
+    ) -> HeddleResult<()> {
+        let repo = self.repo();
+        self.step_nonatomic(
+            move || repo.capture_redaction_sidecar(&blob).map_err(apply_error),
+            move |snapshot| {
+                repo.restore_redaction_sidecar(&blob, snapshot)
+                    .map_err(apply_error)
+            },
+            move || {
+                repo.remove_redaction(&blob, &state, &path, &redaction_id)
+                    .map(|_| ())
+                    .map_err(apply_error)
+            },
+        )
+    }
+
+    /// Run one checkout-repo Git write as a capture-restore step against the
+    /// pre-entry [`GitState`] `snapshot`. Git checkpoint entries make several
+    /// internal writes; restoring to the absolute pre-entry snapshot is
+    /// idempotent across the entry's steps, and registering the restore BEFORE
+    /// each write covers a write that fails partway. A fresh checkout handle is
+    /// opened per step (cold path).
+    fn git_restore_snapshot(
+        &mut self,
+        repo: &'a Repository,
+        branch: &str,
+        snapshot: &GitState,
+        forward: impl FnOnce() -> Result<()>,
+    ) -> HeddleResult<()> {
+        let snapshot = snapshot.clone();
+        let branch = branch.to_string();
+        self.step_nonatomic(
+            move || Ok(snapshot),
+            move |snapshot| restore_git_state(repo, &branch, &snapshot),
+            move || forward().map_err(apply_error),
+        )
+    }
+
+    /// Flip the batch's persisted undone flag; inverse re-marks it redone. A
+    /// single oplog write. Returns the updated batch for the command output.
+    fn mark_batch_undone(&mut self, batch: &OpBatch) -> HeddleResult<OpBatch> {
+        let repo = self.repo();
+        let forward_batch = batch.clone();
+        let inverse_batch = batch.clone();
+        self.step(
+            move || repo.oplog().mark_batch_undone(&forward_batch),
+            move || repo.oplog().mark_batch_redone(&inverse_batch).map(|_| ()),
+        )
+    }
+
+    /// Flip the batch's persisted redone flag; inverse re-marks it undone. The
+    /// mirror of [`mark_batch_undone`](Self::mark_batch_undone).
+    fn mark_batch_redone(&mut self, batch: &OpBatch) -> HeddleResult<OpBatch> {
+        let repo = self.repo();
+        let forward_batch = batch.clone();
+        let inverse_batch = batch.clone();
+        self.step(
+            move || repo.oplog().mark_batch_redone(&forward_batch),
+            move || repo.oplog().mark_batch_undone(&inverse_batch).map(|_| ()),
+        )
+    }
 }
 
-/// Step: delete thread ref `name`; inverse restores its prior value.
-fn step_delete_thread<'a>(tx: &mut Tx<'a>, name: &str) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let forward_name = ThreadName::new(name);
-    let prev = repo.refs().get_thread(&forward_name)?;
-    let restore_name = name.to_string();
-    entry_step(
-        tx,
-        move || repo.refs().delete_thread(&forward_name).map(|_| ()),
-        move || match prev {
-            Some(prev) => repo.refs().set_thread(&ThreadName::new(restore_name), &prev),
-            None => Ok(()),
-        },
-    )
-}
-
-/// Step: create marker `name` at `state`; inverse restores its prior value
-/// (delete if it didn't exist). On a name collision the forward fails, so no
-/// inverse is registered and a pre-existing marker survives the rollback.
-fn step_create_marker<'a>(tx: &mut Tx<'a>, name: &str, state: ChangeId) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let forward_name = MarkerName::new(name);
-    let prev = repo.refs().get_marker(&forward_name)?;
-    let restore_name = name.to_string();
-    entry_step(
-        tx,
-        move || repo.refs().create_marker(&forward_name, &state),
-        move || {
-            let name = MarkerName::new(restore_name);
-            match prev {
-                Some(prev) => repo.refs().create_marker(&name, &prev),
-                None => repo.refs().delete_marker(&name).map(|_| ()),
-            }
-        },
-    )
-}
-
-/// Step: delete marker `name`; inverse recreates it at its prior value.
-fn step_delete_marker<'a>(tx: &mut Tx<'a>, name: &str) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let forward_name = MarkerName::new(name);
-    let prev = repo.refs().get_marker(&forward_name)?;
-    let restore_name = name.to_string();
-    entry_step(
-        tx,
-        move || repo.refs().delete_marker(&forward_name).map(|_| ()),
-        move || match prev {
-            Some(prev) => repo.refs().create_marker(&MarkerName::new(restore_name), &prev),
-            None => Ok(()),
-        },
-    )
-}
-
-/// Step: persist a mutated ThreadManager record; inverse restores the record's
-/// prior persisted form (or removes it if there was none).
-fn step_save_thread_record<'a>(tx: &mut Tx<'a>, record: Thread) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let manager = ThreadManager::new(repo.heddle_dir());
-    let prev = manager.find_by_thread(&record.thread)?;
-    let new_id = record.id.clone();
-    entry_step(
-        tx,
-        move || ThreadManager::new(repo.heddle_dir()).save(&record),
-        move || {
-            let manager = ThreadManager::new(repo.heddle_dir());
-            match prev {
-                Some(prev) => manager.save(&prev),
-                None => manager.delete(&new_id),
-            }
-        },
-    )
-}
-
-/// Step: delete a ThreadManager record; inverse re-saves it.
-fn step_delete_thread_record<'a>(tx: &mut Tx<'a>, record: Thread) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let id = record.id.clone();
-    entry_step(
-        tx,
-        move || ThreadManager::new(repo.heddle_dir()).delete(&id),
-        move || ThreadManager::new(repo.heddle_dir()).save(&record),
-    )
-}
-
-/// Step: restore a ThreadManager record from a redo snapshot; inverse restores
-/// the prior persisted form (or removes the restored record if there was none).
-/// A snapshot that fails to decode is a non-fatal warning (pre-migration parity).
-fn step_restore_thread_record<'a>(
-    tx: &mut Tx<'a>,
-    name: &str,
-    bytes: &[u8],
-) -> HeddleResult<()> {
-    let repo = tx.repo();
-    let manager = ThreadManager::new(repo.heddle_dir());
-    let prev = manager.find_by_thread(name)?;
-    let bytes = bytes.to_vec();
-    let forward_name = name.to_string();
-    let restore_name = name.to_string();
-    entry_step(
-        tx,
-        move || {
-            let manager = ThreadManager::new(repo.heddle_dir());
-            if let Err(e) = manager.restore_thread_record_from_snapshot(&bytes) {
-                eprintln!(
-                    "warning: redo of `ThreadCreate` for '{}' restored the ref but failed to \
-                     decode the ThreadManager record snapshot ({}). Record-backed commands \
-                     (`thread cd`, delegate) may degrade on this thread — run `heddle thread \
-                     start {}` to recreate the record.",
-                    forward_name, e, forward_name
-                );
-            }
-            Ok(())
-        },
-        move || {
-            let manager = ThreadManager::new(repo.heddle_dir());
-            match prev {
-                Some(prev) => manager.save(&prev),
-                None => match manager.find_by_thread(&restore_name)? {
-                    Some(record) => manager.delete(&record.id),
-                    None => Ok(()),
-                },
-            }
-        },
-    )
-}
-
-fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
+fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()> {
     match &entry.operation {
         OpRecord::Snapshot {
             prev_head: Some(prev),
@@ -376,24 +538,21 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             new_state,
             ..
         } => {
-            step_goto(tx, *prev)?;
+            steps.goto(*prev)?;
             if let Some(thread) = thread {
-                step_set_thread(tx, thread.as_str(), *prev)?;
-                step_write_head(
-                    tx,
-                    Head::Attached {
-                        thread: ThreadName::new(thread.as_str()),
-                    },
-                )?;
-                sync_thread_record_state(tx, thread, *prev)?;
-                mark_merged_threads_unintegrated_for_target(tx, thread, new_state, prev)?;
+                steps.set_thread(thread.as_str(), *prev)?;
+                steps.write_head(Head::Attached {
+                    thread: ThreadName::new(thread.as_str()),
+                })?;
+                sync_thread_record_state(steps, thread, *prev)?;
+                mark_merged_threads_unintegrated_for_target(steps, thread, new_state, prev)?;
             }
         }
         OpRecord::Goto {
             prev_head: Some(prev),
             ..
         } => {
-            step_goto(tx, *prev)?;
+            steps.goto(*prev)?;
         }
         OpRecord::Snapshot {
             prev_head: None, ..
@@ -402,7 +561,7 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             prev_head: None, ..
         } => {}
         OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
-            delete_thread_safely(tx, &ThreadName::new(name.as_str()))?;
+            delete_thread_safely(steps, &ThreadName::new(name.as_str()))?;
             // Cross-thread contract rule 4 (docs/design/cross-thread-undo.md):
             // the inverse of `ThreadCreate` must also remove the matching
             // ThreadManager record so `heddle thread show` and the record-
@@ -419,21 +578,21 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             // is recorded for redo, so undo can still destroy the live
             // record without losing the data needed to put it back.
             // Matches the FastForward/V2 shared-undo shape.
-            remove_thread_manager_record(tx, name)?;
+            remove_thread_manager_record(steps, name)?;
         }
         OpRecord::ThreadDelete { name, state } => {
-            step_set_thread(tx, name.as_str(), *state)?;
+            steps.set_thread(name.as_str(), *state)?;
         }
         OpRecord::ThreadUpdate {
             name, old_state, ..
         } => {
-            step_set_thread(tx, name.as_str(), *old_state)?;
+            steps.set_thread(name.as_str(), *old_state)?;
         }
         OpRecord::MarkerCreate { name, .. } => {
-            step_delete_marker(tx, name.as_str())?;
+            steps.delete_marker(name.as_str())?;
         }
         OpRecord::MarkerDelete { name, state } => {
-            step_create_marker(tx, name.as_str(), *state)?;
+            steps.create_marker(name.as_str(), *state)?;
         }
         // Redaction inverse: drop the specific redaction record so
         // subsequent materialize calls restore the original blob
@@ -456,12 +615,13 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             state,
             path,
         } => {
-            // A single write, and redo of a redaction is refused upstream
-            // (`ensure_redaction_redo_supported`), so there is no inverse to
-            // register — matching the pre-migration no-op redo for this record.
-            tx.repo()
-                .remove_redaction(blob, state, path, redaction_id)
-                .map_err(apply_error)?;
+            // NON-atomic, re-exposing forward: `remove_redaction` rewrites or
+            // deletes the per-blob sidecar, so it runs through `step_nonatomic`
+            // with a capture-restore of the whole sidecar. If a LATER batch in
+            // the same undo transaction fails, the rollback restores the sidecar
+            // and the redacted blob is NOT re-exposed — the hazard a plain,
+            // unregistered removal left open.
+            steps.remove_redaction_sidecar(*blob, *state, path.clone(), *redaction_id)?;
         }
         // Fast-forward merge inverse: restore both HEAD and the target
         // thread ref to the pre-FF tip. The source thread never moved
@@ -482,7 +642,7 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             pre_target_id,
             ..
         } => {
-            apply_ff_undo(tx, source_thread, target_thread, pre_target_id)?;
+            apply_ff_undo(steps, source_thread, target_thread, pre_target_id)?;
         }
         OpRecord::GitCheckpoint {
             branch,
@@ -490,7 +650,7 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             new_git_oid,
             ..
         } => {
-            apply_git_checkpoint_undo(tx, branch, previous_git_oid.as_deref(), new_git_oid)?;
+            apply_git_checkpoint_undo(steps, branch, previous_git_oid.as_deref(), new_git_oid)?;
         }
         // No undo inverse: these records don't move a ref the undo chain
         // restores, or their reversal is irreversible / handled outside the
@@ -525,45 +685,39 @@ fn apply_undo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
 }
 
 fn apply_ff_undo(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     source_thread: &str,
     target_thread: &str,
     pre_target_id: &ChangeId,
 ) -> HeddleResult<()> {
-    step_goto(tx, *pre_target_id)?;
-    step_set_thread(tx, target_thread, *pre_target_id)?;
-    step_write_head(
-        tx,
-        Head::Attached {
-            thread: ThreadName::new(target_thread),
-        },
-    )?;
-    sync_thread_record_state(tx, target_thread, *pre_target_id)?;
-    mark_source_thread_unintegrated(tx, source_thread, pre_target_id)
+    steps.goto(*pre_target_id)?;
+    steps.set_thread(target_thread, *pre_target_id)?;
+    steps.write_head(Head::Attached {
+        thread: ThreadName::new(target_thread),
+    })?;
+    sync_thread_record_state(steps, target_thread, *pre_target_id)?;
+    mark_source_thread_unintegrated(steps, source_thread, pre_target_id)
 }
 
-fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
+fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()> {
     match &entry.operation {
         OpRecord::Snapshot {
             new_state,
             prev_head,
             thread,
         } => {
-            step_goto(tx, *new_state)?;
+            steps.goto(*new_state)?;
             if let Some(thread) = thread {
-                step_set_thread(tx, thread.as_str(), *new_state)?;
-                step_write_head(
-                    tx,
-                    Head::Attached {
-                        thread: ThreadName::new(thread.as_str()),
-                    },
-                )?;
-                sync_thread_record_state(tx, thread, *new_state)?;
-                mark_ready_threads_integrated_for_target(tx, thread, new_state, prev_head)?;
+                steps.set_thread(thread.as_str(), *new_state)?;
+                steps.write_head(Head::Attached {
+                    thread: ThreadName::new(thread.as_str()),
+                })?;
+                sync_thread_record_state(steps, thread, *new_state)?;
+                mark_ready_threads_integrated_for_target(steps, thread, new_state, prev_head)?;
             }
         }
         OpRecord::Goto { target, .. } => {
-            step_goto(tx, *target)?;
+            steps.goto(*target)?;
         }
         // V1 ThreadCreate redo: ref-only, with a stderr note that the
         // ThreadManager record is not being restored. V1 records were
@@ -576,7 +730,7 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
         // <name>` if they want the record back. V1 ages out as the
         // live oplog window slides forward.
         OpRecord::ThreadCreate { name, state } => {
-            step_set_thread(tx, name.as_str(), *state)?;
+            steps.set_thread(name.as_str(), *state)?;
             eprintln!(
                 "warning: redo of legacy V1 `ThreadCreate` for '{}' restores the ref only — \
                  the matching ThreadManager record body was not snapshotted by this oplog entry. \
@@ -599,24 +753,24 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             state,
             manager_snapshot,
         } => {
-            step_set_thread(tx, name.as_str(), *state)?;
+            steps.set_thread(name.as_str(), *state)?;
             if let Some(bytes) = manager_snapshot {
-                step_restore_thread_record(tx, name, bytes)?;
+                steps.restore_thread_record(name, bytes)?;
             }
         }
         OpRecord::ThreadDelete { name, .. } => {
-            delete_thread_safely(tx, &ThreadName::new(name.as_str()))?;
+            delete_thread_safely(steps, &ThreadName::new(name.as_str()))?;
         }
         OpRecord::ThreadUpdate {
             name, new_state, ..
         } => {
-            step_set_thread(tx, name.as_str(), *new_state)?;
+            steps.set_thread(name.as_str(), *new_state)?;
         }
         OpRecord::MarkerCreate { name, state } => {
-            step_create_marker(tx, name.as_str(), *state)?;
+            steps.create_marker(name.as_str(), *state)?;
         }
         OpRecord::MarkerDelete { name, .. } => {
-            step_delete_marker(tx, name.as_str())?;
+            steps.delete_marker(name.as_str())?;
         }
         // FF merge redo (V2): replay the *recorded* FF target. We do
         // not re-read `source_thread` — the recorded `post_target_id`
@@ -631,7 +785,7 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             post_target_id,
             ..
         } => {
-            apply_ff_redo(tx, source_thread, target_thread, post_target_id)?;
+            apply_ff_redo(steps, source_thread, target_thread, post_target_id)?;
         }
         OpRecord::GitCheckpoint {
             branch,
@@ -639,7 +793,7 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             new_git_oid,
             ..
         } => {
-            apply_git_checkpoint_redo(tx, branch, previous_git_oid.as_deref(), new_git_oid)?;
+            apply_git_checkpoint_redo(steps, branch, previous_git_oid.as_deref(), new_git_oid)?;
         }
         // FF merge redo (V1, legacy): the r1 implementation didn't
         // record `post_target_id`, so we have to re-resolve
@@ -653,7 +807,7 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
             target_thread,
             ..
         } => {
-            let source_tip = tx
+            let source_tip = steps
                 .repo()
                 .refs()
                 .get_thread(&ThreadName::new(source_thread.as_str()))?
@@ -664,7 +818,7 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
                         source_thread
                     ))
                 })?;
-            apply_ff_redo(tx, source_thread, target_thread, &source_tip)?;
+            apply_ff_redo(steps, source_thread, target_thread, &source_tip)?;
         }
         // No redo replay: these records don't re-advance a ref redo touches, or
         // they are refused upstream. Enumerated explicitly (no wildcard) so a
@@ -699,21 +853,18 @@ fn apply_redo_entry(tx: &mut Tx<'_>, entry: &OpEntry) -> HeddleResult<()> {
 }
 
 fn apply_ff_redo(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     source_thread: &str,
     target_thread: &str,
     post_target_id: &ChangeId,
 ) -> HeddleResult<()> {
-    step_goto(tx, *post_target_id)?;
-    step_set_thread(tx, target_thread, *post_target_id)?;
-    step_write_head(
-        tx,
-        Head::Attached {
-            thread: ThreadName::new(target_thread),
-        },
-    )?;
-    sync_thread_record_state(tx, target_thread, *post_target_id)?;
-    mark_source_thread_integrated(tx, source_thread, post_target_id)
+    steps.goto(*post_target_id)?;
+    steps.set_thread(target_thread, *post_target_id)?;
+    steps.write_head(Head::Attached {
+        thread: ThreadName::new(target_thread),
+    })?;
+    sync_thread_record_state(steps, target_thread, *post_target_id)?;
+    mark_source_thread_integrated(steps, source_thread, post_target_id)
 }
 
 /// The pre-entry Git state a checkpoint undo/redo entry overwrites, captured
@@ -824,32 +975,13 @@ fn delete_ref_if_present(git: &gix::Repository, ref_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Run one checkout-repo Git write as a per-effect step. `forward` performs
-/// exactly one externally-visible write; on a later failure the rollback restores
-/// the captured `snapshot`. A fresh checkout handle is opened per step (cold path).
-fn git_step<'a>(
-    tx: &mut Tx<'a>,
-    repo: &'a Repository,
-    branch: &str,
-    snapshot: &GitState,
-    forward: impl FnOnce() -> Result<()>,
-) -> HeddleResult<()> {
-    let snapshot = snapshot.clone();
-    let branch = branch.to_string();
-    entry_step(
-        tx,
-        move || forward().map_err(apply_error),
-        move || restore_git_state(repo, &branch, &snapshot),
-    )
-}
-
 fn apply_git_checkpoint_undo(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     branch: &str,
     previous_git_oid: Option<&str>,
     new_git_oid: &str,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     ensure_git_head_is(repo, new_git_oid, "undo git checkpoint").map_err(apply_error)?;
     ensure_git_worktree_clean(repo, "undo git checkpoint").map_err(apply_error)?;
     let snapshot = capture_git_state(repo, branch)?;
@@ -862,10 +994,10 @@ fn apply_git_checkpoint_undo(
                 if ref_target_oid(&git, &format!("refs/heads/{branch}")).map_err(apply_error)?
                     != Some(previous_oid)
                 {
-                    git_step(tx, repo, branch, &snapshot, || {
+                    steps.git_restore_snapshot(repo, branch, &snapshot, || {
                         attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
                     })?;
-                    git_step(tx, repo, branch, &snapshot, || {
+                    steps.git_restore_snapshot(repo, branch, &snapshot, || {
                         set_attached_git_head(
                             &git_checkout_repo(repo)?,
                             branch,
@@ -875,22 +1007,22 @@ fn apply_git_checkpoint_undo(
                         )
                     })?;
                 }
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
                 })?;
             }
-            git_step(tx, repo, branch, &snapshot, || {
+            steps.git_restore_snapshot(repo, branch, &snapshot, || {
                 reset_git_index_to_commit(&git_checkout_repo(repo)?, previous_oid)
             })?;
             let previous = previous.to_string();
             let new_git_oid = new_git_oid.to_string();
-            git_step(tx, repo, branch, &snapshot, || {
+            steps.git_restore_snapshot(repo, branch, &snapshot, || {
                 update_mirror_branch_ref(repo, branch, Some(&previous), Some(&new_git_oid))
             })?;
         }
         None => {
             if branch != "HEAD" {
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     delete_reference_matching(
                         &git_checkout_repo(repo)?,
                         &format!("refs/heads/{branch}"),
@@ -899,7 +1031,7 @@ fn apply_git_checkpoint_undo(
                 })?;
             }
             let new_git_oid = new_git_oid.to_string();
-            git_step(tx, repo, branch, &snapshot, || {
+            steps.git_restore_snapshot(repo, branch, &snapshot, || {
                 update_mirror_branch_ref(repo, branch, None, Some(&new_git_oid))
             })?;
         }
@@ -908,12 +1040,12 @@ fn apply_git_checkpoint_undo(
 }
 
 fn apply_git_checkpoint_redo(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     branch: &str,
     previous_git_oid: Option<&str>,
     new_git_oid: &str,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     if let Some(previous) = previous_git_oid {
         ensure_git_head_is(repo, previous, "redo git checkpoint").map_err(apply_error)?;
     }
@@ -923,10 +1055,10 @@ fn apply_git_checkpoint_redo(
         match previous_git_oid {
             Some(previous) => {
                 let previous_oid = parse_git_oid(previous).map_err(apply_error)?;
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
                 })?;
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     set_attached_git_head(
                         &git_checkout_repo(repo)?,
                         branch,
@@ -937,7 +1069,7 @@ fn apply_git_checkpoint_redo(
                 })?;
             }
             None => {
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     set_reference(
                         &git_checkout_repo(repo)?,
                         &format!("refs/heads/{branch}"),
@@ -947,18 +1079,18 @@ fn apply_git_checkpoint_redo(
                     )
                     .map_err(|error| anyhow!(error))
                 })?;
-                git_step(tx, repo, branch, &snapshot, || {
+                steps.git_restore_snapshot(repo, branch, &snapshot, || {
                     attach_git_head_to_branch(&git_checkout_repo(repo)?, branch)
                 })?;
             }
         }
     }
-    git_step(tx, repo, branch, &snapshot, || {
+    steps.git_restore_snapshot(repo, branch, &snapshot, || {
         reset_git_index_to_commit(&git_checkout_repo(repo)?, new_oid)
     })?;
     let previous_git_oid = previous_git_oid.map(|previous| previous.to_string());
     let new_git_oid = new_git_oid.to_string();
-    git_step(tx, repo, branch, &snapshot, || {
+    steps.git_restore_snapshot(repo, branch, &snapshot, || {
         update_mirror_branch_ref(
             repo,
             branch,
@@ -1192,8 +1324,8 @@ fn fsync_file_and_parent(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn delete_thread_safely(tx: &mut Tx<'_>, name: &ThreadName) -> HeddleResult<()> {
-    let repo = tx.repo();
+fn delete_thread_safely(steps: &mut EntrySteps, name: &ThreadName) -> HeddleResult<()> {
+    let repo = steps.repo();
     if let Head::Attached { thread } = repo.head_ref()?
         && thread == *name
     {
@@ -1204,33 +1336,33 @@ fn delete_thread_safely(tx: &mut Tx<'_>, name: &ThreadName) -> HeddleResult<()> 
         })?;
         // Detaching HEAD is its own effect (inverse restores the prior attached
         // HEAD), separate from the ref deletion below.
-        step_write_head(tx, Head::Detached { state })?;
+        steps.write_head(Head::Detached { state })?;
     }
 
-    step_delete_thread(tx, name.as_str())?;
+    steps.delete_thread(name.as_str())?;
     Ok(())
 }
 
 fn sync_thread_record_state(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     thread_name: &str,
     state: objects::object::ChangeId,
 ) -> HeddleResult<()> {
-    let manager = ThreadManager::new(tx.repo().heddle_dir());
+    let manager = ThreadManager::new(steps.repo().heddle_dir());
     if let Some(mut thread) = manager.find_by_thread(thread_name)? {
         thread.current_state = Some(state.short());
         thread.updated_at = chrono::Utc::now();
-        step_save_thread_record(tx, thread)?;
+        steps.save_thread_record(thread)?;
     }
     Ok(())
 }
 
 fn mark_source_thread_unintegrated(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     source_thread: &str,
     target_after_undo: &ChangeId,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     let Some(mut thread) = manager.find_by_thread(source_thread)? else {
         return Ok(());
@@ -1261,17 +1393,17 @@ fn mark_source_thread_unintegrated(
         thread.freshness = ThreadFreshness::Current;
     }
     thread.updated_at = chrono::Utc::now();
-    step_save_thread_record(tx, thread)?;
+    steps.save_thread_record(thread)?;
     Ok(())
 }
 
 fn mark_merged_threads_unintegrated_for_target(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     target_thread: &str,
     integrated_state: &ChangeId,
     target_after_undo: &ChangeId,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     for thread in manager.list()? {
         if thread.thread == target_thread
@@ -1289,18 +1421,18 @@ fn mark_merged_threads_unintegrated_for_target(
         if points_at_integrated_state {
             // Each affected record is saved through its own per-effect step, so a
             // mid-loop failure rolls each one back independently.
-            mark_source_thread_unintegrated(tx, &thread.thread, target_after_undo)?;
+            mark_source_thread_unintegrated(steps, &thread.thread, target_after_undo)?;
         }
     }
     Ok(())
 }
 
 fn mark_source_thread_integrated(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     source_thread: &str,
     target_after_redo: &ChangeId,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     let Some(mut thread) = manager.find_by_thread(source_thread)? else {
         return Ok(());
@@ -1325,17 +1457,17 @@ fn mark_source_thread_integrated(
     };
     thread.freshness = ThreadFreshness::Current;
     thread.updated_at = chrono::Utc::now();
-    step_save_thread_record(tx, thread)?;
+    steps.save_thread_record(thread)?;
     Ok(())
 }
 
 fn mark_ready_threads_integrated_for_target(
-    tx: &mut Tx<'_>,
+    steps: &mut EntrySteps,
     target_thread: &str,
     integrated_state: &ChangeId,
     target_before_redo: &Option<ChangeId>,
 ) -> HeddleResult<()> {
-    let repo = tx.repo();
+    let repo = steps.repo();
     let manager = ThreadManager::new(repo.heddle_dir());
     for thread in manager.list()? {
         if thread.thread == target_thread
@@ -1352,7 +1484,7 @@ fn mark_ready_threads_integrated_for_target(
                 .as_ref()
                 .is_some_and(|before| change_contains(repo, &source_tip, before));
         if newly_integrated {
-            mark_source_thread_integrated(tx, &thread.thread, integrated_state)?;
+            mark_source_thread_integrated(steps, &thread.thread, integrated_state)?;
         }
     }
     Ok(())
@@ -1366,10 +1498,10 @@ fn change_contains(repo: &Repository, ancestor: &ChangeId, descendant: &ChangeId
 /// Remove the ThreadManager record matching `thread_name`. No-op when no
 /// record exists. Used by the `ThreadCreate` inverse to keep refs and
 /// record-store state in lockstep (cross-thread undo contract rule 4).
-fn remove_thread_manager_record(tx: &mut Tx<'_>, thread_name: &str) -> HeddleResult<()> {
-    let manager = ThreadManager::new(tx.repo().heddle_dir());
+fn remove_thread_manager_record(steps: &mut EntrySteps, thread_name: &str) -> HeddleResult<()> {
+    let manager = ThreadManager::new(steps.repo().heddle_dir());
     if let Some(thread) = manager.find_by_thread(thread_name)? {
-        step_delete_thread_record(tx, thread)?;
+        steps.delete_thread_record(thread)?;
     }
     Ok(())
 }
@@ -1389,15 +1521,20 @@ fn remove_thread_manager_record(tx: &mut Tx<'_>, thread_name: &str) -> HeddleRes
 //   * Each sub-op stages its effect through the forward-first `Tx::step`
 //     combinator, which registers the inverse on the granular ledger ONLY after
 //     the forward succeeds (a forward that fails registers no inverse at all).
-//     Crucially this is done PER EFFECT: `apply_undo_entry` / `apply_redo_entry`
-//     wrap EACH individual write (`goto`, each ref/marker/thread-record write,
-//     each git write) in its own `step` with that write's capture-before inverse,
-//     so a failure on the Nth write of an entry leaves the prior N-1 inverses on
-//     the ledger and the rollback restores the exact pre-entry state. A whole-
-//     entry `step` (one forward = many writes) would leave a write half-applied
-//     when a LATER write in the same entry failed (heddle#355 cid 3330966930 /
-//     3330966931) — the granularity bug this migration must NOT reintroduce.
-//   * The parent NESTS the sub-ops via `Tx::enroll` (savepoint enrollment) —
+//     Crucially this is done PER EFFECT through the `EntrySteps` applier:
+//     `apply_undo_entry` / `apply_redo_entry` wrap EACH individual write
+//     (`goto`, each ref/marker/thread-record write, each git write) in its own
+//     `step` (single all-or-nothing write, capture-before inverse) or
+//     `step_nonatomic` (composite/partial-failure forward, capture-restore
+//     inverse registered BEFORE the forward). A failure on the Nth write of an
+//     entry leaves the prior N-1 inverses on the ledger and the rollback
+//     restores the exact pre-entry state. A whole-entry `step` (one forward =
+//     many writes) would leave a write half-applied when a LATER write in the
+//     same entry failed (heddle#355 cid 3330966930 / 3330966931) — the
+//     granularity bug this migration must NOT reintroduce. A plain `step` on a
+//     NON-atomic forward (goto, `ThreadManager::save`, redaction-sidecar
+//     removal) would leak a partially-applied effect — those use `step_nonatomic`.
+//   * The parent NESTS the sub-ops via `Tx::enroll` (deferred enrollment) —
 //     the recovery-ref child then one child per batch — so a child that stages
 //     then fails rewinds the child AND unwinds the parent through the shared
 //     ledger. This is the nesting path the migration exists to validate.
@@ -1420,13 +1557,15 @@ fn remove_thread_manager_record(tx: &mut Tx<'_>, thread_name: &str) -> HeddleRes
 //      the trait optimizes for is both unreachable (a committed undo marks its
 //      batches undone, so a retry re-derives a different batch set) and
 //      unnecessary (re-applying an undo is idempotent) for this op.
-//   2. SAVEPOINT SEMANTICS. The children use the savepoint ENROLLMENT mechanism
-//      (`enroll` + `step`) for its apply+ledger-rewind shape, but their
-//      effects are direct canonical writes (visible immediately), not the
-//      invisible-until-commit staging `SavepointMutation` describes. This adds
-//      FAILURE atomicity (rewind), not concurrent-reader isolation — matching
-//      the pre-migration concurrency semantics, where undo already published
-//      refs batch-by-batch.
+//   2. DEFERRED-COMMIT SEMANTICS. The children use the deferred ENROLLMENT
+//      mechanism (`enroll` + `step`) for its apply+ledger-rewind shape: each
+//      defers its commit marker to the outer transaction and is unwound by the
+//      shared ledger on failure. Their effects are direct canonical writes
+//      (visible immediately) — `DeferredMutation` makes NO invisibility claim;
+//      it names exactly this "defer the commit, be ledger-unwound" contract. So
+//      this adds FAILURE atomicity (rewind), not concurrent-reader isolation —
+//      matching the pre-migration concurrency semantics, where undo already
+//      published refs batch-by-batch.
 //
 // EXACTNESS SCOPE. The rewind restores the exact pre-operation state for `undo`
 // of any batch count and for single-batch `redo` (the `-n 1` default). A
@@ -1485,7 +1624,7 @@ pub(super) fn undo_redo_transaction_id(
     format!("{action}:{scope}:gen{generation}:[{}]", ids.join(","))
 }
 
-/// Savepoint child: preserve the pre-undo HEAD into the heddle-internal
+/// Deferred child: preserve the pre-undo HEAD into the heddle-internal
 /// recovery pointer (the heddle#305 `ORIG_HEAD`-style ref), registering its
 /// restore as the inverse so an outer failure puts the prior pointer back
 /// (or clears it, on the first-ever undo).
@@ -1524,9 +1663,9 @@ impl AtomicMutation for StageUndoRecovery {
     }
 }
 
-impl SavepointMutation for StageUndoRecovery {}
+impl DeferredMutation for StageUndoRecovery {}
 
-/// Savepoint child: undo one batch. `apply_undo_entry` registers a per-EFFECT
+/// Deferred child: undo one batch. `apply_undo_entry` registers a per-EFFECT
 /// inverse for every individual write it performs, so a mid-ENTRY failure rewinds
 /// exactly the writes already applied (not just whole entries); the
 /// `mark_batch_undone` flip is paired with its `mark_batch_redone` inverse.
@@ -1564,15 +1703,16 @@ impl AtomicMutation for ApplyUndoBatch {
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
-        let repo = tx.repo();
+        let mut steps = EntrySteps::new(tx);
         for (applied, entry) in self.batch.entries.iter().rev().enumerate() {
-            // `apply_undo_entry` wraps EACH of its writes in its own `Tx::step`
-            // with that write's specific inverse, so a failure on the Nth write
-            // of the entry leaves the prior N-1 inverses on the ledger and the
-            // rollback restores the exact pre-entry state (heddle#355 cid
-            // 3330966930). No outer per-entry `step` is needed — and a whole-entry
-            // one would reintroduce the granularity bug it once papered over.
-            apply_undo_entry(tx, entry)?;
+            // `apply_undo_entry` drives the per-effect `EntrySteps` applier, which
+            // wraps EACH write in its own `step` / `step_nonatomic`, so a failure
+            // on the Nth write of the entry leaves the prior N-1 inverses on the
+            // ledger and the rollback restores the exact pre-entry state (heddle#355
+            // cid 3330966930). No outer per-entry `step` is needed — and a
+            // whole-entry one would reintroduce the granularity bug it once
+            // papered over.
+            apply_undo_entry(&mut steps, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1582,18 +1722,14 @@ impl AtomicMutation for ApplyUndoBatch {
             #[cfg(not(test))]
             let _ = applied;
         }
-        let batch_for_redo = self.batch.clone();
-        let updated = tx.step(
-            || repo.oplog().mark_batch_undone(&self.batch),
-            move || repo.oplog().mark_batch_redone(&batch_for_redo).map(|_| ()),
-        )?;
+        let updated = steps.mark_batch_undone(&self.batch)?;
         Ok(StagedCommit::pure(updated))
     }
 }
 
-impl SavepointMutation for ApplyUndoBatch {}
+impl DeferredMutation for ApplyUndoBatch {}
 
-/// Savepoint child: redo one batch — the mirror of [`ApplyUndoBatch`]. Entries
+/// Deferred child: redo one batch — the mirror of [`ApplyUndoBatch`]. Entries
 /// replay in forward order; `apply_redo_entry` registers a per-effect inverse for
 /// each write, and the `mark_batch_redone` flip pairs with `mark_batch_undone`.
 struct ApplyRedoBatch {
@@ -1628,13 +1764,12 @@ impl AtomicMutation for ApplyRedoBatch {
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
-        let repo = tx.repo();
+        let mut steps = EntrySteps::new(tx);
         for (applied, entry) in self.batch.entries.iter().enumerate() {
-            // Mirror of `ApplyUndoBatch`: `apply_redo_entry` registers a
-            // per-effect inverse for each of its writes, so a mid-entry redo
-            // failure rolls back per-write to the exact pre-entry state
-            // (heddle#355 cid 3330966931).
-            apply_redo_entry(tx, entry)?;
+            // Mirror of `ApplyUndoBatch`: `apply_redo_entry` drives the per-effect
+            // `EntrySteps` applier, so a mid-entry redo failure rolls back
+            // per-write to the exact pre-entry state (heddle#355 cid 3330966931).
+            apply_redo_entry(&mut steps, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
                 return Err(HeddleError::Conflict(
@@ -1644,16 +1779,12 @@ impl AtomicMutation for ApplyRedoBatch {
             #[cfg(not(test))]
             let _ = applied;
         }
-        let batch_for_undo = self.batch.clone();
-        let updated = tx.step(
-            || repo.oplog().mark_batch_redone(&self.batch),
-            move || repo.oplog().mark_batch_undone(&batch_for_undo).map(|_| ()),
-        )?;
+        let updated = steps.mark_batch_redone(&self.batch)?;
         Ok(StagedCommit::pure(updated))
     }
 }
 
-impl SavepointMutation for ApplyRedoBatch {}
+impl DeferredMutation for ApplyRedoBatch {}
 
 /// Root composite for `heddle undo`: stage the recovery pointer, then nest one
 /// [`ApplyUndoBatch`] per batch. Returns the updated (undone) batches for the
@@ -2430,6 +2561,246 @@ mod atomic_tests {
             repo.refs().get_marker(&marker).unwrap(),
             Some(s1),
             "the pre-existing marker survives the rolled-back redo (no delete inverse ran)"
+        );
+    }
+
+    // ---- step_nonatomic: forward-internal partial-failure rollback (r4 §A) ----
+
+    /// `goto` is a NON-atomic forward (worktree materialize + HEAD write). When it
+    /// applies its effect (moves HEAD + worktree) and then fails, the
+    /// restore-to-snapshot inverse `step_nonatomic` registered BEFORE the forward
+    /// must unwind it. A plain `step` would register NOTHING on the `Err` return
+    /// and leak the moved HEAD/worktree (the hazard this combinator closes).
+    #[test]
+    fn step_nonatomic_rolls_back_partially_applied_goto() {
+        let (temp, repo, _s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+
+        let pre_head = repo.head().unwrap();
+        assert_eq!(pre_head, Some(s2));
+        let pre_main = main_thread(&repo);
+        let pre_markers = commit_marker_count(&repo);
+        assert_eq!(repo.refs().get_undo_recovery().unwrap(), None);
+
+        let batches = repo.oplog().undo_batches_scoped(1, Some(&scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
+        // The goto is the entry's FIRST non-atomic step: it runs (materializing
+        // the worktree + moving HEAD) and then fails.
+        let result = with_nonatomic_forward_fault(0, || {
+            repo::atomic::execute(&repo, UndoOp::new(batches, pre_head, txid))
+        });
+        assert!(
+            result.is_err(),
+            "the injected partial-goto fault must fail the undo"
+        );
+
+        assert_eq!(
+            repo.head().unwrap(),
+            Some(s2),
+            "HEAD restored to the pre-undo tip after a partially-applied goto"
+        );
+        assert_eq!(main_thread(&repo), pre_main, "main ref unchanged");
+        assert!(temp.path().join("a.txt").exists(), "s1 file present");
+        assert!(
+            temp.path().join("b.txt").exists(),
+            "s2 worktree material restored by the goto's restore-before inverse"
+        );
+        assert_eq!(
+            repo.refs().get_undo_recovery().unwrap(),
+            None,
+            "recovery pointer cleared by rewind"
+        );
+        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+    }
+
+    fn sample_main_thread(current_state: &str, materialized: &str) -> Thread {
+        Thread {
+            id: "thread-main".to_string(),
+            thread: "main".to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode: repo::ThreadMode::Solid,
+            state: ThreadState::Active,
+            base_state: "base".to_string(),
+            base_root: "root".to_string(),
+            current_state: Some(current_state.to_string()),
+            merged_state: None,
+            task: None,
+            execution_path: PathBuf::from("/work/exec"),
+            materialized_path: Some(PathBuf::from(materialized)),
+            changed_paths: vec![],
+            impact_categories: vec![],
+            heavy_impact_paths: vec![],
+            promotion_suggested: false,
+            freshness: ThreadFreshness::Current,
+            verification_summary: repo::ThreadVerificationSummary::default(),
+            confidence_summary: repo::ThreadConfidenceSummary::default(),
+            integration_policy_result: ThreadIntegrationPolicy::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        }
+    }
+
+    /// Test-only deferred mutation that saves ONE thread record through the
+    /// `EntrySteps` applier — exercises the real `save_thread_record`
+    /// (`step_nonatomic`) capture-restore path.
+    struct SaveOnly {
+        record: Thread,
+    }
+
+    impl AtomicMutation for SaveOnly {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            "test-save-only".to_string()
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+            let mut steps = EntrySteps::new(tx);
+            steps.save_thread_record(self.record.clone())?;
+            Ok(StagedCommit::pure(()))
+        }
+    }
+
+    impl DeferredMutation for SaveOnly {}
+
+    /// `ThreadManager::save` is a NON-atomic forward — it writes the record file
+    /// AND the workspace file. When the save applies (both halves) and then a
+    /// failure occurs, the `step_nonatomic` capture-restore must rewrite BOTH
+    /// halves back to the prior record. A plain `step` would leak the saved
+    /// record/workspace on the `Err` return.
+    #[test]
+    fn step_nonatomic_restores_record_and_workspace_on_save_failure() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+
+        // R0: the prior persisted record (record half: current_state; workspace
+        // half: materialized_path).
+        let r0 = sample_main_thread("current-A", "/work/A");
+        manager.save(&r0).unwrap();
+
+        // R1: what the (faulted) save writes — different in BOTH halves.
+        let mut r1 = r0.clone();
+        r1.current_state = Some("current-B".to_string());
+        r1.materialized_path = Some(PathBuf::from("/work/B"));
+
+        let result = with_nonatomic_forward_fault(0, || {
+            repo::atomic::execute(&repo, SaveOnly { record: r1 })
+        });
+        assert!(result.is_err(), "the injected save fault must fail the op");
+
+        let restored = manager.find_by_thread("main").unwrap().unwrap();
+        assert_eq!(
+            restored.current_state.as_deref(),
+            Some("current-A"),
+            "the record half (current_state) was restored to R0"
+        );
+        assert_eq!(
+            restored.materialized_path,
+            Some(PathBuf::from("/work/A")),
+            "the workspace half (materialized_path) was restored to R0"
+        );
+    }
+
+    /// Undoing a `Redact` removes the per-blob sidecar (re-exposing the blob). If
+    /// a LATER batch in the same undo transaction fails, the `step_nonatomic`
+    /// capture-restore — registered BEFORE the removal — must restore the sidecar
+    /// so the redacted blob is NOT re-exposed. The pre-migration unregistered
+    /// removal left the blob exposed on a rolled-back undo. (`--allow-redact-undo`
+    /// gates this at the command level; the apply path is exercised directly.)
+    #[test]
+    fn step_nonatomic_restores_redaction_sidecar_when_a_later_batch_fails() {
+        use objects::object::{Principal, Redaction};
+
+        let (_temp, repo, s1, _s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        let main_state = main_thread(&repo).unwrap();
+
+        // A real redaction on disk.
+        let blob = ContentHash::from_bytes([7u8; 32]);
+        let redaction = Redaction {
+            redacted_blob: blob,
+            state: s1,
+            path: "config/secrets.toml".to_string(),
+            reason: "leaked credential".to_string(),
+            redactor: Principal {
+                name: "Grace Hopper".to_string(),
+                email: "grace@example.com".to_string(),
+            },
+            redacted_at: chrono::Utc::now(),
+            signature: None,
+            purged_at: None,
+            supersedes: None,
+        };
+        let redaction_id = repo.put_redaction(redaction).unwrap();
+        assert_eq!(
+            repo.get_redactions_for_blob(&blob).unwrap().redactions.len(),
+            1,
+            "redaction planted on disk"
+        );
+
+        // Older batch (a no-op thread update) recorded first; newer Redact batch
+        // recorded second, so the Redact is undone FIRST and the older batch —
+        // which the injected fault fails — is undone after it.
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::ThreadUpdate {
+                    name: "main".to_string(),
+                    old_state: main_state,
+                    new_state: main_state,
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::Redact {
+                    redaction_id,
+                    blob,
+                    state: s1,
+                    path: "config/secrets.toml".to_string(),
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+
+        let batches = repo.oplog().undo_batches_scoped(2, Some(&scope)).unwrap();
+        assert_eq!(batches.len(), 2);
+        assert!(
+            matches!(batches[0].entries[0].operation, OpRecord::Redact { .. }),
+            "the newest undoable batch is the Redact (undone first)"
+        );
+
+        let recovery_head = repo.head().unwrap();
+        // FaultyUndo fails the LAST enrolled batch (the older ThreadUpdate) after
+        // its first entry — by then the Redact's sidecar removal already ran.
+        let result = repo::atomic::execute(
+            &repo,
+            FaultyUndo {
+                batches,
+                recovery_head,
+                fail_after: 1,
+            },
+        );
+        assert!(
+            result.is_err(),
+            "the injected fault on the later batch must fail the undo"
+        );
+
+        let restored = repo.get_redactions_for_blob(&blob).unwrap();
+        assert_eq!(
+            restored.redactions.len(),
+            1,
+            "redaction sidecar restored by the rollback — the blob is NOT re-exposed"
+        );
+        assert!(
+            repo.get_redaction(&redaction_id).unwrap().is_some(),
+            "the exact redaction record is back on disk"
         );
     }
 }

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -3100,6 +3100,58 @@ fn test_rebase_abort_tolerates_corrupted_pending_advance_line() {
     );
 }
 
+/// heddle#355: the atomic `undo`/`redo` migration commits a record-less
+/// `TransactionCommit` marker batch as its commit point. That marker carries no
+/// user-facing operation, so `undo --list` must filter it out — otherwise every
+/// undo would leave a phantom "transaction commit" batch in the history view
+/// (and the next `undo` would try to undo it). The raw oplog keeps the marker
+/// (it is the dedup/commit sentinel); only the history view hides it.
+#[test]
+fn test_undo_list_hides_atomic_commit_marker_batches() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+    heddle_must_succeed(&["capture", "-m", "a"], temp.path());
+    std::fs::write(temp.path().join("b.txt"), "b").unwrap();
+    heddle_must_succeed(&["capture", "-m", "b"], temp.path());
+
+    // Undo appends a record-less atomic commit-marker batch to the oplog.
+    heddle_must_succeed(&["undo"], temp.path());
+
+    // The RAW oplog does contain the marker-only commit batch (the sentinel)...
+    let repo = Repository::open(temp.path()).unwrap();
+    let scope = repo.op_scope();
+    let raw = repo
+        .oplog()
+        .recent_batches_scoped(50, Some(&scope))
+        .unwrap();
+    assert!(
+        raw.iter().any(|batch| batch.is_transaction_marker_only()),
+        "the atomic undo must have committed a marker-only sentinel batch"
+    );
+
+    // ...but `undo --list` filters it, so no listed batch is marker-only.
+    let list = heddle_must_succeed(
+        &["--output", "json", "undo", "--list", "--depth", "20"],
+        temp.path(),
+    );
+    let parsed: Value = serde_json::from_str(&list).unwrap();
+    let batches = parsed["batches"].as_array().unwrap();
+    for batch in batches {
+        let ops = batch["operations"].as_array().unwrap();
+        let only_markers = !ops.is_empty()
+            && ops.iter().all(|op| {
+                op["description"]
+                    .as_str()
+                    .is_some_and(|desc| desc.starts_with("transaction commit"))
+            });
+        assert!(
+            !only_markers,
+            "undo --list must not surface a record-less commit-marker batch: {list}"
+        );
+    }
+}
+
 /// A rebase batch must show up in `heddle undo --list` as a SINGLE
 /// batch with N entries (one per replayed commit), not N separate
 /// batches with one entry each. The JSON contract is the structured

--- a/crates/devtools/src/check_atomic_ledger_encapsulation.rs
+++ b/crates/devtools/src/check_atomic_ledger_encapsulation.rs
@@ -34,7 +34,10 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use syn::{Attribute, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
+use syn::{
+    Attribute, ImplItemFn, ItemFn, ItemMod, Meta, MetaList, Token, parse::Parser,
+    punctuated::Punctuated, visit::Visit,
+};
 use walkdir::WalkDir;
 
 const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
@@ -190,24 +193,100 @@ fn is_test_path(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// True iff the item carries a `#[cfg(test)]` attribute (directly, or nested in
-/// an `all(...)` / `any(...)` predicate).
+/// True iff the item is genuinely *test-only* — compiled out of every non-test
+/// build — and so legitimately allowed to drive the raw primitive.
+///
+/// This is NOT a substring match on `test`: `#[cfg(not(test))]` mentions `test`
+/// but is *production* code, and skipping it was a real bypass of the exact
+/// `on_rewind` call the gate guards (cid 3330966933). We parse the `cfg`
+/// predicate and skip the item only when it can NEVER be active with the `test`
+/// flag unset. Over-approximating toward *scanning* (the false-positive direction)
+/// is the safe bias for an encapsulation gate, so an unparseable or unknown
+/// predicate is treated as live.
 fn is_cfg_test(attrs: &[Attribute]) -> bool {
-    fn meta_mentions_test(meta: &Meta) -> bool {
-        match meta {
-            Meta::Path(path) => path.is_ident("test"),
-            Meta::List(list) if list.path.is_ident("cfg") => {
-                list.tokens.to_string().contains("test")
-            }
-            Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
-                list.tokens.to_string().contains("test")
-            }
-            _ => false,
-        }
-    }
     attrs
         .iter()
-        .any(|attr| attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta))
+        .any(|attr| attr.path().is_ident("cfg") && cfg_is_test_only(&attr.meta))
+}
+
+/// Evaluate a `#[cfg(...)]` attribute's predicate: is the gated item excluded
+/// from all non-test builds (i.e. test-only)?
+fn cfg_is_test_only(cfg_meta: &Meta) -> bool {
+    let Meta::List(list) = cfg_meta else {
+        return false;
+    };
+    if !list.path.is_ident("cfg") {
+        return false;
+    }
+    match syn::parse2::<Meta>(list.tokens.clone()) {
+        // Test-only iff the predicate can never be true once `test` is unset.
+        Ok(inner) => !pred_can_be_true_without_test(&inner),
+        // Unparseable predicate → don't exempt it (scan, the safe direction).
+        Err(_) => false,
+    }
+}
+
+/// Can this `cfg` predicate be satisfied in a build where `test` is NOT set
+/// (treating every other cfg atom as a free variable)? Mutually recursive with
+/// [`pred_can_be_false_without_test`] to evaluate `not(...)`.
+fn pred_can_be_true_without_test(meta: &Meta) -> bool {
+    match meta {
+        // The `test` atom is false in a non-test build; any other atom is free.
+        Meta::Path(path) => !path.is_ident("test"),
+        Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
+            Some(children) if children.len() == 1 => {
+                pred_can_be_false_without_test(&children[0])
+            }
+            _ => true,
+        },
+        Meta::List(list) if list.path.is_ident("all") => match cfg_children(list) {
+            Some(children) => children.iter().all(pred_can_be_true_without_test),
+            None => true,
+        },
+        Meta::List(list) if list.path.is_ident("any") => match cfg_children(list) {
+            Some(children) => children.iter().any(pred_can_be_true_without_test),
+            None => true,
+        },
+        // `feature = "x"`, `target_os = "y"`, or an unknown predicate fn: a free
+        // atom that can be true in a non-test build.
+        _ => true,
+    }
+}
+
+/// Can this `cfg` predicate be *false* in a build where `test` is NOT set?
+/// Dual of [`pred_can_be_true_without_test`], used to evaluate `not(...)`.
+fn pred_can_be_false_without_test(meta: &Meta) -> bool {
+    match meta {
+        // `test` is false in prod (so the predicate is falsifiable); any other
+        // atom is free and can be left unset.
+        Meta::Path(_) => true,
+        Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
+            Some(children) if children.len() == 1 => {
+                pred_can_be_true_without_test(&children[0])
+            }
+            _ => true,
+        },
+        // `all` is false if any child can be false; `any` is false only if every
+        // child can be false.
+        Meta::List(list) if list.path.is_ident("all") => match cfg_children(list) {
+            Some(children) => children.iter().any(pred_can_be_false_without_test),
+            None => true,
+        },
+        Meta::List(list) if list.path.is_ident("any") => match cfg_children(list) {
+            Some(children) => children.iter().all(pred_can_be_false_without_test),
+            None => true,
+        },
+        _ => true,
+    }
+}
+
+/// Parse the comma-separated child predicates of an `all(...)` / `any(...)` /
+/// `not(...)` cfg combinator.
+fn cfg_children(list: &MetaList) -> Option<Vec<Meta>> {
+    Punctuated::<Meta, Token![,]>::parse_terminated
+        .parse2(list.tokens.clone())
+        .ok()
+        .map(|punctuated| punctuated.into_iter().collect())
 }
 
 struct Finder<'a> {
@@ -259,6 +338,20 @@ impl<'ast> Visit<'ast> for Finder<'_> {
             self.record(node.method.span().start().line);
         }
         syn::visit::visit_expr_method_call(self, node);
+    }
+
+    /// Catch the UFCS / free-function-call form, `Tx::on_rewind(tx, ...)` (or
+    /// `<Tx>::on_rewind(...)`), which `visit_expr_method_call` never sees — a
+    /// real bypass, since `on_rewind` is `pub(crate)` and any other `repo`
+    /// module could reach it this way (cid 3330966935).
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(expr_path) = node.func.as_ref()
+            && let Some(segment) = expr_path.path.segments.last()
+            && segment.ident == LEDGER_METHOD
+        {
+            self.record(segment.ident.span().start().line);
+        }
+        syn::visit::visit_expr_call(self, node);
     }
 }
 
@@ -369,6 +462,91 @@ mod tests {
         assert!(
             check(&[dir.path().to_path_buf()], &[]).is_ok(),
             "on_rewind inside crates/repo/src/atomic/ is allowed"
+        );
+    }
+
+    #[test]
+    fn flags_cfg_not_test_on_rewind() {
+        // `#[cfg(not(test))]` is PRODUCTION code — it mentions `test` but is live
+        // whenever `test` is unset, so the old substring match wrongly exempted
+        // it (cid 3330966933). The predicate-aware walk must flag it.
+        let hits = scan_source(
+            "#[cfg(not(test))] \
+             fn prod(tx: &mut Tx) -> Result<()> { tx.on_rewind(move || Ok(())); Ok(()) }",
+        );
+        assert_eq!(
+            hits.len(),
+            1,
+            "on_rewind under #[cfg(not(test))] is production and must be flagged"
+        );
+    }
+
+    #[test]
+    fn still_skips_genuinely_test_only_cfg() {
+        // The legitimate exemptions stay exempt: `cfg(test)` and any predicate
+        // that requires `test` (e.g. `all(unix, test)`).
+        assert!(
+            scan_source("#[cfg(test)] fn t(tx: &mut Tx) { tx.on_rewind(|| Ok(())); }").is_empty(),
+            "#[cfg(test)] item is test-only and must be skipped"
+        );
+        assert!(
+            scan_source("#[cfg(all(unix, test))] fn t(tx: &mut Tx) { tx.on_rewind(|| Ok(())); }")
+                .is_empty(),
+            "#[cfg(all(unix, test))] requires test → test-only → skipped"
+        );
+    }
+
+    #[test]
+    fn scans_any_test_or_feature_cfg() {
+        // `any(test, feature = "x")` is live in a non-test build (feature x), so
+        // it must NOT be exempted just because it mentions `test`.
+        let hits = scan_source(
+            "#[cfg(any(test, feature = \"x\"))] \
+             fn prod(tx: &mut Tx) { tx.on_rewind(|| Ok(())); }",
+        );
+        assert_eq!(hits.len(), 1, "any(test, feature) is prod-reachable and must be flagged");
+    }
+
+    #[test]
+    fn flags_ufcs_on_rewind() {
+        // The UFCS / path-call form is invisible to method-call scanning but is a
+        // real bypass (cid 3330966935): `on_rewind` is `pub(crate)`.
+        let hits = scan_source(
+            "fn stage(tx: &mut Tx) -> Result<()> { Tx::on_rewind(tx, move || Ok(())); Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1, "a UFCS Tx::on_rewind call must be flagged");
+    }
+
+    #[test]
+    fn check_bails_on_cfg_not_test_bypass() {
+        let dir = tempfile::tempdir().unwrap();
+        let crate_src = dir.path().join("cli/src");
+        std::fs::create_dir_all(&crate_src).unwrap();
+        std::fs::write(
+            crate_src.join("bypass.rs"),
+            "#[cfg(not(test))]\n\
+             fn prod(tx: &mut Tx) -> Result<()> { tx.on_rewind(move || Ok(())); Ok(()) }",
+        )
+        .unwrap();
+        assert!(
+            check(&[dir.path().to_path_buf()], &[]).is_err(),
+            "a #[cfg(not(test))] on_rewind bypass must fail the check"
+        );
+    }
+
+    #[test]
+    fn check_bails_on_ufcs_bypass() {
+        let dir = tempfile::tempdir().unwrap();
+        let crate_src = dir.path().join("cli/src");
+        std::fs::create_dir_all(&crate_src).unwrap();
+        std::fs::write(
+            crate_src.join("bypass.rs"),
+            "fn stage(tx: &mut Tx) -> Result<()> { Tx::on_rewind(tx, move || Ok(())); Ok(()) }",
+        )
+        .unwrap();
+        assert!(
+            check(&[dir.path().to_path_buf()], &[]).is_err(),
+            "a UFCS Tx::on_rewind bypass must fail the check"
         );
     }
 

--- a/crates/devtools/src/check_atomic_ledger_encapsulation.rs
+++ b/crates/devtools/src/check_atomic_ledger_encapsulation.rs
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Workspace-wide AST asserter for the **rewind-ledger encapsulation** invariant
+//! (heddle#355).
+//!
+//! ## The invariant
+//!
+//! The reverse-order rewind ledger is registered through exactly one safe
+//! combinator, [`Tx::step`](../../repo/src/atomic/tx.rs), which runs the forward
+//! effect FIRST and pushes the inverse onto the ledger only on success. The raw
+//! register primitive, `Tx::on_rewind`, has NO ordering enforcement — calling it
+//! directly lets a caller queue a compensator *before* (or *without*) its
+//! forward effect, the register-then-forward footgun that corrupted pre-existing
+//! refs on rollback (cid 3330867774 / 3330867775).
+//!
+//! `on_rewind` is `pub(crate)` in the `repo` crate, so the compiler already
+//! makes a cross-crate call a hard error. This asserter is the belt to that
+//! suspenders: it fails CI if *any* call to `on_rewind` appears OUTSIDE
+//! `crates/repo/src/atomic/` — catching an in-crate (but out-of-module) use, or
+//! a future regression that re-widens the primitive's visibility. The only
+//! legitimate callers (`step`, `enroll`, `enroll_whole_op`) all live inside
+//! `crates/repo/src/atomic/`, which the walk skips; a planted out-of-module
+//! `on_rewind` (see the tests) proves the analyzer is non-vacuous.
+//!
+//! The env-var contract mirrors the sibling asserters:
+//! `HEDDLE_LEDGER_ENCAP_SEARCH_DIRS` (colon-separated, default `crates`) and
+//! `HEDDLE_LEDGER_ENCAP_ALLOWLIST` (semicolon-separated `path:line`; empty
+//! disables, unset uses the built-in default — currently empty).
+
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use syn::{Attribute, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
+use walkdir::WalkDir;
+
+const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+
+/// The raw ledger-registration method. Any call to a method of this name outside
+/// the atomic module is a hit (over-approximating toward flagging is the safe
+/// direction for an encapsulation gate — `on_rewind` is a sufficiently specific
+/// name that a same-named method on an unrelated type is implausible).
+const LEDGER_METHOD: &str = "on_rewind";
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(arg) = args.first() {
+        bail!(
+            "check-atomic-ledger-encapsulation: unexpected argument '{arg}' (configured via env \
+vars: HEDDLE_LEDGER_ENCAP_SEARCH_DIRS, HEDDLE_LEDGER_ENCAP_ALLOWLIST)"
+        );
+    }
+
+    check(&read_search_dirs(), &read_allowlist())
+}
+
+/// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
+/// findings, and `bail!` if any non-allowlisted external `on_rewind` use remains.
+fn check(search_dirs: &[PathBuf], allowlist: &[String]) -> Result<()> {
+    let mut hits: Vec<Hit> = Vec::new();
+    let mut files_scanned = 0usize;
+    for dir in search_dirs {
+        scan_dir(dir, &mut hits, &mut files_scanned)
+            .with_context(|| format!("scan {}", dir.display()))?;
+    }
+
+    let mut failed = 0usize;
+    for hit in &hits {
+        let key = format!("{}:{}", hit.path.display(), hit.line);
+        if allowlist.iter().any(|entry| entry == &key) {
+            println!("ok: exempt: {key} — {}", hit.snippet.trim());
+            continue;
+        }
+        eprintln!(
+            "::error::raw rewind-ledger registration at {key}: `{LEDGER_METHOD}` is called outside \
+`crates/repo/src/atomic/` — {}",
+            hit.snippet.trim()
+        );
+        failed += 1;
+    }
+
+    if failed > 0 {
+        eprintln!(
+            "\n::error::Found {failed} out-of-module `{LEDGER_METHOD}` call site(s). The rewind \
+ledger must be registered through the forward-first `Tx::step` combinator (or `Tx::enroll`), never \
+the raw `{LEDGER_METHOD}` primitive, which has no ordering enforcement and lets a compensator be \
+queued before its forward effect runs (heddle#355 cid 3330867774 / 3330867775). Replace the \
+`{LEDGER_METHOD}` call with `tx.step(forward, inverse)`.\n\
+\n\
+If a site is a legitimate exception, add a `path:line` entry (of the call) to \
+HEDDLE_LEDGER_ENCAP_ALLOWLIST with a one-line justification."
+        );
+        bail!("asserter failed");
+    }
+
+    println!(
+        "asserter clean: no out-of-module `{LEDGER_METHOD}` call sites in production code \
+({files_scanned} file(s) scanned)"
+    );
+    Ok(())
+}
+
+fn read_search_dirs() -> Vec<PathBuf> {
+    match env::var("HEDDLE_LEDGER_ENCAP_SEARCH_DIRS") {
+        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
+        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
+    }
+}
+
+fn read_allowlist() -> Vec<String> {
+    match env::var("HEDDLE_LEDGER_ENCAP_ALLOWLIST") {
+        Ok(value) if value.is_empty() => Vec::new(),
+        Ok(value) => value.split(';').map(str::to_string).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[derive(Debug)]
+struct Hit {
+    path: PathBuf,
+    line: usize,
+    snippet: String,
+}
+
+fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in WalkDir::new(dir).follow_links(false) {
+        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("rs") {
+            continue;
+        }
+        // The atomic module IS the ledger's home — `step`/`enroll`/
+        // `enroll_whole_op` legitimately call `on_rewind` there.
+        if is_atomic_module_path(path) {
+            continue;
+        }
+        // Tests legitimately drive the raw primitive to exercise ledger
+        // behavior; skip them.
+        if is_test_path(path) {
+            continue;
+        }
+        let source =
+            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        *files_scanned += 1;
+        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+        let lines: Vec<&str> = source.lines().collect();
+        let mut visitor = Finder {
+            path: path.to_path_buf(),
+            lines: &lines,
+            hits,
+        };
+        visitor.visit_file(&file);
+    }
+    Ok(())
+}
+
+/// True iff the path is inside the atomic module (`.../repo/src/atomic/...`),
+/// the one place the raw ledger primitive is allowed. Matched on the consecutive
+/// `repo`/`src`/`atomic` component triple so a substring or a sibling `atomic`
+/// dir elsewhere doesn't accidentally exempt code.
+fn is_atomic_module_path(path: &Path) -> bool {
+    let components: Vec<&OsStr> = path.iter().collect();
+    components.windows(3).any(|w| {
+        w[0] == OsStr::new("repo") && w[1] == OsStr::new("src") && w[2] == OsStr::new("atomic")
+    })
+}
+
+/// Tests legitimately exercise the raw `on_rewind` primitive. Three shapes:
+/// integration tests under a `tests/` segment, unit-test files named
+/// `*_tests.rs`, and submodule test files named exactly `tests.rs`. Inline
+/// `#[cfg(test)] mod tests { ... }` blocks are skipped separately at the AST
+/// level (see `is_cfg_test`).
+fn is_test_path(path: &Path) -> bool {
+    for component in path.components() {
+        if component.as_os_str() == "tests" {
+            return true;
+        }
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .map(|name| name.ends_with("_tests.rs") || name == "tests.rs")
+        .unwrap_or(false)
+}
+
+/// True iff the item carries a `#[cfg(test)]` attribute (directly, or nested in
+/// an `all(...)` / `any(...)` predicate).
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    fn meta_mentions_test(meta: &Meta) -> bool {
+        match meta {
+            Meta::Path(path) => path.is_ident("test"),
+            Meta::List(list) if list.path.is_ident("cfg") => {
+                list.tokens.to_string().contains("test")
+            }
+            Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
+                list.tokens.to_string().contains("test")
+            }
+            _ => false,
+        }
+    }
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta))
+}
+
+struct Finder<'a> {
+    path: PathBuf,
+    lines: &'a [&'a str],
+    hits: &'a mut Vec<Hit>,
+}
+
+impl Finder<'_> {
+    fn record(&mut self, line: usize) {
+        let snippet = self
+            .lines
+            .get(line.saturating_sub(1))
+            .copied()
+            .unwrap_or("")
+            .to_string();
+        self.hits.push(Hit {
+            path: self.path.clone(),
+            line,
+            snippet,
+        });
+    }
+}
+
+impl<'ast> Visit<'ast> for Finder<'_> {
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if node.method == LEDGER_METHOD {
+            self.record(node.method.span().start().line);
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn scan_source(src: &str) -> Vec<Hit> {
+        let file = syn::parse_file(src).expect("parse");
+        let lines: Vec<&str> = src.lines().collect();
+        let mut hits = Vec::new();
+        let mut v = Finder {
+            path: PathBuf::from("test.rs"),
+            lines: &lines,
+            hits: &mut hits,
+        };
+        v.visit_file(&file);
+        hits
+    }
+
+    #[test]
+    fn flags_on_rewind_call() {
+        let hits = scan_source(
+            "fn stage(tx: &mut Tx) -> Result<()> { \
+                tx.on_rewind(move || Ok(())); \
+                do_forward()?; \
+                Ok(()) }",
+        );
+        assert_eq!(hits.len(), 1, "an out-of-module on_rewind call must be flagged");
+    }
+
+    #[test]
+    fn ignores_step_combinator() {
+        // The fix shape: `tx.step(forward, inverse)` — no raw on_rewind.
+        let hits = scan_source(
+            "fn stage(tx: &mut Tx) -> Result<()> { \
+                tx.step(|| do_forward(), move || Ok(()))?; \
+                Ok(()) }",
+        );
+        assert!(hits.is_empty(), "the step combinator must not be flagged");
+    }
+
+    #[test]
+    fn ignores_inline_cfg_test_module() {
+        let hits = scan_source(
+            "fn prod() {} \
+             #[cfg(test)] \
+             mod tests { \
+                fn drives_primitive(tx: &mut Tx) { tx.on_rewind(|| Ok(())); } \
+             }",
+        );
+        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+    }
+
+    #[test]
+    fn ignores_string_literal() {
+        let hits = scan_source("fn f() { let s = \"tx.on_rewind(x)\"; let _ = s; }");
+        assert!(hits.is_empty(), "a string mentioning on_rewind is not a call");
+    }
+
+    #[test]
+    fn atomic_module_path_is_recognized() {
+        assert!(is_atomic_module_path(Path::new("crates/repo/src/atomic/tx.rs")));
+        assert!(is_atomic_module_path(Path::new(
+            "/work/crates/repo/src/atomic/tests.rs"
+        )));
+        // A sibling `atomic` dir under a different crate is NOT exempt.
+        assert!(!is_atomic_module_path(Path::new("crates/cli/src/atomic/x.rs")));
+        assert!(!is_atomic_module_path(Path::new(
+            "crates/cli/src/cli/commands/undo_apply.rs"
+        )));
+    }
+
+    const PLANTED: &str = "fn stage(tx: &mut Tx) -> Result<()> { \
+            tx.on_rewind(move || Ok(())); \
+            Ok(()) }";
+
+    #[test]
+    fn check_bails_on_planted_site_and_exempts_via_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        // A non-atomic, non-test path so neither exclusion fires.
+        let crate_src = dir.path().join("cli/src");
+        std::fs::create_dir_all(&crate_src).unwrap();
+        std::fs::write(crate_src.join("bypass.rs"), PLANTED).unwrap();
+        let dirs = vec![dir.path().to_path_buf()];
+
+        assert!(
+            check(&dirs, &[]).is_err(),
+            "a planted out-of-module on_rewind site must fail the check"
+        );
+
+        let key = format!("{}:1", crate_src.join("bypass.rs").display());
+        assert!(
+            check(&dirs, &[key]).is_ok(),
+            "an allowlisted site must pass the check"
+        );
+    }
+
+    #[test]
+    fn check_ignores_planted_site_inside_atomic_module() {
+        let dir = tempfile::tempdir().unwrap();
+        // Same planted call, but under `repo/src/atomic/` — the ledger's home.
+        let atomic = dir.path().join("repo/src/atomic");
+        std::fs::create_dir_all(&atomic).unwrap();
+        std::fs::write(atomic.join("inner.rs"), PLANTED).unwrap();
+        assert!(
+            check(&[dir.path().to_path_buf()], &[]).is_ok(),
+            "on_rewind inside crates/repo/src/atomic/ is allowed"
+        );
+    }
+
+    /// Enforcement test: scan the REAL workspace tree with the built-in (empty)
+    /// allowlist and assert clean. This is what makes the gate fail CI under
+    /// `cargo test --workspace` if an out-of-module `on_rewind` is introduced.
+    #[test]
+    fn production_tree_has_no_external_ledger_use() {
+        let crates_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("devtools crate dir has a parent (the crates/ dir)")
+            .to_path_buf();
+        let mut hits = Vec::new();
+        let mut scanned = 0usize;
+        scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
+        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            hits.is_empty(),
+            "out-of-module on_rewind call site(s) found: {:?}",
+            hits.iter()
+                .map(|h| format!("{}:{}", h.path.display(), h.line))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 
+mod check_atomic_ledger_encapsulation;
 mod check_no_silent_default_tree_load;
 mod check_oprecord_exhaustiveness;
 mod check_snapshot_atomicity;
@@ -22,6 +23,9 @@ fn main() -> Result<()> {
             check_no_silent_default_tree_load::run(args.collect())
         }
         Some("check-snapshot-atomicity") => check_snapshot_atomicity::run(args.collect()),
+        Some("check-atomic-ledger-encapsulation") => {
+            check_atomic_ledger_encapsulation::run(args.collect())
+        }
         Some("check-oprecord-exhaustiveness") => {
             check_oprecord_exhaustiveness::run(args.collect())
         }

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -167,6 +167,21 @@ impl OpLog {
         self.collect_batches_scoped(count, |_| true, scope)
     }
 
+    /// Like [`recent_batches_scoped`](Self::recent_batches_scoped) but counts
+    /// only **user-facing** batches: the record-less `TransactionCommit`
+    /// sentinels an `undo`/`redo` appends are dropped by the predicate BEFORE
+    /// the `count` limit applies, so `--depth N` yields N real operations even
+    /// when the newest batch is a commit marker. Filtering *after* a fixed-count
+    /// fetch returned empty for `--depth 1` whenever the latest op was itself an
+    /// undo/redo (heddle#355 cid 3330867777).
+    pub fn recent_user_batches_scoped(
+        &self,
+        count: usize,
+        scope: Option<&str>,
+    ) -> Result<Vec<OpBatch>> {
+        self.collect_batches_scoped(count, |batch| !batch.is_transaction_marker_only(), scope)
+    }
+
     pub fn undo_batches(&self, count: usize) -> Result<Vec<OpBatch>> {
         self.undo_batches_scoped(count, None)
     }

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -19,6 +19,16 @@ use super::{
     packed_oplog::PackedOpLog,
 };
 
+/// A `TransactionCommit` marker carries no user-facing operation: it is the
+/// atomic commit sentinel, not a forward op. The undo/redo eligibility scans
+/// ignore it so a record-less transaction (e.g. an `undo`/`redo` whose commit
+/// batch holds only the marker) is never itself selected as an undoable or
+/// redoable unit. A batch with at least one *non-marker* entry (the common
+/// `[op, …, TransactionCommit]` shape) still qualifies on that entry.
+fn is_transaction_commit(op: &OpRecord) -> bool {
+    matches!(op, OpRecord::TransactionCommit { .. })
+}
+
 /// Operation log for tracking operations and enabling undo.
 pub struct OpLog {
     pub(crate) root: PathBuf,
@@ -164,7 +174,12 @@ impl OpLog {
     pub fn undo_batches_scoped(&self, count: usize, scope: Option<&str>) -> Result<Vec<OpBatch>> {
         self.collect_batches_scoped(
             count,
-            |batch| batch.entries.iter().any(|e| !e.undone),
+            |batch| {
+                batch
+                    .entries
+                    .iter()
+                    .any(|e| !e.undone && !is_transaction_commit(&e.operation))
+            },
             scope,
         )
     }
@@ -174,7 +189,16 @@ impl OpLog {
     }
 
     pub fn redo_batches_scoped(&self, count: usize, scope: Option<&str>) -> Result<Vec<OpBatch>> {
-        self.collect_batches_scoped(count, |batch| batch.entries.iter().any(|e| e.undone), scope)
+        self.collect_batches_scoped(
+            count,
+            |batch| {
+                batch
+                    .entries
+                    .iter()
+                    .any(|e| e.undone && !is_transaction_commit(&e.operation))
+            },
+            scope,
+        )
     }
 
     /// Mark a batch as undone.

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -225,7 +225,7 @@ pub enum OpRecord {
     /// record body. Opaque to keep the `oplog` crate independent of
     /// `repo`-level types; the `repo` crate owns the encoding via
     /// `ThreadManager::snapshot_thread_record` /
-    /// `ThreadManager::restore_thread_record_from_snapshot`. `None` for
+    /// `ThreadManager::decode_thread_record_snapshot`. `None` for
     /// callsites that don't write a ThreadManager record alongside the
     /// op (rename batch's new-name arm, ingest, harness/agent stubs).
     ///

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -537,6 +537,24 @@ pub struct OpBatch {
     pub entries: Vec<OpEntry>,
 }
 
+impl OpBatch {
+    /// True iff every entry is a [`OpRecord::TransactionCommit`] marker — the
+    /// commit sentinel of an atomic transaction that staged only direct,
+    /// already-durable effects and so contributed no domain record of its own
+    /// (e.g. `undo`/`redo`, which navigate existing states and append no new
+    /// record). Such a batch carries nothing to undo, redo, or surface in
+    /// operation history; the undo/redo eligibility scans and the `undo --list`
+    /// view filter it out so a record-less transaction's sentinel never
+    /// pollutes the user-facing log.
+    pub fn is_transaction_marker_only(&self) -> bool {
+        !self.entries.is_empty()
+            && self
+                .entries
+                .iter()
+                .all(|entry| matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+    }
+}
+
 #[cfg(test)]
 mod verb_catalog_tests {
     use super::*;

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -857,6 +857,27 @@ impl RefManager {
         )
     }
 
+    /// Remove the heddle-internal pre-undo recovery pointer, returning the repo
+    /// to the "no undo has run" state. Routes through the same
+    /// [`write_chokepoint`](Self::write_chokepoint) as the setter so it cannot
+    /// bypass reconciliation, and is a no-op when no pointer exists. Used as the
+    /// inverse of [`set_undo_recovery`](Self::set_undo_recovery) when the atomic
+    /// `undo` transaction rewinds and the pointer had no prior value to restore
+    /// (the first-ever undo): the pointer is written with no oplog record of its
+    /// own, so deleting the canonical file is a complete clear.
+    pub fn clear_undo_recovery(&self) -> Result<()> {
+        self.write_chokepoint(|lock| self.clear_undo_recovery_locked(lock))
+    }
+
+    fn clear_undo_recovery_locked(&self, _lock: &RefsLock) -> Result<()> {
+        let path = self.undo_recovery_path();
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(HeddleError::Io(e)),
+        }
+    }
+
     /// Read the heddle-internal pre-undo recovery pointer, if one has been
     /// recorded. Returns `None` when no undo has run in this repo.
     pub fn get_undo_recovery(&self) -> Result<Option<ChangeId>> {

--- a/crates/repo/src/atomic/mod.rs
+++ b/crates/repo/src/atomic/mod.rs
@@ -12,9 +12,9 @@
 //!   post-commit materialized view; a mutation is committed iff its
 //!   `TransactionCommit` marker is durable, deduplicated by the **unbounded
 //!   indexed `transaction_id`** lookup (`OpLog::record_batch_exactly_once`).
-//! - **Nesting = enroll-into-outermost (savepoint) by default**
+//! - **Nesting = enroll-into-outermost (defer the commit marker) by default**
 //!   ([`Tx::enroll`]); eager-commit only for cross-process-visible effects
-//!   ([`Tx::enroll_eager`] + [`EagerMutation`]). The savepoint/eager split is
+//!   ([`Tx::enroll_eager`] + [`EagerMutation`]). The deferred/eager split is
 //!   enforced at the **type** level (a compile error, no runtime const).
 //! - **Panic-safety:** explicit `Result` plumbing is primary; [`Tx`]'s `Drop`
 //!   is an abort-only backstop that never half-commits.
@@ -33,5 +33,5 @@ mod tests;
 pub use committer::OplogRefCommitter;
 pub use execute::execute;
 pub use reconciler::OplogRefReconciler;
-pub use traits::{AtomicMutation, Compensator, EagerMutation, SavepointMutation, StagedCommit};
+pub use traits::{AtomicMutation, Compensator, DeferredMutation, EagerMutation, StagedCommit};
 pub use tx::{RewindLedger, Tx};

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -116,6 +116,73 @@ fn reverse_order_rewind_on_failure() {
     );
 }
 
+/// `Tx::step` ordering — the heddle#355 hardening. A `forward` that returns
+/// `Err` must leave the ledger EMPTY: no inverse is registered for an effect
+/// that never happened, so a later unwind compensates nothing. This is the
+/// invariant that makes the register-then-forward footgun unrepresentable.
+#[test]
+fn step_registers_no_inverse_when_forward_fails() {
+    let (_t, repo) = test_repo();
+    let mut tx = Tx::root(&repo, "step-forward-fails".to_string());
+    let inverse_ran = Rc::new(RefCell::new(false));
+    let flag = Rc::clone(&inverse_ran);
+
+    let result: Result<()> = tx.step(
+        || Err(HeddleError::Config("forward failed".to_string())),
+        move || {
+            *flag.borrow_mut() = true;
+            Ok(())
+        },
+    );
+
+    assert!(result.is_err(), "step surfaces the forward's error");
+    // Unwind: with an empty ledger this is a no-op and the inverse never runs.
+    tx.rewind_all().unwrap();
+    assert!(
+        !*inverse_ran.borrow(),
+        "a forward that failed must register NO inverse"
+    );
+}
+
+/// `Tx::step` happy path: a successful `forward` returns its value and registers
+/// EXACTLY ONE inverse, which runs (once) on a later unwind — not before.
+#[test]
+fn step_registers_one_inverse_after_forward_succeeds() {
+    let (_t, repo) = test_repo();
+    let mut tx = Tx::root(&repo, "step-forward-ok".to_string());
+    let unwound = Rc::new(RefCell::new(Vec::new()));
+    let sink = Rc::clone(&unwound);
+    let forward_ran = Rc::new(RefCell::new(false));
+    let observed = Rc::clone(&forward_ran);
+
+    let value = tx
+        .step(
+            || {
+                *observed.borrow_mut() = true;
+                Ok(7u32)
+            },
+            move || {
+                sink.borrow_mut().push(1u32);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    assert_eq!(value, 7, "step returns the forward's produced value");
+    assert!(*forward_ran.borrow(), "forward ran");
+    assert!(
+        unwound.borrow().is_empty(),
+        "the inverse must NOT run until the transaction unwinds"
+    );
+
+    tx.rewind_all().unwrap();
+    assert_eq!(
+        *unwound.borrow(),
+        vec![1],
+        "exactly one inverse was registered and it runs once on unwind"
+    );
+}
+
 /// A mutation whose `apply` panics after staging an effect.
 struct Panicker {
     log: Rc<RefCell<Vec<u32>>>,

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -12,7 +12,7 @@ use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
 
 use super::{
-    AtomicMutation, Compensator, EagerMutation, RewindLedger, SavepointMutation, StagedCommit, Tx,
+    AtomicMutation, Compensator, DeferredMutation, EagerMutation, RewindLedger, StagedCommit, Tx,
     execute,
 };
 use crate::Repository;
@@ -41,7 +41,7 @@ impl AtomicMutation for Leg {
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let id = self.id;
         let log = Rc::clone(&self.log);
-        tx.on_rewind(move || {
+        tx.on_rewind("test-leg", move || {
             log.borrow_mut().push(id);
             Ok(())
         });
@@ -52,7 +52,7 @@ impl AtomicMutation for Leg {
     }
 }
 
-impl SavepointMutation for Leg {}
+impl DeferredMutation for Leg {}
 
 /// A composite that enrolls three legs; the third fails.
 struct FailingComposite {
@@ -197,7 +197,7 @@ impl AtomicMutation for Panicker {
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let log = Rc::clone(&self.log);
-        tx.on_rewind(move || {
+        tx.on_rewind("test-panicker", move || {
             log.borrow_mut().push(99);
             Ok(())
         });
@@ -448,9 +448,9 @@ impl AtomicMutation for EagerThenFail {
 
 /// The eager-commit exception (heddle#330 §3.2): an eagerly-committed sub-op's
 /// compensator runs when the outer transaction later fails, so a leaked
-/// reservation is unrepresentable. The savepoint/eager split is enforced at the
+/// reservation is unrepresentable. The deferred/eager split is enforced at the
 /// type level — `tx.enroll(Reserve { .. })` would not compile (`Reserve` is not
-/// a `SavepointMutation`), so `enroll_eager` is the only path.
+/// a `DeferredMutation`), so `enroll_eager` is the only path.
 #[test]
 fn eager_compensator_runs_on_outer_rollback() {
     let (_t, repo) = test_repo();
@@ -683,8 +683,8 @@ fn tx_accessors_and_rewind_error_paths() {
 
     // Two failing inverses: LIFO order ⇒ the last-pushed runs first and its
     // error is surfaced; the earlier one's error is attempted then suppressed.
-    tx.on_rewind(|| Err(HeddleError::Config("second".to_string())));
-    tx.on_rewind(|| Err(HeddleError::Config("first".to_string())));
+    tx.on_rewind("second", || Err(HeddleError::Config("second".to_string())));
+    tx.on_rewind("first", || Err(HeddleError::Config("first".to_string())));
     let err = tx.rewind_all().unwrap_err();
     assert!(
         matches!(err, HeddleError::Config(m) if m == "first"),
@@ -721,7 +721,7 @@ fn tx_accessors_and_rewind_error_paths() {
     // Drop backstop: an uncommitted Tx whose inverse fails logs (never panics).
     {
         let mut tx3 = Tx::root(&repo, "drop-backstop-tx".to_string());
-        tx3.on_rewind(|| Err(HeddleError::Config("drop-time".to_string())));
+        tx3.on_rewind("drop-time", || Err(HeddleError::Config("drop-time".to_string())));
         // tx3 dropped here without commit ⇒ Drop runs rewind_all, gets Err, logs.
     }
 }
@@ -896,7 +896,7 @@ impl AtomicMutation for StageThenFail {
     }
 }
 
-impl SavepointMutation for StageThenFail {}
+impl DeferredMutation for StageThenFail {}
 
 /// The whole-op rewind must run on the `apply`-returns-`Err` path, not only
 /// after a successful `apply` (cid 3329490979). Otherwise a mutation that stages

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -66,8 +66,10 @@ pub trait AtomicMutation {
 
     /// Forward, staged, fallible side effects. Every effect performed here
     /// MUST be paired with an inverse registered via [`Tx::step`] (the
-    /// forward-first granular ledger), OR be undone wholesale by
-    /// [`AtomicMutation::rewind`]. Use one mechanism per mutation, not both.
+    /// forward-first granular ledger, for a single all-or-nothing write) or
+    /// [`Tx::step_nonatomic`] (capture-restore, for a composite/partial-failure
+    /// forward), OR be undone wholesale by [`AtomicMutation::rewind`]. Use one
+    /// mechanism per mutation, not both.
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>>;
 
     /// Undo whatever THIS mutation's `apply` staged. Called in reverse order
@@ -102,16 +104,22 @@ pub trait AtomicMutation {
     }
 }
 
-/// Opt-in marker for a **savepoint-enrollable** mutation: its staged effects
-/// are invisible to other readers until the outer commit publishes them, so it
-/// may defer to the outermost commit (heddle#330 §3.1).
+/// Opt-in marker for a **deferred-commit** mutation: when enrolled it may
+/// *defer its commit marker* to the outermost transaction and is unwound by the
+/// shared rewind ledger if that outer transaction fails (heddle#330 §3.1). It
+/// makes no claim that the staged effects are invisible to other readers —
+/// real consumers (e.g. undo/redo) perform **immediately-visible** canonical
+/// writes and rely on the shared ledger purely for failure-atomicity, not for
+/// concurrent-reader isolation. The invariant is "defer the commit marker to
+/// the outer transaction; be unwound by the shared ledger on failure", not
+/// invisibility.
 ///
 /// There is deliberately **no** blanket `impl<M: AtomicMutation>
-/// SavepointMutation for M` — a mutation opts in explicitly, so a mutation that
+/// DeferredMutation for M` — a mutation opts in explicitly, so a mutation that
 /// is *only* an [`EagerMutation`] does NOT satisfy the [`Tx::enroll`] bound and
-/// cannot be enrolled as a savepoint. This is the type-level half of the
+/// cannot be enrolled as a deferred child. This is the type-level half of the
 /// compile-error guarantee (§3.3).
-pub trait SavepointMutation: AtomicMutation {}
+pub trait DeferredMutation: AtomicMutation {}
 
 /// An **eager** mutation: its forward effect is cross-process-visible the
 /// instant it runs (the #251 op-id reserve exemplar, §3.2), so it must commit

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -45,8 +45,8 @@ impl<T> StagedCommit<T> {
 /// idempotent rewind. `apply` performs only **staged, not-yet-visible** side
 /// effects — object-store puts (orphan until referenced), FS temp writes, ref
 /// temp writes — and registers each effect's inverse on the transaction via
-/// [`Tx::on_rewind`]. It MUST NOT publish a canonical ref or append to the
-/// oplog; both happen at/after the executor's single commit step.
+/// [`Tx::step`] (forward-first). It MUST NOT publish a canonical ref or append
+/// to the oplog; both happen at/after the executor's single commit step.
 pub trait AtomicMutation {
     /// The value produced on a committed run.
     type Output;
@@ -65,16 +65,16 @@ pub trait AtomicMutation {
     fn transaction_id(&self) -> String;
 
     /// Forward, staged, fallible side effects. Every effect performed here
-    /// MUST be paired with an inverse registered via [`Tx::on_rewind`] (the
-    /// granular ledger), OR be undone wholesale by [`AtomicMutation::rewind`].
-    /// Use one mechanism per mutation, not both.
+    /// MUST be paired with an inverse registered via [`Tx::step`] (the
+    /// forward-first granular ledger), OR be undone wholesale by
+    /// [`AtomicMutation::rewind`]. Use one mechanism per mutation, not both.
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>>;
 
     /// Undo whatever THIS mutation's `apply` staged. Called in reverse order
     /// on any pre-commit failure or panic-unwind. MUST be idempotent (may run
     /// after a partial apply) and MUST undo ONLY what this invocation created,
     /// never pre-existing user state (the #302 r4 lesson). The default is a
-    /// no-op for mutations that register their undo via [`Tx::on_rewind`].
+    /// no-op for mutations that register their undo via [`Tx::step`].
     fn rewind(&mut self, _ledger: &RewindLedger) -> Result<()> {
         Ok(())
     }

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -94,9 +94,46 @@ impl<'a> Tx<'a> {
         self.depth
     }
 
+    /// Run a reversible **leaf effect** as one atomic step: execute `forward`
+    /// FIRST, and push `inverse` onto the rewind ledger **only if `forward`
+    /// returned `Ok`**. A `forward` that fails (or panics) leaves the ledger
+    /// untouched, so it is structurally impossible to register an inverse for an
+    /// effect that did not happen — the register-then-forward footgun that
+    /// corrupted pre-existing refs on rollback when a forward failed after its
+    /// compensator was already queued (heddle#355 cid 3330867774 / 3330867775).
+    ///
+    /// This is the ONLY way for code outside `atomic` to add to the rewind
+    /// ledger: the raw `on_rewind` register is `pub(crate)`, so a consumer that
+    /// tried to hand-order a compensator ahead of its forward would not compile.
+    /// `inverse` runs in reverse (LIFO) order with the rest of the ledger on any
+    /// later unwind and may borrow the [`Repository`](crate::Repository) for the
+    /// transaction lifetime. Reach for [`enroll`](Self::enroll) /
+    /// [`enroll_eager`](Self::enroll_eager) instead when the unit of work is a
+    /// whole sub-mutation rather than a single reversible write.
+    pub fn step<T, Fwd, Inv>(&mut self, forward: Fwd, inverse: Inv) -> Result<T>
+    where
+        Fwd: FnOnce() -> Result<T>,
+        Inv: FnOnce() -> Result<()> + 'a,
+    {
+        let value = forward()?;
+        // Reached only on a successful forward: the inverse now compensates an
+        // effect that demonstrably happened.
+        self.on_rewind(inverse);
+        Ok(value)
+    }
+
     /// Register an inverse for an effect just staged. Closures run in reverse
     /// (LIFO) order on unwind. The closure may borrow the `Repository`.
-    pub fn on_rewind<F>(&mut self, f: F)
+    ///
+    /// `pub(crate)` on purpose (heddle#355): this primitive has NO ordering
+    /// enforcement, so calling it directly lets a caller register an inverse
+    /// *before* — or *without* — its forward effect, which is the exact
+    /// register-then-forward footgun the validation migration removed. Consumer
+    /// crates compose reversible leaf effects through the forward-first
+    /// [`step`](Self::step) combinator (or [`enroll`](Self::enroll) for whole
+    /// sub-mutations); inside `atomic`, `step` / `enroll` / `enroll_whole_op` are
+    /// its only callers.
+    pub(crate) fn on_rewind<F>(&mut self, f: F)
     where
         F: FnOnce() -> Result<()> + 'a,
     {

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -3,9 +3,10 @@
 //! (heddle#330 §3.1, §4).
 //!
 //! `Tx` threads through every `apply` in a nest. Inner mutations enroll into
-//! the *same* `Tx` (savepoint default) rather than committing independently;
-//! only the outermost [`execute`](super::execute) reaches `commit`. The ledger
-//! is a LIFO stack of inverse closures, popped in reverse on any unwind.
+//! the *same* `Tx` (deferring their commit marker to the outermost transaction)
+//! rather than committing independently; only the outermost
+//! [`execute`](super::execute) reaches `commit`. The ledger is a LIFO stack of
+//! inverse closures, popped in reverse on any unwind.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -13,16 +14,25 @@ use std::rc::Rc;
 use objects::error::{HeddleError, Result};
 use oplog::OpRecord;
 
-use super::traits::{EagerMutation, SavepointMutation, StagedCommit};
+use super::traits::{DeferredMutation, EagerMutation, StagedCommit};
 use crate::Repository;
 
-/// One entry in the rewind ledger: a boxed inverse closure. Boxing a *closure*
-/// is an implementation detail of the ledger — it is **not** `dyn
-/// AtomicMutation`. The public composition surface (`enroll::<Inner>`) is fully
+/// The boxed inverse closure half of a [`RewindAction`]. Boxing a *closure* is
+/// an implementation detail of the ledger — it is **not** `dyn AtomicMutation`.
+/// The public composition surface (`enroll::<Inner>`) is fully
 /// static/monomorphized; this is just how the executor stores "the work to undo
 /// entry N" uniformly. The `'a` bound lets a closure borrow the `Repository`
 /// (e.g. to restore a ref) for the lifetime of the transaction.
 type RewindFn<'a> = Box<dyn FnOnce() -> Result<()> + 'a>;
+
+/// One entry in the rewind ledger: a boxed inverse closure plus a `'static`
+/// label naming the action that registered it. The label is pure diagnostics —
+/// it lets [`rewind_all`](Tx::rewind_all)'s logging name the action that ran or
+/// failed during an unwind — and carries no public-API or behavioral weight.
+struct RewindAction<'a> {
+    label: &'static str,
+    run: RewindFn<'a>,
+}
 
 pub(crate) type EnrolledMutation<M> = Rc<RefCell<Option<M>>>;
 
@@ -49,7 +59,7 @@ pub struct Tx<'a> {
     scope: String,
     transaction_id: String,
     depth: u32,
-    ledger: Vec<RewindFn<'a>>,
+    ledger: Vec<RewindAction<'a>>,
     committed: bool,
 }
 
@@ -118,26 +128,71 @@ impl<'a> Tx<'a> {
         let value = forward()?;
         // Reached only on a successful forward: the inverse now compensates an
         // effect that demonstrably happened.
-        self.on_rewind(inverse);
+        self.on_rewind("step", inverse);
         Ok(value)
     }
 
-    /// Register an inverse for an effect just staged. Closures run in reverse
-    /// (LIFO) order on unwind. The closure may borrow the `Repository`.
+    /// Run a reversible leaf effect whose `forward` is **NOT** a single
+    /// all-or-nothing write — a composite of several internal writes, or a
+    /// materialization that can fail partway and leave a partial effect behind.
+    ///
+    /// Unlike [`step`](Self::step), which registers its inverse only AFTER an
+    /// atomic `forward` returns `Ok`, this captures the prior state FIRST and
+    /// registers `restore(snapshot)` on the rewind ledger **before** running
+    /// `forward`. So if `forward` applies some of its writes and then fails (or
+    /// applies all of them and a later step in the same transaction fails), the
+    /// restore-to-snapshot inverse is already on the ledger and unwinds the
+    /// partial effect back to exactly the captured state. The two combinators
+    /// guard opposite hazards — `step` must never register before a forward
+    /// could fail (the register-then-forward footgun, cid 3330867774 /
+    /// 3330867775); `step_nonatomic` must register before, because its forward
+    /// can leave state changed even when it returns `Err`. Reach for `step` only
+    /// when the forward is a genuine single all-or-nothing write.
+    ///
+    /// This is NOT the register-then-forward footgun: the inverse here is a
+    /// restore-to-captured-snapshot, which is correct whether the forward fully
+    /// ran, partially failed, or never started — re-applying it from any of
+    /// those states lands on the same captured snapshot. The footgun was a
+    /// *specific-effect* inverse (e.g. "delete the marker I created") registered
+    /// before its forward, which on a failed forward undoes an effect that never
+    /// happened (deleting a pre-existing marker). Capture-restore has no such
+    /// asymmetry.
+    pub fn step_nonatomic<T, S>(
+        &mut self,
+        capture: impl FnOnce() -> Result<S>,
+        restore: impl FnOnce(S) -> Result<()> + 'a,
+        forward: impl FnOnce() -> Result<T>,
+    ) -> Result<T>
+    where
+        S: 'a,
+    {
+        let snapshot = capture()?;
+        self.on_rewind("step_nonatomic", move || restore(snapshot));
+        forward()
+    }
+
+    /// Register an inverse for an effect just staged, under a `'static` `label`
+    /// for rollback diagnostics. Closures run in reverse (LIFO) order on unwind.
+    /// The closure may borrow the `Repository`.
     ///
     /// `pub(crate)` on purpose (heddle#355): this primitive has NO ordering
     /// enforcement, so calling it directly lets a caller register an inverse
     /// *before* — or *without* — its forward effect, which is the exact
     /// register-then-forward footgun the validation migration removed. Consumer
     /// crates compose reversible leaf effects through the forward-first
-    /// [`step`](Self::step) combinator (or [`enroll`](Self::enroll) for whole
-    /// sub-mutations); inside `atomic`, `step` / `enroll` / `enroll_whole_op` are
-    /// its only callers.
-    pub(crate) fn on_rewind<F>(&mut self, f: F)
+    /// [`step`](Self::step) combinator (the capture-restore
+    /// [`step_nonatomic`](Self::step_nonatomic) for non-atomic forwards, or
+    /// [`enroll`](Self::enroll) for whole sub-mutations); inside `atomic`,
+    /// `step` / `step_nonatomic` / `enroll` / `enroll_whole_op` are its only
+    /// callers.
+    pub(crate) fn on_rewind<F>(&mut self, label: &'static str, f: F)
     where
         F: FnOnce() -> Result<()> + 'a,
     {
-        self.ledger.push(Box::new(f));
+        self.ledger.push(RewindAction {
+            label,
+            run: Box::new(f),
+        });
     }
 
     pub(crate) fn enroll_whole_op<M>(&mut self, m: M) -> EnrolledMutation<M>
@@ -147,7 +202,7 @@ impl<'a> Tx<'a> {
         let mutation = Rc::new(RefCell::new(Some(m)));
         let rewind_mutation = Rc::clone(&mutation);
         let ledger = self.ledger_view();
-        self.on_rewind(move || {
+        self.on_rewind("enroll_whole_op", move || {
             let Some(mut mutation) = rewind_mutation.borrow_mut().take() else {
                 return Ok(());
             };
@@ -156,19 +211,16 @@ impl<'a> Tx<'a> {
         mutation
     }
 
-    /// Savepoint enroll — bounded to [`SavepointMutation`] (§3.3). Runs only
-    /// `apply` (staged, reversible) against the *same* ledger, then registers
-    /// the child's `rewind` so an outer failure unwinds it. An
-    /// `EagerMutation`-only mutation fails this bound at compile time.
-    pub fn enroll<M>(&mut self, m: M) -> Result<StagedCommit<M::Output>>
+    /// Shared `enroll`/`enroll_eager` scaffolding: pre-register the child's
+    /// whole-op rewind (so an apply error or panic unwinds it through the shared
+    /// ledger), then run its `apply` against the *same* ledger. Returns the
+    /// enrolled handle (still live, for the eager `commit_eager` follow-up) plus
+    /// the staged result. The caller owns the surrounding `depth` inc/dec.
+    fn enroll_then_apply<M>(&mut self, m: M) -> (EnrolledMutation<M>, Result<StagedCommit<M::Output>>)
     where
-        M: SavepointMutation + 'a,
+        M: super::AtomicMutation + 'a,
     {
-        self.depth += 1;
         let mutation = self.enroll_whole_op(m);
-        // On apply error or panic, the child's whole-op rewind is already on
-        // the shared ledger, so the root unwind compensates both granular and
-        // whole-op savepoint staging uniformly.
         let staged = {
             let mut guard = mutation.borrow_mut();
             guard
@@ -176,6 +228,22 @@ impl<'a> Tx<'a> {
                 .expect("enrolled mutation must be present during apply")
                 .apply(self)
         };
+        (mutation, staged)
+    }
+
+    /// Deferred enroll — bounded to [`DeferredMutation`] (§3.3). Runs only
+    /// `apply` (staged, reversible) against the *same* ledger, then registers
+    /// the child's `rewind` so an outer failure unwinds it. An
+    /// `EagerMutation`-only mutation fails this bound at compile time.
+    pub fn enroll<M>(&mut self, m: M) -> Result<StagedCommit<M::Output>>
+    where
+        M: DeferredMutation + 'a,
+    {
+        self.depth += 1;
+        // On apply error or panic, the child's whole-op rewind is already on
+        // the shared ledger, so the root unwind compensates both granular and
+        // whole-op deferred staging uniformly.
+        let (_mutation, staged) = self.enroll_then_apply(m);
         self.depth -= 1;
         staged
     }
@@ -191,14 +259,7 @@ impl<'a> Tx<'a> {
         M: EagerMutation + 'a,
     {
         self.depth += 1;
-        let mutation = self.enroll_whole_op(m);
-        let staged = {
-            let mut guard = mutation.borrow_mut();
-            guard
-                .as_mut()
-                .expect("enrolled mutation must be present during apply")
-                .apply(self)
-        };
+        let (mutation, staged) = self.enroll_then_apply(m);
         let staged = match staged {
             Ok(staged) => staged,
             Err(err) => {
@@ -220,7 +281,10 @@ impl<'a> Tx<'a> {
                 return Err(err);
             }
         };
-        self.ledger.push(compensator.into_fn());
+        self.ledger.push(RewindAction {
+            label: "compensator",
+            run: compensator.into_fn(),
+        });
         // One-mechanism contract (heddle#354 r4): an eager mutation's undo is its
         // `Compensator` (returned by `commit_eager`), NEVER the whole-op
         // `rewind`. `enroll_whole_op` above registered the whole-op rewind only
@@ -282,12 +346,16 @@ impl<'a> Tx<'a> {
     /// first rewind error after attempting every entry.
     pub(crate) fn rewind_all(&mut self) -> Result<()> {
         let mut first_err: Option<HeddleError> = None;
-        while let Some(f) = self.ledger.pop() {
-            if let Err(e) = f() {
+        while let Some(action) = self.ledger.pop() {
+            if let Err(e) = (action.run)() {
                 if first_err.is_none() {
                     first_err = Some(e);
                 } else {
-                    tracing::error!(error = %e, "additional Tx rewind failure (suppressed)");
+                    tracing::error!(
+                        action = action.label,
+                        error = %e,
+                        "additional Tx rewind failure (suppressed)"
+                    );
                 }
             }
         }

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -312,6 +312,55 @@ impl Repository {
         })
     }
 
+    /// Capture the raw bytes of the per-blob redaction sidecar (or `None` when
+    /// the sidecar file does not exist), for a capture-restore rollback step.
+    /// [`remove_redaction`](Self::remove_redaction) is a non-atomic forward —
+    /// it rewrites or deletes the sidecar — so the undo path snapshots the
+    /// whole sidecar before the removal and restores it via
+    /// [`restore_redaction_sidecar`](Self::restore_redaction_sidecar) if the
+    /// surrounding transaction later fails, so a rolled-back undo never
+    /// re-exposes a still-redacted blob.
+    pub fn capture_redaction_sidecar(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
+        let path = self.redaction_path_for_blob(blob);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(
+            fs::read(&path).with_context(|| format!("read '{}'", path.display()))?,
+        ))
+    }
+
+    /// Restore the per-blob redaction sidecar to a snapshot captured by
+    /// [`capture_redaction_sidecar`](Self::capture_redaction_sidecar): rewrite
+    /// the captured bytes, or delete the sidecar if it was absent at capture
+    /// time. Absolute (write-or-delete), so re-running it on the rollback path
+    /// is idempotent.
+    pub fn restore_redaction_sidecar(
+        &self,
+        blob: &ContentHash,
+        snapshot: Option<Vec<u8>>,
+    ) -> Result<()> {
+        let path = self.redaction_path_for_blob(blob);
+        match snapshot {
+            Some(bytes) => {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("create '{}'", parent.display()))?;
+                }
+                write_file_atomic(&path, &bytes)
+                    .with_context(|| format!("write '{}'", path.display()))?;
+            }
+            None => {
+                if path.exists() {
+                    fs::remove_file(&path).with_context(|| {
+                        format!("remove redactions sidecar '{}'", path.display())
+                    })?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Look up the redaction matching `(blob, state, path)` and report
     /// whether its underlying bytes have been purged. Used by the undo
     /// pre-flight to refuse before any mutation when removing the

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -327,6 +327,27 @@ impl ThreadManager {
         self.workspace_store.delete_value(thread_id)
     }
 
+    /// Converge the persisted state for thread `name` to `target`: delete EVERY
+    /// record currently filed under `name` whose record id differs from the
+    /// target's, then (if `Some`) ensure `target` is saved. Post-condition: the
+    /// set of records with `.thread == name` is exactly `{target}` (or empty),
+    /// so [`find_by_thread`](Self::find_by_thread) returns `target` REGARDLESS of
+    /// what (possibly unknown-id, newer-timestamped) record a rolled-back forward
+    /// left behind. Correct-by-construction: the leaked record's id never has to
+    /// be known, because every non-target record under the name is dropped.
+    pub fn restore_to_snapshot(&self, name: &str, target: Option<&Thread>) -> Result<()> {
+        let keep = target.map(|t| t.id.as_str());
+        for record in self.list()? {
+            if record.thread == name && Some(record.id.as_str()) != keep {
+                self.delete(&record.id)?;
+            }
+        }
+        if let Some(target) = target {
+            self.save(target)?;
+        }
+        Ok(())
+    }
+
     pub fn load_record(&self, record_id: &str) -> Result<Option<ThreadRecord>> {
         self.load_record_file(record_id)
     }
@@ -594,6 +615,121 @@ mod tests {
         assert!(
             hydrated.auto,
             "auto flag must round-trip back into the hydrated Thread"
+        );
+    }
+
+    /// `restore_to_snapshot` is the converge primitive every thread-record undo
+    /// restore routes through (heddle#355 r6, close-the-class). A non-atomic
+    /// forward can write a record under a DIFFERENT id with a NEWER `updated_at`,
+    /// which `find_by_thread`'s `max_by_key(updated_at)` would then return. The
+    /// converge must delete that leaked record so the post-condition holds: the
+    /// records filed under `name` are exactly `{target}`.
+    #[test]
+    fn restore_to_snapshot_drops_leaked_newer_id_record() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+        let name = "feature/converge";
+
+        let mut prev = sample_thread();
+        prev.id = "rec-prev".to_string();
+        prev.thread = name.to_string();
+        prev.updated_at = Utc::now();
+        manager.save(&prev).unwrap();
+
+        // A forward wrote a SECOND record under the same name — different id,
+        // NEWER timestamp — so `find_by_thread` returns the leaked record.
+        let mut leaked = sample_thread();
+        leaked.id = "rec-leaked".to_string();
+        leaked.thread = name.to_string();
+        leaked.updated_at = prev.updated_at + chrono::Duration::seconds(10);
+        manager.save(&leaked).unwrap();
+        assert_eq!(
+            manager.find_by_thread(name).unwrap().unwrap().id,
+            "rec-leaked",
+            "precondition: newer leaked record shadows prev"
+        );
+
+        manager.restore_to_snapshot(name, Some(&prev)).unwrap();
+
+        assert_eq!(
+            manager.find_by_thread(name).unwrap().unwrap().id,
+            "rec-prev",
+            "converge returns find_by_thread to the target, not the leak"
+        );
+        let under_name: Vec<_> = manager
+            .list()
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.thread == name)
+            .collect();
+        assert_eq!(
+            under_name.len(),
+            1,
+            "exactly the target remains filed under the name"
+        );
+    }
+
+    /// `target = None` empties the name: every record filed under it is dropped,
+    /// and records for OTHER names are untouched.
+    #[test]
+    fn restore_to_snapshot_none_empties_only_the_named_thread() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+
+        let mut a1 = sample_thread();
+        a1.id = "a1".to_string();
+        a1.thread = "feature/a".to_string();
+        manager.save(&a1).unwrap();
+        let mut a2 = sample_thread();
+        a2.id = "a2".to_string();
+        a2.thread = "feature/a".to_string();
+        a2.updated_at = a1.updated_at + chrono::Duration::seconds(5);
+        manager.save(&a2).unwrap();
+        let mut other = sample_thread();
+        other.id = "b1".to_string();
+        other.thread = "feature/b".to_string();
+        manager.save(&other).unwrap();
+
+        manager.restore_to_snapshot("feature/a", None).unwrap();
+
+        assert!(
+            manager.find_by_thread("feature/a").unwrap().is_none(),
+            "all records for the named thread are deleted"
+        );
+        assert_eq!(
+            manager.find_by_thread("feature/b").unwrap().unwrap().id,
+            "b1",
+            "records for other threads are untouched"
+        );
+    }
+
+    /// When `target` is already the sole record under the name, the converge is a
+    /// no-op that leaves it intact.
+    #[test]
+    fn restore_to_snapshot_target_already_sole_is_noop() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+        let name = "feature/sole";
+
+        let mut rec = sample_thread();
+        rec.id = "rec-sole".to_string();
+        rec.thread = name.to_string();
+        manager.save(&rec).unwrap();
+
+        manager.restore_to_snapshot(name, Some(&rec)).unwrap();
+
+        assert_eq!(
+            manager.find_by_thread(name).unwrap().unwrap().id,
+            "rec-sole"
+        );
+        assert_eq!(
+            manager
+                .list()
+                .unwrap()
+                .into_iter()
+                .filter(|t| t.thread == name)
+                .count(),
+            1
         );
     }
 

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -336,14 +336,24 @@ impl ThreadManager {
     /// left behind. Correct-by-construction: the leaked record's id never has to
     /// be known, because every non-target record under the name is dropped.
     pub fn restore_to_snapshot(&self, name: &str, target: Option<&Thread>) -> Result<()> {
+        // Acquire the write lock ONCE and perform the whole enumerate→delete→save
+        // under that single guard, via the PRIVATE file-level helpers. The public
+        // `list`/`delete`/`save` each re-acquire `write_lock()`, which is NOT
+        // re-entrant (flock on a second FD in the same process blocks), so calling
+        // them here would deadlock — and a concurrent same-name writer between an
+        // unlocked `list()` snapshot and the deletes could leak a record that
+        // survives the converge.
+        let _lock = self.write_lock()?;
         let keep = target.map(|t| t.id.as_str());
-        for record in self.list()? {
+        for record in self.list_record_files()? {
             if record.thread == name && Some(record.id.as_str()) != keep {
-                self.delete(&record.id)?;
+                self.record_store.delete_value(&record.id)?;
+                self.workspace_store.delete_value(&record.id)?;
             }
         }
         if let Some(target) = target {
-            self.save(target)?;
+            self.save_record_file(&target.to_record())?;
+            self.save_workspace_file(&target.id, &target.workspace_state())?;
         }
         Ok(())
     }
@@ -667,6 +677,74 @@ mod tests {
             1,
             "exactly the target remains filed under the name"
         );
+    }
+
+    /// Lock-atomic converge over MULTIPLE same-name records (heddle#355 r7, Codex
+    /// cid 3331420787). With the target PLUS two other same-name records (one
+    /// newer-timestamped, so it would shadow the target via
+    /// `find_by_thread`'s `max_by_key(updated_at)`), the converge enumerates and
+    /// deletes them all under a SINGLE write lock via the private file-level
+    /// helpers — never re-acquiring the (non-re-entrant) lock through the public
+    /// `list`/`delete`/`save`. Both storage halves (record + workspace file) of
+    /// each dropped record must be gone.
+    #[test]
+    fn restore_to_snapshot_converges_multiple_same_name_records() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+        let name = "feature/multi";
+
+        let mut target = sample_thread();
+        target.id = "rec-target".to_string();
+        target.thread = name.to_string();
+        target.updated_at = Utc::now();
+        manager.save(&target).unwrap();
+
+        let mut older = sample_thread();
+        older.id = "rec-older".to_string();
+        older.thread = name.to_string();
+        older.updated_at = target.updated_at - chrono::Duration::seconds(30);
+        manager.save(&older).unwrap();
+
+        let mut newer = sample_thread();
+        newer.id = "rec-newer".to_string();
+        newer.thread = name.to_string();
+        newer.updated_at = target.updated_at + chrono::Duration::seconds(30);
+        manager.save(&newer).unwrap();
+        assert_eq!(
+            manager.find_by_thread(name).unwrap().unwrap().id,
+            "rec-newer",
+            "precondition: the newer same-name record shadows the target"
+        );
+
+        manager.restore_to_snapshot(name, Some(&target)).unwrap();
+
+        let under_name: Vec<_> = manager
+            .list()
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.thread == name)
+            .collect();
+        assert_eq!(under_name.len(), 1, "exactly the target remains under the name");
+        assert_eq!(under_name[0].id, "rec-target");
+        assert_eq!(
+            manager.find_by_thread(name).unwrap().unwrap().id,
+            "rec-target",
+            "converge returns find_by_thread to the target"
+        );
+        // Both storage halves of every dropped record are gone.
+        for dropped in ["rec-older", "rec-newer"] {
+            assert!(
+                manager.load_record_file(dropped).unwrap().is_none(),
+                "{dropped} record file deleted"
+            );
+            assert!(
+                manager.load_workspace_file(dropped).unwrap().is_none(),
+                "{dropped} workspace file deleted"
+            );
+        }
+        // The target keeps both halves.
+        assert!(manager.load_record_file("rec-target").unwrap().is_some());
+        assert!(manager.load_workspace_file("rec-target").unwrap().is_some());
     }
 
     /// `target = None` empties the name: every record filed under it is dropped,

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -2,6 +2,7 @@
 //! Thread storage and lifecycle management.
 
 use objects::store::ObjectStore;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -327,15 +328,21 @@ impl ThreadManager {
         self.workspace_store.delete_value(thread_id)
     }
 
-    /// Converge the persisted state for thread `name` to `target`: delete EVERY
-    /// record currently filed under `name` whose record id differs from the
-    /// target's, then (if `Some`) ensure `target` is saved. Post-condition: the
-    /// set of records with `.thread == name` is exactly `{target}` (or empty),
-    /// so [`find_by_thread`](Self::find_by_thread) returns `target` REGARDLESS of
-    /// what (possibly unknown-id, newer-timestamped) record a rolled-back forward
-    /// left behind. Correct-by-construction: the leaked record's id never has to
-    /// be known, because every non-target record under the name is dropped.
-    pub fn restore_to_snapshot(&self, name: &str, target: Option<&Thread>) -> Result<()> {
+    /// Converge the persisted record set for thread `name` to EXACTLY `desired`
+    /// (by record id), atomically under a single write lock: delete every record
+    /// filed under `name` whose id is not in `desired`, then save every record in
+    /// `desired`. Post-condition: `{ records with .thread == name }` has exactly
+    /// the id-set of `desired`, so [`find_by_thread`](Self::find_by_thread)
+    /// returns one of `desired` REGARDLESS of what (possibly unknown-id,
+    /// newer-timestamped) record a rolled-back or duplicating forward left behind
+    /// — the leaked record's id never has to be known, because every non-`desired`
+    /// record under the name is dropped.
+    ///
+    /// This is the SOLE lock-atomic mutation point for a thread's record set:
+    /// every undo/redo thread-record convergence (save, redo-restore, undo-remove)
+    /// routes through it, so there is one chokepoint, not a per-path collection of
+    /// save/delete sequences each racing a concurrent same-name writer.
+    pub fn converge_records(&self, name: &str, desired: &[Thread]) -> Result<()> {
         // Acquire the write lock ONCE and perform the whole enumerate→delete→save
         // under that single guard, via the PRIVATE file-level helpers. The public
         // `list`/`delete`/`save` each re-acquire `write_lock()`, which is NOT
@@ -344,18 +351,35 @@ impl ThreadManager {
         // unlocked `list()` snapshot and the deletes could leak a record that
         // survives the converge.
         let _lock = self.write_lock()?;
-        let keep = target.map(|t| t.id.as_str());
+        let keep: HashSet<&str> = desired.iter().map(|t| t.id.as_str()).collect();
         for record in self.list_record_files()? {
-            if record.thread == name && Some(record.id.as_str()) != keep {
+            if record.thread == name && !keep.contains(record.id.as_str()) {
                 self.record_store.delete_value(&record.id)?;
                 self.workspace_store.delete_value(&record.id)?;
             }
         }
-        if let Some(target) = target {
-            self.save_record_file(&target.to_record())?;
-            self.save_workspace_file(&target.id, &target.workspace_state())?;
+        for thread in desired {
+            self.save_record_file(&thread.to_record())?;
+            self.save_workspace_file(&thread.id, &thread.workspace_state())?;
         }
         Ok(())
+    }
+
+    /// Snapshot every record currently filed under `name` (lock-atomic), hydrated
+    /// with its workspace half, for registering a converge-back inverse. Pairs
+    /// with [`converge_records`](Self::converge_records): capture the full prior
+    /// same-name set with this, and `converge_records(name, &prior)` restores it
+    /// exactly on rollback.
+    pub fn snapshot_records(&self, name: &str) -> Result<Vec<Thread>> {
+        // Single write lock across the enumerate→hydrate; the file-level helpers
+        // (`list_record_files`, `load_workspace_file` via `hydrate_…`) never
+        // re-acquire it, so the read is consistent and deadlock-free.
+        let _lock = self.write_lock()?;
+        self.list_record_files()?
+            .into_iter()
+            .filter(|record| record.thread == name)
+            .map(|record| self.hydrate_thread_from_record(record))
+            .collect()
     }
 
     pub fn load_record(&self, record_id: &str) -> Result<Option<ThreadRecord>> {
@@ -419,22 +443,23 @@ impl ThreadManager {
         Ok(Some(bytes))
     }
 
-    /// Decode and persist a `Thread` record from rmp-serde bytes
-    /// produced by `snapshot_thread_record`. Used by `heddle redo` of a
-    /// `ThreadCreateV2` to restore the record body that undo destroyed
+    /// Decode a `Thread` record from rmp-serde bytes produced by
+    /// `snapshot_thread_record`. Used by `heddle redo` of a
+    /// `ThreadCreateV2` to reconstruct the record body that undo destroyed
     /// (heddle#23 r2 Codex P1, mirroring the FastForwardV2 pattern from
     /// heddle#99 r2 — record what redo needs).
     ///
-    /// Returns the restored `Thread` for callers that want to inspect
-    /// it (e.g. for stderr summaries). An empty/invalid snapshot
-    /// surfaces as `HeddleError::Other` — the redo arm logs and falls
-    /// back to ref-only restore rather than failing the whole batch.
-    pub fn restore_thread_record_from_snapshot(&self, bytes: &[u8]) -> Result<Thread> {
-        let thread: Thread = rmp_serde::from_slice(bytes).map_err(|e| {
+    /// Decode ONLY — it does NOT persist. The redo applier converges the
+    /// decoded record onto the thread's record set via
+    /// [`converge_records`](Self::converge_records), so the restore writes the
+    /// record as the SOLE record under the name (a raw `save` would leave a
+    /// pre-existing duplicate behind). An invalid snapshot surfaces as
+    /// `HeddleError::Serialization` — the redo arm logs and falls back to
+    /// ref-only restore rather than failing the whole batch.
+    pub fn decode_thread_record_snapshot(&self, bytes: &[u8]) -> Result<Thread> {
+        rmp_serde::from_slice(bytes).map_err(|e| {
             HeddleError::Serialization(format!("decode thread record snapshot: {}", e))
-        })?;
-        self.save(&thread)?;
-        Ok(thread)
+        })
     }
 }
 
@@ -628,14 +653,15 @@ mod tests {
         );
     }
 
-    /// `restore_to_snapshot` is the converge primitive every thread-record undo
-    /// restore routes through (heddle#355 r6, close-the-class). A non-atomic
-    /// forward can write a record under a DIFFERENT id with a NEWER `updated_at`,
-    /// which `find_by_thread`'s `max_by_key(updated_at)` would then return. The
-    /// converge must delete that leaked record so the post-condition holds: the
-    /// records filed under `name` are exactly `{target}`.
+    /// `converge_records` is the SOLE lock-atomic record-set mutation point every
+    /// thread-record undo/redo path routes through (heddle#355 r8, close-the-class).
+    /// A non-atomic / duplicating forward can write a record under a DIFFERENT id
+    /// with a NEWER `updated_at`, which `find_by_thread`'s `max_by_key(updated_at)`
+    /// would then return. Converging to the single target must delete that leaked
+    /// record so the post-condition holds: the records filed under `name` are
+    /// exactly the id-set of `desired`.
     #[test]
-    fn restore_to_snapshot_drops_leaked_newer_id_record() {
+    fn converge_records_drops_leaked_newer_id_record() {
         let temp = TempDir::new().unwrap();
         let manager = ThreadManager::new(temp.path());
         let name = "feature/converge";
@@ -659,7 +685,7 @@ mod tests {
             "precondition: newer leaked record shadows prev"
         );
 
-        manager.restore_to_snapshot(name, Some(&prev)).unwrap();
+        manager.converge_records(name, std::slice::from_ref(&prev)).unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -679,16 +705,15 @@ mod tests {
         );
     }
 
-    /// Lock-atomic converge over MULTIPLE same-name records (heddle#355 r7, Codex
-    /// cid 3331420787). With the target PLUS two other same-name records (one
-    /// newer-timestamped, so it would shadow the target via
-    /// `find_by_thread`'s `max_by_key(updated_at)`), the converge enumerates and
-    /// deletes them all under a SINGLE write lock via the private file-level
-    /// helpers — never re-acquiring the (non-re-entrant) lock through the public
-    /// `list`/`delete`/`save`. Both storage halves (record + workspace file) of
-    /// each dropped record must be gone.
+    /// Lock-atomic converge over MULTIPLE same-name records (heddle#355 r7/r8).
+    /// With the target PLUS two other same-name records (one newer-timestamped, so
+    /// it would shadow the target via `find_by_thread`'s `max_by_key(updated_at)`),
+    /// the converge enumerates and deletes them all under a SINGLE write lock via
+    /// the private file-level helpers — never re-acquiring the (non-re-entrant)
+    /// lock through the public `list`/`delete`/`save`. Both storage halves (record
+    /// + workspace file) of each dropped record must be gone.
     #[test]
-    fn restore_to_snapshot_converges_multiple_same_name_records() {
+    fn converge_records_converges_multiple_same_name_records() {
         let temp = TempDir::new().unwrap();
         let manager = ThreadManager::new(temp.path());
         let name = "feature/multi";
@@ -716,7 +741,7 @@ mod tests {
             "precondition: the newer same-name record shadows the target"
         );
 
-        manager.restore_to_snapshot(name, Some(&target)).unwrap();
+        manager.converge_records(name, std::slice::from_ref(&target)).unwrap();
 
         let under_name: Vec<_> = manager
             .list()
@@ -747,10 +772,69 @@ mod tests {
         assert!(manager.load_workspace_file("rec-target").unwrap().is_some());
     }
 
-    /// `target = None` empties the name: every record filed under it is dropped,
+    /// Converging to a 2-record `desired` set keeps EXACTLY those two ids and drops
+    /// every other same-name record — the full-set generalization (heddle#355 r8):
+    /// converge is not limited to one-or-empty. Start with ≥3 records under the
+    /// name and converge to a chosen pair.
+    #[test]
+    fn converge_records_converges_to_a_two_record_set() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+        let name = "feature/pair";
+
+        let mut keep_a = sample_thread();
+        keep_a.id = "keep-a".to_string();
+        keep_a.thread = name.to_string();
+        keep_a.updated_at = Utc::now();
+        manager.save(&keep_a).unwrap();
+
+        let mut keep_b = sample_thread();
+        keep_b.id = "keep-b".to_string();
+        keep_b.thread = name.to_string();
+        keep_b.updated_at = keep_a.updated_at - chrono::Duration::seconds(10);
+        manager.save(&keep_b).unwrap();
+
+        let mut drop_c = sample_thread();
+        drop_c.id = "drop-c".to_string();
+        drop_c.thread = name.to_string();
+        drop_c.updated_at = keep_a.updated_at + chrono::Duration::seconds(10);
+        manager.save(&drop_c).unwrap();
+        assert_eq!(
+            manager.list().unwrap().iter().filter(|t| t.thread == name).count(),
+            3,
+            "precondition: three records under the name"
+        );
+
+        manager
+            .converge_records(name, &[keep_a.clone(), keep_b.clone()])
+            .unwrap();
+
+        let ids: HashSet<String> = manager
+            .list()
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.thread == name)
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(
+            ids,
+            HashSet::from(["keep-a".to_string(), "keep-b".to_string()]),
+            "exactly the desired pair remains under the name"
+        );
+        assert!(
+            manager.load_record_file("drop-c").unwrap().is_none(),
+            "the non-desired record is dropped"
+        );
+        assert!(
+            manager.load_workspace_file("drop-c").unwrap().is_none(),
+            "the non-desired record's workspace half is dropped"
+        );
+    }
+
+    /// An empty `desired` empties the name: every record filed under it is dropped,
     /// and records for OTHER names are untouched.
     #[test]
-    fn restore_to_snapshot_none_empties_only_the_named_thread() {
+    fn converge_records_empty_empties_only_the_named_thread() {
         let temp = TempDir::new().unwrap();
         let manager = ThreadManager::new(temp.path());
 
@@ -768,7 +852,7 @@ mod tests {
         other.thread = "feature/b".to_string();
         manager.save(&other).unwrap();
 
-        manager.restore_to_snapshot("feature/a", None).unwrap();
+        manager.converge_records("feature/a", &[]).unwrap();
 
         assert!(
             manager.find_by_thread("feature/a").unwrap().is_none(),
@@ -781,10 +865,10 @@ mod tests {
         );
     }
 
-    /// When `target` is already the sole record under the name, the converge is a
-    /// no-op that leaves it intact.
+    /// When the desired single record is already the sole record under the name,
+    /// the converge is a no-op that leaves it intact.
     #[test]
-    fn restore_to_snapshot_target_already_sole_is_noop() {
+    fn converge_records_target_already_sole_is_noop() {
         let temp = TempDir::new().unwrap();
         let manager = ThreadManager::new(temp.path());
         let name = "feature/sole";
@@ -794,7 +878,7 @@ mod tests {
         rec.thread = name.to_string();
         manager.save(&rec).unwrap();
 
-        manager.restore_to_snapshot(name, Some(&rec)).unwrap();
+        manager.converge_records(name, std::slice::from_ref(&rec)).unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -808,6 +892,45 @@ mod tests {
                 .filter(|t| t.thread == name)
                 .count(),
             1
+        );
+    }
+
+    /// `snapshot_records` returns the full hydrated same-name set (record + the
+    /// workspace half), and only that set — the read paired with
+    /// `converge_records` for capturing a converge-back inverse.
+    #[test]
+    fn snapshot_records_returns_full_hydrated_same_name_set() {
+        let temp = TempDir::new().unwrap();
+        let manager = ThreadManager::new(temp.path());
+        let name = "feature/snap";
+
+        let mut a = sample_thread();
+        a.id = "snap-a".to_string();
+        a.thread = name.to_string();
+        a.materialized_path = Some(PathBuf::from("/work/snap-a"));
+        manager.save(&a).unwrap();
+        let mut b = sample_thread();
+        b.id = "snap-b".to_string();
+        b.thread = name.to_string();
+        manager.save(&b).unwrap();
+        // A record under a DIFFERENT name must not appear in the snapshot.
+        let mut other = sample_thread();
+        other.id = "snap-other".to_string();
+        other.thread = "feature/other".to_string();
+        manager.save(&other).unwrap();
+
+        let snap = manager.snapshot_records(name).unwrap();
+        let ids: HashSet<String> = snap.iter().map(|t| t.id.clone()).collect();
+        assert_eq!(
+            ids,
+            HashSet::from(["snap-a".to_string(), "snap-b".to_string()]),
+            "exactly the same-name set is snapshotted, other names excluded"
+        );
+        let snap_a = snap.iter().find(|t| t.id == "snap-a").unwrap();
+        assert_eq!(
+            snap_a.materialized_path,
+            Some(PathBuf::from("/work/snap-a")),
+            "the workspace half is hydrated into the snapshot"
         );
     }
 

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -249,7 +249,8 @@ bytes of the `Thread` record body — kept opaque so the `oplog` crate
 stays independent of `repo`-level types. The `repo` crate owns the
 encoding via two new helpers on `ThreadManager`:
 `snapshot_thread_record(thread_name) -> Option<Vec<u8>>` and
-`restore_thread_record_from_snapshot(bytes) -> Thread`. `manager_snapshot`
+`decode_thread_record_snapshot(bytes) -> Thread` (the redo applier converges
+the decoded record onto the thread's record set). `manager_snapshot`
 is `None` for callsites that don't write a `ThreadManager` record
 alongside the op (rename batch's new-name arm, ingest, harness/agent
 stubs).

--- a/docs/spikes/heddle-330-atomic-mutation-primitive.md
+++ b/docs/spikes/heddle-330-atomic-mutation-primitive.md
@@ -226,7 +226,7 @@ sketch.
 - **Nesting = enroll-into-outermost (savepoint) by default; eager-commit only
   when an effect must be visible to another process before the outer commit**
   (the #251 reserve). This is a **type-level split**, not a runtime const:
-  savepoint ops implement `SavepointMutation` (opt-in, no blanket impl), eager
+  savepoint ops implement `DeferredMutation` (opt-in, no blanket impl), eager
   ops implement `EagerMutation` whose only method *returns* the compensator;
   `Tx::enroll` is bounded to the former and `Tx::enroll_eager` to the latter, so
   enrolling an eager op without a compensator is a **compile error** — no
@@ -390,7 +390,7 @@ pub trait AtomicMutation {
 }
 
 // NOTE: there is deliberately no `COMMIT_KIND` associated const. Savepoint
-// vs. eager is a *type-level* split (`SavepointMutation` vs `EagerMutation`,
+// vs. eager is a *type-level* split (`DeferredMutation` vs `EagerMutation`,
 // §3.3), not a runtime value the executor branches on — a runtime const that
 // only a `debug_assert!` guards would vanish in release builds and let an
 // eager op be enrolled through the savepoint path with no compensator.
@@ -1812,7 +1812,7 @@ execute — defeating the purpose.
 > A sub-op must be an **`EagerMutation`** (§3.3) **iff its forward effect is
 > durable state that a different process or a different repo handle can read, and
 > the correctness of *that other reader* depends on seeing the effect before the
-> outer transaction commits.** Everything else is a `SavepointMutation`.
+> outer transaction commits.** Everything else is a `DeferredMutation`.
 
 Operationally, a sub-op is eager (implements `EagerMutation`) iff **both**:
 1. its effect lands in a **cross-process-visible** store (a file other processes
@@ -1856,13 +1856,15 @@ Make the wrong combination unrepresentable by splitting the commit discipline at
 the **type** level — two distinct sub-traits, each gating its own enroll path:
 
 ```rust
-/// Opt-in marker for a savepoint-enrollable op: its staged effects are
-/// invisible to other readers until the outer commit publishes them, so it
-/// may defer to the outermost commit (§3.1). There is deliberately NO
-/// blanket `impl<M: AtomicMutation> SavepointMutation for M` — an op opts in
-/// by implementing this explicitly, so an op that is ONLY `EagerMutation`
-/// does NOT satisfy the `enroll` bound and cannot be enrolled as a savepoint.
-pub trait SavepointMutation: AtomicMutation {}
+/// Opt-in marker for a deferred-commit op: when enrolled it defers its commit
+/// marker to the outermost transaction and is unwound by the shared rewind
+/// ledger if that transaction fails (§3.1). It makes NO invisibility claim —
+/// real consumers (undo/redo) do immediately-visible writes and rely on the
+/// ledger only for failure-atomicity. There is deliberately NO blanket
+/// `impl<M: AtomicMutation> DeferredMutation for M` — an op opts in by
+/// implementing this explicitly, so an op that is ONLY `EagerMutation` does
+/// NOT satisfy the `enroll` bound and cannot be enrolled as a deferred child.
+pub trait DeferredMutation: AtomicMutation {}
 
 /// An eager op: its forward effect is cross-process-visible the instant it
 /// runs (§3.2), so it must commit eagerly AND hand back a compensator. The
@@ -1879,9 +1881,9 @@ pub trait EagerMutation: AtomicMutation {
 }
 
 impl<'a> Tx<'a> {
-    /// Savepoint enroll — bounded to `SavepointMutation`. Runs only `apply`
+    /// Savepoint enroll — bounded to `DeferredMutation`. Runs only `apply`
     /// (staged, reversible). An `EagerMutation`-only op fails this bound.
-    pub fn enroll<M: SavepointMutation>(&mut self, m: M) -> Result<StagedCommit<M::Output>> { … }
+    pub fn enroll<M: DeferredMutation>(&mut self, m: M) -> Result<StagedCommit<M::Output>> { … }
 
     /// Eager enroll — bounded to `EagerMutation`. Stages via `apply`, then runs
     /// `commit_eager` and registers the returned `Compensator` into the ledger
@@ -1893,10 +1895,10 @@ impl<'a> Tx<'a> {
 
 Why this closes the hole the `COMMIT_KIND` sketch left open:
 
-- **`enroll` is bounded to `SavepointMutation`.** Passing an op that implements
+- **`enroll` is bounded to `DeferredMutation`.** Passing an op that implements
   only `EagerMutation` is a hard **compile error** (`the trait bound
-  ReserveOpId: SavepointMutation is not satisfied`) — not a release-eliding
-  assert. There is no blanket `SavepointMutation` impl, so eager ops do not
+  ReserveOpId: DeferredMutation is not satisfied`) — not a release-eliding
+  assert. There is no blanket `DeferredMutation` impl, so eager ops do not
   silently acquire savepoint-enrollability.
 - **`enroll_eager` is bounded to `EagerMutation`, whose sole method *returns*
   the `Compensator`.** An op that declares itself eager but supplies no
@@ -1915,7 +1917,7 @@ would have skipped — it simply does not compile.** No `COMMIT_KIND` const, no
 runtime kind-check.
 
 > Note on mutual exclusivity. Stable Rust has no negative bounds, so the type
-> system cannot *forbid* an op from implementing both `SavepointMutation` and
+> system cannot *forbid* an op from implementing both `DeferredMutation` and
 > `EagerMutation`. The structural rule above ("eager effect only in
 > `commit_eager`") makes a double-impl harmless rather than dangerous; sealing
 > the two traits behind a single `CommitDiscipline` associated type to make them
@@ -2288,7 +2290,7 @@ preceding ref-carrying record" holds for the Postgres backend too, by its own me
   sync; the CLI mutation paths are sync today, but the trait may need an
   `async fn apply` variant if a migrated op touches an async backend. Decide per
   migrated op; start with the sync paths (undo/thread/capture are sync).
-- **O6 — Sealing `SavepointMutation` ⊻ `EagerMutation` (belt-and-suspenders).**
+- **O6 — Sealing `DeferredMutation` ⊻ `EagerMutation` (belt-and-suspenders).**
   §3.3's compile-error guarantee does not require the two markers to be mutually
   exclusive — the "eager effect only in `commit_eager`" structural rule makes a
   double-impl harmless. If the impl wants the type system to also *forbid* a
@@ -2868,7 +2870,7 @@ revision, only one migration is in flight, not five.
   Format-stability-sensitive (§6 O9, O10).
 - [x] **(3) Nesting** — §3: enroll-into-outermost (savepoint) default, eager-
   commit exception **rule pinned** (§3.2), **type-level** compensator
-  enforcement (§3.3: `SavepointMutation`/`EagerMutation` bound split on
+  enforcement (§3.3: `DeferredMutation`/`EagerMutation` bound split on
   `enroll`/`enroll_eager` — a compile error, no `COMMIT_KIND` const or
   `debug_assert!`), `Tx` context + depth/reverse-order tracking (§3.1), op_scope
   tie-in + sentinel bridge (§3.4).


### PR DESCRIPTION
## Summary

Migrates `heddle undo` / `heddle redo` onto the `AtomicMutation` primitive (heddle#354 / heddle#330) so the whole operation is **all-or-nothing**. A failure anywhere mid-apply now rewinds every already-applied step back to the pre-operation state instead of leaving the repo half-rewound (the spike §5.1 hazard: batch *N* fails after batches `0..N` were applied **and** marked undone, with no rollback).

This is **impl-b, the model-validation migration** — the first real consumer of the primitive, landed alone before the cascade (#356/#357/#358) so it can prove the nesting/lock/compensation model on a genuinely-nested operation. Closes #355.

## What changed

- **`UndoOp` / `RedoOp`** (root composites) nest one `ApplyUndoBatch` / `ApplyRedoBatch` child **per batch** via the savepoint `Tx::enroll` path; `UndoOp` first enrolls a `StageUndoRecovery` child for the heddle#305 pre-undo recovery pointer. Each sub-op registers its inverse on the **shared rewind ledger** via `Tx::on_rewind` — the inverse of "undo entry E" is "redo entry E" and vice-versa (both are absolute SET ops, so the inverse restores the pre-step state regardless of how far a failed step got). A child that stages then fails rewinds the child **and** unwinds the parent.
- **Commit point**: undo/redo append no domain record (they navigate states that already exist), so the executor's lone `TransactionCommit` marker over an empty batch is the commit point. `OpBatch::is_transaction_marker_only` keeps that record-less sentinel out of the undo/redo eligibility scans and the `undo --list` view (otherwise every undo would leave a phantom batch the next undo would try to undo).
- **Reads** stay on the reconciled path (`repo.head()`, `get_undo_recovery`); no raw-ref bypass.
- Adds `RefManager::clear_undo_recovery` (routed through the write chokepoint) as the inverse of `set_undo_recovery` when the first-ever undo rewinds and there is no prior pointer to restore.
- Does **not** modify the atomic primitive itself.

## Validation findings (model is sufficient — no revision needed)

The primitive's **nesting / lock / compensation** model expresses undo/redo cleanly. Two *contract nuances* surfaced (documented in `undo_apply.rs`); neither blocks the migration, both are general properties of mapping a **self-mutating, immediately-visible** op onto the primitive — worth heeding for the cascade:

1. **Idempotency key.** undo/redo have no unique content identity (they revisit existing states), so a key derived from "operation identity" (batch ids + head) *collides* on the legitimate `undo → redo → undo` toggle, and the primitive's dedup-then-`rewind_all` on a hit would **silently revert** the second undo. The key is therefore derived from the **oplog generation** (`head_id`) at command start — unique per committed transaction — so the dedup branch is never taken. The crash-retry dedup the trait optimizes for is both unreachable (a committed undo marks its batches undone, so a retry re-derives a different batch set) and unnecessary (re-applying an undo is idempotent) for this op. **Eager ops with a real unique resource id (e.g. #358 op-id-reserve) are unaffected;** any future *self-mutating* consumer must use a generational key.
2. **Savepoint semantics.** The children reuse the savepoint *enrollment mechanism* (`enroll` + `on_rewind`) for its apply+ledger-rewind shape, but their effects are direct canonical writes (visible immediately), not the invisible-until-commit staging `SavepointMutation` describes. This adds **failure atomicity**, not concurrent-reader isolation — matching the pre-migration concurrency semantics (undo already published refs batch-by-batch).

**Exactness scope (honest caveat):** the rewind restores the exact pre-op state for `undo` of any batch count and for single-batch `redo` (the `-n 1` default). A multi-batch `redo -n N>1` replays newest-first with absolute `goto`s (pre-existing forward behavior this migration preserves), so a mid-redo fault there rewinds to a consistent intermediate, not the precise pre-redo tip — still strictly safer than the pre-migration no-rollback path. Fixing it means reordering redo replay (a forward-behavior change), out of scope here.

## r6 — close the leaked-record class in thread-record restore

`ThreadManager::find_by_thread(name)` scans **all** records sharing a thread *name* and returns the newest `updated_at` — it does not key on record id. A non-atomic thread-record forward can write a record under a **different** id with a fresher timestamp; if its `step_nonatomic` restore only re-saves the captured `prev` (or deletes one known id), the leaked record survives rollback and `find_by_thread` returns the rolled-back-away state. r5 fixed one arm by deleting the known `new_id`; Codex r5 found the same leak in a second arm (the redo-snapshot path, cid 3331275128) whose id is buried in opaque snapshot bytes. The 2nd sibling ⇒ a class-fix, not a third patch.

**Fix:** `ThreadManager::restore_to_snapshot(name, target)` — deletes every record filed under `name` whose id differs from `target`'s, then saves `target`. Post-condition is *exactly* `{target}` (or empty) under the name, so `find_by_thread`'s `max_by_key(updated_at)` cannot pick a leak — **correct-by-construction, the leaked id never has to be known.** Lives in `thread_storage.rs` next to `find_by_thread`, unit-testable at the layer that owns the invariant.

**Arm audit (every thread-record restore in `undo_apply.rs`):**
- `save_thread_record` — **routed** through `restore_to_snapshot` (subsumes r5's known-`new_id` delete; replacement saves under a new id can't leak).
- `restore_thread_record` (redo snapshot) — **routed**; closes cid 3331275128.
- `delete_thread_record` — **safe, not routed**: its forward only *deletes* (writes no new-id record); the inverse re-saves the captured record under its own id, so no second record can shadow it under the name.
- All record writers (`sync_thread_record_state`, `mark_source_thread_(un)integrated`, `mark_*_threads_*_for_target`, `remove_thread_manager_record`) funnel through the two routed arms above — covered transitively.

**Tests (non-vacuous — fail pre-fix, pass post-fix):**
- Storage-layer: `restore_to_snapshot_drops_leaked_newer_id_record` (leaked newer-id record dropped), `_none_empties_only_the_named_thread`, `_target_already_sole_is_noop`.
- Round-trip rollback over **both** arms: the existing `step_nonatomic_restores_replacement_save_deleting_leaked_new_record` (save arm) + new `step_nonatomic_restores_redo_snapshot_deleting_leaked_record` (redo-snapshot sibling — the arm this round adds coverage for). r0–r5 + #354 atomic suites stay green.

## r7 — finish the close-the-class: make the converge lock-atomic + route the last bypassing path through it

r6 introduced `restore_to_snapshot` and routed both restore arms through it, but Codex r6 found two real gaps that mean the class wasn't fully closed. r7 closes both.

**A — `restore_to_snapshot` is now lock-atomic (cid 3331420787).** r6's converge called the public `list()` (an *unlocked* read snapshot) then per-record `delete()` / `save()`, each re-acquiring the write lock independently. A concurrent same-name writer (`thread start` / `save` runs under the thread-record lock, **not** the undo/redo serialization lock) could land a record *between* the `list()` snapshot and the deletes; that record survives the converge and `find_by_thread` reselects it → the post-condition is false. **Fix:** acquire `write_lock()` **once** at the top and run the whole enumerate→delete→save under that single guard via the **private file-level helpers** (`list_record_files` / `record_store.delete_value` + `workspace_store.delete_value` / `save_record_file` + `save_workspace_file`). The public methods can't be used inside the guard because `RepoLock` write locks are **not** re-entrant (flock on a second FD in the same process blocks) — confirmed before the change; calling them under the guard would deadlock, which is exactly why the converge uses the file-level path.

**B — the created-thread inverse now converges the name to empty (cid 3331420788).** `remove_thread_manager_record` (the `ThreadCreate` / `ThreadCreateV2` inverse) did `find_by_thread(name)` → `delete_thread_record(winner)`, deleting only the `max_by_key(updated_at)` winner. If multiple records were already filed under the name (the very duplicate class the converge tolerates), the older same-name records survived as **phantoms after the thread ref was gone**, and `find_by_thread` would then surface a thread whose ref no longer exists. **Fix:** iterate **every** record filed under `name` and `delete_thread_record` each. `delete_thread_record` already wraps each delete in its own `step_nonatomic` whose inverse re-saves that exact record, so a later transaction failure rolls back **all** of them — preserving the per-record rollback granularity invariant (no bulk single-step delete that would lose per-record inverses).

**Residual (pre-existing, out of scope — stated explicitly per the reviewer's request):** B's consumer-side `list()` → per-record-`delete` still has a narrow window vs a concurrent **non-undo** writer (a `thread start` racing an in-flight undo). That window is a pre-existing property of the thread store — plain thread commands already race each other identically — and is **not** introduced by this migration; the per-effect `step_nonatomic` ledger model cannot hold a file lock across a whole multi-step entry. A's lock-atomic guard closes the window *inside* the converge primitive; the entry-level window across B's multi-step delete is the conscious scope boundary, not an oversight.

**Tests (non-vacuous — fail pre-fix, pass post-fix):**
- A: `restore_to_snapshot_converges_multiple_same_name_records` — target + two other same-name records (one newer-timestamped, shadowing the target) converged under the single-lock file-level path; asserts exactly `{target}` remains and **both** storage halves (record + workspace file) of every dropped record are gone. r6's `restore_to_snapshot_drops_leaked_newer_id_record` stays green.
- B: `remove_thread_manager_record_converges_name_to_empty` (a winner + an older duplicate → ALL removed, `find_by_thread` None) + `remove_thread_manager_record_rollback_resaves_all_records` (a later-step fault after both deletes → rollback re-saves **all** same-name records, not just the winner; the index-1 fault also proves the inverse issues a delete *per* record — pre-fix only the winner is deleted, so the fault never trips and the op wrongly succeeds).
- All r0–r6 + #354 atomic suites stay green.

## Test plan

- [x] **Fault-injection mid-undo** (`fault_mid_undo_rewinds_to_pre_operation_state`): failure after the first batch, partway into the second → HEAD, main ref, worktree, oplog undone-flags, and recovery pointer all restored; no `TransactionCommit` committed.
- [x] **Fault-injection mid-redo** (`fault_mid_redo_rewinds_to_pre_operation_state`): rewinds to the fully-undone pre-redo state.
- [x] **Nesting**: the fault tests reuse the real children through the real `enroll` path; a child failure unwinds the parent.
- [x] **Behavioral parity / success path**: `atomic_undo_success_reverts_and_records_recovery`, `atomic_undo_redo_round_trip_ignores_commit_markers`, plus **114 existing undo/redo/rebase integration tests stay green**.
- [x] **Marker filter**: `test_undo_list_hides_atomic_commit_marker_batches` (raw oplog keeps the sentinel; `undo --list` hides it).
- [x] `bash scripts/check-no-silent-default-tree-load.sh` (clean), `cargo test --workspace` (clean), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo build -p heddle-cli`, `doctor docs --all` (verified, 0 issues) + `doctor schemas` (available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782849030&installation_id=132405951&pr_number=380&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F380&signature=59e12883d499517efd9c92d123d234f3276413938e8b10360c6f872c905b499a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

