### PR TITLE
perf(objects): validate install_pack entries over zero-copy bytes (#404)

### DIFF
--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -40,7 +40,9 @@ fn validate_loaded_tree(tree: Tree) -> Result<Tree> {
 }
 
 fn validate_blob_bytes(data: &[u8], hash: ContentHash) -> Result<()> {
-    let found = ContentHash::compute_typed("blob", data);
+    let mut hasher = ContentHash::typed_hasher("blob", data.len() as u64);
+    hasher.update(data);
+    let found = ContentHash::from_bytes(hasher.finalize().into());
     if found != hash {
         return Err(HeddleError::Corruption {
             expected: hash,
@@ -906,10 +908,10 @@ impl ObjectStore for FsStore {
         let reader = crate::store::pack::PackReader::from_slice(pack_data, index_data)?;
         let ids = reader.list_ids();
         for id in &ids {
-            let Some((obj_type, data)) = reader.get_object(id)? else {
+            let Some((obj_type, data)) = reader.get_object_bytes(id)? else {
                 continue;
             };
-            validate_pack_entry(id, obj_type, &data)?;
+            validate_pack_entry(id, obj_type, data.as_ref())?;
         }
         self.install_pack_files(pack_data, index_data)?;
         Ok(ids)

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -3,8 +3,8 @@ use chrono::{TimeZone, Utc};
 use tempfile::TempDir;
 
 use super::{
-    fs_paths::{blobs_dir, hash_path, packs_dir},
     FsStore, LooseObjectWriteMode,
+    fs_paths::{blobs_dir, hash_path, packs_dir},
 };
 use crate::{
     object::{
@@ -12,10 +12,10 @@ use crate::{
         TreeEntry,
     },
     store::{
+        HeddleError, ObjectStore,
         atomic::temp_path,
         compression::CompressionConfig,
         pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
-        HeddleError, ObjectStore,
     },
 };
 
@@ -322,6 +322,35 @@ fn install_pack_accepts_valid_mixed_native_pack() {
     assert_eq!(
         store.get_action(&action_id).unwrap().unwrap().description,
         "packed action",
+    );
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn install_pack_accepts_valid_compressed_blob_pack() {
+    let (_temp, store) = create_test_store();
+
+    let content = b"compressible native pack blob\n".repeat(512);
+    let blob = Blob::from(content);
+    let blob_hash = blob.hash();
+    let mut builder = PackBuilder::new(CompressionConfig {
+        enabled: true,
+        min_size: 0,
+        max_delta_size: 0,
+        ..CompressionConfig::default()
+    });
+    builder.add(blob_hash, PackObjectType::Blob, blob.clone().into_content());
+    let (pack_data, index_data, stats) = builder.build().unwrap();
+    assert!(
+        stats.total_compressed < stats.total_uncompressed,
+        "test pack must exercise the compressed get_object_bytes fallback",
+    );
+
+    let ids = store.install_pack(&pack_data, &index_data).unwrap();
+    assert_eq!(ids, vec![PackObjectId::Hash(blob_hash)]);
+    assert_eq!(
+        store.get_blob(&blob_hash).unwrap().unwrap().content(),
+        blob.content(),
     );
 }
 


### PR DESCRIPTION
Validate each pack entry via `get_object_bytes` (zero-copy) + incremental hash instead of an owned `Vec` per object on the sync-receive path; #363 per-entry validation intact (every entry, all-or-nothing). Builds on #400. Local patch cov 100%. Closes #404.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782989322&installation_id=132405951&pr_number=421&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F421&signature=ff2c83cd706a079e02a0dd5af653b9c49d744afe703ba5692fcbb4def70c9112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->