### PR TITLE
ci: run the CLI fault-injection #[ignore] suite (closes the no-CI-coverage gap)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -37,7 +37,7 @@ jobs:
   #
   # Outputs:
   #   docs_only — every changed path is doc-only (see below); skip all Rust.
-  #   rust      — !docs_only; gates check-and-test / coverage / postgres.
+  #   rust      — !docs_only; gates check-and-test / coverage / postgres / CLI fault-injection.
   #   mount     — a mount-relevant path changed; gates fuse/projfs smoke.
   changes:
     name: Detect changed paths
@@ -280,6 +280,38 @@ jobs:
           DATABASE_URL: postgres://heddle_test:heddle_test@localhost:5432/heddle_test
         run: |
           cargo test --locked -p heddle-refs -p heddle-oplog --features postgres \
+            -- --ignored --test-threads=1 --nocapture
+
+      - name: sccache stats
+        run: sccache --show-stats
+
+  # CLI crash-recovery / atomicity tests. These are `#[ignore]` because they
+  # spawn child `heddle` processes with `HEDDLE_FAULT_INJECT` armed, so the
+  # default workspace test run intentionally skips them. Keep this filter on
+  # the `fault_injection` module only: the same `cli_integration` ignored set
+  # also contains timing-sensitive perf smoke and real-world Git fixture tests
+  # that are not deterministic enough to become a required Rust gate.
+  cli-fault-injection-tests:
+    name: CLI fault-injection tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cli-fault-injection-tests-${{ runner.os }}
+          cache-on-failure: true
+
+      - name: CLI fault-injection tests
+        run: |
+          cargo test --locked -p heddle-cli --test cli_integration fault_injection:: \
             -- --ignored --test-threads=1 --nocapture
 
       - name: sccache stats


### PR DESCRIPTION
Closes #388. The CLI fault-injection tests (`crates/cli/tests/cli_integration/fault_injection.rs`, all `#[ignore]`, spawn child procs with `HEDDLE_FAULT_INJECT`) ran in **no CI job** — which let #357's stale fault test (arming a deleted checkpoint) pass green. This adds a `CLI fault-injection tests` job to `rust-tests.yml`.

## Scope
Filter is `fault_injection::` only — runs the 3 deterministic crash/atomicity tests:
- `snapshot_atomicity_before_commit_crash_stays_on_baseline`
- `snapshot_atomicity_after_commit_crash_recovers_once`
- `bridge_recovers_from_crash_after_tmp_before_commit`

Deliberately **excludes** the other `cli_integration --ignored` tests that are environment-flaky (`perf_core_loop::…perf_smoke`, `realworld_git::…round_trip`) so this stays a deterministic gate. Local `--list` confirmed exactly those 3 selected; the run passed 3/3.

## Note
To make this a **required** (merge-blocking) check, add "CLI fault-injection tests" to the repo's branch-protection required-checks (repo setting; not doable in the workflow file).

## Provenance
Codex-implemented; reviewed by an independent Claude agent (cross-engine).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782962093&installation_id=132405951&pr_number=391&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F391&signature=0d54ab59cd1155e815706aa6a94bef03d158da677e393e3793a9ed45c1d9a082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->