### PR TITLE
fix(security): validate materialized symlink targets against repo root (#367)

### DIFF
--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -25,7 +25,7 @@ use super::repository_worktree_apply::is_directory_not_empty;
 use super::{HeddleError, Repository, Result};
 use crate::{
     worktree_index::IndexEntry,
-    worktree_walk::{build_cached_entry, cache_key},
+    worktree_walk::{build_cached_entry, cache_key, validate_symlink_target},
 };
 
 /// State threaded through a single `materialize_write_ops_seeded` call.
@@ -94,6 +94,7 @@ const MATERIALIZE_PARALLEL_THRESHOLD: usize = 32;
 const MATERIALIZE_THREADS_ENV: &str = "HEDDLE_MATERIALIZE_THREADS";
 
 struct MaterializationPlan {
+    validation_root: PathBuf,
     directories: Vec<PathBuf>,
     directory_contexts: Vec<MaterializedDirectoryContext>,
     leaves: Vec<WorktreeWriteOp>,
@@ -131,6 +132,7 @@ pub(crate) enum WorktreeWriteOp {
     Symlink {
         path: PathBuf,
         hash: ContentHash,
+        validation_root: PathBuf,
     },
 }
 
@@ -307,6 +309,7 @@ impl Repository {
     ) -> Result<MaterializedTree> {
         let plan_start = Instant::now();
         let mut plan = MaterializationPlan {
+            validation_root: dir.to_path_buf(),
             directories: Vec::new(),
             directory_contexts: Vec::new(),
             leaves: Vec::new(),
@@ -380,6 +383,7 @@ impl Repository {
                 plan.leaves.push(WorktreeWriteOp::Symlink {
                     path,
                     hash: entry.hash,
+                    validation_root: plan.validation_root.clone(),
                 });
                 continue;
             }
@@ -496,7 +500,11 @@ impl Repository {
             } => {
                 self.materialize_blob(path, hash, *executable, context)?;
             }
-            WorktreeWriteOp::Symlink { path, hash } => {
+            WorktreeWriteOp::Symlink {
+                path,
+                hash,
+                validation_root,
+            } => {
                 let blob = self
                     .store
                     .get_blob(hash)?
@@ -506,6 +514,11 @@ impl Repository {
                     let target = std::str::from_utf8(blob.content()).map_err(|_| {
                         HeddleError::InvalidObject("invalid symlink target".to_string())
                     })?;
+                    let target_path = Path::new(target);
+                    let symlink_dir = path.parent().unwrap_or(validation_root);
+                    if !validate_symlink_target(validation_root, symlink_dir, target_path) {
+                        return Err(HeddleError::InvalidSymlinkTarget(target_path.to_path_buf()));
+                    }
                     remove_materialized_leaf(path)?;
                     std::os::unix::fs::symlink(target, path)?;
                 }
@@ -517,7 +530,7 @@ impl Repository {
                 // bindings rather than ship a half-implementation.
                 #[cfg(not(unix))]
                 {
-                    let _ = (blob, path);
+                    let _ = (blob, path, validation_root);
                 }
             }
         }
@@ -1166,6 +1179,7 @@ mod tests {
         repo.materialize_write_ops(&[WorktreeWriteOp::Symlink {
             path: path.clone(),
             hash: symlink_hash,
+            validation_root: temp_dir.path().to_path_buf(),
         }])
         .unwrap();
 
@@ -1193,11 +1207,13 @@ mod tests {
         repo.materialize_write_ops(&[WorktreeWriteOp::Symlink {
             path: path.clone(),
             hash: first_hash,
+            validation_root: temp_dir.path().to_path_buf(),
         }])
         .unwrap();
         repo.materialize_write_ops(&[WorktreeWriteOp::Symlink {
             path: path.clone(),
             hash: second_hash,
+            validation_root: temp_dir.path().to_path_buf(),
         }])
         .unwrap();
 
@@ -1226,6 +1242,7 @@ mod tests {
             WorktreeWriteOp::Symlink {
                 path: link_path.clone(),
                 hash: symlink_hash,
+                validation_root: temp_dir.path().to_path_buf(),
             },
         ])
         .unwrap();

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -2,7 +2,10 @@
 use objects::store::ObjectStore;
 use std::fs;
 
-use objects::object::{ChangeId, ThreadName};
+use objects::{
+    object::{Blob, ChangeId, ThreadName, Tree, TreeEntry},
+    util::symlink_target_bytes,
+};
 use oplog::OpRecord;
 use refs::Head;
 use serde_json::json;
@@ -18,6 +21,13 @@ fn create_test_repo() -> (TempDir, Repository) {
     let temp_dir = TempDir::new().unwrap();
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     (temp_dir, repo)
+}
+
+#[cfg(unix)]
+fn handcrafted_symlink_tree(repo: &Repository, target: &std::path::Path) -> Tree {
+    let blob = Blob::new(symlink_target_bytes(target));
+    let hash = repo.store().put_blob(&blob).unwrap();
+    Tree::from_entries(vec![TreeEntry::symlink("link", hash).unwrap()])
 }
 
 #[test]
@@ -629,6 +639,99 @@ fn test_materialize_tree_creates_symlinks() {
     let target = fs::read_link(&link_path).expect("readlink should succeed");
     assert_eq!(target, std::path::Path::new("target.txt"));
     assert!(target_path.exists());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_materialize_tree_rejects_relative_symlink_escape() {
+    let (temp_dir, repo) = create_test_repo();
+    let materialize_root = temp_dir.path().join("materialized");
+    let tree = handcrafted_symlink_tree(&repo, std::path::Path::new("../outside"));
+
+    let result = repo.materialize_tree(&tree, &materialize_root);
+
+    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(
+        fs::symlink_metadata(materialize_root.join("link")).is_err(),
+        "escaping symlink must fail before the link is created"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_materialize_tree_rejects_normalized_relative_symlink_escape() {
+    let (temp_dir, repo) = create_test_repo();
+    let materialize_root = temp_dir.path().join("materialized");
+    let tree = handcrafted_symlink_tree(&repo, std::path::Path::new(".heddle/../../outside"));
+
+    let result = repo.materialize_tree(&tree, &materialize_root);
+
+    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(
+        fs::symlink_metadata(materialize_root.join("link")).is_err(),
+        "normalized escaping symlink must fail before the link is created"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_materialize_tree_rejects_absolute_symlink_escape() {
+    let (temp_dir, repo) = create_test_repo();
+    let materialize_root = temp_dir.path().join("materialized");
+    let outside_target = temp_dir.path().join("outside-target");
+    let tree = handcrafted_symlink_tree(&repo, &outside_target);
+
+    let result = repo.materialize_tree(&tree, &materialize_root);
+
+    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(
+        fs::symlink_metadata(materialize_root.join("link")).is_err(),
+        "absolute escaping symlink must fail before the link is created"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_materialize_tree_allows_handcrafted_in_repo_symlink() {
+    let (temp_dir, repo) = create_test_repo();
+    let materialize_root = temp_dir.path().join("materialized");
+    let tree = handcrafted_symlink_tree(&repo, std::path::Path::new("target.txt"));
+
+    repo.materialize_tree(&tree, &materialize_root).unwrap();
+
+    let link_path = materialize_root.join("link");
+    let meta = fs::symlink_metadata(&link_path).unwrap();
+    assert!(meta.file_type().is_symlink());
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        std::path::Path::new("target.txt")
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_capture_and_materialize_reject_same_escaping_symlink_target() {
+    let (temp_dir, repo) = create_test_repo();
+    let target = std::path::Path::new("../outside");
+    std::os::unix::fs::symlink(target, temp_dir.path().join("capture-link")).unwrap();
+
+    let capture_result = repo.build_tree(temp_dir.path());
+    assert!(matches!(
+        capture_result,
+        Err(HeddleError::InvalidSymlinkTarget(_))
+    ));
+
+    let materialize_root = temp_dir.path().join("materialized");
+    let tree = handcrafted_symlink_tree(&repo, target);
+    let materialize_result = repo.materialize_tree(&tree, &materialize_root);
+    assert!(matches!(
+        materialize_result,
+        Err(HeddleError::InvalidSymlinkTarget(_))
+    ));
+    assert!(
+        fs::symlink_metadata(materialize_root.join("link")).is_err(),
+        "materialize must reject the same target capture rejects"
+    );
 }
 
 #[test]

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -365,6 +365,7 @@ impl Repository {
                 plan.writes.push(WorktreeWriteOp::Symlink {
                     path: self.root().join(rel_path),
                     hash: entry.hash,
+                    validation_root: self.root().to_path_buf(),
                 });
             }
             EntryType::Tree => {
@@ -460,6 +461,7 @@ impl Repository {
             plan.writes.push(WorktreeWriteOp::Symlink {
                 path: self.root().join(rel_path),
                 hash: to_entry.hash,
+                validation_root: self.root().to_path_buf(),
             });
             return Ok(());
         }

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -483,24 +483,89 @@ pub(crate) fn validate_symlink_target(base: &Path, symlink_dir: &Path, target: &
     if !canonical_symlink_dir.starts_with(&canonical_base) {
         return false;
     }
-    if target.is_absolute() {
-        return target
-            .canonicalize()
-            .map(|resolved| resolved.starts_with(&canonical_base))
-            .unwrap_or_else(|_| target.starts_with(&canonical_base));
+    let target_path = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        canonical_symlink_dir.join(target)
+    };
+    if let Ok(resolved) = target_path.canonicalize() {
+        return resolved.starts_with(&canonical_base);
     }
-    let mut depth_from_base = canonical_symlink_dir
-        .components()
-        .skip(canonical_base.components().count())
-        .count();
-    for component in target.components() {
+    dangling_path_stays_within_base(&canonical_base, &target_path)
+}
+
+fn dangling_path_stays_within_base(base: &Path, path: &Path) -> bool {
+    let mut existing = path.to_path_buf();
+    let mut missing_components = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            return false;
+        };
+        missing_components.push(name.to_os_string());
+        let Some(parent) = existing.parent() else {
+            return false;
+        };
+        existing = parent.to_path_buf();
+    }
+
+    let Ok(mut resolved) = existing.canonicalize() else {
+        return false;
+    };
+    if !resolved.starts_with(base) {
+        return false;
+    }
+    for component in missing_components.iter().rev() {
+        resolved.push(component);
+    }
+    path_stays_within_base_lexically(base, &resolved)
+}
+
+fn path_stays_within_base_lexically(base: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(base) else {
+        return false;
+    };
+    let mut depth = 0_usize;
+    for component in relative.components() {
         match component {
-            Component::ParentDir if depth_from_base == 0 => return false,
-            Component::ParentDir => depth_from_base -= 1,
+            Component::ParentDir if depth == 0 => return false,
+            Component::ParentDir => depth -= 1,
             Component::CurDir => {}
-            Component::Normal(_) => depth_from_base += 1,
+            Component::Normal(_) => depth += 1,
             Component::RootDir | Component::Prefix(_) => return false,
         }
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_symlink_target;
+    use std::path::Path;
+
+    #[test]
+    #[cfg(unix)]
+    fn validate_symlink_target_rejects_dangling_target_through_escaping_ancestor() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        assert!(!validate_symlink_target(
+            root.path(),
+            root.path(),
+            Path::new("escape/missing")
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn validate_symlink_target_allows_dangling_target_under_real_in_repo_dir() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("inside")).unwrap();
+
+        assert!(validate_symlink_target(
+            root.path(),
+            root.path(),
+            Path::new("inside/missing")
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
**Security P2 (#367):** capture rejected repo-escaping symlinks (`worktree_walk.rs:474`) but materialization (`repository_materialization.rs:499/:510`) did NOT — a crafted/remote tree could materialize a symlink pointing outside the repo root (write-outside-repo on a malicious pull).

Fix: a shared `validate_symlink_target` used by **both** capture and materialization — materialization now validates symlink targets against the repo root before creating them and fails on escape. The shared helper resolves the deepest existing ancestor for dangling targets, so symlinked-ancestor escapes are rejected by both paths (identical invariant, correct-by-construction).

## Test evidence
- Escape rejection (relative `../` + absolute + symlinked-ancestor escape) → materialization fails; legit in-repo symlinks still materialize; capture/materialize parity.
- Gates: `check-no-silent-default-tree-load.sh`, `cargo test --workspace`, `cargo test -p heddle-repo`, `cargo clippy --locked -- -D warnings`, `cargo build -p heddle-cli`.

Closes #367.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994822&installation_id=132405951&pr_number=430&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F430&signature=4bebebe43f6a216afeaee8c10193dc9f0799dcd156a59142fa6f2ba00b211824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->