### PR TITLE
feat(oplog): packed oplog v3 tail + transaction_id indexes (#423)

### DIFF
--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -19,7 +19,7 @@ use super::{
         ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
         isolation_keys_for_record,
     },
-    packed_oplog::PackedOpLog,
+    packed_oplog::{Latest, OplogFormat, PackedOpLog, PackedOpLogIndex, V2},
 };
 
 /// A `TransactionCommit` marker carries no user-facing operation: it is the
@@ -35,7 +35,7 @@ fn is_transaction_commit(op: &OpRecord) -> bool {
 /// Operation log for tracking operations and enabling undo.
 pub struct OpLog {
     pub(crate) root: PathBuf,
-    cached: Mutex<Option<PackedOpLog>>,
+    cached: Mutex<Option<PackedOpLogIndex>>,
     actor: Arc<Principal>,
 }
 
@@ -107,21 +107,64 @@ impl OpLog {
             .collect()
     }
 
+    fn ensure_current_format(&self) -> Result<()> {
+        let path = self.oplog_path();
+        if !path.exists() {
+            return Ok(());
+        }
+        match PackedOpLog::on_disk_version(&path)? {
+            version if version == u32::from(Latest::VERSION) => {
+                let _ = PackedOpLogIndex::open(&path)?;
+                Ok(())
+            }
+            version if version == u32::from(V2::VERSION) => {
+                let _lock = self.write_lock()?;
+                PackedOpLog::ensure_latest(&path)
+            }
+            version => Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {version}"
+            ))),
+        }
+    }
+
     /// Load from disk, bypassing cache (used after acquiring write lock).
