### PR TITLE
perf(objects): drop whole-pack to_vec() clone in FsStore::install_pack (#400)

### DIFF
--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -607,8 +607,7 @@ fn encode_native_pack(objects: &[ObjectData]) -> (Vec<u8>, Vec<u8>) {
 }
 
 fn decode_native_pack(pack_data: &[u8], index_data: &[u8]) -> Vec<ObjectData> {
-    let reader =
-        objects::store::PackReader::from_bytes(pack_data.to_vec(), index_data.to_vec()).unwrap();
+    let reader = objects::store::PackReader::from_slice(pack_data, index_data).unwrap();
     reader
         .list_ids()
         .into_iter()

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -903,8 +903,7 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self, pack_data, index_data))]
     fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<PackObjectId>> {
-        let reader =
-            crate::store::pack::PackReader::from_bytes(pack_data.to_vec(), index_data.to_vec())?;
+        let reader = crate::store::pack::PackReader::from_slice(pack_data, index_data)?;
         let ids = reader.list_ids();
         for id in &ids {
             let Some((obj_type, data)) = reader.get_object(id)? else {

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -533,7 +533,7 @@ pub trait ObjectStore: Send + Sync {
     }
 
     fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<pack::PackObjectId>> {
-        let reader = pack::PackReader::from_bytes(pack_data.to_vec(), index_data.to_vec())?;
+        let reader = pack::PackReader::from_slice(pack_data, index_data)?;
         let ids = reader.list_ids();
         for id in &ids {
             let Some((obj_type, data)) = reader.get_object(id)? else {

--- a/crates/objects/src/store/pack/manager.rs
+++ b/crates/objects/src/store/pack/manager.rs
@@ -24,7 +24,7 @@ pub struct PackManager {
 struct CachedPack {
     pack_path: PathBuf,
     index_path: PathBuf,
-    reader: PackReader,
+    reader: PackReader<'static>,
 }
 
 impl PackManager {

--- a/crates/objects/src/store/pack/pack_reader.rs
+++ b/crates/objects/src/store/pack/pack_reader.rs
@@ -25,13 +25,34 @@ const MAX_DELTA_CHAIN_DEPTH: usize = 50;
 /// backed `Bytes` (via [`Bytes::from_owner`] on the
 /// `memmap2::Mmap`) survives across reads without copying the
 /// whole pack into the heap.
-pub struct PackReader {
-    data: Bytes,
+enum PackData<'a> {
+    Borrowed(&'a [u8]),
+    Owned(Bytes),
+}
+
+impl<'a> PackData<'a> {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(data) => data,
+            Self::Owned(data) => data,
+        }
+    }
+
+    fn slice(&self, range: std::ops::Range<usize>) -> Bytes {
+        match self {
+            Self::Borrowed(data) => Bytes::copy_from_slice(&data[range]),
+            Self::Owned(data) => data.slice(range),
+        }
+    }
+}
+
+pub struct PackReader<'a> {
+    data: PackData<'a>,
     index: PackIndex,
     content_end: usize,
 }
 
-impl PackReader {
+impl PackReader<'static> {
     /// Open a pack file. mmap-backed when the pack is large enough
     /// to benefit (the same threshold the loose-blob path uses for
     /// its own mmap decision); read-into-heap otherwise.
@@ -41,17 +62,33 @@ impl PackReader {
         let (_, _, content_end) = verify_container(&pack_bytes, pack_container_spec())?;
         let index = PackIndex::from_bytes(&index_data)?;
         Ok(Self {
-            data: pack_bytes,
+            data: PackData::Owned(pack_bytes),
             index,
             content_end,
         })
     }
 
-    pub fn from_bytes(pack_data: Vec<u8>, index_data: Vec<u8>) -> Result<Self> {
+    pub fn from_bytes(
+        pack_data: impl Into<Bytes>,
+        index_data: impl AsRef<[u8]>,
+    ) -> Result<Self> {
+        let pack_data = pack_data.into();
         let (_, _, content_end) = verify_container(&pack_data, pack_container_spec())?;
-        let index = PackIndex::from_bytes(&index_data)?;
+        let index = PackIndex::from_bytes(index_data.as_ref())?;
         Ok(Self {
-            data: Bytes::from(pack_data),
+            data: PackData::Owned(pack_data),
+            index,
+            content_end,
+        })
+    }
+}
+
+impl<'a> PackReader<'a> {
+    pub fn from_slice(pack_data: &'a [u8], index_data: impl AsRef<[u8]>) -> Result<Self> {
+        let (_, _, content_end) = verify_container(pack_data, pack_container_spec())?;
+        let index = PackIndex::from_bytes(index_data.as_ref())?;
+        Ok(Self {
+            data: PackData::Borrowed(pack_data),
             index,
             content_end,
         })
@@ -234,7 +271,7 @@ impl PackReader {
 
         let data_end = checked_data_end(data_start, compressed_size, self.content_end)?;
 
-        let stored_data = &self.data[data_start..data_end];
+        let stored_data = &self.data.as_slice()[data_start..data_end];
 
         // Raw zstd (no wrapper). For non-delta entries, decompress
         // if sizes differ. For delta entries, the stored data IS the delta
@@ -329,7 +366,7 @@ impl PackReader {
                 "Entry header out of bounds".to_string(),
             ));
         }
-        Ok(&self.data[offset..self.content_end])
+        Ok(&self.data.as_slice()[offset..self.content_end])
     }
 }
 

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -564,7 +564,7 @@ fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
 /// Helper to write a pack+index to disk and open a reader.
 fn build_and_open_pack(
     objects: Vec<(ContentHash, ObjectType, Vec<u8>, Option<String>)>,
-) -> PackReader {
+) -> PackReader<'static> {
     let temp_dir = TempDir::new().unwrap();
     let pack_path = temp_dir.path().join("test.pack");
     let index_path = temp_dir.path().join("test.idx");

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub const PACK_CHECKSUM_LEN: usize = 32;
 pub const MAX_PACK_OBJECT_OUTPUT_SIZE: usize = 1024 * 1024 * 1024;
-#[cfg(any(feature = "zstd", test))]
+#[cfg(feature = "zstd")]
 pub(super) const PACK_DECOMPRESSION_INITIAL_CAP: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -7,6 +7,7 @@ use crate::{
 
 pub const PACK_CHECKSUM_LEN: usize = 32;
 pub const MAX_PACK_OBJECT_OUTPUT_SIZE: usize = 1024 * 1024 * 1024;
+#[cfg(any(feature = "zstd", test))]
 pub(super) const PACK_DECOMPRESSION_INITIAL_CAP: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]


### PR DESCRIPTION
## Summary
`FsStore::install_pack` cloned the whole received pack via `pack_data.to_vec()` before constructing the `PackReader` — a full-pack copy on every `pull`. Now constructs `PackReader` from borrowed pack/index slices; no copy. The per-entry content-hash validation (#363) is unchanged.

## Test evidence
- objects + workspace tests green; clippy `--locked` clean; `check-no-silent-default-tree-load.sh`; `cargo build -p heddle-cli`.

Closes #400.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782976899&installation_id=132405951&pr_number=416&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F416&signature=c91bfe892af5f5e72206ca83d5a5a2ea289e961b5b772de35aeedfc774f5de63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->