### PR TITLE
heddle#356: migrate thread start + hydrate to the AtomicMutation primitive (impl-c)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -654,6 +654,19 @@ pub struct ThreadStartArgs {
     /// and a no-op for repositories without a top-level `Cargo.toml`.
     #[arg(long, hide = true)]
     pub shared_target: bool,
+
+    /// Symlink the origin checkout's top-level ignored dependency
+    /// directories (`node_modules`, `.venv`, `target`, …) into this
+    /// isolated checkout so it's immediately buildable — run
+    /// `tsc`/`eslint`/tests without reinstalling deps from scratch.
+    ///
+    /// The links point back at the origin's directories and stay
+    /// ignored, so the deps are never captured into heddle. Admin dirs
+    /// (`.git`, `.heddle`) are excluded; only top-level ignored
+    /// directories are linked. Has no effect on virtualized (mounted)
+    /// threads.
+    #[arg(long)]
+    pub hydrate: bool,
 }
 
 /// Arguments for the `merge` command.

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -285,6 +285,7 @@ pub fn cmd_attempt(cli: &Cli, args: AttemptArgs) -> Result<()> {
             daemon: true,
             no_daemon: false,
             shared_target,
+            hydrate: false,
         };
         match start_thread(&repo, start_args) {
             Ok(out) => {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -76,6 +76,7 @@ mod shell;
 mod show;
 pub(crate) mod snapshot;
 mod stack;
+mod start_atomic;
 mod stash;
 mod stash_ops;
 mod status;

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -125,6 +125,73 @@ fn hydrate_fault_trips() -> bool {
     })
 }
 
+/// What the target-dir claim ([`create_target_dir`]) established about the
+/// worktree leaf, and how the two directory rewinds may treat it. This is the
+/// SINGLE determination both the checkout writer (implicitly — a refusal aborts
+/// the transaction before the writer's step runs) and BOTH rewinds key on, so
+/// nothing writes through, clears, or deletes a path that was not established as
+/// a real, empty directory we own (heddle#356 cid 3335586962 / 3335052857).
+///
+/// A leaf that is anything else — a symlink, a non-directory file, or a
+/// non-empty directory — is NOT representable here: `create_target_dir` refuses
+/// the start with an `Err` instead, so there is no "owned" value that can stand
+/// for a foreign object.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TargetDir {
+    /// THIS invocation created the leaf as a fresh, real, empty directory →
+    /// rollback removes it wholesale (restoring "didn't exist"). Its dep symlinks
+    /// go with it: `remove_dir_all` unlinks symlinks without following them.
+    Created,
+    /// A real, EMPTY directory already existed at the leaf that we may safely
+    /// write into — a user-supplied `--path`, or a concurrent process that
+    /// created a *real empty dir* between plan time and the transaction. The
+    /// checkout writes into it; rollback clears ONLY the contents we wrote and
+    /// never removes the directory itself (it is not ours to delete).
+    AdoptedEmpty,
+}
+
+/// Validate that `abs_path` is, on disk RIGHT NOW, a real (non-symlink) EMPTY
+/// directory we may write the isolated checkout into and clear-on-rollback —
+/// refuse the start otherwise. Uses `symlink_metadata` so a symlink leaf is
+/// detected AS a symlink and never followed: writing the checkout through it (or
+/// `clear_dir_contents`-ing it on rollback) would mutate/delete data in the
+/// symlink's target (heddle#356 cid 3335586962, data loss).
+fn adopt_existing_empty_dir(abs_path: &Path) -> HeddleResult<TargetDir> {
+    let meta = std::fs::symlink_metadata(abs_path).map_err(HeddleError::from)?;
+    if meta.file_type().is_symlink() {
+        return Err(target_dir_shape_refusal(abs_path, "is a symlink"));
+    }
+    if !meta.is_dir() {
+        return Err(target_dir_shape_refusal(abs_path, "is not a directory"));
+    }
+    if std::fs::read_dir(abs_path)
+        .map_err(HeddleError::from)?
+        .next()
+        .transpose()
+        .map_err(HeddleError::from)?
+        .is_some()
+    {
+        return Err(target_dir_shape_refusal(abs_path, "is not empty"));
+    }
+    Ok(TargetDir::AdoptedEmpty)
+}
+
+/// The refusal raised when the target leaf is not a real, empty, ownable
+/// directory at claim time — a symlink, a non-directory file, or a non-empty
+/// directory a concurrent process dropped in after `plan_worktree_target` saw
+/// the leaf absent. Refusing here (rather than returning a "not ours" signal the
+/// writer proceeds on) is what closes the data-loss class.
+fn target_dir_shape_refusal(abs_path: &Path, reason: &str) -> HeddleError {
+    HeddleError::Conflict(format!(
+        "refusing to start: worktree target '{}' {} — not a real empty directory heddle can \
+         own. A concurrent process or a pre-existing filesystem object occupies the target, and \
+         heddle will not write the isolated checkout through it. Choose an empty real directory \
+         for `--path`, or let heddle create a managed materialized checkout.",
+        abs_path.display(),
+        reason,
+    ))
+}
+
 /// Remove every entry inside `dir` without removing `dir` itself, so a
 /// pre-existing user-provided directory survives a rollback while the contents
 /// this invocation materialized are cleared. Symlinks are unlinked directly
@@ -143,22 +210,26 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// The precise checkout-rewind inverse. `created` is the runtime ownership
-/// signal from [`create_target_dir`] (NOT the stale plan-time bool — cid
-/// 3335052857). `true` → this invocation made the worktree directory, so remove
-/// it entirely (restoring "didn't exist"); its dep symlinks go with it, since
-/// `remove_dir_all` unlinks symlinks without following them, so the origin's
-/// deps are never touched. `false` → the user supplied an already-existing empty
-/// `--path` dir, OR a concurrent process created the target between plan time
-/// and the transaction; either way it is not ours to delete — preserve the
-/// directory and clear only the contents we materialized inside it
-/// (`prepare_worktree_target` only accepts a pre-existing dir when it is empty).
+/// The precise checkout-rewind inverse, keyed on the runtime [`TargetDir`] claim
+/// from [`create_target_dir`] (NOT a stale plan-time bool — cid 3335052857 /
+/// 3335586962):
+///   * [`TargetDir::Created`] → this invocation made the worktree directory, so
+///     remove it entirely (restoring "didn't exist"); its dep symlinks go with
+///     it, since `remove_dir_all` unlinks symlinks without following them, so the
+///     origin's deps are never touched.
+///   * [`TargetDir::AdoptedEmpty`] → we adopted a real, empty pre-existing dir
+///     (user `--path`, or a concurrent real-empty-dir) — not ours to delete, so
+///     preserve the directory and clear only the contents we materialized inside.
+///   * `None` → the claim never established an owned empty dir here (the forward
+///     refused on a symlink/foreign object, or never ran). Touch NOTHING — the
+///     whole point of the close-the-class fix is that rollback never clears or
+///     deletes through a path it did not itself establish as a real empty dir.
 /// Tolerant of an already-absent target so it composes with other rewind steps.
