### PR TITLE
fix(repo): reconstruct HEAD from Snapshot/Goto records (#379)

### DIFF
--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -124,6 +124,7 @@ pub(super) fn ff_advance_deferred(
         Head::Detached { state } => OpRecord::Goto {
             target: *post_target_id,
             prev_head: Some(state),
+            head: *post_target_id,
         },
     })
 }

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -263,6 +263,7 @@ fn resume_manual_resolution_if_present(
         Head::Detached { .. } => OpRecord::Goto {
             target: current_state.change_id,
             prev_head: Some(pre_conflict_head),
+            head: current_state.change_id,
         },
     };
     state.pending_advances.push(resolution_advance);
@@ -701,9 +702,11 @@ mod tests {
     }
 
     fn synthetic_goto_advance() -> OpRecord {
+        let target = objects::object::ChangeId::generate();
         OpRecord::Goto {
-            target: objects::object::ChangeId::generate(),
+            target,
             prev_head: Some(objects::object::ChangeId::generate()),
+            head: target,
         }
     }
 

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -715,6 +715,7 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             new_state,
             prev_head,
             thread,
+            ..
         } => {
             steps.goto(*new_state)?;
             if let Some(thread) = thread {

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -809,6 +809,7 @@ mod tests {
                 OpRecord::Snapshot {
                     new_state: cid_a,
                     prev_head: None,
+                    head: None,
                     thread: Some("modulo-race".into()),
                 },
                 OpRecord::ThreadCreate {
@@ -839,12 +840,14 @@ mod tests {
             json: true,
             filter: Some(vec!["snapshot".into()]),
         };
+        let snap_id = ChangeId::generate();
         let snap = EmittedEntry {
             entry: make_entry(
                 1,
                 OpRecord::Snapshot {
-                    new_state: ChangeId::generate(),
+                    new_state: snap_id,
                     prev_head: None,
+                    head: Some(snap_id),
                     thread: None,
                 },
             ),
@@ -887,6 +890,7 @@ mod tests {
                 OpRecord::Snapshot {
                     new_state: cid,
                     prev_head: None,
+                    head: None,
                     thread: Some("modulo-race/approach-anthropic".into()),
                 },
             ),
@@ -932,6 +936,7 @@ mod tests {
                 OpRecord::Snapshot {
                     new_state: cid,
                     prev_head: None,
+                    head: None,
                     thread: Some("modulo-race/approach-anthropic".into()),
                 },
             ),
@@ -963,11 +968,13 @@ mod tests {
             OpRecord::Snapshot {
                 new_state: cid,
                 prev_head: None,
+                head: Some(cid),
                 thread: None,
             },
             OpRecord::Goto {
                 target: cid,
                 prev_head: None,
+                head: cid,
             },
             OpRecord::ThreadCreate {
                 name: "x".into(),

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -165,6 +165,17 @@ fn current_main_tip(repo: &std::path::Path) -> String {
         .to_string()
 }
 
+fn current_head_tip(repo: &std::path::Path) -> String {
+    let log: Value = serde_json::from_str(
+        &heddle(&["--output", "json", "log", "--limit", "1"], Some(repo)).expect("log"),
+    )
+    .unwrap();
+    log["states"][0]["change_id"]
+        .as_str()
+        .expect("tip change_id")
+        .to_string()
+}
+
 fn assert_intentional_snapshot_crash(crashed: std::process::Output, checkpoint: &str) {
     assert!(
         !crashed.status.success(),
@@ -182,6 +193,16 @@ fn assert_intentional_snapshot_crash(crashed: std::process::Output, checkpoint: 
 fn crash_capture_at(repo: &std::path::Path, checkpoint: &str, message: &str) {
     let crashed = heddle_output_with_env(
         &["capture", "-m", message],
+        Some(repo),
+        &[("HEDDLE_FAULT_INJECT", checkpoint)],
+    )
+    .expect("spawn child");
+    assert_intentional_snapshot_crash(crashed, checkpoint);
+}
+
+fn crash_goto_at(repo: &std::path::Path, checkpoint: &str, target: &str) {
+    let crashed = heddle_output_with_env(
+        &["goto", target],
         Some(repo),
         &[("HEDDLE_FAULT_INJECT", checkpoint)],
     )
@@ -278,5 +299,45 @@ fn snapshot_atomicity_after_commit_crash_recovers_once() {
     assert_eq!(
         retry_read_tip, recovered_tip,
         "retrying reconcile-on-read must not advance the tip again",
+    );
+}
+
+/// Goto is record-first: a crash after its `OpRecord::Goto` commits but before
+/// HEAD is published must reconstruct detached HEAD from the record on the next
+/// read. Re-reading must be idempotent and must not move the still-attached
+/// source thread.
+#[test]
+#[ignore = "fault-injection: spawns child processes with HEDDLE_FAULT_INJECT"]
+fn goto_after_commit_crash_recovers_detached_head_once() {
+    let (temp, baseline_tip) = init_repo_with_baseline();
+
+    std::fs::write(temp.path().join("base.txt"), "second").unwrap();
+    heddle(&["capture", "-m", "second"], Some(temp.path())).expect("second snapshot");
+    let second_tip = current_main_tip(temp.path());
+    assert_ne!(
+        second_tip, baseline_tip,
+        "fixture must have a distinct second tip"
+    );
+
+    crash_goto_at(
+        temp.path(),
+        "goto_after_oplog_commit_before_ref_publish",
+        &baseline_tip,
+    );
+
+    let recovered_head = current_head_tip(temp.path());
+    assert_eq!(
+        recovered_head, baseline_tip,
+        "post-commit goto crash recovery must detach HEAD to the committed target",
+    );
+    assert_eq!(
+        current_head_tip(temp.path()),
+        recovered_head,
+        "a second HEAD read must not apply the committed goto a second time",
+    );
+    assert_eq!(
+        current_main_tip(temp.path()),
+        second_tip,
+        "goto recovery must not move the source thread ref",
     );
 }

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -456,7 +456,7 @@ mod tests {
 
         let ops = all_ops(&log);
         assert_eq!(ops.len(), 1);
-        assert!(matches!(&ops[0], OpRecord::Goto { target, prev_head }
+        assert!(matches!(&ops[0], OpRecord::Goto { target, prev_head, .. }
             if *target == cid_a && *prev_head == Some(cid_b)));
     }
 

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -130,6 +130,7 @@ pub trait OpLogBackend: Send + Sync {
             vec![OpRecord::Snapshot {
                 new_state: *new_state,
                 prev_head: prev_head.copied(),
+                head: thread.is_none().then_some(*new_state),
                 thread: thread.map(str::to_string),
             }],
             scope,
@@ -147,6 +148,7 @@ pub trait OpLogBackend: Send + Sync {
             vec![OpRecord::Goto {
                 target: *target,
                 prev_head: prev_head.copied(),
+                head: *target,
             }],
             scope,
         )?;

--- a/crates/oplog/src/oplog/oplog_records.rs
+++ b/crates/oplog/src/oplog/oplog_records.rs
@@ -21,6 +21,7 @@ impl OpLog {
             OpRecord::Snapshot {
                 new_state: *new_state,
                 prev_head: prev_head.copied(),
+                head: thread.is_none().then_some(*new_state),
                 thread: thread.map(str::to_string),
             },
             scope,
@@ -38,6 +39,7 @@ impl OpLog {
             OpRecord::Goto {
                 target: *target,
                 prev_head: prev_head.copied(),
+                head: *target,
             },
             scope,
         )

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -341,6 +341,7 @@ fn committed_batch_records_refreshes_for_cross_process_dedup_hit() {
                 OpRecord::Snapshot {
                     new_state: committed_state,
                     prev_head: None,
+                    head: Some(committed_state),
                     thread: None,
                 },
                 OpRecord::TransactionCommit {
@@ -357,12 +358,14 @@ fn committed_batch_records_refreshes_for_cross_process_dedup_hit() {
     // B replays the same transaction id: a cross-process dedup hit. B's
     // regenerated Snapshot id differs from A's, so a stale reconstruction
     // would diverge even if it found anything.
+    let replay_state = ChangeId::generate();
     let replay = proc_b
         .record_batch_exactly_once(
             vec![
                 OpRecord::Snapshot {
-                    new_state: ChangeId::generate(),
+                    new_state: replay_state,
                     prev_head: None,
+                    head: Some(replay_state),
                     thread: None,
                 },
                 OpRecord::TransactionCommit {
@@ -412,16 +415,19 @@ fn op_record_variants_roundtrip_and_describe() {
         OpRecord::Snapshot {
             new_state: st,
             prev_head: Some(st2),
+            head: None,
             thread: Some("main".into()),
         },
         OpRecord::Snapshot {
             new_state: st,
             prev_head: None,
+            head: Some(st),
             thread: None,
         },
         OpRecord::Goto {
             target: st,
             prev_head: Some(st2),
+            head: st,
         },
         OpRecord::ThreadCreate {
             name: "feat".into(),
@@ -904,6 +910,7 @@ mod default_backend {
             .record_batch(vec![OpRecord::Goto {
                 target: cid,
                 prev_head: Some(from),
+                head: cid,
             }])
             .unwrap();
 

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -18,12 +18,20 @@ pub enum OpRecord {
     Snapshot {
         new_state: ChangeId,
         prev_head: Option<ChangeId>,
+        /// Detached HEAD published by this snapshot, if any. Attached
+        /// snapshots publish their `thread` ref instead; detached snapshots
+        /// publish `HEAD = Detached(head)`.
+        head: Option<ChangeId>,
         thread: Option<String>,
     },
     /// Goto operation.
     Goto {
         target: ChangeId,
         prev_head: Option<ChangeId>,
+        /// HEAD published by this goto. This intentionally duplicates `target`
+        /// for the current detached-only command shape so crash replay folds the
+        /// published ref state directly instead of inferring it from intent.
+        head: ChangeId,
     },
     /// Thread creation.
     ThreadCreate { name: String, state: ChangeId },
@@ -576,6 +584,7 @@ mod verb_catalog_tests {
         let sample = OpRecord::Snapshot {
             new_state: cid(),
             prev_head: None,
+            head: Some(cid()),
             thread: None,
         };
         // Exhaustiveness anchor: this match has no wildcard, so a new variant
@@ -610,6 +619,7 @@ mod verb_catalog_tests {
             OpRecord::Goto {
                 target: cid(),
                 prev_head: None,
+                head: cid(),
             },
             OpRecord::ThreadCreate {
                 name: "t".into(),

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -387,6 +387,7 @@ mod tests {
             operation: OpRecord::Snapshot {
                 new_state: state,
                 prev_head: None,
+                head: Some(state),
                 thread: None,
             },
             undone: false,

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -79,11 +79,11 @@ enum HeadFold {
     #[default]
     Untouched,
     /// Latest mover is a record-first atomic publish (Fork / Collapse /
-    /// detached Snapshot / Goto): reconstruct and republish to recover a
+    /// Snapshot / Goto): reconstruct and republish to recover a
     /// crash-lost HEAD publish.
     Republish(Head),
-    /// Latest mover is a publish-first direct write (Goto / detached
-    /// Checkpoint / FastForward): canonical wins.
+    /// Latest mover is a publish-first direct write (detached Checkpoint /
+    /// FastForward): canonical wins.
     Canonical,
 }
 
@@ -302,8 +302,8 @@ impl OplogRefReconciler {
                 }
             }
             RefClass::Local => {
-                // Only a record-first mover (Fork / Collapse / detached
-                // Snapshot) republishes a reconstructed HEAD; a publish-first
+                // Only a record-first mover (Fork / Collapse / Snapshot /
+                // Goto) republishes a reconstructed HEAD; a publish-first
                 // mover defers to canonical (`HeadFold::Canonical`) so it never
                 // clobbers a newer HEAD.
                 if let HeadFold::Republish(head) = &fold.head {

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -57,21 +57,16 @@ impl OplogRefReconciler {
 ///   but HEAD unpublished, so reconstruct from the record and republish to
 ///   recover it (the `crash_replay_reconstructs_committed_head_update` case).
 ///   This set is the *HEAD-moving* shapes only: a named `Fork` (creates a
-///   thread and attaches HEAD to it), a detached `Fork`/`Collapse`/`Snapshot`
-///   (publishes a detached HEAD). An ATTACHED `Collapse` or `Snapshot` is NOT
-///   here — it only advances the thread it is already attached to, so HEAD's
-///   identity is unchanged and canonical already reflects it (the attached
-///   collapse was wrongly republishing `Attached` until heddle#354 r9, cid
-///   3330304665). The detached snapshot joined this set in heddle#354 r8 when
-///   its publish moved record-first through `commit_and_publish`.
-/// - [`HeadFold::Canonical`] — `Goto`, detached `Checkpoint`, and `FastForward`
-///   write HEAD DIRECTLY *before* recording (`repository_goto.rs` `:160`,
-///   `ff_record.rs`). Canonical therefore already reflects the move; worse, an
-///   unrecorded follow-up write (e.g. `fast_forward_attached`'s re-attach to a
-///   thread) may have superseded it. Defer to canonical — republishing the
-///   record's intermediate target here would clobber a newer,
-///   legitimately-published HEAD. Reaching this mode still MASKS an earlier
-///   `Republish`, which is what stops the stale Fork from resurrecting.
+///   thread and attaches HEAD to it), a detached `Fork`/`Collapse`/`Snapshot`,
+///   and `Goto` (publishes a detached HEAD).
+/// - [`HeadFold::Canonical`] — detached `Checkpoint` and `FastForward` write
+///   HEAD DIRECTLY *before* recording. Canonical therefore already reflects the
+///   move; worse, an unrecorded follow-up write (e.g.
+///   `fast_forward_attached`'s re-attach to a thread) may have superseded it.
+///   Defer to canonical — republishing the record's intermediate target here
+///   would clobber a newer, legitimately-published HEAD. Reaching this mode
+///   still MASKS an earlier `Republish`, which is what stops the stale Fork from
+///   resurrecting.
 ///
 /// Invariant: HEAD reconciliation considers EVERY HEAD-moving record shape, not
 /// a Fork/Collapse allowlist. A publish-first mover defers to canonical (never
@@ -84,8 +79,8 @@ enum HeadFold {
     #[default]
     Untouched,
     /// Latest mover is a record-first atomic publish (Fork / Collapse /
-    /// detached Snapshot): reconstruct and republish to recover a crash-lost
-    /// HEAD publish.
+    /// detached Snapshot / Goto): reconstruct and republish to recover a
+    /// crash-lost HEAD publish.
     Republish(Head),
     /// Latest mover is a publish-first direct write (Goto / detached
     /// Checkpoint / FastForward): canonical wins.
@@ -106,24 +101,28 @@ impl Fold {
     fn apply(&mut self, op: &OpRecord) {
         match op {
             OpRecord::Snapshot {
-                new_state, thread, ..
+                new_state,
+                thread,
+                head,
+                ..
             } => match thread {
                 Some(name) => {
-                    // Attached snapshot advances the thread; HEAD stays
-                    // `Attached{name}` (identity unchanged), so it is not a
-                    // HEAD-mover. Now record-first (commit_and_publish,
-                    // heddle#354 r8), so a later record IS the later write —
-                    // the authoritative thread fold can no longer be clobbered
-                    // by a stale snapshot appended after a concurrent write.
+                    // Attached snapshot advances the thread and leaves HEAD
+                    // attached to that thread. Treat it as the latest
+                    // reconstructable HEAD state so it masks any earlier
+                    // HEAD-mover and materializes the paired thread target
+                    // during Local recovery.
                     self.threads.insert(name.clone(), Some(*new_state));
+                    self.head = HeadFold::Republish(Head::Attached {
+                        thread: ThreadName::new(name),
+                    });
                 }
-                // Detached snapshot is record-first as of heddle#354 r8
-                // (commit_and_publish appends the `Snapshot` record before
-                // publishing HEAD). A crash between phase-4 commit and phase-5
-                // publish must therefore reconstruct HEAD = Detached{new_state}
-                // from the record — the symmetric recovery to Fork/Collapse.
+                // Detached snapshot is record-first. Use the record's published
+                // HEAD field directly so the replay target is explicit.
                 None => {
-                    self.head = HeadFold::Republish(Head::Detached { state: *new_state });
+                    if let Some(head) = head {
+                        self.head = HeadFold::Republish(Head::Detached { state: *head });
+                    }
                 }
             },
             OpRecord::ThreadCreate { name, state }
@@ -225,12 +224,14 @@ impl Fold {
             OpRecord::UndoRecoveryUpdate { state } => {
                 self.undo_recovery = Some(*state);
             }
-            // Publish-first HEAD moves: `goto` writes `Head::Detached` directly
-            // before recording (repository_goto.rs:160); legacy V1 `FastForward`
-            // likewise moved HEAD via a direct write. Canonical already reflects
-            // them (and may carry a newer unrecorded re-attach), so defer — while
-            // masking any earlier `Republish` so a stale Fork cannot resurrect.
-            OpRecord::Goto { .. } | OpRecord::FastForward { .. } => {
+            OpRecord::Goto { head, .. } => {
+                self.head = HeadFold::Republish(Head::Detached { state: *head });
+            }
+            // Publish-first HEAD move: legacy V1 `FastForward` moved HEAD via a
+            // direct write. Canonical already reflects it (and may carry a
+            // newer unrecorded re-attach), so defer — while masking any earlier
+            // `Republish` so a stale Fork cannot resurrect.
+            OpRecord::FastForward { .. } => {
                 self.head = HeadFold::Canonical;
             }
             // Records that do not move canonical HEAD: transaction markers,

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -305,11 +305,13 @@ impl AtomicMutation for CommitFailsRewindFails {
             std::fs::remove_file(&oplog_path)?;
         }
         std::fs::create_dir(&oplog_path)?;
+        let state = ChangeId::generate();
         Ok(StagedCommit::new(
             (),
             vec![OpRecord::Snapshot {
-                new_state: ChangeId::generate(),
+                new_state: state,
                 prev_head: None,
+                head: Some(state),
                 thread: None,
             }],
         ))
@@ -355,6 +357,7 @@ impl AtomicMutation for Recorder {
             vec![OpRecord::Snapshot {
                 new_state: self.state,
                 prev_head: None,
+                head: Some(self.state),
                 thread: None,
             }],
         ))
@@ -693,15 +696,19 @@ fn tx_accessors_and_rewind_error_paths() {
 
     // A second commit after a successful one is a no-op (committed guard).
     let mut tx2 = Tx::root(&repo, "double-commit-tx".to_string());
+    let first_state = ChangeId::generate();
     tx2.commit(vec![OpRecord::Snapshot {
-        new_state: ChangeId::generate(),
+        new_state: first_state,
         prev_head: None,
+        head: Some(first_state),
         thread: None,
     }])
     .unwrap();
+    let second_state = ChangeId::generate();
     tx2.commit(vec![OpRecord::Snapshot {
-        new_state: ChangeId::generate(),
+        new_state: second_state,
         prev_head: None,
+        head: Some(second_state),
         thread: None,
     }])
     .unwrap();
@@ -996,6 +1003,7 @@ impl AtomicMutation for StableKeyed {
             vec![OpRecord::Snapshot {
                 new_state: self.state,
                 prev_head: None,
+                head: Some(self.state),
                 thread: None,
             }],
         ))
@@ -1074,11 +1082,13 @@ impl AtomicMutation for ReplayStages {
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
         *self.staged_count.borrow_mut() += 1;
+        let state = ChangeId::generate();
         Ok(StagedCommit::new(
             7,
             vec![OpRecord::Snapshot {
-                new_state: ChangeId::generate(),
+                new_state: state,
                 prev_head: None,
+                head: Some(state),
                 thread: None,
             }],
         ))
@@ -1468,6 +1478,7 @@ fn fork_then_goto_reconcile_yields_goto_target_not_stale_fork() {
             vec![OpRecord::Goto {
                 target: goto_b,
                 prev_head: Some(fork_a),
+                head: goto_b,
             }],
             Some(&scope),
         )
@@ -1577,6 +1588,7 @@ fn detached_snapshot_after_fork_reconcile_yields_snapshot_head() {
             vec![OpRecord::Snapshot {
                 new_state: snap_b,
                 prev_head: Some(fork_a),
+                head: Some(snap_b),
                 thread: None,
             }],
             Some(&scope),
@@ -1634,6 +1646,77 @@ fn detached_snapshot_record_first_crash_recovery_reconstructs_head() {
         repo.refs().read_head().unwrap(),
         Head::Detached { state: snap },
         "a record-first detached snapshot's HEAD must be reconstructed after a phase-5 crash"
+    );
+}
+
+#[test]
+fn attached_snapshot_record_first_crash_recovery_materializes_head_state() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    let main = ThreadName::new("main");
+    repo.refs().set_thread(&main, &base).unwrap();
+    repo.refs()
+        .write_head(&Head::Attached {
+            thread: main.clone(),
+        })
+        .unwrap();
+
+    let snap = ChangeId::generate();
+    repo.oplog()
+        .record_snapshot(&snap, Some(&base), Some(main.as_str()), Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.head().unwrap(),
+        Some(snap),
+        "a record-first attached snapshot must reconstruct the resolved HEAD state"
+    );
+
+    let raw = RefManager::new(repo.heddle_dir());
+    assert_eq!(
+        raw.get_thread(&main).unwrap(),
+        Some(snap),
+        "the attached thread target must be materialized exactly once"
+    );
+
+    assert_eq!(
+        repo.head().unwrap(),
+        Some(snap),
+        "a second HEAD read must be idempotent"
+    );
+}
+
+#[test]
+fn goto_record_first_crash_recovery_reconstructs_head() {
+    let (_t, repo) = test_repo();
+    let scope = repo.op_scope();
+    let base = ChangeId::generate();
+    repo.refs()
+        .write_head(&Head::Detached { state: base })
+        .unwrap();
+
+    let target = ChangeId::generate();
+    repo.oplog()
+        .record_goto(&target, Some(&base), Some(&scope))
+        .unwrap();
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: target },
+        "a record-first goto's HEAD must be reconstructed after a phase-5 crash"
+    );
+
+    assert_eq!(
+        RefManager::new(repo.heddle_dir()).read_head().unwrap(),
+        Head::Detached { state: target },
+        "the reconstructed goto HEAD must be materialized exactly once"
+    );
+
+    assert_eq!(
+        repo.refs().read_head().unwrap(),
+        Head::Detached { state: target },
+        "a second HEAD read must be idempotent"
     );
 }
 
@@ -2481,6 +2564,7 @@ impl AtomicMutation for RegeneratesChangeId {
             vec![OpRecord::Snapshot {
                 new_state: fresh,
                 prev_head: None,
+                head: Some(fresh),
                 thread: None,
             }],
         ))

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1749,6 +1749,7 @@ impl Repository {
         let record = OpRecord::Snapshot {
             new_state: *new_state,
             prev_head,
+            head: thread.is_none().then_some(*new_state),
             thread: thread.map(|name| name.to_string()),
         };
         let ref_update = match thread {

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -157,12 +157,12 @@ impl Repository {
             )
         };
 
-        self.refs.write_head(&Head::Detached { state: *target })?;
-
         if record {
             self.oplog
                 .record_goto(target, prev_head.as_ref(), Some(&self.op_scope()))?;
+            objects::fault_inject::maybe_panic_at("goto_after_oplog_commit_before_ref_publish");
         }
+        self.refs.write_head(&Head::Detached { state: *target })?;
 
         debug!(
             load_duration_ms,

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -107,6 +107,7 @@ impl AtomicMutation for SnapshotMutation<'_> {
         let record = OpRecord::Snapshot {
             new_state: execution.state.change_id,
             prev_head: self.prev_head,
+            head: self.thread().is_none().then_some(execution.state.change_id),
             thread: self.thread(),
         };
         Ok(StagedCommit::new(execution, vec![record]))


### PR DESCRIPTION
## Summary
impl-a follow-up (#379): `Snapshot`/`Goto` `OpRecord`s now carry the post-HEAD state the reconciler needs, so HEAD is fully reconstructable from EVERY HEAD-moving record class after a crash between oplog commit and ref publish (parity with fork/collapse).

- Extended `Snapshot` with explicit `head: Option<ChangeId>` and `Goto` with explicit `head: ChangeId` (in-place record shape change, pre-1.0 — no compat shim).
- Updated all record emitters/readers/tests for the new shape.
- Moved `goto` to record-before-HEAD-publish + added a crash injection point.
- Reconciler folds a committed-but-unpublished `Snapshot`/`Goto` to reconstruct the correct HEAD on next read; idempotent re-read.

## Test evidence (TDD)
- Red: `goto_record_first_crash_recovery_reconstructs_head` fails on `main` (445a511) pre-fix.
- Green: `e6fd777`.
- Gates under isolated target: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `--ignored` fault suite (not regressed), `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #379.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782967637&installation_id=132405951&pr_number=394&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F394&signature=c1b4379d982118c9fc1ce11c1fb5526d2cf7c4a72ee6543bf7f743386c3d8068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->