### PR TITLE
heddle#358: migrate op-id reserve to EagerMutation (eager-commit exemplar)

### DIFF
--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -11,13 +11,15 @@
 //! generate and save an op-id for interrupted retry loops. Current
 //! explicit replay support does not imply generated persistence.
 
-use std::{io::Write, path::PathBuf, process::Command, str::FromStr};
+use std::{io::Write, path::PathBuf, process::Command, str::FromStr, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
 use objects::object::OperationId;
 use repo::{
     Repository,
-    operation_dedup::{DedupOutcome, OperationDedupStore, hash_request_body},
+    operation_dedup::{
+        DedupOutcome, OperationDedupStore, hash_request_body, reserve_operation_id_eager,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -87,12 +89,16 @@ pub fn run_local_idempotency_if_requested(
             .as_ref()
             .map(|scope| scope.hash_material.as_str()),
     )?;
+    let repo_for_eager;
     let store = if bootstrap_store {
         let scope = bootstrap_scope
             .as_ref()
             .expect("bootstrap scope should be present for bootstrap store");
-        OperationDedupStore::open(bootstrap_op_id_store_dir(scope))
-            .context("open bootstrap op-id dedup store")?
+        repo_for_eager = None;
+        Arc::new(
+            OperationDedupStore::open(bootstrap_op_id_store_dir(scope))
+                .context("open bootstrap op-id dedup store")?,
+        )
     } else {
         let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
         let bootstrap_scope = bootstrap_op_id_scope_for_root(repo.root().to_path_buf())?;
@@ -108,11 +114,21 @@ pub fn run_local_idempotency_if_requested(
                 Some(existing),
             )));
         }
-        OperationDedupStore::open(repo.heddle_dir()).context("open op-id dedup store")?
+        let store = Arc::new(
+            OperationDedupStore::open(repo.heddle_dir()).context("open op-id dedup store")?,
+        );
+        repo_for_eager = Some(repo);
+        store
     };
     let json_mode = explicit_json_requested(cli);
 
