### PR TITLE
perf(oplog): single-pass collect_batches_scoped (O(entries²)→O(entries)) (#405)

### DIFF
--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -203,6 +203,54 @@ fn test_undo_batches_scoped() {
 }
 
 #[test]
+fn recent_batches_scoped_merges_non_adjacent_coalesced_batches() {
+    let (_temp, oplog) = create_oplog();
+    let state1 = ChangeId::generate();
+    let state2 = ChangeId::generate();
+    let state3 = ChangeId::generate();
+
+    let first = oplog
+        .record_snapshot(&state1, None, None, Some("lane-a"))
+        .unwrap();
+    let middle = oplog
+        .record_snapshot(&state2, Some(&state1), None, Some("lane-a"))
+        .unwrap();
+    let last = oplog
+        .record_snapshot(&state3, Some(&state2), None, Some("lane-a"))
+        .unwrap();
+
+    oplog.coalesce_batches(first, last).unwrap();
+
+    let batches = oplog.recent_batches_scoped(2, Some("lane-a")).unwrap();
+
+    assert_eq!(
+        batches.iter().map(|batch| batch.id).collect::<Vec<_>>(),
+        vec![first, middle]
+    );
+    assert_eq!(
+        batches[0]
+            .entries
+            .iter()
+            .map(|entry| entry.id)
+            .collect::<Vec<_>>(),
+        vec![first, last]
+    );
+    assert_eq!(
+        batches[0]
+            .entries
+            .iter()
+            .map(|entry| entry.batch_index)
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+
+    let limited = oplog.recent_batches_scoped(1, Some("lane-a")).unwrap();
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].id, first);
+    assert_eq!(limited[0].entries.len(), 2);
+}
+
+#[test]
 fn test_oplogbackend_trait_async_methods_dispatch() {
     // The CLI calls OpLog's inherent (sync) batch methods; the generic
     // backend plumbing and the hosted server reach the async trait

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -272,32 +272,8 @@ impl PackedOpLog {
             scope_matches: bool,
         }
 
-        let mut batches: Vec<OpBatch> = Vec::new();
-        // Entries are append-ordered, so a batch is complete once the reverse
-        // scan reaches a different batch id. Pending therefore stays <= count.
-        let mut pending: HashMap<u64, PendingBatch> = HashMap::with_capacity(count.min(1));
-        let mut current_batch_id: Option<u64> = None;
-
-        let finalize_batch = |batch_id: u64,
-                              pending: &mut HashMap<u64, PendingBatch>,
-                              batches: &mut Vec<OpBatch>| {
-            let Some(mut pending_batch) = pending.remove(&batch_id) else {
-                return;
-            };
-            if !pending_batch.scope_matches {
-                return;
-            }
-
-            pending_batch.entries.sort_by_key(|e| e.batch_index);
-            let batch = OpBatch {
-                id: batch_id,
-                entries: pending_batch.entries,
-            };
-
-            if predicate(&batch) {
-                batches.push(batch);
-            }
-        };
+        let mut batch_order = Vec::new();
+        let mut pending: HashMap<u64, PendingBatch> = HashMap::new();
 
         for entry in self.entries.iter().rev() {
             let batch_id = if entry.batch_id == 0 {
@@ -306,19 +282,12 @@ impl PackedOpLog {
                 entry.batch_id
             };
 
-            if current_batch_id != Some(batch_id) {
-                if let Some(previous_batch_id) = current_batch_id {
-                    finalize_batch(previous_batch_id, &mut pending, &mut batches);
-                    if batches.len() == count {
-                        break;
-                    }
+            let batch = pending.entry(batch_id).or_insert_with(|| {
+                batch_order.push(batch_id);
+                PendingBatch {
+                    entries: Vec::new(),
+                    scope_matches: true,
                 }
-                current_batch_id = Some(batch_id);
-            }
-
-            let batch = pending.entry(batch_id).or_insert_with(|| PendingBatch {
-                entries: Vec::new(),
-                scope_matches: true,
             });
             if let Some(scope) = scope
                 && entry.scope.as_deref() != Some(scope)
@@ -328,10 +297,28 @@ impl PackedOpLog {
             batch.entries.push(entry.clone());
         }
 
-        if batches.len() < count
-            && let Some(batch_id) = current_batch_id
-        {
-            finalize_batch(batch_id, &mut pending, &mut batches);
+        let mut batches: Vec<OpBatch> = Vec::new();
+        for batch_id in batch_order {
+            let Some(mut pending_batch) = pending.remove(&batch_id) else {
+                continue;
+            };
+            if !pending_batch.scope_matches {
+                continue;
+            }
+
+            pending_batch.entries.reverse();
+            pending_batch.entries.sort_by_key(|e| e.batch_index);
+            let batch = OpBatch {
+                id: batch_id,
+                entries: pending_batch.entries,
+            };
+
+            if predicate(&batch) {
+                batches.push(batch);
+                if batches.len() == count {
+                    break;
+                }
+            }
         }
 
         batches
@@ -523,6 +510,44 @@ mod tests {
                 .map(|entry| entry.batch_index)
                 .collect::<Vec<_>>(),
             vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn collect_batches_scoped_merges_non_contiguous_runs_before_counting() {
+        let tmp = TempDir::new().unwrap();
+        let mut log = PackedOpLog::new(tmp.path().join("oplog.bin"));
+        log.append(vec![
+            make_batch_entry(1, 10, 0, Some("lane-a")),
+            make_batch_entry(2, 10, 1, Some("lane-a")),
+            make_batch_entry(3, 20, 0, Some("lane-a")),
+            make_batch_entry(4, 20, 1, Some("lane-a")),
+            make_batch_entry(5, 10, 2, Some("lane-a")),
+            make_batch_entry(6, 10, 3, Some("lane-a")),
+            make_batch_entry(7, 30, 0, Some("lane-a")),
+        ]);
+
+        let batches = log.collect_batches_scoped(2, |_| true, Some("lane-a"));
+
+        assert_eq!(
+            batches.iter().map(|batch| batch.id).collect::<Vec<_>>(),
+            vec![30, 10]
+        );
+        assert_eq!(
+            batches[1]
+                .entries
+                .iter()
+                .map(|entry| entry.batch_index)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+        assert_eq!(
+            batches[1]
+                .entries
+                .iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 5, 6]
         );
     }
 

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Packed binary oplog: all entries in a single file, loaded into memory.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use chrono::{TimeZone, Utc};
@@ -267,8 +267,37 @@ impl PackedOpLog {
             return Vec::new();
         }
 
+        struct PendingBatch {
+            entries: Vec<OpEntry>,
+            scope_matches: bool,
+        }
+
         let mut batches: Vec<OpBatch> = Vec::new();
-        let mut seen_batch_ids: HashSet<u64> = HashSet::new();
+        // Entries are append-ordered, so a batch is complete once the reverse
+        // scan reaches a different batch id. Pending therefore stays <= count.
+        let mut pending: HashMap<u64, PendingBatch> = HashMap::with_capacity(count.min(1));
+        let mut current_batch_id: Option<u64> = None;
+
+        let finalize_batch = |batch_id: u64,
+                              pending: &mut HashMap<u64, PendingBatch>,
+                              batches: &mut Vec<OpBatch>| {
+            let Some(mut pending_batch) = pending.remove(&batch_id) else {
+                return;
+            };
+            if !pending_batch.scope_matches {
+                return;
+            }
+
+            pending_batch.entries.sort_by_key(|e| e.batch_index);
+            let batch = OpBatch {
+                id: batch_id,
+                entries: pending_batch.entries,
+            };
+
+            if predicate(&batch) {
+                batches.push(batch);
+            }
+        };
 
         for entry in self.entries.iter().rev() {
             let batch_id = if entry.batch_id == 0 {
@@ -276,47 +305,33 @@ impl PackedOpLog {
             } else {
                 entry.batch_id
             };
-            if !seen_batch_ids.insert(batch_id) {
-                continue;
-            }
 
-            // Check scope filter before cloning
-            if let Some(scope) = scope {
-                let all_match = self.entries.iter().all(|e| {
-                    let bid = if e.batch_id == 0 { e.id } else { e.batch_id };
-                    bid != batch_id || e.scope.as_deref() == Some(scope)
-                });
-                if !all_match {
-                    continue;
+            if current_batch_id != Some(batch_id) {
+                if let Some(previous_batch_id) = current_batch_id {
+                    finalize_batch(previous_batch_id, &mut pending, &mut batches);
+                    if batches.len() == count {
+                        break;
+                    }
                 }
+                current_batch_id = Some(batch_id);
             }
 
-            let mut batch_entries: Vec<OpEntry> = self
-                .entries
-                .iter()
-                .filter(|e| {
-                    let bid = if e.batch_id == 0 { e.id } else { e.batch_id };
-                    bid == batch_id
-                })
-                .cloned()
-                .collect();
-
-            if batch_entries.is_empty() {
-                continue;
+            let batch = pending.entry(batch_id).or_insert_with(|| PendingBatch {
+                entries: Vec::new(),
+                scope_matches: true,
+            });
+            if let Some(scope) = scope
+                && entry.scope.as_deref() != Some(scope)
+            {
+                batch.scope_matches = false;
             }
+            batch.entries.push(entry.clone());
+        }
 
-            batch_entries.sort_by_key(|e| e.batch_index);
-            let batch = OpBatch {
-                id: batch_id,
-                entries: batch_entries,
-            };
-
-            if predicate(&batch) {
-                batches.push(batch);
-                if batches.len() == count {
-                    break;
-                }
-            }
+        if batches.len() < count
+            && let Some(batch_id) = current_batch_id
+        {
+            finalize_batch(batch_id, &mut pending, &mut batches);
         }
 
         batches
@@ -399,6 +414,13 @@ mod tests {
         }
     }
 
+    fn make_batch_entry(id: u64, batch_id: u64, batch_index: u32, scope: Option<&str>) -> OpEntry {
+        let mut entry = make_entry(id, scope);
+        entry.batch_id = batch_id;
+        entry.batch_index = batch_index;
+        entry
+    }
+
     #[test]
     fn round_trip_empty() {
         let tmp = TempDir::new().unwrap();
@@ -473,6 +495,35 @@ mod tests {
         assert!(log.entries[0].undone);
         log.set_undone(1, false);
         assert!(!log.entries[0].undone);
+    }
+
+    #[test]
+    fn collect_batches_scoped_excludes_mixed_scope_batches_without_counting_them() {
+        let tmp = TempDir::new().unwrap();
+        let mut log = PackedOpLog::new(tmp.path().join("oplog.bin"));
+        log.append(vec![
+            make_batch_entry(1, 10, 0, Some("lane-a")),
+            make_batch_entry(2, 10, 1, Some("lane-a")),
+            make_batch_entry(3, 20, 0, Some("lane-a")),
+            make_batch_entry(4, 20, 1, Some("lane-b")),
+            make_batch_entry(5, 30, 0, Some("lane-a")),
+            make_batch_entry(6, 40, 0, Some("lane-a")),
+        ]);
+
+        let batches = log.collect_batches_scoped(3, |_| true, Some("lane-a"));
+
+        assert_eq!(
+            batches.iter().map(|batch| batch.id).collect::<Vec<_>>(),
+            vec![40, 30, 10]
+        );
+        assert_eq!(
+            batches[2]
+                .entries
+                .iter()
+                .map(|entry| entry.batch_index)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`collect_batches_scoped` did a per-candidate-batch `entries.iter().all(...)` + a second full filter+clone — quadratic over the materialized entries on `recent_batches_scoped`. Rewritten as a **single reverse pass** grouping by batch, bounded by `count`.

## Correctness (output identical)
Scope-all-match semantics preserved by accumulating each batch's `scope_matches` across ALL its entries before finalizing, then applying the existing predicate/count logic newest-first. Output (which batches, order, count) is unchanged.

## Test evidence
- New focused packed-oplog test: mixed-scope batch exclusion + count/order behavior.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-oplog`, `cargo test --workspace`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #405.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782976107&installation_id=132405951&pr_number=415&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F415&signature=8e1c253423b3e7d8ddbb0f7485696112e71e94b58ecaad1da7a6de411317fa9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->