-    fn load_fresh(&self) -> Result<PackedOpLog> {
+    fn load_fresh_for_write(&self) -> Result<PackedOpLog> {
         let path = self.oplog_path();
         if path.exists() {
+            PackedOpLog::ensure_latest(&path)?;
             PackedOpLog::load(&path)
         } else {
             Ok(PackedOpLog::new(path))
         }
     }
 
+    fn open_index_for_write(&self) -> Result<PackedOpLogIndex> {
+        let path = self.oplog_path();
+        if path.exists() {
+            PackedOpLog::ensure_latest(&path)?;
+        } else {
+            PackedOpLog::new(path.clone()).save()?;
+        }
+        PackedOpLogIndex::open(&path)
+    }
+
     /// Load from cache or disk (for read operations).
-    fn load_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLog>>> {
+    fn load_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLogIndex>>> {
+        let guard = self.cached.lock().unwrap();
+        if guard.is_some() {
+            return Ok(guard);
+        }
+        drop(guard);
+
+        self.ensure_current_format()?;
         let mut guard = self.cached.lock().unwrap();
         if guard.is_none() {
-            *guard = Some(self.load_fresh()?);
+            let path = self.oplog_path();
+            *guard = Some(if path.exists() {
+                PackedOpLogIndex::open(&path)?
+            } else {
+                PackedOpLogIndex::empty(path)
+            });
         }
         Ok(guard)
     }
@@ -131,9 +174,15 @@ impl OpLog {
     /// [`load_cached`]: a long-lived handle's already-populated cache is a stale
     /// view that would miss a batch another process wrote (heddle#354 r6, cid
     /// 3329711888).
-    fn refresh_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLog>>> {
+    fn refresh_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLogIndex>>> {
+        self.ensure_current_format()?;
         let mut guard = self.cached.lock().unwrap();
-        *guard = Some(self.load_fresh()?);
+        let path = self.oplog_path();
+        *guard = Some(if path.exists() {
+            PackedOpLogIndex::open(&path)?
+        } else {
+            PackedOpLogIndex::empty(path)
+        });
         Ok(guard)
     }
 
@@ -153,13 +202,13 @@ impl OpLog {
     /// Get the last operation entry.
     pub fn last(&self) -> Result<Option<OpEntry>> {
         let guard = self.load_cached()?;
-        Ok(guard.as_ref().unwrap().last_entry().cloned())
+        guard.as_ref().unwrap().last_entry()
     }
 
     /// Get the last N operations.
     pub fn recent(&self, count: usize) -> Result<Vec<OpEntry>> {
         let guard = self.load_cached()?;
-        Ok(guard.as_ref().unwrap().recent_entries(count))
+        guard.as_ref().unwrap().recent_entries(count)
     }
 
     pub fn recent_batches(&self, count: usize) -> Result<Vec<OpBatch>> {
@@ -168,6 +217,19 @@ impl OpLog {
 
     pub fn recent_batches_scoped(&self, count: usize, scope: Option<&str>) -> Result<Vec<OpBatch>> {
         self.collect_batches_scoped(count, |_| true, scope)
+    }
+
+    pub fn recent_batches_after_scoped(
+        &self,
+        since_head_id: u64,
+        count: usize,
+        scope: Option<&str>,
+    ) -> Result<Vec<OpBatch>> {
+        let guard = self.refresh_cached()?;
+        guard
+            .as_ref()
+            .unwrap()
+            .collect_batches_after_scoped(since_head_id, count, |_| true, scope)
     }
 
     /// Like [`recent_batches_scoped`](Self::recent_batches_scoped) but counts
@@ -248,7 +310,7 @@ impl OpLog {
         }
 
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let mut packed = self.load_fresh_for_write()?;
         let mut matching_indices = Vec::new();
         let mut saw_primary = false;
         let mut saw_secondary = false;
@@ -286,7 +348,7 @@ impl OpLog {
             .into_iter()
             .map(|idx| packed.entries[idx].clone())
             .collect::<Vec<_>>();
-        *self.cached.lock().unwrap() = Some(packed);
+        *self.cached.lock().unwrap() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
 
         Ok(OpBatch {
             id: primary_batch_id,
@@ -310,18 +372,17 @@ impl OpLog {
 
         let _lock = self.write_lock()?;
         // Reload from disk to catch any writes from other processes
-        let mut packed = self.load_fresh()?;
+        let index = self.open_index_for_write()?;
 
-        let start_id = packed.head_id + 1;
+        let start_id = index.head_id() + 1;
         let timestamp = Utc::now();
         let scope_owned = scope.map(str::to_string);
         let new_entries =
             Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
-        packed.append(new_entries);
-        packed.save()?;
-        *self.cached.lock().unwrap() = Some(packed);
+        let updated = index.append_entries(&new_entries)?;
+        *self.cached.lock().unwrap() = Some(updated);
 
         Ok(ids)
     }
@@ -356,9 +417,9 @@ impl OpLog {
         }
 
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let index = self.open_index_for_write()?;
 
-        let recent = packed.collect_batches_scoped(recent_window, |_| true, scope);
+        let recent = index.collect_batches_scoped(recent_window, |_| true, scope)?;
         if recent.iter().any(|batch| {
             batch.entries.iter().any(|entry| {
                 matches!(
@@ -371,16 +432,15 @@ impl OpLog {
             return Ok(None);
         }
 
-        let start_id = packed.head_id + 1;
+        let start_id = index.head_id() + 1;
         let timestamp = Utc::now();
         let scope_owned = scope.map(str::to_string);
         let new_entries =
             Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
-        packed.append(new_entries);
-        packed.save()?;
-        *self.cached.lock().unwrap() = Some(packed);
+        let updated = index.append_entries(&new_entries)?;
+        *self.cached.lock().unwrap() = Some(updated);
 
         Ok(Some(ids))
     }
@@ -414,30 +474,21 @@ impl OpLog {
         }
 
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let index = self.open_index_for_write()?;
 
-        // Unbounded scan over the ENTIRE committed history — not a window.
-        let already_committed = packed.entries.iter().any(|entry| {
-            matches!(
-                &entry.operation,
-                OpRecord::TransactionCommit { transaction_id: id, .. }
-                    if id == transaction_id
-            )
-        });
-        if already_committed {
+        if index.transaction_commit(transaction_id)?.is_some() {
             return Ok(None);
         }
 
-        let start_id = packed.head_id + 1;
+        let start_id = index.head_id() + 1;
         let timestamp = Utc::now();
         let scope_owned = scope.map(str::to_string);
         let new_entries =
             Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
-        packed.append(new_entries);
-        packed.save()?;
-        *self.cached.lock().unwrap() = Some(packed);
+        let updated = index.append_entries(&new_entries)?;
+        *self.cached.lock().unwrap() = Some(updated);
 
         Ok(Some(ids))
     }
@@ -454,31 +505,15 @@ impl OpLog {
         }
 
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let index = self.open_index_for_write()?;
 
-        if let Some(commit_entry) = packed.entries.iter().find(|entry| {
-            matches!(
-                &entry.operation,
-                OpRecord::TransactionCommit { transaction_id: id, .. }
-                    if id == transaction_id
-            )
-        }) {
-            let committed = packed
-                .entries
-                .iter()
-                .filter(|entry| entry.batch_id == commit_entry.batch_id)
-                .filter(|entry| !is_transaction_commit(&entry.operation))
-                .map(|entry| entry.operation.clone())
-                .collect();
+        if index.transaction_commit(transaction_id)?.is_some() {
+            let committed = index.committed_batch_records(transaction_id)?;
             return Ok(ConditionalCommitOutcome::AlreadyCommitted(committed));
         }
 
-        if !precondition.keys.is_empty() && packed.head_id != precondition.since_head_id {
-            for entry in packed
-                .entries
-                .iter()
-                .filter(|entry| entry.id > precondition.since_head_id)
-            {
+        if !precondition.keys.is_empty() && index.head_id() != precondition.since_head_id {
+            for entry in index.entries_after(precondition.since_head_id)? {
                 let touched = isolation_keys_for_record(&entry.operation, entry.scope.as_deref());
                 if let Some(key) = touched.intersection(&precondition.keys).next().cloned() {
                     return Ok(ConditionalCommitOutcome::IsolationConflict {
@@ -490,16 +525,15 @@ impl OpLog {
             }
         }
 
-        let start_id = packed.head_id + 1;
+        let start_id = index.head_id() + 1;
         let timestamp = Utc::now();
         let scope_owned = scope.map(str::to_string);
         let new_entries =
             Self::build_entries(&self.actor, operations, start_id, timestamp, &scope_owned);
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
-        packed.append(new_entries);
-        packed.save()?;
-        *self.cached.lock().unwrap() = Some(packed);
+        let updated = index.append_entries(&new_entries)?;
+        *self.cached.lock().unwrap() = Some(updated);
 
         Ok(ConditionalCommitOutcome::Committed(ids))
     }
@@ -512,6 +546,7 @@ impl OpLog {
     /// one integer compare against a cached watermark — no tail scan. Returns 0
     /// when the oplog file does not exist yet.
     pub fn head_id(&self) -> Result<u64> {
+        self.ensure_current_format()?;
         match PackedOpLog::read_head_id(&self.oplog_path()) {
             Ok(id) => Ok(id),
             // Treat a not-yet-created oplog as generation 0.
@@ -539,38 +574,10 @@ impl OpLog {
         // 3329711888). The committed batch is durable and append-only, so a
         // lock-free fresh read observes it consistently.
         let guard = self.refresh_cached()?;
-        let packed = guard.as_ref().unwrap();
-
-        let Some(commit_entry) = packed.entries.iter().find(|entry| {
-            matches!(
-                &entry.operation,
-                OpRecord::TransactionCommit { transaction_id: id, .. }
-                    if id == transaction_id
-            )
-        }) else {
-            return Ok(Vec::new());
-        };
-        let batch_id = if commit_entry.batch_id == 0 {
-            commit_entry.id
-        } else {
-            commit_entry.batch_id
-        };
-
-        let records = packed
-            .entries
-            .iter()
-            .filter(|entry| {
-                let bid = if entry.batch_id == 0 {
-                    entry.id
-                } else {
-                    entry.batch_id
-                };
-                bid == batch_id
-            })
-            .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
-            .map(|entry| entry.operation.clone())
-            .collect();
-        Ok(records)
+        guard
+            .as_ref()
+            .unwrap()
+            .committed_batch_records(transaction_id)
     }
 
     pub(super) fn record_single_scoped(
@@ -579,9 +586,9 @@ impl OpLog {
         scope: Option<&str>,
     ) -> Result<u64> {
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let index = self.open_index_for_write()?;
 
-        let id = packed.head_id + 1;
+        let id = index.head_id() + 1;
         let entry = OpEntry {
             id,
             timestamp: Utc::now(),
@@ -594,9 +601,8 @@ impl OpLog {
             operation_id: None,
         };
 
-        packed.append(vec![entry]);
-        packed.save()?;
-        *self.cached.lock().unwrap() = Some(packed);
+        let updated = index.append_entries(&[entry])?;
+        *self.cached.lock().unwrap() = Some(updated);
 
         Ok(id)
     }
@@ -607,7 +613,7 @@ impl OpLog {
 
     fn update_batch_undone_state(&self, batch: &OpBatch, undone: bool) -> Result<OpBatch> {
         let _lock = self.write_lock()?;
-        let mut packed = self.load_fresh()?;
+        let mut packed = self.load_fresh_for_write()?;
         packed.set_undone(batch.id, undone);
         packed.save()?;
 
@@ -616,7 +622,7 @@ impl OpLog {
             e.undone = undone;
         }
 
-        *self.cached.lock().unwrap() = Some(packed);
+        *self.cached.lock().unwrap() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
 
         Ok(OpBatch {
             id: batch.id,
@@ -634,10 +640,10 @@ impl OpLog {
         F: Fn(&OpBatch) -> bool,
     {
         let guard = self.load_cached()?;
-        Ok(guard
+        guard
             .as_ref()
             .unwrap()
-            .collect_batches_scoped(count, predicate, scope))
+            .collect_batches_scoped(count, predicate, scope)
     }
 }
 

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -251,6 +251,53 @@ fn recent_batches_scoped_merges_non_adjacent_coalesced_batches() {
 }
 
 #[test]
+fn committed_batch_records_uses_rebuilt_index_for_non_adjacent_coalesced_batch() {
+    let (_temp, oplog) = create_oplog();
+    let committed_state = ChangeId::generate();
+    let later_state = ChangeId::generate();
+    let middle_state = ChangeId::generate();
+
+    let committed = oplog
+        .record_batch_exactly_once(
+            vec![
+                OpRecord::Snapshot {
+                    new_state: committed_state,
+                    prev_head: None,
+                    head: Some(committed_state),
+                    thread: None,
+                },
+                OpRecord::TransactionCommit {
+                    transaction_id: "tx-coalesced".into(),
+                    op_count: 1,
+                },
+            ],
+            Some("lane-a"),
+            "tx-coalesced",
+        )
+        .unwrap()
+        .unwrap();
+    let middle = oplog
+        .record_snapshot(&middle_state, Some(&committed_state), None, Some("lane-a"))
+        .unwrap();
+    let later = oplog
+        .record_snapshot(&later_state, Some(&middle_state), None, Some("lane-a"))
+        .unwrap();
+
+    oplog.coalesce_batches(committed[0], later).unwrap();
+
+    let records = oplog.committed_batch_records("tx-coalesced").unwrap();
+    let recovered = records
+        .iter()
+        .filter_map(|record| match record {
+            OpRecord::Snapshot { new_state, .. } => Some(*new_state),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(middle, committed[0] + 2, "precondition: non-adjacent batch");
+    assert_eq!(recovered, vec![committed_state, later_state]);
+}
+
+#[test]
 fn test_oplogbackend_trait_async_methods_dispatch() {
     // The CLI calls OpLog's inherent (sync) batch methods; the generic
     // backend plumbing and the hosted server reach the async trait
@@ -677,7 +724,9 @@ fn record_methods_persist_expected_variants() {
     let blob = ContentHash::from_bytes([7u8; 32]);
     let redaction = ContentHash::from_bytes([9u8; 32]);
 
-    oplog.record_goto(&result, Some(&from), Some("lane")).unwrap();
+    oplog
+        .record_goto(&result, Some(&from), Some("lane"))
+        .unwrap();
     oplog
         .record_thread_create("feat", &result, Some(vec![9, 8, 7]), Some("lane"))
         .unwrap();
@@ -716,7 +765,10 @@ fn record_methods_persist_expected_variants() {
             _ => None,
         })
         .expect("a Fork record was written");
-    assert_eq!(fork.0, from, "record_fork's `from` must be the source state");
+    assert_eq!(
+        fork.0, from,
+        "record_fork's `from` must be the source state"
+    );
     assert_eq!(fork.1, result);
     assert_eq!(fork.2.as_deref(), Some("topic"));
     assert_eq!(fork.3, None);
@@ -821,8 +873,8 @@ mod default_backend {
     use objects::error::Result;
     use objects::object::Principal;
 
-    use super::OpLogBackend;
     use super::super::oplog_types::{OpBatch, OpEntry, OpRecord};
+    use super::OpLogBackend;
 
     #[derive(Default)]
     struct MemOpLog {
@@ -973,7 +1025,12 @@ mod default_backend {
             .record_thread_delete(&ThreadName::new("ft"), &cid, Some("s"))
             .unwrap();
         let rename_ids = backend
-            .record_thread_rename(&ThreadName::new("old"), &ThreadName::new("new"), &cid, Some("s"))
+            .record_thread_rename(
+                &ThreadName::new("old"),
+                &ThreadName::new("new"),
+                &cid,
+                Some("s"),
+            )
             .unwrap();
         assert_eq!(rename_ids.len(), 2, "rename emits create + delete");
         backend
@@ -988,7 +1045,9 @@ mod default_backend {
         backend
             .record_remote_thread_delete("origin", "rt", &cid, Some("s"))
             .unwrap();
-        backend.record_undo_recovery_update(&cid, Some("s")).unwrap();
+        backend
+            .record_undo_recovery_update(&cid, Some("s"))
+            .unwrap();
         backend
             .record_marker_create(&MarkerName::new("v1"), &cid)
             .unwrap();
@@ -1000,7 +1059,13 @@ mod default_backend {
             .unwrap();
         backend.record_purge(&redaction, &blob, Some("s")).unwrap();
         backend
-            .record_fast_forward(&ThreadName::new("topic"), &ThreadName::new("main"), &from, &cid, Some("s"))
+            .record_fast_forward(
+                &ThreadName::new("topic"),
+                &ThreadName::new("main"),
+                &from,
+                &cid,
+                Some("s"),
+            )
             .unwrap();
 
         // `coalesce_batches` default is fail-closed.
@@ -1030,7 +1095,10 @@ mod default_backend {
             o,
             OpRecord::RemoteThreadUpdate { remote, thread, .. } if remote == "origin" && thread == "rt"
         )));
-        assert!(ops.iter().any(|o| matches!(o, OpRecord::UndoRecoveryUpdate { .. })));
+        assert!(
+            ops.iter()
+                .any(|o| matches!(o, OpRecord::UndoRecoveryUpdate { .. }))
+        );
         assert!(ops.iter().any(|o| matches!(
             o,
             OpRecord::FastForwardV2 { post_target_id, .. } if *post_target_id == cid

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -1,30 +1,178 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Packed binary oplog: all entries in a single file, loaded into memory.
+//! Packed binary oplog.
+//!
+//! The in-memory model is version-agnostic. Format versions are codecs over
+//! that model: v2 is accepted only as a migration source, and v3 is the latest
+//! single-file container with an EOF index footer.
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, HashMap};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use chrono::{TimeZone, Utc};
 use objects::{
     error::{HeddleError, Result},
-    fs_atomic::write_file_atomic,
+    fs_atomic::{sync_directory, temp_path, write_file_atomic},
 };
 
 use super::oplog_types::{OpBatch, OpEntry, OpRecord};
 
 const MAGIC: &[u8; 8] = b"LMOPLOG\0";
-/// Binary oplog format version.
-///
-/// `2` adds the W1 fields: each entry now encodes its `actor` (principal
-/// name + email, length-prefixed UTF-8) and `operation_id` (tag byte +
-/// optional 16-byte UUID). Pre-W1 v1 files are rejected — there are no
-/// live deployments to migrate from.
-const VERSION: u32 = 2;
+const INDEX_MAGIC: &[u8; 8] = b"LMOPIDX\0";
+const INDEX_VERSION: u32 = 1;
+const HEADER_LEN: u64 = 8 + 4 + 8 + 8;
+const FOOTER_U64_FIELDS: u64 = 13;
+const FOOTER_LEN: u64 = 8 + 4 + 4 + (FOOTER_U64_FIELDS * 8);
+const ENTRY_OFFSET_RECORD_LEN: u64 = 16;
+const BATCH_DIR_RECORD_LEN: u64 = 48;
+const TX_DIR_RECORD_LEN: u64 = 32;
 
+/// Version-agnostic materialized oplog data.
+#[derive(Clone)]
+pub(crate) struct OplogData {
+    pub(crate) entries: Vec<OpEntry>, // sorted by id ascending
+    pub(crate) head_id: u64,
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub(crate) trait OplogFormat: sealed::Sealed {
+    const VERSION: u8;
+    fn decode(bytes: &[u8]) -> Result<OplogData>;
+}
+
+pub(crate) trait OplogWriteFormat: OplogFormat {
+    fn encode(data: &OplogData, out: &mut Vec<u8>) -> Result<()>;
+}
+
+pub(crate) struct V2;
+pub(crate) struct V3;
+pub(crate) type Latest = V3;
+
+impl sealed::Sealed for V2 {}
+impl sealed::Sealed for V3 {}
+
+impl OplogFormat for V2 {
+    const VERSION: u8 = 2;
+
+    fn decode(bytes: &[u8]) -> Result<OplogData> {
+        let (header, mut cursor) = parse_header_with_cursor(bytes)?;
+        if header.version != u32::from(Self::VERSION) {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {}",
+                header.version
+            )));
+        }
+        let entries = parse_entries(&mut cursor, header.entry_count as usize)?;
+        Ok(OplogData {
+            entries,
+            head_id: header.head_id,
+        })
+    }
+}
+
+impl OplogFormat for V3 {
+    const VERSION: u8 = 3;
+
+    fn decode(bytes: &[u8]) -> Result<OplogData> {
+        let (header, cursor) = parse_header_with_cursor(bytes)?;
+        if header.version != u32::from(Self::VERSION) {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {}",
+                header.version
+            )));
+        }
+        let footer = PackedFooter::parse(bytes, &header)?;
+        if cursor.offset as u64 > footer.entry_data_end {
+            return Err(HeddleError::InvalidObject(
+                "oplog footer points before the entry stream".to_string(),
+            ));
+        }
+        let entry_bytes_end = usize::try_from(footer.entry_data_end)
+            .map_err(|_| HeddleError::InvalidObject("oplog entry section too large".to_string()))?;
+        let mut entry_cursor = Cursor::new(&bytes[cursor.offset..entry_bytes_end]);
+        let entries = parse_entries(&mut entry_cursor, header.entry_count as usize)?;
+        if cursor.offset + entry_cursor.offset != entry_bytes_end {
+            return Err(HeddleError::InvalidObject(
+                "oplog entry/index boundary disagreement".to_string(),
+            ));
+        }
+        Ok(OplogData {
+            entries,
+            head_id: header.head_id,
+        })
+    }
+}
+
+impl OplogWriteFormat for V3 {
+    fn encode(data: &OplogData, out: &mut Vec<u8>) -> Result<()> {
+        encode_data_v3(data, out)
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct PackedOpLog {
     pub(crate) entries: Vec<OpEntry>, // sorted by id ascending
     pub(crate) head_id: u64,
     pub(crate) path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PackedOpLogIndex {
+    path: PathBuf,
+    header: PackedHeader,
+    footer: PackedFooter,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PackedHeader {
+    version: u32,
+    entry_count: u64,
+    head_id: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PackedFooter {
+    entry_data_end: u64,
+    entry_offsets_offset: u64,
+    entry_offsets_count: u64,
+    batch_offsets_offset: u64,
+    batch_offsets_count: u64,
+    batch_dir_offset: u64,
+    batch_dir_count: u64,
+    tx_key_bytes_offset: u64,
+    tx_key_bytes_len: u64,
+    tx_dir_offset: u64,
+    tx_dir_count: u64,
+    entry_count: u64,
+    head_id: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct EntryOffsetRecord {
+    entry_id: u64,
+    entry_offset: u64,
+}
+
+#[derive(Clone, Debug)]
+struct BatchDirRecord {
+    batch_id: u64,
+    newest_entry_id: u64,
+    first_offset_index: u64,
+    entry_count: u32,
+    scope_state: u8,
+}
+
+#[derive(Clone, Debug)]
+struct TxDirRecord {
+    key_offset: u64,
+    key_len: u32,
+    commit_entry_id: u64,
+    batch_id: u64,
 }
 
 impl PackedOpLog {
@@ -38,203 +186,91 @@ impl PackedOpLog {
 
     pub(crate) fn load(path: &Path) -> Result<Self> {
         let bytes = std::fs::read(path)?;
-        Self::parse(&bytes, path.to_path_buf())
+        let data = load(&bytes)?;
+        Ok(Self {
+            entries: data.entries,
+            head_id: data.head_id,
+            path: path.to_path_buf(),
+        })
     }
 
-    /// Read only the `head_id` from the fixed-size header — the cheap O(1)
-    /// generation gate (heddle#330). Layout: MAGIC(8) + VERSION(4) +
-    /// entry_count(8) + head_id(8); `head_id` is at byte offset 20.
-    ///
-    /// Validates BOTH the magic AND the version: the fast path must reject the
-    /// same headers the full [`parse`](Self::parse) would (heddle#354 r6, cid
-    /// 3329711891). Otherwise a right-magic / unsupported-version file yields a
-    /// generation and lets a reconciled read take the `tip == watermark`
-    /// shortcut, silently trusting a format the parser would refuse.
-    pub(crate) fn read_head_id(path: &Path) -> Result<u64> {
-        use std::io::Read;
-        let mut file = std::fs::File::open(path)?;
-        let mut header = [0u8; 28];
-        file.read_exact(&mut header)?;
-        if &header[0..8] != MAGIC {
-            return Err(HeddleError::InvalidObject(
-                "invalid oplog magic".to_string(),
-            ));
+    pub(crate) fn ensure_latest(path: &Path) -> Result<()> {
+        if !path.exists() {
+            return Ok(());
         }
-        let mut version_bytes = [0u8; 4];
-        version_bytes.copy_from_slice(&header[8..12]);
-        let version = u32::from_le_bytes(version_bytes);
-        if version != VERSION {
-            return Err(HeddleError::InvalidObject(format!(
+        match read_header_version(path)? {
+            version if version == u32::from(Latest::VERSION) => {
+                let _ = PackedOpLogIndex::open_v3(path)?;
+                Ok(())
+            }
+            version if version == u32::from(V2::VERSION) => {
+                let bytes = std::fs::read(path)?;
+                let data = load(&bytes)?;
+                let mut out = Vec::new();
+                Latest::encode(&data, &mut out)?;
+                write_file_atomic(path, &out)?;
+                Ok(())
+            }
+            version => Err(HeddleError::InvalidObject(format!(
                 "unsupported oplog version {version}"
+            ))),
+        }
+    }
+
+    /// Read only the `head_id` from the fixed-size current-format header.
+    ///
+    /// v2 has the same first 28 bytes, but this fast path deliberately rejects
+    /// it. Callers that own the oplog write lock must migrate v2 before asking
+    /// for a v3 head; callers that do not own the lock route through `OpLog`,
+    /// which performs the locked migration first.
+    pub(crate) fn read_head_id(path: &Path) -> Result<u64> {
+        let header = read_header(path)?;
+        if header.version != u32::from(Latest::VERSION) {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {}",
+                header.version
             )));
         }
-        let mut head_id_bytes = [0u8; 8];
-        head_id_bytes.copy_from_slice(&header[20..28]);
-        Ok(u64::from_le_bytes(head_id_bytes))
+        Ok(header.head_id)
+    }
+
+    pub(crate) fn on_disk_version(path: &Path) -> Result<u32> {
+        read_header_version(path)
     }
 
     pub(crate) fn save(&self) -> Result<()> {
-        let bytes = self.serialize()?;
+        let data = OplogData {
+            entries: self.entries.clone(),
+            head_id: self.head_id,
+        };
+        let mut bytes = Vec::new();
+        Latest::encode(&data, &mut bytes)?;
         write_file_atomic(&self.path, &bytes)?;
         Ok(())
     }
 
+    #[cfg(test)]
     fn serialize(&self) -> Result<Vec<u8>> {
+        let data = OplogData {
+            entries: self.entries.clone(),
+            head_id: self.head_id,
+        };
         let mut buf = Vec::new();
-        buf.extend_from_slice(MAGIC);
-        buf.extend_from_slice(&VERSION.to_le_bytes());
-        buf.extend_from_slice(&(self.entries.len() as u64).to_le_bytes());
-        buf.extend_from_slice(&self.head_id.to_le_bytes());
-
-        for entry in &self.entries {
-            buf.extend_from_slice(&entry.id.to_le_bytes());
-            buf.extend_from_slice(&entry.batch_id.to_le_bytes());
-            buf.extend_from_slice(&entry.batch_index.to_le_bytes());
-            buf.extend_from_slice(&entry.timestamp.timestamp().to_le_bytes());
-            buf.extend_from_slice(&entry.timestamp.timestamp_subsec_nanos().to_le_bytes());
-            buf.push(if entry.undone { 1 } else { 0 });
-
-            let scope_bytes = entry.scope.as_deref().unwrap_or("").as_bytes();
-            buf.extend_from_slice(&(scope_bytes.len() as u16).to_le_bytes());
-            buf.extend_from_slice(scope_bytes);
-
-            let op_data = rmp_serde::to_vec(&entry.operation)
-                .map_err(|e| HeddleError::Serialization(e.to_string()))?;
-            buf.extend_from_slice(&(op_data.len() as u32).to_le_bytes());
-            buf.extend_from_slice(&op_data);
-
-            // v2: actor (name + email) + operation_id.
-            let actor_name = entry.actor.name.as_bytes();
-            buf.extend_from_slice(&(actor_name.len() as u16).to_le_bytes());
-            buf.extend_from_slice(actor_name);
-            let actor_email = entry.actor.email.as_bytes();
-            buf.extend_from_slice(&(actor_email.len() as u16).to_le_bytes());
-            buf.extend_from_slice(actor_email);
-            match entry.operation_id {
-                Some(op_id) => {
-                    buf.push(1);
-                    buf.extend_from_slice(op_id.as_bytes());
-                }
-                None => buf.push(0),
-            }
-        }
-
+        Latest::encode(&data, &mut buf)?;
         Ok(buf)
     }
 
+    #[cfg(test)]
     fn parse(bytes: &[u8], path: PathBuf) -> Result<Self> {
-        let mut c = Cursor::new(bytes);
-
-        let magic = c.read_array::<8>()?;
-        if &magic != MAGIC {
-            return Err(HeddleError::InvalidObject(
-                "invalid oplog magic".to_string(),
-            ));
-        }
-
-        let version = c.read_u32()?;
-        if version != VERSION {
-            return Err(HeddleError::InvalidObject(format!(
-                "unsupported oplog version {version}"
-            )));
-        }
-
-        let entry_count = c.read_u64()? as usize;
-        let head_id = c.read_u64()?;
-        let mut entries = Vec::with_capacity(entry_count);
-
-        for _ in 0..entry_count {
-            let id = c.read_u64()?;
-            let batch_id = c.read_u64()?;
-            let batch_index = c.read_u32()?;
-            let timestamp_secs = c.read_i64()?;
-            let timestamp_ns = c.read_u32()?;
-            let undone = c.read_u8()? != 0;
-
-            let scope_len = c.read_u16()? as usize;
-            let scope_bytes = c.read_bytes(scope_len)?;
-            let scope = if scope_bytes.is_empty() {
-                None
-            } else {
-                Some(String::from_utf8(scope_bytes).map_err(|_| {
-                    HeddleError::InvalidObject("invalid UTF-8 in scope".to_string())
-                })?)
-            };
-
-            let op_data_len = c.read_u32()? as usize;
-            let op_data = c.read_bytes(op_data_len)?;
-            let operation: OpRecord = rmp_serde::from_slice(&op_data)
-                .map_err(|e| HeddleError::Serialization(e.to_string()))?;
-
-            // v2 fields: actor (name + email) and operation_id.
-            let actor_name_len = c.read_u16()? as usize;
-            let actor_name = String::from_utf8(c.read_bytes(actor_name_len)?).map_err(|_| {
-                HeddleError::InvalidObject("invalid UTF-8 in actor.name".to_string())
-            })?;
-            let actor_email_len = c.read_u16()? as usize;
-            let actor_email = String::from_utf8(c.read_bytes(actor_email_len)?).map_err(|_| {
-                HeddleError::InvalidObject("invalid UTF-8 in actor.email".to_string())
-            })?;
-            let actor = std::sync::Arc::new(objects::object::Principal {
-                name: actor_name,
-                email: actor_email,
-            });
-            let operation_id_tag = c.read_u8()?;
-            let operation_id = match operation_id_tag {
-                0 => None,
-                1 => {
-                    let bytes = c.read_array::<16>()?;
-                    Some(objects::object::OperationId::from_uuid(
-                        uuid::Uuid::from_bytes(bytes),
-                    ))
-                }
-                other => {
-                    return Err(HeddleError::InvalidObject(format!(
-                        "invalid operation_id tag byte {other}"
-                    )));
-                }
-            };
-
-            // Reject nanos in the leap-second range (>= 1e9) explicitly.
-            // Heddle's serializer writes `timestamp_subsec_nanos()` which
-            // is always < 1e9 in normal time; chrono's `timestamp_opt`
-            // accepts nanos up to 2e9 for leap-second representation, so
-            // without this guard a corrupted oplog with nanos in
-            // [1e9, 2e9) would parse as a phantom leap-second timestamp.
-            if timestamp_ns >= 1_000_000_000 {
-                return Err(HeddleError::InvalidObject(format!(
-                    "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
-                )));
-            }
-            let timestamp = Utc
-                .timestamp_opt(timestamp_secs, timestamp_ns)
-                .single()
-                .ok_or_else(|| {
-                    HeddleError::InvalidObject(format!(
-                        "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
-                    ))
-                })?;
-
-            entries.push(OpEntry {
-                id,
-                timestamp,
-                operation,
-                undone,
-                batch_id,
-                batch_index,
-                scope,
-                actor,
-                operation_id,
-            });
-        }
-
+        let data = load(bytes)?;
         Ok(Self {
-            entries,
-            head_id,
+            entries: data.entries,
+            head_id: data.head_id,
             path,
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn append(&mut self, new_entries: Vec<OpEntry>) {
         let last_id = new_entries.last().map(|e| e.id).unwrap_or(self.head_id);
         self.entries.extend(new_entries);
@@ -249,12 +285,99 @@ impl PackedOpLog {
         }
     }
 
-    pub(crate) fn last_entry(&self) -> Option<&OpEntry> {
-        self.entries.last()
+    #[cfg(test)]
+    pub(crate) fn collect_batches_scoped(
+        &self,
+        count: usize,
+        predicate: impl Fn(&OpBatch) -> bool,
+        scope: Option<&str>,
+    ) -> Vec<OpBatch> {
+        collect_batches_from_entries(self.entries.iter().rev().cloned(), count, predicate, scope)
+    }
+}
+
+impl PackedOpLogIndex {
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        Self::open_v3(path)
     }
 
-    pub(crate) fn recent_entries(&self, count: usize) -> Vec<OpEntry> {
-        self.entries.iter().rev().take(count).cloned().collect()
+    fn open_v3(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)?;
+        let header = parse_header(&bytes)?;
+        if header.version != u32::from(Latest::VERSION) {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog version {}",
+                header.version
+            )));
+        }
+        let footer = PackedFooter::parse(&bytes, &header)?;
+        let index = Self {
+            path: path.to_path_buf(),
+            header,
+            footer,
+        };
+        index.validate_index_records(&bytes)?;
+        Ok(index)
+    }
+
+    pub(crate) fn empty(path: PathBuf) -> Self {
+        Self {
+            path,
+            header: PackedHeader {
+                version: u32::from(Latest::VERSION),
+                entry_count: 0,
+                head_id: 0,
+            },
+            footer: PackedFooter {
+                entry_data_end: HEADER_LEN,
+                entry_offsets_offset: HEADER_LEN,
+                entry_offsets_count: 0,
+                batch_offsets_offset: HEADER_LEN,
+                batch_offsets_count: 0,
+                batch_dir_offset: HEADER_LEN,
+                batch_dir_count: 0,
+                tx_key_bytes_offset: HEADER_LEN,
+                tx_key_bytes_len: 0,
+                tx_dir_offset: HEADER_LEN,
+                tx_dir_count: 0,
+                entry_count: 0,
+                head_id: 0,
+            },
+        }
+    }
+
+    pub(crate) fn head_id(&self) -> u64 {
+        self.header.head_id
+    }
+
+    pub(crate) fn last_entry(&self) -> Result<Option<OpEntry>> {
+        let mut entries = self.recent_entries(1)?;
+        Ok(entries.pop())
+    }
+
+    pub(crate) fn recent_entries(&self, count: usize) -> Result<Vec<OpEntry>> {
+        if count == 0 || self.header.entry_count == 0 {
+            return Ok(Vec::new());
+        }
+        let offsets = self.read_entry_offsets()?;
+        let take = count.min(offsets.len());
+        let mut file = File::open(&self.path)?;
+        let mut out = Vec::with_capacity(take);
+        for record in offsets.iter().rev().take(take) {
+            out.push(read_entry_at(&mut file, record.entry_offset)?);
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn entries_after(&self, since_head_id: u64) -> Result<Vec<OpEntry>> {
+        let offsets = self.read_entry_offsets()?;
+        let start = offsets.partition_point(|record| record.entry_id <= since_head_id);
+        let mut file = File::open(&self.path)?;
+        let mut out = Vec::with_capacity(offsets.len().saturating_sub(start));
+        for record in &offsets[start..] {
+            out.push(read_entry_at(&mut file, record.entry_offset)?);
+        }
+        Ok(out)
     }
 
     pub(crate) fn collect_batches_scoped(
@@ -262,57 +385,66 @@ impl PackedOpLog {
         count: usize,
         predicate: impl Fn(&OpBatch) -> bool,
         scope: Option<&str>,
-    ) -> Vec<OpBatch> {
-        if count == 0 {
-            return Vec::new();
+    ) -> Result<Vec<OpBatch>> {
+        self.collect_batches_after_scoped(0, count, predicate, scope)
+    }
+
+    pub(crate) fn collect_batches_after_scoped(
+        &self,
+        since_head_id: u64,
+        count: usize,
+        predicate: impl Fn(&OpBatch) -> bool,
+        scope: Option<&str>,
+    ) -> Result<Vec<OpBatch>> {
+        if count == 0 || self.header.entry_count == 0 {
+            return Ok(Vec::new());
         }
 
-        struct PendingBatch {
-            entries: Vec<OpEntry>,
-            scope_matches: bool,
-        }
+        let batch_offsets = self.read_batch_offsets()?;
+        let batch_dir = self.read_batch_dir()?;
+        let mut file = File::open(&self.path)?;
+        let mut batches = Vec::new();
 
-        let mut batch_order = Vec::new();
-        let mut pending: HashMap<u64, PendingBatch> = HashMap::new();
-
-        for entry in self.entries.iter().rev() {
-            let batch_id = if entry.batch_id == 0 {
-                entry.id
-            } else {
-                entry.batch_id
-            };
-
-            let batch = pending.entry(batch_id).or_insert_with(|| {
-                batch_order.push(batch_id);
-                PendingBatch {
-                    entries: Vec::new(),
-                    scope_matches: true,
-                }
-            });
+        for record in batch_dir {
+            if record.newest_entry_id <= since_head_id {
+                continue;
+            }
             if let Some(scope) = scope
-                && entry.scope.as_deref() != Some(scope)
+                && record.scope_state == ScopeState::None as u8
+                && !scope.is_empty()
             {
-                batch.scope_matches = false;
-            }
-            batch.entries.push(entry.clone());
-        }
-
-        let mut batches: Vec<OpBatch> = Vec::new();
-        for batch_id in batch_order {
-            let Some(mut pending_batch) = pending.remove(&batch_id) else {
-                continue;
-            };
-            if !pending_batch.scope_matches {
                 continue;
             }
 
-            pending_batch.entries.reverse();
-            pending_batch.entries.sort_by_key(|e| e.batch_index);
+            let first = usize::try_from(record.first_offset_index).map_err(|_| {
+                HeddleError::InvalidObject("batch offset index too large".to_string())
+            })?;
+            let len = usize::try_from(record.entry_count).map_err(|_| {
+                HeddleError::InvalidObject("batch entry count too large".to_string())
+            })?;
+            let mut entries = Vec::with_capacity(len);
+            for offset in &batch_offsets[first..first + len] {
+                let entry = read_entry_at(&mut file, *offset)?;
+                if entry.id > since_head_id {
+                    entries.push(entry);
+                }
+            }
+            if entries.is_empty() {
+                continue;
+            }
+            entries.sort_by_key(|entry| entry.batch_index);
             let batch = OpBatch {
-                id: batch_id,
-                entries: pending_batch.entries,
+                id: record.batch_id,
+                entries,
             };
-
+            if let Some(scope) = scope
+                && !batch
+                    .entries
+                    .iter()
+                    .all(|entry| entry.scope.as_deref() == Some(scope))
+            {
+                continue;
+            }
             if predicate(&batch) {
                 batches.push(batch);
                 if batches.len() == count {
@@ -321,11 +453,1231 @@ impl PackedOpLog {
             }
         }
 
-        batches
+        Ok(batches)
+    }
+
+    pub(crate) fn transaction_commit(&self, transaction_id: &str) -> Result<Option<(u64, u64)>> {
+        let key_bytes = self.read_tx_key_bytes()?;
+        let records = self.read_tx_dir()?;
+        let needle = transaction_id.as_bytes();
+
+        let mut left = 0;
+        let mut right = records.len();
+        while left < right {
+            let mid = left + ((right - left) / 2);
+            let key = tx_record_key(&key_bytes, &records[mid])?;
+            match key.cmp(needle) {
+                std::cmp::Ordering::Less => left = mid + 1,
+                std::cmp::Ordering::Greater => right = mid,
+                std::cmp::Ordering::Equal => {
+                    let record = &records[mid];
+                    return Ok(Some((record.commit_entry_id, record.batch_id)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn committed_batch_records(&self, transaction_id: &str) -> Result<Vec<OpRecord>> {
+        let Some((_commit_entry_id, batch_id)) = self.transaction_commit(transaction_id)? else {
+            return Ok(Vec::new());
+        };
+        let mut batches = self.collect_batches_scoped(1, |batch| batch.id == batch_id, None)?;
+        let Some(batch) = batches.pop() else {
+            return Ok(Vec::new());
+        };
+        Ok(batch
+            .entries
+            .into_iter()
+            .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+            .map(|entry| entry.operation)
+            .collect())
+    }
+
+    pub(crate) fn append_entries(&self, new_entries: &[OpEntry]) -> Result<Self> {
+        if new_entries.is_empty() {
+            return Ok(self.clone());
+        }
+        // TODO(#423 follow-up): segmented/rollover append if write-amplification
+        // becomes a ceiling on large logs.
+        let new_head = new_entries
+            .last()
+            .map(|entry| entry.id)
+            .unwrap_or(self.header.head_id);
+        let new_count = self.header.entry_count + new_entries.len() as u64;
+        let mut tmp_new_entry_bytes = Vec::new();
+        let mut new_entry_offsets = Vec::with_capacity(new_entries.len());
+        let mut offset = self.footer.entry_data_end;
+        for entry in new_entries {
+            new_entry_offsets.push(EntryOffsetRecord {
+                entry_id: entry.id,
+                entry_offset: offset,
+            });
+            encode_entry(entry, &mut tmp_new_entry_bytes)?;
+            offset += u64::try_from(tmp_new_entry_bytes.len()).map_err(|_| {
+                HeddleError::InvalidObject("oplog entry stream too large".to_string())
+            })? - (offset - self.footer.entry_data_end);
+        }
+
+        let mut old_offsets = self.read_entry_offsets()?;
+        old_offsets.extend(new_entry_offsets);
+        let mut old_batch_offsets = self.read_batch_offsets()?;
+        let new_entries_by_offset = new_entries
+            .iter()
+            .zip(old_offsets[self.header.entry_count as usize..].iter())
+            .map(|(entry, offset)| (entry.clone(), offset.entry_offset))
+            .collect::<Vec<_>>();
+        let batch_index = build_index_sections_from_existing(
+            &mut old_batch_offsets,
+            &self.read_batch_dir()?,
+            &self.read_tx_key_bytes()?,
+            &self.read_tx_dir()?,
+            &new_entries_by_offset,
+        )?;
+
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        let tmp = temp_path(&self.path);
+        let write_result = self.write_appended_tmp(
+            &tmp,
+            new_count,
+            new_head,
+            &tmp_new_entry_bytes,
+            &old_offsets,
+            &batch_index,
+        );
+        if let Err(err) = write_result {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(err);
+        }
+        std::fs::rename(&tmp, &self.path)?;
+        sync_directory(parent)?;
+
+        Self::open_v3(&self.path)
+    }
+
+    fn write_appended_tmp(
+        &self,
+        tmp: &Path,
+        new_count: u64,
+        new_head: u64,
+        new_entry_bytes: &[u8],
+        entry_offsets: &[EntryOffsetRecord],
+        batch_index: &BuiltIndexSections,
+    ) -> Result<()> {
+        let mut out = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .read(true)
+            .open(tmp)?;
+        write_header(&mut out, u32::from(Latest::VERSION), new_count, new_head)?;
+
+        let mut old = File::open(&self.path)?;
+        old.seek(SeekFrom::Start(HEADER_LEN))?;
+        let old_entry_len = self.footer.entry_data_end - HEADER_LEN;
+        std::io::copy(&mut old.take(old_entry_len), &mut out)?;
+        out.write_all(new_entry_bytes)?;
+
+        let entry_data_end = out.stream_position()?;
+        write_index_sections(
+            &mut out,
+            IndexWritePlan {
+                entry_data_end,
+                entry_offsets,
+                batch_offsets: &batch_index.batch_offsets,
+                batch_dir: &batch_index.batch_dir,
+                tx_key_bytes: &batch_index.tx_key_bytes,
+                tx_dir: &batch_index.tx_dir,
+                entry_count: new_count,
+                head_id: new_head,
+            },
+        )?;
+        out.sync_all()?;
+        Ok(())
+    }
+
+    fn read_entry_offsets(&self) -> Result<Vec<EntryOffsetRecord>> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.footer.entry_offsets_offset))?;
+        let mut records = Vec::with_capacity(self.footer.entry_offsets_count as usize);
+        for _ in 0..self.footer.entry_offsets_count {
+            records.push(EntryOffsetRecord {
+                entry_id: read_u64_from_file(&mut file)?,
+                entry_offset: read_u64_from_file(&mut file)?,
+            });
+        }
+        Ok(records)
+    }
+
+    fn read_batch_offsets(&self) -> Result<Vec<u64>> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.footer.batch_offsets_offset))?;
+        let mut offsets = Vec::with_capacity(self.footer.batch_offsets_count as usize);
+        for _ in 0..self.footer.batch_offsets_count {
+            offsets.push(read_u64_from_file(&mut file)?);
+        }
+        Ok(offsets)
+    }
+
+    fn read_batch_dir(&self) -> Result<Vec<BatchDirRecord>> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.footer.batch_dir_offset))?;
+        let mut records = Vec::with_capacity(self.footer.batch_dir_count as usize);
+        for _ in 0..self.footer.batch_dir_count {
+            let batch_id = read_u64_from_file(&mut file)?;
+            let newest_entry_id = read_u64_from_file(&mut file)?;
+            let first_offset_index = read_u64_from_file(&mut file)?;
+            let entry_count = read_u32_from_file(&mut file)?;
+            let scope_state = read_u8_from_file(&mut file)?;
+            let _padding = read_array_from_file::<3>(&mut file)?;
+            let _scope_key_off = read_u64_from_file(&mut file)?;
+            let _scope_key_len = read_u32_from_file(&mut file)?;
+            let _padding = read_array_from_file::<4>(&mut file)?;
+            records.push(BatchDirRecord {
+                batch_id,
+                newest_entry_id,
+                first_offset_index,
+                entry_count,
+                scope_state,
+            });
+        }
+        Ok(records)
+    }
+
+    fn read_tx_key_bytes(&self) -> Result<Vec<u8>> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.footer.tx_key_bytes_offset))?;
+        let len = usize::try_from(self.footer.tx_key_bytes_len).map_err(|_| {
+            HeddleError::InvalidObject("transaction key bytes section too large".to_string())
+        })?;
+        let mut bytes = vec![0; len];
+        file.read_exact(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    fn read_tx_dir(&self) -> Result<Vec<TxDirRecord>> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.footer.tx_dir_offset))?;
+        let mut records = Vec::with_capacity(self.footer.tx_dir_count as usize);
+        for _ in 0..self.footer.tx_dir_count {
+            let key_offset = read_u64_from_file(&mut file)?;
+            let key_len = read_u32_from_file(&mut file)?;
+            let _padding = read_array_from_file::<4>(&mut file)?;
+            let commit_entry_id = read_u64_from_file(&mut file)?;
+            let batch_id = read_u64_from_file(&mut file)?;
+            records.push(TxDirRecord {
+                key_offset,
+                key_len,
+                commit_entry_id,
+                batch_id,
+            });
+        }
+        Ok(records)
+    }
+
+    fn validate_index_records(&self, bytes: &[u8]) -> Result<()> {
+        let offsets = self.read_entry_offsets()?;
+        if offsets.len() as u64 != self.header.entry_count {
+            return Err(HeddleError::InvalidObject(
+                "oplog entry-offset count disagrees with header".to_string(),
+            ));
+        }
+        if self.header.entry_count == 0 {
+            if self.header.head_id != 0 {
+                return Err(HeddleError::InvalidObject(
+                    "empty oplog has non-zero head_id".to_string(),
+                ));
+            }
+        } else if offsets.last().map(|record| record.entry_id) != Some(self.header.head_id) {
+            return Err(HeddleError::InvalidObject(
+                "oplog entry-offset tail disagrees with head_id".to_string(),
+            ));
+        }
+
+        let mut last_id = None;
+        for record in &offsets {
+            if record.entry_offset < HEADER_LEN || record.entry_offset >= self.footer.entry_data_end
+            {
+                return Err(HeddleError::InvalidObject(
+                    "oplog entry offset points outside entry section".to_string(),
+                ));
+            }
+            if last_id.is_some_and(|id| record.entry_id <= id) {
+                return Err(HeddleError::InvalidObject(
+                    "oplog entry offsets are not sorted by id".to_string(),
+                ));
+            }
+            last_id = Some(record.entry_id);
+        }
+
+        let batch_offsets = self.read_batch_offsets()?;
+        for offset in &batch_offsets {
+            if *offset < HEADER_LEN || *offset >= self.footer.entry_data_end {
+                return Err(HeddleError::InvalidObject(
+                    "oplog batch directory points outside entry section".to_string(),
+                ));
+            }
+        }
+
+        let batch_dir = self.read_batch_dir()?;
+        let mut batch_offset_total = 0u64;
+        let mut prev_newest = None;
+        for record in &batch_dir {
+            if prev_newest.is_some_and(|id| record.newest_entry_id >= id) {
+                return Err(HeddleError::InvalidObject(
+                    "oplog batch directory is not newest-first".to_string(),
+                ));
+            }
+            prev_newest = Some(record.newest_entry_id);
+            let end = record.first_offset_index + u64::from(record.entry_count);
+            if end > self.footer.batch_offsets_count {
+                return Err(HeddleError::InvalidObject(
+                    "oplog batch directory range points outside offset list".to_string(),
+                ));
+            }
+            batch_offset_total += u64::from(record.entry_count);
+        }
+        if batch_offset_total != self.footer.batch_offsets_count {
+            return Err(HeddleError::InvalidObject(
+                "oplog batch offset list disagrees with batch directory".to_string(),
+            ));
+        }
+
+        let key_bytes = self.read_tx_key_bytes()?;
+        let tx_dir = self.read_tx_dir()?;
+        let offset_by_id = offsets
+            .iter()
+            .map(|record| (record.entry_id, record.entry_offset))
+            .collect::<HashMap<_, _>>();
+        let mut prev_key: Option<Vec<u8>> = None;
+        for record in &tx_dir {
+            let key = tx_record_key(&key_bytes, record)?;
+            if prev_key.as_deref().is_some_and(|prev| key <= prev) {
+                return Err(HeddleError::InvalidObject(
+                    "oplog transaction directory is not sorted".to_string(),
+                ));
+            }
+            prev_key = Some(key.to_vec());
+
+            let Some(offset) = offset_by_id.get(&record.commit_entry_id) else {
+                return Err(HeddleError::InvalidObject(
+                    "oplog transaction directory references a missing entry".to_string(),
+                ));
+            };
+            if *offset >= self.footer.entry_data_end {
+                return Err(HeddleError::InvalidObject(
+                    "oplog transaction directory points past entry data".to_string(),
+                ));
+            }
+            let mut cursor =
+                Cursor::new(&bytes[*offset as usize..self.footer.entry_data_end as usize]);
+            let entry = parse_entry(&mut cursor)?;
+            if !matches!(entry.operation, OpRecord::TransactionCommit { .. }) {
+                return Err(HeddleError::InvalidObject(
+                    "oplog transaction directory references a non-commit entry".to_string(),
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
-// Cursor for parsing
+impl PackedFooter {
+    fn parse(bytes: &[u8], header: &PackedHeader) -> Result<Self> {
+        let file_len = bytes.len() as u64;
+        if file_len < HEADER_LEN + FOOTER_LEN {
+            return Err(HeddleError::InvalidObject(
+                "oplog v3 missing index footer".to_string(),
+            ));
+        }
+        let footer_start = file_len - FOOTER_LEN;
+        let mut cursor = Cursor::new(&bytes[footer_start as usize..]);
+        let magic = cursor.read_array::<8>()?;
+        if &magic != INDEX_MAGIC {
+            return Err(HeddleError::InvalidObject(
+                "invalid oplog index magic".to_string(),
+            ));
+        }
+        let index_version = cursor.read_u32()?;
+        if index_version != INDEX_VERSION {
+            return Err(HeddleError::InvalidObject(format!(
+                "unsupported oplog index version {index_version}"
+            )));
+        }
+        let footer_len = cursor.read_u32()?;
+        if footer_len != FOOTER_LEN as u32 {
+            return Err(HeddleError::InvalidObject(
+                "oplog index footer length mismatch".to_string(),
+            ));
+        }
+        let footer = Self {
+            entry_data_end: cursor.read_u64()?,
+            entry_offsets_offset: cursor.read_u64()?,
+            entry_offsets_count: cursor.read_u64()?,
+            batch_offsets_offset: cursor.read_u64()?,
+            batch_offsets_count: cursor.read_u64()?,
+            batch_dir_offset: cursor.read_u64()?,
+            batch_dir_count: cursor.read_u64()?,
+            tx_key_bytes_offset: cursor.read_u64()?,
+            tx_key_bytes_len: cursor.read_u64()?,
+            tx_dir_offset: cursor.read_u64()?,
+            tx_dir_count: cursor.read_u64()?,
+            entry_count: cursor.read_u64()?,
+            head_id: cursor.read_u64()?,
+        };
+        footer.validate(header, file_len, footer_start)?;
+        Ok(footer)
+    }
+
+    fn validate(&self, header: &PackedHeader, file_len: u64, footer_start: u64) -> Result<()> {
+        if self.entry_count != header.entry_count || self.head_id != header.head_id {
+            return Err(HeddleError::InvalidObject(
+                "oplog header/footer entry metadata disagreement".to_string(),
+            ));
+        }
+        if self.entry_data_end < HEADER_LEN || self.entry_data_end > footer_start {
+            return Err(HeddleError::InvalidObject(
+                "oplog entry section points outside file".to_string(),
+            ));
+        }
+        if self.entry_offsets_count != header.entry_count {
+            return Err(HeddleError::InvalidObject(
+                "oplog footer entry count disagrees with offset table".to_string(),
+            ));
+        }
+
+        let sections = [
+            (
+                self.entry_offsets_offset,
+                self.entry_offsets_count,
+                ENTRY_OFFSET_RECORD_LEN,
+                "entry offsets",
+            ),
+            (
+                self.batch_offsets_offset,
+                self.batch_offsets_count,
+                8,
+                "batch offsets",
+            ),
+            (
+                self.batch_dir_offset,
+                self.batch_dir_count,
+                BATCH_DIR_RECORD_LEN,
+                "batch directory",
+            ),
+            (
+                self.tx_key_bytes_offset,
+                self.tx_key_bytes_len,
+                1,
+                "tx keys",
+            ),
+            (
+                self.tx_dir_offset,
+                self.tx_dir_count,
+                TX_DIR_RECORD_LEN,
+                "tx dir",
+            ),
+        ];
+        for (offset, count, width, name) in sections {
+            checked_section(offset, count, width, footer_start, name)?;
+            if offset < self.entry_data_end && count > 0 {
+                return Err(HeddleError::InvalidObject(format!(
+                    "oplog {name} section overlaps entry data"
+                )));
+            }
+        }
+        if self.entry_data_end > self.entry_offsets_offset {
+            return Err(HeddleError::InvalidObject(
+                "oplog entry offsets start before entry data ends".to_string(),
+            ));
+        }
+        if footer_start + FOOTER_LEN != file_len {
+            return Err(HeddleError::InvalidObject(
+                "oplog footer length disagrees with file length".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[repr(u8)]
+enum ScopeState {
+    None = 0,
+    One = 1,
+    Mixed = 2,
+}
+
+struct BuiltIndexSections {
+    batch_offsets: Vec<u64>,
+    batch_dir: Vec<BatchDirRecord>,
+    tx_key_bytes: Vec<u8>,
+    tx_dir: Vec<TxDirRecord>,
+}
+
+fn load(bytes: &[u8]) -> Result<OplogData> {
+    let header = parse_header(bytes)?;
+    match header.version {
+        version if version == u32::from(V2::VERSION) => V2::decode(bytes),
+        version if version == u32::from(V3::VERSION) => V3::decode(bytes),
+        version => Err(HeddleError::InvalidObject(format!(
+            "unsupported oplog version {version}"
+        ))),
+    }
+}
+
+fn encode_data_v3(data: &OplogData, out: &mut Vec<u8>) -> Result<()> {
+    out.clear();
+    write_header_to_vec(
+        out,
+        u32::from(Latest::VERSION),
+        data.entries.len() as u64,
+        data.head_id,
+    );
+    let mut entry_offsets = Vec::with_capacity(data.entries.len());
+    for entry in &data.entries {
+        entry_offsets.push(EntryOffsetRecord {
+            entry_id: entry.id,
+            entry_offset: out.len() as u64,
+        });
+        encode_entry(entry, out)?;
+    }
+    let entry_data_end = out.len() as u64;
+    let batch_index = build_index_sections(
+        data.entries
+            .iter()
+            .cloned()
+            .zip(entry_offsets.iter().copied()),
+    )?;
+    write_index_sections_to_vec(
+        out,
+        IndexWritePlan {
+            entry_data_end,
+            entry_offsets: &entry_offsets,
+            batch_offsets: &batch_index.batch_offsets,
+            batch_dir: &batch_index.batch_dir,
+            tx_key_bytes: &batch_index.tx_key_bytes,
+            tx_dir: &batch_index.tx_dir,
+            entry_count: data.entries.len() as u64,
+            head_id: data.head_id,
+        },
+    );
+    Ok(())
+}
+
+struct IndexWritePlan<'a> {
+    entry_data_end: u64,
+    entry_offsets: &'a [EntryOffsetRecord],
+    batch_offsets: &'a [u64],
+    batch_dir: &'a [BatchDirRecord],
+    tx_key_bytes: &'a [u8],
+    tx_dir: &'a [TxDirRecord],
+    entry_count: u64,
+    head_id: u64,
+}
+
+fn write_index_sections<W: Write + Seek>(out: &mut W, plan: IndexWritePlan<'_>) -> Result<()> {
+    let entry_offsets_offset = out.stream_position()?;
+    for record in plan.entry_offsets {
+        out.write_all(&record.entry_id.to_le_bytes())?;
+        out.write_all(&record.entry_offset.to_le_bytes())?;
+    }
+    let batch_offsets_offset = out.stream_position()?;
+    for offset in plan.batch_offsets {
+        out.write_all(&offset.to_le_bytes())?;
+    }
+    let batch_dir_offset = out.stream_position()?;
+    for record in plan.batch_dir {
+        write_batch_dir_record(out, record)?;
+    }
+    let tx_key_bytes_offset = out.stream_position()?;
+    out.write_all(plan.tx_key_bytes)?;
+    let tx_dir_offset = out.stream_position()?;
+    for record in plan.tx_dir {
+        write_tx_dir_record(out, record)?;
+    }
+    write_footer(
+        out,
+        &PackedFooter {
+            entry_data_end: plan.entry_data_end,
+            entry_offsets_offset,
+            entry_offsets_count: plan.entry_offsets.len() as u64,
+            batch_offsets_offset,
+            batch_offsets_count: plan.batch_offsets.len() as u64,
+            batch_dir_offset,
+            batch_dir_count: plan.batch_dir.len() as u64,
+            tx_key_bytes_offset,
+            tx_key_bytes_len: plan.tx_key_bytes.len() as u64,
+            tx_dir_offset,
+            tx_dir_count: plan.tx_dir.len() as u64,
+            entry_count: plan.entry_count,
+            head_id: plan.head_id,
+        },
+    )?;
+    Ok(())
+}
+
+fn write_index_sections_to_vec(out: &mut Vec<u8>, plan: IndexWritePlan<'_>) {
+    let entry_offsets_offset = out.len() as u64;
+    for record in plan.entry_offsets {
+        out.extend_from_slice(&record.entry_id.to_le_bytes());
+        out.extend_from_slice(&record.entry_offset.to_le_bytes());
+    }
+    let batch_offsets_offset = out.len() as u64;
+    for offset in plan.batch_offsets {
+        out.extend_from_slice(&offset.to_le_bytes());
+    }
+    let batch_dir_offset = out.len() as u64;
+    for record in plan.batch_dir {
+        write_batch_dir_record_to_vec(out, record);
+    }
+    let tx_key_bytes_offset = out.len() as u64;
+    out.extend_from_slice(plan.tx_key_bytes);
+    let tx_dir_offset = out.len() as u64;
+    for record in plan.tx_dir {
+        write_tx_dir_record_to_vec(out, record);
+    }
+    write_footer_to_vec(
+        out,
+        &PackedFooter {
+            entry_data_end: plan.entry_data_end,
+            entry_offsets_offset,
+            entry_offsets_count: plan.entry_offsets.len() as u64,
+            batch_offsets_offset,
+            batch_offsets_count: plan.batch_offsets.len() as u64,
+            batch_dir_offset,
+            batch_dir_count: plan.batch_dir.len() as u64,
+            tx_key_bytes_offset,
+            tx_key_bytes_len: plan.tx_key_bytes.len() as u64,
+            tx_dir_offset,
+            tx_dir_count: plan.tx_dir.len() as u64,
+            entry_count: plan.entry_count,
+            head_id: plan.head_id,
+        },
+    );
+}
+
+fn build_index_sections(
+    entries: impl IntoIterator<Item = (OpEntry, EntryOffsetRecord)>,
+) -> Result<BuiltIndexSections> {
+    let mut groups: BTreeMap<u64, Vec<(OpEntry, u64)>> = BTreeMap::new();
+    let mut tx_first: BTreeMap<Vec<u8>, (u64, u64)> = BTreeMap::new();
+
+    for (entry, offset) in entries {
+        let batch_id = effective_batch_id(&entry);
+        if let OpRecord::TransactionCommit { transaction_id, .. } = &entry.operation {
+            tx_first
+                .entry(transaction_id.as_bytes().to_vec())
+                .or_insert((entry.id, batch_id));
+        }
+        groups
+            .entry(batch_id)
+            .or_default()
+            .push((entry, offset.entry_offset));
+    }
+
+    let mut batch_records = groups
+        .into_iter()
+        .map(|(batch_id, mut entries)| {
+            entries.sort_by_key(|(entry, _)| (entry.batch_index, entry.id));
+            let newest_entry_id = entries
+                .iter()
+                .map(|(entry, _)| entry.id)
+                .max()
+                .unwrap_or_default();
+            let scope_state = scope_state(entries.iter().map(|(entry, _)| entry.scope.as_deref()));
+            (batch_id, newest_entry_id, scope_state, entries)
+        })
+        .collect::<Vec<_>>();
+    batch_records.sort_by_key(|record| Reverse(record.1));
+
+    let mut batch_offsets = Vec::new();
+    let mut batch_dir = Vec::with_capacity(batch_records.len());
+    for (batch_id, newest_entry_id, scope_state, entries) in batch_records {
+        let first_offset_index = batch_offsets.len() as u64;
+        for (_entry, offset) in &entries {
+            batch_offsets.push(*offset);
+        }
+        batch_dir.push(BatchDirRecord {
+            batch_id,
+            newest_entry_id,
+            first_offset_index,
+            entry_count: entries.len() as u32,
+            scope_state,
+        });
+    }
+
+    let mut tx_key_bytes = Vec::new();
+    let mut tx_dir = Vec::with_capacity(tx_first.len());
+    for (key, (commit_entry_id, batch_id)) in tx_first {
+        let key_offset = tx_key_bytes.len() as u64;
+        tx_key_bytes.extend_from_slice(&key);
+        tx_dir.push(TxDirRecord {
+            key_offset,
+            key_len: key.len() as u32,
+            commit_entry_id,
+            batch_id,
+        });
+    }
+
+    Ok(BuiltIndexSections {
+        batch_offsets,
+        batch_dir,
+        tx_key_bytes,
+        tx_dir,
+    })
+}
+
+fn build_index_sections_from_existing(
+    old_batch_offsets: &mut Vec<u64>,
+    old_batch_dir: &[BatchDirRecord],
+    old_tx_key_bytes: &[u8],
+    old_tx_dir: &[TxDirRecord],
+    new_entries: &[(OpEntry, u64)],
+) -> Result<BuiltIndexSections> {
+    let mut batch_groups: BTreeMap<u64, Vec<(OpEntry, u64)>> = BTreeMap::new();
+    for (entry, offset) in new_entries {
+        batch_groups
+            .entry(effective_batch_id(entry))
+            .or_default()
+            .push((entry.clone(), *offset));
+    }
+
+    let mut batch_dir = old_batch_dir.to_vec();
+    for (batch_id, mut entries) in batch_groups {
+        entries.sort_by_key(|(entry, _)| (entry.batch_index, entry.id));
+        let newest_entry_id = entries
+            .iter()
+            .map(|(entry, _)| entry.id)
+            .max()
+            .unwrap_or_default();
+        let first_offset_index = old_batch_offsets.len() as u64;
+        for (_entry, offset) in &entries {
+            old_batch_offsets.push(*offset);
+        }
+        batch_dir.push(BatchDirRecord {
+            batch_id,
+            newest_entry_id,
+            first_offset_index,
+            entry_count: entries.len() as u32,
+            scope_state: scope_state(entries.iter().map(|(entry, _)| entry.scope.as_deref())),
+        });
+    }
+    batch_dir.sort_by_key(|record| Reverse(record.newest_entry_id));
+
+    let mut tx_map = BTreeMap::new();
+    for record in old_tx_dir {
+        let key = tx_record_key(old_tx_key_bytes, record)?.to_vec();
+        tx_map.insert(key, (record.commit_entry_id, record.batch_id));
+    }
+    for (entry, _offset) in new_entries {
+        if let OpRecord::TransactionCommit { transaction_id, .. } = &entry.operation {
+            tx_map
+                .entry(transaction_id.as_bytes().to_vec())
+                .or_insert((entry.id, effective_batch_id(entry)));
+        }
+    }
+
+    let mut tx_key_bytes = Vec::new();
+    let mut tx_dir = Vec::with_capacity(tx_map.len());
+    for (key, (commit_entry_id, batch_id)) in tx_map {
+        let key_offset = tx_key_bytes.len() as u64;
+        tx_key_bytes.extend_from_slice(&key);
+        tx_dir.push(TxDirRecord {
+            key_offset,
+            key_len: key.len() as u32,
+            commit_entry_id,
+            batch_id,
+        });
+    }
+
+    Ok(BuiltIndexSections {
+        batch_offsets: old_batch_offsets.clone(),
+        batch_dir,
+        tx_key_bytes,
+        tx_dir,
+    })
+}
+
+fn scope_state<'a>(scopes: impl Iterator<Item = Option<&'a str>>) -> u8 {
+    let mut first = None;
+    for scope in scopes {
+        match (first, scope) {
+            (None, None) => first = Some(None),
+            (None, Some(value)) => first = Some(Some(value)),
+            (Some(prev), current) if prev == current => {}
+            _ => return ScopeState::Mixed as u8,
+        }
+    }
+    match first {
+        Some(None) | None => ScopeState::None as u8,
+        Some(Some(_)) => ScopeState::One as u8,
+    }
+}
+
+#[cfg(test)]
+fn collect_batches_from_entries(
+    entries: impl Iterator<Item = OpEntry>,
+    count: usize,
+    predicate: impl Fn(&OpBatch) -> bool,
+    scope: Option<&str>,
+) -> Vec<OpBatch> {
+    if count == 0 {
+        return Vec::new();
+    }
+
+    struct PendingBatch {
+        entries: Vec<OpEntry>,
+        scope_matches: bool,
+    }
+
+    let mut batch_order = Vec::new();
+    let mut pending: HashMap<u64, PendingBatch> = HashMap::new();
+
+    for entry in entries {
+        let batch_id = effective_batch_id(&entry);
+        let batch = pending.entry(batch_id).or_insert_with(|| {
+            batch_order.push(batch_id);
+            PendingBatch {
+                entries: Vec::new(),
+                scope_matches: true,
+            }
+        });
+        if let Some(scope) = scope
+            && entry.scope.as_deref() != Some(scope)
+        {
+            batch.scope_matches = false;
+        }
+        batch.entries.push(entry);
+    }
+
+    let mut batches = Vec::new();
+    for batch_id in batch_order {
+        let Some(mut pending_batch) = pending.remove(&batch_id) else {
+            continue;
+        };
+        if !pending_batch.scope_matches {
+            continue;
+        }
+
+        pending_batch.entries.reverse();
+        pending_batch.entries.sort_by_key(|entry| entry.batch_index);
+        let batch = OpBatch {
+            id: batch_id,
+            entries: pending_batch.entries,
+        };
+        if predicate(&batch) {
+            batches.push(batch);
+            if batches.len() == count {
+                break;
+            }
+        }
+    }
+    batches
+}
+
+fn effective_batch_id(entry: &OpEntry) -> u64 {
+    if entry.batch_id == 0 {
+        entry.id
+    } else {
+        entry.batch_id
+    }
+}
+
+fn tx_record_key<'a>(key_bytes: &'a [u8], record: &TxDirRecord) -> Result<&'a [u8]> {
+    let start = usize::try_from(record.key_offset)
+        .map_err(|_| HeddleError::InvalidObject("transaction key offset too large".to_string()))?;
+    let len = usize::try_from(record.key_len)
+        .map_err(|_| HeddleError::InvalidObject("transaction key length too large".to_string()))?;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| HeddleError::InvalidObject("transaction key range overflow".to_string()))?;
+    if end > key_bytes.len() {
+        return Err(HeddleError::InvalidObject(
+            "transaction key range points outside key section".to_string(),
+        ));
+    }
+    Ok(&key_bytes[start..end])
+}
+
+fn checked_section(
+    offset: u64,
+    count: u64,
+    width: u64,
+    footer_start: u64,
+    name: &str,
+) -> Result<()> {
+    let len = count
+        .checked_mul(width)
+        .ok_or_else(|| HeddleError::InvalidObject(format!("oplog {name} section overflow")))?;
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| HeddleError::InvalidObject(format!("oplog {name} section overflow")))?;
+    if offset > footer_start || end > footer_start {
+        return Err(HeddleError::InvalidObject(format!(
+            "oplog {name} section points outside file"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_header(bytes: &[u8]) -> Result<PackedHeader> {
+    let (header, _cursor) = parse_header_with_cursor(bytes)?;
+    Ok(header)
+}
+
+fn parse_header_with_cursor(bytes: &[u8]) -> Result<(PackedHeader, Cursor<'_>)> {
+    let mut cursor = Cursor::new(bytes);
+    let magic = cursor.read_array::<8>()?;
+    if &magic != MAGIC {
+        return Err(HeddleError::InvalidObject(
+            "invalid oplog magic".to_string(),
+        ));
+    }
+    let version = cursor.read_u32()?;
+    let entry_count = cursor.read_u64()?;
+    let head_id = cursor.read_u64()?;
+    Ok((
+        PackedHeader {
+            version,
+            entry_count,
+            head_id,
+        },
+        cursor,
+    ))
+}
+
+fn read_header(path: &Path) -> Result<PackedHeader> {
+    let bytes = std::fs::read(path)?;
+    if bytes.len() < HEADER_LEN as usize {
+        return Err(HeddleError::InvalidObject("oplog truncated".to_string()));
+    }
+    parse_header(&bytes[..HEADER_LEN as usize])
+}
+
+fn read_header_version(path: &Path) -> Result<u32> {
+    Ok(read_header(path)?.version)
+}
+
+fn parse_entries(cursor: &mut Cursor<'_>, entry_count: usize) -> Result<Vec<OpEntry>> {
+    let mut entries = Vec::with_capacity(entry_count);
+    for _ in 0..entry_count {
+        entries.push(parse_entry(cursor)?);
+    }
+    Ok(entries)
+}
+
+fn parse_entry(cursor: &mut Cursor<'_>) -> Result<OpEntry> {
+    let id = cursor.read_u64()?;
+    let batch_id = cursor.read_u64()?;
+    let batch_index = cursor.read_u32()?;
+    let timestamp_secs = cursor.read_i64()?;
+    let timestamp_ns = cursor.read_u32()?;
+    let undone = cursor.read_u8()? != 0;
+
+    let scope_len = cursor.read_u16()? as usize;
+    let scope_bytes = cursor.read_bytes(scope_len)?;
+    let scope = if scope_bytes.is_empty() {
+        None
+    } else {
+        Some(
+            String::from_utf8(scope_bytes)
+                .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in scope".to_string()))?,
+        )
+    };
+
+    let op_data_len = cursor.read_u32()? as usize;
+    let op_data = cursor.read_bytes(op_data_len)?;
+    let operation: OpRecord =
+        rmp_serde::from_slice(&op_data).map_err(|e| HeddleError::Serialization(e.to_string()))?;
+
+    let actor_name_len = cursor.read_u16()? as usize;
+    let actor_name = String::from_utf8(cursor.read_bytes(actor_name_len)?)
+        .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in actor.name".to_string()))?;
+    let actor_email_len = cursor.read_u16()? as usize;
+    let actor_email = String::from_utf8(cursor.read_bytes(actor_email_len)?)
+        .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in actor.email".to_string()))?;
+    let actor = std::sync::Arc::new(objects::object::Principal {
+        name: actor_name,
+        email: actor_email,
+    });
+    let operation_id_tag = cursor.read_u8()?;
+    let operation_id = match operation_id_tag {
+        0 => None,
+        1 => {
+            let bytes = cursor.read_array::<16>()?;
+            Some(objects::object::OperationId::from_uuid(
+                uuid::Uuid::from_bytes(bytes),
+            ))
+        }
+        other => {
+            return Err(HeddleError::InvalidObject(format!(
+                "invalid operation_id tag byte {other}"
+            )));
+        }
+    };
+
+    if timestamp_ns >= 1_000_000_000 {
+        return Err(HeddleError::InvalidObject(format!(
+            "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
+        )));
+    }
+    let timestamp = Utc
+        .timestamp_opt(timestamp_secs, timestamp_ns)
+        .single()
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
+            ))
+        })?;
+
+    Ok(OpEntry {
+        id,
+        timestamp,
+        operation,
+        undone,
+        batch_id,
+        batch_index,
+        scope,
+        actor,
+        operation_id,
+    })
+}
+
+fn read_entry_at(file: &mut File, offset: u64) -> Result<OpEntry> {
+    file.seek(SeekFrom::Start(offset))?;
+    let id = read_u64_from_file(file)?;
+    let batch_id = read_u64_from_file(file)?;
+    let batch_index = read_u32_from_file(file)?;
+    let timestamp_secs = read_i64_from_file(file)?;
+    let timestamp_ns = read_u32_from_file(file)?;
+    let undone = read_u8_from_file(file)? != 0;
+
+    let scope_len = read_u16_from_file(file)? as usize;
+    let scope_bytes = read_vec_from_file(file, scope_len)?;
+    let scope = if scope_bytes.is_empty() {
+        None
+    } else {
+        Some(
+            String::from_utf8(scope_bytes)
+                .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in scope".to_string()))?,
+        )
+    };
+
+    let op_data_len = read_u32_from_file(file)? as usize;
+    let op_data = read_vec_from_file(file, op_data_len)?;
+    let operation: OpRecord =
+        rmp_serde::from_slice(&op_data).map_err(|e| HeddleError::Serialization(e.to_string()))?;
+
+    let actor_name_len = read_u16_from_file(file)? as usize;
+    let actor_name = String::from_utf8(read_vec_from_file(file, actor_name_len)?)
+        .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in actor.name".to_string()))?;
+    let actor_email_len = read_u16_from_file(file)? as usize;
+    let actor_email = String::from_utf8(read_vec_from_file(file, actor_email_len)?)
+        .map_err(|_| HeddleError::InvalidObject("invalid UTF-8 in actor.email".to_string()))?;
+    let actor = std::sync::Arc::new(objects::object::Principal {
+        name: actor_name,
+        email: actor_email,
+    });
+    let operation_id_tag = read_u8_from_file(file)?;
+    let operation_id = match operation_id_tag {
+        0 => None,
+        1 => Some(objects::object::OperationId::from_uuid(
+            uuid::Uuid::from_bytes(read_array_from_file::<16>(file)?),
+        )),
+        other => {
+            return Err(HeddleError::InvalidObject(format!(
+                "invalid operation_id tag byte {other}"
+            )));
+        }
+    };
+
+    if timestamp_ns >= 1_000_000_000 {
+        return Err(HeddleError::InvalidObject(format!(
+            "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
+        )));
+    }
+    let timestamp = Utc
+        .timestamp_opt(timestamp_secs, timestamp_ns)
+        .single()
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "invalid oplog timestamp secs={timestamp_secs} nanos={timestamp_ns}"
+            ))
+        })?;
+
+    Ok(OpEntry {
+        id,
+        timestamp,
+        operation,
+        undone,
+        batch_id,
+        batch_index,
+        scope,
+        actor,
+        operation_id,
+    })
+}
+
+fn encode_entry(entry: &OpEntry, out: &mut Vec<u8>) -> Result<()> {
+    out.extend_from_slice(&entry.id.to_le_bytes());
+    out.extend_from_slice(&entry.batch_id.to_le_bytes());
+    out.extend_from_slice(&entry.batch_index.to_le_bytes());
+    out.extend_from_slice(&entry.timestamp.timestamp().to_le_bytes());
+    out.extend_from_slice(&entry.timestamp.timestamp_subsec_nanos().to_le_bytes());
+    out.push(if entry.undone { 1 } else { 0 });
+
+    let scope_bytes = entry.scope.as_deref().unwrap_or("").as_bytes();
+    out.extend_from_slice(&(scope_bytes.len() as u16).to_le_bytes());
+    out.extend_from_slice(scope_bytes);
+
+    let op_data = rmp_serde::to_vec(&entry.operation)
+        .map_err(|e| HeddleError::Serialization(e.to_string()))?;
+    out.extend_from_slice(&(op_data.len() as u32).to_le_bytes());
+    out.extend_from_slice(&op_data);
+
+    let actor_name = entry.actor.name.as_bytes();
+    out.extend_from_slice(&(actor_name.len() as u16).to_le_bytes());
+    out.extend_from_slice(actor_name);
+    let actor_email = entry.actor.email.as_bytes();
+    out.extend_from_slice(&(actor_email.len() as u16).to_le_bytes());
+    out.extend_from_slice(actor_email);
+    match entry.operation_id {
+        Some(op_id) => {
+            out.push(1);
+            out.extend_from_slice(op_id.as_bytes());
+        }
+        None => out.push(0),
+    }
+    Ok(())
+}
+
+fn write_header<W: Write>(out: &mut W, version: u32, entry_count: u64, head_id: u64) -> Result<()> {
+    out.write_all(MAGIC)?;
+    out.write_all(&version.to_le_bytes())?;
+    out.write_all(&entry_count.to_le_bytes())?;
+    out.write_all(&head_id.to_le_bytes())?;
+    Ok(())
+}
+
+fn write_header_to_vec(out: &mut Vec<u8>, version: u32, entry_count: u64, head_id: u64) {
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&version.to_le_bytes());
+    out.extend_from_slice(&entry_count.to_le_bytes());
+    out.extend_from_slice(&head_id.to_le_bytes());
+}
+
+fn write_footer<W: Write>(out: &mut W, footer: &PackedFooter) -> Result<()> {
+    out.write_all(INDEX_MAGIC)?;
+    out.write_all(&INDEX_VERSION.to_le_bytes())?;
+    out.write_all(&(FOOTER_LEN as u32).to_le_bytes())?;
+    for value in footer_u64_values(footer) {
+        out.write_all(&value.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+fn write_footer_to_vec(out: &mut Vec<u8>, footer: &PackedFooter) {
+    out.extend_from_slice(INDEX_MAGIC);
+    out.extend_from_slice(&INDEX_VERSION.to_le_bytes());
+    out.extend_from_slice(&(FOOTER_LEN as u32).to_le_bytes());
+    for value in footer_u64_values(footer) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
+fn footer_u64_values(footer: &PackedFooter) -> [u64; FOOTER_U64_FIELDS as usize] {
+    [
+        footer.entry_data_end,
+        footer.entry_offsets_offset,
+        footer.entry_offsets_count,
+        footer.batch_offsets_offset,
+        footer.batch_offsets_count,
+        footer.batch_dir_offset,
+        footer.batch_dir_count,
+        footer.tx_key_bytes_offset,
+        footer.tx_key_bytes_len,
+        footer.tx_dir_offset,
+        footer.tx_dir_count,
+        footer.entry_count,
+        footer.head_id,
+    ]
+}
+
+fn write_batch_dir_record<W: Write>(out: &mut W, record: &BatchDirRecord) -> Result<()> {
+    out.write_all(&record.batch_id.to_le_bytes())?;
+    out.write_all(&record.newest_entry_id.to_le_bytes())?;
+    out.write_all(&record.first_offset_index.to_le_bytes())?;
+    out.write_all(&record.entry_count.to_le_bytes())?;
+    out.write_all(&[record.scope_state])?;
+    out.write_all(&[0; 3])?;
+    out.write_all(&0u64.to_le_bytes())?;
+    out.write_all(&0u32.to_le_bytes())?;
+    out.write_all(&[0; 4])?;
+    Ok(())
+}
+
+fn write_batch_dir_record_to_vec(out: &mut Vec<u8>, record: &BatchDirRecord) {
+    out.extend_from_slice(&record.batch_id.to_le_bytes());
+    out.extend_from_slice(&record.newest_entry_id.to_le_bytes());
+    out.extend_from_slice(&record.first_offset_index.to_le_bytes());
+    out.extend_from_slice(&record.entry_count.to_le_bytes());
+    out.push(record.scope_state);
+    out.extend_from_slice(&[0; 3]);
+    out.extend_from_slice(&0u64.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());
+    out.extend_from_slice(&[0; 4]);
+}
+
+fn write_tx_dir_record<W: Write>(out: &mut W, record: &TxDirRecord) -> Result<()> {
+    out.write_all(&record.key_offset.to_le_bytes())?;
+    out.write_all(&record.key_len.to_le_bytes())?;
+    out.write_all(&[0; 4])?;
+    out.write_all(&record.commit_entry_id.to_le_bytes())?;
+    out.write_all(&record.batch_id.to_le_bytes())?;
+    Ok(())
+}
+
+fn write_tx_dir_record_to_vec(out: &mut Vec<u8>, record: &TxDirRecord) {
+    out.extend_from_slice(&record.key_offset.to_le_bytes());
+    out.extend_from_slice(&record.key_len.to_le_bytes());
+    out.extend_from_slice(&[0; 4]);
+    out.extend_from_slice(&record.commit_entry_id.to_le_bytes());
+    out.extend_from_slice(&record.batch_id.to_le_bytes());
+}
+
+fn read_vec_from_file(file: &mut File, len: usize) -> Result<Vec<u8>> {
+    let mut out = vec![0; len];
+    file.read_exact(&mut out)?;
+    Ok(out)
+}
+
+fn read_array_from_file<const N: usize>(file: &mut File) -> Result<[u8; N]> {
+    let mut out = [0; N];
+    file.read_exact(&mut out)?;
+    Ok(out)
+}
+
+fn read_u8_from_file(file: &mut File) -> Result<u8> {
+    Ok(read_array_from_file::<1>(file)?[0])
+}
+
+fn read_u16_from_file(file: &mut File) -> Result<u16> {
+    Ok(u16::from_le_bytes(read_array_from_file::<2>(file)?))
+}
+
+fn read_u32_from_file(file: &mut File) -> Result<u32> {
+    Ok(u32::from_le_bytes(read_array_from_file::<4>(file)?))
+}
+
+fn read_u64_from_file(file: &mut File) -> Result<u64> {
+    Ok(u64::from_le_bytes(read_array_from_file::<8>(file)?))
+}
+
+fn read_i64_from_file(file: &mut File) -> Result<i64> {
+    Ok(i64::from_le_bytes(read_array_from_file::<8>(file)?))
+}
+
 struct Cursor<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -337,7 +1689,10 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
-        let end = self.offset + N;
+        let end = self
+            .offset
+            .checked_add(N)
+            .ok_or_else(|| HeddleError::InvalidObject("oplog cursor overflow".to_string()))?;
         if end > self.bytes.len() {
             return Err(HeddleError::InvalidObject("oplog truncated".to_string()));
         }
@@ -348,7 +1703,10 @@ impl<'a> Cursor<'a> {
     }
 
     fn read_bytes(&mut self, n: usize) -> Result<Vec<u8>> {
-        let end = self.offset + n;
+        let end = self
+            .offset
+            .checked_add(n)
+            .ok_or_else(|| HeddleError::InvalidObject("oplog cursor overflow".to_string()))?;
         if end > self.bytes.len() {
             return Err(HeddleError::InvalidObject("oplog truncated".to_string()));
         }
@@ -360,15 +1718,19 @@ impl<'a> Cursor<'a> {
     fn read_u8(&mut self) -> Result<u8> {
         Ok(self.read_array::<1>()?[0])
     }
+
     fn read_u16(&mut self) -> Result<u16> {
         Ok(u16::from_le_bytes(self.read_array::<2>()?))
     }
+
     fn read_u32(&mut self) -> Result<u32> {
         Ok(u32::from_le_bytes(self.read_array::<4>()?))
     }
+
     fn read_u64(&mut self) -> Result<u64> {
         Ok(u64::from_le_bytes(self.read_array::<8>()?))
     }
+
     fn read_i64(&mut self) -> Result<i64> {
         Ok(i64::from_le_bytes(self.read_array::<8>()?))
     }
@@ -408,6 +1770,20 @@ mod tests {
         entry
     }
 
+    fn write_v2(path: &Path, entries: Vec<OpEntry>, head_id: u64) {
+        let mut bytes = Vec::new();
+        write_header_to_vec(
+            &mut bytes,
+            u32::from(V2::VERSION),
+            entries.len() as u64,
+            head_id,
+        );
+        for entry in &entries {
+            encode_entry(entry, &mut bytes).unwrap();
+        }
+        std::fs::write(path, bytes).unwrap();
+    }
+
     #[test]
     fn round_trip_empty() {
         let tmp = TempDir::new().unwrap();
@@ -417,10 +1793,11 @@ mod tests {
         let loaded = PackedOpLog::load(&path).unwrap();
         assert_eq!(loaded.entries.len(), 0);
         assert_eq!(loaded.head_id, 0);
+        assert_eq!(PackedOpLog::read_head_id(&path).unwrap(), 0);
     }
 
     #[test]
-    fn round_trip_with_entries() {
+    fn round_trip_with_entries_and_index_reads() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("oplog.bin");
         let mut log = PackedOpLog::new(path.clone());
@@ -437,12 +1814,21 @@ mod tests {
         assert_eq!(loaded.entries[0].id, 1);
         assert_eq!(loaded.entries[1].id, 2);
         assert_eq!(loaded.entries[0].scope.as_deref(), Some("lane-a"));
+
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        assert_eq!(index.head_id(), 2);
+        assert_eq!(index.last_entry().unwrap().unwrap().id, 2);
+        assert_eq!(
+            index
+                .recent_entries(2)
+                .unwrap()
+                .iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            vec![2, 1]
+        );
     }
 
-    /// Finding 2 (heddle#354 r6, cid 3329711891) — the fast-path header read
-    /// rejects an unsupported version just as the full parser does, so a
-    /// right-magic / wrong-version file can never yield a silently-trusted
-    /// generation.
     #[test]
     fn read_head_id_rejects_unsupported_version() {
         let tmp = TempDir::new().unwrap();
@@ -452,13 +1838,10 @@ mod tests {
         log.head_id = 1;
         log.save().unwrap();
 
-        // A valid file's fast-path read succeeds.
         assert_eq!(PackedOpLog::read_head_id(&path).unwrap(), 1);
 
-        // Bump the version field (bytes 8..12) to a forward-incompatible value,
-        // leaving the magic intact.
         let mut bytes = std::fs::read(&path).unwrap();
-        bytes[8..12].copy_from_slice(&(VERSION + 1).to_le_bytes());
+        bytes[8..12].copy_from_slice(&(u32::from(Latest::VERSION) + 1).to_le_bytes());
         std::fs::write(&path, &bytes).unwrap();
 
         let err = PackedOpLog::read_head_id(&path).unwrap_err();
@@ -466,12 +1849,83 @@ mod tests {
             matches!(&err, HeddleError::InvalidObject(message) if message.contains("unsupported oplog version")),
             "fast path must reject an unsupported version, got: {err:?}"
         );
-        // And the full parser agrees — the two paths stay in lockstep.
         assert!(PackedOpLog::load(&path).is_err());
     }
 
     #[test]
-    fn set_undone_flips_entries() {
+    fn v2_decodes_and_ensure_latest_migrates_to_v3() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let entries = vec![make_entry(1, Some("lane")), make_entry(2, Some("lane"))];
+        write_v2(&path, entries.clone(), 2);
+
+        assert!(PackedOpLog::read_head_id(&path).is_err());
+        let loaded = PackedOpLog::load(&path).unwrap();
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(
+            PackedOpLog::on_disk_version(&path).unwrap(),
+            u32::from(V2::VERSION)
+        );
+
+        PackedOpLog::ensure_latest(&path).unwrap();
+        assert_eq!(
+            PackedOpLog::on_disk_version(&path).unwrap(),
+            u32::from(Latest::VERSION)
+        );
+        assert_eq!(PackedOpLog::read_head_id(&path).unwrap(), 2);
+        assert_eq!(
+            PackedOpLogIndex::open(&path)
+                .unwrap()
+                .last_entry()
+                .unwrap()
+                .unwrap()
+                .id,
+            2
+        );
+    }
+
+    #[test]
+    fn v2_migration_crash_temp_file_leaves_old_file_authoritative() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        write_v2(&path, vec![make_entry(1, Some("lane"))], 1);
+        std::fs::write(temp_path(&path), b"partial v3").unwrap();
+
+        let loaded = PackedOpLog::load(&path).unwrap();
+        assert_eq!(loaded.head_id, 1);
+        assert_eq!(
+            PackedOpLog::on_disk_version(&path).unwrap(),
+            u32::from(V2::VERSION)
+        );
+
+        PackedOpLog::ensure_latest(&path).unwrap();
+        assert_eq!(PackedOpLog::read_head_id(&path).unwrap(), 1);
+    }
+
+    #[test]
+    fn v1_and_corrupt_headers_fail_loudly() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+
+        let mut bytes = Vec::new();
+        write_header_to_vec(&mut bytes, 1, 0, 0);
+        std::fs::write(&path, bytes).unwrap();
+        let err = PackedOpLog::ensure_latest(&path).unwrap_err();
+        assert!(
+            matches!(&err, HeddleError::InvalidObject(message) if message.contains("unsupported oplog version 1")),
+            "v1 must fail loudly, got {err:?}"
+        );
+
+        std::fs::write(&path, b"not an oplog").unwrap();
+        let err = PackedOpLog::ensure_latest(&path).unwrap_err();
+        assert!(
+            matches!(&err, HeddleError::InvalidObject(message) if message.contains("invalid oplog magic") || message.contains("truncated")),
+            "corrupt header must fail loudly, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn set_undone_flips_entries_and_rebuilt_index_agrees() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("oplog.bin");
         let mut log = PackedOpLog::new(path.clone());
@@ -480,8 +1934,10 @@ mod tests {
         assert!(!log.entries[0].undone);
         log.set_undone(1, true);
         assert!(log.entries[0].undone);
-        log.set_undone(1, false);
-        assert!(!log.entries[0].undone);
+        log.save().unwrap();
+
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        assert!(index.last_entry().unwrap().unwrap().undone);
     }
 
     #[test]
@@ -514,9 +1970,10 @@ mod tests {
     }
 
     #[test]
-    fn collect_batches_scoped_merges_non_contiguous_runs_before_counting() {
+    fn index_collect_batches_merges_non_contiguous_runs_before_counting() {
         let tmp = TempDir::new().unwrap();
-        let mut log = PackedOpLog::new(tmp.path().join("oplog.bin"));
+        let path = tmp.path().join("oplog.bin");
+        let mut log = PackedOpLog::new(path.clone());
         log.append(vec![
             make_batch_entry(1, 10, 0, Some("lane-a")),
             make_batch_entry(2, 10, 1, Some("lane-a")),
@@ -526,8 +1983,13 @@ mod tests {
             make_batch_entry(6, 10, 3, Some("lane-a")),
             make_batch_entry(7, 30, 0, Some("lane-a")),
         ]);
+        log.head_id = 7;
+        log.save().unwrap();
 
-        let batches = log.collect_batches_scoped(2, |_| true, Some("lane-a"));
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        let batches = index
+            .collect_batches_scoped(2, |_| true, Some("lane-a"))
+            .unwrap();
 
         assert_eq!(
             batches.iter().map(|batch| batch.id).collect::<Vec<_>>(),
@@ -552,6 +2014,91 @@ mod tests {
     }
 
     #[test]
+    fn transaction_index_finds_commit_and_batch_records() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let mut op = make_entry(1, Some("lane"));
+        op.operation = OpRecord::Snapshot {
+            new_state: ChangeId::generate(),
+            prev_head: None,
+            head: None,
+            thread: Some("main".into()),
+        };
+        op.batch_id = 1;
+        let mut commit = make_batch_entry(2, 1, 1, Some("lane"));
+        commit.operation = OpRecord::TransactionCommit {
+            transaction_id: "tx-1".into(),
+            op_count: 1,
+        };
+        let mut log = PackedOpLog::new(path.clone());
+        log.append(vec![op, commit]);
+        log.head_id = 2;
+        log.save().unwrap();
+
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        assert_eq!(index.transaction_commit("tx-1").unwrap(), Some((2, 1)));
+        assert_eq!(index.committed_batch_records("tx-1").unwrap().len(), 1);
+        assert!(index.committed_batch_records("missing").unwrap().is_empty());
+    }
+
+    #[test]
+    fn append_rebuilds_indexes_atomically() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let log = PackedOpLog::new(path.clone());
+        log.save().unwrap();
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        let mut first = make_entry(1, Some("lane"));
+        first.batch_id = 1;
+        let updated = index.append_entries(&[first]).unwrap();
+
+        assert_eq!(updated.head_id(), 1);
+        assert_eq!(updated.last_entry().unwrap().unwrap().id, 1);
+        assert_eq!(PackedOpLog::load(&path).unwrap().entries.len(), 1);
+    }
+
+    #[test]
+    fn torn_footer_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let mut log = PackedOpLog::new(path.clone());
+        log.append(vec![make_entry(1, None)]);
+        log.head_id = 1;
+        log.save().unwrap();
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.truncate(bytes.len() - 1);
+        std::fs::write(&path, bytes).unwrap();
+
+        let err = PackedOpLogIndex::open(&path).unwrap_err();
+        assert!(
+            matches!(&err, HeddleError::InvalidObject(message) if message.contains("index magic") || message.contains("footer")),
+            "torn file must reject loudly, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn footer_header_disagreement_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let mut log = PackedOpLog::new(path.clone());
+        log.append(vec![make_entry(1, None)]);
+        log.head_id = 1;
+        log.save().unwrap();
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        let footer_head_offset = bytes.len() - 8;
+        bytes[footer_head_offset..].copy_from_slice(&99u64.to_le_bytes());
+        std::fs::write(&path, bytes).unwrap();
+
+        let err = PackedOpLogIndex::open(&path).unwrap_err();
+        assert!(
+            matches!(&err, HeddleError::InvalidObject(message) if message.contains("header/footer")),
+            "metadata disagreement must reject loudly, got {err:?}"
+        );
+    }
+
+    #[test]
     fn parse_rejects_invalid_timestamp() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("oplog.bin");
@@ -560,7 +2107,7 @@ mod tests {
         log.head_id = 1;
 
         let mut bytes = log.serialize().unwrap();
-        let header_len = 8 + 4 + 8 + 8;
+        let header_len = HEADER_LEN as usize;
         let timestamp_ns_offset = header_len + 8 + 8 + 4 + 8;
         bytes[timestamp_ns_offset..timestamp_ns_offset + 4]
             .copy_from_slice(&1_500_000_000u32.to_le_bytes());

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -359,7 +359,9 @@ impl RefReconciler for OplogRefReconciler {
 
         // Replay committed (non-undone) entries newer than the watermark, in id
         // order, so the fold reflects the newest committed target per ref.
-        let batches = self.oplog().recent_batches_scoped(usize::MAX, scope)?;
+        let batches = self
+            .oplog()
+            .recent_batches_after_scoped(since, usize::MAX, scope)?;
         let fold = self.fold_batches(batches, since);
 
         let (republish, remote_updates, undo_recovery) = Self::class_materialization(class, &fold);


### PR DESCRIPTION
## Summary
Implements the #406 spike design: a v3 single-file packed oplog with an EOF footer (entry-offset table + batch directory + sorted transaction_id directory), ending the full-history `Vec<OpEntry>` materialization on every read and the unbounded dedup scans.

## Structure (version the codec, not the data)
- Sealed `OplogFormat` (`const VERSION` + `decode → OplogData`) + `OplogWriteFormat` (`encode`). `V2` decode-only, `V3` decode+encode, `type Latest = V3`. ONE version-agnostic `OplogData` (no `*V3` data-type suffix). `load` dispatches on the header version byte.
- **Migration = `decode∘encode`** (no migration trait): lazy v2→v3 under the oplog write lock via atomic temp-write/rename. `OpLog::head_id()` calls `ensure_current_format()` first, so `read_head_id`'s fast header-seek never reads a v2 file with v3 offsets. v1/corrupt = loud fail; crash mid-migration = old file authoritative.
- **Indexed** `recent`/`last`/`head_id`/batch reads + transaction dedup + the #392 CAS tail-scan — **dedup-first, then CAS scan** (the #392 invariant preserved). `set_undone`/`coalesce` stay full-rewrite paths that rebuild the indexes.
- Footer/index validation rejects torn files + header/footer/index disagreements.

## Test evidence (TDD)
- Red `ed68e11` → Green `1f2163d`.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `cargo test -p heddle-refs -p heddle-oplog --features postgres`, `cargo build/clippy --features postgres -- -D warnings`, `--ignored` fault suite (not regressed), `cargo build -p heddle-cli`.

Closes #423.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994691&installation_id=132405951&pr_number=429&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F429&signature=16e2ed1ed776aabc80ebf7521f3c1095caedd13be84c4519e180dcb92b6aca67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->