-    match store.reserve(op_id, command_name, request_hash)? {
+    let reserve_outcome = if let Some(repo) = repo_for_eager.as_ref() {
+        reserve_operation_id_eager(repo, Arc::clone(&store), op_id, command_name, request_hash)?
+    } else {
+        store.reserve(op_id, command_name, request_hash)?
+    };
+
+    match reserve_outcome {
         DedupOutcome::Replay { response } => {
             let replay: LocalOpIdResponse =
                 serde_json::from_slice(&response).context("decode cached op-id response")?;

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -242,7 +242,7 @@ impl DiscussionService for LocalDiscussionService {
         let inner = self.inner.clone();
 
         let result = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op_id,
             "discussion.open",
             &req_bytes,
@@ -317,7 +317,7 @@ impl DiscussionService for LocalDiscussionService {
         let inner = self.inner.clone();
 
         let result = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op_id,
             "discussion.append_turn",
             &req_bytes,
@@ -377,7 +377,7 @@ impl DiscussionService for LocalDiscussionService {
         let inner = self.inner.clone();
 
         let result = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op_id,
             "discussion.resolve",
             &req_bytes,

--- a/crates/daemon/src/grpc_local_impl/hook.rs
+++ b/crates/daemon/src/grpc_local_impl/hook.rs
@@ -174,11 +174,10 @@ impl HookService for LocalHookService {
         let req = request.into_inner();
         let body = req.encode_to_vec();
         let heddle_dir = self.inner.repo().heddle_dir().to_path_buf();
-        let dedup = self.inner.dedup();
         let client_op = req.client_operation_id.clone();
 
         let result = with_idempotency(
-            dedup,
+            &self.inner,
             &client_op,
             "hook.register_hook",
             &body,
@@ -224,10 +223,9 @@ impl HookService for LocalHookService {
         let req = request.into_inner();
         let body = req.encode_to_vec();
         let heddle_dir = self.inner.repo().heddle_dir().to_path_buf();
-        let dedup = self.inner.dedup();
         let client_op = req.client_operation_id.clone();
         let result = with_idempotency(
-            dedup,
+            &self.inner,
             &client_op,
             "hook.deregister_hook",
             &body,
@@ -317,11 +315,10 @@ impl HookService for LocalHookService {
     ) -> Result<Response<RespondToHookResponse>, Status> {
         let req = request.into_inner();
         let body = req.encode_to_vec();
-        let dedup = self.inner.dedup();
         let client_op = req.client_operation_id.clone();
         let broker = self.inner.hook_events.clone();
         let result = with_idempotency(
-            dedup,
+            &self.inner,
             &client_op,
             "hook.respond_to_hook",
             &body,

--- a/crates/daemon/src/grpc_local_impl/mod.rs
+++ b/crates/daemon/src/grpc_local_impl/mod.rs
@@ -25,7 +25,10 @@ pub use discussion::LocalDiscussionService;
 pub use hook::LocalHookService;
 pub use hook_events::{EmitWaiter, HookEventBroadcaster, HookResponse};
 pub use operation_log_query::LocalOperationLogQueryService;
-use repo::{Repository, operation_dedup::OperationDedupStore};
+use repo::{
+    Repository,
+    operation_dedup::{OperationDedupStore, reserve_operation_id_eager},
+};
 pub use signal::LocalSignalService;
 pub use state_review::LocalStateReviewService;
 pub use transaction::LocalTransactionService;
@@ -79,7 +82,7 @@ impl GrpcLocalService {
 /// must be a deterministic byte representation of the request (typically
 /// the protobuf-encoded request).
 pub(super) async fn with_idempotency<F, Fut, T>(
-    dedup: &OperationDedupStore,
+    service: &GrpcLocalService,
     client_operation_id: &str,
     verb: &'static str,
     request_body: &[u8],
@@ -101,12 +104,12 @@ where
         tonic::Status::invalid_argument(format!("invalid client_operation_id: {err}"))
     })?;
     let hash = hash_request_body(request_body);
-    // `reserve` atomically claims the (op_id, verb) slot before we run the
-    // mutation. Two concurrent retries with the same operation_id can no
-    // longer both observe "Fresh" and both apply side effects: the second
-    // sees `InFlight` and surfaces a transient `Aborted` to the client.
-    let outcome = dedup
-        .reserve(op_id, verb, hash)
+    // The eager reservation atomically claims the (op_id, verb) slot before
+    // we run the mutation. Two concurrent retries with the same operation_id
+    // can no longer both observe "Fresh" and both apply side effects: the
+    // second sees `InFlight` and surfaces a transient `Aborted` to the client.
+    let dedup = Arc::clone(&service.dedup);
+    let outcome = reserve_operation_id_eager(service.repo(), Arc::clone(&dedup), op_id, verb, hash)
         .map_err(|err| tonic::Status::internal(format!("dedup reserve failed: {err}")))?;
     match outcome {
         DedupOutcome::Replay { response } => decode_response(response),
@@ -168,29 +171,28 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use objects::object::OperationId;
-    use repo::operation_dedup::OperationDedupStore;
+    use repo::{Repository, operation_dedup::OperationDedupStore};
     use tempfile::TempDir;
     use tokio::sync::oneshot;
 
-    use super::with_idempotency;
+    use super::{GrpcLocalService, with_idempotency};
 
-    fn make_store() -> (TempDir, Arc<OperationDedupStore>) {
+    fn make_service() -> (TempDir, GrpcLocalService) {
         let temp = TempDir::new().unwrap();
-        let heddle = temp.path().join(".heddle");
-        std::fs::create_dir_all(&heddle).unwrap();
-        let store = OperationDedupStore::open(&heddle).unwrap();
-        (temp, Arc::new(store))
+        let repo = Arc::new(Repository::init_default(temp.path()).unwrap());
+        let store = Arc::new(OperationDedupStore::open(repo.heddle_dir()).unwrap());
+        (temp, GrpcLocalService::new(repo, store))
     }
 
     #[tokio::test]
     async fn replays_recorded_response() {
-        let (_t, store) = make_store();
+        let (_t, service) = make_service();
         let op_id = OperationId::new().to_string();
         let body = b"req";
 
         // First call executes and records.
         let first: i32 = with_idempotency(
-            &store,
+            &service,
             &op_id,
             "verb",
             body,
@@ -209,7 +211,7 @@ mod tests {
         // Second call must replay without re-executing — proven by the
         // execute closure returning a sentinel that would mismatch.
         let second: i32 = with_idempotency(
-            &store,
+            &service,
             &op_id,
             "verb",
             body,
@@ -236,18 +238,18 @@ mod tests {
         // Both used to apply side effects. With reservation, B must see
         // `InFlight` and surface `Aborted`.
 
-        let (_t, store) = make_store();
+        let (_t, service) = make_service();
         let op_id = OperationId::new().to_string();
         let body = b"req";
 
         // We gate the first execution on a oneshot so caller B starts
         // while A is still pending.
         let (tx, rx) = oneshot::channel::<()>();
-        let store_a = Arc::clone(&store);
+        let service_a = service.clone();
         let op_a = op_id.clone();
         let a_handle = tokio::spawn(async move {
             with_idempotency(
-                &store_a,
+                &service_a,
                 &op_a,
                 "verb",
                 body,
@@ -270,10 +272,10 @@ mod tests {
         // awaits, so once we yield the entry is visible.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let store_b = Arc::clone(&store);
+        let service_b = service.clone();
         let op_b = op_id.clone();
         let b_result = with_idempotency(
-            &store_b,
+            &service_b,
             &op_b,
             "verb",
             body,
@@ -301,7 +303,7 @@ mod tests {
         // After A finishes, the entry is finalised: a third call with the
         // same body replays.
         let third = with_idempotency(
-            &store,
+            &service,
             &op_id,
             "verb",
             body,
@@ -328,12 +330,12 @@ mod tests {
         // every subsequent retry would see Conflict/InFlight until
         // compaction.
 
-        let (_t, store) = make_store();
+        let (_t, service) = make_service();
         let op_id = OperationId::new().to_string();
         let body = b"req";
 
         let first = with_idempotency::<_, _, i32>(
-            &store,
+            &service,
             &op_id,
             "verb",
             body,
@@ -350,7 +352,7 @@ mod tests {
 
         // Retry must succeed — the reservation was released.
         let second = with_idempotency(
-            &store,
+            &service,
             &op_id,
             "verb",
             body,

--- a/crates/daemon/src/grpc_local_impl/state_review.rs
+++ b/crates/daemon/src/grpc_local_impl/state_review.rs
@@ -259,7 +259,7 @@ impl StateReviewService for LocalStateReviewService {
         let inner = self.inner.clone();
 
         let response = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_operation_id,
             "state_review.sign_state",
             &req_bytes,

--- a/crates/daemon/src/grpc_local_impl/transaction.rs
+++ b/crates/daemon/src/grpc_local_impl/transaction.rs
@@ -130,7 +130,7 @@ impl TransactionService for LocalTransactionService {
         let inner = self.inner.clone();
 
         let response = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op,
             "TransactionService.BeginTransaction",
             &request_body,
@@ -202,7 +202,7 @@ impl TransactionService for LocalTransactionService {
         let inner = self.inner.clone();
 
         let response = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op,
             "TransactionService.CommitTransaction",
             &request_body,
@@ -267,7 +267,7 @@ impl TransactionService for LocalTransactionService {
         let inner = self.inner.clone();
 
         let response = with_idempotency(
-            self.inner.dedup(),
+            &self.inner,
             &client_op,
             "TransactionService.AbortTransaction",
             &request_body,

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -22,7 +22,7 @@
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -33,6 +33,9 @@ use objects::{
     object::OperationId,
 };
 use serde::{Deserialize, Serialize};
+
+use crate::Repository;
+use crate::atomic::{AtomicMutation, Compensator, EagerMutation, StagedCommit, Tx, execute};
 
 const DEDUP_FORMAT_VERSION: u8 = 1;
 const DEDUP_FILE_NAME: &str = "operation_dedup.bin";
@@ -118,6 +121,149 @@ pub struct DedupConflictMetadata {
     pub request_hash: [u8; 32],
     pub created_at_secs: i64,
     pub pending: bool,
+}
+
+#[derive(Clone)]
+pub struct ReserveOpIdClaim {
+    outcome: Arc<Mutex<Option<DedupOutcome>>>,
+}
+
+impl ReserveOpIdClaim {
+    fn new() -> Self {
+        Self {
+            outcome: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn set(&self, outcome: DedupOutcome) {
+        *self.outcome.lock().expect("reserve op-id outcome poisoned") = Some(outcome);
+    }
+
+    fn into_outcome(self) -> Result<DedupOutcome> {
+        self.outcome
+            .lock()
+            .expect("reserve op-id outcome poisoned")
+            .take()
+            .ok_or_else(|| HeddleError::Conflict("eager op-id reserve produced no outcome".into()))
+    }
+}
+
+/// Eager op-id reservation for use inside an existing [`Tx`].
+///
+/// The reservation is written in [`EagerMutation::commit_eager`], not
+/// [`AtomicMutation::apply`], so it is cross-process visible before the outer
+/// transaction can continue. The compensator is intentionally a no-op: once an
+/// op-id has been handed out, an unrelated outer abort must not make that
+/// unique reservation disappear.
+pub struct ReserveOpId {
+    store: Arc<OperationDedupStore>,
+    operation_id: OperationId,
+    verb: String,
+    request_hash: [u8; 32],
+    claim: ReserveOpIdClaim,
+}
+
+impl ReserveOpId {
+    pub fn new(
+        store: Arc<OperationDedupStore>,
+        operation_id: OperationId,
+        verb: impl Into<String>,
+        request_hash: [u8; 32],
+    ) -> Self {
+        Self {
+            store,
+            operation_id,
+            verb: verb.into(),
+            request_hash,
+            claim: ReserveOpIdClaim::new(),
+        }
+    }
+}
+
+impl AtomicMutation for ReserveOpId {
+    type Output = ReserveOpIdClaim;
+
+    fn transaction_id(&self) -> String {
+        reserve_transaction_id(self.operation_id, &self.verb, self.request_hash)
+    }
+
+    fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>> {
+        Ok(StagedCommit::pure(self.claim.clone()))
+    }
+}
+
+impl EagerMutation for ReserveOpId {
+    fn commit_eager(&mut self, _tx: &mut Tx<'_>) -> Result<Compensator> {
+        let outcome = self
+            .store
+            .reserve(self.operation_id, &self.verb, self.request_hash)?;
+        self.claim.set(outcome);
+        Ok(Compensator::new(|| Ok(())))
+    }
+}
+
+struct ReserveOpIdTransaction {
+    store: Arc<OperationDedupStore>,
+    operation_id: OperationId,
+    verb: String,
+    request_hash: [u8; 32],
+}
+
+impl ReserveOpIdTransaction {
+    fn new(
+        store: Arc<OperationDedupStore>,
+        operation_id: OperationId,
+        verb: impl Into<String>,
+        request_hash: [u8; 32],
+    ) -> Self {
+        Self {
+            store,
+            operation_id,
+            verb: verb.into(),
+            request_hash,
+        }
+    }
+}
+
+impl AtomicMutation for ReserveOpIdTransaction {
+    type Output = DedupOutcome;
+
+    fn transaction_id(&self) -> String {
+        reserve_transaction_id(self.operation_id, &self.verb, self.request_hash)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>> {
+        let claim = tx.enroll_eager(ReserveOpId::new(
+            Arc::clone(&self.store),
+            self.operation_id,
+            self.verb.clone(),
+            self.request_hash,
+        ))?;
+        Ok(StagedCommit::pure(claim.into_outcome()?))
+    }
+}
+
+pub fn reserve_operation_id_eager(
+    repo: &Repository,
+    store: Arc<OperationDedupStore>,
+    operation_id: OperationId,
+    verb: impl Into<String>,
+    request_hash: [u8; 32],
+) -> Result<DedupOutcome> {
+    execute(
+        repo,
+        ReserveOpIdTransaction::new(store, operation_id, verb, request_hash),
+    )
+}
+
+fn reserve_transaction_id(operation_id: OperationId, verb: &str, request_hash: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+
+    let mut hash = String::with_capacity(64);
+    for byte in request_hash {
+        let _ = write!(&mut hash, "{byte:02x}");
+    }
+    format!("op-id-reserve/{verb}/{operation_id}/{hash}")
 }
 
 /// File-backed dedup store.
@@ -396,9 +542,9 @@ pub fn hash_request_body(bytes: &[u8]) -> [u8; 32] {
 mod tests {
     use std::sync::Arc;
 
+    use crate::Repository;
     use crate::atomic::{AtomicMutation, StagedCommit, Tx, execute};
     use crate::operation_dedup::{ReserveOpId, reserve_operation_id_eager};
-    use crate::Repository;
     use objects::error::{HeddleError, Result};
     use tempfile::TempDir;
 
@@ -704,8 +850,7 @@ mod tests {
                 store.reserve(op, "capture", hash).unwrap()
             }));
         }
-        let outcomes: Vec<DedupOutcome> =
-            handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let outcomes: Vec<DedupOutcome> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
         let reserved = outcomes
             .iter()

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -394,6 +394,12 @@ pub fn hash_request_body(bytes: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::atomic::{AtomicMutation, StagedCommit, Tx, execute};
+    use crate::operation_dedup::{ReserveOpId, reserve_operation_id_eager};
+    use crate::Repository;
+    use objects::error::{HeddleError, Result};
     use tempfile::TempDir;
 
     use super::*;
@@ -405,6 +411,85 @@ mod tests {
         std::fs::create_dir_all(&heddle).unwrap();
         let store = OperationDedupStore::open(&heddle).unwrap();
         (temp, store)
+    }
+
+    fn make_repo_store() -> (TempDir, Repository, Arc<OperationDedupStore>) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let store = Arc::new(OperationDedupStore::open(repo.heddle_dir()).unwrap());
+        (temp, repo, store)
+    }
+
+    struct ReserveThenAbort {
+        store: Arc<OperationDedupStore>,
+        op: OperationId,
+        hash: [u8; 32],
+    }
+
+    impl AtomicMutation for ReserveThenAbort {
+        type Output = ();
+
+        fn transaction_id(&self) -> String {
+            format!("reserve-then-abort/{}", self.op)
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+            tx.enroll_eager(ReserveOpId::new(
+                Arc::clone(&self.store),
+                self.op,
+                "capture",
+                self.hash,
+            ))?;
+            Err(HeddleError::Config("outer transaction aborted".to_string()))
+        }
+    }
+
+    #[test]
+    fn eager_reserve_survives_outer_abort() {
+        let (_t, repo, store) = make_repo_store();
+        let op = OperationId::new();
+        let hash = hash_request_body(b"x");
+
+        let result = execute(
+            &repo,
+            ReserveThenAbort {
+                store: Arc::clone(&store),
+                op,
+                hash,
+            },
+        );
+
+        assert!(result.is_err(), "outer transaction must abort");
+        let reopened = OperationDedupStore::open(repo.heddle_dir()).unwrap();
+        assert_eq!(
+            reopened.reserve(op, "capture", hash).unwrap(),
+            DedupOutcome::InFlight,
+            "eager op-id reservation must remain durable after outer abort"
+        );
+    }
+
+    #[test]
+    fn eager_parallel_distinct_reserves_both_win() {
+        let (_t, repo, store) = make_repo_store();
+        let op_a = OperationId::new();
+        let op_b = OperationId::new();
+        let hash = hash_request_body(b"x");
+
+        std::thread::scope(|scope| {
+            let a = scope.spawn(|| {
+                reserve_operation_id_eager(&repo, Arc::clone(&store), op_a, "capture", hash)
+                    .unwrap()
+            });
+            let b = scope.spawn(|| {
+                reserve_operation_id_eager(&repo, Arc::clone(&store), op_b, "capture", hash)
+                    .unwrap()
+            });
+
+            assert_eq!(a.join().unwrap(), DedupOutcome::Reserved);
+            assert_eq!(b.join().unwrap(), DedupOutcome::Reserved);
+        });
+
+        assert_eq!(store.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #358 (atomic-mutation impl-e). The eager-commit exemplar: op-id reserve must commit IMMEDIATELY (not enroll into the outer savepoint), so a reserved id is durable the moment it's handed out and an outer abort can't roll it back — closing the #251 cross-process race by construction.

## What changed
- `ReserveOpId` is now an `EagerMutation`; the reservation commits in `commit_eager`.
- `reserve_operation_id_eager` helper for non-nested callers.
- Routed the repo-backed CLI (`operation_id.rs`) + local gRPC op-id reservation (`grpc_local_impl/*`) through the eager helper.

## Red → green
- Red `45a9dec` — eager op-id reservation contract test (verified failing pre-migration).
- Green `10cfe73`.

## Test evidence (local, isolated target)
- Contract tests: outer-abort-after-eager-reserve keeps the reservation durable; two concurrent distinct eager reserves both succeed.
- `check-no-silent-default-tree-load.sh` ✓ · `cargo test --workspace` ✓ (one unrelated `shallow_clone::test_shallow_clone_depth_1` flake under contended local run — passed in isolation; CI authoritative) · `--ignored` fault suite ✓ · `cargo clippy --locked … -D warnings` ✓ · `doctor docs`/`schemas` ✓

## Provenance
Codex-implemented; reviewed by an independent Claude agent (cross-engine — @codex reaction is not the gate for codex-authored code).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782959432&installation_id=132405951&pr_number=386&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F386&signature=4e52dae71d6e83f41caf11f2a2e7abdcdfe977d14203ccdb98fdc5f88d820c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->