### PR TITLE
perf(objects): avoid per-entry allocations on the tree_diff hot path (#331)

### DIFF
--- a/crates/objects/src/object/tree_diff.rs
+++ b/crates/objects/src/object/tree_diff.rs
@@ -36,33 +36,27 @@ fn diff_trees_recursive<S: ObjectStore + ?Sized>(
     prefix: &str,
     changes: &mut FileChangeSet,
 ) -> Result<(), anyhow::Error> {
-    let from_entries: HashMap<_, _> = from
+    let from_entries: HashMap<&str, _> = from
         .as_ref()
         .map(|tree| {
             tree.entries()
                 .iter()
-                .map(|entry| (entry.name.clone(), entry))
+                .map(|entry| (entry.name.as_str(), entry))
                 .collect()
         })
         .unwrap_or_default();
 
-    let to_entries: HashMap<_, _> = to
+    let to_entries: HashMap<&str, _> = to
         .as_ref()
         .map(|tree| {
             tree.entries()
                 .iter()
-                .map(|entry| (entry.name.clone(), entry))
+                .map(|entry| (entry.name.as_str(), entry))
                 .collect()
         })
         .unwrap_or_default();
 
-    for (name, to_entry) in &to_entries {
-        let path = if prefix.is_empty() {
-            name.clone()
-        } else {
-            format!("{}/{}", prefix, name)
-        };
-
+    for (&name, &to_entry) in &to_entries {
         match from_entries.get(name) {
             None => {
                 // Symmetric with the delete branch below: if the added
@@ -75,6 +69,7 @@ fn diff_trees_recursive<S: ObjectStore + ?Sized>(
                 // file-level overlap to score candidate sessions, and
                 // a root commit's `src/` directory would otherwise
                 // collapse to one entry and miss the actual files.
+                let path = child_path(prefix, name);
                 if to_entry.entry_type == EntryType::Tree {
                     let to_subtree = store.get_tree(&to_entry.hash)?;
                     diff_trees_recursive(store, &None, &to_subtree, &path, changes)?;
@@ -89,8 +84,10 @@ fn diff_trees_recursive<S: ObjectStore + ?Sized>(
                     {
                         let from_subtree = store.get_tree(&from_entry.hash)?;
                         let to_subtree = store.get_tree(&to_entry.hash)?;
+                        let path = child_path(prefix, name);
                         diff_trees_recursive(store, &from_subtree, &to_subtree, &path, changes)?;
                     } else {
+                        let path = child_path(prefix, name);
                         changes.push_modified(&path);
                     }
                 }
@@ -98,13 +95,9 @@ fn diff_trees_recursive<S: ObjectStore + ?Sized>(
         }
     }
 
-    for (name, from_entry) in &from_entries {
+    for (&name, &from_entry) in &from_entries {
         if !to_entries.contains_key(name) {
-            let path = if prefix.is_empty() {
-                name.clone()
-            } else {
-                format!("{}/{}", prefix, name)
-            };
+            let path = child_path(prefix, name);
             // Recursively handle deleted entries - if it's a directory, descend into it
             if from_entry.entry_type == EntryType::Tree {
                 let from_subtree = store.get_tree(&from_entry.hash)?;
@@ -116,6 +109,18 @@ fn diff_trees_recursive<S: ObjectStore + ?Sized>(
     }
 
     Ok(())
+}
+
+fn child_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        let mut path = String::with_capacity(prefix.len() + 1 + name.len());
+        path.push_str(prefix);
+        path.push('/');
+        path.push_str(name);
+        path
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
`tree_diff` ran `entry.name.clone()` into two lookup-map keys and a per-entry `format!("{}/{}", prefix, name)` for every child path — O(entries) allocations per diff, most thrown away on the unchanged path.

This change (deferred-allocation approach):
- Keys the lookup maps by borrowed `&str` from the entries (which outlive the map) — no `name.clone()`.
- Allocates a child path `String` only when an add/delete/modify or a subtree recursion actually needs one.

## Test evidence
- Diff output byte-identical (existing `tree_diff` tests unchanged + green).
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-objects`, `cargo test --workspace`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #331.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782972588&installation_id=132405951&pr_number=399&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F399&signature=719749a1f9b765172cef9682ebb3cb0eb8dcc8a44e4ada9023c1b2b0ed74460b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->