### PR TITLE
fix(objects): checked arithmetic in pack reader size/offset decode (#365)

### DIFF
--- a/crates/objects/src/store/pack/pack_reader.rs
+++ b/crates/objects/src/store/pack/pack_reader.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use bytes::Bytes;
 
 use super::{
-    ObjectType, PackObjectId, PackObjectRecord, decompress_pack_payload, has_zstd_magic,
-    pack_container_spec, pack_index::PackIndex, varint, verify_container,
+    decompress_pack_payload, has_zstd_magic, pack_container_spec, pack_index::PackIndex, varint,
+    verify_container, ObjectType, PackObjectId, PackObjectRecord,
 };
 use crate::{
     object::ContentHash,
@@ -90,11 +90,11 @@ impl PackReader {
     /// `FsStore::loose_blob_path` for the blob equivalent).
     pub fn get_object(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Vec<u8>)>> {
         let offset = match self.index.find(id) {
-            Some(offset) => offset,
+            Some(offset) => checked_index_offset(offset)?,
             None => return Ok(None),
         };
 
-        let record = self.read_record_at_depth(offset as usize, 0)?;
+        let record = self.read_record_at_depth(offset, 0)?;
         verify_record_id_matches(id, &record.id)?;
         Ok(Some((record.obj_type, record.data)))
     }
@@ -116,7 +116,7 @@ impl PackReader {
         let Some(offset) = self.index.find(id) else {
             return Ok(None);
         };
-        let offset = offset as usize;
+        let offset = checked_index_offset(offset)?;
         if offset >= self.content_end {
             return Err(StoreError::InvalidObject(
                 "Entry offset out of bounds".to_string(),
@@ -127,32 +127,25 @@ impl PackReader {
         // requested id — guards against stale-index misrouting (see
         // `get_object` for the long-form rationale). 32-byte
         // compare; cheaper than the size+varint decode that follows.
-        let (record_id, id_len) = PackObjectId::decode_tagged(&self.data[offset..])?;
+        let (record_id, id_len) = PackObjectId::decode_tagged(self.content_from(offset)?)?;
         verify_record_id_matches(id, &record_id)?;
-        let header_start = offset + id_len;
+        let header_start = checked_index_add(offset, id_len, "record header start")?;
         let (obj_type, uncompressed_size, type_len) =
-            varint::decode_type_and_size(&self.data[header_start..]).ok_or_else(|| {
+            varint::decode_type_and_size(self.content_from(header_start)?).ok_or_else(|| {
                 StoreError::InvalidObject("Truncated type+size varint".to_string())
             })?;
-        let uncompressed_size = uncompressed_size as usize;
-        let varint_start = header_start + type_len;
-        let (compressed_size, comp_len) = varint::decode_varint(&self.data[varint_start..])
-            .ok_or_else(|| {
-                StoreError::InvalidObject("Truncated compressed_size varint".to_string())
-            })?;
-        let compressed_size = compressed_size as usize;
+        let uncompressed_size = checked_decoded_size("uncompressed_size", uncompressed_size)?;
+        let varint_start = checked_index_add(header_start, type_len, "compressed_size start")?;
+        let (compressed_size, comp_len) = varint::decode_varint(self.content_from(varint_start)?)
+            .ok_or_else(truncated_compressed_size_varint)?;
+        let compressed_size = checked_decoded_size("compressed_size", compressed_size)?;
 
         // Fast path: non-delta entry stored uncompressed. The most
         // common shape for snapshot-time packs (the builder skips
         // the delta search for unrelated blobs).
         if obj_type != ObjectType::Delta && compressed_size == uncompressed_size {
-            let data_start = varint_start + comp_len;
-            let data_end = data_start + compressed_size;
-            if data_end > self.content_end {
-                return Err(StoreError::InvalidObject(
-                    "Entry data out of bounds".to_string(),
-                ));
-            }
+            let data_start = checked_index_add(varint_start, comp_len, "entry data start")?;
+            let data_end = checked_data_end(data_start, compressed_size, self.content_end)?;
             return Ok(Some((obj_type, self.data.slice(data_start..data_end))));
         }
 
@@ -184,19 +177,19 @@ impl PackReader {
         let Some(offset) = self.index.find(&id) else {
             return Ok(None);
         };
-        let offset = offset as usize;
+        let offset = checked_index_offset(offset)?;
         if offset >= self.content_end {
             return Err(StoreError::InvalidObject(
                 "Entry offset out of bounds".to_string(),
             ));
         }
-        let (record_id, id_len) = PackObjectId::decode_tagged(&self.data[offset..])?;
+        let (record_id, id_len) = PackObjectId::decode_tagged(self.content_from(offset)?)?;
         verify_record_id_matches(&id, &record_id)?;
-        let header_start = offset + id_len;
-        let (obj_type, uncompressed_size, _type_len) =
-            super::varint::decode_type_and_size(&self.data[header_start..]).ok_or_else(|| {
-                StoreError::InvalidObject("Truncated type+size varint".to_string())
-            })?;
+        let header_start = checked_index_add(offset, id_len, "record header start")?;
+        let (obj_type, uncompressed_size, _type_len) = super::varint::decode_type_and_size(
+            self.content_from(header_start)?,
+        )
+        .ok_or_else(|| StoreError::InvalidObject("Truncated type+size varint".to_string()))?;
         if obj_type == ObjectType::Delta {
             // Delta entries record the *resolved* output size in the
             // type+size varint already (see `read_record_at_depth`'s
@@ -214,39 +207,32 @@ impl PackReader {
             ));
         }
 
-        let (id, id_len) = PackObjectId::decode_tagged(&self.data[offset..])?;
-        let header_start = offset + id_len;
+        let (id, id_len) = PackObjectId::decode_tagged(self.content_from(offset)?)?;
+        let header_start = checked_index_add(offset, id_len, "record header start")?;
 
         let (obj_type, uncompressed_size, type_len) =
-            varint::decode_type_and_size(&self.data[header_start..]).ok_or_else(|| {
+            varint::decode_type_and_size(self.content_from(header_start)?).ok_or_else(|| {
                 StoreError::InvalidObject("Truncated type+size varint".to_string())
             })?;
-        let uncompressed_size = uncompressed_size as usize;
+        let uncompressed_size = checked_decoded_size("uncompressed_size", uncompressed_size)?;
 
-        let varint_start = header_start + type_len;
-        let (compressed_size, comp_len) = varint::decode_varint(&self.data[varint_start..])
-            .ok_or_else(|| {
-                StoreError::InvalidObject("Truncated compressed_size varint".to_string())
-            })?;
-        let compressed_size = compressed_size as usize;
+        let varint_start = checked_index_add(header_start, type_len, "compressed_size start")?;
+        let (compressed_size, comp_len) = varint::decode_varint(self.content_from(varint_start)?)
+            .ok_or_else(truncated_compressed_size_varint)?;
+        let compressed_size = checked_decoded_size("compressed_size", compressed_size)?;
 
-        let mut data_start = varint_start + comp_len;
+        let mut data_start = checked_index_add(varint_start, comp_len, "entry data start")?;
 
         // Delta entries carry a tagged base id in pack v2.
         let base_id = if obj_type == ObjectType::Delta {
-            let (base_id, base_len) = PackObjectId::decode_tagged(&self.data[data_start..])?;
-            data_start += base_len;
+            let (base_id, base_len) = PackObjectId::decode_tagged(self.content_from(data_start)?)?;
+            data_start = checked_index_add(data_start, base_len, "delta data start")?;
             Some(base_id)
         } else {
             None
         };
 
-        let data_end = data_start + compressed_size;
-        if data_end > self.content_end {
-            return Err(StoreError::InvalidObject(
-                "Entry data out of bounds".to_string(),
-            ));
-        }
+        let data_end = checked_data_end(data_start, compressed_size, self.content_end)?;
 
         let stored_data = &self.data[data_start..data_end];
 
@@ -314,7 +300,8 @@ impl PackReader {
             .index
             .find(&PackObjectId::Hash(base_hash))
             .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
-        let base_record = self.read_record_at_depth(base_offset as usize, depth + 1)?;
+        let base_offset = checked_index_offset(base_offset)?;
+        let base_record = self.read_record_at_depth(base_offset, depth + 1)?;
         let base_type = base_record.obj_type;
         let base_data = base_record.data;
 
@@ -335,6 +322,51 @@ impl PackReader {
             )),
         }
     }
+
+    fn content_from(&self, offset: usize) -> Result<&[u8]> {
+        if offset > self.content_end {
+            return Err(StoreError::InvalidObject(
+                "Entry header out of bounds".to_string(),
+            ));
+        }
+        Ok(&self.data[offset..self.content_end])
+    }
+}
+
+fn checked_index_offset(offset: u64) -> Result<usize> {
+    usize::try_from(offset)
+        .map_err(|_| StoreError::InvalidObject("Entry offset exceeds platform limits".to_string()))
+}
+
+fn checked_decoded_size(field: &str, size: u64) -> Result<usize> {
+    usize::try_from(size)
+        .map_err(|_| StoreError::InvalidObject(format!("Decoded {field} exceeds platform limits")))
+}
+
+fn checked_index_add(start: usize, len: usize, field: &str) -> Result<usize> {
+    start.checked_add(len).ok_or_else(|| {
+        StoreError::InvalidObject(format!("{field} offset overflows platform limits"))
+    })
+}
+
+fn checked_data_end(
+    data_start: usize,
+    compressed_size: usize,
+    content_end: usize,
+) -> Result<usize> {
+    let data_end = data_start.checked_add(compressed_size).ok_or_else(|| {
+        StoreError::InvalidObject("Entry data range overflows platform limits".to_string())
+    })?;
+    if data_end > content_end {
+        return Err(StoreError::InvalidObject(
+            "Entry data out of bounds".to_string(),
+        ));
+    }
+    Ok(data_end)
+}
+
+fn truncated_compressed_size_varint() -> StoreError {
+    StoreError::InvalidObject("Truncated compressed_size varint".to_string())
 }
 
 /// Reject a record whose tagged id at the indexed offset doesn't
@@ -358,7 +390,7 @@ fn verify_record_id_matches(requested: &PackObjectId, found: &PackObjectId) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::{PackObjectId, PackReader, verify_record_id_matches};
+    use super::{verify_record_id_matches, PackObjectId, PackReader};
     use crate::{object::ContentHash, store::StoreError};
 
     #[test]

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -297,6 +297,80 @@ fn test_pack_reader_rejects_delta_output_above_limit() {
     );
 }
 
+#[cfg(feature = "zstd")]
+#[test]
+fn test_pack_reader_rejects_compressed_record_claiming_huge_uncompressed_size() {
+    let hash = create_test_hash(46);
+    let payload = b"small compressed payload".repeat(32);
+    let compressed = zstd::encode_all(payload.as_slice(), 3).expect("test zstd compression works");
+
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, 0xFFFF_FFFF, record);
+        super::varint::encode_varint(compressed.len() as u64, record);
+        record.extend_from_slice(&compressed);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let error = reader
+        .get_hashed_object(&hash)
+        .expect_err("hostile uncompressed_size must be rejected without eager allocation");
+    assert_invalid_object_message_contains(error, "Pack object output size");
+
+    let bytes_error = reader
+        .get_hashed_object_bytes(&hash)
+        .expect_err("zero-copy fallback must reject hostile uncompressed_size too");
+    assert_invalid_object_message_contains(bytes_error, "Pack object output size");
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn test_pack_decompression_rejects_streaming_output_past_limit() {
+    let payload = vec![0xA5; 64 * 1024];
+    let compressed = zstd::encode_all(payload.as_slice(), 3).expect("test zstd compression works");
+    assert!(
+        compressed.len() < 1024,
+        "test payload should exercise compressed-small/decompressed-large shape"
+    );
+
+    let error = super::shared::decompress_pack_payload_with_limit(&compressed, 0, 32 * 1024)
+        .expect_err("streaming output above the cap must fail cleanly");
+    assert_invalid_object_message_contains(error, "Pack object output size");
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn test_pack_reader_decodes_compressed_object_larger_than_initial_hint() {
+    let hash = create_test_hash(47);
+    let payload = vec![0x5C; super::shared::PACK_DECOMPRESSION_INITIAL_CAP + 64 * 1024];
+    assert!(payload.len() < super::shared::MAX_PACK_OBJECT_OUTPUT_SIZE);
+    let compressed = zstd::encode_all(payload.as_slice(), 3).expect("test zstd compression works");
+    assert!(
+        compressed.len() < payload.len(),
+        "manual pack must use the compressed reader path"
+    );
+
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, payload.len() as u64, record);
+        super::varint::encode_varint(compressed.len() as u64, record);
+        record.extend_from_slice(&compressed);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let (obj_type, data) = reader
+        .get_hashed_object(&hash)
+        .expect("large compressed object should decode")
+        .expect("record should exist");
+    assert_eq!(obj_type, ObjectType::Blob);
+    assert_eq!(data, payload);
+
+    let (bytes_type, bytes) = reader
+        .get_hashed_object_bytes(&hash)
+        .expect("large compressed object should decode through bytes path")
+        .expect("record should exist");
+    assert_eq!(bytes_type, ObjectType::Blob);
+    assert_eq!(bytes.as_ref(), payload.as_slice());
+}
+
 #[test]
 fn test_pack_index_rejects_impossible_entry_count() {
     let mut bytes = Vec::new();

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -3,16 +3,44 @@
 
 use tempfile::TempDir;
 
-use super::{ObjectType, PackBuilder, PackObjectId, PackReader, pack_index::PackIndex};
+use super::{pack_index::PackIndex, ObjectType, PackBuilder, PackObjectId, PackReader};
 use crate::{
     delta::MAX_DELTA_OUTPUT_SIZE,
     object::{ChangeId, ContentHash},
-    store::{compression::CompressionConfig, pack::pack_container_spec},
+    store::{compression::CompressionConfig, pack::pack_container_spec, StoreError},
 };
 
 fn create_test_hash(n: u8) -> ContentHash {
     let bytes: [u8; 32] = [n; 32];
     ContentHash::from_bytes(bytes)
+}
+
+fn single_record_pack(
+    hash: ContentHash,
+    write_record_tail: impl FnOnce(&mut Vec<u8>),
+) -> (Vec<u8>, Vec<u8>) {
+    let mut pack_data = Vec::new();
+    pack_data.extend_from_slice(pack_container_spec().magic);
+    pack_data.extend_from_slice(&pack_container_spec().version.to_be_bytes());
+    pack_data.extend_from_slice(&1u64.to_be_bytes());
+
+    let entry_offset = u64::try_from(pack_data.len()).expect("test pack offset fits in u64");
+    PackObjectId::Hash(hash).encode_tagged(&mut pack_data);
+    write_record_tail(&mut pack_data);
+    super::append_container_checksum(&mut pack_data);
+
+    let mut index = PackIndex::new();
+    index.add(PackObjectId::Hash(hash), entry_offset);
+    index.sort();
+
+    (pack_data, index.to_bytes())
+}
+
+fn assert_invalid_object_message_contains(error: StoreError, expected: &str) {
+    assert!(
+        matches!(error, StoreError::InvalidObject(ref message) if message.contains(expected)),
+        "expected InvalidObject containing '{expected}', got: {error:?}"
+    );
 }
 
 #[test]
@@ -110,6 +138,107 @@ fn test_delta_compression() {
 
     assert!(stats.delta_count > 0);
     assert!(stats.compression_ratio < 1.0);
+}
+
+#[test]
+fn test_pack_reader_rejects_compressed_size_that_overflows_record_end() {
+    let hash = create_test_hash(42);
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, u64::MAX, record);
+        super::varint::encode_varint(u64::MAX, record);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let error = reader
+        .get_hashed_object(&hash)
+        .expect_err("oversized compressed_size must fail before slicing");
+    assert!(
+        matches!(
+            error,
+            StoreError::InvalidObject(ref message)
+                if message.contains("overflows") || message.contains("platform limits")
+        ),
+        "expected overflow/platform-limit error, got: {error:?}",
+    );
+
+    let bytes_error = reader
+        .get_hashed_object_bytes(&hash)
+        .expect_err("zero-copy path must reject oversized compressed_size too");
+    assert!(
+        matches!(
+            bytes_error,
+            StoreError::InvalidObject(ref message)
+                if message.contains("overflows") || message.contains("platform limits")
+        ),
+        "expected overflow/platform-limit error, got: {bytes_error:?}",
+    );
+}
+
+#[test]
+fn test_pack_reader_rejects_truncated_compressed_size_varint() {
+    let hash = create_test_hash(43);
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, 4, record);
+        record.push(0x80);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let error = reader
+        .get_hashed_object(&hash)
+        .expect_err("truncated compressed_size must not read into checksum bytes");
+    assert_invalid_object_message_contains(error, "Truncated compressed_size varint");
+
+    let bytes_error = reader
+        .get_hashed_object_bytes(&hash)
+        .expect_err("zero-copy path must reject truncated compressed_size too");
+    assert_invalid_object_message_contains(bytes_error, "Truncated compressed_size varint");
+}
+
+#[test]
+fn test_pack_reader_rejects_compressed_size_past_content_end() {
+    let hash = create_test_hash(44);
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, 10, record);
+        super::varint::encode_varint(10, record);
+        record.extend_from_slice(b"abc");
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let error = reader
+        .get_hashed_object(&hash)
+        .expect_err("record payload shorter than compressed_size must fail");
+    assert_invalid_object_message_contains(error, "Entry data out of bounds");
+
+    let bytes_error = reader
+        .get_hashed_object_bytes(&hash)
+        .expect_err("zero-copy path must reject payload shorter than compressed_size too");
+    assert_invalid_object_message_contains(bytes_error, "Entry data out of bounds");
+}
+
+#[test]
+fn test_pack_reader_decodes_well_formed_manual_record() {
+    let hash = create_test_hash(45);
+    let payload = b"manual-pack-record".to_vec();
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, payload.len() as u64, record);
+        super::varint::encode_varint(payload.len() as u64, record);
+        record.extend_from_slice(&payload);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let (obj_type, data) = reader
+        .get_hashed_object(&hash)
+        .expect("well-formed record should decode")
+        .expect("record should exist");
+    assert_eq!(obj_type, ObjectType::Blob);
+    assert_eq!(data, payload);
+
+    let (bytes_type, bytes) = reader
+        .get_hashed_object_bytes(&hash)
+        .expect("well-formed zero-copy record should decode")
+        .expect("record should exist");
+    assert_eq!(bytes_type, ObjectType::Blob);
+    assert_eq!(bytes.as_ref(), payload.as_slice());
 }
 
 #[test]
@@ -300,7 +429,7 @@ fn test_pack_reader_missing_object_returns_none() {
 /// with the expected diagnostic phrase.
 #[test]
 fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
-    use crate::store::{StoreError, pack::pack_index::PackIndex};
+    use crate::store::{pack::pack_index::PackIndex, StoreError};
 
     let blob_a = b"alpha-payload alpha-payload alpha-payload alpha".to_vec();
     let blob_b = b"bravo-payload bravo-payload bravo-payload bravo".to_vec();

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 
 pub const PACK_CHECKSUM_LEN: usize = 32;
+pub const MAX_PACK_OBJECT_OUTPUT_SIZE: usize = 1024 * 1024 * 1024;
+pub(super) const PACK_DECOMPRESSION_INITIAL_CAP: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum PackObjectId {
@@ -308,25 +310,76 @@ pub fn compress_pack_payload(data: &[u8], config: &CompressionConfig) -> Result<
 pub fn decompress_pack_payload(data: &[u8], expected_size: usize) -> Result<Vec<u8>> {
     #[cfg(feature = "zstd")]
     {
-        use std::io::Read;
-        let mut decoder = zstd::stream::read::Decoder::new(data)
-            .map_err(|e| StoreError::InvalidObject(format!("zstd decode init failed: {e}")))?;
-        let capacity = if expected_size > 0 {
-            expected_size
-        } else {
-            data.len() * 2
-        };
-        let mut buf = Vec::with_capacity(capacity);
-        decoder
-            .read_to_end(&mut buf)
-            .map_err(|e| StoreError::InvalidObject(format!("zstd decompression failed: {e}")))?;
-        Ok(buf)
+        decompress_pack_payload_with_limit(data, expected_size, MAX_PACK_OBJECT_OUTPUT_SIZE)
     }
     #[cfg(not(feature = "zstd"))]
     {
-        let _ = expected_size;
+        reject_pack_object_output_over_limit(expected_size, MAX_PACK_OBJECT_OUTPUT_SIZE)?;
+        reject_pack_object_output_over_limit(data.len(), MAX_PACK_OBJECT_OUTPUT_SIZE)?;
         Ok(data.to_vec())
     }
+}
+
+#[cfg(feature = "zstd")]
+pub(super) fn decompress_pack_payload_with_limit(
+    data: &[u8],
+    expected_size: usize,
+    max_output_size: usize,
+) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    // Pack objects may be raw blobs, so this bound must be materially
+    // larger than the delta-output limit. It is also intentionally
+    // above the protocol default and loose-compression cap, while
+    // still bounding one untrusted pack record to a finite allocation.
+    reject_pack_object_output_over_limit(expected_size, max_output_size)?;
+
+    let mut decoder = zstd::stream::read::Decoder::new(data)
+        .map_err(|e| StoreError::InvalidObject(format!("zstd decode init failed: {e}")))?;
+    let capacity = initial_decompression_capacity(data.len(), expected_size, max_output_size);
+    let mut buf = Vec::with_capacity(capacity);
+    let mut chunk = [0u8; 8192];
+
+    loop {
+        let bytes_read = decoder
+            .read(&mut chunk)
+            .map_err(|e| StoreError::InvalidObject(format!("zstd decompression failed: {e}")))?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let next_len = buf.len().checked_add(bytes_read).ok_or_else(|| {
+            StoreError::InvalidObject("Pack object output size overflows".to_string())
+        })?;
+        reject_pack_object_output_over_limit(next_len, max_output_size)?;
+        buf.extend_from_slice(&chunk[..bytes_read]);
+    }
+
+    Ok(buf)
+}
+
+#[cfg(feature = "zstd")]
+fn initial_decompression_capacity(
+    compressed_len: usize,
+    expected_size: usize,
+    max_output_size: usize,
+) -> usize {
+    let hint = if expected_size > 0 {
+        expected_size
+    } else {
+        compressed_len.saturating_mul(2)
+    };
+    hint.min(PACK_DECOMPRESSION_INITIAL_CAP)
+        .min(max_output_size)
+}
+
+fn reject_pack_object_output_over_limit(size: usize, max: usize) -> Result<()> {
+    if size > max {
+        return Err(StoreError::InvalidObject(format!(
+            "Pack object output size {size} exceeds max {max}"
+        )));
+    }
+    Ok(())
 }
 
 pub fn has_zstd_magic(data: &[u8]) -> bool {


### PR DESCRIPTION
## Summary
**Security P1 (#365):** the pack record reader decoded `compressed_size`/`uncompressed_size` from untrusted pack bytes and computed `data_start + size` WITHOUT checked arithmetic — the bounds guard ran *after* the add, so a hostile size panicked in debug (DoS) or wrapped past the guard in release. Reachable via hosted sync pack parsing.

This change:
- Hardens every decoded offset/size site in `pack_reader.rs` with `usize::try_from` + `checked_add`, returning an error BEFORE any slicing (overflow/oversize check precedes indexing).
- Constrains record header decoding to `content_end` so a truncated size field can't read into checksum bytes.
- Closes the whole arithmetic class, not just the two originally-cited lines.

## Test evidence
- Malformed-pack regressions: overflowing `compressed_size`, truncated size varint, size past `content_end`.
- Well-formed manual-record no-regression test.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-objects`, `cargo test --workspace`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #365.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968862&installation_id=132405951&pr_number=396&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F396&signature=04fb07ab3c0e7d3aeaa04c8224c54e6b0c0a3a7a3b6a99ddd51bc611b1aa52ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->