### PR TITLE
ci: weekly scheduled benchmark workflow + bench-target rot guard (#427)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,26 +50,7 @@ jobs:
 
       - name: Discover benchmark targets
         run: |
-          python3 - <<'PY' > benchmark-plan.tsv
-          from pathlib import Path
-          import tomllib
-
-          for manifest in sorted(Path("crates").glob("*/Cargo.toml")):
-              data = tomllib.loads(manifest.read_text())
-              benches = data.get("bench", [])
-              if not benches:
-                  continue
-              package = data["package"]["name"]
-              package_features = set(data.get("features", {}))
-              for bench in benches:
-                  features = []
-                  for feature in bench.get("required-features", []):
-                      if feature not in features:
-                          features.append(feature)
-                  if "zstd" in package_features and "zstd" not in features:
-                      features.append("zstd")
-                  print(f"{package}\t{bench['name']}\t{','.join(features)}")
-          PY
+          python3 scripts/discover-benches.py > benchmark-plan.tsv
           cat benchmark-plan.tsv
 
       # `fuse_worker_ipc` resolves the worker as a sibling release

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,6 +72,7 @@ jobs:
             if [ -n "$features" ]; then
               cmd+=(--features "$features")
             fi
+            cmd+=(-- --output-format bencher)
             printf 'running:'
             printf ' %q' "${cmd[@]}"
             printf '\n'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,143 @@
+name: Benchmarks
+
+on:
+  schedule:
+    # Weekly full Criterion suite: Sunday 00:00 UTC.
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: benchmarks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  criterion:
+    name: Criterion suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: benchmarks-${{ runner.os }}
+          cache-on-failure: true
+
+      - name: Install FUSE
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fuse3 libfuse3-dev
+          fusermount3 --version
+          ls -l /dev/fuse
+
+      - name: Discover benchmark targets
+        run: |
+          python3 - <<'PY' > benchmark-plan.tsv
+          from pathlib import Path
+          import tomllib
+
+          for manifest in sorted(Path("crates").glob("*/Cargo.toml")):
+              data = tomllib.loads(manifest.read_text())
+              benches = data.get("bench", [])
+              if not benches:
+                  continue
+              package = data["package"]["name"]
+              package_features = set(data.get("features", {}))
+              for bench in benches:
+                  features = []
+                  for feature in bench.get("required-features", []):
+                      if feature not in features:
+                          features.append(feature)
+                  if "zstd" in package_features and "zstd" not in features:
+                      features.append("zstd")
+                  print(f"{package}\t{bench['name']}\t{','.join(features)}")
+          PY
+          cat benchmark-plan.tsv
+
+      # `fuse_worker_ipc` resolves the worker as a sibling release
+      # artifact. Build it once before the generic bench loop so that
+      # the discovered mount bench can measure the real IPC path.
+      - name: Build FUSE worker
+        run: cargo build --locked -p heddle-cli --bin heddle-fuse-worker --features mount
+
+      - name: Clear stale Criterion residue
+        run: rm -rf target/criterion
+
+      - name: Run discovered Criterion benches
+        run: |
+          : > benchmark-output.txt
+          while IFS=$'\t' read -r package bench features; do
+            [ -n "$package" ] || continue
+            echo "::group::$package/$bench"
+            cmd=(cargo bench --locked -p "$package" --bench "$bench")
+            if [ -n "$features" ]; then
+              cmd+=(--features "$features")
+            fi
+            printf 'running:'
+            printf ' %q' "${cmd[@]}"
+            printf '\n'
+            "${cmd[@]}" 2>&1 | tee -a benchmark-output.txt
+            echo "::endgroup::"
+          done < benchmark-plan.tsv
+
+      # Use github-action-benchmark for the broad scheduled suite instead
+      # of extending the committed FUSE baseline pattern. The workspace now
+      # has many Criterion targets, and more can appear independently; the
+      # action stores every run on gh-pages, charts history, and emits alert
+      # comments without forcing PR checks to wait on benchmark execution.
+      - name: Store benchmark history
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Heddle Criterion Suite
+          tool: cargo
+          output-file-path: benchmark-output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-threshold: '120%'
+          benchmark-data-dir-path: dev/bench
+
+      - name: Publish benchmark summary
+        if: always()
+        run: |
+          {
+            echo '## Benchmarks'
+            echo
+            echo 'Trend tracking: benchmark-action/github-action-benchmark writes scheduled/manual results to gh-pages and surfaces >20% regressions as alerts without failing normal PR CI.'
+            echo
+            echo 'Discovered targets:'
+            sed 's/^/- /; s/\t/ /g' benchmark-plan.tsv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-suite
+          path: |
+            benchmark-plan.tsv
+            benchmark-output.txt
+            target/criterion/
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,7 +57,7 @@ jobs:
       # artifact. Build it once before the generic bench loop so that
       # the discovered mount bench can measure the real IPC path.
       - name: Build FUSE worker
-        run: cargo build --locked -p heddle-cli --bin heddle-fuse-worker --features mount
+        run: cargo build --locked --release -p heddle-cli --bin heddle-fuse-worker --features mount
 
       - name: Clear stale Criterion residue
         run: rm -rf target/criterion

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -190,16 +190,17 @@ jobs:
       - name: Bench-compare script unit tests
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 
-      # 3c. Compile every workspace benchmark target without running the
-      #     measurements. The weekly benchmark workflow owns performance
-      #     trend tracking and shares the same discovery helper. This cheap
-      #     PR-safe guard catches rotten bench code and Cargo.toml `[[bench]]`
-      #     entries before they land, including non-default required features.
+      # 3c. Compile every workspace benchmark target in the dev profile
+      #     without running the measurements. The weekly benchmark workflow
+      #     owns optimized performance trend tracking and shares the same
+      #     discovery helper. This cheap PR-safe guard catches rotten bench
+      #     code and Cargo.toml `[[bench]]` entries before they land,
+      #     including non-default required features.
       #     Invariant: every target enumerated by `discover-benches.py` is
       #     compile-checked by a PR-time gate. Non-FUSE benches are checked
       #     here; FUSE benches are skipped here only because the dedicated
       #     `fuse-bench` job below has libfuse and compile-checks all
-      #     `heddle-mount` benches with `--features fuse --no-run`.
+      #     `heddle-mount` benches with `cargo build --features fuse --benches`.
       - name: Compile benchmark targets
         run: |
           python3 scripts/discover-benches.py > benchmark-plan.tsv
@@ -211,11 +212,10 @@ jobs:
               continue
             fi
             echo "::group::$package/$bench"
-            cmd=(cargo bench --locked -p "$package" --bench "$bench")
+            cmd=(cargo build --locked -p "$package" --bench "$bench")
             if [ -n "$features" ]; then
               cmd+=(--features "$features")
             fi
-            cmd+=(--no-run)
             printf 'running:'
             printf ' %q' "${cmd[@]}"
             printf '\n'
@@ -651,13 +651,14 @@ jobs:
 
       # Complete the benchmark rot-guard invariant documented in the
       # `Compile benchmark targets` step: this FUSE-capable job
-      # compile-checks every `heddle-mount` bench target, including
-      # future FUSE benches, before running the measured suite.
+      # compile-checks every `heddle-mount` bench target in the dev
+      # profile, including future FUSE benches, before running the
+      # measured optimized suite.
       - name: Compile FUSE benchmark targets
         env:
           RUSTC_WRAPPER: sccache
           SCCACHE_GHA_ENABLED: "true"
-        run: cargo bench --locked --features fuse -p heddle-mount --no-run
+        run: cargo build --locked --features fuse -p heddle-mount --benches
 
       # Run the bench. Criterion writes per-workload `estimates.json`
       # under `target/criterion/<group>/<variant>/new/` which the

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -190,7 +190,14 @@ jobs:
       - name: Bench-compare script unit tests
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 
-      # 3c. Compile gate for the `postgres` (server / weft) feature. This is
+      # 3c. Compile every workspace benchmark target without running the
+      #     measurements. The weekly benchmark workflow owns performance
+      #     trend tracking; this cheap PR-safe guard catches rotten bench
+      #     code and Cargo.toml `[[bench]]` entries before they land.
+      - name: Compile benchmark targets
+        run: cargo bench --locked --workspace --no-run
+
+      # 3d. Compile gate for the `postgres` (server / weft) feature. This is
       #     the silent-rot guard: `--features postgres` is NOT exercised by
       #     the default-feature build above, so a server-path regression
       #     (e.g. a backend that wasn't updated after a newtype migration)

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -195,8 +195,11 @@ jobs:
       #     trend tracking and shares the same discovery helper. This cheap
       #     PR-safe guard catches rotten bench code and Cargo.toml `[[bench]]`
       #     entries before they land, including non-default required features.
-      #     FUSE-required benches are delegated to the dedicated `fuse-bench`
-      #     job because this check job does not install libfuse.
+      #     Invariant: every target enumerated by `discover-benches.py` is
+      #     compile-checked by a PR-time gate. Non-FUSE benches are checked
+      #     here; FUSE benches are skipped here only because the dedicated
+      #     `fuse-bench` job below has libfuse and compile-checks all
+      #     `heddle-mount` benches with `--features fuse --no-run`.
       - name: Compile benchmark targets
         run: |
           python3 scripts/discover-benches.py > benchmark-plan.tsv
@@ -645,6 +648,16 @@ jobs:
       # is untouched.
       - name: Clear stale criterion residue
         run: rm -rf target/criterion
+
+      # Complete the benchmark rot-guard invariant documented in the
+      # `Compile benchmark targets` step: this FUSE-capable job
+      # compile-checks every `heddle-mount` bench target, including
+      # future FUSE benches, before running the measured suite.
+      - name: Compile FUSE benchmark targets
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+        run: cargo bench --locked --features fuse -p heddle-mount --no-run
 
       # Run the bench. Criterion writes per-workload `estimates.json`
       # under `target/criterion/<group>/<variant>/new/` which the

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -192,10 +192,33 @@ jobs:
 
       # 3c. Compile every workspace benchmark target without running the
       #     measurements. The weekly benchmark workflow owns performance
-      #     trend tracking; this cheap PR-safe guard catches rotten bench
-      #     code and Cargo.toml `[[bench]]` entries before they land.
+      #     trend tracking and shares the same discovery helper. This cheap
+      #     PR-safe guard catches rotten bench code and Cargo.toml `[[bench]]`
+      #     entries before they land, including non-default required features.
+      #     FUSE-required benches are delegated to the dedicated `fuse-bench`
+      #     job because this check job does not install libfuse.
       - name: Compile benchmark targets
-        run: cargo bench --locked --workspace --no-run
+        run: |
+          python3 scripts/discover-benches.py > benchmark-plan.tsv
+          cat benchmark-plan.tsv
+          while IFS=$'\t' read -r package bench features; do
+            [ -n "$package" ] || continue
+            if [ "$features" = "fuse" ] || [[ "$features" == fuse,* ]] || [[ "$features" == *,fuse ]] || [[ "$features" == *,fuse,* ]]; then
+              echo "skipping $package/$bench: fuse benches are covered by the fuse-bench job"
+              continue
+            fi
+            echo "::group::$package/$bench"
+            cmd=(cargo bench --locked -p "$package" --bench "$bench")
+            if [ -n "$features" ]; then
+              cmd+=(--features "$features")
+            fi
+            cmd+=(--no-run)
+            printf 'running:'
+            printf ' %q' "${cmd[@]}"
+            printf '\n'
+            "${cmd[@]}"
+            echo "::endgroup::"
+          done < benchmark-plan.tsv
 
       # 3d. Compile gate for the `postgres` (server / weft) feature. This is
       #     the silent-rot guard: `--features postgres` is NOT exercised by

--- a/crates/mount/benches/fuse_worker_ipc.rs
+++ b/crates/mount/benches/fuse_worker_ipc.rs
@@ -123,6 +123,15 @@ fn run_bench(worker_bin: &Path) {
     let p99 = durs[(SAMPLES * 99) / 100];
     let max = *durs.last().unwrap();
     println!("fuse_worker_ipc: p50={:?} p99={:?} max={:?}", p50, p99, max);
+    // Invariant: every [[bench]] the weekly workflow feeds to github-action-benchmark
+    // must emit a libtest-format line parseable by `tool: cargo`; Criterion benches
+    // get this from `--output-format bencher`, while custom-main benches print it.
+    let p50_ns = p50.as_nanos();
+    let spread_ns = p99.saturating_sub(p50).as_nanos();
+    println!(
+        "test fuse_worker_ipc/control_plane_rtt ... bench: {} ns/iter (+/- {})",
+        p50_ns, spread_ns
+    );
 
     // Budget gate — spike §7. Worst-case-driven, not median.
     // 1ms is the explicit ceiling.

--- a/scripts/discover-benches.py
+++ b/scripts/discover-benches.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Emit benchmark targets as TSV: package, bench, comma-separated features."""
+
+from pathlib import Path
+import tomllib
+
+
+def unique(values):
+    seen = set()
+    result = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+for manifest in sorted(Path("crates").glob("*/Cargo.toml")):
+    data = tomllib.loads(manifest.read_text())
+    benches = data.get("bench", [])
+    if not benches:
+        continue
+
+    package = data["package"]["name"]
+    package_features = set(data.get("features", {}))
+    for bench in benches:
+        features = unique(bench.get("required-features", []))
+        if "zstd" in package_features and "zstd" not in features:
+            features.append("zstd")
+        print(f"{package}\t{bench['name']}\t{','.join(features)}")


### PR DESCRIPTION
## Summary
Per maintainer decision (benches run **weekly, not per-PR**):
- New `.github/workflows/benchmarks.yml`: `schedule` weekly (Sun 00:00 UTC) + `workflow_dispatch` only — **no `push`/`pull_request` trigger**. Discovers `[[bench]]` targets from crate manifests (honors `required-features`), runs the criterion suite, uploads artifacts, and feeds `benchmark-action/github-action-benchmark` for gh-pages trend charts + >20% regression alerts (`fail-on-alert: false` — surfaces, doesn't gate).
- Rot guard in `rust-tests.yml`: `cargo bench --locked --workspace --no-run` (compile-only, per-PR-safe) so a bench target can't silently fail to compile.

Pairs with the `bench`-feature gating (#426 r2 / #434): feature-gated benches must be built/run with `--features bench`.

Closes #427.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000506&installation_id=132405951&pr_number=435&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F435&signature=15571e9458f3a380456e81525ed665f0843d9fcbce9129bf2fac2d79c0a83cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->