-fn rewind_checkout(abs_path: &Path, created: bool) -> HeddleResult<()> {
-    let result = if created {
-        std::fs::remove_dir_all(abs_path)
-    } else {
-        clear_dir_contents(abs_path)
+fn rewind_checkout(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()> {
+    let result = match claim {
+        Some(TargetDir::Created) => std::fs::remove_dir_all(abs_path),
+        Some(TargetDir::AdoptedEmpty) => clear_dir_contents(abs_path),
+        None => return Ok(()),
     };
     match result {
         Ok(()) => Ok(()),
@@ -167,50 +238,57 @@ fn rewind_checkout(abs_path: &Path, created: bool) -> HeddleResult<()> {
     }
 }
 
-/// Create the materialization target directory and report whether THIS
-/// invocation actually created it — the ownership signal both directory rewinds
-/// (the target-dir inverse and the checkout rewind) key their destructive
-/// branch on.
+/// Atomically establish that the materialization target is a real, empty, owned
+/// directory, returning the [`TargetDir`] claim both directory rewinds key on —
+/// or REFUSING the start (`Err`) when the leaf is anything else. This single
+/// determination drives both whether the checkout writer may proceed (a refusal
+/// aborts the transaction before its step runs) and how rollback treats the leaf
+/// (heddle#356 cid 3335586962 / 3335052857).
 ///
 /// `plan_created` is the plan-time observation from `plan_worktree_target` (the
-/// dir was absent then). It is NOT trusted for the remove decision: a concurrent
-/// process can create the target between plan time and now, after which a stale
-/// `plan_created == true` would make rollback delete a directory this start
-/// never made (heddle#356 cid 3335052857). So ownership is re-established
-/// atomically HERE:
-///   * `plan_created == false` → `plan_worktree_target` accepted a pre-existing
-///     (empty) user `--path` dir; never ours to create or remove → `Ok(false)`.
-///   * `plan_created == true` → `create_dir` (NOT `create_dir_all`) on the leaf
-///     fails with `AlreadyExists` exactly when a concurrent process won the
-///     creation race; that branch returns `Ok(false)` so neither rewind removes
-///     their dir. Only the branch where `create_dir` itself created the leaf
-///     returns `Ok(true)`.
+/// dir was absent then). It is NOT trusted: a concurrent process can create — or
+/// drop a symlink/file at — the target between plan time and now, so the shape is
+/// re-established atomically HERE:
+///   * `plan_created == false` → `plan_worktree_target` accepted a pre-existing,
+///     validated-empty, non-symlink user `--path` dir. Re-validate the shape now
+///     (TOCTOU) and adopt it ([`TargetDir::AdoptedEmpty`]) — never created, never
+///     removed by us — or refuse if it is no longer a real empty dir.
+///   * `plan_created == true` → `create_dir` (NOT `create_dir_all`) on the leaf:
+///     - `Ok` → this start created the leaf → [`TargetDir::Created`].
+///     - `AlreadyExists` → a concurrent process won the race. It may have created
+///       a real empty dir (safe to adopt) OR dropped a symlink / file / non-empty
+///       dir — `adopt_existing_empty_dir` adopts the former and REFUSES the
+///       latter, so the checkout is never written through a foreign object and
+///       rollback never clears/deletes through it (cid 3335586962, data loss).
 ///
 /// Parents are created with `create_dir_all` (shared infrastructure, left in
 /// place on rollback — `remove_self_created_dir` only targets the leaf).
-fn create_target_dir(abs_path: &Path, plan_created: bool) -> HeddleResult<bool> {
+fn create_target_dir(abs_path: &Path, plan_created: bool) -> HeddleResult<TargetDir> {
     if !plan_created {
-        return Ok(false);
+        return adopt_existing_empty_dir(abs_path);
     }
     if let Some(parent) = abs_path.parent() {
         std::fs::create_dir_all(parent).map_err(HeddleError::from)?;
     }
     match std::fs::create_dir(abs_path) {
-        Ok(()) => Ok(true),
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Ok(()) => Ok(TargetDir::Created),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            adopt_existing_empty_dir(abs_path)
+        }
         Err(err) => Err(HeddleError::from(err)),
     }
 }
 
 /// Inverse of the target-dir creation step: remove the worktree directory ONLY
-/// when this invocation created it (restoring "didn't exist"). `created` is the
-/// runtime ownership signal from [`create_target_dir`], NOT the stale plan-time
-/// bool — a concurrently-created or pre-existing user-supplied `--path` dir is
-/// never removed here. Tolerant of an already-absent dir so it composes after
-/// the checkout rewind (which removes a self-created dir first; this then
-/// no-ops on `NotFound`).
-fn remove_self_created_dir(abs_path: &Path, created: bool) -> HeddleResult<()> {
-    if !created {
+/// when this invocation created it ([`TargetDir::Created`], restoring "didn't
+/// exist"). `claim` is the runtime [`TargetDir`] signal from
+/// [`create_target_dir`], NOT a stale plan-time bool — an adopted (concurrent or
+/// user-supplied) dir, or a leaf this step never established (`None`), is never
+/// removed here. Tolerant of an already-absent dir so it composes after the
+/// checkout rewind (which removes a self-created dir first; this then no-ops on
+/// `NotFound`).
+fn remove_self_created_dir(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()> {
+    if claim != Some(TargetDir::Created) {
         return Ok(());
     }
     match std::fs::remove_dir_all(abs_path) {
@@ -330,30 +408,31 @@ impl StartThread {
     /// failure in the remaining pre-transaction work would orphan a dir created
     /// before the executor had a ledger (heddle#356 cid 3333881552).
     ///
-    /// The inverse removes the directory ONLY when this invocation created it; a
-    /// user-supplied pre-existing `--path` dir — or one a concurrent process
-    /// created between plan time and now (cid 3335052857) — is preserved.
-    /// Ownership is decided at the moment of creation by [`create_target_dir`]
-    /// and stored in `created_by_us`, a cell BOTH this inverse and the checkout
-    /// rewind read so neither trusts the stale plan-time bool. Forward-first
-    /// (`Tx::step`): the inverse is registered only after the create succeeds,
-    /// and a forward that fails created nothing of ours to remove.
+    /// The inverse removes the directory ONLY when this invocation created it
+    /// ([`TargetDir::Created`]); an adopted pre-existing/concurrent dir, or a leaf
+    /// the forward refused (a symlink/foreign object — the cell stays `None`), is
+    /// never removed (cid 3335052857 / 3335586962). The [`TargetDir`] claim is
+    /// decided at the moment of creation by [`create_target_dir`] and stored in
+    /// `target_claim`, a cell BOTH this inverse and the checkout rewind read so
+    /// neither trusts the stale plan-time bool. Forward-first (`Tx::step`): the
+    /// inverse is registered only after the create succeeds, and a forward that
+    /// refused (or never ran) leaves the cell `None`, so rollback touches nothing.
     fn stage_target_dir(
         &self,
         tx: &mut Tx<'_>,
-        created_by_us: Rc<Cell<bool>>,
+        target_claim: Rc<Cell<Option<TargetDir>>>,
     ) -> HeddleResult<()> {
         let abs = self.abs_path.clone();
         let rewind_abs = self.abs_path.clone();
         let plan_created = self.target_dir_created;
-        let fwd_flag = Rc::clone(&created_by_us);
+        let fwd_claim = Rc::clone(&target_claim);
         tx.step(
             move || {
-                let made = create_target_dir(&abs, plan_created)?;
-                fwd_flag.set(made);
+                let established = create_target_dir(&abs, plan_created)?;
+                fwd_claim.set(Some(established));
                 Ok(())
             },
-            move || remove_self_created_dir(&rewind_abs, created_by_us.get()),
+            move || remove_self_created_dir(&rewind_abs, target_claim.get()),
         )
     }
 
@@ -397,20 +476,21 @@ impl StartThread {
     fn stage_checkout(
         &self,
         tx: &mut Tx<'_>,
-        created_by_us: Rc<Cell<bool>>,
+        target_claim: Rc<Cell<Option<TargetDir>>>,
     ) -> HeddleResult<()> {
         let repo = tx.repo();
         let abs = self.abs_path.clone();
         let rewind_abs = self.abs_path.clone();
         let base_state = self.base_state;
         let name = self.name.clone();
-        // Ownership is the runtime signal set by `stage_target_dir`'s forward
-        // (which ran first), read at rewind time when it is settled — never the
-        // stale plan-time bool, so a concurrently-created dir is cleared, not
-        // deleted wholesale (cid 3335052857).
+        // The [`TargetDir`] claim set by `stage_target_dir`'s forward (which ran
+        // first), read at rewind time when it is settled — never the stale
+        // plan-time bool. An adopted dir is cleared (not deleted), a self-created
+        // dir is removed wholesale, and a refused/unestablished leaf (`None`) is
+        // left untouched (cid 3335052857 / 3335586962).
         tx.step_nonatomic(
             move || Ok(()),
-            move |()| rewind_checkout(&rewind_abs, created_by_us.get()),
+            move |()| rewind_checkout(&rewind_abs, target_claim.get()),
             move || {
                 #[cfg(test)]
                 if materialize_fault_trips() {
@@ -579,16 +659,17 @@ impl AtomicMutation for StartThread {
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<String>>> {
         let mut oplog: Vec<OpRecord> = Vec::new();
 
-        // Runtime ownership of the target dir, decided atomically by
+        // The single [`TargetDir`] claim, decided atomically by
         // `stage_target_dir`'s forward and consumed by BOTH directory rewinds
-        // (the target-dir inverse and the checkout rewind) so neither trusts the
-        // stale plan-time bool and deletes a dir a concurrent process created
-        // (heddle#356 cid 3335052857).
-        let created_by_us = Rc::new(Cell::new(false));
+        // (the target-dir inverse and the checkout rewind). It starts `None` — an
+        // unestablished claim — so if the forward refuses on a symlink/foreign
+        // object (or never runs), neither rewind clears or deletes through the
+        // leaf (heddle#356 cid 3335052857 / 3335586962).
+        let target_claim = Rc::new(Cell::new(None));
 
         // 0. Create the target dir inside the transaction (first, so its removal
         //    inverse runs last and a self-created dir never leaks).
-        self.stage_target_dir(tx, Rc::clone(&created_by_us))?;
+        self.stage_target_dir(tx, Rc::clone(&target_claim))?;
 
         // 1. Thread ref (+ staged ThreadCreateV2 for a brand-new thread).
         self.stage_ref(tx, &mut oplog)?;
@@ -596,7 +677,7 @@ impl AtomicMutation for StartThread {
         // 2. Mode-specific materialization.
         let linked = match self.thread_mode {
             ThreadMode::Solid | ThreadMode::Materialized => {
-                self.stage_checkout(tx, Rc::clone(&created_by_us))?;
+                self.stage_checkout(tx, Rc::clone(&target_claim))?;
                 if matches!(self.thread_mode, ThreadMode::Materialized) {
                     self.stage_manifest(tx)?;
                 }
@@ -661,7 +742,9 @@ fn symlink_unsupported_error(link: &str) -> HeddleError {
 
 #[cfg(test)]
 mod tests {
-    use super::super::thread::{resolve_start_epoch, start_thread, start_transaction_id};
+    use super::super::thread::{
+        find_active_thread_entry, resolve_start_epoch, start_thread, start_transaction_id,
+    };
     use super::super::thread_cmd::drop_thread_silent;
     use super::super::worktree_cmd::helpers::plan_worktree_target;
     use super::*;
@@ -910,6 +993,68 @@ mod tests {
         );
     }
 
+    // ---- heddle#356 r4 close-the-class: Class A commit-detection gate ----
+
+    /// cid 3335586969 (the new sibling): a committed-before-bookkeeping retry.
+    /// The start transaction committed (checkout + ref + record + commit marker),
+    /// then a crash interrupted the post-commit `AgentRegistry` reservation — so
+    /// there is NO live reservation, yet the checkout is now NON-EMPTY. The retry
+    /// must be RECOGNIZED as a committed retry (the epoch re-derived from the
+    /// durable Active record yields the SAME key) and short-circuit exactly-once,
+    /// NOT rejected by `plan_worktree_target`'s `worktree_target_not_empty` (which
+    /// fires before `execute` could ever see the matching `TransactionCommit`).
+    #[test]
+    fn committed_before_bookkeeping_retry_short_circuits() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+
+        // A first start fully succeeds: checkout + ref + Active record + commit
+        // marker + the post-commit AgentRegistry reservation.
+        start_thread(&repo, solid_args("iso", &checkout, &state, false))
+            .expect("first start should succeed");
+        assert!(checkout.join(".heddle").is_dir(), "the first start materialized the checkout");
+
+        // Recreate the crash window: the write-path committed, but the post-commit
+        // bookkeeping never landed — delete the reservation so no live owner
+        // exists (find_active_thread_entry → None, the committed-before-bookkeeping
+        // state). The checkout, ref, record, and commit marker all remain.
+        let entry = find_active_thread_entry(&repo, "iso")
+            .unwrap()
+            .expect("the first start created a reservation");
+        objects::store::AgentRegistry::new(repo.heddle_dir())
+            .delete(&entry.session_id)
+            .unwrap();
+        assert!(
+            find_active_thread_entry(&repo, "iso").unwrap().is_none(),
+            "the reservation is gone — exactly the committed-before-bookkeeping window"
+        );
+
+        // The retry must NOT fail with worktree_target_not_empty: commit-detection
+        // gates the preflight, so the committed marker short-circuits the start and
+        // completes the interrupted bookkeeping instead.
+        start_thread(&repo, solid_args("iso", &checkout, &state, false)).expect(
+            "a committed-before-bookkeeping retry must short-circuit, not be rejected by \
+             worktree_target_not_empty",
+        );
+
+        // The committed checkout is left exactly as it was — neither re-created nor
+        // cleared (the short-circuit never ran the write-path or its rewind).
+        assert!(checkout.join(".heddle").is_dir(), "the committed checkout survives the retry");
+        assert!(checkout.join("a.txt").is_file(), "the committed tree survives the retry");
+
+        // The record stays the single committed Active record (no duplicate, no
+        // Abandoned). And the interrupted reservation is now completed.
+        let record = ThreadManager::new(repo.heddle_dir())
+            .load("iso")
+            .unwrap()
+            .expect("the committed record persists");
+        assert_eq!(record.state, repo::ThreadState::Active);
+        assert!(
+            find_active_thread_entry(&repo, "iso").unwrap().is_some(),
+            "the retry completes the interrupted reservation exactly-once"
+        );
+    }
+
     /// cid 3333881561: the manifest rollback must restore the prior manifest
     /// snapshot (a stale manifest from a reused thread ref), not blind-delete.
     #[test]
@@ -991,30 +1136,31 @@ mod tests {
         );
     }
 
-    // ---- heddle#356 r3 fixes ----
+    // ---- heddle#356 r3 fixes (updated to the TargetDir claim — r4) ----
 
     /// cid 3335052857: target-dir ownership is re-established atomically at
     /// creation, so rollback never deletes a directory a concurrent process
     /// created between `plan_worktree_target` time and the transaction. Here the
     /// plan saw the target absent (`plan_created = true`) but a concurrent
-    /// process created it first — `create_target_dir` must NOT claim it, and the
-    /// runtime-keyed rewind must leave it intact.
+    /// process created a REAL EMPTY dir first — `create_target_dir` adopts it
+    /// (does NOT claim it as created), and the claim-keyed rewind leaves it intact.
     #[test]
     fn target_dir_rollback_leaves_concurrently_created_dir_intact() {
         let temp = TempDir::new().unwrap();
         let target = temp.path().join("iso");
 
-        // The concurrent creation that races our forward.
+        // The concurrent creation that races our forward (a real empty dir).
         std::fs::create_dir(&target).unwrap();
-        let created_by_us = create_target_dir(&target, true).unwrap();
-        assert!(
-            !created_by_us,
-            "a target a concurrent process created must NOT be claimed as ours \
-             (stale plan-time bool would have)"
+        let claim = create_target_dir(&target, true).unwrap();
+        assert_eq!(
+            claim,
+            TargetDir::AdoptedEmpty,
+            "a real empty dir a concurrent process created is ADOPTED, not claimed as created \
+             (a stale plan-time bool would have claimed it)"
         );
-        // The rewind keys on the runtime signal, so it must spare their dir.
-        remove_self_created_dir(&target, created_by_us).unwrap();
-        rewind_checkout(&target, created_by_us).unwrap();
+        // The rewind keys on the runtime claim, so it must spare their dir.
+        remove_self_created_dir(&target, Some(claim)).unwrap();
+        rewind_checkout(&target, Some(claim)).unwrap();
         assert!(
             target.is_dir(),
             "rollback must not delete a directory this start did not create"
@@ -1028,10 +1174,10 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let target = temp.path().join("nested").join("iso");
 
-        let created_by_us = create_target_dir(&target, true).unwrap();
-        assert!(created_by_us, "an absent target this start creates is owned by us");
+        let claim = create_target_dir(&target, true).unwrap();
+        assert_eq!(claim, TargetDir::Created, "an absent target this start creates is owned by us");
         assert!(target.is_dir(), "the forward must create the leaf (and its parents)");
-        remove_self_created_dir(&target, created_by_us).unwrap();
+        remove_self_created_dir(&target, Some(claim)).unwrap();
         assert!(
             std::fs::symlink_metadata(&target).is_err(),
             "rollback must remove a directory this start genuinely created"
@@ -1039,16 +1185,96 @@ mod tests {
     }
 
     /// cid 3335052857: a pre-existing user `--path` dir (`plan_created = false`)
-    /// is never created or removed by us — the runtime signal stays `false`.
+    /// is adopted (never created or removed by us); the claim is `AdoptedEmpty`.
     #[test]
     fn target_dir_user_supplied_dir_is_never_removed() {
         let temp = TempDir::new().unwrap();
         let target = temp.path().join("iso");
         std::fs::create_dir(&target).unwrap();
 
-        let created_by_us = create_target_dir(&target, false).unwrap();
-        assert!(!created_by_us, "a user-supplied pre-existing dir is not ours to own");
-        remove_self_created_dir(&target, created_by_us).unwrap();
+        let claim = create_target_dir(&target, false).unwrap();
+        assert_eq!(
+            claim,
+            TargetDir::AdoptedEmpty,
+            "a user-supplied pre-existing empty dir is adopted, not ours to own/remove"
+        );
+        remove_self_created_dir(&target, Some(claim)).unwrap();
         assert!(target.is_dir(), "a user-supplied dir must survive rollback");
+    }
+
+    // ---- heddle#356 r4 close-the-class: target-dir SHAPE validation (cid 3335586962) ----
+
+    /// cid 3335586962 (P1, the new sibling): `plan_created = true` but a
+    /// concurrent process dropped a SYMLINK-to-a-dir at the leaf between plan time
+    /// and the transaction. `create_target_dir` must REFUSE (not return a
+    /// "not-ours" value the checkout writer proceeds on), and because the forward
+    /// refuses, the claim is never established (`None`) so rollback NEVER clears
+    /// or deletes through the symlink — the symlink target's contents survive.
+    #[test]
+    fn create_target_dir_refuses_symlink_leaf_and_spares_target_contents() {
+        let temp = TempDir::new().unwrap();
+        // The symlink target with precious contents that MUST survive.
+        let victim = temp.path().join("victim");
+        std::fs::create_dir(&victim).unwrap();
+        std::fs::write(victim.join("precious.txt"), b"precious").unwrap();
+        // A concurrent process dropped a symlink-to-dir at the leaf.
+        let leaf = temp.path().join("iso");
+        std::os::unix::fs::symlink(&victim, &leaf).unwrap();
+
+        // The plan saw the leaf absent (`plan_created = true`); the claim must refuse.
+        let claim = create_target_dir(&leaf, true);
+        assert!(
+            claim.is_err(),
+            "a symlink at the leaf must REFUSE the start, never be adopted/written through"
+        );
+
+        // The forward refused, so no claim was established → rollback (driven by a
+        // `None` cell) must touch nothing.
+        rewind_checkout(&leaf, None).unwrap();
+        remove_self_created_dir(&leaf, None).unwrap();
+        assert!(
+            std::fs::symlink_metadata(&leaf).unwrap().file_type().is_symlink(),
+            "the symlink itself must be left untouched"
+        );
+        assert!(
+            victim.join("precious.txt").is_file(),
+            "rollback must NOT delete through the symlink into its target's contents"
+        );
+        assert_eq!(
+            std::fs::read(victim.join("precious.txt")).unwrap(),
+            b"precious",
+            "the symlink target's data must survive intact"
+        );
+    }
+
+    /// cid 3335586962: a plain FILE (not a dir) occupying the leaf is likewise
+    /// refused — the checkout is never written over a non-directory object.
+    #[test]
+    fn create_target_dir_refuses_non_directory_leaf() {
+        let temp = TempDir::new().unwrap();
+        let leaf = temp.path().join("iso");
+        std::fs::write(&leaf, b"i am a file, not a dir").unwrap();
+
+        let claim = create_target_dir(&leaf, true);
+        assert!(claim.is_err(), "a non-directory leaf must refuse the start");
+        assert!(leaf.is_file(), "the pre-existing file must be left untouched");
+        assert_eq!(std::fs::read(&leaf).unwrap(), b"i am a file, not a dir");
+    }
+
+    /// cid 3335586962: a NON-EMPTY directory at the leaf is refused — adopting it
+    /// would let rollback `clear_dir_contents` someone else's populated dir.
+    #[test]
+    fn create_target_dir_refuses_non_empty_dir_leaf() {
+        let temp = TempDir::new().unwrap();
+        let leaf = temp.path().join("iso");
+        std::fs::create_dir(&leaf).unwrap();
+        std::fs::write(leaf.join("someone-elses-work.txt"), b"keep me").unwrap();
+
+        let claim = create_target_dir(&leaf, true);
+        assert!(claim.is_err(), "a non-empty dir at the leaf must refuse the start");
+        assert!(
+            leaf.join("someone-elses-work.txt").is_file(),
+            "the pre-existing contents must be left untouched"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -39,6 +39,8 @@
 //! all lives here, exactly like undo/redo's `EntrySteps`.
 
 use std::cell::Cell;
+#[cfg(unix)]
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -53,9 +55,7 @@ use repo::{
 
 use super::mount_lifecycle::{self, MountOwnership};
 use super::worktree_cmd::{
-    helpers::write_isolated_checkout,
-    hydrate,
-    shared_target::write_cargo_config,
+    helpers::write_isolated_checkout, hydrate, shared_target::write_cargo_config,
 };
 
 /// Wrap an `anyhow` error from a materialize/hydrate helper into the
@@ -126,45 +126,179 @@ fn hydrate_fault_trips() -> bool {
 }
 
 /// What the target-dir claim ([`create_target_dir`]) established about the
-/// worktree leaf, and how the two directory rewinds may treat it. This is the
-/// SINGLE determination both the checkout writer (implicitly — a refusal aborts
-/// the transaction before the writer's step runs) and BOTH rewinds key on, so
-/// nothing writes through, clears, or deletes a path that was not established as
-/// a real, empty directory we own (heddle#356 cid 3335586962 / 3335052857).
+/// worktree leaf, and how writers/rewinds may treat it. This is the SINGLE
+/// determination both the checkout writer and BOTH rewinds key on, and it carries
+/// the opened directory handle captured at claim time. Later writes use that
+/// handle-backed path instead of re-resolving `abs_path`, so a post-claim path
+/// swap cannot redirect checkout bytes into a symlink target (heddle#356 cid
+/// 3336120590).
 ///
 /// A leaf that is anything else — a symlink, a non-directory file, or a
 /// non-empty directory — is NOT representable here: `create_target_dir` refuses
 /// the start with an `Err` instead, so there is no "owned" value that can stand
 /// for a foreign object.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) enum TargetDirKind {
+    Created,
+    AdoptedEmpty,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) enum TargetDir {
     /// THIS invocation created the leaf as a fresh, real, empty directory →
     /// rollback removes it wholesale (restoring "didn't exist"). Its dep symlinks
     /// go with it: `remove_dir_all` unlinks symlinks without following them.
-    Created,
+    Created(TargetDirHandle),
     /// A real, EMPTY directory already existed at the leaf that we may safely
     /// write into — a user-supplied `--path`, or a concurrent process that
     /// created a *real empty dir* between plan time and the transaction. The
     /// checkout writes into it; rollback clears ONLY the contents we wrote and
     /// never removes the directory itself (it is not ours to delete).
-    AdoptedEmpty,
+    AdoptedEmpty(TargetDirHandle),
+}
+
+impl TargetDir {
+    fn created(handle: TargetDirHandle) -> Self {
+        Self::Created(handle)
+    }
+
+    fn adopted_empty(handle: TargetDirHandle) -> Self {
+        Self::AdoptedEmpty(handle)
+    }
+
+    fn kind(&self) -> TargetDirKind {
+        match self {
+            Self::Created(_) => TargetDirKind::Created,
+            Self::AdoptedEmpty(_) => TargetDirKind::AdoptedEmpty,
+        }
+    }
+
+    fn handle(&self) -> &TargetDirHandle {
+        match self {
+            Self::Created(handle) | Self::AdoptedEmpty(handle) => handle,
+        }
+    }
+}
+
+/// The open directory identity captured by `create_target_dir`. The handle is
+/// the root of trust: checkout writes and rollback cleanup use `io_path()`, a
+/// path that names this open directory (`/proc/self/fd/N` on Linux) rather than
+/// the mutable user-facing leaf path.
+#[derive(Clone)]
+pub(crate) struct TargetDirHandle {
+    #[cfg(unix)]
+    dir: Rc<File>,
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+    #[cfg(not(unix))]
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for TargetDirHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(unix)]
+        {
+            f.debug_struct("TargetDirHandle")
+                .field("dev", &self.dev)
+                .field("ino", &self.ino)
+                .finish_non_exhaustive()
+        }
+        #[cfg(not(unix))]
+        {
+            f.debug_struct("TargetDirHandle")
+                .field("path", &self.path)
+                .finish()
+        }
+    }
+}
+
+impl TargetDirHandle {
+    fn open(abs_path: &Path) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+            let dir = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+                .open(abs_path)?;
+            let metadata = dir.metadata()?;
+            if !metadata.is_dir() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "target is not a directory",
+                ));
+            }
+            Ok(Self {
+                dir: Rc::new(dir),
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            let metadata = std::fs::symlink_metadata(abs_path)?;
+            if !metadata.is_dir() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "target is not a directory",
+                ));
+            }
+            Ok(Self {
+                path: abs_path.to_path_buf(),
+            })
+        }
+    }
+
+    fn io_path(&self) -> PathBuf {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let fd = self.dir.as_raw_fd();
+            if Path::new("/proc/self/fd").is_dir() {
+                PathBuf::from(format!("/proc/self/fd/{fd}"))
+            } else {
+                PathBuf::from(format!("/dev/fd/{fd}"))
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            self.path.clone()
+        }
+    }
+
+    fn same_identity_at_path(&self, abs_path: &Path) -> std::io::Result<bool> {
+        #[cfg(unix)]
+        {
+            let current = Self::open(abs_path)?;
+            Ok(current.dev == self.dev && current.ino == self.ino)
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(abs_path == self.path)
+        }
+    }
+}
+
+fn claim_from_cell(target_claim: &Cell<Option<TargetDir>>) -> Option<TargetDir> {
+    let claim = target_claim.take();
+    let snapshot = claim.clone();
+    target_claim.set(claim);
+    snapshot
 }
 
 /// Validate that `abs_path` is, on disk RIGHT NOW, a real (non-symlink) EMPTY
-/// directory we may write the isolated checkout into and clear-on-rollback —
-/// refuse the start otherwise. Uses `symlink_metadata` so a symlink leaf is
-/// detected AS a symlink and never followed: writing the checkout through it (or
-/// `clear_dir_contents`-ing it on rollback) would mutate/delete data in the
-/// symlink's target (heddle#356 cid 3335586962, data loss).
-fn adopt_existing_empty_dir(abs_path: &Path) -> HeddleResult<TargetDir> {
-    let meta = std::fs::symlink_metadata(abs_path).map_err(HeddleError::from)?;
-    if meta.file_type().is_symlink() {
-        return Err(target_dir_shape_refusal(abs_path, "is a symlink"));
-    }
-    if !meta.is_dir() {
-        return Err(target_dir_shape_refusal(abs_path, "is not a directory"));
-    }
-    if std::fs::read_dir(abs_path)
+/// directory we may write the isolated checkout into and clear-on-rollback, and
+/// retain the directory handle that later writes/rewinds must use. Opening uses
+/// `O_NOFOLLOW | O_DIRECTORY` on Unix, so a symlink leaf is refused before it can
+/// become an owned claim.
+fn adopt_existing_empty_dir(abs_path: &Path) -> HeddleResult<TargetDirHandle> {
+    let handle = TargetDirHandle::open(abs_path)
+        .map_err(|_| target_dir_shape_refusal(abs_path, &target_dir_shape_reason(abs_path)))?;
+    if std::fs::read_dir(handle.io_path())
         .map_err(HeddleError::from)?
         .next()
         .transpose()
@@ -173,7 +307,17 @@ fn adopt_existing_empty_dir(abs_path: &Path) -> HeddleResult<TargetDir> {
     {
         return Err(target_dir_shape_refusal(abs_path, "is not empty"));
     }
-    Ok(TargetDir::AdoptedEmpty)
+    Ok(handle)
+}
+
+fn target_dir_shape_reason(abs_path: &Path) -> String {
+    match std::fs::symlink_metadata(abs_path) {
+        Ok(meta) if meta.file_type().is_symlink() => "is a symlink".to_string(),
+        Ok(meta) if !meta.is_dir() => "is not a directory".to_string(),
+        Ok(_) => "could not be opened as a real directory".to_string(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => "does not exist".to_string(),
+        Err(err) => format!("could not be inspected ({err})"),
+    }
 }
 
 /// The refusal raised when the target leaf is not a real, empty, ownable
@@ -210,6 +354,15 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+fn clear_claimed_dir_contents(claim: &TargetDir) -> HeddleResult<()> {
+    match clear_dir_contents(&claim.handle().io_path()) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => Ok(()),
+        Err(err) => Err(HeddleError::from(err)),
+    }
+}
+
 /// The precise checkout-rewind inverse, keyed on the runtime [`TargetDir`] claim
 /// from [`create_target_dir`] (NOT a stale plan-time bool — cid 3335052857 /
 /// 3335586962):
@@ -227,15 +380,51 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
 ///
 /// Tolerant of an already-absent target so it composes with other rewind steps.
 fn rewind_checkout(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()> {
-    let result = match claim {
-        Some(TargetDir::Created) => std::fs::remove_dir_all(abs_path),
-        Some(TargetDir::AdoptedEmpty) => clear_dir_contents(abs_path),
-        None => return Ok(()),
+    let Some(claim) = claim else {
+        return Ok(());
     };
-    match result {
+    match claim.kind() {
+        TargetDirKind::Created => {
+            clear_claimed_dir_contents(&claim)?;
+            remove_claimed_created_dir_if_still_at_path(abs_path, &claim)
+        }
+        TargetDirKind::AdoptedEmpty => clear_claimed_dir_contents(&claim),
+    }
+}
+
+fn remove_claimed_created_dir_if_still_at_path(
+    abs_path: &Path,
+    claim: &TargetDir,
+) -> HeddleResult<()> {
+    match claim.handle().same_identity_at_path(abs_path) {
+        Ok(true) => {}
+        Ok(false) => return Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => return Ok(()),
+        Err(err) => return Err(HeddleError::from(err)),
+    }
+    match std::fs::remove_dir(abs_path) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => Ok(()),
         Err(err) => Err(HeddleError::from(err)),
+    }
+}
+
+fn claimed_worktree_path(claim: Option<TargetDir>, abs_path: &Path) -> HeddleResult<PathBuf> {
+    match claim {
+        Some(claim) => match claim.handle().same_identity_at_path(abs_path) {
+            Ok(true) => Ok(claim.handle().io_path()),
+            Ok(false) => Err(target_dir_shape_refusal(
+                abs_path,
+                "changed since it was claimed",
+            )),
+            Err(err) => Err(target_dir_shape_refusal(
+                abs_path,
+                &format!("changed since it was claimed ({err})"),
+            )),
+        },
+        None => Err(target_dir_shape_refusal(abs_path, "was not established")),
     }
 }
 
@@ -266,15 +455,17 @@ fn rewind_checkout(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()
 /// place on rollback — `remove_self_created_dir` only targets the leaf).
 fn create_target_dir(abs_path: &Path, plan_created: bool) -> HeddleResult<TargetDir> {
     if !plan_created {
-        return adopt_existing_empty_dir(abs_path);
+        return adopt_existing_empty_dir(abs_path).map(TargetDir::adopted_empty);
     }
     if let Some(parent) = abs_path.parent() {
         std::fs::create_dir_all(parent).map_err(HeddleError::from)?;
     }
     match std::fs::create_dir(abs_path) {
-        Ok(()) => Ok(TargetDir::Created),
+        Ok(()) => TargetDirHandle::open(abs_path)
+            .map(TargetDir::created)
+            .map_err(HeddleError::from),
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            adopt_existing_empty_dir(abs_path)
+            adopt_existing_empty_dir(abs_path).map(TargetDir::adopted_empty)
         }
         Err(err) => Err(HeddleError::from(err)),
     }
@@ -289,13 +480,11 @@ fn create_target_dir(abs_path: &Path, plan_created: bool) -> HeddleResult<Target
 /// checkout rewind (which removes a self-created dir first; this then no-ops on
 /// `NotFound`).
 fn remove_self_created_dir(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()> {
-    if claim != Some(TargetDir::Created) {
-        return Ok(());
-    }
-    match std::fs::remove_dir_all(abs_path) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(HeddleError::from(err)),
+    match claim {
+        Some(claim) if claim.kind() == TargetDirKind::Created => {
+            remove_claimed_created_dir_if_still_at_path(abs_path, &claim)
+        }
+        _ => Ok(()),
     }
 }
 
@@ -433,7 +622,7 @@ impl StartThread {
                 fwd_claim.set(Some(established));
                 Ok(())
             },
-            move || remove_self_created_dir(&rewind_abs, target_claim.get()),
+            move || remove_self_created_dir(&rewind_abs, claim_from_cell(&target_claim)),
         )
     }
 
@@ -447,7 +636,13 @@ impl StartThread {
                 let fwd_name = ThreadName::new(&self.name);
                 let inv_name = ThreadName::new(&self.name);
                 tx.step(
-                    move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Value(existing), &base_state),
+                    move || {
+                        repo.refs().set_thread_cas(
+                            &fwd_name,
+                            RefExpectation::Value(existing),
+                            &base_state,
+                        )
+                    },
                     move || cas_guarded_ref_rollback(repo, &inv_name, base_state, Some(existing)),
                 )?;
             }
@@ -455,7 +650,10 @@ impl StartThread {
                 let fwd_name = ThreadName::new(&self.name);
                 let inv_name = ThreadName::new(&self.name);
                 tx.step(
-                    move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Missing, &base_state),
+                    move || {
+                        repo.refs()
+                            .set_thread_cas(&fwd_name, RefExpectation::Missing, &base_state)
+                    },
                     move || cas_guarded_ref_rollback(repo, &inv_name, base_state, None),
                 )?;
                 // The domain commit record. `manager_snapshot = None` matches the
@@ -484,6 +682,7 @@ impl StartThread {
         let rewind_abs = self.abs_path.clone();
         let base_state = self.base_state;
         let name = self.name.clone();
+        let rewind_claim = Rc::clone(&target_claim);
         // The [`TargetDir`] claim set by `stage_target_dir`'s forward (which ran
         // first), read at rewind time when it is settled — never the stale
         // plan-time bool. An adopted dir is cleared (not deleted), a self-created
@@ -491,7 +690,7 @@ impl StartThread {
         // left untouched (cid 3335052857 / 3335586962).
         tx.step_nonatomic(
             move || Ok(()),
-            move |()| rewind_checkout(&rewind_abs, target_claim.get()),
+            move |()| rewind_checkout(&rewind_abs, claim_from_cell(&rewind_claim)),
             move || {
                 #[cfg(test)]
                 if materialize_fault_trips() {
@@ -499,7 +698,9 @@ impl StartThread {
                         "injected materialize fault".to_string(),
                     ));
                 }
-                write_isolated_checkout(repo, &abs, &base_state, Some(&name)).map_err(apply_error)
+                let checkout_root = claimed_worktree_path(claim_from_cell(&target_claim), &abs)?;
+                write_isolated_checkout(repo, &checkout_root, &base_state, Some(&name))
+                    .map_err(apply_error)
             },
         )
     }
@@ -537,22 +738,45 @@ impl StartThread {
     /// untouched). Capture-restore on the config file so a later failure
     /// restores the pre-write state precisely even though the checkout rewind
     /// would also reach it.
-    fn stage_cargo_config(&self, tx: &mut Tx<'_>, dir: &Path) -> HeddleResult<bool> {
-        let cfg = self.abs_path.join(".cargo").join("config.toml");
-        let restore_cfg = cfg.clone();
-        let abs = self.abs_path.clone();
+    fn stage_cargo_config(
+        &self,
+        tx: &mut Tx<'_>,
+        dir: &Path,
+        target_claim: Rc<Cell<Option<TargetDir>>>,
+    ) -> HeddleResult<bool> {
+        let cap_abs = self.abs_path.clone();
+        let restore_abs = self.abs_path.clone();
+        let fwd_abs = self.abs_path.clone();
         let dir = dir.to_path_buf();
+        let cap_claim = Rc::clone(&target_claim);
+        let restore_claim = Rc::clone(&target_claim);
         tx.step_nonatomic(
-            move || Ok(std::fs::read(&cfg).ok()),
-            move |prior| match prior {
-                Some(bytes) => std::fs::write(&restore_cfg, bytes).map_err(HeddleError::from),
-                None => match std::fs::remove_file(&restore_cfg) {
-                    Ok(()) => Ok(()),
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                    Err(err) => Err(HeddleError::from(err)),
-                },
+            move || {
+                let checkout_root = claimed_worktree_path(claim_from_cell(&cap_claim), &cap_abs)?;
+                Ok(std::fs::read(checkout_root.join(".cargo").join("config.toml")).ok())
             },
-            move || write_cargo_config(&abs, &dir).map_err(apply_error),
+            move |prior| match prior {
+                Some(bytes) => {
+                    let checkout_root =
+                        claimed_worktree_path(claim_from_cell(&restore_claim), &restore_abs)?;
+                    std::fs::write(checkout_root.join(".cargo").join("config.toml"), bytes)
+                        .map_err(HeddleError::from)
+                }
+                None => {
+                    let checkout_root =
+                        claimed_worktree_path(claim_from_cell(&restore_claim), &restore_abs)?;
+                    match std::fs::remove_file(checkout_root.join(".cargo").join("config.toml")) {
+                        Ok(()) => Ok(()),
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                        Err(err) => Err(HeddleError::from(err)),
+                    }
+                }
+            },
+            move || {
+                let checkout_root =
+                    claimed_worktree_path(claim_from_cell(&target_claim), &fwd_abs)?;
+                write_cargo_config(&checkout_root, &dir).map_err(apply_error)
+            },
         )
     }
 
@@ -561,17 +785,22 @@ impl StartThread {
     /// all-or-nothing `symlink`), so its unlink inverse is registered only after
     /// the link is created and a partial hydrate unwinds every created link.
     /// Returns the names linked (for the post-commit note).
-    fn stage_hydrate(&self, tx: &mut Tx<'_>) -> HeddleResult<Vec<String>> {
+    fn stage_hydrate(
+        &self,
+        tx: &mut Tx<'_>,
+        target_claim: Rc<Cell<Option<TargetDir>>>,
+    ) -> HeddleResult<Vec<String>> {
         let repo = tx.repo();
         let sources = hydrate::hydratable_ignored_dirs(repo).map_err(apply_error)?;
         let mut linked: Vec<String> = Vec::new();
+        let checkout_root = claimed_worktree_path(claim_from_cell(&target_claim), &self.abs_path)?;
         for source in &sources {
-            let Some((dest, link_name)) = hydrate::plan_link(&self.abs_path, source) else {
+            let Some((dest, link_name)) = hydrate::plan_link(&checkout_root, source) else {
                 continue;
             };
             let src = source.clone();
             let dest_fwd = dest.clone();
-            let inv_checkout = self.abs_path.clone();
+            let inv_checkout = checkout_root.clone();
             let inv_name = link_name.clone();
             let err_name = link_name.clone();
             tx.step(
@@ -595,9 +824,9 @@ impl StartThread {
         // possibly-tracked `.heddleignore` — keeps a successful `start
         // --hydrate` from dirtying tracked state (heddle#356 cid 3333881577).
         if !linked.is_empty() {
-            let exclude_path = hydrate::hydrate_exclude_path(&self.abs_path);
+            let exclude_path = hydrate::hydrate_exclude_path(&checkout_root);
             let restore_path = exclude_path.clone();
-            let abs = self.abs_path.clone();
+            let abs = checkout_root.clone();
             let linked_fwd = linked.clone();
             tx.step_nonatomic(
                 move || Ok(std::fs::read(&exclude_path).ok()),
@@ -683,7 +912,7 @@ impl AtomicMutation for StartThread {
                     self.stage_manifest(tx)?;
                 }
                 if let Some(dir) = self.shared_target_dir.clone() {
-                    let applied = self.stage_cargo_config(tx, &dir)?;
+                    let applied = self.stage_cargo_config(tx, &dir, Rc::clone(&target_claim))?;
                     // The writer no-ops on a pre-staged config; don't advertise a
                     // redirect that isn't in effect (`thread show` would lie).
                     if !applied {
@@ -691,7 +920,7 @@ impl AtomicMutation for StartThread {
                     }
                 }
                 if self.hydrate {
-                    self.stage_hydrate(tx)?
+                    self.stage_hydrate(tx, Rc::clone(&target_claim))?
                 } else {
                     Vec::new()
                 }
@@ -756,7 +985,12 @@ mod tests {
     /// A `--path` solid-thread start that pins its base on `from` (no current-
     /// state bootstrap) and never spawns a daemon — minimal machinery for the
     /// in-process rollback assertions.
-    fn solid_args(name: &str, path: &std::path::Path, from: &ChangeId, hydrate: bool) -> ThreadStartArgs {
+    fn solid_args(
+        name: &str,
+        path: &std::path::Path,
+        from: &ChangeId,
+        hydrate: bool,
+    ) -> ThreadStartArgs {
         ThreadStartArgs {
             name: name.to_string(),
             from: Some(from.to_string()),
@@ -796,10 +1030,7 @@ mod tests {
         let repo = Repository::init_default(temp.path()).unwrap();
         std::fs::write(temp.path().join("a.txt"), "a").unwrap();
         if !deps.is_empty() {
-            let ignore = deps
-                .iter()
-                .map(|d| format!("{d}/\n"))
-                .collect::<String>();
+            let ignore = deps.iter().map(|d| format!("{d}/\n")).collect::<String>();
             std::fs::write(temp.path().join(".heddleignore"), ignore).unwrap();
             for dep in deps {
                 std::fs::create_dir_all(temp.path().join(dep)).unwrap();
@@ -814,10 +1045,20 @@ mod tests {
         let (temp, repo, state) = repo_with_state(&["dep_a", "dep_b"]);
         let checkout = temp.path().join("iso");
         let out = start_thread(&repo, solid_args("iso", &checkout, &state, true));
-        assert!(out.is_ok(), "happy-path start should succeed: {:?}", out.err());
+        assert!(
+            out.is_ok(),
+            "happy-path start should succeed: {:?}",
+            out.err()
+        );
 
-        assert!(checkout.join(".heddle").is_dir(), "checkout .heddle should exist");
-        assert!(checkout.join("a.txt").is_file(), "tracked file should materialize");
+        assert!(
+            checkout.join(".heddle").is_dir(),
+            "checkout .heddle should exist"
+        );
+        assert!(
+            checkout.join("a.txt").is_file(),
+            "tracked file should materialize"
+        );
         // Both ignored dep dirs hydrated as symlinks.
         for dep in ["dep_a", "dep_b"] {
             assert!(
@@ -828,7 +1069,38 @@ mod tests {
             );
         }
         assert!(has_thread_ref(&repo, "iso"), "thread ref should be created");
-        assert!(has_thread_record(&repo, "iso"), "thread record should be persisted");
+        assert!(
+            has_thread_record(&repo, "iso"),
+            "thread record should be persisted"
+        );
+    }
+
+    #[test]
+    fn start_shared_target_writes_cargo_config_through_claimed_dir() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("Cargo.toml"), "[package]\nname = \"p\"\n").unwrap();
+        let state = repo.snapshot(Some("rust workspace".to_string()), None).unwrap();
+        let checkout = temp.path().join("iso");
+        let mut args = solid_args("iso", &checkout, &state.change_id, false);
+        args.shared_target = true;
+
+        start_thread(&repo, args).expect("shared-target start should succeed");
+
+        let config = std::fs::read_to_string(checkout.join(".cargo").join("config.toml"))
+            .expect("cargo config should be written inside the checkout");
+        assert!(
+            config.contains(".heddle/targets"),
+            "cargo config should point at the shared target dir: {config}"
+        );
+        let record = ThreadManager::new(repo.heddle_dir())
+            .load("iso")
+            .unwrap()
+            .expect("thread record should persist");
+        assert!(
+            record.shared_target_dir.is_some(),
+            "record should advertise the applied shared target"
+        );
     }
 
     #[test]
@@ -843,8 +1115,14 @@ mod tests {
             std::fs::symlink_metadata(&checkout).is_err(),
             "the self-created checkout must be removed on rollback"
         );
-        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
-        assert!(!has_thread_record(&repo, "iso"), "no record must survive the rollback");
+        assert!(
+            !has_thread_ref(&repo, "iso"),
+            "the thread ref must be rolled back"
+        );
+        assert!(
+            !has_thread_record(&repo, "iso"),
+            "no record must survive the rollback"
+        );
     }
 
     #[test]
@@ -857,13 +1135,22 @@ mod tests {
         });
         assert!(out.is_err(), "a materialize fault must fail the start");
         // The user-supplied dir survives, emptied of what we materialized.
-        assert!(checkout.is_dir(), "a pre-existing user dir must not be deleted");
+        assert!(
+            checkout.is_dir(),
+            "a pre-existing user dir must not be deleted"
+        );
         let remaining: Vec<_> = std::fs::read_dir(&checkout)
             .unwrap()
             .map(|e| e.unwrap().file_name())
             .collect();
-        assert!(remaining.is_empty(), "rollback must clear materialized contents: {remaining:?}");
-        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
+        assert!(
+            remaining.is_empty(),
+            "rollback must clear materialized contents: {remaining:?}"
+        );
+        assert!(
+            !has_thread_ref(&repo, "iso"),
+            "the thread ref must be rolled back"
+        );
     }
 
     #[test]
@@ -880,7 +1167,10 @@ mod tests {
             std::fs::symlink_metadata(&checkout).is_err(),
             "a partial hydrate must remove the checkout (and every created link)"
         );
-        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
+        assert!(
+            !has_thread_ref(&repo, "iso"),
+            "the thread ref must be rolled back"
+        );
         // The origin's dep dirs are untouched (we unlink, never follow).
         assert!(temp.path().join("dep_a").is_dir());
         assert!(temp.path().join("dep_b").is_dir());
@@ -945,7 +1235,11 @@ mod tests {
         let epoch = resolve_start_epoch(&repo, "iso").unwrap();
         let retry_id = start_transaction_id(&scope, "iso", &state, epoch);
         assert!(
-            !repo.oplog().committed_batch_records(&retry_id).unwrap().is_empty(),
+            !repo
+                .oplog()
+                .committed_batch_records(&retry_id)
+                .unwrap()
+                .is_empty(),
             "a crash-retry must re-derive the committed key (the Active record's epoch) so \
              the executor dedups it instead of re-applying the committed start"
         );
@@ -1013,7 +1307,10 @@ mod tests {
         // marker + the post-commit AgentRegistry reservation.
         start_thread(&repo, solid_args("iso", &checkout, &state, false))
             .expect("first start should succeed");
-        assert!(checkout.join(".heddle").is_dir(), "the first start materialized the checkout");
+        assert!(
+            checkout.join(".heddle").is_dir(),
+            "the first start materialized the checkout"
+        );
 
         // Recreate the crash window: the write-path committed, but the post-commit
         // bookkeeping never landed — delete the reservation so no live owner
@@ -1040,8 +1337,14 @@ mod tests {
 
         // The committed checkout is left exactly as it was — neither re-created nor
         // cleared (the short-circuit never ran the write-path or its rewind).
-        assert!(checkout.join(".heddle").is_dir(), "the committed checkout survives the retry");
-        assert!(checkout.join("a.txt").is_file(), "the committed tree survives the retry");
+        assert!(
+            checkout.join(".heddle").is_dir(),
+            "the committed checkout survives the retry"
+        );
+        assert!(
+            checkout.join("a.txt").is_file(),
+            "the committed tree survives the retry"
+        );
 
         // The record stays the single committed Active record (no duplicate, no
         // Abandoned). And the interrupted reservation is now completed.
@@ -1154,13 +1457,13 @@ mod tests {
         std::fs::create_dir(&target).unwrap();
         let claim = create_target_dir(&target, true).unwrap();
         assert_eq!(
-            claim,
-            TargetDir::AdoptedEmpty,
+            claim.kind(),
+            TargetDirKind::AdoptedEmpty,
             "a real empty dir a concurrent process created is ADOPTED, not claimed as created \
              (a stale plan-time bool would have claimed it)"
         );
         // The rewind keys on the runtime claim, so it must spare their dir.
-        remove_self_created_dir(&target, Some(claim)).unwrap();
+        remove_self_created_dir(&target, Some(claim.clone())).unwrap();
         rewind_checkout(&target, Some(claim)).unwrap();
         assert!(
             target.is_dir(),
@@ -1176,8 +1479,15 @@ mod tests {
         let target = temp.path().join("nested").join("iso");
 
         let claim = create_target_dir(&target, true).unwrap();
-        assert_eq!(claim, TargetDir::Created, "an absent target this start creates is owned by us");
-        assert!(target.is_dir(), "the forward must create the leaf (and its parents)");
+        assert_eq!(
+            claim.kind(),
+            TargetDirKind::Created,
+            "an absent target this start creates is owned by us"
+        );
+        assert!(
+            target.is_dir(),
+            "the forward must create the leaf (and its parents)"
+        );
         remove_self_created_dir(&target, Some(claim)).unwrap();
         assert!(
             std::fs::symlink_metadata(&target).is_err(),
@@ -1195,12 +1505,102 @@ mod tests {
 
         let claim = create_target_dir(&target, false).unwrap();
         assert_eq!(
-            claim,
-            TargetDir::AdoptedEmpty,
+            claim.kind(),
+            TargetDirKind::AdoptedEmpty,
             "a user-supplied pre-existing empty dir is adopted, not ours to own/remove"
         );
         remove_self_created_dir(&target, Some(claim)).unwrap();
         assert!(target.is_dir(), "a user-supplied dir must survive rollback");
+    }
+
+    // ---- heddle#356 r5 close-the-class: write-time target-dir identity (cid 3336120590) ----
+
+    /// cid 3336120590: after the target claim is established, a concurrent
+    /// process swaps the leaf for a symlink to an outside dir before checkout
+    /// materialization. The writer must refuse from the claim's handle identity
+    /// check (not follow the symlink), and rollback must clear/delete only
+    /// through the retained handle, never through the substituted path.
+    #[cfg(unix)]
+    #[test]
+    fn claimed_target_swap_refuses_write_and_spares_symlink_target() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+        let victim = temp.path().join("victim");
+        std::fs::create_dir(&victim).unwrap();
+        std::fs::write(victim.join("precious.txt"), b"precious").unwrap();
+
+        let claim = create_target_dir(&checkout, true).unwrap();
+        assert_eq!(claim.kind(), TargetDirKind::Created);
+
+        std::fs::remove_dir(&checkout).unwrap();
+        std::os::unix::fs::symlink(&victim, &checkout).unwrap();
+
+        let checkout_root = claimed_worktree_path(Some(claim.clone()), &checkout);
+        assert!(
+            checkout_root.is_err(),
+            "a post-claim leaf swap must refuse before any checkout write"
+        );
+
+        rewind_checkout(&checkout, Some(claim.clone())).unwrap();
+        remove_self_created_dir(&checkout, Some(claim)).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&checkout)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "rollback must not remove the substituted symlink"
+        );
+        assert!(
+            !victim.join("a.txt").exists() && !victim.join(".heddle").exists(),
+            "checkout materialization must not write into the symlink target"
+        );
+        assert_eq!(
+            std::fs::read(victim.join("precious.txt")).unwrap(),
+            b"precious",
+            "rollback must not clear the symlink target's existing data"
+        );
+
+        let _ = (repo, state);
+    }
+
+    #[test]
+    fn claimed_created_and_adopted_dirs_still_write_and_rewind() {
+        let (temp, repo, state) = repo_with_state(&[]);
+
+        let created = temp.path().join("created");
+        let created_claim = create_target_dir(&created, true).unwrap();
+        let created_root = claimed_worktree_path(Some(created_claim.clone()), &created).unwrap();
+        write_isolated_checkout(&repo, &created_root, &state, Some("created")).unwrap();
+        assert!(
+            created.join("a.txt").is_file(),
+            "created dir still receives checkout bytes"
+        );
+        rewind_checkout(&created, Some(created_claim)).unwrap();
+        assert!(
+            std::fs::symlink_metadata(&created).is_err(),
+            "created dir is removed on rollback"
+        );
+
+        let adopted = temp.path().join("adopted");
+        std::fs::create_dir(&adopted).unwrap();
+        let adopted_claim = create_target_dir(&adopted, false).unwrap();
+        let adopted_root = claimed_worktree_path(Some(adopted_claim.clone()), &adopted).unwrap();
+        write_isolated_checkout(&repo, &adopted_root, &state, Some("adopted")).unwrap();
+        assert!(
+            adopted.join("a.txt").is_file(),
+            "adopted dir still receives checkout bytes"
+        );
+        rewind_checkout(&adopted, Some(adopted_claim)).unwrap();
+        assert!(adopted.is_dir(), "adopted dir itself survives rollback");
+        let remaining: Vec<_> = std::fs::read_dir(&adopted)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert!(
+            remaining.is_empty(),
+            "adopted dir contents are cleared: {remaining:?}"
+        );
     }
 
     // ---- heddle#356 r4 close-the-class: target-dir SHAPE validation (cid 3335586962) ----
@@ -1234,7 +1634,10 @@ mod tests {
         rewind_checkout(&leaf, None).unwrap();
         remove_self_created_dir(&leaf, None).unwrap();
         assert!(
-            std::fs::symlink_metadata(&leaf).unwrap().file_type().is_symlink(),
+            std::fs::symlink_metadata(&leaf)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
             "the symlink itself must be left untouched"
         );
         assert!(
@@ -1258,7 +1661,10 @@ mod tests {
 
         let claim = create_target_dir(&leaf, true);
         assert!(claim.is_err(), "a non-directory leaf must refuse the start");
-        assert!(leaf.is_file(), "the pre-existing file must be left untouched");
+        assert!(
+            leaf.is_file(),
+            "the pre-existing file must be left untouched"
+        );
         assert_eq!(std::fs::read(&leaf).unwrap(), b"i am a file, not a dir");
     }
 
@@ -1272,7 +1678,10 @@ mod tests {
         std::fs::write(leaf.join("someone-elses-work.txt"), b"keep me").unwrap();
 
         let claim = create_target_dir(&leaf, true);
-        assert!(claim.is_err(), "a non-empty dir at the leaf must refuse the start");
+        assert!(
+            claim.is_err(),
+            "a non-empty dir at the leaf must refuse the start"
+        );
         assert!(
             leaf.join("someone-elses-work.txt").is_file(),
             "the pre-existing contents must be left untouched"

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -224,6 +224,7 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
 ///     refused on a symlink/foreign object, or never ran). Touch NOTHING — the
 ///     whole point of the close-the-class fix is that rollback never clears or
 ///     deletes through a path it did not itself establish as a real empty dir.
+///
 /// Tolerant of an already-absent target so it composes with other rewind steps.
 fn rewind_checkout(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()> {
     let result = match claim {

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -45,7 +45,7 @@ use objects::object::{ChangeId, ThreadName};
 use oplog::OpRecord;
 use refs::RefExpectation;
 use repo::{
-    Thread, ThreadManager, ThreadMode,
+    Repository, Thread, ThreadManager, ThreadMode,
     atomic::{AtomicMutation, StagedCommit, Tx},
 };
 
@@ -163,14 +163,91 @@ fn rewind_checkout(abs_path: &Path, target_dir_created: bool) -> HeddleResult<()
     }
 }
 
+/// Inverse of the target-dir creation step: remove the worktree directory ONLY
+/// when this invocation created it (restoring "didn't exist"). A pre-existing
+/// user-supplied `--path` dir is never removed here. Tolerant of an
+/// already-absent dir so it composes after the checkout rewind (which removes a
+/// self-created dir first; this then no-ops on `NotFound`).
+fn remove_self_created_dir(abs_path: &Path, created: bool) -> HeddleResult<()> {
+    if !created {
+        return Ok(());
+    }
+    match std::fs::remove_dir_all(abs_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(HeddleError::from(err)),
+    }
+}
+
+/// CAS-guarded rollback of the thread-ref forward (heddle#356 cid 3333881583).
+///
+/// The forward set the ref to `set_value` (the start's base state). Undo it
+/// ONLY if the ref STILL points there: restore the prior value, or delete a ref
+/// this start created. If a concurrent process advanced/changed the ref after
+/// our forward (a concurrent start or crash-recovery), leave their write in
+/// place — an unconditional reset/delete would clobber it.
+fn cas_guarded_ref_rollback(
+    repo: &Repository,
+    name: &ThreadName,
+    set_value: ChangeId,
+    restore_to: Option<ChangeId>,
+) -> HeddleResult<()> {
+    // Compare-before-write: bail without touching the ref if it no longer holds
+    // the value our forward set.
+    if repo.refs().get_thread(name)? != Some(set_value) {
+        return Ok(());
+    }
+    let result = match restore_to {
+        Some(prior) => repo
+            .refs()
+            .set_thread_cas(name, RefExpectation::Value(set_value), &prior),
+        None => repo
+            .refs()
+            .delete_thread_cas(name, RefExpectation::Value(set_value)),
+    };
+    match result {
+        Ok(()) => Ok(()),
+        // Lost the race between the read above and this CAS: a concurrent writer
+        // advanced the ref. The expectation guard means we wrote nothing — leave
+        // their advance intact (the whole point of the guard).
+        Err(HeddleError::Conflict(_)) => Ok(()),
+        Err(other) => Err(other),
+    }
+}
+
+/// Restore the thread manifest sidecar to its captured pre-start snapshot:
+/// rewrite the prior `manifest.toml` bytes if one existed, or remove the
+/// directory this start created. Restoring (not blind-deleting) preserves an
+/// OLD manifest left by a prior materialization of a reused thread ref
+/// (heddle#356 cid 3333881561).
+fn restore_thread_manifest(
+    heddle_dir: &Path,
+    thread: &str,
+    prior: Option<Vec<u8>>,
+) -> HeddleResult<()> {
+    match prior {
+        Some(bytes) => {
+            let path = repo::thread_manifest::manifest_path(heddle_dir, thread);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(HeddleError::from)?;
+            }
+            std::fs::write(&path, bytes).map_err(HeddleError::from)
+        }
+        None => repo::thread_manifest::remove_thread_manifest_dir(heddle_dir, thread)
+            .map(|_| ())
+            .map_err(HeddleError::from),
+    }
+}
+
 /// A fully all-or-nothing `thread start` (the bytes-on-disk + virtualized
 /// write-path). Holds owned inputs the surrounding `start_thread` precomputed
 /// from reads; `apply` performs the staged writes and registers each effect's
 /// inverse. The executor reaches the single commit point exactly once.
 pub(crate) struct StartThread {
-    /// Stable idempotency key (derived from scope + name + oplog generation in
-    /// `start_thread`, like undo/redo) — identical across retries of the same
-    /// logical start so a crash-retry dedups instead of double-applying.
+    /// Retry-stable idempotency key (derived in `start_thread` from scope +
+    /// name + base state — NOT the advancing oplog head) — identical across
+    /// retries of the same logical start so a crash-retry dedups instead of
+    /// double-applying (heddle#356 cid 3333881568).
     pub transaction_id: String,
     /// The thread name (ref name + record key).
     pub name: String,
@@ -199,6 +276,27 @@ pub(crate) struct StartThread {
 }
 
 impl StartThread {
+    /// Create the materialization target directory as the FIRST transaction
+    /// step, so it lands on the rewind ledger and a self-created dir is removed
+    /// on any later failure. The command resolves + validates the target before
+    /// `execute` but defers the actual `create_dir_all` to here — otherwise a
+    /// failure in the remaining pre-transaction work would orphan a dir created
+    /// before the executor had a ledger (heddle#356 cid 3333881552).
+    ///
+    /// The inverse removes the directory ONLY when this invocation created it; a
+    /// user-supplied pre-existing `--path` dir is preserved (its materialized
+    /// contents are cleared by the checkout rewind, which runs first).
+    fn stage_target_dir(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+        let abs = self.abs_path.clone();
+        let rewind_abs = self.abs_path.clone();
+        let created = self.target_dir_created;
+        tx.step_nonatomic(
+            move || Ok(created),
+            move |created| remove_self_created_dir(&rewind_abs, created),
+            move || std::fs::create_dir_all(&abs).map_err(HeddleError::from),
+        )
+    }
+
     /// Stage the thread-ref write (atomic, forward-first), pushing the staged
     /// `ThreadCreateV2` commit record for a brand-new thread.
     fn stage_ref(&self, tx: &mut Tx<'_>, oplog: &mut Vec<OpRecord>) -> HeddleResult<()> {
@@ -210,7 +308,7 @@ impl StartThread {
                 let inv_name = ThreadName::new(&self.name);
                 tx.step(
                     move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Value(existing), &base_state),
-                    move || repo.refs().set_thread(&inv_name, &existing),
+                    move || cas_guarded_ref_rollback(repo, &inv_name, base_state, Some(existing)),
                 )?;
             }
             None => {
@@ -218,7 +316,7 @@ impl StartThread {
                 let inv_name = ThreadName::new(&self.name);
                 tx.step(
                     move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Missing, &base_state),
-                    move || repo.refs().delete_thread(&inv_name).map(|_| ()),
+                    move || cas_guarded_ref_rollback(repo, &inv_name, base_state, None),
                 )?;
                 // The domain commit record. `manager_snapshot = None` matches the
                 // pre-migration `cmd_start` (the record is written below, so
@@ -267,13 +365,18 @@ impl StartThread {
         let base_state = self.base_state;
         let fwd_name = self.name.clone();
         let inv_name = self.name.clone();
+        let cap_name = self.name.clone();
+        // Capture the prior manifest bytes (or absence) so the inverse restores
+        // it to its pre-start snapshot. A re-start that reuses an existing
+        // thread ref may have an OLD materialized manifest under
+        // `.heddle/threads/<name>`; blind-deleting it on rollback would lose the
+        // prior manifest (heddle#356 cid 3333881561).
         tx.step_nonatomic(
-            || Ok(()),
-            move |()| {
-                repo::thread_manifest::remove_thread_manifest_dir(repo.heddle_dir(), &inv_name)
-                    .map(|_| ())
-                    .map_err(HeddleError::from)
+            move || {
+                let path = repo::thread_manifest::manifest_path(repo.heddle_dir(), &cap_name);
+                Ok(std::fs::read(&path).ok())
             },
+            move |prior| restore_thread_manifest(repo.heddle_dir(), &inv_name, prior),
             move || {
                 repo.record_thread_manifest(&fwd_name, &base_state, &abs)
                     .map(|_| ())
@@ -338,15 +441,18 @@ impl StartThread {
             )?;
             linked.push(link_name);
         }
-        // Preserve the hydrated deps' ignore rule in the checkout's native
-        // `.heddleignore` (capture-restore so a later failure restores it).
+        // Preserve the hydrated deps' ignore rule in the checkout's
+        // worktree-local, never-captured exclude file (capture-restore so a
+        // later failure restores it). Writing to the exclude file — not the
+        // possibly-tracked `.heddleignore` — keeps a successful `start
+        // --hydrate` from dirtying tracked state (heddle#356 cid 3333881577).
         if !linked.is_empty() {
-            let ignore_path = self.abs_path.join(".heddleignore");
-            let restore_path = ignore_path.clone();
+            let exclude_path = hydrate::hydrate_exclude_path(&self.abs_path);
+            let restore_path = exclude_path.clone();
             let abs = self.abs_path.clone();
             let linked_fwd = linked.clone();
             tx.step_nonatomic(
-                move || Ok(std::fs::read(&ignore_path).ok()),
+                move || Ok(std::fs::read(&exclude_path).ok()),
                 move |prior| restore_ignore_file(&restore_path, prior),
                 move || hydrate::preserve_hydrated_ignores(&abs, &linked_fwd).map_err(apply_error),
             )?;
@@ -406,6 +512,10 @@ impl AtomicMutation for StartThread {
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<String>>> {
         let mut oplog: Vec<OpRecord> = Vec::new();
 
+        // 0. Create the target dir inside the transaction (first, so its removal
+        //    inverse runs last and a self-created dir never leaks).
+        self.stage_target_dir(tx)?;
+
         // 1. Thread ref (+ staged ThreadCreateV2 for a brand-new thread).
         self.stage_ref(tx, &mut oplog)?;
 
@@ -443,8 +553,8 @@ impl AtomicMutation for StartThread {
     }
 }
 
-/// Restore the checkout's `.heddleignore` to its captured pre-hydrate state:
-/// rewrite the prior bytes, or remove the file we created.
+/// Restore the checkout's hydrate exclude file to its captured pre-hydrate
+/// state: rewrite the prior bytes, or remove the file we created.
 fn restore_ignore_file(path: &Path, prior: Option<Vec<u8>>) -> HeddleResult<()> {
     match prior {
         Some(bytes) => std::fs::write(path, bytes).map_err(HeddleError::from),
@@ -477,7 +587,8 @@ fn symlink_unsupported_error(link: &str) -> HeddleError {
 
 #[cfg(test)]
 mod tests {
-    use super::super::thread::start_thread;
+    use super::super::thread::{start_thread, start_transaction_id};
+    use super::super::worktree_cmd::helpers::plan_worktree_target;
     use super::*;
     use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
     use repo::Repository;
@@ -614,5 +725,149 @@ mod tests {
         // The origin's dep dirs are untouched (we unlink, never follow).
         assert!(temp.path().join("dep_a").is_dir());
         assert!(temp.path().join("dep_b").is_dir());
+    }
+
+    // ---- heddle#356 r2 fixes ----
+
+    /// cid 3333881552: the target dir must be created INSIDE the transaction.
+    /// `plan_worktree_target` resolves + validates but defers creation, so a
+    /// failure in the remaining pre-transaction work can't orphan a directory.
+    #[test]
+    fn plan_worktree_target_defers_dir_creation() {
+        let (temp, repo, _state) = repo_with_state(&[]);
+        let target = temp.path().join("iso-deferred");
+        let prepared = plan_worktree_target(&repo, &target).unwrap();
+        assert!(
+            prepared.target_dir_created,
+            "a non-existent target is flagged as one this start will create"
+        );
+        assert!(
+            std::fs::symlink_metadata(&target).is_err(),
+            "plan must NOT create the target dir — creation is deferred into the \
+             transaction so a pre-execute failure can't orphan it"
+        );
+    }
+
+    /// cid 3333881568: the transaction key must not fold in the live oplog head,
+    /// which advances when the commit marker appends. A re-derivation after an
+    /// unrelated oplog advance must yield the identical key.
+    #[test]
+    fn start_transaction_id_is_stable_across_oplog_advance() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let scope = repo.op_scope();
+        let id1 = start_transaction_id(&scope, "iso", &state);
+        // Advance the oplog head with an unrelated capture.
+        std::fs::write(temp.path().join("b.txt"), "b").unwrap();
+        repo.snapshot(Some("s2".to_string()), None).unwrap();
+        let id2 = start_transaction_id(&scope, "iso", &state);
+        assert_eq!(
+            id1, id2,
+            "the start transaction key must be independent of the advancing oplog head"
+        );
+    }
+
+    /// cid 3333881568: simulate a post-commit retry. After a start commits, a
+    /// retry re-derives the SAME key (via the same retry-stable derivation), so
+    /// the executor's `transaction_id` dedup makes it exact-once instead of
+    /// re-applying. Pre-fix the committed key folded in the oplog head (which
+    /// advanced at commit), so the re-derived key missed the committed batch.
+    #[test]
+    fn post_commit_retry_rederives_the_committed_key() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+        let scope = repo.op_scope();
+        let id = start_transaction_id(&scope, "iso", &state);
+        assert!(
+            repo.oplog().committed_batch_records(&id).unwrap().is_empty(),
+            "no transaction should be committed under the start key before the start runs"
+        );
+        start_thread(&repo, solid_args("iso", &checkout, &state, false))
+            .expect("start should succeed");
+        assert!(
+            !repo.oplog().committed_batch_records(&id).unwrap().is_empty(),
+            "a post-commit retry must re-derive the committed transaction key so the \
+             executor dedups it instead of re-applying the already-committed start"
+        );
+    }
+
+    /// cid 3333881561: the manifest rollback must restore the prior manifest
+    /// snapshot (a stale manifest from a reused thread ref), not blind-delete.
+    #[test]
+    fn restore_thread_manifest_restores_prior_and_removes_when_absent() {
+        let temp = TempDir::new().unwrap();
+        let heddle_dir = temp.path();
+
+        // Prior = Some: an OLD manifest existed. The forward overwrote it; the
+        // inverse must restore the OLD bytes, not the forward's, and not delete.
+        let path = repo::thread_manifest::manifest_path(heddle_dir, "foo");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"OLD").unwrap();
+        let prior = std::fs::read(&path).ok();
+        std::fs::write(&path, b"NEW").unwrap();
+        restore_thread_manifest(heddle_dir, "foo", prior).unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"OLD",
+            "rollback must restore the prior manifest snapshot, not delete it"
+        );
+
+        // Prior = None: no manifest existed. The inverse removes what we created.
+        let path2 = repo::thread_manifest::manifest_path(heddle_dir, "bar");
+        std::fs::create_dir_all(path2.parent().unwrap()).unwrap();
+        std::fs::write(&path2, b"NEW").unwrap();
+        restore_thread_manifest(heddle_dir, "bar", None).unwrap();
+        assert!(
+            std::fs::symlink_metadata(&path2).is_err(),
+            "rollback of a freshly-created manifest must remove it"
+        );
+    }
+
+    /// cid 3333881583: the thread-ref rollback is CAS-guarded — it must NOT
+    /// clobber a ref a concurrent process advanced past this transaction's
+    /// forward value, but must still undo a ref that still holds it.
+    #[test]
+    fn cas_guarded_ref_rollback_does_not_clobber_concurrent_advance() {
+        let (temp, repo, base) = repo_with_state(&[]);
+        let _ = &temp;
+        let name = ThreadName::new("foo");
+        let advanced = ChangeId::generate();
+        let prior = ChangeId::generate();
+
+        // Brand-new case (restore_to = None → would otherwise delete). A
+        // concurrent writer advanced the ref past our forward value → leave it.
+        repo.refs().set_thread(&name, &advanced).unwrap();
+        cas_guarded_ref_rollback(&repo, &name, base, None).unwrap();
+        assert_eq!(
+            repo.refs().get_thread(&name).unwrap(),
+            Some(advanced),
+            "rollback must not delete a ref a concurrent process advanced"
+        );
+
+        // Brand-new case, ref still holds our forward value → delete it.
+        repo.refs().set_thread(&name, &base).unwrap();
+        cas_guarded_ref_rollback(&repo, &name, base, None).unwrap();
+        assert_eq!(
+            repo.refs().get_thread(&name).unwrap(),
+            None,
+            "rollback must delete a ref still holding our forward value"
+        );
+
+        // Re-start case (restore_to = Some(prior)). Concurrent advance → leave.
+        repo.refs().set_thread(&name, &advanced).unwrap();
+        cas_guarded_ref_rollback(&repo, &name, base, Some(prior)).unwrap();
+        assert_eq!(
+            repo.refs().get_thread(&name).unwrap(),
+            Some(advanced),
+            "rollback must not reset a ref a concurrent process advanced"
+        );
+
+        // Re-start case, ref still holds our forward value → restore prior.
+        repo.refs().set_thread(&name, &base).unwrap();
+        cas_guarded_ref_rollback(&repo, &name, base, Some(prior)).unwrap();
+        assert_eq!(
+            repo.refs().get_thread(&name).unwrap(),
+            Some(prior),
+            "rollback must restore the prior value when the ref still holds our forward value"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -38,7 +38,9 @@
 //! checkout. No thread/ref/git domain knowledge leaks into the primitive — it
 //! all lives here, exactly like undo/redo's `EntrySteps`.
 
+use std::cell::Cell;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 use objects::error::{HeddleError, Result as HeddleResult};
 use objects::object::{ChangeId, ThreadName};
@@ -141,17 +143,19 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// The precise checkout-rewind inverse. `target_dir_created` true → this
-/// invocation made the worktree directory, so remove it entirely (restoring
-/// "didn't exist"); its dep symlinks go with it, since `remove_dir_all`
-/// unlinks symlinks without following them, so the origin's deps are never
-/// touched. `target_dir_created` false → the user supplied an already-existing
-/// empty `--path` dir; preserve the directory and clear only the contents we
-/// materialized inside it (`prepare_worktree_target` only accepts a
-/// pre-existing dir when it is empty). Tolerant of an already-absent target so
-/// it composes with other rewind steps.
-fn rewind_checkout(abs_path: &Path, target_dir_created: bool) -> HeddleResult<()> {
-    let result = if target_dir_created {
+/// The precise checkout-rewind inverse. `created` is the runtime ownership
+/// signal from [`create_target_dir`] (NOT the stale plan-time bool — cid
+/// 3335052857). `true` → this invocation made the worktree directory, so remove
+/// it entirely (restoring "didn't exist"); its dep symlinks go with it, since
+/// `remove_dir_all` unlinks symlinks without following them, so the origin's
+/// deps are never touched. `false` → the user supplied an already-existing empty
+/// `--path` dir, OR a concurrent process created the target between plan time
+/// and the transaction; either way it is not ours to delete — preserve the
+/// directory and clear only the contents we materialized inside it
+/// (`prepare_worktree_target` only accepts a pre-existing dir when it is empty).
+/// Tolerant of an already-absent target so it composes with other rewind steps.
+fn rewind_checkout(abs_path: &Path, created: bool) -> HeddleResult<()> {
+    let result = if created {
         std::fs::remove_dir_all(abs_path)
     } else {
         clear_dir_contents(abs_path)
@@ -163,11 +167,48 @@ fn rewind_checkout(abs_path: &Path, target_dir_created: bool) -> HeddleResult<()
     }
 }
 
+/// Create the materialization target directory and report whether THIS
+/// invocation actually created it — the ownership signal both directory rewinds
+/// (the target-dir inverse and the checkout rewind) key their destructive
+/// branch on.
+///
+/// `plan_created` is the plan-time observation from `plan_worktree_target` (the
+/// dir was absent then). It is NOT trusted for the remove decision: a concurrent
+/// process can create the target between plan time and now, after which a stale
+/// `plan_created == true` would make rollback delete a directory this start
+/// never made (heddle#356 cid 3335052857). So ownership is re-established
+/// atomically HERE:
+///   * `plan_created == false` → `plan_worktree_target` accepted a pre-existing
+///     (empty) user `--path` dir; never ours to create or remove → `Ok(false)`.
+///   * `plan_created == true` → `create_dir` (NOT `create_dir_all`) on the leaf
+///     fails with `AlreadyExists` exactly when a concurrent process won the
+///     creation race; that branch returns `Ok(false)` so neither rewind removes
+///     their dir. Only the branch where `create_dir` itself created the leaf
+///     returns `Ok(true)`.
+///
+/// Parents are created with `create_dir_all` (shared infrastructure, left in
+/// place on rollback — `remove_self_created_dir` only targets the leaf).
+fn create_target_dir(abs_path: &Path, plan_created: bool) -> HeddleResult<bool> {
+    if !plan_created {
+        return Ok(false);
+    }
+    if let Some(parent) = abs_path.parent() {
+        std::fs::create_dir_all(parent).map_err(HeddleError::from)?;
+    }
+    match std::fs::create_dir(abs_path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(err) => Err(HeddleError::from(err)),
+    }
+}
+
 /// Inverse of the target-dir creation step: remove the worktree directory ONLY
-/// when this invocation created it (restoring "didn't exist"). A pre-existing
-/// user-supplied `--path` dir is never removed here. Tolerant of an
-/// already-absent dir so it composes after the checkout rewind (which removes a
-/// self-created dir first; this then no-ops on `NotFound`).
+/// when this invocation created it (restoring "didn't exist"). `created` is the
+/// runtime ownership signal from [`create_target_dir`], NOT the stale plan-time
+/// bool — a concurrently-created or pre-existing user-supplied `--path` dir is
+/// never removed here. Tolerant of an already-absent dir so it composes after
+/// the checkout rewind (which removes a self-created dir first; this then
+/// no-ops on `NotFound`).
 fn remove_self_created_dir(abs_path: &Path, created: bool) -> HeddleResult<()> {
     if !created {
         return Ok(());
@@ -245,9 +286,12 @@ fn restore_thread_manifest(
 /// inverse. The executor reaches the single commit point exactly once.
 pub(crate) struct StartThread {
     /// Retry-stable idempotency key (derived in `start_thread` from scope +
-    /// name + base state — NOT the advancing oplog head) — identical across
-    /// retries of the same logical start so a crash-retry dedups instead of
-    /// double-applying (heddle#356 cid 3333881568).
+    /// name + base state + a per-start epoch — NOT the advancing oplog head).
+    /// Identical across retries of the same logical start so a crash-retry dedups
+    /// instead of double-applying (heddle#356 cid 3333881568), yet distinct for a
+    /// genuinely-new start after a prior committed-then-dropped one whose ref
+    /// still points at the same base (cid 3335052848). See
+    /// `start_thread::start_transaction_id` / `resolve_start_epoch`.
     pub transaction_id: String,
     /// The thread name (ref name + record key).
     pub name: String,
@@ -260,8 +304,11 @@ pub(crate) struct StartThread {
     pub thread_mode: ThreadMode,
     /// The materialization target (mount point for virtualized).
     pub abs_path: PathBuf,
-    /// Whether THIS invocation created `abs_path` (drives the precise checkout
-    /// rewind: remove-wholesale vs clear-contents).
+    /// The plan-time observation (`plan_worktree_target`) that `abs_path` was
+    /// absent, so this start expects to create it. It is only the INPUT to the
+    /// at-creation ownership recheck ([`create_target_dir`]); the rewind keys on
+    /// that runtime result, not this stale bool, so a concurrent create between
+    /// plan and the transaction is never deleted (cid 3335052857).
     pub target_dir_created: bool,
     /// The candidate `--shared-target` redirect dir, or `None`. The cargo-config
     /// write reports whether it actually applied; if not, the record's
@@ -284,16 +331,29 @@ impl StartThread {
     /// before the executor had a ledger (heddle#356 cid 3333881552).
     ///
     /// The inverse removes the directory ONLY when this invocation created it; a
-    /// user-supplied pre-existing `--path` dir is preserved (its materialized
-    /// contents are cleared by the checkout rewind, which runs first).
-    fn stage_target_dir(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+    /// user-supplied pre-existing `--path` dir — or one a concurrent process
+    /// created between plan time and now (cid 3335052857) — is preserved.
+    /// Ownership is decided at the moment of creation by [`create_target_dir`]
+    /// and stored in `created_by_us`, a cell BOTH this inverse and the checkout
+    /// rewind read so neither trusts the stale plan-time bool. Forward-first
+    /// (`Tx::step`): the inverse is registered only after the create succeeds,
+    /// and a forward that fails created nothing of ours to remove.
+    fn stage_target_dir(
+        &self,
+        tx: &mut Tx<'_>,
+        created_by_us: Rc<Cell<bool>>,
+    ) -> HeddleResult<()> {
         let abs = self.abs_path.clone();
         let rewind_abs = self.abs_path.clone();
-        let created = self.target_dir_created;
-        tx.step_nonatomic(
-            move || Ok(created),
-            move |created| remove_self_created_dir(&rewind_abs, created),
-            move || std::fs::create_dir_all(&abs).map_err(HeddleError::from),
+        let plan_created = self.target_dir_created;
+        let fwd_flag = Rc::clone(&created_by_us);
+        tx.step(
+            move || {
+                let made = create_target_dir(&abs, plan_created)?;
+                fwd_flag.set(made);
+                Ok(())
+            },
+            move || remove_self_created_dir(&rewind_abs, created_by_us.get()),
         )
     }
 
@@ -334,16 +394,23 @@ impl StartThread {
     /// Materialize the isolated checkout tree (`.heddle` metadata + worktree
     /// bytes) under a capture-restore step whose inverse precisely rewinds the
     /// created directory.
-    fn stage_checkout(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+    fn stage_checkout(
+        &self,
+        tx: &mut Tx<'_>,
+        created_by_us: Rc<Cell<bool>>,
+    ) -> HeddleResult<()> {
         let repo = tx.repo();
         let abs = self.abs_path.clone();
         let rewind_abs = self.abs_path.clone();
-        let created = self.target_dir_created;
         let base_state = self.base_state;
         let name = self.name.clone();
+        // Ownership is the runtime signal set by `stage_target_dir`'s forward
+        // (which ran first), read at rewind time when it is settled — never the
+        // stale plan-time bool, so a concurrently-created dir is cleared, not
+        // deleted wholesale (cid 3335052857).
         tx.step_nonatomic(
-            move || Ok(created),
-            move |created| rewind_checkout(&rewind_abs, created),
+            move || Ok(()),
+            move |()| rewind_checkout(&rewind_abs, created_by_us.get()),
             move || {
                 #[cfg(test)]
                 if materialize_fault_trips() {
@@ -512,9 +579,16 @@ impl AtomicMutation for StartThread {
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<String>>> {
         let mut oplog: Vec<OpRecord> = Vec::new();
 
+        // Runtime ownership of the target dir, decided atomically by
+        // `stage_target_dir`'s forward and consumed by BOTH directory rewinds
+        // (the target-dir inverse and the checkout rewind) so neither trusts the
+        // stale plan-time bool and deletes a dir a concurrent process created
+        // (heddle#356 cid 3335052857).
+        let created_by_us = Rc::new(Cell::new(false));
+
         // 0. Create the target dir inside the transaction (first, so its removal
         //    inverse runs last and a self-created dir never leaks).
-        self.stage_target_dir(tx)?;
+        self.stage_target_dir(tx, Rc::clone(&created_by_us))?;
 
         // 1. Thread ref (+ staged ThreadCreateV2 for a brand-new thread).
         self.stage_ref(tx, &mut oplog)?;
@@ -522,7 +596,7 @@ impl AtomicMutation for StartThread {
         // 2. Mode-specific materialization.
         let linked = match self.thread_mode {
             ThreadMode::Solid | ThreadMode::Materialized => {
-                self.stage_checkout(tx)?;
+                self.stage_checkout(tx, Rc::clone(&created_by_us))?;
                 if matches!(self.thread_mode, ThreadMode::Materialized) {
                     self.stage_manifest(tx)?;
                 }
@@ -587,7 +661,8 @@ fn symlink_unsupported_error(link: &str) -> HeddleError {
 
 #[cfg(test)]
 mod tests {
-    use super::super::thread::{start_thread, start_transaction_id};
+    use super::super::thread::{resolve_start_epoch, start_thread, start_transaction_id};
+    use super::super::thread_cmd::drop_thread_silent;
     use super::super::worktree_cmd::helpers::plan_worktree_target;
     use super::*;
     use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
@@ -755,38 +830,83 @@ mod tests {
     fn start_transaction_id_is_stable_across_oplog_advance() {
         let (temp, repo, state) = repo_with_state(&[]);
         let scope = repo.op_scope();
-        let id1 = start_transaction_id(&scope, "iso", &state);
+        // A fixed epoch isolates the property under test (oplog-head independence)
+        // from the epoch's own freshness.
+        let epoch = chrono::Utc::now();
+        let id1 = start_transaction_id(&scope, "iso", &state, epoch);
         // Advance the oplog head with an unrelated capture.
         std::fs::write(temp.path().join("b.txt"), "b").unwrap();
         repo.snapshot(Some("s2".to_string()), None).unwrap();
-        let id2 = start_transaction_id(&scope, "iso", &state);
+        let id2 = start_transaction_id(&scope, "iso", &state, epoch);
         assert_eq!(
             id1, id2,
             "the start transaction key must be independent of the advancing oplog head"
         );
     }
 
-    /// cid 3333881568: simulate a post-commit retry. After a start commits, a
-    /// retry re-derives the SAME key (via the same retry-stable derivation), so
-    /// the executor's `transaction_id` dedup makes it exact-once instead of
-    /// re-applying. Pre-fix the committed key folded in the oplog head (which
-    /// advanced at commit), so the re-derived key missed the committed batch.
+    /// cid 3333881568 + 3335052848: a crash-retry of the SAME start dedups
+    /// exactly-once. After a start commits, its thread record is still Active, so
+    /// `resolve_start_epoch` returns that record's creation instant and the key
+    /// folds back to the committed one — the executor's `transaction_id` dedup
+    /// makes the retry a no-op instead of double-applying.
     #[test]
-    fn post_commit_retry_rederives_the_committed_key() {
+    fn crash_retry_of_same_start_rederives_committed_key() {
         let (temp, repo, state) = repo_with_state(&[]);
         let checkout = temp.path().join("iso");
         let scope = repo.op_scope();
-        let id = start_transaction_id(&scope, "iso", &state);
-        assert!(
-            repo.oplog().committed_batch_records(&id).unwrap().is_empty(),
-            "no transaction should be committed under the start key before the start runs"
-        );
         start_thread(&repo, solid_args("iso", &checkout, &state, false))
             .expect("start should succeed");
+        // A crash-retry re-derives the epoch from the still-Active record, so the
+        // key matches the committed batch and the executor dedups it.
+        let epoch = resolve_start_epoch(&repo, "iso").unwrap();
+        let retry_id = start_transaction_id(&scope, "iso", &state, epoch);
         assert!(
-            !repo.oplog().committed_batch_records(&id).unwrap().is_empty(),
-            "a post-commit retry must re-derive the committed transaction key so the \
-             executor dedups it instead of re-applying the already-committed start"
+            !repo.oplog().committed_batch_records(&retry_id).unwrap().is_empty(),
+            "a crash-retry must re-derive the committed key (the Active record's epoch) so \
+             the executor dedups it instead of re-applying the committed start"
+        );
+    }
+
+    /// cid 3335052848: a genuinely-new start after a SILENT drop (which keeps the
+    /// ref at the same base) must NOT be deduped into the dropped start's
+    /// committed marker — it must actually materialize a fresh checkout + record.
+    /// Pre-fix the base-only key collided, so the second start dedup-rewound to a
+    /// no-op (empty checkout, Abandoned record).
+    #[test]
+    fn start_after_silent_drop_at_same_base_actually_starts() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+
+        start_thread(&repo, solid_args("iso", &checkout, &state, false))
+            .expect("first start should succeed");
+        // Silent drop (delete_thread = false) keeps the ref at `state` and leaves
+        // an Abandoned record; force skips the worktree-clean guard.
+        drop_thread_silent(&repo, "iso", false, true).expect("silent drop should succeed");
+        assert!(
+            has_thread_ref(&repo, "iso"),
+            "a silent drop keeps the ref at the same base (the collision premise)"
+        );
+        assert!(
+            std::fs::symlink_metadata(&checkout).is_err(),
+            "the drop removes the prior checkout"
+        );
+
+        // The new start mints a fresh epoch (the prior record is Abandoned), so
+        // its key differs from the dropped start's committed marker and it runs.
+        start_thread(&repo, solid_args("iso", &checkout, &state, false))
+            .expect("start after a silent drop must actually start, not dedup to a no-op");
+        assert!(
+            checkout.join(".heddle").is_dir(),
+            "the restart must re-materialize the checkout (not dedup into a no-op)"
+        );
+        let record = ThreadManager::new(repo.heddle_dir())
+            .load("iso")
+            .unwrap()
+            .expect("the restart must persist a record");
+        assert_eq!(
+            record.state,
+            repo::ThreadState::Active,
+            "the restart must leave an Active record, not the dropped Abandoned one"
         );
     }
 
@@ -869,5 +989,66 @@ mod tests {
             Some(prior),
             "rollback must restore the prior value when the ref still holds our forward value"
         );
+    }
+
+    // ---- heddle#356 r3 fixes ----
+
+    /// cid 3335052857: target-dir ownership is re-established atomically at
+    /// creation, so rollback never deletes a directory a concurrent process
+    /// created between `plan_worktree_target` time and the transaction. Here the
+    /// plan saw the target absent (`plan_created = true`) but a concurrent
+    /// process created it first — `create_target_dir` must NOT claim it, and the
+    /// runtime-keyed rewind must leave it intact.
+    #[test]
+    fn target_dir_rollback_leaves_concurrently_created_dir_intact() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("iso");
+
+        // The concurrent creation that races our forward.
+        std::fs::create_dir(&target).unwrap();
+        let created_by_us = create_target_dir(&target, true).unwrap();
+        assert!(
+            !created_by_us,
+            "a target a concurrent process created must NOT be claimed as ours \
+             (stale plan-time bool would have)"
+        );
+        // The rewind keys on the runtime signal, so it must spare their dir.
+        remove_self_created_dir(&target, created_by_us).unwrap();
+        rewind_checkout(&target, created_by_us).unwrap();
+        assert!(
+            target.is_dir(),
+            "rollback must not delete a directory this start did not create"
+        );
+    }
+
+    /// cid 3335052857: the genuinely-created case still rewinds — a target absent
+    /// at the forward is owned by this start and removed wholesale on rollback.
+    #[test]
+    fn target_dir_rollback_removes_genuinely_created_dir() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("nested").join("iso");
+
+        let created_by_us = create_target_dir(&target, true).unwrap();
+        assert!(created_by_us, "an absent target this start creates is owned by us");
+        assert!(target.is_dir(), "the forward must create the leaf (and its parents)");
+        remove_self_created_dir(&target, created_by_us).unwrap();
+        assert!(
+            std::fs::symlink_metadata(&target).is_err(),
+            "rollback must remove a directory this start genuinely created"
+        );
+    }
+
+    /// cid 3335052857: a pre-existing user `--path` dir (`plan_created = false`)
+    /// is never created or removed by us — the runtime signal stays `false`.
+    #[test]
+    fn target_dir_user_supplied_dir_is_never_removed() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("iso");
+        std::fs::create_dir(&target).unwrap();
+
+        let created_by_us = create_target_dir(&target, false).unwrap();
+        assert!(!created_by_us, "a user-supplied pre-existing dir is not ours to own");
+        remove_self_created_dir(&target, created_by_us).unwrap();
+        assert!(target.is_dir(), "a user-supplied dir must survive rollback");
     }
 }

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `thread start` on the `AtomicMutation` primitive (heddle#356, impl-c).
+//!
+//! `heddle start` materializes a thread out of several independently-failable
+//! filesystem + ref + oplog effects: a thread-ref write, an isolated-checkout
+//! tree, a manifest sidecar, an optional `.cargo/config.toml` redirect, the
+//! optional `--hydrate` dependency symlinks, and a `ThreadManager` record. Any
+//! one of them can fail partway — most visibly `--hydrate` on a host that
+//! rejects directory symlinks — and a non-atomic `start` would leave a
+//! half-materialized checkout / dangling thread ref behind.
+//!
+//! [`StartThread`] maps the whole write-path onto the merged primitive
+//! ([`repo::atomic`]) so it is all-or-nothing: each effect registers its own
+//! inverse through the right combinator, and a failure anywhere rewinds every
+//! applied effect — with **precise directory rewind** — back to the exact
+//! pre-start state. The structure mirrors the impl-b undo/redo migration:
+//!
+//!   * **Atomic single writes** (the thread-ref CAS) → [`Tx::step`]
+//!     (forward-first; the restore inverse is registered only after the write
+//!     lands, so a failed write leaves a pre-existing ref untouched).
+//!   * **Non-atomic / partial-failure-prone effects** (checkout materialize,
+//!     manifest sidecar, cargo-config write, each hydrate symlink) →
+//!     [`Tx::step_nonatomic`] (capture-restore, registered BEFORE the forward)
+//!     or, for the genuinely all-or-nothing per-symlink create, [`Tx::step`].
+//!   * **Thread-record writes** route through [`ThreadManager::converge_records`]
+//!     — the same lock-atomic record-set chokepoint undo/redo uses — captured
+//!     via [`ThreadManager::snapshot_records`] for the converge-back inverse.
+//!   * **The oplog `ThreadCreateV2`** is the staged domain record handed to the
+//!     executor's single commit point (it is NOT appended inside `apply`); the
+//!     commit marker dedups on the stable `transaction_id`.
+//!
+//! Precise directory rewind is the load-bearing property (heddle#302 r4 / #324):
+//! the checkout inverse removes EXACTLY what this invocation created — a
+//! self-created target dir is removed wholesale, but a user-supplied
+//! pre-existing empty `--path` dir is only cleared of the contents we wrote, never
+//! deleted. Each hydrate symlink gets its own unlink inverse, so a partial
+//! hydrate (k of N links, the (k+1)-th fails) unwinds all k links AND the
+//! checkout. No thread/ref/git domain knowledge leaks into the primitive — it
+//! all lives here, exactly like undo/redo's `EntrySteps`.
+
+use std::path::{Path, PathBuf};
+
+use objects::error::{HeddleError, Result as HeddleResult};
+use objects::object::{ChangeId, ThreadName};
+use oplog::OpRecord;
+use refs::RefExpectation;
+use repo::{
+    Thread, ThreadManager, ThreadMode,
+    atomic::{AtomicMutation, StagedCommit, Tx},
+};
+
+use super::mount_lifecycle::{self, MountOwnership};
+use super::worktree_cmd::{
+    helpers::write_isolated_checkout,
+    hydrate,
+    shared_target::write_cargo_config,
+};
+
+/// Wrap an `anyhow` error from a materialize/hydrate helper into the
+/// `HeddleError` the primitive's `Result` requires (mirrors undo/redo's
+/// `apply_error`). The command-level preflights produce the structured
+/// refusals; a message wrapped here only ever surfaces a genuinely
+/// unexpected mid-apply failure whose rewind has already run.
+fn apply_error(err: anyhow::Error) -> HeddleError {
+    HeddleError::Conflict(format!("{err:#}"))
+}
+
+// ---- In-process fault seam (unit tests only) ----
+//
+// The binary integration tests drive rollback through the env-var fault
+// points inside `write_isolated_checkout` (`start_materialize_checkout`) and
+// `hydrate::create_symlink` (`hydrate_symlink_dir`). For in-process unit-test
+// coverage of the rewind closures — which a separate-process binary run can't
+// always attribute to patch coverage — this thread-local seam trips a chosen
+// forward without the env-var `OnceLock` caching hazard.
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(crate) enum StartFault {
+    /// Fail the checkout-materialize forward.
+    Materialize,
+    /// Fail the (n+1)-th hydrate-symlink forward (0 = the first link).
+    HydrateNth(usize),
+}
+
+#[cfg(test)]
+thread_local! {
+    static START_FAULT: std::cell::Cell<Option<StartFault>> = const { std::cell::Cell::new(None) };
+}
+
+/// Arm `fault` for the duration of `body`, clearing it afterwards so it never
+/// leaks into another test on the same thread.
+#[cfg(test)]
+pub(crate) fn with_start_fault<T>(fault: StartFault, body: impl FnOnce() -> T) -> T {
+    START_FAULT.with(|f| f.set(Some(fault)));
+    let out = body();
+    START_FAULT.with(|f| f.set(None));
+    out
+}
+
+#[cfg(test)]
+fn materialize_fault_trips() -> bool {
+    START_FAULT.with(|f| match f.get() {
+        Some(StartFault::Materialize) => {
+            f.set(None);
+            true
+        }
+        _ => false,
+    })
+}
+
+#[cfg(test)]
+fn hydrate_fault_trips() -> bool {
+    START_FAULT.with(|f| match f.get() {
+        Some(StartFault::HydrateNth(0)) => {
+            f.set(None);
+            true
+        }
+        Some(StartFault::HydrateNth(n)) => {
+            f.set(Some(StartFault::HydrateNth(n - 1)));
+            false
+        }
+        _ => false,
+    })
+}
+
+/// Remove every entry inside `dir` without removing `dir` itself, so a
+/// pre-existing user-provided directory survives a rollback while the contents
+/// this invocation materialized are cleared. Symlinks are unlinked directly
+/// (never followed): `file_type()` does not traverse symlinks, so a symlinked
+/// dep dir takes the `remove_file` branch and the origin's deps stay untouched.
+fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            std::fs::remove_dir_all(&path)?;
+        } else {
+            std::fs::remove_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+/// The precise checkout-rewind inverse. `target_dir_created` true → this
+/// invocation made the worktree directory, so remove it entirely (restoring
+/// "didn't exist"); its dep symlinks go with it, since `remove_dir_all`
+/// unlinks symlinks without following them, so the origin's deps are never
+/// touched. `target_dir_created` false → the user supplied an already-existing
+/// empty `--path` dir; preserve the directory and clear only the contents we
+/// materialized inside it (`prepare_worktree_target` only accepts a
+/// pre-existing dir when it is empty). Tolerant of an already-absent target so
+/// it composes with other rewind steps.
+fn rewind_checkout(abs_path: &Path, target_dir_created: bool) -> HeddleResult<()> {
+    let result = if target_dir_created {
+        std::fs::remove_dir_all(abs_path)
+    } else {
+        clear_dir_contents(abs_path)
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(HeddleError::from(err)),
+    }
+}
+
+/// A fully all-or-nothing `thread start` (the bytes-on-disk + virtualized
+/// write-path). Holds owned inputs the surrounding `start_thread` precomputed
+/// from reads; `apply` performs the staged writes and registers each effect's
+/// inverse. The executor reaches the single commit point exactly once.
+pub(crate) struct StartThread {
+    /// Stable idempotency key (derived from scope + name + oplog generation in
+    /// `start_thread`, like undo/redo) — identical across retries of the same
+    /// logical start so a crash-retry dedups instead of double-applying.
+    pub transaction_id: String,
+    /// The thread name (ref name + record key).
+    pub name: String,
+    /// The base state the checkout materializes / the ref points at.
+    pub base_state: ChangeId,
+    /// `Some(prior)` when a thread ref already exists (re-start reuses it via a
+    /// CAS against `prior`); `None` for a brand-new thread (CAS-against-missing
+    /// + a staged `ThreadCreateV2` commit record).
+    pub existing_thread_state: Option<ChangeId>,
+    pub thread_mode: ThreadMode,
+    /// The materialization target (mount point for virtualized).
+    pub abs_path: PathBuf,
+    /// Whether THIS invocation created `abs_path` (drives the precise checkout
+    /// rewind: remove-wholesale vs clear-contents).
+    pub target_dir_created: bool,
+    /// The candidate `--shared-target` redirect dir, or `None`. The cargo-config
+    /// write reports whether it actually applied; if not, the record's
+    /// `shared_target_dir` is cleared before it is persisted.
+    pub shared_target_dir: Option<PathBuf>,
+    pub hydrate: bool,
+    /// Mount ownership for the virtualized path (unused for solid/materialized).
+    pub mount_ownership: MountOwnership,
+    /// The fully-built thread record; `shared_target_dir` is reconciled with the
+    /// cargo-config outcome inside `apply` before it is converged onto disk.
+    pub record: Thread,
+}
+
+impl StartThread {
+    /// Stage the thread-ref write (atomic, forward-first), pushing the staged
+    /// `ThreadCreateV2` commit record for a brand-new thread.
+    fn stage_ref(&self, tx: &mut Tx<'_>, oplog: &mut Vec<OpRecord>) -> HeddleResult<()> {
+        let repo = tx.repo();
+        let base_state = self.base_state;
+        match self.existing_thread_state {
+            Some(existing) => {
+                let fwd_name = ThreadName::new(&self.name);
+                let inv_name = ThreadName::new(&self.name);
+                tx.step(
+                    move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Value(existing), &base_state),
+                    move || repo.refs().set_thread(&inv_name, &existing),
+                )?;
+            }
+            None => {
+                let fwd_name = ThreadName::new(&self.name);
+                let inv_name = ThreadName::new(&self.name);
+                tx.step(
+                    move || repo.refs().set_thread_cas(&fwd_name, RefExpectation::Missing, &base_state),
+                    move || repo.refs().delete_thread(&inv_name).map(|_| ()),
+                )?;
+                // The domain commit record. `manager_snapshot = None` matches the
+                // pre-migration `cmd_start` (the record is written below, so
+                // there is nothing to snapshot yet — heddle#23 r2).
+                oplog.push(OpRecord::ThreadCreateV2 {
+                    name: self.name.clone(),
+                    state: base_state,
+                    manager_snapshot: None,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Materialize the isolated checkout tree (`.heddle` metadata + worktree
+    /// bytes) under a capture-restore step whose inverse precisely rewinds the
+    /// created directory.
+    fn stage_checkout(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+        let repo = tx.repo();
+        let abs = self.abs_path.clone();
+        let rewind_abs = self.abs_path.clone();
+        let created = self.target_dir_created;
+        let base_state = self.base_state;
+        let name = self.name.clone();
+        tx.step_nonatomic(
+            move || Ok(created),
+            move |created| rewind_checkout(&rewind_abs, created),
+            move || {
+                #[cfg(test)]
+                if materialize_fault_trips() {
+                    return Err(HeddleError::Conflict(
+                        "injected materialize fault".to_string(),
+                    ));
+                }
+                write_isolated_checkout(repo, &abs, &base_state, Some(&name)).map_err(apply_error)
+            },
+        )
+    }
+
+    /// Write the materialized-thread manifest sidecar (it lives under
+    /// `.heddle/threads/<name>/`, OUTSIDE the checkout, so it needs its own
+    /// inverse — the checkout rewind won't reach it).
+    fn stage_manifest(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+        let repo = tx.repo();
+        let abs = self.abs_path.clone();
+        let base_state = self.base_state;
+        let fwd_name = self.name.clone();
+        let inv_name = self.name.clone();
+        tx.step_nonatomic(
+            || Ok(()),
+            move |()| {
+                repo::thread_manifest::remove_thread_manifest_dir(repo.heddle_dir(), &inv_name)
+                    .map(|_| ())
+                    .map_err(HeddleError::from)
+            },
+            move || {
+                repo.record_thread_manifest(&fwd_name, &base_state, &abs)
+                    .map(|_| ())
+            },
+        )
+    }
+
+    /// Apply the `--shared-target` cargo-config redirect (inside the checkout),
+    /// returning whether it landed (a pre-staged `.cargo/config.toml` is left
+    /// untouched). Capture-restore on the config file so a later failure
+    /// restores the pre-write state precisely even though the checkout rewind
+    /// would also reach it.
+    fn stage_cargo_config(&self, tx: &mut Tx<'_>, dir: &Path) -> HeddleResult<bool> {
+        let cfg = self.abs_path.join(".cargo").join("config.toml");
+        let restore_cfg = cfg.clone();
+        let abs = self.abs_path.clone();
+        let dir = dir.to_path_buf();
+        tx.step_nonatomic(
+            move || Ok(std::fs::read(&cfg).ok()),
+            move |prior| match prior {
+                Some(bytes) => std::fs::write(&restore_cfg, bytes).map_err(HeddleError::from),
+                None => match std::fs::remove_file(&restore_cfg) {
+                    Ok(()) => Ok(()),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(err) => Err(HeddleError::from(err)),
+                },
+            },
+            move || write_cargo_config(&abs, &dir).map_err(apply_error),
+        )
+    }
+
+    /// `--hydrate`: symlink the origin's top-level ignored dependency dirs into
+    /// the checkout. Each link is one forward-first `Tx::step` (a single
+    /// all-or-nothing `symlink`), so its unlink inverse is registered only after
+    /// the link is created and a partial hydrate unwinds every created link.
+    /// Returns the names linked (for the post-commit note).
+    fn stage_hydrate(&self, tx: &mut Tx<'_>) -> HeddleResult<Vec<String>> {
+        let repo = tx.repo();
+        let sources = hydrate::hydratable_ignored_dirs(repo).map_err(apply_error)?;
+        let mut linked: Vec<String> = Vec::new();
+        for source in &sources {
+            let Some((dest, link_name)) = hydrate::plan_link(&self.abs_path, source) else {
+                continue;
+            };
+            let src = source.clone();
+            let dest_fwd = dest.clone();
+            let inv_checkout = self.abs_path.clone();
+            let inv_name = link_name.clone();
+            let err_name = link_name.clone();
+            tx.step(
+                move || {
+                    #[cfg(test)]
+                    if hydrate_fault_trips() {
+                        return Err(symlink_unsupported_error(&err_name));
+                    }
+                    hydrate::create_symlink(&src, &dest_fwd)
+                        .map_err(|e| symlink_unsupported_error_from(&err_name, e))
+                },
+                move || {
+                    hydrate::unlink_hydrated(&inv_checkout, &inv_name).map_err(HeddleError::from)
+                },
+            )?;
+            linked.push(link_name);
+        }
+        // Preserve the hydrated deps' ignore rule in the checkout's native
+        // `.heddleignore` (capture-restore so a later failure restores it).
+        if !linked.is_empty() {
+            let ignore_path = self.abs_path.join(".heddleignore");
+            let restore_path = ignore_path.clone();
+            let abs = self.abs_path.clone();
+            let linked_fwd = linked.clone();
+            tx.step_nonatomic(
+                move || Ok(std::fs::read(&ignore_path).ok()),
+                move |prior| restore_ignore_file(&restore_path, prior),
+                move || hydrate::preserve_hydrated_ignores(&abs, &linked_fwd).map_err(apply_error),
+            )?;
+        }
+        Ok(linked)
+    }
+
+    /// Establish the FUSE mount for a virtualized thread, registering an unmount
+    /// inverse so an outer failure tears the mount down (it would otherwise
+    /// outlive the failed start — the daemon owns it across process exit).
+    fn stage_mount(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+        let repo = tx.repo();
+        let root = repo.root().to_path_buf();
+        let abs = self.abs_path.clone();
+        let fwd_name = self.name.clone();
+        let inv_name = self.name.clone();
+        let ownership = self.mount_ownership;
+        tx.step(
+            move || {
+                mount_lifecycle::establish_virtualized_mount(&root, &fwd_name, &abs, ownership)
+                    .map_err(apply_error)
+            },
+            move || {
+                mount_lifecycle::unmount_thread_if_mounted(&inv_name);
+                Ok(())
+            },
+        )
+    }
+
+    /// Persist the thread record as the SOLE record under its name, via the
+    /// lock-atomic [`ThreadManager::converge_records`] chokepoint. Capture the
+    /// full prior same-name set so the inverse converges back to it.
+    fn stage_record(&self, tx: &mut Tx<'_>) -> HeddleResult<()> {
+        let repo = tx.repo();
+        let record = self.record.clone();
+        let fwd_name = self.name.clone();
+        let inv_name = self.name.clone();
+        let prior = ThreadManager::new(repo.heddle_dir()).snapshot_records(&self.name)?;
+        tx.step_nonatomic(
+            || Ok(prior),
+            move |prior| ThreadManager::new(repo.heddle_dir()).converge_records(&inv_name, &prior),
+            move || {
+                ThreadManager::new(repo.heddle_dir())
+                    .converge_records(&fwd_name, std::slice::from_ref(&record))
+            },
+        )
+    }
+}
+
+impl AtomicMutation for StartThread {
+    type Output = Vec<String>;
+
+    fn transaction_id(&self) -> String {
+        self.transaction_id.clone()
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<String>>> {
+        let mut oplog: Vec<OpRecord> = Vec::new();
+
+        // 1. Thread ref (+ staged ThreadCreateV2 for a brand-new thread).
+        self.stage_ref(tx, &mut oplog)?;
+
+        // 2. Mode-specific materialization.
+        let linked = match self.thread_mode {
+            ThreadMode::Solid | ThreadMode::Materialized => {
+                self.stage_checkout(tx)?;
+                if matches!(self.thread_mode, ThreadMode::Materialized) {
+                    self.stage_manifest(tx)?;
+                }
+                if let Some(dir) = self.shared_target_dir.clone() {
+                    let applied = self.stage_cargo_config(tx, &dir)?;
+                    // The writer no-ops on a pre-staged config; don't advertise a
+                    // redirect that isn't in effect (`thread show` would lie).
+                    if !applied {
+                        self.record.shared_target_dir = None;
+                    }
+                }
+                if self.hydrate {
+                    self.stage_hydrate(tx)?
+                } else {
+                    Vec::new()
+                }
+            }
+            ThreadMode::Virtualized => {
+                self.stage_mount(tx)?;
+                Vec::new()
+            }
+        };
+
+        // 3. Thread record (sole record under the name), via converge_records.
+        self.stage_record(tx)?;
+
+        Ok(StagedCommit::new(linked, oplog))
+    }
+}
+
+/// Restore the checkout's `.heddleignore` to its captured pre-hydrate state:
+/// rewrite the prior bytes, or remove the file we created.
+fn restore_ignore_file(path: &Path, prior: Option<Vec<u8>>) -> HeddleResult<()> {
+    match prior {
+        Some(bytes) => std::fs::write(path, bytes).map_err(HeddleError::from),
+        None => match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(HeddleError::from(err)),
+        },
+    }
+}
+
+/// The user-facing error a rejected directory symlink raises. Names the
+/// host/FS limitation (the integration test asserts on "directory symlink")
+/// and notes the start was rolled back.
+fn symlink_unsupported_error_from(link: &str, err: anyhow::Error) -> HeddleError {
+    HeddleError::Conflict(format!(
+        "--hydrate could not create a directory symlink for '{link}' in the new checkout. \
+         This host or filesystem appears to reject directory symlinks (e.g. Windows without \
+         Developer Mode / the SeCreateSymbolicLink privilege, or a filesystem that doesn't \
+         support them). The partially-created thread has been rolled back — re-run \
+         `heddle start` without --hydrate, or enable directory-symlink support on this host \
+         and retry. (cause: {err:#})"
+    ))
+}
+
+#[cfg(test)]
+fn symlink_unsupported_error(link: &str) -> HeddleError {
+    symlink_unsupported_error_from(link, anyhow::anyhow!("injected hydrate symlink fault"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::thread::start_thread;
+    use super::*;
+    use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
+    use repo::Repository;
+    use tempfile::TempDir;
+
+    /// A `--path` solid-thread start that pins its base on `from` (no current-
+    /// state bootstrap) and never spawns a daemon — minimal machinery for the
+    /// in-process rollback assertions.
+    fn solid_args(name: &str, path: &std::path::Path, from: &ChangeId, hydrate: bool) -> ThreadStartArgs {
+        ThreadStartArgs {
+            name: name.to_string(),
+            from: Some(from.to_string()),
+            path: Some(path.to_path_buf()),
+            workspace: WorkspaceModeArg::Solid,
+            agent_provider: None,
+            agent_model: None,
+            task: None,
+            parent_thread: None,
+            automated: true,
+            print_cd_path: false,
+            daemon: false,
+            no_daemon: true,
+            shared_target: false,
+            hydrate,
+        }
+    }
+
+    fn has_thread_ref(repo: &Repository, name: &str) -> bool {
+        repo.refs()
+            .get_thread(&ThreadName::new(name))
+            .unwrap()
+            .is_some()
+    }
+
+    fn has_thread_record(repo: &Repository, name: &str) -> bool {
+        ThreadManager::new(repo.heddle_dir())
+            .find_by_thread(name)
+            .unwrap()
+            .is_some()
+    }
+
+    /// Repo with one captured state holding a tracked `a.txt` (+ optional
+    /// ignored dep dirs). Returns the temp dir, repo, and base state id.
+    fn repo_with_state(deps: &[&str]) -> (TempDir, Repository, ChangeId) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+        if !deps.is_empty() {
+            let ignore = deps
+                .iter()
+                .map(|d| format!("{d}/\n"))
+                .collect::<String>();
+            std::fs::write(temp.path().join(".heddleignore"), ignore).unwrap();
+            for dep in deps {
+                std::fs::create_dir_all(temp.path().join(dep)).unwrap();
+            }
+        }
+        let state = repo.snapshot(Some("s1".to_string()), None).unwrap();
+        (temp, repo, state.change_id)
+    }
+
+    #[test]
+    fn start_happy_path_materializes_records_and_hydrates() {
+        let (temp, repo, state) = repo_with_state(&["dep_a", "dep_b"]);
+        let checkout = temp.path().join("iso");
+        let out = start_thread(&repo, solid_args("iso", &checkout, &state, true));
+        assert!(out.is_ok(), "happy-path start should succeed: {:?}", out.err());
+
+        assert!(checkout.join(".heddle").is_dir(), "checkout .heddle should exist");
+        assert!(checkout.join("a.txt").is_file(), "tracked file should materialize");
+        // Both ignored dep dirs hydrated as symlinks.
+        for dep in ["dep_a", "dep_b"] {
+            assert!(
+                std::fs::symlink_metadata(checkout.join(dep))
+                    .map(|m| m.file_type().is_symlink())
+                    .unwrap_or(false),
+                "{dep} should be hydrated as a symlink"
+            );
+        }
+        assert!(has_thread_ref(&repo, "iso"), "thread ref should be created");
+        assert!(has_thread_record(&repo, "iso"), "thread record should be persisted");
+    }
+
+    #[test]
+    fn start_materialize_fault_rolls_back_self_created_dir() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+        let out = with_start_fault(StartFault::Materialize, || {
+            start_thread(&repo, solid_args("iso", &checkout, &state, false))
+        });
+        assert!(out.is_err(), "a materialize fault must fail the start");
+        assert!(
+            std::fs::symlink_metadata(&checkout).is_err(),
+            "the self-created checkout must be removed on rollback"
+        );
+        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
+        assert!(!has_thread_record(&repo, "iso"), "no record must survive the rollback");
+    }
+
+    #[test]
+    fn start_materialize_fault_preserves_preexisting_dir() {
+        let (temp, repo, state) = repo_with_state(&[]);
+        let checkout = temp.path().join("iso");
+        std::fs::create_dir(&checkout).unwrap();
+        let out = with_start_fault(StartFault::Materialize, || {
+            start_thread(&repo, solid_args("iso", &checkout, &state, false))
+        });
+        assert!(out.is_err(), "a materialize fault must fail the start");
+        // The user-supplied dir survives, emptied of what we materialized.
+        assert!(checkout.is_dir(), "a pre-existing user dir must not be deleted");
+        let remaining: Vec<_> = std::fs::read_dir(&checkout)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert!(remaining.is_empty(), "rollback must clear materialized contents: {remaining:?}");
+        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
+    }
+
+    #[test]
+    fn start_partial_hydrate_unwinds_links_and_checkout() {
+        let (temp, repo, state) = repo_with_state(&["dep_a", "dep_b"]);
+        let checkout = temp.path().join("iso");
+        // Fail the SECOND hydrate link (dep_b, sorted) → the first (dep_a) must
+        // still be unwound, along with the whole checkout.
+        let out = with_start_fault(StartFault::HydrateNth(1), || {
+            start_thread(&repo, solid_args("iso", &checkout, &state, true))
+        });
+        assert!(out.is_err(), "a partial hydrate must fail the start");
+        assert!(
+            std::fs::symlink_metadata(&checkout).is_err(),
+            "a partial hydrate must remove the checkout (and every created link)"
+        );
+        assert!(!has_thread_ref(&repo, "iso"), "the thread ref must be rolled back");
+        // The origin's dep dirs are untouched (we unlink, never follow).
+        assert!(temp.path().join("dep_a").is_dir());
+        assert!(temp.path().join("dep_b").is_dir());
+    }
+}

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -44,7 +44,7 @@ use super::{
     start_atomic,
     thread_cmd::{refresh_thread_freshness, thread_not_found_advice},
     worktree_cmd::{
-        helpers::{prepare_worktree_target, write_isolated_checkout},
+        helpers::{plan_worktree_target, write_isolated_checkout},
         shared_target,
     },
     worktree_safety::ensure_worktree_clean,
@@ -1590,6 +1590,21 @@ fn render_thread_entry(entry: &ThreadSummary, verbose: bool) {
     }
 }
 
+/// Retry-stable idempotency key for `thread start`.
+///
+/// Derived only from the op scope, the thread name, and the resolved base
+/// state — values fixed before the transaction and identical across a retry of
+/// the same logical start. It deliberately does NOT fold in the live oplog
+/// head: that advances when the `TransactionCommit` marker appends, so a
+/// post-commit crash-retry would read the advanced head, derive a *fresh* key,
+/// miss the executor's `transaction_id` dedup, and re-apply an already-committed
+/// start (heddle#356 cid 3333881568). After the commit the thread ref points at
+/// `base_state`, so a re-run of "start <name> from <base>" re-derives the same
+/// key and dedups exactly-once.
+pub(crate) fn start_transaction_id(scope: &str, name: &str, base_state: &ChangeId) -> String {
+    format!("thread-start:{scope}:{name}:{}", base_state.to_string_full())
+}
+
 pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<ThreadOpOutput> {
     let existing = find_active_thread_entry(repo, &args.name)?;
     if let Some(entry) = existing {
@@ -1686,7 +1701,11 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     if args.path.is_some() {
         ensure_explicit_start_path_outside_repo(repo, &args.name, &path)?;
     }
-    let prepared_target = prepare_worktree_target(repo, &path)?;
+    // Resolve + validate the target but DO NOT create it here: the directory
+    // creation is the transaction's first step, so a failure in the remaining
+    // pre-transaction work below can't orphan a dir we made before `execute`
+    // had a rewind ledger (heddle#356 cid 3333881552).
+    let prepared_target = plan_worktree_target(repo, &path)?;
     let target_dir_created = prepared_target.target_dir_created;
     let abs_path = normalize_path_for_containment(&prepared_target.path)?;
 
@@ -1804,11 +1823,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     let mount_ownership =
         mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
     let scope = repo.op_scope();
-    let generation = repo.oplog().head_id()?;
-    // Stable across retries of the same logical start (generation-keyed like
-    // undo/redo, so a legitimately-repeated `(scope, name)` at a later
-    // generation never collides on the dedup key — heddle#355 idempotency note).
-    let transaction_id = format!("thread-start:{scope}:{}:gen{generation}", args.name);
+    let transaction_id = start_transaction_id(&scope, &args.name, &base_state);
     let hydrate_requested =
         args.hydrate && matches!(thread_mode, ThreadMode::Solid | ThreadMode::Materialized);
     let linked = repo::atomic::execute(

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1738,6 +1738,36 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     if args.path.is_some() {
         ensure_explicit_start_path_outside_repo(repo, &args.name, &path)?;
     }
+    // The retry-stable idempotency key, resolved BEFORE the fresh-start preflight
+    // so a committed retry is recognized before any precondition can reject it
+    // (heddle#356 cid 3335586969). The per-start epoch comes from the durable
+    // committed thread record (`resolve_start_epoch` reads its `created_at`), so a
+    // start that committed its write-path but crashed before the post-commit
+    // bookkeeping re-derives the SAME key here — not a fresh one.
+    let scope = repo.op_scope();
+    let start_epoch = resolve_start_epoch(repo, &args.name)?;
+    let transaction_id = start_transaction_id(&scope, &args.name, &base_state, start_epoch);
+
+    // Commit-detection GATES the fresh-start preflight — ONE decision point, not
+    // two disconnected guards. If this start's transaction already committed
+    // (checkout + ref + record + `TransactionCommit` marker landed, then a crash
+    // interrupted the post-commit bookkeeping), recognize it as a committed retry
+    // and complete the interrupted bookkeeping from the durable record. Do NOT run
+    // `plan_worktree_target` (which would reject the now-non-empty checkout with
+    // `worktree_target_not_empty`) or re-run `execute` (whose `apply` would fail on
+    // the existing `.heddle`, never reaching the commit-point dedup). A
+    // genuinely-new start — including a post-silent-drop restart at the same base,
+    // whose Abandoned record yields a FRESH epoch — derives a distinct key that is
+    // absent here and runs the preflight + execute below (cid 3335586969 /
+    // 3335052848).
+    if !repo
+        .oplog()
+        .committed_batch_records(&transaction_id)?
+        .is_empty()
+    {
+        return finalize_committed_start(repo, &args, base_state, &actor_identity);
+    }
+
     // Resolve + validate the target but DO NOT create it here: the directory
     // creation is the transaction's first step, so a failure in the remaining
     // pre-transaction work below can't orphan a dir we made before `execute`
@@ -1812,12 +1842,10 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
             ))
         })?;
     let (base_root, verification_summary, confidence_summary) = base_state_summary;
-    // The per-start epoch anchors the retry-stable idempotency key. Resolved
-    // BEFORE the record is built so the record persists the same instant the key
-    // folds in: a crash-retry reuses the Active record's instant (→ dedup), a
-    // post-drop restart mints a fresh one (→ actually starts). See
-    // `resolve_start_epoch` / `start_transaction_id` (heddle#356 cid 3335052848).
-    let start_epoch = resolve_start_epoch(repo, &args.name)?;
+    // `start_epoch` was resolved above (before the commit-detection gate) and is
+    // the record's creation instant: the idempotency key folds it, and a
+    // crash-retry reuses it from this still-Active record (heddle#356 cid
+    // 3335052848 / 3335586969).
     let thread_state = Thread {
         id: args.name.clone(),
         thread: args.name.clone(),
@@ -1867,8 +1895,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     // the single commit point. See `start_atomic::StartThread`.
     let mount_ownership =
         mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
-    let scope = repo.op_scope();
-    let transaction_id = start_transaction_id(&scope, &args.name, &base_state, start_epoch);
+    // `scope` + `transaction_id` were resolved above the commit-detection gate.
     let hydrate_requested =
         args.hydrate && matches!(thread_mode, ThreadMode::Solid | ThreadMode::Materialized);
     let linked = repo::atomic::execute(
@@ -1889,6 +1916,83 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     )
     .map_err(|e| anyhow!(e))?;
 
+    finalize_thread_start(
+        repo,
+        &args,
+        &thread_mode,
+        &abs_path,
+        base_state,
+        &base_short,
+        &base_root,
+        &actor_identity,
+        hydrate_requested,
+        linked,
+    )
+}
+
+/// Complete a `thread start` that was found ALREADY committed at the
+/// commit-detection gate (heddle#356 cid 3335586969): the write-path landed
+/// exactly-once, then a crash interrupted the post-commit bookkeeping. The
+/// durable thread record is the source of truth for where the checkout lives and
+/// what it anchors on, so reconstruct the finalize inputs from it rather than
+/// re-running the fresh-start preflight (which would reject the now-non-empty
+/// checkout) or `execute` (whose `apply` would fail on the existing `.heddle`).
+/// `base_state` is the full `ChangeId` already resolved by `start_thread` (the
+/// record only persists the short form). No hydrate is re-run, so no hydrate
+/// note is emitted (the original start already linked the deps).
+fn finalize_committed_start(
+    repo: &Repository,
+    args: &ThreadStartArgs,
+    base_state: ChangeId,
+    actor_identity: &StartActorIdentity,
+) -> Result<ThreadOpOutput> {
+    let committed = ThreadManager::new(repo.heddle_dir())
+        .load(&args.name)?
+        .ok_or_else(|| {
+            anyhow!(
+                "thread '{}' has a committed start transaction but no durable record to \
+                 complete the interrupted start from",
+                args.name
+            )
+        })?;
+    let abs_path = committed.execution_path.clone();
+    let base_short = base_state.short();
+    finalize_thread_start(
+        repo,
+        args,
+        &committed.mode,
+        &abs_path,
+        base_state,
+        &base_short,
+        &committed.base_root,
+        actor_identity,
+        // The original start owns the hydrate note; the retry only completes the
+        // post-commit bookkeeping.
+        false,
+        Vec::new(),
+    )
+}
+
+/// The post-commit bookkeeping shared by a fresh `thread start` and a committed
+/// retry ([`finalize_committed_start`]): emit the hydrate note, create the
+/// `AgentRegistry` reservation entry (the "active reservation" a crash before
+/// this step leaves missing), and build the command output. Idempotent w.r.t. the
+/// reservation: it is only reached when no live owner exists (a live owner is
+/// caught earlier by `find_active_thread_entry`), so the retry completes the
+/// interrupted reservation exactly-once.
+#[allow(clippy::too_many_arguments)]
+fn finalize_thread_start(
+    repo: &Repository,
+    args: &ThreadStartArgs,
+    thread_mode: &ThreadMode,
+    abs_path: &Path,
+    base_state: ChangeId,
+    base_short: &str,
+    base_root: &str,
+    actor_identity: &StartActorIdentity,
+    hydrate_requested: bool,
+    linked: Vec<String>,
+) -> Result<ThreadOpOutput> {
     // Post-commit hydrate note (stderr; JSON consumers on stdout unaffected).
     if hydrate_requested {
         if linked.is_empty() {
@@ -1910,7 +2014,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     }
 
     let registry = AgentRegistry::new(repo.heddle_dir());
-    let path_for_entry = abs_path.clone();
+    let path_for_entry = abs_path.to_path_buf();
     let thread_name = args.name.clone();
     let entry = registry.create_generated_entry_for_thread(&thread_name, |session_id| {
         Ok(AgentEntry {
@@ -1931,14 +2035,14 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
             ),
             heartbeat_at: Some(Utc::now()),
             anchor_state: Some(base_state.to_string_full()),
-            anchor_root: Some(base_root.clone()),
+            anchor_root: Some(base_root.to_string()),
             reservation_token: Some(objects::store::generate_agent_id()),
             path: match thread_mode {
                 ThreadMode::Solid | ThreadMode::Materialized | ThreadMode::Virtualized => {
                     Some(path_for_entry.clone())
                 }
             },
-            base_state: base_short.clone(),
+            base_state: base_short.to_string(),
             started_at: Utc::now(),
             provider: actor_identity.provider.clone(),
             model: actor_identity.model.clone(),
@@ -1985,7 +2089,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     Ok(thread_op_output(
         "thread_start",
         "start",
-        args.name,
+        args.name.clone(),
         message,
         summary.as_ref().and_then(|thread| thread.path.clone()),
         Some(abs_path.display().to_string()),

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -41,6 +41,7 @@ use super::{
     },
     operator_loop::{primary_next_action, primary_next_action_with_verification},
     snapshot::{ensure_current_state, summarize_confidence, summarize_verification},
+    start_atomic,
     thread_cmd::{refresh_thread_freshness, thread_not_found_advice},
     worktree_cmd::{
         helpers::{prepare_worktree_target, write_isolated_checkout},
@@ -1641,27 +1642,6 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
 
     let actor_identity = resolve_start_actor_identity(repo, &args)?;
 
-    let thread_name = ThreadName::new(&args.name);
-    if let Some(existing) = existing_thread_state {
-        repo.refs()
-            .set_thread_cas(&thread_name, RefExpectation::Value(existing), &base_state)?;
-    } else {
-        repo.refs()
-            .set_thread_cas(&thread_name, RefExpectation::Missing, &base_state)?;
-        // `cmd_start` writes the ThreadManager record only after
-        // materializing the worktree below — there's no record yet to
-        // snapshot, so pass `None`. The `ensure_thread_worktree_undo_safe`
-        // gate (undo.rs) refuses undo whenever this create has a live
-        // materialized worktree on disk, so the only path where redo
-        // would actually run for a `start` op is one where the user has
-        // manually torn the worktree down. Redo then restores the ref
-        // only (no record body to put back); a subsequent `heddle
-        // thread start` re-establishes the record if the user wants
-        // one. heddle#23 r2.
-        repo.oplog()
-            .record_thread_create(&thread_name, &base_state, None, Some(&repo.op_scope()))?;
-    }
-
     let thread_mode = resolve_thread_mode(repo, &args);
     // Honesty pass for explicit `--workspace materialized` on a
     // filesystem that doesn't support reflinks. `resolve_thread_mode`
@@ -1706,7 +1686,9 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     if args.path.is_some() {
         ensure_explicit_start_path_outside_repo(repo, &args.name, &path)?;
     }
-    let abs_path = normalize_path_for_containment(&prepare_worktree_target(repo, &path)?)?;
+    let prepared_target = prepare_worktree_target(repo, &path)?;
+    let target_dir_created = prepared_target.target_dir_created;
+    let abs_path = normalize_path_for_containment(&prepared_target.path)?;
 
     // Item 2.1 of the heddle 6→8 plan: when starting a heavy
     // (materialized/lightweight) thread in a Rust workspace, redirect
@@ -1750,61 +1732,8 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         shared_target::print_advisory(&args.name);
     }
 
-    // Track whether `write_cargo_config` actually applied the
-    // redirect. When the user has pre-staged `.cargo/config.toml`
-    // the writer is a no-op and we must NOT advertise a
-    // `shared_target_dir` on the thread record — `thread show`
-    // would otherwise lie about a redirect that isn't in effect.
-    let mut shared_target_dir_path = shared_target_dir_path;
-    match thread_mode {
-        ThreadMode::Solid | ThreadMode::Materialized => {
-            write_isolated_checkout(repo, &abs_path, &base_state, Some(&args.name))?;
-            // Materialized threads ship with a manifest sidecar that
-            // ties the on-disk worktree to the captured state via a
-            // per-file stat-cache. Solid threads are full file copies
-            // with no shared extents and stat-cache reuse wouldn't be
-            // semantically right (the bytes can drift without us
-            // noticing the way clonefile shares would expose).
-            if matches!(thread_mode, ThreadMode::Materialized) {
-                repo.record_thread_manifest(&args.name, &base_state, &abs_path)?;
-            }
-            if let Some(dir) = shared_target_dir_path.as_ref() {
-                let applied = shared_target::write_cargo_config(&abs_path, dir)?;
-                if !applied {
-                    tracing::info!(
-                        thread = %args.name,
-                        config = %abs_path.join(".cargo").join("config.toml").display(),
-                        "existing .cargo/config.toml preserved; --shared-target redirect not applied"
-                    );
-                    shared_target_dir_path = None;
-                }
-            }
-        }
-        ThreadMode::Virtualized => {
-            // Light workspaces use the daemon-owned mount by default:
-            // `heddled` keeps the FUSE
-            // session alive after this CLI exits and across subsequent
-            // invocations. `--no-daemon` opts out and pins the mount to
-            // this process (the legacy behaviour). When the daemon is
-            // unavailable on this host (no `fusermount`, exec failed,
-            // etc.) we silently fall back to the in-process path with
-            // a warning so the user still gets a working mount. See
-            // `docs/design/mount-daemon.md` § History.
-            let ownership =
-                mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
-            mount_lifecycle::establish_virtualized_mount(
-                repo.root(),
-                &args.name,
-                &abs_path,
-                ownership,
-            )?;
-        }
-    }
-
-    let registry = AgentRegistry::new(repo.heddle_dir());
-    let task = args.task.clone();
-    let path_for_entry = abs_path.clone();
-    let thread_name = args.name.clone();
+    // Reads the thread record + the post-commit agent entry both need;
+    // computed before the transaction (the record carries them in).
     let current_target_thread = match repo.head_ref()? {
         Head::Attached { thread } => Some(thread.to_string()),
         Head::Detached { .. } => None,
@@ -1827,7 +1756,6 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
             ))
         })?;
     let (base_root, verification_summary, confidence_summary) = base_state_summary;
-    let thread_manager = ThreadManager::new(repo.heddle_dir());
     let thread_state = Thread {
         id: args.name.clone(),
         thread: args.name.clone(),
@@ -1839,7 +1767,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         base_root: base_root.clone(),
         current_state: Some(base_short.clone()),
         merged_state: None,
-        task: task.clone(),
+        task: args.task.clone(),
         execution_path: abs_path.clone(),
         materialized_path: match thread_mode {
             ThreadMode::Solid | ThreadMode::Materialized => Some(abs_path.clone()),
@@ -1860,9 +1788,70 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         updated_at: Utc::now(),
         ephemeral: None,
         auto: false,
+        // The candidate redirect; the transaction clears it if the cargo
+        // config writer no-ops on a pre-staged `.cargo/config.toml` (so
+        // `thread show` never advertises a redirect that isn't in effect).
         shared_target_dir: shared_target_dir_path.clone(),
     };
-    thread_manager.save(&thread_state)?;
+
+    // The ENTIRE start write-path — thread ref, checkout materialize, manifest,
+    // cargo-config redirect, `--hydrate` symlinks, and the ThreadManager record
+    // — runs as ONE atomic transaction on the heddle#330 primitive (impl-c). A
+    // failure anywhere mid-materialize rewinds every applied effect, with
+    // precise directory + symlink rewind, back to the exact pre-start state;
+    // the oplog `ThreadCreateV2` is the staged commit record appended once at
+    // the single commit point. See `start_atomic::StartThread`.
+    let mount_ownership =
+        mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
+    let scope = repo.op_scope();
+    let generation = repo.oplog().head_id()?;
+    // Stable across retries of the same logical start (generation-keyed like
+    // undo/redo, so a legitimately-repeated `(scope, name)` at a later
+    // generation never collides on the dedup key — heddle#355 idempotency note).
+    let transaction_id = format!("thread-start:{scope}:{}:gen{generation}", args.name);
+    let hydrate_requested =
+        args.hydrate && matches!(thread_mode, ThreadMode::Solid | ThreadMode::Materialized);
+    let linked = repo::atomic::execute(
+        repo,
+        start_atomic::StartThread {
+            transaction_id,
+            name: args.name.clone(),
+            base_state,
+            existing_thread_state,
+            thread_mode: thread_mode.clone(),
+            abs_path: abs_path.clone(),
+            target_dir_created,
+            shared_target_dir: shared_target_dir_path,
+            hydrate: hydrate_requested,
+            mount_ownership,
+            record: thread_state,
+        },
+    )
+    .map_err(|e| anyhow!(e))?;
+
+    // Post-commit hydrate note (stderr; JSON consumers on stdout unaffected).
+    if hydrate_requested {
+        if linked.is_empty() {
+            eprintln!(
+                "{}: --hydrate found no ignored dependency directories at the origin \
+                 checkout root to link.",
+                style::warn("note"),
+            );
+        } else {
+            eprintln!(
+                "{}: hydrated {} ignored dependency dir(s) into '{}' via symlink: {} \
+                 (shared with the origin checkout; they stay ignored and are not captured).",
+                style::warn("note"),
+                linked.len(),
+                args.name,
+                linked.join(", "),
+            );
+        }
+    }
+
+    let registry = AgentRegistry::new(repo.heddle_dir());
+    let path_for_entry = abs_path.clone();
+    let thread_name = args.name.clone();
     let entry = registry.create_generated_entry_for_thread(&thread_name, |session_id| {
         Ok(AgentEntry {
             session_id: session_id.to_string(),

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use gix::bstr::ByteSlice;
 use objects::{
     object::{ChangeId, State, ThreadName, Tree},
@@ -1592,17 +1592,54 @@ fn render_thread_entry(entry: &ThreadSummary, verbose: bool) {
 
 /// Retry-stable idempotency key for `thread start`.
 ///
-/// Derived only from the op scope, the thread name, and the resolved base
-/// state — values fixed before the transaction and identical across a retry of
-/// the same logical start. It deliberately does NOT fold in the live oplog
-/// head: that advances when the `TransactionCommit` marker appends, so a
-/// post-commit crash-retry would read the advanced head, derive a *fresh* key,
-/// miss the executor's `transaction_id` dedup, and re-apply an already-committed
-/// start (heddle#356 cid 3333881568). After the commit the thread ref points at
-/// `base_state`, so a re-run of "start <name> from <base>" re-derives the same
-/// key and dedups exactly-once.
-pub(crate) fn start_transaction_id(scope: &str, name: &str, base_state: &ChangeId) -> String {
-    format!("thread-start:{scope}:{name}:{}", base_state.to_string_full())
+/// Folds the op scope, the thread name, the resolved base state, AND a per-start
+/// epoch ([`resolve_start_epoch`] — the in-flight thread record's creation
+/// instant). Two properties have to hold at once:
+///
+///   * **Stable across a crash-retry of the *same* start.** It deliberately does
+///     NOT fold in the live oplog head: that advances when the
+///     `TransactionCommit` marker appends, so a post-commit crash-retry would
+///     read the advanced head, derive a *fresh* key, miss the executor's
+///     `transaction_id` dedup, and re-apply an already-committed start
+///     (heddle#356 cid 3333881568). A crash-retry finds the still-Active thread
+///     record and reuses its creation instant, so it re-derives this exact key
+///     and dedups exactly-once.
+///   * **Fresh for a genuinely-new start after a prior one was dropped.** A
+///     silent drop (no `--delete-thread`) leaves the ref at `base_state`, so a
+///     key folding only scope+name+base would collide with the dropped start's
+///     committed marker and the new start would be wrongly deduped into a no-op
+///     (heddle#356 cid 3335052848). The epoch breaks the collision: a post-drop
+///     restart finds an Abandoned (non-Active) record and mints a fresh epoch,
+///     so it derives a DISTINCT key and actually starts.
+pub(crate) fn start_transaction_id(
+    scope: &str,
+    name: &str,
+    base_state: &ChangeId,
+    start_epoch: DateTime<Utc>,
+) -> String {
+    format!(
+        "thread-start:{scope}:{name}:{}:{}",
+        base_state.to_string_full(),
+        start_epoch.timestamp_nanos_opt().unwrap_or_default(),
+    )
+}
+
+/// The per-start epoch folded into the idempotency key ([`start_transaction_id`]).
+///
+/// The thread record is the durable "start reservation": it is written inside
+/// the transaction (before the commit point) and survives a crash, so it is the
+/// one artifact a crash-retry can read back. A crash-retry of an in-flight start
+/// finds the still-[`ThreadState::Active`] record and reuses its creation
+/// instant → identical key → the executor dedups it exactly-once. A
+/// genuinely-new start — no record, or a record a prior silent drop left
+/// [`ThreadState::Abandoned`] (the drop keeps the ref at the same base, so a
+/// base-only key would otherwise collide — cid 3335052848) — mints a FRESH
+/// instant → distinct key → it actually starts.
+pub(crate) fn resolve_start_epoch(repo: &Repository, name: &str) -> Result<DateTime<Utc>> {
+    let prior_active = ThreadManager::new(repo.heddle_dir())
+        .load(name)?
+        .filter(|thread| thread.state == ThreadState::Active);
+    Ok(prior_active.map_or_else(Utc::now, |thread| thread.created_at))
 }
 
 pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<ThreadOpOutput> {
@@ -1775,6 +1812,12 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
             ))
         })?;
     let (base_root, verification_summary, confidence_summary) = base_state_summary;
+    // The per-start epoch anchors the retry-stable idempotency key. Resolved
+    // BEFORE the record is built so the record persists the same instant the key
+    // folds in: a crash-retry reuses the Active record's instant (→ dedup), a
+    // post-drop restart mints a fresh one (→ actually starts). See
+    // `resolve_start_epoch` / `start_transaction_id` (heddle#356 cid 3335052848).
+    let start_epoch = resolve_start_epoch(repo, &args.name)?;
     let thread_state = Thread {
         id: args.name.clone(),
         thread: args.name.clone(),
@@ -1803,7 +1846,9 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         verification_summary,
         confidence_summary,
         integration_policy_result: ThreadIntegrationPolicy::default(),
-        created_at: Utc::now(),
+        // The start epoch IS the record's creation instant: the idempotency key
+        // folds it, and a crash-retry reuses it from this still-Active record.
+        created_at: start_epoch,
         updated_at: Utc::now(),
         ephemeral: None,
         auto: false,
@@ -1823,7 +1868,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     let mount_ownership =
         mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
     let scope = repo.op_scope();
-    let transaction_id = start_transaction_id(&scope, &args.name, &base_state);
+    let transaction_id = start_transaction_id(&scope, &args.name, &base_state, start_epoch);
     let hydrate_requested =
         args.hydrate && matches!(thread_mode, ThreadMode::Solid | ThreadMode::Materialized);
     let linked = repo::atomic::execute(

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1135,7 +1135,7 @@ fn cmd_thread_promote(
         }
     }
     let path = path.unwrap_or_else(|| default_materialized_thread_path(repo, thread_id));
-    let abs_path = prepare_worktree_target(repo, &path)?;
+    let abs_path = prepare_worktree_target(repo, &path)?.path;
     write_isolated_checkout(repo, &abs_path, &state_id, Some(&thread.thread))?;
 
     thread.mode = ThreadMode::Solid;

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -182,6 +182,7 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
         daemon: true,
         no_daemon: false,
         shared_target: false,
+        hydrate: false,
     };
     let start_output = start_thread(&repo, start_args)?;
     let thread_path = start_output

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -938,6 +938,10 @@ pub fn cmd_delegate(cli: &Cli, args: DelegateArgs) -> Result<()> {
                     // shouldn't make filesystem-layout decisions for
                     // the user.
                     shared_target: false,
+                    // Delegated children don't auto-hydrate: delegate is a
+                    // thin orchestration verb and shouldn't symlink deps
+                    // into a spawned checkout without an explicit ask.
+                    hydrate: false,
                 },
             )?;
             Ok(DelegatedThreadOutput {

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -8,7 +8,21 @@ use repo::Repository;
 
 use super::super::advice::RecoveryAdvice;
 
-pub(crate) fn prepare_worktree_target(repo: &Repository, path: &Path) -> Result<PathBuf> {
+/// The prepared `--path` target plus whether THIS invocation created the
+/// target directory. A compensating rollback must only undo what this
+/// invocation created: a directory we created is removed entirely, but a
+/// pre-existing empty directory the user supplied is preserved (only the
+/// contents we materialized inside it are cleared) — never destroy user
+/// state we merely wrote into.
+pub(crate) struct PreparedWorktreeTarget {
+    pub path: PathBuf,
+    pub target_dir_created: bool,
+}
+
+pub(crate) fn prepare_worktree_target(
+    repo: &Repository,
+    path: &Path,
+) -> Result<PreparedWorktreeTarget> {
     let requested = absolute_path(path)?;
     if let Ok(metadata) = std::fs::symlink_metadata(&requested)
         && metadata.file_type().is_symlink()
@@ -17,11 +31,18 @@ pub(crate) fn prepare_worktree_target(repo: &Repository, path: &Path) -> Result<
     }
     let resolved = canonicalize_existing_ancestor(&requested)?;
     validate_worktree_target(repo, &resolved)?;
+    // Capture pre-existence BEFORE we create the dir: this is the only
+    // point where "the user gave us an existing empty dir" vs "we made
+    // it" is still distinguishable.
+    let target_dir_created = !resolved.exists();
     std::fs::create_dir_all(&resolved).map_err(|error| {
         anyhow::anyhow!(worktree_target_prepare_failed_advice(&requested, error))
     })?;
     validate_worktree_target(repo, &resolved)?;
-    Ok(resolved)
+    Ok(PreparedWorktreeTarget {
+        path: resolved,
+        target_dir_created,
+    })
 }
 
 fn absolute_path(path: &Path) -> Result<PathBuf> {
@@ -229,6 +250,14 @@ pub(crate) fn write_isolated_checkout(
         pointer_file.sync_all()?;
     }
     std::fs::create_dir_all(heddle_dir.join("state"))?;
+    // Fault point for the partial-materialize rollback test (heddle#356):
+    // the checkout's `.heddle` metadata is already on disk here but no tree
+    // bytes are, modeling a materialize that fails partway. The transaction's
+    // checkout-rewind inverse must remove the whole created tree (incl
+    // `.heddle`) — or, for a user-supplied pre-existing dir, clear its
+    // contents. No-op in production (env var unset).
+    objects::fault_inject::maybe_fail_at("start_materialize_checkout")
+        .map_err(|error| anyhow::anyhow!(error))?;
 
     let checkout_head = heddle_dir.join("HEAD");
     let head_content = match thread {

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -23,6 +23,27 @@ pub(crate) fn prepare_worktree_target(
     repo: &Repository,
     path: &Path,
 ) -> Result<PreparedWorktreeTarget> {
+    let prepared = plan_worktree_target(repo, path)?;
+    let requested = absolute_path(path)?;
+    std::fs::create_dir_all(&prepared.path).map_err(|error| {
+        anyhow::anyhow!(worktree_target_prepare_failed_advice(&requested, error))
+    })?;
+    validate_worktree_target(repo, &prepared.path)?;
+    Ok(prepared)
+}
+
+/// Validate + resolve a `--path` target WITHOUT creating the directory, and
+/// report whether the resolved target is absent (so the caller can create it
+/// itself and know to remove it on rollback).
+///
+/// The atomic `thread start` path uses this so the target-dir creation happens
+/// *inside* the transaction (its first step), not before `execute` has a rewind
+/// ledger — otherwise a failure in the remaining pre-transaction work would
+/// orphan a directory this command created (heddle#356 cid 3333881552).
+pub(crate) fn plan_worktree_target(
+    repo: &Repository,
+    path: &Path,
+) -> Result<PreparedWorktreeTarget> {
     let requested = absolute_path(path)?;
     if let Ok(metadata) = std::fs::symlink_metadata(&requested)
         && metadata.file_type().is_symlink()
@@ -31,14 +52,11 @@ pub(crate) fn prepare_worktree_target(
     }
     let resolved = canonicalize_existing_ancestor(&requested)?;
     validate_worktree_target(repo, &resolved)?;
-    // Capture pre-existence BEFORE we create the dir: this is the only
-    // point where "the user gave us an existing empty dir" vs "we made
-    // it" is still distinguishable.
+    // Capture pre-existence: this is the only point where "the user gave us an
+    // existing empty dir" vs "we will create it" is still distinguishable. The
+    // creation itself is deferred to the caller (the transaction) so a failure
+    // before the dir is made leaves nothing to clean up.
     let target_dir_created = !resolved.exists();
-    std::fs::create_dir_all(&resolved).map_err(|error| {
-        anyhow::anyhow!(worktree_target_prepare_failed_advice(&requested, error))
-    })?;
-    validate_worktree_target(repo, &resolved)?;
     Ok(PreparedWorktreeTarget {
         path: resolved,
         target_dir_created,

--- a/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Implementation of `heddle start --hydrate` (heddle#302).
+//!
+//! An isolated `heddle start --path` checkout is a faithful *source*
+//! tree: ignored dependency directories (`node_modules`, `.venv`,
+//! `target/`, …) are correctly left out, because heddle never captures
+//! ignored paths. The cost is that the checkout isn't immediately
+//! buildable — you can't run `tsc`/`eslint`/tests to validate the change
+//! you isolated without first re-installing dependencies from scratch.
+//!
+//! `--hydrate` closes that gap: after the checkout is materialized, it
+//! **symlinks** the origin checkout's top-level ignored directories into
+//! the new checkout, so the isolated tree is buildable with the deps
+//! already present.
+//!
+//! ## Mechanism: symlink (not copy, not a hook)
+//!
+//! - **Symlink** keeps the "cheap isolated threads" property intact — a
+//!   `node_modules` can be many gigabytes; copying it per thread defeats
+//!   the point of a lightweight checkout. A symlink is O(1).
+//! - The links stay **ignored**, so the deps are never captured into
+//!   heddle (satisfying the issue's correctness AC). heddle's ignore
+//!   matcher probes directory entries with `is_dir = true`, so a
+//!   trailing-slash rule like `node_modules/` fires on the bare symlink
+//!   entry just as it does on a real directory (locked in by
+//!   heddle#303's regression tests).
+//! - A **copy** would be correct but expensive; a **post-checkout hook**
+//!   pushes the work back onto the user and isn't a first-class
+//!   affordance. Symlink is the ergonomic + correct middle ground.
+//!
+//! ## Atomicity (heddle#356)
+//!
+//! `--hydrate` is the last fallible leg of `thread start` and can fail on
+//! a host/filesystem that rejects directory symlinks. The whole start runs
+//! under the [`AtomicMutation`](repo::atomic) primitive, so the rollback is
+//! not hand-rolled here: the start mutation calls [`symlink_one`] inside a
+//! `Tx::step`, registering a precise unlink inverse per created link, and
+//! the checkout materialization registers its own dir-rewind inverse. A
+//! partial hydrate (k of N links made, the (k+1)-th fails) unwinds all k
+//! links AND the checkout, back to the exact pre-start state.
+//!
+//! ## Scope
+//!
+//! - Top-level ignored directories only. The dogfood case
+//!   (`node_modules` at the repo root) is covered; per-package
+//!   `node_modules` in a monorepo is not auto-discovered.
+//! - Admin directories (`.git`, `.heddle`) are never hydrated even
+//!   though they're ignored.
+//! - Bytes-on-disk thread modes only (solid / materialized). Virtualized
+//!   mounts project the captured tree and aren't hydrated.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use repo::Repository;
+
+/// Directories that are ignored but must never be hydrated: linking
+/// `.git` or `.heddle` into a checkout would cross-wire two repos'
+/// metadata.
+const ADMIN_DIRS: &[&str] = &[".git", ".heddle"];
+
+/// Enumerate the absolute paths of top-level directories in the origin
+/// checkout that are ignored (by `.gitignore` in git-overlay mode and/or
+/// `.heddleignore`) — the dependency/build dirs an isolated checkout
+/// omits. Admin dirs (`.git`, `.heddle`) are excluded. Results are
+/// sorted for deterministic output.
+pub(crate) fn hydratable_ignored_dirs(repo: &Repository) -> Result<Vec<PathBuf>> {
+    let patterns = repo.ignore_patterns()?;
+    let root = repo.root();
+
+    let read = std::fs::read_dir(root)
+        .with_context(|| format!("read origin checkout root '{}'", root.display()))?;
+
+    let mut dirs = Vec::new();
+    for entry in read {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if ADMIN_DIRS.contains(&name_str.as_ref()) {
+            continue;
+        }
+
+        // A dependency dir is either a real directory or a symlink that
+        // resolves to one (the origin itself may already be hydrated via
+        // a link, e.g. a pnpm store). Plain files (`.env`, `*.log`) are
+        // out of scope — the issue is specifically about deps *dirs*.
+        let file_type = entry.file_type()?;
+        let is_dir_like = file_type.is_dir() || (file_type.is_symlink() && entry.path().is_dir());
+        if !is_dir_like {
+            continue;
+        }
+
+        // `should_ignore` probes with `is_dir = true`, so a
+        // trailing-slash rule (`node_modules/`) fires on the bare
+        // directory entry — matching how heddle prunes ignored trees
+        // during capture (heddle#303).
+        if objects::worktree::should_ignore(Path::new(name_str.as_ref()), &patterns) {
+            dirs.push(entry.path());
+        }
+    }
+
+    dirs.sort();
+    Ok(dirs)
+}
+
+/// Decide whether `source` should be hydrated into `checkout`, returning
+/// the `(dest, link_name)` to create or `None` to skip. Skips a `source`
+/// with no final component, or a destination that already exists (captured
+/// or pre-staged) so we never clobber.
+///
+/// Separated from [`create_symlink`] so the start mutation can wrap ONLY
+/// the actual link creation in a forward-first `Tx::step`: the per-link
+/// unlink inverse is registered after the create succeeds, and a skipped
+/// `source` (`None`) never touches the rewind ledger.
+pub(crate) fn plan_link(checkout: &Path, source: &Path) -> Option<(PathBuf, String)> {
+    let name = source.file_name()?;
+    let dest = checkout.join(name);
+
+    // `symlink_metadata` (not `exists`) so a broken symlink or any
+    // already-present entry counts as a collision — we never clobber
+    // captured content or a user's pre-staged link.
+    if dest.symlink_metadata().is_ok() {
+        return None;
+    }
+
+    Some((dest, name.to_string_lossy().into_owned()))
+}
+
+/// Create one hydrate symlink: `dest` -> `source`. A single all-or-nothing
+/// filesystem op (the forward of a `Tx::step`); the caller registers
+/// [`unlink_hydrated`] as the inverse only after this returns `Ok`.
+pub(crate) fn create_symlink(source: &Path, dest: &Path) -> Result<()> {
+    symlink_dir(source, dest)
+        .with_context(|| format!("hydrate '{}' -> '{}'", dest.display(), source.display()))
+}
+
+/// Best-effort inverse of [`create_symlink`]: unlink a hydrate symlink this
+/// invocation created. Tolerant of a missing link — the checkout-rewind
+/// inverse (LIFO, after this) may already have removed the whole tree.
+pub(crate) fn unlink_hydrated(checkout: &Path, name: &str) -> std::io::Result<()> {
+    match std::fs::remove_file(checkout.join(name)) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Make the hydrated dep symlinks stay ignored in the isolated checkout.
+///
+/// The origin may ignore deps only via `.gitignore` (the common
+/// git-overlay setup). The isolated checkout has no `.git` and is
+/// reopened as a *native* heddle repo, whose ignore resolution reads
+/// `.heddleignore` — never `.gitignore`. Without preserving the rule the
+/// symlinked dep dirs surface as uncaptured *added* paths, and capture
+/// fails trying to follow the absolute link target out of the checkout.
+///
+/// We materialize the effective ignore rule for each linked name into
+/// the checkout's own `.heddleignore`, so the checkout is self-consistent
+/// regardless of which ignore source the origin used. Names already
+/// covered by an existing `.heddleignore` are left untouched. When we
+/// create the file from scratch it self-ignores, so the generated
+/// artifact does not itself surface as uncaptured content.
+pub(crate) fn preserve_hydrated_ignores(checkout: &Path, linked: &[String]) -> Result<()> {
+    if linked.is_empty() {
+        return Ok(());
+    }
+
+    let ignore_path = checkout.join(".heddleignore");
+    let existing = match std::fs::read_to_string(&ignore_path) {
+        Ok(contents) => Some(contents),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            return Err(err).with_context(|| format!("read '{}'", ignore_path.display()));
+        }
+    };
+
+    let patterns: Vec<String> = existing
+        .iter()
+        .flat_map(|c| c.lines())
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect();
+
+    let mut to_add: Vec<String> = Vec::new();
+
+    // When creating the file fresh, ignore it too — it's a hydration
+    // artifact local to this checkout, not source the user authored.
+    if existing.is_none() {
+        to_add.push(".heddleignore".to_string());
+    }
+
+    for name in linked {
+        // Already covered by the checkout's native ignore source? Leave
+        // the existing rule in place rather than appending a duplicate.
+        let mut probe = patterns.clone();
+        probe.extend(to_add.iter().cloned());
+        if objects::worktree::should_ignore(Path::new(name), &probe) {
+            continue;
+        }
+        // Trailing-slash (dir-only) rule mirrors how deps are ignored —
+        // it fires on the bare symlink entry (heddle#303).
+        to_add.push(format!("{name}/"));
+    }
+
+    if to_add.is_empty() {
+        return Ok(());
+    }
+
+    let mut out = existing.unwrap_or_default();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    for line in &to_add {
+        out.push_str(line);
+        out.push('\n');
+    }
+    std::fs::write(&ignore_path, out)
+        .with_context(|| format!("write hydrate ignore rules to '{}'", ignore_path.display()))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+    // Test seam: lets integration tests simulate a host/FS that rejects
+    // directory symlinks (Windows without the privilege, exotic FS) so
+    // the hydrate rollback contract is exercised on a platform that
+    // *does* support them. No-op in production (env var unset).
+    objects::fault_inject::maybe_fail_at("hydrate_symlink_dir")?;
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+    objects::fault_inject::maybe_fail_at("hydrate_symlink_dir")?;
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Link one source into the checkout via plan + create, mirroring the
+    /// start mutation's per-link `Tx::step`. Returns the linked name (or
+    /// `None` when the plan skipped a collision).
+    fn link_one(checkout: &Path, source: &Path) -> Option<String> {
+        let (dest, name) = plan_link(checkout, source)?;
+        create_symlink(source, &dest).unwrap();
+        Some(name)
+    }
+
+    #[test]
+    fn plan_link_links_source_and_skips_existing() {
+        let temp = TempDir::new().unwrap();
+        let origin = temp.path().join("origin");
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(origin.join("node_modules")).unwrap();
+        std::fs::create_dir_all(origin.join(".venv")).unwrap();
+        std::fs::create_dir_all(&checkout).unwrap();
+        // Pre-existing entry in the checkout must not be clobbered.
+        std::fs::create_dir_all(checkout.join(".venv")).unwrap();
+
+        let linked_nm = link_one(&checkout, &origin.join("node_modules"));
+        let skipped_venv = plan_link(&checkout, &origin.join(".venv"));
+
+        assert_eq!(linked_nm.as_deref(), Some("node_modules"));
+        assert!(skipped_venv.is_none(), "a colliding source links nothing");
+        let nm = checkout.join("node_modules");
+        assert!(
+            std::fs::symlink_metadata(&nm)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "node_modules should be a symlink"
+        );
+        assert_eq!(std::fs::read_link(&nm).unwrap(), origin.join("node_modules"));
+        // The pre-existing .venv stayed a real directory (not clobbered).
+        assert!(
+            !std::fs::symlink_metadata(checkout.join(".venv"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "pre-existing .venv must be preserved, not replaced by a link"
+        );
+    }
+
+    #[test]
+    fn unlink_hydrated_removes_link_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let origin = temp.path().join("origin");
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(origin.join("node_modules")).unwrap();
+        std::fs::create_dir_all(&checkout).unwrap();
+
+        link_one(&checkout, &origin.join("node_modules")).unwrap();
+        assert!(std::fs::symlink_metadata(checkout.join("node_modules")).is_ok());
+
+        unlink_hydrated(&checkout, "node_modules").unwrap();
+        assert!(
+            std::fs::symlink_metadata(checkout.join("node_modules")).is_err(),
+            "the hydrate link must be unlinked"
+        );
+        // The origin dir behind the link must survive (we unlink, never follow).
+        assert!(origin.join("node_modules").is_dir());
+        // Idempotent: unlinking an already-gone link is a no-op.
+        unlink_hydrated(&checkout, "node_modules").unwrap();
+    }
+}

--- a/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
@@ -139,11 +139,36 @@ pub(crate) fn create_symlink(source: &Path, dest: &Path) -> Result<()> {
 /// invocation created. Tolerant of a missing link — the checkout-rewind
 /// inverse (LIFO, after this) may already have removed the whole tree.
 pub(crate) fn unlink_hydrated(checkout: &Path, name: &str) -> std::io::Result<()> {
-    match std::fs::remove_file(checkout.join(name)) {
+    match remove_symlink_dir(&checkout.join(name)) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
     }
+}
+
+/// Remove a directory symlink created by [`create_symlink`]/[`symlink_dir`]. The
+/// forward always makes a *directory* symlink, and on Windows a directory
+/// symlink must be removed with `RemoveDirectory` (`remove_dir`) — `DeleteFile`
+/// (`remove_file`) errors on it, so the rollback would fail (heddle#356 cid
+/// 3333881572). On Unix a symlink (file or dir) is removed by `unlink`
+/// (`remove_file`).
+#[cfg(not(windows))]
+fn remove_symlink_dir(link: &Path) -> std::io::Result<()> {
+    std::fs::remove_file(link)
+}
+
+#[cfg(windows)]
+fn remove_symlink_dir(link: &Path) -> std::io::Result<()> {
+    std::fs::remove_dir(link)
+}
+
+/// The worktree-local, never-captured exclude file hydrate records its
+/// dep-ignore rules in — heddle's analogue of `.git/info/exclude`. It lives
+/// under the checkout's own `.heddle/` (which is always ignored), so writing to
+/// it never surfaces as worktree content. [`Repository::ignore_patterns`]
+/// reads it alongside `.heddleignore`.
+pub(crate) fn hydrate_exclude_path(checkout: &Path) -> PathBuf {
+    checkout.join(".heddle").join("info").join("exclude")
 }
 
 /// Make the hydrated dep symlinks stay ignored in the isolated checkout.
@@ -151,50 +176,52 @@ pub(crate) fn unlink_hydrated(checkout: &Path, name: &str) -> std::io::Result<()
 /// The origin may ignore deps only via `.gitignore` (the common
 /// git-overlay setup). The isolated checkout has no `.git` and is
 /// reopened as a *native* heddle repo, whose ignore resolution reads
-/// `.heddleignore` — never `.gitignore`. Without preserving the rule the
-/// symlinked dep dirs surface as uncaptured *added* paths, and capture
-/// fails trying to follow the absolute link target out of the checkout.
+/// `.heddleignore` + the worktree-local exclude — never `.gitignore`.
+/// Without preserving the rule the symlinked dep dirs surface as uncaptured
+/// *added* paths, and capture fails trying to follow the absolute link target
+/// out of the checkout.
 ///
-/// We materialize the effective ignore rule for each linked name into
-/// the checkout's own `.heddleignore`, so the checkout is self-consistent
-/// regardless of which ignore source the origin used. Names already
-/// covered by an existing `.heddleignore` are left untouched. When we
-/// create the file from scratch it self-ignores, so the generated
-/// artifact does not itself surface as uncaptured content.
+/// We materialize the rule for each linked name into the checkout's
+/// worktree-local exclude file ([`hydrate_exclude_path`]) — NOT the
+/// possibly-tracked `.heddleignore`. The exclude file is never captured, so a
+/// successful `start --hydrate` leaves the tracked tree clean even when the
+/// checkout already carries a tracked `.heddleignore` (heddle#356 cid
+/// 3333881577). Names already covered by the checkout's `.heddleignore` or a
+/// prior exclude entry are skipped rather than duplicated.
 pub(crate) fn preserve_hydrated_ignores(checkout: &Path, linked: &[String]) -> Result<()> {
     if linked.is_empty() {
         return Ok(());
     }
 
-    let ignore_path = checkout.join(".heddleignore");
-    let existing = match std::fs::read_to_string(&ignore_path) {
-        Ok(contents) => Some(contents),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
-        Err(err) => {
-            return Err(err).with_context(|| format!("read '{}'", ignore_path.display()));
+    let read_opt = |path: &Path| -> Result<Option<String>> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err).with_context(|| format!("read '{}'", path.display())),
         }
     };
+    let active_patterns = |contents: &Option<String>| -> Vec<String> {
+        contents
+            .iter()
+            .flat_map(|c| c.lines())
+            .map(str::trim)
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(str::to_string)
+            .collect()
+    };
 
-    let patterns: Vec<String> = existing
-        .iter()
-        .flat_map(|c| c.lines())
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .map(str::to_string)
-        .collect();
+    // Rules already in force via the checkout's tracked `.heddleignore` plus any
+    // prior exclude entries — a dep already covered needs no new rule.
+    let tracked = read_opt(&checkout.join(".heddleignore"))?;
+    let exclude_path = hydrate_exclude_path(checkout);
+    let existing_exclude = read_opt(&exclude_path)?;
+
+    let mut covered: Vec<String> = active_patterns(&tracked);
+    covered.extend(active_patterns(&existing_exclude));
 
     let mut to_add: Vec<String> = Vec::new();
-
-    // When creating the file fresh, ignore it too — it's a hydration
-    // artifact local to this checkout, not source the user authored.
-    if existing.is_none() {
-        to_add.push(".heddleignore".to_string());
-    }
-
     for name in linked {
-        // Already covered by the checkout's native ignore source? Leave
-        // the existing rule in place rather than appending a duplicate.
-        let mut probe = patterns.clone();
+        let mut probe = covered.clone();
         probe.extend(to_add.iter().cloned());
         if objects::worktree::should_ignore(Path::new(name), &probe) {
             continue;
@@ -208,7 +235,11 @@ pub(crate) fn preserve_hydrated_ignores(checkout: &Path, linked: &[String]) -> R
         return Ok(());
     }
 
-    let mut out = existing.unwrap_or_default();
+    if let Some(parent) = exclude_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create '{}'", parent.display()))?;
+    }
+    let mut out = existing_exclude.unwrap_or_default();
     if !out.is_empty() && !out.ends_with('\n') {
         out.push('\n');
     }
@@ -216,8 +247,8 @@ pub(crate) fn preserve_hydrated_ignores(checkout: &Path, linked: &[String]) -> R
         out.push_str(line);
         out.push('\n');
     }
-    std::fs::write(&ignore_path, out)
-        .with_context(|| format!("write hydrate ignore rules to '{}'", ignore_path.display()))?;
+    std::fs::write(&exclude_path, out)
+        .with_context(|| format!("write hydrate ignore rules to '{}'", exclude_path.display()))?;
     Ok(())
 }
 
@@ -307,5 +338,33 @@ mod tests {
         assert!(origin.join("node_modules").is_dir());
         // Idempotent: unlinking an already-gone link is a no-op.
         unlink_hydrated(&checkout, "node_modules").unwrap();
+    }
+
+    /// heddle#356 cid 3333881572: on Windows a *directory* symlink must be
+    /// removed with `RemoveDirectory` (`remove_dir`) — `DeleteFile`
+    /// (`remove_file`) errors on it, so the rollback would fail. The forward
+    /// always creates a directory symlink, so the inverse must use the dir
+    /// remover. (Gated to Windows; on Unix the same contract is covered by
+    /// `unlink_hydrated_removes_link_and_is_idempotent`, which unlinks a dir
+    /// symlink via `remove_file`.)
+    #[cfg(windows)]
+    #[test]
+    fn unlink_hydrated_removes_directory_symlink_on_windows() {
+        let temp = TempDir::new().unwrap();
+        let origin = temp.path().join("origin");
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(origin.join("node_modules")).unwrap();
+        std::fs::create_dir_all(&checkout).unwrap();
+
+        // Create a directory symlink exactly like the hydrate forward does.
+        symlink_dir(&origin.join("node_modules"), &checkout.join("node_modules")).unwrap();
+        assert!(std::fs::symlink_metadata(checkout.join("node_modules")).is_ok());
+
+        unlink_hydrated(&checkout, "node_modules").unwrap();
+        assert!(
+            std::fs::symlink_metadata(checkout.join("node_modules")).is_err(),
+            "a directory symlink must be removed on rollback (remove_dir, not remove_file)"
+        );
+        assert!(origin.join("node_modules").is_dir(), "the link target must survive");
     }
 }

--- a/crates/cli/src/cli/commands/worktree_cmd/mod.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/mod.rs
@@ -2,4 +2,5 @@
 //! Internal helpers for materialized thread checkouts.
 
 pub(crate) mod helpers;
+pub(crate) mod hydrate;
 pub(crate) mod shared_target;

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -1028,7 +1028,7 @@ impl HarnessBridgeRuntime {
             // wiring before they can become the default execution root.
             ThreadMode::Virtualized => default_private_thread_path(&self.repo, name),
         };
-        let abs_path = prepare_worktree_target(&self.repo, &path)?;
+        let abs_path = prepare_worktree_target(&self.repo, &path)?.path;
         write_isolated_checkout(&self.repo, &abs_path, &base_state, Some(name))?;
 
         let base_state_obj = self

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -54,6 +54,8 @@ mod git_overlay_sync_adoption;
 mod git_replacement_matrix;
 #[path = "cli_integration/hooks.rs"]
 mod hooks;
+#[path = "cli_integration/hydrate.rs"]
+mod hydrate;
 #[path = "cli_integration/misc.rs"]
 mod misc;
 #[path = "cli_integration/oss_cli_polish.rs"]

--- a/crates/cli/tests/cli_integration/hydrate.rs
+++ b/crates/cli/tests/cli_integration/hydrate.rs
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end coverage of `heddle start --hydrate` + the atomic start
+//! rollback (heddle#302 / heddle#356).
+//!
+//! `--hydrate` symlinks the origin checkout's top-level ignored
+//! dependency directories (`node_modules`, `.venv`, …) into a fresh
+//! isolated checkout so it's immediately buildable. The whole `start`
+//! write-path runs as one atomic transaction on the heddle#330 primitive,
+//! so a failure mid-materialize (or mid-hydrate) rewinds every applied
+//! effect — with precise directory + symlink rewind — back to the exact
+//! pre-start state. These tests run the built `heddle` binary inside temp
+//! dirs and inspect what `start` leaves on disk.
+
+use super::*;
+
+/// Seed a project whose dependencies live in ignored directories.
+/// `.heddleignore` is itself tracked (no rule covers it), so it
+/// materializes into every thread checkout and the same ignore rules
+/// apply there.
+fn init_deps_in_ignored_dir_project(dir: &std::path::Path) {
+    std::fs::write(dir.join(".heddleignore"), "node_modules/\n.venv/\n").unwrap();
+    // A tracked source file so the checkout has real captured content.
+    std::fs::write(dir.join("index.ts"), "export const x = 1;\n").unwrap();
+
+    // Populated ignored dependency dirs in the origin.
+    let node_modules = dir.join("node_modules");
+    std::fs::create_dir_all(node_modules.join("left-pad")).unwrap();
+    std::fs::write(
+        node_modules.join("left-pad").join("index.js"),
+        "module.exports = () => {};\n",
+    )
+    .unwrap();
+
+    let venv = dir.join(".venv");
+    std::fs::create_dir_all(venv.join("bin")).unwrap();
+    std::fs::write(venv.join("bin").join("python"), "#!/bin/sh\n").unwrap();
+}
+
+/// Set up a git-overlay heddle repo whose dependency dirs are ignored
+/// ONLY via `.gitignore` (no `.heddleignore` anywhere) — the common
+/// drop-in git-overlay setup. The origin's effective ignore set includes
+/// `.gitignore` because the repo is in git-overlay mode; the isolated
+/// checkout reopened as a native heddle repo does NOT read `.gitignore`.
+fn init_gitignore_only_overlay_project(dir: &std::path::Path) {
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git should run");
+        assert!(status.success(), "git {args:?} should succeed");
+    };
+    git(&["init"]);
+    git(&["config", "user.name", "Heddle Test"]);
+    git(&["config", "user.email", "heddle@example.com"]);
+    git(&["checkout", "-b", "main"]);
+
+    // Deps ignored ONLY via .gitignore — deliberately no .heddleignore.
+    std::fs::write(dir.join(".gitignore"), "node_modules/\n.venv/\n").unwrap();
+    std::fs::write(dir.join("index.ts"), "export const x = 1;\n").unwrap();
+
+    let node_modules = dir.join("node_modules");
+    std::fs::create_dir_all(node_modules.join("left-pad")).unwrap();
+    std::fs::write(
+        node_modules.join("left-pad").join("index.js"),
+        "module.exports = () => {};\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn hydrate_preserves_gitignore_only_ignores_in_isolated_checkout() {
+    // P1 (cid 3327140634): in a git-overlay repo that ignores deps ONLY
+    // via `.gitignore`, the isolated checkout is reopened as a native
+    // heddle repo whose ignore resolution reads `.heddleignore`, not
+    // `.gitignore`. hydrate must materialize the ignore rule into the
+    // checkout's native source so the symlinked dep dirs stay ignored —
+    // otherwise they surface as added symlinks and capture fails on the
+    // absolute, out-of-checkout link target.
+    let temp = TempDir::new().unwrap();
+    init_gitignore_only_overlay_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    // A git-overlay repo refuses to start a thread inside itself, so the
+    // isolated checkout lives in a sibling temp dir.
+    let checkout_root = TempDir::new().unwrap();
+    let thread_path = checkout_root.path().join("iso");
+    heddle(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+    )
+    .expect("start --hydrate should succeed");
+
+    // The dep dir is hydrated as a symlink...
+    let linked = thread_path.join("node_modules");
+    assert!(
+        std::fs::symlink_metadata(&linked)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        "node_modules should be hydrated as a symlink"
+    );
+
+    // ...and IGNORED in the isolated checkout even though the origin
+    // expressed the rule only via `.gitignore`: `status` from the
+    // checkout must not surface it as added worktree content.
+    let status = heddle(&["status"], Some(&thread_path))
+        .expect("status should run from the hydrated checkout");
+    assert!(
+        !status.contains("node_modules"),
+        "hydrated node_modules must stay ignored in a .gitignore-only overlay; got:\n{status}"
+    );
+
+    // Capture must not choke on the absolute, out-of-checkout link
+    // target — the ignored link is pruned before capture follows it.
+    heddle(&["capture", "-m", "iso work"], Some(&thread_path))
+        .expect("capture in the hydrated checkout must succeed");
+}
+
+#[test]
+fn hydrate_symlinks_ignored_dep_dirs_into_checkout() {
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso");
+    heddle(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+    )
+    .expect("start --hydrate should succeed");
+
+    // node_modules is a symlink in the checkout, pointing at the origin.
+    let linked = thread_path.join("node_modules");
+    let meta = std::fs::symlink_metadata(&linked)
+        .unwrap_or_else(|e| panic!("expected node_modules symlink at {}: {e}", linked.display()));
+    assert!(
+        meta.file_type().is_symlink(),
+        "node_modules must be a symlink, not a real dir"
+    );
+    let target = std::fs::read_link(&linked).unwrap();
+    assert!(
+        target.is_absolute(),
+        "hydrate link target should be absolute, got {}",
+        target.display()
+    );
+
+    // Dependency content is reachable through the link — the whole point
+    // is that the checkout is buildable without reinstalling.
+    let dep_file = linked.join("left-pad").join("index.js");
+    assert!(
+        dep_file.is_file(),
+        "dependency file must be reachable through the link: {}",
+        dep_file.display()
+    );
+
+    // .venv is hydrated too (multiple ignored dep dirs).
+    assert!(
+        std::fs::symlink_metadata(thread_path.join(".venv"))
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        ".venv should also be hydrated"
+    );
+
+    // Tracked source still materializes as a real file, not a link.
+    let src = thread_path.join("index.ts");
+    assert!(src.is_file());
+    assert!(
+        !std::fs::symlink_metadata(&src)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "tracked source must be a real captured file, not a symlink"
+    );
+}
+
+#[test]
+fn hydrate_symlink_failure_leaves_no_partial_thread() {
+    // P2 (cid 3327247262): on a host/filesystem that REJECTS directory
+    // symlinks (Windows without the privilege, or an FS that doesn't
+    // support dir symlinks), the symlink step fails AFTER the thread
+    // ref + checkout were created — leaving a half-started thread.
+    // `start --hydrate` must be atomic: either it fully succeeds, or it
+    // fails cleanly with NO partial thread/checkout left behind.
+    //
+    // We simulate the unsupported-symlink host with the
+    // `hydrate_symlink_dir` fault checkpoint so the contract is
+    // exercised even on a platform that natively supports dir symlinks.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso");
+    let output = heddle_output_with_env(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_FAULT_INJECT", "hydrate_symlink_dir")],
+    )
+    .expect("the heddle binary should run");
+
+    // (a) The command fails cleanly...
+    assert!(
+        !output.status.success(),
+        "start --hydrate must fail when directory symlinks are rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("directory symlink"),
+        "error must name the platform/FS limitation (directory symlinks); got:\n{stderr}"
+    );
+
+    // (b) ...and leaves NO half-started thread or checkout — the repo is
+    // as if `start` never ran.
+    assert!(
+        std::fs::symlink_metadata(&thread_path).is_err(),
+        "a hydrate failure must not leave the partially-materialized checkout at {}",
+        thread_path.display()
+    );
+    let list = heddle(&["thread", "list"], Some(temp.path()))
+        .expect("thread list should run after the rolled-back start");
+    assert!(
+        !list.contains("iso"),
+        "a hydrate failure must not leave a dangling thread ref; got:\n{list}"
+    );
+}
+
+#[test]
+fn hydrate_symlink_failure_removes_self_created_target_dir() {
+    // Case (a): `--path` points at a directory that did NOT exist before
+    // this invocation. A symlink failure rolls back by removing the dir
+    // entirely — it was created by this `start`, so "didn't exist" is the
+    // correct pre-start state to restore.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso-new");
+    assert!(
+        std::fs::symlink_metadata(&thread_path).is_err(),
+        "precondition: target dir must not exist before start"
+    );
+
+    let output = heddle_output_with_env(
+        &[
+            "start",
+            "iso-new",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_FAULT_INJECT", "hydrate_symlink_dir")],
+    )
+    .expect("the heddle binary should run");
+
+    assert!(
+        !output.status.success(),
+        "start --hydrate must fail when directory symlinks are rejected"
+    );
+    assert!(
+        std::fs::symlink_metadata(&thread_path).is_err(),
+        "a self-created target dir must be removed entirely on rollback: {}",
+        thread_path.display()
+    );
+}
+
+#[test]
+fn hydrate_symlink_failure_preserves_preexisting_empty_target_dir() {
+    // Case (b): `--path` points at an empty directory the USER created
+    // before running `start`. A symlink failure must roll back the
+    // contents this invocation materialized WITHOUT destroying the
+    // user-provided directory — restoring it to the empty dir they gave us
+    // (cid 3327521537). Blanket-deleting the dir would obliterate user
+    // state this command never created.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    // The user pre-creates an empty dir and hands it to `--path`.
+    let thread_path = temp.path().join("iso-existing");
+    std::fs::create_dir(&thread_path).unwrap();
+
+    let output = heddle_output_with_env(
+        &[
+            "start",
+            "iso-existing",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_FAULT_INJECT", "hydrate_symlink_dir")],
+    )
+    .expect("the heddle binary should run");
+
+    assert!(
+        !output.status.success(),
+        "start --hydrate must fail when directory symlinks are rejected"
+    );
+
+    // The user's directory must STILL EXIST...
+    let meta = std::fs::symlink_metadata(&thread_path).unwrap_or_else(|e| {
+        panic!(
+            "a pre-existing user dir must NOT be deleted on rollback ({}): {e}",
+            thread_path.display()
+        )
+    });
+    assert!(
+        meta.is_dir(),
+        "the pre-existing target must remain a directory after rollback"
+    );
+
+    // ...and be EMPTY again — every entry this invocation materialized
+    // (the .heddle metadata, the checkout, any partial symlinks) cleared.
+    let remaining: Vec<_> = std::fs::read_dir(&thread_path)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        remaining.is_empty(),
+        "rollback must clear materialized contents from a pre-existing dir, leaving it empty; \
+         found: {remaining:?}"
+    );
+
+    // And no dangling thread ref, same as the self-created case.
+    let list = heddle(&["thread", "list"], Some(temp.path()))
+        .expect("thread list should run after the rolled-back start");
+    assert!(
+        !list.contains("iso-existing"),
+        "a hydrate failure must not leave a dangling thread ref; got:\n{list}"
+    );
+}
+
+#[test]
+fn hydrate_does_not_link_admin_dirs() {
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso");
+    heddle(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    // `.heddle` is ignored at the origin but must never be hydrated —
+    // linking it into a checkout would cross-wire two repos' metadata.
+    let heddle_link = thread_path.join(".heddle");
+    if let Ok(meta) = std::fs::symlink_metadata(&heddle_link) {
+        assert!(
+            !meta.file_type().is_symlink(),
+            ".heddle must never be hydrated as a symlink"
+        );
+    }
+}
+
+#[test]
+fn no_hydrate_flag_means_no_links() {
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("plain");
+    heddle(
+        &["start", "plain", "--path", thread_path.to_str().unwrap()],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    assert!(
+        std::fs::symlink_metadata(thread_path.join("node_modules")).is_err(),
+        "without --hydrate, node_modules must not be linked into the checkout"
+    );
+}
+
+#[test]
+fn hydrated_deps_stay_ignored_in_checkout() {
+    // AC: hydrated deps are not captured into heddle. The symlinked
+    // node_modules name matches the checkout's own `.heddleignore` rule,
+    // so `status` from inside the checkout must not surface it as
+    // uncaptured worktree content.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso");
+    heddle(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    let status = heddle(&["status"], Some(&thread_path))
+        .expect("status should run from the hydrated checkout");
+    assert!(
+        !status.contains("node_modules"),
+        "hydrated node_modules must stay ignored (not reported by status); got:\n{status}"
+    );
+}
+
+#[test]
+fn start_partial_materialize_rolls_back_self_created_dir() {
+    // heddle#356: a failure PARTWAY THROUGH the checkout materialize (the
+    // `.heddle` metadata is on disk but the tree bytes are not) must rewind
+    // the whole created checkout — the self-created target dir is removed
+    // wholesale, and no `.heddle` is left behind. Pre-migration this left a
+    // half-written checkout + a dangling thread ref; post-migration the repo
+    // is as if `start` never ran.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso");
+    let output = heddle_output_with_env(
+        &["start", "iso", "--path", thread_path.to_str().unwrap()],
+        Some(temp.path()),
+        &[("HEDDLE_FAULT_INJECT", "start_materialize_checkout")],
+    )
+    .expect("the heddle binary should run");
+
+    assert!(
+        !output.status.success(),
+        "a mid-materialize fault must fail the start"
+    );
+    // The created checkout dir (and its partial `.heddle`) is fully removed.
+    assert!(
+        std::fs::symlink_metadata(&thread_path).is_err(),
+        "a partial materialize must remove the self-created checkout dir: {}",
+        thread_path.display()
+    );
+    // No dangling thread ref.
+    let list = heddle(&["thread", "list"], Some(temp.path()))
+        .expect("thread list should run after the rolled-back start");
+    assert!(
+        !list.contains("iso"),
+        "a materialize fault must not leave a dangling thread ref; got:\n{list}"
+    );
+}
+
+#[test]
+fn start_partial_materialize_preserves_preexisting_empty_dir() {
+    // heddle#356, mirror of the hydrate case: a mid-materialize fault into a
+    // USER-supplied empty `--path` dir must clear only the contents this
+    // invocation wrote (the partial `.heddle`), never delete the directory
+    // the user created.
+    let temp = TempDir::new().unwrap();
+    init_deps_in_ignored_dir_project(temp.path());
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let thread_path = temp.path().join("iso-existing");
+    std::fs::create_dir(&thread_path).unwrap();
+
+    let output = heddle_output_with_env(
+        &[
+            "start",
+            "iso-existing",
+            "--path",
+            thread_path.to_str().unwrap(),
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_FAULT_INJECT", "start_materialize_checkout")],
+    )
+    .expect("the heddle binary should run");
+
+    assert!(
+        !output.status.success(),
+        "a mid-materialize fault must fail the start"
+    );
+    let meta = std::fs::symlink_metadata(&thread_path).unwrap_or_else(|e| {
+        panic!(
+            "a pre-existing user dir must NOT be deleted on rollback ({}): {e}",
+            thread_path.display()
+        )
+    });
+    assert!(meta.is_dir(), "the pre-existing target must remain a directory");
+    let remaining: Vec<_> = std::fs::read_dir(&thread_path)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        remaining.is_empty(),
+        "rollback must clear materialized contents from a pre-existing dir; found: {remaining:?}"
+    );
+    let list = heddle(&["thread", "list"], Some(temp.path()))
+        .expect("thread list should run after the rolled-back start");
+    assert!(
+        !list.contains("iso-existing"),
+        "a materialize fault must not leave a dangling thread ref; got:\n{list}"
+    );
+}

--- a/crates/cli/tests/cli_integration/hydrate.rs
+++ b/crates/cli/tests/cli_integration/hydrate.rs
@@ -124,6 +124,99 @@ fn hydrate_preserves_gitignore_only_ignores_in_isolated_checkout() {
 }
 
 #[test]
+fn hydrate_does_not_dirty_a_tracked_heddleignore() {
+    // heddle#356 cid 3333881577: a git-overlay repo that tracks a root
+    // `.heddleignore` (covering unrelated paths) while ignoring deps via
+    // `.gitignore`. The isolated checkout materializes that TRACKED
+    // `.heddleignore`, so `existing` is `Some`. hydrate must record the
+    // dep-ignore rule in the worktree-local, never-captured exclude file —
+    // NOT by appending to the tracked `.heddleignore` — so a successful
+    // `start --hydrate` leaves the checkout's tracked tree clean.
+    let temp = TempDir::new().unwrap();
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .status()
+            .expect("git should run");
+        assert!(status.success(), "git {args:?} should succeed");
+    };
+    git(&["init"]);
+    git(&["config", "user.name", "Heddle Test"]);
+    git(&["config", "user.email", "heddle@example.com"]);
+    git(&["checkout", "-b", "main"]);
+
+    // Deps ignored via `.gitignore`; a TRACKED `.heddleignore` with an
+    // unrelated rule that does NOT cover the deps.
+    std::fs::write(temp.path().join(".gitignore"), "node_modules/\n").unwrap();
+    std::fs::write(temp.path().join(".heddleignore"), "*.log\n").unwrap();
+    std::fs::write(temp.path().join("index.ts"), "export const x = 1;\n").unwrap();
+    let node_modules = temp.path().join("node_modules");
+    std::fs::create_dir_all(node_modules.join("left-pad")).unwrap();
+    std::fs::write(
+        node_modules.join("left-pad").join("index.js"),
+        "module.exports = () => {};\n",
+    )
+    .unwrap();
+
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "main"], Some(temp.path())).unwrap();
+
+    let checkout_root = TempDir::new().unwrap();
+    let thread_path = checkout_root.path().join("iso");
+    heddle(
+        &[
+            "start",
+            "iso",
+            "--path",
+            thread_path.to_str().unwrap(),
+            "--hydrate",
+        ],
+        Some(temp.path()),
+    )
+    .expect("start --hydrate should succeed");
+
+    // node_modules is hydrated as a symlink...
+    assert!(
+        std::fs::symlink_metadata(thread_path.join("node_modules"))
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        "node_modules should be hydrated as a symlink"
+    );
+
+    // ...and the TRACKED `.heddleignore` is byte-for-byte UNCHANGED (pre-fix
+    // hydrate appended `node_modules/` to it, dirtying the tracked tree).
+    let checkout_ignore = std::fs::read_to_string(thread_path.join(".heddleignore")).unwrap();
+    assert_eq!(
+        checkout_ignore, "*.log\n",
+        "hydrate must not modify the tracked .heddleignore"
+    );
+
+    // The dep-ignore rule landed in the worktree-local, never-captured exclude.
+    let exclude = std::fs::read_to_string(
+        thread_path.join(".heddle").join("info").join("exclude"),
+    )
+    .expect("hydrate should write the worktree-local exclude");
+    assert!(
+        exclude.contains("node_modules"),
+        "the dep-ignore rule must live in the worktree-local exclude; got:\n{exclude}"
+    );
+
+    // `status` from the checkout is clean: the dep stays ignored, and the
+    // tracked `.heddleignore` is not reported as modified.
+    let status = heddle(&["status"], Some(&thread_path))
+        .expect("status should run from the hydrated checkout");
+    assert!(
+        !status.contains("node_modules"),
+        "hydrated node_modules must stay ignored in the checkout; got:\n{status}"
+    );
+
+    // Capture must not choke on the absolute, out-of-checkout link target.
+    heddle(&["capture", "-m", "iso work"], Some(&thread_path))
+        .expect("capture in the hydrated checkout must succeed");
+}
+
+#[test]
 fn hydrate_symlinks_ignored_dep_dirs_into_checkout() {
     let temp = TempDir::new().unwrap();
     init_deps_in_ignored_dir_project(temp.path());

--- a/crates/objects/src/fault_inject.rs
+++ b/crates/objects/src/fault_inject.rs
@@ -71,6 +71,26 @@ pub fn maybe_panic_at(name: &str) {
     }
 }
 
+/// Like [`maybe_panic_at`], but returns an `io::Error` instead of
+/// panicking — for exercising *in-process* error-recovery paths (a
+/// graceful failure that drives a rollback) rather than crash recovery.
+///
+/// Production callers thread this where a returned error must unwind a
+/// partially-applied operation; tests opt in by listing the checkpoint
+/// name in `HEDDLE_FAULT_INJECT` and assert the rollback left no
+/// partial state. With the env var unset the cached `None`
+/// short-circuits, exactly like [`maybe_panic_at`].
+pub fn maybe_fail_at(name: &str) -> std::io::Result<()> {
+    if let Some(points) = active_points().as_ref()
+        && points.iter().any(|active| active == name)
+    {
+        return Err(std::io::Error::other(format!(
+            "HEDDLE_FAULT_INJECT: failing at checkpoint `{name}` (intentional)"
+        )));
+    }
+    Ok(())
+}
+
 /// Test-only helper: clear the cached env-var read so a single
 /// process can re-parse `HEDDLE_FAULT_INJECT` between phases. Not
 /// for production use — the cache is what makes the production

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1787,6 +1787,17 @@ impl Repository {
             patterns.push(".git".to_string());
             append_ignore_file_patterns(&mut patterns, &self.root.join(".gitignore"))?;
         }
+        // Worktree-local, never-captured excludes (heddle's analogue of
+        // `.git/info/exclude`). Lives under THIS worktree's own `.heddle/`
+        // (`root/.heddle`, which is local even for a shared-store checkout), so
+        // it is never captured. Lets `start --hydrate` ignore symlinked deps
+        // without dirtying a tracked `.heddleignore` (heddle#356 cid 3333881577).
+        // `append_ignore_file_patterns` no-ops when the file is absent — the
+        // common case for a plain repo.
+        append_ignore_file_patterns(
+            &mut patterns,
+            &self.root.join(".heddle").join("info").join("exclude"),
+        )?;
         let path = self.root.join(".heddleignore");
 
         if path.exists() {


### PR DESCRIPTION
## Summary

Migrates the `thread start` write-path (including `start --path` / `--hydrate`) onto the heddle#330 `AtomicMutation` primitive (impl-a #354, impl-b #355), making the whole operation **all-or-nothing**: a failure anywhere mid-materialize rewinds every applied effect — with **precise directory rewind** — back to the exact pre-start state.

- New `start_atomic::StartThread` mutation wraps the entire write-path in `execute(|tx| …)`. Each independently-failable effect registers its own ledger inverse:
  - **Atomic single writes** (thread-ref CAS) → `Tx::step` (forward-first).
  - **Non-atomic / partial-failure-prone effects** (checkout materialize, manifest sidecar, cargo-config redirect, each `--hydrate` symlink) → `Tx::step_nonatomic` (capture-restore) / `Tx::step` per-symlink.
  - **Thread-record writes** → `ThreadManager::converge_records` (the impl-b lock-atomic chokepoint).
  - The oplog `ThreadCreateV2` is the **staged commit record** appended once at the single commit point (no longer a direct mid-`apply` oplog write).
- **Precise directory rewind**: a self-created checkout dir is removed wholesale; a user-supplied pre-existing empty `--path` dir is only cleared of what this invocation wrote (never deleted). Each hydrate symlink gets its own unlink inverse, so a partial hydrate (k of N links, the (k+1)-th fails) unwinds all k created links **and** the checkout.
- **Absorbs and reworks** the `start --hydrate` symlink logic under the primitive, **superseding draft PR #324** — its hand-rolled `rollback_started_thread` is replaced by per-effect ledger inverses; #324's tests are ported/adapted. Closes #302.

## Test plan

- [x] **Partial materialize rollback** (binary + in-process): a mid-checkout-materialize fault removes the self-created checkout (incl `.heddle`), HEAD/refs restored, no dangling thread ref; a pre-existing empty `--path` dir is preserved and only emptied.
- [x] **Partial hydrate rollback** (binary + in-process): the (k+1)-th symlink fails → all k created links unwound + checkout removed + ref rolled back; origin dep dirs untouched.
- [x] **Happy path**: start + full hydrate → checkout materialized, all symlinks present, record via `converge_records`, oplog committed exactly once.
- [x] #324's adapted hydrate tests green (gitignore-only overlay, admin-dir exclusion, stays-ignored, no-flag-no-links).
- [x] Existing thread-start + #354/#355 atomic suites green (undo_apply ×23, repo `atomic::` ×48, undo/redo workflow).
- [x] CI parity (local, all once): `check-no-silent-default-tree-load.sh`, `cargo test --workspace` (3567 passed / 0 failed), `cargo clippy --workspace --all-targets -D warnings`, `cargo build -p heddle-cli`, `doctor docs --all` (no issues), `doctor schemas` (no drift).

Closes #356. Supersedes #324 (do not separately merge). Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905220&installation_id=132405951&pr_number=383&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F383&signature=c910f13e14dc6eaa626fdaf41dc7da6ac98e1e5c0f427883f6cd68225c9da806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->