### PR TITLE
bench(objects): core engine micro-benchmarks (hashing, compression, pack I/O, tree-diff, delta) (#425)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
+ "criterion",
  "fs2",
  "heddle-runtime-bridge",
  "hex",

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -45,6 +45,7 @@ memory-backend = []
 zstd = ["dep:zstd"]
 
 [dev-dependencies]
+criterion = "0.8"
 tempfile.workspace = true
 tokio-test.workspace = true
 serial_test.workspace = true
@@ -58,3 +59,23 @@ proptest.workspace = true
 [lib]
 path = "src/lib.rs"
 name = "objects"
+
+[[bench]]
+name = "hashing"
+harness = false
+
+[[bench]]
+name = "compression"
+harness = false
+
+[[bench]]
+name = "pack_io"
+harness = false
+
+[[bench]]
+name = "tree_diff"
+harness = false
+
+[[bench]]
+name = "delta"
+harness = false

--- a/crates/objects/benches/compression.rs
+++ b/crates/objects/benches/compression.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+//! zstd compression/decompression throughput benchmarks.
+//!
+//! Run: `cargo bench -p heddle-objects --features zstd --bench compression`
+
+use std::hint::black_box;
+
+#[cfg(feature = "zstd")]
+use criterion::{BenchmarkId, Throughput};
+use criterion::{Criterion, criterion_group, criterion_main};
+#[cfg(feature = "zstd")]
+use objects::store::compression::{compress_zstd, decompress_zstd};
+
+#[cfg(feature = "zstd")]
+const LEVELS: &[i32] = &[1, 3, 19];
+#[cfg(feature = "zstd")]
+const CORPUS_SIZE: usize = 1024 * 1024;
+
+#[cfg(feature = "zstd")]
+fn representative_blob_corpus() -> Vec<u8> {
+    let mut out = Vec::with_capacity(CORPUS_SIZE);
+    let patterns = [
+        b"fn main() { println!(\"heddle object store benchmark\"); }\n".as_slice(),
+        b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n".as_slice(),
+        b"\x00\x01\x02\x03\x05\x08\x0d\x15\x22\x37\x59\x90\xea".as_slice(),
+    ];
+    let mut state = 0xa5a5_5a5a_dead_beefu64;
+    while out.len() < CORPUS_SIZE {
+        state = state
+            .wrapping_mul(2862933555777941757)
+            .wrapping_add(3037000493);
+        let selector = (state as usize) % patterns.len();
+        out.extend_from_slice(patterns[selector]);
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(CORPUS_SIZE);
+    out
+}
+
+fn bench_zstd(c: &mut Criterion) {
+    #[cfg(not(feature = "zstd"))]
+    {
+        let mut group = c.benchmark_group("compression_zstd_unavailable");
+        group.bench_function("feature_disabled", |b| {
+            b.iter(|| black_box(()));
+        });
+        group.finish();
+    }
+
+    #[cfg(feature = "zstd")]
+    {
+        let corpus = representative_blob_corpus();
+
+        let mut compress_group = c.benchmark_group("compression_zstd_compress");
+        for &level in LEVELS {
+            compress_group.throughput(Throughput::Bytes(corpus.len() as u64));
+            compress_group.bench_with_input(
+                BenchmarkId::new("level", level),
+                &level,
+                |b, &level| {
+                    b.iter(|| {
+                        let compressed =
+                            compress_zstd(black_box(&corpus), black_box(level)).unwrap();
+                        black_box(compressed);
+                    });
+                },
+            );
+        }
+        compress_group.finish();
+
+        let compressed_by_level: Vec<(i32, Vec<u8>)> = LEVELS
+            .iter()
+            .copied()
+            .map(|level| {
+                let compressed = compress_zstd(&corpus, level).unwrap();
+                eprintln!(
+                    "[ratio] level={level} raw={} compressed={} ratio={:.3}",
+                    corpus.len(),
+                    compressed.len(),
+                    compressed.len() as f64 / corpus.len() as f64
+                );
+                (level, compressed)
+            })
+            .collect();
+
+        let mut decompress_group = c.benchmark_group("compression_zstd_decompress");
+        for (level, compressed) in &compressed_by_level {
+            decompress_group.throughput(Throughput::Bytes(corpus.len() as u64));
+            decompress_group.bench_with_input(
+                BenchmarkId::new("level", level),
+                compressed,
+                |b, compressed| {
+                    b.iter(|| {
+                        let decompressed =
+                            decompress_zstd(black_box(compressed), black_box(corpus.len() as u64))
+                                .unwrap();
+                        black_box(decompressed);
+                    });
+                },
+            );
+        }
+        decompress_group.finish();
+    }
+}
+
+criterion_group!(benches, bench_zstd);
+criterion_main!(benches);

--- a/crates/objects/benches/delta.rs
+++ b/crates/objects/benches/delta.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Delta encoder/decoder throughput benchmarks.
+//!
+//! Run: `cargo bench -p heddle-objects --bench delta`
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::delta::{DeltaDecoder, DeltaEncoder, MAX_DELTA_OUTPUT_SIZE};
+
+const SIZES: &[usize] = &[64 * 1024, 1024 * 1024];
+
+fn base_blob(size: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(size);
+    for i in 0..size {
+        out.push(((i.wrapping_mul(31) ^ (i >> 7)) & 0xff) as u8);
+    }
+    out
+}
+
+fn target_blob(base: &[u8]) -> Vec<u8> {
+    let mut target = base.to_vec();
+    for i in (0..target.len()).step_by(4096) {
+        let end = (i + 64).min(target.len());
+        for (j, byte) in target[i..end].iter_mut().enumerate() {
+            *byte = byte
+                .wrapping_add((j as u8).wrapping_mul(17))
+                .wrapping_add(3);
+        }
+    }
+    target
+}
+
+fn bench_delta(c: &mut Criterion) {
+    let mut encode_group = c.benchmark_group("delta_encode");
+    for &size in SIZES {
+        let base = base_blob(size);
+        let target = target_blob(&base);
+        encode_group.throughput(Throughput::Bytes(target.len() as u64));
+        encode_group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                let delta = DeltaEncoder::encode(black_box(&base), black_box(&target));
+                black_box(delta);
+            });
+        });
+    }
+    encode_group.finish();
+
+    let mut decode_group = c.benchmark_group("delta_decode");
+    for &size in SIZES {
+        let base = base_blob(size);
+        let target = target_blob(&base);
+        let delta = DeltaEncoder::encode(&base, &target);
+        decode_group.throughput(Throughput::Bytes(target.len() as u64));
+        decode_group.bench_with_input(BenchmarkId::from_parameter(size), &delta, |b, delta| {
+            b.iter(|| {
+                let decoded =
+                    DeltaDecoder::decode(black_box(&base), black_box(delta), MAX_DELTA_OUTPUT_SIZE)
+                        .unwrap();
+                black_box(decoded);
+            });
+        });
+    }
+    decode_group.finish();
+}
+
+criterion_group!(benches, bench_delta);
+criterion_main!(benches);

