### PR TITLE
fix(objects): validate per-entry content hash in FsStore::install_pack (#363)

### DIFF
--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -39,6 +39,32 @@ fn validate_loaded_tree(tree: Tree) -> Result<Tree> {
     Ok(tree)
 }
 
+fn validate_blob_bytes(data: &[u8], hash: ContentHash) -> Result<()> {
+    let found = ContentHash::compute_typed("blob", data);
+    if found != hash {
+        return Err(HeddleError::Corruption {
+            expected: hash,
+            found,
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_tree_serialized(data: &[u8], hash: ContentHash) -> Result<Tree> {
+    let tree: Tree = rmp_serde::from_slice(data)?;
+    let tree = validate_loaded_tree(tree)?;
+    let found = tree.hash();
+    if found != hash {
+        return Err(HeddleError::Corruption {
+            expected: hash,
+            found,
+        });
+    }
+
+    Ok(tree)
+}
+
 fn validate_loaded_state(requested_id: &ChangeId, state: State) -> Result<State> {
     if state.change_id != *requested_id {
         return Err(HeddleError::InvalidObject(format!(
@@ -48,6 +74,11 @@ fn validate_loaded_state(requested_id: &ChangeId, state: State) -> Result<State>
     }
 
     Ok(state)
+}
+
+fn validate_state_serialized(data: &[u8], id: ChangeId) -> Result<State> {
+    let state: State = rmp_serde::from_slice(data)?;
+    validate_loaded_state(&id, state)
 }
 
 fn validate_loaded_action(requested_id: &ActionId, action: Action) -> Result<Action> {
@@ -60,6 +91,30 @@ fn validate_loaded_action(requested_id: &ActionId, action: Action) -> Result<Act
     }
 
     Ok(action)
+}
+
+fn validate_action_serialized(data: &[u8], id: ActionId) -> Result<Action> {
+    let action: Action = rmp_serde::from_slice(data)?;
+    validate_loaded_action(&id, action)
+}
+
+fn validate_pack_entry(id: &PackObjectId, obj_type: ObjectType, data: &[u8]) -> Result<()> {
+    match (id, obj_type) {
+        (PackObjectId::Hash(hash), ObjectType::Blob) => validate_blob_bytes(data, *hash),
+        (PackObjectId::Hash(hash), ObjectType::Tree) => {
+            validate_tree_serialized(data, *hash).map(|_| ())
+        }
+        (PackObjectId::Hash(hash), ObjectType::Action) => {
+            validate_action_serialized(data, ActionId::from_hash(*hash)).map(|_| ())
+        }
+        (PackObjectId::ChangeId(change_id), ObjectType::State) => {
+            validate_state_serialized(data, *change_id).map(|_| ())
+        }
+        _ => Err(HeddleError::InvalidObject(format!(
+            "unsupported native pack object: {:?} {:?}",
+            id, obj_type
+        ))),
+    }
 }
 
 impl FsStore {
@@ -393,13 +448,7 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self, data), fields(hash = %hash.short(), size = data.len()))]
     fn put_blob_bytes_with_hash(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
-        let found = ContentHash::compute_typed("blob", data);
-        if found != hash {
-            return Err(HeddleError::Corruption {
-                expected: hash,
-                found,
-            });
-        }
+        validate_blob_bytes(data, hash)?;
 
         let path = hash_path(&blobs_dir(&self.root), &hash);
         if !path.exists() {
@@ -595,15 +644,7 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self, data), fields(hash = %hash.short(), size = data.len()))]
     fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
-        let tree: Tree = rmp_serde::from_slice(data)?;
-        validate_loaded_tree(tree.clone())?;
-        let found = tree.hash();
-        if found != hash {
-            return Err(HeddleError::Corruption {
-                expected: hash,
-                found,
-            });
-        }
+        let tree = validate_tree_serialized(data, hash)?;
 
         let path = hash_path(&trees_dir(&self.root), &hash);
         if !path.exists() {
@@ -657,13 +698,7 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self, data), fields(id = %id.short(), size = data.len()))]
     fn put_state_serialized(&self, data: &[u8], id: ChangeId) -> Result<()> {
-        let state: State = rmp_serde::from_slice(data)?;
-        if state.change_id != id {
-            return Err(HeddleError::InvalidObject(format!(
-                "state change_id mismatch: expected {}, found {}",
-                id, state.change_id
-            )));
-        }
+        let state = validate_state_serialized(data, id)?;
         let path = state_path(&self.root, &id);
         trace!(size = data.len(), "Writing raw serialized state");
         self.write_loose_object_atomic(&path, data)?;
@@ -871,6 +906,12 @@ impl ObjectStore for FsStore {
         let reader =
             crate::store::pack::PackReader::from_bytes(pack_data.to_vec(), index_data.to_vec())?;
         let ids = reader.list_ids();
+        for id in &ids {
+            let Some((obj_type, data)) = reader.get_object(id)? else {
+                continue;
+            };
+            validate_pack_entry(id, obj_type, &data)?;
+        }
         self.install_pack_files(pack_data, index_data)?;
         Ok(ids)
     }

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -3,15 +3,20 @@ use chrono::{TimeZone, Utc};
 use tempfile::TempDir;
 
 use super::{
+    fs_paths::{blobs_dir, hash_path, packs_dir},
     FsStore, LooseObjectWriteMode,
-    fs_paths::{blobs_dir, hash_path},
 };
 use crate::{
     object::{
         Action, Attribution, Blob, ChangeId, ContentHash, Operation, Principal, State, Tree,
         TreeEntry,
     },
-    store::{HeddleError, ObjectStore, atomic::temp_path},
+    store::{
+        atomic::temp_path,
+        compression::CompressionConfig,
+        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
+        HeddleError, ObjectStore,
+    },
 };
 
 fn create_test_store() -> (TempDir, FsStore) {
@@ -215,6 +220,109 @@ fn put_blobs_packed_with_empty_input_is_a_noop() {
         .map(|iter| iter.count())
         .unwrap_or(0);
     assert_eq!(pack_count, 0, "empty bulk install should not touch packs/");
+}
+
+#[test]
+fn install_pack_rejects_hash_mismatch_without_partial_commit() {
+    let (_temp, store) = create_test_store();
+
+    let valid_blob = Blob::from("valid object that must not be committed");
+    let valid_hash = valid_blob.hash();
+    let claimed_hash = Blob::from("claimed object bytes").hash();
+    let poisoned_bytes = b"different object bytes".to_vec();
+    assert_ne!(
+        ContentHash::compute_typed("blob", &poisoned_bytes),
+        claimed_hash
+    );
+
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(
+        valid_hash,
+        PackObjectType::Blob,
+        valid_blob.clone().into_content(),
+    );
+    builder.add(claimed_hash, PackObjectType::Blob, poisoned_bytes);
+    let (pack_data, index_data, _) = builder.build().unwrap();
+
+    let error = store
+        .install_pack(&pack_data, &index_data)
+        .expect_err("poisoned native pack must be rejected");
+    assert!(
+        matches!(error, HeddleError::Corruption { expected, .. } if expected == claimed_hash),
+        "expected claimed-hash mismatch corruption, got {error:?}",
+    );
+
+    assert!(
+        store.get_blob(&valid_hash).unwrap().is_none(),
+        "valid entry before the poisoned entry must not be partially committed",
+    );
+    assert!(
+        store.get_blob(&claimed_hash).unwrap().is_none(),
+        "poisoned object must not be readable under its claimed hash",
+    );
+    let pack_count = std::fs::read_dir(packs_dir(store.root()))
+        .map(|iter| iter.count())
+        .unwrap_or(0);
+    assert_eq!(pack_count, 0, "rejected pack must not commit pack files");
+}
+
+#[test]
+fn install_pack_accepts_valid_mixed_native_pack() {
+    let (_temp, store) = create_test_store();
+
+    let blob = Blob::from("native pack blob");
+    let blob_hash = blob.hash();
+    let tree = Tree::from_entries(vec![TreeEntry::file("file.txt", blob_hash, false).unwrap()]);
+    let tree_hash = tree.hash();
+    let attribution = Attribution::human(Principal::new("Pack Test", "pack@example.com"));
+    let state = State::new(tree_hash, vec![], attribution.clone()).with_intent("packed state");
+    let mut action = Action::new(
+        None,
+        state.change_id,
+        Operation::Snapshot,
+        "packed action",
+        attribution,
+    )
+    .with_timestamp(Utc.timestamp_opt(1_700_000_000, 0).unwrap());
+    let action_id = action.id();
+
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(blob_hash, PackObjectType::Blob, blob.clone().into_content());
+    builder.add(
+        tree_hash,
+        PackObjectType::Tree,
+        rmp_serde::to_vec_named(&tree).unwrap(),
+    );
+    builder.add_id(
+        PackObjectId::ChangeId(state.change_id),
+        PackObjectType::State,
+        rmp_serde::to_vec_named(&state).unwrap(),
+    );
+    builder.add(
+        *action_id.as_hash(),
+        PackObjectType::Action,
+        rmp_serde::to_vec_named(&action).unwrap(),
+    );
+    let (pack_data, index_data, _) = builder.build().unwrap();
+
+    let ids = store.install_pack(&pack_data, &index_data).unwrap();
+    assert_eq!(ids.len(), 4);
+    assert_eq!(
+        store.get_blob(&blob_hash).unwrap().unwrap().content(),
+        blob.content(),
+    );
+    assert_eq!(
+        store.get_tree(&tree_hash).unwrap().unwrap().entries(),
+        tree.entries(),
+    );
+    assert_eq!(
+        store.get_state(&state.change_id).unwrap().unwrap().intent,
+        Some("packed state".to_string()),
+    );
+    assert_eq!(
+        store.get_action(&action_id).unwrap().unwrap().description,
+        "packed action",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
**Security P1 (#363):** `FsStore::install_pack` previously wrote a received native pack's pack+index files without validating that each object's bytes hash to the content-address its index entry claims — diverging from the default `ObjectStore::install_pack` (which routes every entry through `put_blob_bytes_with_hash` / serialized-validation). A malicious/corrupt server (hosted sync: `sync.rs` → `proto::install_received_pack` → `FsStore::install_pack`) could store object bytes under a content-address they don't match, poisoning the content-addressed store.

This change validates **every** pack entry **before** the pack/index files are committed:
- Blob typed hashes, tree hashes/validation, state `ChangeId`, and action IDs.
- All-or-nothing: a single mismatch rejects the whole pack — no pack files committed, no earlier valid entry becomes readable.

## Test evidence
- New mixed native-pack test covering blob/tree/state/action install.
- Poisoned-pack rejection (whole-pack reject + nothing committed).
- Gates under isolated target: `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-objects`, `cargo test --workspace`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #363.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968614&installation_id=132405951&pr_number=395&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F395&signature=d47670855d432e3d70bd8b14bdc2094949f6ed13bb9ec6bf70166db269462f79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->