### PR TITLE
feat(atomic): CAS-on-commit for same-thread AtomicMutation isolation (#392)

### DIFF
--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -194,6 +194,10 @@ pub(super) fn flush_rebase_batch(
     // past it is acceptable because the worst-case outcome is a
     // duplicate batch the operator can collapse with a second
     // `heddle undo`.
+    //
+    // heddle#382 boundary: rebase still uses the older exact-once-windowed
+    // append and is explicitly outside same-thread AtomicMutation isolation
+    // until this flow is migrated to an AtomicMutation root.
     repo.oplog().record_batch_scoped_if_no_transaction(
         batch,
         Some(&repo.op_scope()),

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -39,6 +39,7 @@
 //! all lives here, exactly like undo/redo's `EntrySteps`.
 
 use std::cell::Cell;
+use std::collections::BTreeSet;
 #[cfg(unix)]
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -46,11 +47,11 @@ use std::rc::Rc;
 
 use objects::error::{HeddleError, Result as HeddleResult};
 use objects::object::{ChangeId, ThreadName};
-use oplog::OpRecord;
+use oplog::{IsolationKey, OpRecord};
 use refs::RefExpectation;
 use repo::{
-    atomic::{AtomicMutation, StagedCommit, Tx},
     Repository, Thread, ThreadManager, ThreadMode,
+    atomic::{AtomicMutation, StagedCommit, Tx},
 };
 
 use super::mount_lifecycle::{self, MountOwnership};
@@ -969,6 +970,18 @@ impl AtomicMutation for StartThread {
 
     fn transaction_id(&self) -> String {
         self.transaction_id.clone()
+    }
+
+    fn isolation_keys(&self, _repo: &repo::Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::Thread(self.name.clone()));
+        if let Some(thread) = &self.record.target_thread {
+            keys.insert(IsolationKey::Thread(thread.clone()));
+        }
+        if let Some(thread) = &self.record.parent_thread {
+            keys.insert(IsolationKey::Thread(thread.clone()));
+        }
+        Ok(keys)
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<String>>> {

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -2,6 +2,7 @@
 //! Apply undo/redo operations to the repository.
 
 use std::{
+    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -18,12 +19,13 @@ use gix::{
 use objects::error::{HeddleError, Result as HeddleResult};
 use objects::lock::{RepoLock, WriteLockGuard};
 use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName};
-use oplog::{OpBatch, OpEntry, OpRecord};
+use oplog::{IsolationKey, OpBatch, OpEntry, OpRecord, isolation_keys_for_record};
 use refs::Head;
 use repo::{
     CommitGraphIndex, Repository, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
-    ThreadState, refresh_thread_freshness,
+    ThreadState,
     atomic::{AtomicMutation, DeferredMutation, StagedCommit, Tx},
+    refresh_thread_freshness,
 };
 
 use super::{advice::RecoveryAdvice, thread_cmd::thread_not_found_advice};
@@ -198,7 +200,9 @@ fn with_nonatomic_forward_fault<T>(skip_then_fail_at: usize, body: impl FnOnce()
 /// Decrement-and-test one of the per-entry fault counters; `true` iff this call
 /// is the armed trip point (the counter disarms on trip).
 #[cfg(test)]
-fn fault_counter_trips(cell: &'static std::thread::LocalKey<std::cell::Cell<Option<usize>>>) -> bool {
+fn fault_counter_trips(
+    cell: &'static std::thread::LocalKey<std::cell::Cell<Option<usize>>>,
+) -> bool {
     cell.with(|f| match f.get() {
         Some(0) => {
             f.set(None);
@@ -337,7 +341,9 @@ impl<'a> EntrySteps<'_, 'a> {
         self.step(
             move || repo.refs().delete_thread(&forward_name).map(|_| ()),
             move || match prev {
-                Some(prev) => repo.refs().set_thread(&ThreadName::new(restore_name), &prev),
+                Some(prev) => repo
+                    .refs()
+                    .set_thread(&ThreadName::new(restore_name), &prev),
                 None => Ok(()),
             },
         )
@@ -374,7 +380,9 @@ impl<'a> EntrySteps<'_, 'a> {
         self.step(
             move || repo.refs().delete_marker(&forward_name).map(|_| ()),
             move || match prev {
-                Some(prev) => repo.refs().create_marker(&MarkerName::new(restore_name), &prev),
+                Some(prev) => repo
+                    .refs()
+                    .create_marker(&MarkerName::new(restore_name), &prev),
                 None => Ok(()),
             },
         )
@@ -404,9 +412,7 @@ impl<'a> EntrySteps<'_, 'a> {
             move |prior| {
                 ThreadManager::new(repo.heddle_dir()).converge_records(&restore_name, &prior)
             },
-            move || {
-                ThreadManager::new(repo.heddle_dir()).converge_records(&forward_name, &desired)
-            },
+            move || ThreadManager::new(repo.heddle_dir()).converge_records(&forward_name, &desired),
         )
     }
 
@@ -1660,6 +1666,14 @@ impl AtomicMutation for StageUndoRecovery {
         "undo:stage-recovery".to_string()
     }
 
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::LocalHead {
+            scope: repo.op_scope(),
+        });
+        Ok(keys)
+    }
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
         let Some(state) = self.head else {
             return Ok(StagedCommit::pure(()));
@@ -1721,6 +1735,13 @@ impl AtomicMutation for ApplyUndoBatch {
         format!("undo:batch:{}", self.batch.id)
     }
 
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        Ok(isolation_keys_for_batches(
+            std::slice::from_ref(&self.batch),
+            &repo.op_scope(),
+        ))
+    }
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
         let mut steps = EntrySteps::new(tx);
         for (applied, entry) in self.batch.entries.iter().rev().enumerate() {
@@ -1734,9 +1755,7 @@ impl AtomicMutation for ApplyUndoBatch {
             apply_undo_entry(&mut steps, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
-                return Err(HeddleError::Conflict(
-                    "injected mid-undo fault".to_string(),
-                ));
+                return Err(HeddleError::Conflict("injected mid-undo fault".to_string()));
             }
             #[cfg(not(test))]
             let _ = applied;
@@ -1782,6 +1801,13 @@ impl AtomicMutation for ApplyRedoBatch {
         format!("redo:batch:{}", self.batch.id)
     }
 
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        Ok(isolation_keys_for_batches(
+            std::slice::from_ref(&self.batch),
+            &repo.op_scope(),
+        ))
+    }
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<OpBatch>> {
         let mut steps = EntrySteps::new(tx);
         for (applied, entry) in self.batch.entries.iter().enumerate() {
@@ -1791,9 +1817,7 @@ impl AtomicMutation for ApplyRedoBatch {
             apply_redo_entry(&mut steps, entry)?;
             #[cfg(test)]
             if self.fail_after_entries == Some(applied + 1) {
-                return Err(HeddleError::Conflict(
-                    "injected mid-redo fault".to_string(),
-                ));
+                return Err(HeddleError::Conflict("injected mid-redo fault".to_string()));
             }
             #[cfg(not(test))]
             let _ = applied;
@@ -1804,6 +1828,22 @@ impl AtomicMutation for ApplyRedoBatch {
 }
 
 impl DeferredMutation for ApplyRedoBatch {}
+
+fn isolation_keys_for_batches(batches: &[OpBatch], scope: &str) -> BTreeSet<IsolationKey> {
+    let mut keys = BTreeSet::new();
+    for batch in batches {
+        for entry in &batch.entries {
+            keys.extend(isolation_keys_for_record(
+                &entry.operation,
+                entry.scope.as_deref(),
+            ));
+        }
+    }
+    keys.insert(IsolationKey::LocalHead {
+        scope: scope.to_string(),
+    });
+    keys
+}
 
 /// Root composite for `heddle undo`: stage the recovery pointer, then nest one
 /// [`ApplyUndoBatch`] per batch. Returns the updated (undone) batches for the
@@ -1834,6 +1874,10 @@ impl AtomicMutation for UndoOp {
 
     fn transaction_id(&self) -> String {
         self.transaction_id.clone()
+    }
+
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        Ok(isolation_keys_for_batches(&self.batches, &repo.op_scope()))
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<OpBatch>>> {
@@ -1871,6 +1915,10 @@ impl AtomicMutation for RedoOp {
 
     fn transaction_id(&self) -> String {
         self.transaction_id.clone()
+    }
+
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        Ok(isolation_keys_for_batches(&self.batches, &repo.op_scope()))
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<OpBatch>>> {
@@ -1955,6 +2003,10 @@ mod atomic_tests {
             "test-undo-fault".to_string()
         }
 
+        fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+            Ok(isolation_keys_for_batches(&self.batches, &repo.op_scope()))
+        }
+
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
             tx.enroll(StageUndoRecovery {
                 head: self.recovery_head,
@@ -1962,7 +2014,10 @@ mod atomic_tests {
             let last = self.batches.len() - 1;
             for (i, batch) in self.batches.iter().enumerate() {
                 if i == last {
-                    tx.enroll(ApplyUndoBatch::failing_after(batch.clone(), self.fail_after))?;
+                    tx.enroll(ApplyUndoBatch::failing_after(
+                        batch.clone(),
+                        self.fail_after,
+                    ))?;
                 } else {
                     tx.enroll(ApplyUndoBatch::new(batch.clone()))?;
                 }
@@ -1985,11 +2040,18 @@ mod atomic_tests {
             "test-redo-fault".to_string()
         }
 
+        fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+            Ok(isolation_keys_for_batches(&self.batches, &repo.op_scope()))
+        }
+
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
             let last = self.batches.len() - 1;
             for (i, batch) in self.batches.iter().enumerate() {
                 if i == last {
-                    tx.enroll(ApplyRedoBatch::failing_after(batch.clone(), self.fail_after))?;
+                    tx.enroll(ApplyRedoBatch::failing_after(
+                        batch.clone(),
+                        self.fail_after,
+                    ))?;
                 } else {
                     tx.enroll(ApplyRedoBatch::new(batch.clone()))?;
                 }
@@ -2060,7 +2122,11 @@ mod atomic_tests {
         assert!(result.is_err(), "the injected fault must fail the undo");
 
         // Exact pre-operation state restored across every dimension.
-        assert_eq!(repo.head().unwrap(), Some(s2), "HEAD rewound to pre-undo tip");
+        assert_eq!(
+            repo.head().unwrap(),
+            Some(s2),
+            "HEAD rewound to pre-undo tip"
+        );
         assert_eq!(main_thread(&repo), pre_main, "main ref rewound");
         assert!(temp.path().join("a.txt").exists(), "s1 file restored");
         assert!(temp.path().join("b.txt").exists(), "s2 file restored");
@@ -2129,7 +2195,10 @@ mod atomic_tests {
         // Rewound to the fully-undone pre-redo state.
         assert_eq!(repo.head().unwrap(), pre_redo_head, "HEAD rewound");
         assert_eq!(main_thread(&repo), pre_redo_main, "main ref rewound");
-        assert!(!temp.path().join("a.txt").exists(), "s1 file not resurrected");
+        assert!(
+            !temp.path().join("a.txt").exists(),
+            "s1 file not resurrected"
+        );
         assert_eq!(
             repo.oplog()
                 .redo_batches_scoped(1, Some(&scope))
@@ -2171,7 +2240,10 @@ mod atomic_tests {
         let result = with_entry_write_fault(1, || {
             repo::atomic::execute(&repo, UndoOp::new(batches, pre_head, txid))
         });
-        assert!(result.is_err(), "the injected 2nd-write fault must fail the undo");
+        assert!(
+            result.is_err(),
+            "the injected 2nd-write fault must fail the undo"
+        );
 
         // The goto was rolled back along with everything else.
         assert_eq!(
@@ -2198,7 +2270,11 @@ mod atomic_tests {
             None,
             "recovery pointer cleared by rewind"
         );
-        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+        assert_eq!(
+            commit_marker_count(&repo),
+            pre_markers,
+            "no marker committed"
+        );
     }
 
     /// Per-effect rollback, REDO direction (heddle#355 cid 3330966931). Mirror of
@@ -2231,7 +2307,10 @@ mod atomic_tests {
         let result = with_entry_write_fault(1, || {
             repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid))
         });
-        assert!(result.is_err(), "the injected 2nd-write fault must fail the redo");
+        assert!(
+            result.is_err(),
+            "the injected 2nd-write fault must fail the redo"
+        );
 
         assert_eq!(
             repo.head().unwrap(),
@@ -2252,7 +2331,11 @@ mod atomic_tests {
             1,
             "batch still redoable"
         );
-        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+        assert_eq!(
+            commit_marker_count(&repo),
+            pre_markers,
+            "no marker committed"
+        );
     }
 
     /// Per-effect rollback of marker writes. Undoing a batch whose entries delete
@@ -2265,7 +2348,9 @@ mod atomic_tests {
         let scope = repo.op_scope();
         // `mc` exists (its MarkerCreate undo = delete_marker, inverse recreate);
         // `md` does not (its MarkerDelete undo = create_marker, inverse delete).
-        repo.refs().create_marker(&MarkerName::new("mc"), &s1).unwrap();
+        repo.refs()
+            .create_marker(&MarkerName::new("mc"), &s1)
+            .unwrap();
         let main_state = main_thread(&repo).unwrap();
 
         repo.oplog()
@@ -2322,7 +2407,9 @@ mod atomic_tests {
         let scope = repo.op_scope();
         // `old` exists (its ThreadCreate undo = delete_thread, inverse re-set);
         // `new` does not (its ThreadDelete undo = set_thread, inverse delete).
-        repo.refs().set_thread(&ThreadName::new("old"), &s1).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("old"), &s1)
+            .unwrap();
         let main_state = main_thread(&repo).unwrap();
 
         repo.oplog()
@@ -2400,7 +2487,10 @@ mod atomic_tests {
         let txid = undo_redo_transaction_id("redo", &scope, generation, &redo_batches);
         repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid)).unwrap();
         assert_eq!(repo.head().unwrap(), Some(s2), "redo restored the s2 tip");
-        assert!(temp.path().join("b.txt").exists(), "s2 file restored by redo");
+        assert!(
+            temp.path().join("b.txt").exists(),
+            "s2 file restored by redo"
+        );
     }
 
     /// The undo/redo serialization lock is mutually exclusive: while one holder
@@ -2493,7 +2583,11 @@ mod atomic_tests {
             .oplog()
             .recent_user_batches_scoped(1, Some(&scope))
             .unwrap();
-        assert_eq!(user.len(), 1, "depth 1 returns exactly one user-facing batch");
+        assert_eq!(
+            user.len(),
+            1,
+            "depth 1 returns exactly one user-facing batch"
+        );
         assert!(
             !user[0].is_transaction_marker_only(),
             "the returned batch is a real op, not the marker sentinel"
@@ -2549,7 +2643,10 @@ mod atomic_tests {
         let txid = undo_redo_transaction_id("undo", &scope, generation, &batches);
         let result = repo::atomic::execute(&repo, UndoOp::new(batches, recovery_head, txid));
 
-        assert!(result.is_err(), "the colliding create_marker must fail the undo");
+        assert!(
+            result.is_err(),
+            "the colliding create_marker must fail the undo"
+        );
         assert_eq!(
             repo.refs().get_marker(&marker).unwrap(),
             Some(s1),
@@ -2595,7 +2692,10 @@ mod atomic_tests {
         let txid = undo_redo_transaction_id("redo", &scope, generation, &redo_batches);
         let result = repo::atomic::execute(&repo, RedoOp::new(redo_batches, txid));
 
-        assert!(result.is_err(), "the colliding create_marker must fail the redo");
+        assert!(
+            result.is_err(),
+            "the colliding create_marker must fail the redo"
+        );
         assert_eq!(
             repo.refs().get_marker(&marker).unwrap(),
             Some(s1),
@@ -2650,7 +2750,11 @@ mod atomic_tests {
             None,
             "recovery pointer cleared by rewind"
         );
-        assert_eq!(commit_marker_count(&repo), pre_markers, "no marker committed");
+        assert_eq!(
+            commit_marker_count(&repo),
+            pre_markers,
+            "no marker committed"
+        );
     }
 
     fn sample_main_thread(current_state: &str, materialized: &str) -> Thread {
@@ -2696,6 +2800,12 @@ mod atomic_tests {
 
         fn transaction_id(&self) -> String {
             "test-save-only".to_string()
+        }
+
+        fn isolation_keys(&self, _repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+            let mut keys = BTreeSet::new();
+            keys.insert(IsolationKey::Thread(self.record.thread.clone()));
+            Ok(keys)
         }
 
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
@@ -2788,7 +2898,10 @@ mod atomic_tests {
             "only the prior record survives for the thread, no leaked newer record"
         );
         let restored = manager.find_by_thread("main").unwrap().unwrap();
-        assert_eq!(restored.id, "thread-main-v1", "find_by_thread returns ONLY prev");
+        assert_eq!(
+            restored.id, "thread-main-v1",
+            "find_by_thread returns ONLY prev"
+        );
         assert_eq!(restored.current_state.as_deref(), Some("current-A"));
     }
 
@@ -2833,6 +2946,12 @@ mod atomic_tests {
 
         fn transaction_id(&self) -> String {
             "test-restore-snapshot-only".to_string()
+        }
+
+        fn isolation_keys(&self, _repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+            let mut keys = BTreeSet::new();
+            keys.insert(IsolationKey::Thread(self.name.clone()));
+            Ok(keys)
         }
 
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
@@ -2940,7 +3059,12 @@ mod atomic_tests {
         dup.updated_at = to_restore.updated_at + chrono::Duration::seconds(60);
         manager.save(&dup).unwrap();
         assert_eq!(
-            manager.list().unwrap().iter().filter(|t| t.thread == "main").count(),
+            manager
+                .list()
+                .unwrap()
+                .iter()
+                .filter(|t| t.thread == "main")
+                .count(),
             1,
             "precondition: only the duplicate is filed at redo time"
         );
@@ -2993,6 +3117,12 @@ mod atomic_tests {
             "test-remove-record-only".to_string()
         }
 
+        fn isolation_keys(&self, _repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+            let mut keys = BTreeSet::new();
+            keys.insert(IsolationKey::Thread(self.name.clone()));
+            Ok(keys)
+        }
+
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
             let mut steps = EntrySteps::new(tx);
             remove_thread_manager_record(&mut steps, &self.name)?;
@@ -3024,9 +3154,19 @@ mod atomic_tests {
         older.id = "rec-older".to_string();
         older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
         manager.save(&older).unwrap();
-        assert_eq!(manager.list().unwrap().len(), 2, "precondition: two records");
+        assert_eq!(
+            manager.list().unwrap().len(),
+            2,
+            "precondition: two records"
+        );
 
-        repo::atomic::execute(&repo, RemoveRecordOnly { name: "main".to_string() }).unwrap();
+        repo::atomic::execute(
+            &repo,
+            RemoveRecordOnly {
+                name: "main".to_string(),
+            },
+        )
+        .unwrap();
 
         assert!(
             manager.find_by_thread("main").unwrap().is_none(),
@@ -3064,9 +3204,17 @@ mod atomic_tests {
         // under one lock), then the op fails — the inverse must re-converge to the
         // full captured prior set, restoring BOTH records.
         let result = with_nonatomic_forward_fault(0, || {
-            repo::atomic::execute(&repo, RemoveRecordOnly { name: "main".to_string() })
+            repo::atomic::execute(
+                &repo,
+                RemoveRecordOnly {
+                    name: "main".to_string(),
+                },
+            )
         });
-        assert!(result.is_err(), "the injected forward fault must fail the op");
+        assert!(
+            result.is_err(),
+            "the injected forward fault must fail the op"
+        );
 
         let remaining = manager.list().unwrap();
         assert_eq!(
@@ -3074,8 +3222,7 @@ mod atomic_tests {
             2,
             "rollback re-converged to ALL same-name records, not just the winner"
         );
-        let ids: std::collections::HashSet<_> =
-            remaining.iter().map(|t| t.id.clone()).collect();
+        let ids: std::collections::HashSet<_> = remaining.iter().map(|t| t.id.clone()).collect();
         assert!(
             ids.contains("rec-winner") && ids.contains("rec-older"),
             "both the winner and the older duplicate were restored"
@@ -3119,7 +3266,10 @@ mod atomic_tests {
         };
         let redaction_id = repo.put_redaction(redaction).unwrap();
         assert_eq!(
-            repo.get_redactions_for_blob(&blob).unwrap().redactions.len(),
+            repo.get_redactions_for_blob(&blob)
+                .unwrap()
+                .redactions
+                .len(),
             1,
             "redaction planted on disk"
         );

--- a/crates/daemon/src/grpc_local_impl/transaction.rs
+++ b/crates/daemon/src/grpc_local_impl/transaction.rs
@@ -228,6 +228,11 @@ impl TransactionService for LocalTransactionService {
                 // append `OpRecord::TransactionCommit` to the oplog. Real
                 // per-op replay (executing the buffered verbs at commit
                 // time rather than at call time) is the next follow-on.
+                //
+                // heddle#382 boundary: the daemon transaction service is not a
+                // local AtomicMutation root and remains outside the same-thread
+                // CAS-on-commit guarantee until this service is migrated to the
+                // conditional oplog API or an AtomicMutation-backed flow.
                 let op_count = sentinel.buffered_ops.len() as u32;
                 let transaction_id = sentinel.transaction_id.clone();
                 sentinel.state = STATE_COMMITTED.to_string();

--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -15,6 +15,9 @@ mod oplog_tests;
 
 pub use oplog_backend::OpLogBackend;
 pub use oplog_core::OpLog;
-pub use oplog_types::{OpBatch, OpEntry, OpRecord};
+pub use oplog_types::{
+    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
+    isolation_keys_for_record,
+};
 #[cfg(feature = "postgres")]
 pub use pg_oplog::PgOpLogBackend;

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -11,7 +11,9 @@ use objects::{
     object::{ChangeId, ContentHash, MarkerName, ThreadName},
 };
 
-use super::oplog_types::{OpBatch, OpEntry, OpRecord};
+use super::oplog_types::{
+    ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
+};
 
 /// Backend-agnostic interface for the operation log.
 ///
@@ -74,12 +76,26 @@ pub trait OpLogBackend: Send + Sync {
         }
     }
 
+    /// Exact-once transaction append guarded by a per-key isolation
+    /// precondition. Implementations that support local/hosted AtomicMutation
+    /// commits must override this so dedup, conflict detection, and append are
+    /// serialized at the backend's write authority.
+    fn record_batch_exactly_once_if_unchanged(
+        &self,
+        operations: Vec<OpRecord>,
+        scope: Option<&str>,
+        transaction_id: &str,
+        precondition: &IsolationPrecondition,
+    ) -> Result<ConditionalCommitOutcome> {
+        let _ = (operations, scope, transaction_id, precondition);
+        Err(objects::error::HeddleError::Config(
+            "oplog backend does not support conditional transaction commits".to_string(),
+        ))
+    }
+
     fn last(&self) -> Result<Option<OpEntry>>;
     fn recent(&self, count: usize) -> Result<Vec<OpEntry>>;
-    fn recent_batches(
-        &self,
-        count: usize,
-    ) -> impl Future<Output = Result<Vec<OpBatch>>> + Send {
+    fn recent_batches(&self, count: usize) -> impl Future<Output = Result<Vec<OpBatch>>> + Send {
         async move { self.recent_batches_scoped(count, None).await }
     }
     fn recent_batches_scoped(
@@ -317,15 +333,9 @@ pub trait OpLogBackend: Send + Sync {
 
     /// Record an undo-recovery pointer publish (heddle#330 r9). Local
     /// (per-checkout) ref, so `scope` carries `op_scope()`.
-    fn record_undo_recovery_update(
-        &self,
-        state: &ChangeId,
-        scope: Option<&str>,
-    ) -> Result<u64> {
-        let ids = self.record_batch_scoped(
-            vec![OpRecord::UndoRecoveryUpdate { state: *state }],
-            scope,
-        )?;
+    fn record_undo_recovery_update(&self, state: &ChangeId, scope: Option<&str>) -> Result<u64> {
+        let ids =
+            self.record_batch_scoped(vec![OpRecord::UndoRecoveryUpdate { state: *state }], scope)?;
         Ok(ids[0])
     }
 

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -15,7 +15,10 @@ use objects::{
 
 use super::{
     oplog_backend::OpLogBackend,
-    oplog_types::{OpBatch, OpEntry, OpRecord},
+    oplog_types::{
+        ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
+        isolation_keys_for_record,
+    },
     packed_oplog::PackedOpLog,
 };
 
@@ -439,6 +442,68 @@ impl OpLog {
         Ok(Some(ids))
     }
 
+    pub fn record_batch_exactly_once_if_unchanged(
+        &self,
+        operations: Vec<OpRecord>,
+        scope: Option<&str>,
+        transaction_id: &str,
+        precondition: &IsolationPrecondition,
+    ) -> Result<ConditionalCommitOutcome> {
+        if operations.is_empty() {
+            return Ok(ConditionalCommitOutcome::Committed(Vec::new()));
+        }
+
+        let _lock = self.write_lock()?;
+        let mut packed = self.load_fresh()?;
+
+        if let Some(commit_entry) = packed.entries.iter().find(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::TransactionCommit { transaction_id: id, .. }
+                    if id == transaction_id
+            )
+        }) {
+            let committed = packed
+                .entries
+                .iter()
+                .filter(|entry| entry.batch_id == commit_entry.batch_id)
+                .filter(|entry| !is_transaction_commit(&entry.operation))
+                .map(|entry| entry.operation.clone())
+                .collect();
+            return Ok(ConditionalCommitOutcome::AlreadyCommitted(committed));
+        }
+
+        if !precondition.keys.is_empty() && packed.head_id != precondition.since_head_id {
+            for entry in packed
+                .entries
+                .iter()
+                .filter(|entry| entry.id > precondition.since_head_id)
+            {
+                let touched = isolation_keys_for_record(&entry.operation, entry.scope.as_deref());
+                if let Some(key) = touched.intersection(&precondition.keys).next().cloned() {
+                    return Ok(ConditionalCommitOutcome::IsolationConflict {
+                        key,
+                        since_head_id: precondition.since_head_id,
+                        conflicting_entry_id: entry.id,
+                    });
+                }
+            }
+        }
+
+        let start_id = packed.head_id + 1;
+        let timestamp = Utc::now();
+        let scope_owned = scope.map(str::to_string);
+        let new_entries =
+            Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
+        let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
+
+        packed.append(new_entries);
+        packed.save()?;
+        *self.cached.lock().unwrap() = Some(packed);
+
+        Ok(ConditionalCommitOutcome::Committed(ids))
+    }
+
     /// Current oplog generation — the monotonic `head_id`
     /// (`packed_oplog.rs` leading field). Reads only the **fixed-size header**
     /// from disk (not the whole log), so it is the cheap O(1) gate the per-read
@@ -601,6 +666,22 @@ impl OpLogBackend for OpLog {
         )
     }
 
+    fn record_batch_exactly_once_if_unchanged(
+        &self,
+        operations: Vec<OpRecord>,
+        scope: Option<&str>,
+        transaction_id: &str,
+        precondition: &IsolationPrecondition,
+    ) -> Result<ConditionalCommitOutcome> {
+        OpLog::record_batch_exactly_once_if_unchanged(
+            self,
+            operations,
+            scope,
+            transaction_id,
+            precondition,
+        )
+    }
+
     fn last(&self) -> Result<Option<OpEntry>> {
         OpLog::last(self)
     }
@@ -609,7 +690,11 @@ impl OpLogBackend for OpLog {
         OpLog::recent(self, count)
     }
 
-    async fn recent_batches_scoped(&self, count: usize, scope: Option<&str>) -> Result<Vec<OpBatch>> {
+    async fn recent_batches_scoped(
+        &self,
+        count: usize,
+        scope: Option<&str>,
+    ) -> Result<Vec<OpBatch>> {
         OpLog::recent_batches_scoped(self, count, scope)
     }
 

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -1,11 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Types for the operation log.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use objects::object::{ChangeId, ContentHash, OperationId, Principal};
 use serde::{Deserialize, Serialize};
+
+/// Logical key used by conditional transaction commits to detect intervening
+/// same-thread changes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum IsolationKey {
+    Thread(String),
+    LocalHead { scope: String },
+}
+
+/// The oplog generation and logical keys a transaction observed before apply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IsolationPrecondition {
+    pub since_head_id: u64,
+    pub keys: BTreeSet<IsolationKey>,
+}
+
+/// Result of an exact-once append guarded by an isolation precondition.
+#[derive(Debug, Clone)]
+pub enum ConditionalCommitOutcome {
+    Committed(Vec<u64>),
+    AlreadyCommitted(Vec<OpRecord>),
+    IsolationConflict {
+        key: IsolationKey,
+        since_head_id: u64,
+        conflicting_entry_id: u64,
+    },
+}
 
 /// Record of an operation that can be undone.
 ///
@@ -281,6 +308,93 @@ pub enum OpRecord {
     UndoRecoveryUpdate { state: ChangeId },
 }
 
+/// The logical isolation keys touched by one committed record.
+///
+/// This is intentionally explicit and shared by the backends and tests. Records
+/// that do not publish or read a thread/head key return an empty set.
+pub fn isolation_keys_for_record(record: &OpRecord, scope: Option<&str>) -> BTreeSet<IsolationKey> {
+    let mut keys = BTreeSet::new();
+    match record {
+        OpRecord::Snapshot {
+            thread: Some(thread),
+            ..
+        }
+        | OpRecord::Checkpoint {
+            thread: Some(thread),
+            ..
+        }
+        | OpRecord::ThreadCreate { name: thread, .. }
+        | OpRecord::ThreadDelete { name: thread, .. }
+        | OpRecord::ThreadUpdate { name: thread, .. }
+        | OpRecord::EphemeralThreadCollapse { thread, .. }
+        | OpRecord::ThreadCreateV2 { name: thread, .. }
+        | OpRecord::GitCheckpoint { branch: thread, .. }
+        | OpRecord::RemoteThreadUpdate { thread, .. }
+        | OpRecord::RemoteThreadDelete { thread, .. } => {
+            keys.insert(IsolationKey::Thread(thread.clone()));
+        }
+        OpRecord::Snapshot { thread: None, .. }
+        | OpRecord::Checkpoint { thread: None, .. }
+        | OpRecord::Goto { .. }
+        | OpRecord::UndoRecoveryUpdate { .. } => {
+            if let Some(scope) = scope {
+                keys.insert(IsolationKey::LocalHead {
+                    scope: scope.to_string(),
+                });
+            }
+        }
+        OpRecord::FastForward {
+            source_thread,
+            target_thread,
+            ..
+        }
+        | OpRecord::FastForwardV2 {
+            source_thread,
+            target_thread,
+            ..
+        } => {
+            keys.insert(IsolationKey::Thread(source_thread.clone()));
+            keys.insert(IsolationKey::Thread(target_thread.clone()));
+        }
+        OpRecord::Fork {
+            thread: Some(thread),
+            ..
+        }
+        | OpRecord::Collapse {
+            thread: Some(thread),
+            ..
+        } => {
+            keys.insert(IsolationKey::Thread(thread.clone()));
+        }
+        OpRecord::Fork {
+            thread: None, head, ..
+        } => {
+            if head.is_some()
+                && let Some(scope) = scope
+            {
+                keys.insert(IsolationKey::LocalHead {
+                    scope: scope.to_string(),
+                });
+            }
+        }
+        OpRecord::Collapse { thread: None, .. } => {
+            if let Some(scope) = scope {
+                keys.insert(IsolationKey::LocalHead {
+                    scope: scope.to_string(),
+                });
+            }
+        }
+        OpRecord::MarkerCreate { .. }
+        | OpRecord::MarkerDelete { .. }
+        | OpRecord::TransactionAbort { .. }
+        | OpRecord::ConflictResolved { .. }
+        | OpRecord::TransactionCommit { .. }
+        | OpRecord::Redact { .. }
+        | OpRecord::Purge { .. } => {}
+    }
+    keys
+}
+
 impl OpRecord {
     /// Get a short description of the operation.
     pub fn description(&self) -> String {
@@ -404,7 +518,12 @@ impl OpRecord {
                 thread,
                 state,
             } => {
-                format!("update remote thread {}/{} -> {}", remote, thread, state.short())
+                format!(
+                    "update remote thread {}/{} -> {}",
+                    remote,
+                    thread,
+                    state.short()
+                )
             }
             OpRecord::RemoteThreadDelete { remote, thread, .. } => {
                 format!("delete remote thread {}/{}", remote, thread)
@@ -736,7 +855,11 @@ mod verb_catalog_tests {
     fn only_checkpoint_is_checkpoint_verb() {
         for op in one_per_variant() {
             let expected = matches!(op, OpRecord::Checkpoint { .. });
-            assert_eq!(op.is_checkpoint_verb(), expected, "checkpoint flag for {op:?}");
+            assert_eq!(
+                op.is_checkpoint_verb(),
+                expected,
+                "checkpoint flag for {op:?}"
+            );
         }
     }
 

--- a/crates/oplog/src/oplog/pg_oplog.rs
+++ b/crates/oplog/src/oplog/pg_oplog.rs
@@ -19,7 +19,10 @@ use uuid::Uuid;
 
 use super::{
     oplog_backend::OpLogBackend,
-    oplog_types::{OpBatch, OpEntry, OpRecord},
+    oplog_types::{
+        ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
+        isolation_keys_for_record,
+    },
 };
 
 fn sqlx_err(e: sqlx::Error) -> HeddleError {
@@ -276,6 +279,146 @@ impl OpLogBackend for PgOpLogBackend {
         })
     }
 
+    fn record_batch_exactly_once_if_unchanged(
+        &self,
+        operations: Vec<OpRecord>,
+        scope: Option<&str>,
+        transaction_id: &str,
+        precondition: &IsolationPrecondition,
+    ) -> Result<ConditionalCommitOutcome> {
+        if operations.is_empty() {
+            return Ok(ConditionalCommitOutcome::Committed(Vec::new()));
+        }
+
+        let pool = Arc::clone(&self.pool);
+        let repo_id = self.repo_id;
+        let scope = scope.map(str::to_string);
+        let transaction_id = transaction_id.to_string();
+        let precondition = precondition.clone();
+
+        self.block(async move {
+            let mut tx = pool.begin().await.map_err(sqlx_err)?;
+
+            sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
+                .bind(repo_id.to_string())
+                .execute(&mut *tx)
+                .await
+                .map_err(sqlx_err)?;
+
+            let committed_batch_id: Option<i64> = sqlx::query_scalar(
+                "SELECT batch_id FROM oplog
+                 WHERE repo_id = $1
+                   AND op_data->'TransactionCommit'->>'transaction_id' = $2
+                 ORDER BY id ASC
+                 LIMIT 1",
+            )
+            .bind(repo_id)
+            .bind(&transaction_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(sqlx_err)?;
+
+            if let Some(batch_id) = committed_batch_id {
+                let rows = sqlx::query(
+                    "SELECT id, batch_id, batch_index, op_data, undone, created_at, scope
+                     FROM oplog
+                     WHERE repo_id = $1 AND batch_id = $2
+                     ORDER BY batch_index ASC",
+                )
+                .bind(repo_id)
+                .bind(batch_id)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(sqlx_err)?;
+                let records = rows
+                    .iter()
+                    .map(Self::row_to_entry)
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+                    .map(|entry| entry.operation)
+                    .collect();
+                tx.rollback().await.map_err(sqlx_err)?;
+                return Ok(ConditionalCommitOutcome::AlreadyCommitted(records));
+            }
+
+            let current_head_id: i64 =
+                sqlx::query_scalar("SELECT COALESCE(MAX(id), 0) FROM oplog WHERE repo_id = $1")
+                    .bind(repo_id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(sqlx_err)?;
+
+            if !precondition.keys.is_empty() && current_head_id as u64 != precondition.since_head_id
+            {
+                let rows = sqlx::query(
+                    "SELECT id, batch_id, batch_index, op_data, undone, created_at, scope
+                     FROM oplog
+                     WHERE repo_id = $1 AND id > $2
+                     ORDER BY id ASC",
+                )
+                .bind(repo_id)
+                .bind(precondition.since_head_id as i64)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(sqlx_err)?;
+                for entry in rows
+                    .iter()
+                    .map(Self::row_to_entry)
+                    .collect::<Result<Vec<_>>>()?
+                {
+                    let touched =
+                        isolation_keys_for_record(&entry.operation, entry.scope.as_deref());
+                    if let Some(key) = touched.intersection(&precondition.keys).next().cloned() {
+                        tx.rollback().await.map_err(sqlx_err)?;
+                        return Ok(ConditionalCommitOutcome::IsolationConflict {
+                            key,
+                            since_head_id: precondition.since_head_id,
+                            conflicting_entry_id: entry.id,
+                        });
+                    }
+                }
+            }
+
+            let batch_id = sqlx::query_scalar::<_, i64>(
+                "INSERT INTO oplog_batch_counters (repo_id, next_batch_id, updated_at)
+                 VALUES ($1, 2, NOW())
+                 ON CONFLICT (repo_id)
+                 DO UPDATE SET
+                   next_batch_id = oplog_batch_counters.next_batch_id + 1,
+                   updated_at = NOW()
+                 RETURNING next_batch_id - 1",
+            )
+            .bind(repo_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(sqlx_err)?;
+
+            let mut ids = Vec::with_capacity(operations.len());
+            for (index, op) in operations.iter().enumerate() {
+                let op_data = serde_json::to_value(op)
+                    .map_err(|e| HeddleError::Serialization(e.to_string()))?;
+                let id: i64 = sqlx::query_scalar::<_, i64>(
+                    "INSERT INTO oplog (repo_id, batch_id, batch_index, op_data, undone, scope)
+                     VALUES ($1, $2, $3, $4, false, $5)
+                     RETURNING id",
+                )
+                .bind(repo_id)
+                .bind(batch_id)
+                .bind(index as i32)
+                .bind(op_data)
+                .bind(scope.as_deref())
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(sqlx_err)?;
+                ids.push(id as u64);
+            }
+
+            tx.commit().await.map_err(sqlx_err)?;
+            Ok(ConditionalCommitOutcome::Committed(ids))
+        })
+    }
+
     fn last(&self) -> Result<Option<OpEntry>> {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
@@ -309,7 +452,11 @@ impl OpLogBackend for PgOpLogBackend {
         })
     }
 
-    async fn recent_batches_scoped(&self, count: usize, scope: Option<&str>) -> Result<Vec<OpBatch>> {
+    async fn recent_batches_scoped(
+        &self,
+        count: usize,
+        scope: Option<&str>,
+    ) -> Result<Vec<OpBatch>> {
         self.fetch_scoped_batches(count, scope, "", "DESC", false)
             .await
     }

--- a/crates/repo/src/atomic/committer.rs
+++ b/crates/repo/src/atomic/committer.rs
@@ -41,6 +41,10 @@ impl RefCommitter for OplogRefCommitter {
                     .map_err(|e| HeddleError::Serialization(e.to_string()))
             })
             .collect::<Result<Vec<_>>>()?;
+        // heddle#382 boundary: ref commit-and-publish is not an AtomicMutation
+        // transaction and does not append a TransactionCommit marker. Commands
+        // needing same-thread isolation must enter through an AtomicMutation
+        // root; this committer intentionally does not grow an ad hoc CAS layer.
         // Fresh handle so the append reloads the current log under the write
         // lock; preserves the configured principal for attribution.
         let oplog = OpLog::new(&self.heddle_dir, self.principal.clone());

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -6,7 +6,14 @@
 //! zero vtable. The bound `M: AtomicMutation` makes "register an atomic op
 //! without a `rewind`" a compile error.
 
+use std::{
+    rc::Rc,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
 use objects::error::{HeddleError, Result};
+use oplog::IsolationPrecondition;
 
 use super::traits::{AtomicMutation, StagedCommit};
 use super::tx::{CommitOutcome, Tx};
@@ -30,48 +37,106 @@ where
     // The stable idempotency key, supplied by the mutation (cid 3329490982);
     // identical across retries so a crash-retry deduplicates instead of
     // double-applying.
-    let mut tx = Tx::root(repo, m.transaction_id());
-    let mutation = tx.enroll_whole_op(m);
+    let transaction_id = m.transaction_id();
+    execute_attempts(repo, m, transaction_id)
+}
 
-    let staged = {
-        let mut guard = mutation.borrow_mut();
-        guard
-            .as_mut()
-            .expect("root mutation must be present during apply")
-            .apply(&mut tx)
-    };
-    let staged = match staged {
-        Ok(staged) => staged,
-        Err(e) => return rewind_error(&mut tx, e),
-    };
+fn execute_attempts<'a, M>(
+    repo: &'a Repository,
+    mut m: M,
+    transaction_id: String,
+) -> Result<M::Output>
+where
+    M: AtomicMutation + 'a,
+{
+    const MAX_ATTEMPTS: u32 = 4;
 
-    let StagedCommit { output, oplog } = staged;
+    for attempt in 0..MAX_ATTEMPTS {
+        let keys = m.isolation_keys(repo)?;
+        let since_head_id = repo.oplog().head_id()?;
+        let isolation = IsolationPrecondition {
+            since_head_id,
+            keys,
+        };
+        let mut tx = Tx::root(repo, transaction_id.clone(), isolation);
+        let mutation = tx.enroll_root(m);
 
-    match tx.commit(oplog) {
-        Ok(CommitOutcome::Committed) => Ok(output),
-        Ok(CommitOutcome::AlreadyCommitted(prior_records)) => {
-            // Dedup hit: this run's `output` may diverge from what was actually
-            // committed (e.g. a regenerated `ChangeId`), so reconstruct the
-            // originally-committed identity from the prior batch (cid 3329631075).
-            // Reconstruct BEFORE rewinding — `rewind_all` runs the whole-op
-            // rewind, which takes the mutation out of its cell.
-            let reconstructed = mutation
-                .borrow()
-                .as_ref()
-                .expect("root mutation present before replay rewind")
-                .reconstruct_committed_output(&prior_records, output);
-            match (reconstructed, tx.rewind_all()) {
-                (Ok(committed_output), Ok(())) => Ok(committed_output),
-                (Ok(_), Err(rewind_err)) => Err(HeddleError::Conflict(format!(
-                    "transaction {} was already committed, but replay rewind failed: {}",
-                    tx.transaction_id(),
-                    rewind_err
-                ))),
-                (Err(reconstruct_err), _) => Err(reconstruct_err),
+        let staged = mutation.borrow_mut().apply(&mut tx);
+        let staged = match staged {
+            Ok(staged) => staged,
+            Err(e) => return rewind_error(&mut tx, e),
+        };
+
+        let StagedCommit { output, oplog } = staged;
+
+        match tx.commit(oplog) {
+            Ok(CommitOutcome::Committed) => return Ok(output),
+            Ok(CommitOutcome::AlreadyCommitted(prior_records)) => {
+                // Dedup hit: this run's `output` may diverge from what was
+                // actually committed (e.g. a regenerated `ChangeId`), so
+                // reconstruct the originally-committed identity from the prior
+                // batch (cid 3329631075). Reconstruct BEFORE rewinding.
+                let reconstructed = mutation
+                    .borrow()
+                    .reconstruct_committed_output(&prior_records, output);
+                match (reconstructed, tx.rewind_all()) {
+                    (Ok(committed_output), Ok(())) => return Ok(committed_output),
+                    (Ok(_), Err(rewind_err)) => {
+                        return Err(HeddleError::Conflict(format!(
+                            "transaction {} was already committed, but replay rewind failed: {}",
+                            tx.transaction_id(),
+                            rewind_err
+                        )));
+                    }
+                    (Err(reconstruct_err), _) => return Err(reconstruct_err),
+                }
             }
+            Ok(CommitOutcome::IsolationConflict {
+                key,
+                since_head_id,
+                conflicting_entry_id,
+            }) => {
+                if let Err(rewind_err) = tx.rewind_all() {
+                    return Err(HeddleError::Conflict(format!(
+                        "transaction {} isolation conflict on {:?} since head {} at oplog entry {}; rewind failed: {}",
+                        tx.transaction_id(),
+                        key,
+                        since_head_id,
+                        conflicting_entry_id,
+                        rewind_err
+                    )));
+                }
+                if attempt + 1 == MAX_ATTEMPTS {
+                    return Err(HeddleError::Conflict(format!(
+                        "transaction {} isolation conflict on {:?} since head {} at oplog entry {} after {} attempts",
+                        tx.transaction_id(),
+                        key,
+                        since_head_id,
+                        conflicting_entry_id,
+                        MAX_ATTEMPTS
+                    )));
+                }
+
+                m = Rc::try_unwrap(mutation)
+                    .ok()
+                    .expect("root mutation must have no ledger clones after rewind")
+                    .into_inner();
+                sleep_full_jitter(attempt);
+            }
+            Err(e) => return rewind_error(&mut tx, e),
         }
-        Err(e) => rewind_error(&mut tx, e),
     }
+
+    unreachable!("bounded retry loop always returns on final attempt")
+}
+
+fn sleep_full_jitter(attempt: u32) {
+    let max_ms = 10u64.saturating_mul(1u64 << attempt).min(250);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.subsec_nanos() as u64)
+        .unwrap_or(0);
+    thread::sleep(Duration::from_millis(nanos % (max_ms + 1)));
 }
 
 fn rewind_error<T>(tx: &mut Tx<'_>, original: HeddleError) -> Result<T> {

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -2,12 +2,16 @@
 //! Unit tests for the atomic-mutation primitive (heddle#330 §7 item 1).
 
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
 use objects::object::{ChangeId, MarkerName, ThreadName};
-use oplog::{OpLogBackend, OpRecord};
+use oplog::{
+    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord,
+    isolation_keys_for_record,
+};
 use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
 
@@ -21,6 +25,47 @@ fn test_repo() -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
     let repo = Repository::init_default(temp.path()).unwrap();
     (temp, repo)
+}
+
+macro_rules! empty_isolation_keys {
+    () => {
+        fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+            Ok(BTreeSet::new())
+        }
+    };
+}
+
+fn test_precondition() -> IsolationPrecondition {
+    IsolationPrecondition {
+        since_head_id: 0,
+        keys: BTreeSet::new(),
+    }
+}
+
+fn thread_precondition(since_head_id: u64, thread: &str) -> IsolationPrecondition {
+    let mut keys = BTreeSet::new();
+    keys.insert(IsolationKey::Thread(thread.to_string()));
+    IsolationPrecondition {
+        since_head_id,
+        keys,
+    }
+}
+
+fn snapshot_on(thread: &str) -> OpRecord {
+    let state = ChangeId::generate();
+    OpRecord::Snapshot {
+        new_state: state,
+        prev_head: None,
+        head: None,
+        thread: Some(thread.to_string()),
+    }
+}
+
+fn commit_marker(transaction_id: &str, op_count: u32) -> OpRecord {
+    OpRecord::TransactionCommit {
+        transaction_id: transaction_id.to_string(),
+        op_count,
+    }
 }
 
 /// A savepoint leg that records its id when its inverse runs, and can be made
@@ -37,6 +82,8 @@ impl AtomicMutation for Leg {
     fn transaction_id(&self) -> String {
         format!("leg-{}", self.id)
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let id = self.id;
@@ -65,6 +112,8 @@ impl AtomicMutation for FailingComposite {
     fn transaction_id(&self) -> String {
         "failing-composite".to_string()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll(Leg {
@@ -123,7 +172,7 @@ fn reverse_order_rewind_on_failure() {
 #[test]
 fn step_registers_no_inverse_when_forward_fails() {
     let (_t, repo) = test_repo();
-    let mut tx = Tx::root(&repo, "step-forward-fails".to_string());
+    let mut tx = Tx::root(&repo, "step-forward-fails".to_string(), test_precondition());
     let inverse_ran = Rc::new(RefCell::new(false));
     let flag = Rc::clone(&inverse_ran);
 
@@ -149,7 +198,7 @@ fn step_registers_no_inverse_when_forward_fails() {
 #[test]
 fn step_registers_one_inverse_after_forward_succeeds() {
     let (_t, repo) = test_repo();
-    let mut tx = Tx::root(&repo, "step-forward-ok".to_string());
+    let mut tx = Tx::root(&repo, "step-forward-ok".to_string(), test_precondition());
     let unwound = Rc::new(RefCell::new(Vec::new()));
     let sink = Rc::clone(&unwound);
     let forward_ran = Rc::new(RefCell::new(false));
@@ -195,6 +244,8 @@ impl AtomicMutation for Panicker {
         "panicker".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let log = Rc::clone(&self.log);
         tx.on_rewind("test-panicker", move || {
@@ -219,6 +270,8 @@ impl AtomicMutation for WholeOpPanicker {
     fn transaction_id(&self) -> String {
         "whole-op-panicker".to_string()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         *self.staged.borrow_mut() = true;
@@ -299,6 +352,8 @@ impl AtomicMutation for CommitFailsRewindFails {
         "commit-fails-rewind-fails".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         let oplog_path = tx.repo().heddle_dir().join("oplog").join("oplog.bin");
         if oplog_path.exists() {
@@ -350,6 +405,8 @@ impl AtomicMutation for Recorder {
     fn transaction_id(&self) -> String {
         format!("recorder-{}", self.state.to_string_full())
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
         Ok(StagedCommit::new(
@@ -404,6 +461,8 @@ impl AtomicMutation for Reserve {
         "reserve".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         Ok(StagedCommit::pure(()))
     }
@@ -434,6 +493,8 @@ impl AtomicMutation for EagerThenFail {
     fn transaction_id(&self) -> String {
         "eager-then-fail".to_string()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll_eager(Reserve {
@@ -675,7 +736,7 @@ fn tx_accessors_and_rewind_error_paths() {
     let (_t, repo) = test_repo();
 
     // Accessors.
-    let mut tx = Tx::root(&repo, "accessor-tx".to_string());
+    let mut tx = Tx::root(&repo, "accessor-tx".to_string(), test_precondition());
     assert_eq!(tx.depth(), 0);
     assert_eq!(tx.scope(), repo.op_scope());
     assert_eq!(tx.transaction_id(), "accessor-tx");
@@ -695,7 +756,7 @@ fn tx_accessors_and_rewind_error_paths() {
     );
 
     // A second commit after a successful one is a no-op (committed guard).
-    let mut tx2 = Tx::root(&repo, "double-commit-tx".to_string());
+    let mut tx2 = Tx::root(&repo, "double-commit-tx".to_string(), test_precondition());
     let first_state = ChangeId::generate();
     tx2.commit(vec![OpRecord::Snapshot {
         new_state: first_state,
@@ -727,9 +788,291 @@ fn tx_accessors_and_rewind_error_paths() {
 
     // Drop backstop: an uncommitted Tx whose inverse fails logs (never panics).
     {
-        let mut tx3 = Tx::root(&repo, "drop-backstop-tx".to_string());
-        tx3.on_rewind("drop-time", || Err(HeddleError::Config("drop-time".to_string())));
+        let mut tx3 = Tx::root(&repo, "drop-backstop-tx".to_string(), test_precondition());
+        tx3.on_rewind("drop-time", || {
+            Err(HeddleError::Config("drop-time".to_string()))
+        });
         // tx3 dropped here without commit ⇒ Drop runs rewind_all, gets Err, logs.
+    }
+}
+
+struct ConflictOnce {
+    transaction_id: String,
+    thread: String,
+    applied: Rc<RefCell<u32>>,
+    rewound: Rc<RefCell<u32>>,
+    injected: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for ConflictOnce {
+    type Output = u32;
+
+    fn transaction_id(&self) -> String {
+        self.transaction_id.clone()
+    }
+
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::Thread(self.thread.clone()));
+        Ok(keys)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
+        *self.applied.borrow_mut() += 1;
+        let rewound = Rc::clone(&self.rewound);
+        tx.on_rewind("conflict-once", move || {
+            *rewound.borrow_mut() += 1;
+            Ok(())
+        });
+        if !*self.injected.borrow() {
+            *self.injected.borrow_mut() = true;
+            tx.repo().oplog().record_batch(vec![
+                snapshot_on(&self.thread),
+                commit_marker("racer-once", 1),
+            ])?;
+        }
+        Ok(StagedCommit::new(
+            *self.applied.borrow(),
+            vec![snapshot_on(&self.thread)],
+        ))
+    }
+}
+
+#[test]
+fn same_thread_conflict_rewinds_and_retries_successfully() {
+    let (_t, repo) = test_repo();
+    let applied = Rc::new(RefCell::new(0));
+    let rewound = Rc::new(RefCell::new(0));
+    let injected = Rc::new(RefCell::new(false));
+
+    let output = execute(
+        &repo,
+        ConflictOnce {
+            transaction_id: "retry-main".to_string(),
+            thread: "main".to_string(),
+            applied: Rc::clone(&applied),
+            rewound: Rc::clone(&rewound),
+            injected,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(output, 2, "the second attempt must be the committed run");
+    assert_eq!(*applied.borrow(), 2, "the logical mutation retried once");
+    assert_eq!(*rewound.borrow(), 1, "the conflicted staging was rewound");
+    let commits = repo
+        .oplog()
+        .recent(16)
+        .unwrap()
+        .into_iter()
+        .filter(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::TransactionCommit { transaction_id, .. }
+                    if transaction_id == "retry-main"
+            )
+        })
+        .count();
+    assert_eq!(commits, 1, "the retried transaction commits once");
+}
+
+#[test]
+fn conditional_commit_allows_different_thread_tail() {
+    let (_t, repo) = test_repo();
+    let since = repo.oplog().head_id().unwrap();
+    let precondition = thread_precondition(since, "main");
+
+    repo.oplog()
+        .record_batch(vec![
+            snapshot_on("feature"),
+            commit_marker("feature-advance", 1),
+        ])
+        .unwrap();
+
+    let outcome = repo
+        .oplog()
+        .record_batch_exactly_once_if_unchanged(
+            vec![snapshot_on("main"), commit_marker("main-after-feature", 1)],
+            Some(&repo.op_scope()),
+            "main-after-feature",
+            &precondition,
+        )
+        .unwrap();
+    assert!(matches!(outcome, ConditionalCommitOutcome::Committed(_)));
+}
+
+#[test]
+fn conditional_commit_dedups_before_isolation_scan() {
+    let (_t, repo) = test_repo();
+    let precondition = thread_precondition(repo.oplog().head_id().unwrap(), "main");
+    let first = repo
+        .oplog()
+        .record_batch_exactly_once_if_unchanged(
+            vec![snapshot_on("main"), commit_marker("dedup-main", 1)],
+            Some(&repo.op_scope()),
+            "dedup-main",
+            &precondition,
+        )
+        .unwrap();
+    assert!(matches!(first, ConditionalCommitOutcome::Committed(_)));
+
+    repo.oplog()
+        .record_batch(vec![snapshot_on("main"), commit_marker("main-advanced", 1)])
+        .unwrap();
+
+    let replay = repo
+        .oplog()
+        .record_batch_exactly_once_if_unchanged(
+            vec![snapshot_on("main"), commit_marker("dedup-main", 1)],
+            Some(&repo.op_scope()),
+            "dedup-main",
+            &precondition,
+        )
+        .unwrap();
+    assert!(
+        matches!(replay, ConditionalCommitOutcome::AlreadyCommitted(records) if records.len() == 1),
+        "a replay must dedup even after the isolated thread advanced"
+    );
+}
+
+struct SavepointConflict {
+    log: Rc<RefCell<Vec<u32>>>,
+    injected: Rc<RefCell<bool>>,
+}
+
+impl AtomicMutation for SavepointConflict {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "savepoint-conflict".to_string()
+    }
+
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::Thread("main".to_string()));
+        Ok(keys)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        tx.enroll(Leg {
+            id: *self.log.borrow().last().unwrap_or(&0) + 1,
+            fail: false,
+            log: Rc::clone(&self.log),
+        })?;
+        if !*self.injected.borrow() {
+            *self.injected.borrow_mut() = true;
+            tx.repo().oplog().record_batch(vec![
+                snapshot_on("main"),
+                commit_marker("savepoint-racer", 1),
+            ])?;
+        }
+        Ok(StagedCommit::new((), vec![snapshot_on("main")]))
+    }
+}
+
+#[test]
+fn savepoint_child_effects_rewind_on_isolation_conflict() {
+    let (_t, repo) = test_repo();
+    let log = Rc::new(RefCell::new(Vec::new()));
+    execute(
+        &repo,
+        SavepointConflict {
+            log: Rc::clone(&log),
+            injected: Rc::new(RefCell::new(false)),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        *log.borrow(),
+        vec![1],
+        "the first attempt's savepoint child must rewind on conflict"
+    );
+}
+
+struct AlwaysConflict {
+    applied: Rc<RefCell<u32>>,
+    rewound: Rc<RefCell<u32>>,
+}
+
+impl AtomicMutation for AlwaysConflict {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "always-conflict".to_string()
+    }
+
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::Thread("main".to_string()));
+        Ok(keys)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
+        *self.applied.borrow_mut() += 1;
+        let attempt = *self.applied.borrow();
+        let rewound = Rc::clone(&self.rewound);
+        tx.on_rewind("always-conflict", move || {
+            *rewound.borrow_mut() += 1;
+            Ok(())
+        });
+        tx.repo().oplog().record_batch(vec![
+            snapshot_on("main"),
+            commit_marker(&format!("always-racer-{attempt}"), 1),
+        ])?;
+        Ok(StagedCommit::new((), vec![snapshot_on("main")]))
+    }
+}
+
+#[test]
+fn retry_cap_returns_structured_conflict() {
+    let (_t, repo) = test_repo();
+    let applied = Rc::new(RefCell::new(0));
+    let rewound = Rc::new(RefCell::new(0));
+    let err = execute(
+        &repo,
+        AlwaysConflict {
+            applied: Rc::clone(&applied),
+            rewound: Rc::clone(&rewound),
+        },
+    )
+    .unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("isolation conflict on Thread(\"main\")"));
+    assert!(message.contains("oplog entry"));
+    assert_eq!(*applied.borrow(), 4, "initial attempt plus three retries");
+    assert_eq!(*rewound.borrow(), 4, "every conflicted attempt is rewound");
+}
+
+#[test]
+fn staged_record_keys_are_covered_by_declared_root_keys() {
+    let scope = "lane-a";
+    let mut declared = BTreeSet::new();
+    declared.insert(IsolationKey::Thread("main".to_string()));
+    declared.insert(IsolationKey::Thread("feature".to_string()));
+    declared.insert(IsolationKey::LocalHead {
+        scope: scope.to_string(),
+    });
+    let records = vec![
+        snapshot_on("main"),
+        OpRecord::FastForwardV2 {
+            source_thread: "feature".to_string(),
+            target_thread: "main".to_string(),
+            pre_target_id: ChangeId::generate(),
+            post_target_id: ChangeId::generate(),
+        },
+        OpRecord::Goto {
+            target: ChangeId::generate(),
+            prev_head: None,
+            head: ChangeId::generate(),
+        },
+    ];
+
+    for record in records {
+        let touched = isolation_keys_for_record(&record, Some(scope));
+        assert!(
+            touched.is_subset(&declared),
+            "staged record {record:?} touched {touched:?}, outside {declared:?}"
+        );
     }
 }
 
@@ -887,6 +1230,8 @@ impl AtomicMutation for StageThenFail {
         "stage-then-fail".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         // Stage state, relying on the whole-op `rewind` (NOT a granular inverse)
         // to undo it — then fail.
@@ -946,6 +1291,8 @@ impl AtomicMutation for EnrollStageThenFail {
         "enroll-stage-then-fail".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll(StageThenFail {
             staged: Rc::clone(&self.staged),
@@ -995,6 +1342,8 @@ impl AtomicMutation for StableKeyed {
     fn transaction_id(&self) -> String {
         self.key.clone()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         *self.applied.borrow_mut() += 1;
@@ -1079,6 +1428,8 @@ impl AtomicMutation for ReplayStages {
     fn transaction_id(&self) -> String {
         self.key.clone()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<u32>> {
         *self.staged_count.borrow_mut() += 1;
@@ -2000,6 +2351,8 @@ impl AtomicMutation for EagerOverrideRewind {
         "eager-override-rewind".to_string()
     }
 
+    empty_isolation_keys!();
+
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         Ok(StagedCommit::pure(()))
     }
@@ -2032,6 +2385,8 @@ impl AtomicMutation for EagerOverrideThenFail {
     fn transaction_id(&self) -> String {
         "eager-override-then-fail".to_string()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
         tx.enroll_eager(EagerOverrideRewind {
@@ -2201,7 +2556,10 @@ fn shared_watermark_is_cross_worktree_no_resurrect() {
     // the current (pre-create) generation — the "behind" per-worktree state.
     {
         let repo_b = Repository::open(&wt_b).unwrap();
-        let _ = repo_b.refs().get_thread(&ThreadName::new("not-yet")).unwrap();
+        let _ = repo_b
+            .refs()
+            .get_thread(&ThreadName::new("not-yet"))
+            .unwrap();
     }
 
     // A records + publishes a shared-ref create, then a read advances + persists
@@ -2527,7 +2885,9 @@ fn lagging_reader_never_clobbers_concurrent_publish() {
             .recent(64)
             .unwrap()
             .into_iter()
-            .filter(|e| matches!(&e.operation, OpRecord::Fork { thread: Some(t), .. } if t == "main"))
+            .filter(
+                |e| matches!(&e.operation, OpRecord::Fork { thread: Some(t), .. } if t == "main"),
+            )
             .max_by_key(|e| e.id)
             .map(|e| match e.operation {
                 OpRecord::Fork { new_state, .. } => new_state,
@@ -2553,6 +2913,8 @@ impl AtomicMutation for RegeneratesChangeId {
     fn transaction_id(&self) -> String {
         self.key.clone()
     }
+
+    empty_isolation_keys!();
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<ChangeId>> {
         // A fresh, NON-deterministic output each run — a crash-retry's value
@@ -2620,10 +2982,7 @@ fn dedup_hit_returns_prior_committed_output_not_replays_fresh_one() {
         minted[0], minted[1],
         "the replay regenerated a DIFFERENT id (non-vacuous)"
     );
-    assert_eq!(
-        first, minted[0],
-        "the first run returns its committed id"
-    );
+    assert_eq!(first, minted[0], "the first run returns its committed id");
     assert_eq!(
         second, minted[0],
         "the dedup-hit replay returns the ORIGINALLY committed id, not its own fresh one"

--- a/crates/repo/src/atomic/traits.rs
+++ b/crates/repo/src/atomic/traits.rs
@@ -7,10 +7,13 @@
 //! public surface — `execute`/`enroll` are monomorphized per mutation type and
 //! no mutation is ever invoked through a vtable.
 
+use std::collections::BTreeSet;
+
 use objects::error::Result;
-use oplog::OpRecord;
+use oplog::{IsolationKey, OpRecord};
 
 use super::tx::{RewindLedger, Tx};
+use crate::Repository;
 
 /// What `apply` returns: the value to surface to the caller plus the oplog
 /// record(s) the executor appends **at the commit point**. The mutation never
@@ -63,6 +66,11 @@ pub trait AtomicMutation {
     /// "minted fresh" footgun is unrepresentable. Only the *root* mutation's key
     /// is used — an enrolled child never reaches the commit point.
     fn transaction_id(&self) -> String;
+
+    /// Logical thread/head keys this root mutation read or may write. The root
+    /// executor captures these keys with the current oplog head before apply and
+    /// uses them for CAS-on-commit isolation.
+    fn isolation_keys(&self, repo: &Repository) -> Result<BTreeSet<IsolationKey>>;
 
     /// Forward, staged, fallible side effects. Every effect performed here
     /// MUST be paired with an inverse registered via [`Tx::step`] (the

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -12,7 +12,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
-use oplog::OpRecord;
+use oplog::{ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpRecord};
 
 use super::traits::{DeferredMutation, EagerMutation, StagedCommit};
 use crate::Repository;
@@ -35,6 +35,7 @@ struct RewindAction<'a> {
 }
 
 pub(crate) type EnrolledMutation<M> = Rc<RefCell<Option<M>>>;
+pub(crate) type EnrolledRoot<M> = Rc<RefCell<M>>;
 
 /// The ledger snapshot handed to [`AtomicMutation::rewind`](super::AtomicMutation::rewind).
 /// Carries the per-transaction scope + depth captured at apply time; a mutation
@@ -58,6 +59,7 @@ pub struct Tx<'a> {
     repo: &'a Repository,
     scope: String,
     transaction_id: String,
+    isolation: IsolationPrecondition,
     depth: u32,
     ledger: Vec<RewindAction<'a>>,
     committed: bool,
@@ -71,11 +73,16 @@ impl<'a> Tx<'a> {
     /// [`AtomicMutation::transaction_id`](super::AtomicMutation::transaction_id)
     /// — so a crash-retry deduplicates against the prior commit instead of
     /// minting a new key and double-applying.
-    pub(crate) fn root(repo: &'a Repository, transaction_id: String) -> Self {
+    pub(crate) fn root(
+        repo: &'a Repository,
+        transaction_id: String,
+        isolation: IsolationPrecondition,
+    ) -> Self {
         Self {
             repo,
             scope: repo.op_scope(),
             transaction_id,
+            isolation,
             depth: 0,
             ledger: Vec::new(),
             committed: false,
@@ -211,12 +218,28 @@ impl<'a> Tx<'a> {
         mutation
     }
 
+    pub(crate) fn enroll_root<M>(&mut self, m: M) -> EnrolledRoot<M>
+    where
+        M: super::AtomicMutation + 'a,
+    {
+        let mutation = Rc::new(RefCell::new(m));
+        let rewind_mutation = Rc::clone(&mutation);
+        let ledger = self.ledger_view();
+        self.on_rewind("enroll_root", move || {
+            rewind_mutation.borrow_mut().rewind(&ledger)
+        });
+        mutation
+    }
+
     /// Shared `enroll`/`enroll_eager` scaffolding: pre-register the child's
     /// whole-op rewind (so an apply error or panic unwinds it through the shared
     /// ledger), then run its `apply` against the *same* ledger. Returns the
     /// enrolled handle (still live, for the eager `commit_eager` follow-up) plus
     /// the staged result. The caller owns the surrounding `depth` inc/dec.
-    fn enroll_then_apply<M>(&mut self, m: M) -> (EnrolledMutation<M>, Result<StagedCommit<M::Output>>)
+    fn enroll_then_apply<M>(
+        &mut self,
+        m: M,
+    ) -> (EnrolledMutation<M>, Result<StagedCommit<M::Output>>)
     where
         M: super::AtomicMutation + 'a,
     {
@@ -321,23 +344,33 @@ impl<'a> Tx<'a> {
             transaction_id: self.transaction_id.clone(),
             op_count,
         });
-        let outcome = self.repo.oplog().record_batch_exactly_once(
+        let outcome = self.repo.oplog().record_batch_exactly_once_if_unchanged(
             records,
             Some(&self.scope),
             &self.transaction_id,
+            &self.isolation,
         )?;
-        if outcome.is_some() {
-            self.committed = true;
-            Ok(CommitOutcome::Committed)
-        } else {
-            // Dedup hit: a prior (possibly cross-process) run already committed
-            // this transaction. Carry its records back so the executor can
-            // reconstruct the originally-committed output (cid 3329631075).
-            let prior = self
-                .repo
-                .oplog()
-                .committed_batch_records(&self.transaction_id)?;
-            Ok(CommitOutcome::AlreadyCommitted(prior))
+        match outcome {
+            ConditionalCommitOutcome::Committed(_) => {
+                self.committed = true;
+                Ok(CommitOutcome::Committed)
+            }
+            ConditionalCommitOutcome::AlreadyCommitted(prior) => {
+                // Dedup hit: a prior (possibly cross-process) run already
+                // committed this transaction. Carry its records back so the
+                // executor can reconstruct the originally-committed output
+                // (cid 3329631075).
+                Ok(CommitOutcome::AlreadyCommitted(prior))
+            }
+            ConditionalCommitOutcome::IsolationConflict {
+                key,
+                since_head_id,
+                conflicting_entry_id,
+            } => Ok(CommitOutcome::IsolationConflict {
+                key,
+                since_head_id,
+                conflicting_entry_id,
+            }),
         }
     }
 
@@ -373,6 +406,11 @@ pub(crate) enum CommitOutcome {
     /// committed batch's records (marker stripped) so the executor can
     /// reconstruct the originally-committed output (cid 3329631075).
     AlreadyCommitted(Vec<OpRecord>),
+    IsolationConflict {
+        key: IsolationKey,
+        since_head_id: u64,
+        conflicting_entry_id: u64,
+    },
 }
 
 impl Drop for Tx<'_> {

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -20,7 +20,7 @@
 //! middleware code is identical regardless of backend.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
@@ -32,6 +32,7 @@ use objects::{
     lock::{RepoLock, WriteLockGuard},
     object::OperationId,
 };
+use oplog::IsolationKey;
 use serde::{Deserialize, Serialize};
 
 use crate::Repository;
@@ -187,6 +188,10 @@ impl AtomicMutation for ReserveOpId {
         reserve_transaction_id(self.operation_id, &self.verb, self.request_hash)
     }
 
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        Ok(BTreeSet::new())
+    }
+
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>> {
         Ok(StagedCommit::pure(self.claim.clone()))
     }
@@ -230,6 +235,10 @@ impl AtomicMutation for ReserveOpIdTransaction {
 
     fn transaction_id(&self) -> String {
         reserve_transaction_id(self.operation_id, &self.verb, self.request_hash)
+    }
+
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        Ok(BTreeSet::new())
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>> {
@@ -579,6 +588,10 @@ mod tests {
             format!("reserve-then-abort/{}", self.op)
         }
 
+        fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+            Ok(BTreeSet::new())
+        }
+
         fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<()>> {
             tx.enroll_eager(ReserveOpId::new(
                 Arc::clone(&self.store),
@@ -868,5 +881,77 @@ mod tests {
             in_flight, 1,
             "the losing reserve must see InFlight: {outcomes:?}"
         );
+    }
+
+    struct ReserveThenConflictOnce {
+        store: Arc<OperationDedupStore>,
+        op: OperationId,
+        hash: [u8; 32],
+        injected: bool,
+    }
+
+    impl AtomicMutation for ReserveThenConflictOnce {
+        type Output = DedupOutcome;
+
+        fn transaction_id(&self) -> String {
+            format!("reserve-conflict-once/{}", self.op)
+        }
+
+        fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+            let mut keys = BTreeSet::new();
+            keys.insert(IsolationKey::Thread("main".to_string()));
+            Ok(keys)
+        }
+
+        fn apply(&mut self, tx: &mut Tx<'_>) -> Result<StagedCommit<DedupOutcome>> {
+            let claim = tx.enroll_eager(ReserveOpId::new(
+                Arc::clone(&self.store),
+                self.op,
+                "capture",
+                self.hash,
+            ))?;
+            if !self.injected {
+                self.injected = true;
+                let state = objects::object::ChangeId::generate();
+                tx.repo().oplog().record_batch(vec![
+                    oplog::OpRecord::Snapshot {
+                        new_state: state,
+                        prev_head: None,
+                        head: None,
+                        thread: Some("main".to_string()),
+                    },
+                    oplog::OpRecord::TransactionCommit {
+                        transaction_id: "reserve-conflict-racer".to_string(),
+                        op_count: 1,
+                    },
+                ])?;
+            }
+            Ok(StagedCommit::pure(claim.into_outcome()?))
+        }
+    }
+
+    #[test]
+    fn eager_reserve_observes_existing_reservation_after_conflict_retry() {
+        let (_t, repo, store) = make_repo_store();
+        let op = OperationId::new();
+        let hash = hash_request_body(b"x");
+
+        let outcome = execute(
+            &repo,
+            ReserveThenConflictOnce {
+                store: Arc::clone(&store),
+                op,
+                hash,
+                injected: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            DedupOutcome::InFlight,
+            "retrying the same op-id reserve must observe the first attempt's pending slot"
+        );
+        assert_eq!(store.len(), 1, "the retry must not create a second slot");
     }
 }

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Snapshot operations for Repository.
 
+use std::collections::BTreeSet;
+
 use objects::store::ObjectStore;
 use objects::{
     lock::RepositoryLockExt,
     object::{Attribution, Blob, ChangeId, ContentHash, State, Tree, TreeEntry},
 };
-use oplog::OpRecord;
+use oplog::{IsolationKey, OpRecord};
 use refs::Head;
 use tracing::{debug, instrument};
 
@@ -94,6 +96,21 @@ impl AtomicMutation for SnapshotMutation<'_> {
 
     fn transaction_id(&self) -> String {
         self.transaction_id.clone()
+    }
+
+    fn isolation_keys(&self, _repo: &Repository) -> Result<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        match &self.head {
+            Head::Attached { thread } => {
+                keys.insert(IsolationKey::Thread(thread.to_string()));
+            }
+            Head::Detached { .. } => {
+                keys.insert(IsolationKey::LocalHead {
+                    scope: self.repo.op_scope(),
+                });
+            }
+        }
+        Ok(keys)
     }
 
     fn apply(&mut self, _tx: &mut Tx<'_>) -> Result<StagedCommit<Self::Output>> {
@@ -452,12 +469,14 @@ impl Repository {
     fn snapshot_worktree_fingerprint(&self) -> Result<ContentHash> {
         let patterns = self.ignore_patterns()?;
         let nested_exclusions = self.nested_thread_worktree_exclusions(&self.root)?;
-        let ignore_matcher =
-            WorktreeIgnoreMatcher::new(&patterns).with_nested_worktree_exclusions(nested_exclusions);
+        let ignore_matcher = WorktreeIgnoreMatcher::new(&patterns)
+            .with_nested_worktree_exclusions(nested_exclusions);
         let mut policy = SnapshotFingerprintPolicy::new(&self.root);
-        Ok(walk_worktree(self, &self.root, &ignore_matcher, None, &mut policy)?
-            .tree
-            .hash())
+        Ok(
+            walk_worktree(self, &self.root, &ignore_matcher, None, &mut policy)?
+                .tree
+                .hash(),
+        )
     }
 
     /// Create a snapshot of the current worktree.


### PR DESCRIPTION
## Summary
Implements the CAS-on-commit mechanism chosen in `docs/spikes/heddle-382-same-thread-isolation.md` (#382). The oplog append remains the commit point but becomes **conditional** on the transaction's declared per-thread isolation keys having no newer committed entry since the transaction started — turning dedup+append into dedup-first-then-CAS+append. Gives serializable per-thread isolation for `AtomicMutation` roots without serializing unrelated threads or holding a long lock.

## What landed
- `IsolationKey` / `IsolationPrecondition` / `ConditionalCommitOutcome` + `record_batch_exactly_once_if_unchanged` for **both** the local packed oplog and the Postgres backend (6-step semantics under the write lock / SQL txn; **dedup checked first** so a replay returns `AlreadyCommitted`, never a false conflict).
- `AtomicMutation::isolation_keys` + root declarations (Snapshot/StartThread/Undo/Redo/ReserveOpId); shared `OpRecord`→`IsolationKey` mapper + coverage test.
- `Tx` conditional-commit outcome (distinct `IsolationConflict`); bounded full-jitter retry (4 attempts / 10 ms base / 250 ms cap) for conflicts only in `execute`; structured `HeddleError::Conflict` after the cap.
- Explicit #382 boundary comments for `rebase_ops`, the daemon transaction service, and `OplogRefCommitter`/`commit_and_publish`.

## Test evidence
- Six behavioral tests: same-thread retry (one wins, loser rewinds+retries), different-thread no-conflict, dedup-first `AlreadyCommitted` after advance, savepoint child rewind, eager compensator + op-id replay-safety, retry-cap structured conflict.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `cargo test -p heddle-refs -p heddle-oplog --features postgres`, `cargo build/clippy --features postgres -- -D warnings`, `--ignored` fault suite (4 passed). DB-specific Postgres integration tests deferred to CI (no local DATABASE_URL).

Closes #392.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782971218&installation_id=132405951&pr_number=397&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F397&signature=ac0ed711a977bb294b827ea4338e8624d8f9919526309a11e3e6c98871476997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->