--- a/crates/objects/benches/hashing.rs
+++ b/crates/objects/benches/hashing.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Direct throughput benchmarks for typed content hashing.
+//!
+//! Run: `cargo bench -p heddle-objects --bench hashing`
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::object::ContentHash;
+
+const SIZES: &[usize] = &[1024, 64 * 1024, 1024 * 1024, 16 * 1024 * 1024];
+
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_9abc_def0u64 ^ len as u64;
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        bytes.extend_from_slice(&state.to_le_bytes());
+    }
+    bytes.truncate(len);
+    bytes
+}
+
+fn bench_compute_typed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hashing_compute_typed");
+    for &size in SIZES {
+        let data = deterministic_bytes(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
+            b.iter(|| {
+                let hash = ContentHash::compute_typed("blob", black_box(data));
+                black_box(hash);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_compute_typed);
+criterion_main!(benches);

--- a/crates/objects/benches/pack_io.rs
+++ b/crates/objects/benches/pack_io.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Pack reader and streaming pack build/install benchmarks.
+//!
+//! Run: `cargo bench -p heddle-objects --bench pack_io`
+
+use std::{fs::OpenOptions, hint::black_box};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::{
+    object::ContentHash,
+    store::{
+        CompressionConfig, FsStore, ObjectStore,
+        pack::{ObjectType, PackBuilder, PackObjectId, PackReader, StreamingPackBuilder},
+    },
+};
+use tempfile::TempDir;
+
+const OBJECT_COUNT: usize = 2_048;
+const BLOB_SIZE: usize = 8 * 1024;
+const DELTA_DEPTHS: &[usize] = &[0, 8];
+
+struct PackFixture {
+    pack_data: Vec<u8>,
+    index_data: Vec<u8>,
+    ids: Vec<PackObjectId>,
+    total_bytes: u64,
+}
+
+fn compression_for_bench() -> CompressionConfig {
+    CompressionConfig {
+        enabled: false,
+        level: 0,
+        min_size: usize::MAX,
+        max_delta_size: 10 * 1024 * 1024,
+    }
+}
+
+fn blob_bytes(index: usize, size: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(size);
+    for i in 0..size {
+        out.push(((index * 131 + i * 17 + (i >> 5)) & 0xff) as u8);
+    }
+    out
+}
+
+fn versioned_blob(version: usize, size: usize) -> Vec<u8> {
+    let mut out = blob_bytes(7, size);
+    for i in 0..=version {
+        let pos = (i * 4099) % out.len();
+        out[pos] = out[pos].wrapping_add((version as u8).wrapping_add(1));
+    }
+    out
+}
+
+fn raw_pack_fixture() -> PackFixture {
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    let mut ids = Vec::with_capacity(OBJECT_COUNT);
+    let mut total_bytes = 0;
+    for i in 0..OBJECT_COUNT {
+        let data = blob_bytes(i, BLOB_SIZE);
+        let hash = ContentHash::compute_typed("blob", &data);
+        ids.push(PackObjectId::Hash(hash));
+        total_bytes += data.len() as u64;
+        builder.add(hash, ObjectType::Blob, data);
+    }
+    let (pack_data, index_data, _stats) = builder.build().unwrap();
+    PackFixture {
+        pack_data,
+        index_data,
+        ids,
+        total_bytes,
+    }
+}
+
+fn delta_pack_fixture(depth: usize) -> PackFixture {
+    let mut builder = PackBuilder::new(compression_for_bench());
+    let mut ids = Vec::with_capacity(depth + 1);
+    let mut total_bytes = 0;
+    for version in 0..=depth {
+        let data = versioned_blob(version, BLOB_SIZE);
+        let hash = ContentHash::compute_typed("blob", &data);
+        ids.push(PackObjectId::Hash(hash));
+        total_bytes += data.len() as u64;
+        builder.add_with_path(
+            hash,
+            ObjectType::Blob,
+            data,
+            Some("src/versioned.rs".to_string()),
+        );
+    }
+    let (pack_data, index_data, stats) = builder.build().unwrap();
+    eprintln!(
+        "[pack] delta-depth={depth} objects={} deltas={} ratio={:.3}",
+        stats.object_count, stats.delta_count, stats.compression_ratio
+    );
+    PackFixture {
+        pack_data,
+        index_data,
+        ids,
+        total_bytes,
+    }
+}
+
+fn streaming_pack_layout() -> (TempDir, std::path::PathBuf, std::path::PathBuf, u64) {
+    let dir = TempDir::new().unwrap();
+    let pack_path = dir.path().join("stream.pack");
+    let index_path = dir.path().join("stream.idx");
+    let bucket_dir = dir.path().join("buckets");
+    let pack_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&pack_path)
+        .unwrap();
+    let mut builder = StreamingPackBuilder::new(
+        pack_file,
+        index_path.clone(),
+        CompressionConfig::disabled(),
+        bucket_dir,
+    )
+    .unwrap();
+
+    let mut total_bytes = 0;
+    for i in 0..OBJECT_COUNT {
+        let data = blob_bytes(i, BLOB_SIZE);
+        let hash = ContentHash::compute_typed("blob", &data);
+        total_bytes += data.len() as u64;
+        builder.add(hash, ObjectType::Blob, data).unwrap();
+    }
+    let (_file, _stats) = builder.finalize().unwrap();
+    (dir, pack_path, index_path, total_bytes)
+}
+
+fn bench_pack_reads(c: &mut Criterion) {
+    let raw = raw_pack_fixture();
+    let reader = PackReader::from_bytes(raw.pack_data.clone(), &raw.index_data).unwrap();
+    let sample_ids: Vec<PackObjectId> = raw.ids.iter().step_by(32).copied().collect();
+
+    let mut warm = c.benchmark_group("pack_io_get_object_bytes_warm");
+    warm.throughput(Throughput::Bytes((sample_ids.len() * BLOB_SIZE) as u64));
+    warm.bench_with_input(
+        BenchmarkId::new("raw", sample_ids.len()),
+        &sample_ids,
+        |b, ids| {
+            b.iter(|| {
+                for id in ids {
+                    let (_ty, bytes) = reader.get_object_bytes(black_box(id)).unwrap().unwrap();
+                    black_box(bytes);
+                }
+            });
+        },
+    );
+    warm.finish();
+
+    let mut cold = c.benchmark_group("pack_io_get_object_bytes_cold");
+    cold.throughput(Throughput::Bytes(BLOB_SIZE as u64));
+    let cold_id = raw.ids[raw.ids.len() / 2];
+    cold.bench_function("raw_reopen", |b| {
+        b.iter_batched(
+            || PackReader::from_bytes(raw.pack_data.clone(), &raw.index_data).unwrap(),
+            |reader| {
+                let (_ty, bytes) = reader
+                    .get_object_bytes(black_box(&cold_id))
+                    .unwrap()
+                    .unwrap();
+                black_box(bytes);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    cold.finish();
+
+    let mut delta = c.benchmark_group("pack_io_get_object_bytes_delta_chain");
+    for &depth in DELTA_DEPTHS {
+        let fixture = if depth == 0 {
+            raw_pack_fixture()
+        } else {
+            delta_pack_fixture(depth)
+        };
+        let reader =
+            PackReader::from_bytes(fixture.pack_data.clone(), &fixture.index_data).unwrap();
+        let id = *fixture.ids.last().unwrap();
+        delta.throughput(Throughput::Bytes(BLOB_SIZE as u64));
+        delta.bench_with_input(BenchmarkId::from_parameter(depth), &id, |b, id| {
+            b.iter(|| {
+                let (_ty, bytes) = reader.get_object_bytes(black_box(id)).unwrap().unwrap();
+                black_box(bytes);
+            });
+        });
+    }
+    delta.finish();
+}
+
+fn bench_streaming_build_install(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pack_io_streaming_build_install");
+    group.throughput(Throughput::Bytes((OBJECT_COUNT * BLOB_SIZE) as u64));
+    group.bench_function(BenchmarkId::from_parameter(OBJECT_COUNT), |b| {
+        b.iter_batched(
+            streaming_pack_layout,
+            |(_layout_dir, pack_path, index_path, total_bytes)| {
+                let store_dir = TempDir::new().unwrap();
+                let store = FsStore::new(store_dir.path());
+                store.init().unwrap();
+                store
+                    .install_pack_streaming(black_box(&pack_path), black_box(&index_path))
+                    .unwrap();
+                black_box(total_bytes);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_pack_build_in_memory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pack_io_packbuilder_build");
+    group.throughput(Throughput::Bytes((OBJECT_COUNT * BLOB_SIZE) as u64));
+    group.bench_function(BenchmarkId::from_parameter(OBJECT_COUNT), |b| {
+        b.iter(|| {
+            let fixture = raw_pack_fixture();
+            black_box((fixture.pack_data, fixture.index_data, fixture.total_bytes));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_pack_reads,
+    bench_pack_build_in_memory,
+    bench_streaming_build_install
+);
+criterion_main!(benches);

--- a/crates/objects/benches/tree_diff.rs
+++ b/crates/objects/benches/tree_diff.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Merge-join tree diff hot-path benchmarks.
+//!
+//! Run: `cargo bench -p heddle-objects --bench tree_diff`
+
+use std::{collections::HashMap, hint::black_box, sync::RwLock};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use objects::{
+    object::{
+        Action, ActionId, Blob, ChangeId, ContentHash, EntryType, FileMode, State, Tree, TreeEntry,
+        diff_trees,
+    },
+    store::{ObjectStore, Result},
+};
+
+const SIZES: &[usize] = &[1_000, 10_000, 100_000];
+
+#[derive(Clone, Copy)]
+enum DeltaShape {
+    Small,
+    Large,
+    Disjoint,
+}
+
+impl DeltaShape {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Small => "small",
+            Self::Large => "large",
+            Self::Disjoint => "disjoint",
+        }
+    }
+}
+
+#[derive(Default)]
+struct BenchStore {
+    blobs: RwLock<HashMap<ContentHash, Blob>>,
+    trees: RwLock<HashMap<ContentHash, Tree>>,
+}
+
+impl ObjectStore for BenchStore {
+    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
+        Ok(self.blobs.read().unwrap().get(hash).cloned())
+    }
+
+    fn put_blob(&self, blob: &Blob) -> Result<ContentHash> {
+        let hash = blob.hash();
+        self.blobs.write().unwrap().insert(hash, blob.clone());
+        Ok(hash)
+    }
+
+    fn has_blob(&self, hash: &ContentHash) -> Result<bool> {
+        Ok(self.blobs.read().unwrap().contains_key(hash))
+    }
+
+    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        Ok(self.trees.read().unwrap().get(hash).cloned())
+    }
+
+    fn put_tree(&self, tree: &Tree) -> Result<ContentHash> {
+        let hash = tree.hash();
+        self.trees.write().unwrap().insert(hash, tree.clone());
+        Ok(hash)
+    }
+
+    fn has_tree(&self, hash: &ContentHash) -> Result<bool> {
+        Ok(self.trees.read().unwrap().contains_key(hash))
+    }
+
+    fn get_state(&self, _id: &ChangeId) -> Result<Option<State>> {
+        Ok(None)
+    }
+
+    fn put_state(&self, _state: &State) -> Result<()> {
+        Ok(())
+    }
+
+    fn has_state(&self, _id: &ChangeId) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn list_states(&self) -> Result<Vec<ChangeId>> {
+        Ok(Vec::new())
+    }
+
+    fn get_action(&self, _id: &ActionId) -> Result<Option<Action>> {
+        Ok(None)
+    }
+
+    fn put_action(&self, action: &mut Action) -> Result<ActionId> {
+        Ok(action.id())
+    }
+
+    fn list_actions(&self) -> Result<Vec<ActionId>> {
+        Ok(Vec::new())
+    }
+
+    fn list_blobs(&self) -> Result<Vec<ContentHash>> {
+        Ok(self.blobs.read().unwrap().keys().copied().collect())
+    }
+
+    fn list_trees(&self) -> Result<Vec<ContentHash>> {
+        Ok(self.trees.read().unwrap().keys().copied().collect())
+    }
+}
+
+fn blob_hash(store: &BenchStore, content: String) -> ContentHash {
+    store.put_blob(&Blob::from(content)).unwrap()
+}
+
+fn tree_for(store: &BenchStore, size: usize, shape: DeltaShape, side: usize) -> ContentHash {
+    let mut entries = Vec::with_capacity(size);
+    for i in 0..size {
+        let include = match shape {
+            DeltaShape::Disjoint if side == 0 => i % 2 == 0,
+            DeltaShape::Disjoint if side == 1 => i % 2 == 1,
+            _ => true,
+        };
+        if !include {
+            continue;
+        }
+
+        let changed = match shape {
+            DeltaShape::Small => side == 1 && i % (size / 100).max(1) == 0,
+            DeltaShape::Large => side == 1 && i % 2 == 0,
+            DeltaShape::Disjoint => false,
+        };
+        let name = format!("file-{i:06}.txt");
+        let content = format!(
+            "entry={i}; side={}; changed={changed}\n",
+            side * changed as usize
+        );
+        entries.push(TreeEntry {
+            name,
+            mode: FileMode::Normal,
+            entry_type: EntryType::Blob,
+            hash: blob_hash(store, content),
+        });
+    }
+    let tree = Tree::from_entries(entries);
+    store.put_tree(&tree).unwrap()
+}
+
+fn bench_tree_diff(c: &mut Criterion) {
+    let shapes = [DeltaShape::Small, DeltaShape::Large, DeltaShape::Disjoint];
+    for shape in shapes {
+        let mut group = c.benchmark_group(format!("tree_diff_{}", shape.label()));
+        for &size in SIZES {
+            let store = BenchStore::default();
+            let from = tree_for(&store, size, shape, 0);
+            let to = tree_for(&store, size, shape, 1);
+            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+                b.iter(|| {
+                    let changes =
+                        diff_trees(black_box(&store), black_box(&from), black_box(&to)).unwrap();
+                    black_box(changes.len());
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_tree_diff);
+criterion_main!(benches);

--- a/crates/objects/src/store/compression/mod.rs
+++ b/crates/objects/src/store/compression/mod.rs
@@ -120,12 +120,12 @@ pub enum CompressionError {
 
 #[cfg(feature = "zstd")]
 /// Compress data using zstd.
-fn compress_zstd(data: &[u8], level: i32) -> Result<Vec<u8>, CompressionError> {
+pub fn compress_zstd(data: &[u8], level: i32) -> Result<Vec<u8>, CompressionError> {
     zstd::encode_all(data, level).map_err(|e| CompressionError::CompressionFailed(e.to_string()))
 }
 
 #[cfg(not(feature = "zstd"))]
-fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionError> {
+pub fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionError> {
     Err(CompressionError::InvalidOperation(
         "zstd compression support not compiled into this build".to_string(),
     ))
@@ -133,7 +133,7 @@ fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionError>
 
 #[cfg(feature = "zstd")]
 /// Decompress zstd data while enforcing the recorded output size.
-fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
+pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
     validate_size(expected_size)?;
 
     let mut decoder = zstd::stream::read::Decoder::new(data)
@@ -163,7 +163,7 @@ fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, Compressi
 }
 
 #[cfg(not(feature = "zstd"))]
-fn decompress_zstd(_data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
+pub fn decompress_zstd(_data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
     validate_size(expected_size)?;
     Err(CompressionError::InvalidOperation(
         "zstd-compressed data is unsupported in this build".to_string(),


### PR DESCRIPTION
## Summary
Closes the bench-coverage gap on the core object-store engine (`crates/objects/` had zero benches). New `crates/objects/benches/` (criterion, `harness = false`):
- `hashing` — `ContentHash::compute_typed` size sweep (Throughput::Bytes).
- `compression` — zstd compress + decompress × levels.
- `delta` — encode + decode.
- `pack_io` — `get_object_bytes` warm/cold/delta-chain + PackBuilder build + streaming build/install.
- `tree_diff` — small/large/disjoint deltas (the merge-join hot path).

13 bench groups total. Feeds the weekly bench CI job (#427).

## Test evidence
- `cargo bench -p heddle-objects --no-run` compiles; smoke runs (incl. `--features zstd`); `cargo test -p heddle-objects` green; `cargo clippy --locked -- -D warnings`; `cargo build -p heddle-cli`.

Closes #425.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782997268&installation_id=132405951&pr_number=432&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F432&signature=7896fbbd3a66353372e58ceae5ff7ff55f438f0e7ccee1dae6b7d00c644ca8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->