### PR TITLE
fix(security): atomic secret-write primitive — 0600 before bytes, hard-error perms (#364)

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use objects::fs_atomic::write_file_atomic;
+use objects::fs_atomic::write_file_atomic_secret;
 use proto::AuthToken;
 use repo::{FsMonitorMode, FsMonitorSettings, OutputFormat, WorktreeStatusOptions};
 use serde::{Deserialize, Serialize};
@@ -318,7 +318,7 @@ impl UserConfig {
             fs::create_dir_all(parent)?;
         }
         let contents = toml::to_string_pretty(self)?;
-        write_file_atomic(path, contents.as_bytes())?;
+        write_file_atomic_secret(path, contents.as_bytes())?;
         Ok(())
     }
 

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -23,6 +23,11 @@ use tempfile::TempDir;
 
 use super::{assert_json_recovery_advice_fields, heddle, heddle_output};
 
+fn write_test_private_key(path: &std::path::Path, pem: &str) {
+    objects::fs_atomic::write_file_atomic_secret(path, pem.as_bytes())
+        .expect("write test private key");
+}
+
 /// Bootstrap a repo containing a fake-secret file in a captured state.
 /// Returns the temp dir and the short change-id of the capture.
 fn setup_repo_with_secret() -> (TempDir, String) {
@@ -371,7 +376,7 @@ fn redact_apply_with_sign_with_records_signature_verifiable_on_show() {
     let signer = Ed25519Signer::generate().expect("generate ed25519 signing key");
     let key_pem = signer.to_pem().expect("export PEM");
     let key_path = temp.path().join("redact_signing_key.pem");
-    fs::write(&key_path, &key_pem).unwrap();
+    write_test_private_key(&key_path, &key_pem);
 
     let apply_raw = heddle(
         &[
@@ -603,7 +608,7 @@ fn redact_apply_signed_propagates_to_cloned_replica() {
     let signer = Ed25519Signer::generate().unwrap();
     let pem = signer.to_pem().unwrap();
     let pem_path = a.path().join("ed25519.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
     let apply = signed_redact_on_repo_a(&a, &state, &pem_path);
     let redaction_id = apply["redaction_id"].as_str().unwrap().to_string();
 
@@ -709,7 +714,7 @@ fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
     let signer = Ed25519Signer::generate().unwrap();
     let pem = signer.to_pem().unwrap();
     let pem_path = a.path().join("ed25519.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
     let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
 
     heddle(
@@ -774,7 +779,7 @@ fn tampered_redaction_is_refused_at_fetch_boundary() {
     let signer = Ed25519Signer::generate().unwrap();
     let pem = signer.to_pem().unwrap();
     let pem_path = a.path().join("ed25519.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
     let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
 
     // Tamper with A's stored redaction sidecar by mutating the reason
@@ -1056,7 +1061,7 @@ fn redact_after_peer_fetch_still_propagates_on_resync() {
     let signer = Ed25519Signer::generate().unwrap();
     let pem = signer.to_pem().unwrap();
     let pem_path = a.path().join("ed25519.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
     let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
 
     // Re-sync: B trusts A's signing key, registers A as a remote,
@@ -1111,7 +1116,7 @@ fn untrusted_signed_redaction_is_refused_at_fetch_boundary() {
     let attacker = Ed25519Signer::generate().unwrap();
     let pem = attacker.to_pem().unwrap();
     let pem_path = a.path().join("attacker.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
     let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
 
     let b_dir = TempDir::new().unwrap();
@@ -1155,7 +1160,7 @@ fn redact_trust_add_and_list_round_trip() {
     let signer = Ed25519Signer::generate().unwrap();
     let pem = signer.to_pem().unwrap();
     let pem_path = temp.path().join("key.pem");
-    fs::write(&pem_path, &pem).unwrap();
+    write_test_private_key(&pem_path, &pem);
 
     let add_raw = heddle(
         &[

--- a/crates/cli/tests/production_features/state_signing.rs
+++ b/crates/cli/tests/production_features/state_signing.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use crypto::{Ed25519Signer, P256Signer, RsaSigner, Signer, SignerError};
+use objects::store::ObjectStore;
 
 use super::*;
 
@@ -54,7 +54,7 @@ fn test_snapshot_sign_cli() {
     let signer = Ed25519Signer::generate().expect("generate key");
     let key_pem = signer.to_pem().expect("export PEM");
     let key_path = temp.path().join("signing_key.pem");
-    fs::write(&key_path, &key_pem).unwrap();
+    objects::fs_atomic::write_file_atomic_secret(&key_path, key_pem.as_bytes()).unwrap();
 
     let result = heddle(
         &[

--- a/crates/client/src/credentials.rs
+++ b/crates/client/src/credentials.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
 use anyhow::{Context, Result};
-use objects::fs_atomic::write_file_atomic;
+use objects::fs_atomic::write_file_atomic_secret;
 use serde::{Deserialize, Serialize};
 
 static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -77,15 +77,8 @@ pub fn save_credentials(store: &CredentialStore) -> Result<()> {
             .with_context(|| format!("creating directory {}", parent.display()))?;
     }
     let contents = toml::to_string_pretty(store).context("serializing credentials")?;
-    write_file_atomic(&path, contents.as_bytes())
+    write_file_atomic_secret(&path, contents.as_bytes())
         .with_context(|| format!("writing {}", path.display()))?;
-
-    // Best-effort: restrict file permissions on unix.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
-    }
 
     Ok(())
 }
@@ -262,6 +255,81 @@ mod tests {
             assert_eq!(cred.token, "token-123");
         });
 
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_credentials_writes_credential_file_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = unique_temp_dir("heddle-credentials-mode-test");
+        fs::create_dir_all(&home).expect("create temp home");
+
+        with_home_dir(home.clone(), || {
+            let mut store = CredentialStore::default();
+            store.servers.insert(
+                "heddle.example:8421".to_string(),
+                ServerCredential {
+                    token: "token-123".to_string(),
+                    subject: "dev".to_string(),
+                    device_id: None,
+                    credential_id: None,
+                    private_key_pem: Some("pem".to_string()),
+                    expires_at: None,
+                },
+            );
+            save_credentials(&store).expect("save credentials");
+
+            let mode = fs::metadata(credentials_path())
+                .expect("credentials metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
+        });
+
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_credentials_permission_failure_returns_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = unique_temp_dir("heddle-credentials-permission-test");
+        let heddle_dir = home.join(".heddle");
+        fs::create_dir_all(&heddle_dir).expect("create credentials dir");
+        fs::set_permissions(&heddle_dir, fs::Permissions::from_mode(0o500))
+            .expect("make credentials dir unwritable");
+
+        with_home_dir(home.clone(), || {
+            let mut store = CredentialStore::default();
+            store.servers.insert(
+                "heddle.example:8421".to_string(),
+                ServerCredential {
+                    token: "token-123".to_string(),
+                    subject: "dev".to_string(),
+                    device_id: None,
+                    credential_id: None,
+                    private_key_pem: Some("pem".to_string()),
+                    expires_at: None,
+                },
+            );
+
+            let err = save_credentials(&store).expect_err("permission failure must propagate");
+            assert!(
+                err.to_string().contains("writing") || err.to_string().contains("Permission"),
+                "unexpected error: {err:?}"
+            );
+            assert!(
+                !credentials_path().exists(),
+                "failed write must not publish credentials"
+            );
+        });
+
+        fs::set_permissions(&heddle_dir, fs::Permissions::from_mode(0o700))
+            .expect("restore credentials dir");
         let _ = fs::remove_dir_all(home);
     }
 

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -18,6 +18,7 @@ pub enum SignerError {
     P256(String),
     Pkcs8(String),
     KeyNotFound(PathBuf),
+    InsecureKeyPermissions { path: PathBuf, mode: u32 },
     VerificationFailed,
 }
 
@@ -38,6 +39,11 @@ impl std::fmt::Display for SignerError {
             SignerError::P256(msg) => write!(f, "P256 error: {}", msg),
             SignerError::Pkcs8(msg) => write!(f, "PKCS8 error: {}", msg),
             SignerError::KeyNotFound(path) => write!(f, "key file not found: {}", path.display()),
+            SignerError::InsecureKeyPermissions { path, mode } => write!(
+                f,
+                "private key file {} is group/world-accessible ({mode:o}); set permissions to 0600",
+                path.display()
+            ),
             SignerError::VerificationFailed => write!(f, "signature verification failed"),
         }
     }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -36,6 +36,7 @@ pub trait Signer: Send + Sync {
 /// header (or raw-seed shape) selects the backend via
 /// [`pem_loader::load_signer_from_pem`].
 pub fn load_signer(path: &Path, algorithm: Option<&str>) -> Result<Box<dyn Signer>, SignerError> {
+    reject_group_or_world_readable_key(path)?;
     let key_data = std::fs::read(path)?;
     let pem_content = String::from_utf8_lossy(&key_data);
 
@@ -53,6 +54,25 @@ pub fn load_signer(path: &Path, algorithm: Option<&str>) -> Result<Box<dyn Signe
     }
 
     pem_loader::load_signer_from_pem(&pem_content)
+}
+
+#[cfg(unix)]
+fn reject_group_or_world_readable_key(path: &Path) -> Result<(), SignerError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        return Err(SignerError::InsecureKeyPermissions {
+            path: path.to_path_buf(),
+            mode,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_group_or_world_readable_key(_path: &Path) -> Result<(), SignerError> {
+    Ok(())
 }
 
 /// Verify a state's signature.
@@ -84,6 +104,10 @@ pub fn verify_payload_signature(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use objects::fs_atomic::write_file_atomic_secret;
     use tempfile::TempDir;
 
     use super::*;
@@ -117,10 +141,32 @@ mod tests {
 
         let signer = Ed25519Signer::generate().expect("generate key");
         let pem = signer.to_pem().expect("export to PEM");
-        std::fs::write(&key_path, &pem).expect("write key file");
+        write_file_atomic_secret(&key_path, pem.as_bytes()).expect("write key file");
 
         let loaded = load_signer(&key_path, Some("ed25519")).expect("load signer");
         assert_eq!(loaded.algorithm(), "ed25519");
         assert_eq!(loaded.public_key(), signer.public_key());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_signer_refuses_group_or_world_readable_private_key() {
+        let temp = TempDir::new().expect("create temp dir");
+        let key_path = temp.path().join("test_ed25519.pem");
+
+        let signer = Ed25519Signer::generate().expect("generate key");
+        let pem = signer.to_pem().expect("export to PEM");
+        write_file_atomic_secret(&key_path, pem.as_bytes()).expect("write key file");
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644))
+            .expect("make key insecure");
+
+        let err = match load_signer(&key_path, Some("ed25519")) {
+            Ok(_) => panic!("insecure key must fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(
+            err,
+            SignerError::InsecureKeyPermissions { mode: 0o644, .. }
+        ));
     }
 }

--- a/crates/objects/src/fs_atomic.rs
+++ b/crates/objects/src/fs_atomic.rs
@@ -1,11 +1,62 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
-    fs::{self, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+#[derive(Clone, Copy)]
+enum AtomicWriteKind {
+    Normal,
+    Secret,
+}
+
+impl AtomicWriteKind {
+    fn open_tmp(self, tmp: &Path) -> io::Result<File> {
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+
+        #[cfg(unix)]
+        if matches!(self, Self::Secret) {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        options.open(tmp)
+    }
+
+    fn enforce_before_write(self, file: &File) -> io::Result<()> {
+        match self {
+            Self::Normal => Ok(()),
+            Self::Secret => enforce_secret_permissions_before_write(file),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn enforce_secret_permissions_before_write(file: &File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    let mode = file.metadata()?.permissions().mode() & 0o777;
+    if mode != 0o600 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("secret temp file permissions are {mode:o}, expected 600"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn enforce_secret_permissions_before_write(_file: &File) -> io::Result<()> {
+    // Non-Unix platforms do not expose POSIX mode bits through
+    // OpenOptions. The secret variant still uses the same create-new,
+    // write-fsync-rename discipline, but cannot verify a 0600 mode.
+    Ok(())
+}
 
 static TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -319,17 +370,20 @@ impl std::error::Error for EnrichedFsError {
     }
 }
 
-pub fn write_file_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+fn write_file_atomic_impl(
+    path: &Path,
+    bytes: &[u8],
+    kind: AtomicWriteKind,
+    before_write: impl FnOnce(&File, &Path) -> io::Result<()>,
+) -> io::Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(parent).map_err(|e| enrich_fs_error(parent, "creating", e))?;
 
     let tmp = temp_path(path);
     let inner = (|| -> io::Result<()> {
-        let mut file = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(&tmp)?;
+        let mut file = kind.open_tmp(&tmp)?;
+        kind.enforce_before_write(&file)?;
+        before_write(&file, &tmp)?;
         file.write_all(bytes)?;
         file.sync_all()?;
         Ok(())
@@ -345,6 +399,23 @@ pub fn write_file_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
     fs::rename(&tmp, path).map_err(|e| enrich_rename_error(&tmp, path, e))?;
     sync_directory(parent).map_err(|e| enrich_fs_error(parent, "syncing", e))
+}
+
+pub fn write_file_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    write_file_atomic_impl(path, bytes, AtomicWriteKind::Normal, |_, _| Ok(()))
+}
+
+/// Atomically write secret material without ever creating a group/world
+/// readable temporary file.
+///
+/// On Unix the temp inode is created with `OpenOptions::mode(0o600)` before
+/// any bytes are written, then the open file descriptor is enforced to exact
+/// `0600` before the payload is written. Permission failures are hard errors
+/// and the temp file is removed best-effort. On non-Unix platforms there is no
+/// portable POSIX mode API, so this uses the normal create-new temp file,
+/// fsync, and rename sequence.
+pub fn write_file_atomic_secret(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    write_file_atomic_impl(path, bytes, AtomicWriteKind::Secret, |_, _| Ok(()))
 }
 
 #[cfg(test)]
@@ -602,6 +673,50 @@ mod tests {
         let target = dir.path().join("nested/under/here/file.bin");
         write_file_atomic(&target, b"hello").unwrap();
         assert_eq!(fs::read(&target).unwrap(), b"hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_file_atomic_secret_is_0600_before_write_and_after_rename() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("nested/secret.txt");
+        let mut observed_tmp_mode = None;
+
+        write_file_atomic_impl(&target, b"secret", AtomicWriteKind::Secret, |file, tmp| {
+            let fd_mode = file.metadata()?.permissions().mode() & 0o777;
+            let path_mode = fs::metadata(tmp)?.permissions().mode() & 0o777;
+            observed_tmp_mode = Some((fd_mode, path_mode));
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(observed_tmp_mode, Some((0o600, 0o600)));
+        let final_mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(final_mode, 0o600);
+        assert_eq!(fs::read(&target).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn write_file_atomic_secret_cleans_up_when_pre_write_check_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("secret.txt");
+        let mut tmp_path = None;
+
+        let err = write_file_atomic_impl(&target, b"secret", AtomicWriteKind::Secret, |_, tmp| {
+            tmp_path = Some(tmp.to_path_buf());
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected permission failure",
+            ))
+        })
+        .expect_err("permission failure should propagate");
+
+        assert!(is_permission_denied(&err), "unexpected error: {err}");
+        assert!(!target.exists(), "secret write must not publish target");
+        let tmp = tmp_path.expect("pre-write hook observed temp path");
+        assert!(!tmp.exists(), "failed secret write should remove temp file");
     }
 
     /// Regression for heddle#105: `sync_directory` must succeed on any


### PR DESCRIPTION
## Summary
**Security P2 (#364):** `write_file_atomic` created its temp file with umask-default perms then chmod'd `0600` post-rename, best-effort (discarded result) — leaving secrets (credentials.toml: token + private_key_pem) briefly group/world-readable, with a silently-swallowed chmod failure.

Lift-to-primitive fix:
- New `write_file_atomic_secret` — on unix, creates the temp file with `OpenOptions::mode(0o600)` **before any bytes are written** (no readable window), and enforces exact `0600`; a permission failure is a **hard error** for secrets, not best-effort.
- `save_credentials` + user-config saves (can persist `remote.token`) route through the secret primitive; the post-rename best-effort chmod is gone.
- `load_signer` refuses unix private keys with group/other permission bits (defense-in-depth on read).

## Test evidence
- temp + final file are `0600` (no readable window); pre-write failure cleanup; credential write hard-errors on perm failure; loader refuses a `0644` key.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #364.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994103&installation_id=132405951&pr_number=428&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F428&signature=1318647ed009a319efa6b6d0428ab42a410189ff30e4ad67fd0f49b85c72a969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->