### PR TITLE
fix(repo): refuse dirty FullRematerialize by default; explicit opt-in to discard (#368)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -269,7 +269,7 @@ Examples:
         /// Target state.
         target: String,
 
-        /// Discard uncommitted changes.
+        /// Discard unsnapped local changes.
         #[arg(short, long)]
         force: bool,
     },

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -375,13 +375,10 @@ fn finish_git_overlay_clone(
             &remote_label
         ))
     })?;
-    // Materialize the imported tip *while HEAD is still on the
-    // init-time default* — `goto` writes `Head::Detached`, which is
-    // fine here because we re-attach immediately below. Switching to
-    // `fast_forward_attached` would mis-advance whichever thread HEAD
-    // happens to be on at this point (the seeded `main`, not the
-    // cloned thread).
-    repo.goto(&state_id)?;
+    // Materialize the imported tip from a fresh clone baseline. Imported
+    // refs may already make HEAD resolve to the target, but the files on
+    // disk do not yet represent that target.
+    repo.goto_from_materialized_state(&state_id, None)?;
     // Re-attach HEAD to the cloned thread, AND mirror the choice into
     // `.git/HEAD`. `Repository::open` on a git-overlay repo
     // unconditionally syncs heddle's HEAD from `.git/HEAD` via
@@ -1022,15 +1019,13 @@ async fn clone_local(
         sync.fetch_state(&local_repo, &state_id)?
     };
 
-    // Set up the thread locally
+    // Materialize from a fresh clone baseline before publishing the local
+    // thread ref. Otherwise HEAD can resolve to the target first and make
+    // the empty worktree look like deleted target files.
+    local_repo.goto_from_materialized_state(&state_id, None)?;
+    // Set up the thread locally after materialization so the dirty-worktree
+    // guard does not mistake an empty fresh clone for deleted target files.
     local_repo.refs().set_thread(&tn, &state_id)?;
-
-    // Intentional raw `goto`: a fresh `Repository::init` writes HEAD as
-    // `Attached { thread: "main" }`, but we may be cloning a non-"main"
-    // thread (e.g. `develop`). `fast_forward_attached` here would
-    // mis-advance the "main" thread ref instead of the cloned one. Clone
-    // post-HEAD-attach is tracked separately.
-    local_repo.goto(&state_id)?;
     local_repo.refs().write_head(&Head::Attached {
         thread: ThreadName::new(track_name),
     })?;

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -15,11 +15,13 @@
 //! thread ref to strand, and the legacy `Goto` inverse correctly
 //! rewinds HEAD on its own.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::OpRecord;
 use refs::Head;
 use repo::Repository;
+
+use super::advice::RecoveryAdvice;
 
 /// Perform a fast-forward of the attached thread to `post_target_id`
 /// and record the operation so undo restores the target thread ref to
@@ -46,10 +48,7 @@ pub(super) fn record_ff_advance(
 ) -> Result<()> {
     let head_before = repo.head_ref()?;
     let pre_target_id = match &head_before {
-        Head::Attached { thread } => repo
-            .refs()
-            .get_thread(thread)?
-            .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
+        Head::Attached { thread } => attached_thread_tip(repo, thread)?,
         Head::Detached { state } => *state,
     };
     record_ff_advance_inner(
@@ -59,6 +58,7 @@ pub(super) fn record_ff_advance(
         &pre_target_id,
         post_target_id,
         false,
+        None,
     )
 }
 
@@ -70,9 +70,9 @@ pub(super) fn record_ff_advance(
 ///
 /// Caller must capture `pre_target_id` *before* the mutating
 /// operation that precedes the FF. The preceding mutation must also
-/// have run its dirty-worktree guard: this helper opts into the repo
-/// discard path because the pre-published ref makes the old clean
-/// worktree look dirty against the new ref.
+/// have run its dirty-worktree guard. This helper passes that captured
+/// state as the materialized baseline because the pre-published ref
+/// makes the old clean worktree look dirty against the new ref.
 pub(super) fn record_ff_advance_explicit(
     repo: &Repository,
     source_thread: &str,
@@ -86,7 +86,8 @@ pub(super) fn record_ff_advance_explicit(
         &head_before,
         pre_target_id,
         post_target_id,
-        true,
+        false,
+        Some(Some(*pre_target_id)),
     )
 }
 
@@ -100,10 +101,7 @@ pub(super) fn record_ff_advance_discard_local(
 ) -> Result<()> {
     let head_before = repo.head_ref()?;
     let pre_target_id = match &head_before {
-        Head::Attached { thread } => repo
-            .refs()
-            .get_thread(thread)?
-            .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
+        Head::Attached { thread } => attached_thread_tip(repo, thread)?,
         Head::Detached { state } => *state,
     };
     record_ff_advance_inner(
@@ -113,6 +111,7 @@ pub(super) fn record_ff_advance_discard_local(
         &pre_target_id,
         post_target_id,
         true,
+        None,
     )
 }
 
@@ -139,10 +138,7 @@ pub(super) fn ff_advance_deferred(
 ) -> Result<OpRecord> {
     let head_before = repo.head_ref()?;
     let pre_target_id = match &head_before {
-        Head::Attached { thread } => repo
-            .refs()
-            .get_thread(thread)?
-            .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
+        Head::Attached { thread } => attached_thread_tip(repo, thread)?,
         Head::Detached { state } => *state,
     };
     if discard_local_changes {
@@ -165,6 +161,25 @@ pub(super) fn ff_advance_deferred(
     })
 }
 
+fn attached_thread_tip(repo: &Repository, thread: &ThreadName) -> Result<ChangeId> {
+    repo.refs()
+        .get_thread(thread)?
+        .ok_or_else(|| anyhow!(attached_thread_missing_ref_advice(thread)))
+}
+
+fn attached_thread_missing_ref_advice(thread: &ThreadName) -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "fast_forward_missing_attached_thread",
+        format!("Attached thread '{thread}' has no ref before fast-forward"),
+        "Inspect repository refs before retrying the operation.",
+        format!("HEAD is attached to '{thread}', but that thread ref does not resolve"),
+        "fast-forward cannot determine the pre-operation thread tip for undo/redo",
+        "repository refs and worktree files were left unchanged",
+        "heddle status",
+        vec!["heddle status".to_string()],
+    )
+}
+
 fn record_ff_advance_inner(
     repo: &Repository,
     source_thread: &str,
@@ -172,9 +187,15 @@ fn record_ff_advance_inner(
     pre_target_id: &ChangeId,
     post_target_id: &ChangeId,
     discard_local_changes: bool,
+    materialized_baseline: Option<Option<ChangeId>>,
 ) -> Result<()> {
     if discard_local_changes {
         repo.fast_forward_attached_without_record_discard_local(post_target_id)?;
+    } else if let Some(materialized_baseline) = materialized_baseline {
+        repo.fast_forward_attached_from_materialized_state_without_record(
+            post_target_id,
+            materialized_baseline.as_ref(),
+        )?;
     } else {
         repo.fast_forward_attached_without_record(post_target_id)?;
     }

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -2,7 +2,7 @@
 //! Shared helper for fast-forward call sites that need to record an
 //! `OpRecord::FastForwardV2` instead of the implicit `OpRecord::Goto`.
 //!
-//! See heddle#99 (merge FF) and heddle#110 (rebase / pull / ship /
+//! See heddle#99 (merge FF) and heddle#110 (rebase / ship /
 //! merge-abort): recording a thread-advancing fast-forward as a plain
 //! `OpRecord::Goto` strands the target thread ref on undo, because the
 //! `Goto` inverse only rewinds HEAD. The fix is to perform the FF
@@ -31,8 +31,9 @@ use super::advice::RecoveryAdvice;
 /// Reads the pre-FF tip from the attached thread's ref (or from HEAD
 /// for detached). Use this overload at call sites where the thread
 /// ref has *not* been mutated since whatever you want undo to restore
-/// — e.g. merge / rebase / ship. Pull pre-sets the thread ref before
-/// materializing and must call [`record_ff_advance_explicit`].
+/// — e.g. merge / rebase / ship. Callers that also materialize a
+/// worktree must not publish the ref first: a dirty refusal must never
+/// leave a ref advanced without the matching worktree materialization.
 ///
 /// `source_thread` is the thread name surfaced in the OpRecord for
 /// forensic context. Neither undo nor redo reads it. For rebase-replay
@@ -59,35 +60,6 @@ pub(super) fn record_ff_advance(
         post_target_id,
         false,
         None,
-    )
-}
-
-/// Variant of [`record_ff_advance`] that takes an explicit
-/// `pre_target_id`. Use when the thread ref was already mutated
-/// before the FF (e.g. `cmd_pull` advances the local thread ref
-/// directly so a non-materializing pull still advances the ref), so
-/// reading it back would return the *post* state.
-///
-/// Caller must capture `pre_target_id` *before* the mutating
-/// operation that precedes the FF. The preceding mutation must also
-/// have run its dirty-worktree guard. This helper passes that captured
-/// state as the materialized baseline because the pre-published ref
-/// makes the old clean worktree look dirty against the new ref.
-pub(super) fn record_ff_advance_explicit(
-    repo: &Repository,
-    source_thread: &str,
-    pre_target_id: &ChangeId,
-    post_target_id: &ChangeId,
-) -> Result<()> {
-    let head_before = repo.head_ref()?;
-    record_ff_advance_inner(
-        repo,
-        source_thread,
-        &head_before,
-        pre_target_id,
-        post_target_id,
-        false,
-        Some(Some(*pre_target_id)),
     )
 }
 

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -58,6 +58,7 @@ pub(super) fn record_ff_advance(
         &head_before,
         &pre_target_id,
         post_target_id,
+        false,
     )
 }
 
@@ -68,7 +69,10 @@ pub(super) fn record_ff_advance(
 /// reading it back would return the *post* state.
 ///
 /// Caller must capture `pre_target_id` *before* the mutating
-/// operation that precedes the FF.
+/// operation that precedes the FF. The preceding mutation must also
+/// have run its dirty-worktree guard: this helper opts into the repo
+/// discard path because the pre-published ref makes the old clean
+/// worktree look dirty against the new ref.
 pub(super) fn record_ff_advance_explicit(
     repo: &Repository,
     source_thread: &str,
@@ -82,6 +86,33 @@ pub(super) fn record_ff_advance_explicit(
         &head_before,
         pre_target_id,
         post_target_id,
+        true,
+    )
+}
+
+/// Record a fast-forward whose worktree reset is itself the explicit
+/// destructive action, such as aborting a merge with conflict markers
+/// in the worktree.
+pub(super) fn record_ff_advance_discard_local(
+    repo: &Repository,
+    source_thread: &str,
+    post_target_id: &ChangeId,
+) -> Result<()> {
+    let head_before = repo.head_ref()?;
+    let pre_target_id = match &head_before {
+        Head::Attached { thread } => repo
+            .refs()
+            .get_thread(thread)?
+            .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
+        Head::Detached { state } => *state,
+    };
+    record_ff_advance_inner(
+        repo,
+        source_thread,
+        &head_before,
+        &pre_target_id,
+        post_target_id,
+        true,
     )
 }
 
@@ -104,6 +135,7 @@ pub(super) fn ff_advance_deferred(
     repo: &Repository,
     source_thread: &str,
     post_target_id: &ChangeId,
+    discard_local_changes: bool,
 ) -> Result<OpRecord> {
     let head_before = repo.head_ref()?;
     let pre_target_id = match &head_before {
@@ -113,7 +145,11 @@ pub(super) fn ff_advance_deferred(
             .ok_or_else(|| anyhow!("attached thread '{}' has no ref before FF", thread))?,
         Head::Detached { state } => *state,
     };
-    repo.fast_forward_attached_without_record(post_target_id)?;
+    if discard_local_changes {
+        repo.fast_forward_attached_without_record_discard_local(post_target_id)?;
+    } else {
+        repo.fast_forward_attached_without_record(post_target_id)?;
+    }
     Ok(match head_before {
         Head::Attached { thread } => OpRecord::FastForwardV2 {
             source_thread: source_thread.to_string(),
@@ -135,8 +171,13 @@ fn record_ff_advance_inner(
     head_before: &Head,
     pre_target_id: &ChangeId,
     post_target_id: &ChangeId,
+    discard_local_changes: bool,
 ) -> Result<()> {
-    repo.fast_forward_attached_without_record(post_target_id)?;
+    if discard_local_changes {
+        repo.fast_forward_attached_without_record_discard_local(post_target_id)?;
+    } else {
+        repo.fast_forward_attached_without_record(post_target_id)?;
+    }
     match head_before {
         Head::Attached { thread } => {
             repo.oplog().record_fast_forward(

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -188,3 +188,154 @@ fn record_ff_advance_inner(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use objects::object::ThreadName;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn create_repo() -> (TempDir, Repository) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        (temp, repo)
+    }
+
+    fn snapshot_file(
+        repo: &Repository,
+        root: &std::path::Path,
+        name: &str,
+        content: &str,
+    ) -> ChangeId {
+        fs::write(root.join(name), content).unwrap();
+        repo.snapshot(Some(name.to_string()), None)
+            .unwrap()
+            .change_id
+    }
+
+    #[test]
+    fn record_ff_advance_attached_records_fast_forward_v2() {
+        let (temp, repo) = create_repo();
+        let base = snapshot_file(&repo, temp.path(), "base.txt", "base\n");
+        let target = snapshot_file(&repo, temp.path(), "target.txt", "target\n");
+
+        repo.goto(&base).unwrap();
+        let thread = ThreadName::new("main");
+        repo.refs().set_thread(&thread, &base).unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: thread.clone(),
+            })
+            .unwrap();
+
+        record_ff_advance(&repo, "source", &target).unwrap();
+
+        assert_eq!(repo.refs().get_thread(&thread).unwrap(), Some(target));
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Attached { thread: current } if current == thread
+        ));
+        let batches = repo
+            .oplog()
+            .recent_batches_scoped(4, Some(&repo.op_scope()))
+            .unwrap();
+        assert!(
+            batches
+                .iter()
+                .flat_map(|batch| &batch.entries)
+                .any(|entry| matches!(
+                    &entry.operation,
+                    oplog::OpRecord::FastForwardV2 {
+                        source_thread,
+                        target_thread,
+                        pre_target_id,
+                        post_target_id,
+                    } if source_thread == "source"
+                        && target_thread == "main"
+                        && *pre_target_id == base
+                        && *post_target_id == target
+                ))
+        );
+    }
+
+    #[test]
+    fn record_ff_advance_discard_local_overwrites_dirty_checkout() {
+        let (temp, repo) = create_repo();
+        let tracked = temp.path().join("tracked.txt");
+        let base = snapshot_file(&repo, temp.path(), "tracked.txt", "base\n");
+        fs::write(&tracked, "target\n").unwrap();
+        let target = repo
+            .snapshot(Some("target".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&base).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("main"), &base)
+            .unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: ThreadName::new("main"),
+            })
+            .unwrap();
+        fs::write(&tracked, "local edit\n").unwrap();
+
+        record_ff_advance_discard_local(&repo, "source", &target).unwrap();
+
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "target\n");
+        assert_eq!(
+            repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
+            Some(target)
+        );
+    }
+
+    #[test]
+    fn ff_advance_deferred_detached_returns_goto_record() {
+        let (temp, repo) = create_repo();
+        let base = snapshot_file(&repo, temp.path(), "base.txt", "base\n");
+        let target = snapshot_file(&repo, temp.path(), "target.txt", "target\n");
+        repo.goto(&base).unwrap();
+
+        let advance = ff_advance_deferred(&repo, "source", &target, false).unwrap();
+
+        assert!(matches!(
+            advance,
+            oplog::OpRecord::Goto {
+                target: recorded_target,
+                prev_head: Some(prev),
+                head
+            } if recorded_target == target && prev == base && head == target
+        ));
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Detached { state } if state == target
+        ));
+    }
+
+    #[test]
+    fn record_ff_advance_refuses_attached_head_without_thread_ref() {
+        let (temp, repo) = create_repo();
+        let target = snapshot_file(&repo, temp.path(), "target.txt", "target\n");
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: ThreadName::new("missing"),
+            })
+            .unwrap();
+
+        let err = record_ff_advance(&repo, "source", &target).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("fast_forward_missing_attached_thread")
+                || msg.contains("Attached thread 'missing' has no ref"),
+            "missing attached thread should produce typed recovery advice: {msg}"
+        );
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Attached { thread } if thread == "missing"
+        ));
+    }
+}

--- a/crates/cli/src/cli/commands/goto.rs
+++ b/crates/cli/src/cli/commands/goto.rs
@@ -67,6 +67,8 @@ pub fn cmd_goto(cli: &Cli, target: String, force: bool) -> Result<()> {
 
     if current_worktree_verified_clean {
         repo.goto_verified_clean(&target_id)?;
+    } else if force {
+        repo.goto_discard_local(&target_id)?;
     } else {
         repo.goto(&target_id)?;
     }

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -68,17 +68,16 @@ pub fn cmd_rebase(
         Repository::open(&target_path)?
     };
 
-    // Rebase replays commits onto another thread by mutating the worktree
-    // (fast-forward via `fast_forward_attached` flows through
-    // `plan_worktree_apply`, which silently auto-falls back to
-    // `FullRematerialize` on a dirty worktree — that wipes uncommitted
-    // edits). The guard runs only on the entry path (not `--abort` /
-    // `--continue`, which need access to the in-progress state on disk).
+    // Rebase replays commits onto another thread by mutating the worktree.
+    // The guard runs only on the entry path (not `--abort` / `--continue`,
+    // which need access to the in-progress state on disk). `--force` is
+    // threaded down to the repo apply layer as the explicit opt-in to discard
+    // local worktree changes during the fast-forward materialization.
     if !force && !abort && !cont {
         ensure_worktree_clean(&repo, "rebase")?;
     }
 
-    run_rebase(&repo, thread, abort, cont, Some(cli))
+    run_rebase(&repo, thread, abort, cont, force, Some(cli))
 }
 
 pub(crate) fn cmd_rebase_silent(
@@ -87,7 +86,7 @@ pub(crate) fn cmd_rebase_silent(
     abort: bool,
     cont: bool,
 ) -> Result<()> {
-    run_rebase(repo, thread, abort, cont, None)
+    run_rebase(repo, thread, abort, cont, false, None)
 }
 
 pub(crate) fn continue_rebase_for_operator(repo: &Repository) -> Result<OperatorContinueStatus> {
@@ -146,6 +145,7 @@ fn run_rebase(
     thread: Option<&str>,
     abort: bool,
     cont: bool,
+    discard_local_changes: bool,
     cli: Option<&Cli>,
 ) -> Result<()> {
     let rebase_state_path = repo.heddle_dir().join(REBASE_STATE_FILE);
@@ -189,7 +189,12 @@ fn run_rebase(
         // Wrap the single-FF arm in the same TransactionCommit-bracketed
         // batch shape replay_commits uses, so `heddle undo` treats this
         // path identically to a multi-commit rebase (heddle#198).
-        let advance = ff_advance_deferred(repo, target_thread, &target_change_id)?;
+        let advance = ff_advance_deferred(
+            repo,
+            target_thread,
+            &target_change_id,
+            discard_local_changes,
+        )?;
         flush_rebase_batch(repo, &[advance], &mint_rebase_transaction_id())?;
 
         if let Some(cli) = cli
@@ -253,7 +258,7 @@ fn run_rebase(
     }
 
     if let Some(cli) = cli {
-        replay_commits(repo, &rebase_state_path, cli)
+        replay_commits(repo, &rebase_state_path, cli, discard_local_changes)
     } else {
         replay_commits_silent(repo, &rebase_state_path)
     }
@@ -359,7 +364,7 @@ fn handle_abort(
     // REBASE_STATE (malformed pending_advance entry) still lets the
     // operator rewind via --abort; only `original_head` is required.
     let state = load_rebase_state_for_abort(rebase_state_path)?;
-    repo.goto_without_record(&state.original_head)?;
+    repo.goto_without_record_discard_local(&state.original_head)?;
 
     fs::remove_file(rebase_state_path)?;
 
@@ -384,7 +389,7 @@ fn handle_continue(
     }
 
     if let Some(cli) = cli {
-        replay_commits(repo, rebase_state_path, cli)
+        replay_commits(repo, rebase_state_path, cli, false)
     } else {
         replay_commits_silent(repo, rebase_state_path)
     }

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -699,6 +699,10 @@ fn apply_changes_to_tree(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use objects::object::ThreadName;
+    use refs::Head;
     use tempfile::TempDir;
 
     use super::*;
@@ -737,6 +741,99 @@ mod tests {
             prev_head: Some(objects::object::ChangeId::generate()),
             head: target,
         }
+    }
+
+    fn rebase_replay_fixture() -> (TempDir, Repository, ChangeId) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+        let base = repo
+            .snapshot(Some("base".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        fs::write(temp.path().join("feature.txt"), "feature\n").unwrap();
+        let feature = repo
+            .snapshot(Some("feature".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&base).unwrap();
+        fs::write(temp.path().join("main.txt"), "main\n").unwrap();
+        let main = repo
+            .snapshot(Some("main".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&feature).unwrap();
+        let feature_thread = ThreadName::new("feature");
+        repo.refs().set_thread(&feature_thread, &feature).unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: feature_thread,
+            })
+            .unwrap();
+
+        let rebase_state = super::super::rebase_state::RebaseState {
+            onto: main,
+            commits_to_replay: vec![feature],
+            current_index: 0,
+            original_head: feature,
+            pending_manual_resolution: None,
+            pre_conflict_head: None,
+            pending_advances: Vec::new(),
+            transaction_id: "rebase-dirty-routing-test".to_string(),
+        };
+        save_rebase_state(&repo.heddle_dir().join("REBASE_STATE"), &rebase_state).unwrap();
+
+        (temp, repo, main)
+    }
+
+    #[test]
+    fn replay_commits_refuses_dirty_worktree_without_discard_opt_in() {
+        let (temp, repo, _main) = rebase_replay_fixture();
+        let tracked = temp.path().join("feature.txt");
+        fs::write(&tracked, "local edit\n").unwrap();
+
+        let err =
+            replay_commits_internal(&repo, &repo.heddle_dir().join("REBASE_STATE"), None, false)
+                .unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("dirty worktree") && msg.contains("feature.txt"),
+            "dirty replay should refuse and name the at-risk edit: {msg}"
+        );
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "local edit\n");
+        assert!(
+            repo.heddle_dir().join("REBASE_STATE").exists(),
+            "failed replay must leave rebase state for retry or abort"
+        );
+    }
+
+    #[test]
+    fn replay_commits_with_discard_opt_in_overwrites_dirty_worktree() {
+        let (temp, repo, _main) = rebase_replay_fixture();
+        fs::write(temp.path().join("feature.txt"), "local edit\n").unwrap();
+        fs::write(temp.path().join("scratch.txt"), "scratch\n").unwrap();
+
+        replay_commits_internal(&repo, &repo.heddle_dir().join("REBASE_STATE"), None, true)
+            .unwrap();
+
+        assert!(!temp.path().join("scratch.txt").exists());
+        assert_eq!(
+            fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+            "feature\n"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("main.txt")).unwrap(),
+            "main\n"
+        );
+        assert!(
+            !repo.heddle_dir().join("REBASE_STATE").exists(),
+            "successful replay should remove rebase state"
+        );
     }
 
     /// heddle#198 r2 (Codex PR #218 P2): `flush_rebase_batch` must be

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -35,21 +35,23 @@ pub(super) fn replay_commits(
     repo: &Repository,
     rebase_state_path: &std::path::Path,
     cli: &Cli,
+    discard_local_changes: bool,
 ) -> Result<()> {
-    replay_commits_internal(repo, rebase_state_path, Some(cli))
+    replay_commits_internal(repo, rebase_state_path, Some(cli), discard_local_changes)
 }
 
 pub(super) fn replay_commits_silent(
     repo: &Repository,
     rebase_state_path: &std::path::Path,
 ) -> Result<()> {
-    replay_commits_internal(repo, rebase_state_path, None)
+    replay_commits_internal(repo, rebase_state_path, None, false)
 }
 
 fn replay_commits_internal(
     repo: &Repository,
     rebase_state_path: &std::path::Path,
     cli: Option<&Cli>,
+    discard_local_changes: bool,
 ) -> Result<()> {
     let mut state = load_rebase_state(rebase_state_path)?;
     resume_manual_resolution_if_present(repo, &mut state, rebase_state_path, cli)?;
@@ -90,7 +92,12 @@ fn replay_commits_internal(
             println!("Applying {}...", commit_id.short());
         }
 
-        let result = apply_commit(repo, &commit_state, &current_head)?;
+        let result = apply_commit(
+            repo,
+            &commit_state,
+            &current_head,
+            discard_local_changes,
+        )?;
 
         match result {
             ApplyResult::Success { new_head, advance } => {
@@ -312,6 +319,7 @@ fn apply_commit(
     repo: &Repository,
     commit_state: &objects::object::State,
     current_head: &ChangeId,
+    discard_local_changes: bool,
 ) -> Result<ApplyResult> {
     let current_tree_hash = get_tree_for_state(repo, current_head)?;
     let commit_tree_hash = commit_state.tree;
@@ -339,7 +347,13 @@ fn apply_commit(
     let parent_tree_hash = if let Some(parent_id) = commit_state.parents.first() {
         get_tree_for_state(repo, parent_id)?
     } else {
-        return apply_tree_to_worktree(repo, commit_state, &commit_tree, current_head);
+        return apply_tree_to_worktree(
+            repo,
+            commit_state,
+            &commit_tree,
+            current_head,
+            discard_local_changes,
+        );
     };
 
     let parent_tree = repo
@@ -434,7 +448,12 @@ fn apply_commit(
 
     let new_state_id = new_state.change_id;
     repo.store().put_state(&new_state)?;
-    let advance = ff_advance_deferred(repo, REBASE_REPLAY_SOURCE, &new_state_id)?;
+    let advance = ff_advance_deferred(
+        repo,
+        REBASE_REPLAY_SOURCE,
+        &new_state_id,
+        discard_local_changes,
+    )?;
 
     Ok(ApplyResult::Success {
         new_head: new_state_id,
@@ -525,6 +544,7 @@ fn apply_tree_to_worktree(
     commit_state: &objects::object::State,
     tree: &objects::object::Tree,
     current_head: &ChangeId,
+    discard_local_changes: bool,
 ) -> Result<ApplyResult> {
     let tree_hash = repo.store().put_tree(tree)?;
     let new_state = State::new_refresh_of(
@@ -544,7 +564,12 @@ fn apply_tree_to_worktree(
 
     let new_state_id = new_state.change_id;
     repo.store().put_state(&new_state)?;
-    let advance = ff_advance_deferred(repo, REBASE_REPLAY_SOURCE, &new_state_id)?;
+    let advance = ff_advance_deferred(
+        repo,
+        REBASE_REPLAY_SOURCE,
+        &new_state_id,
+        discard_local_changes,
+    )?;
 
     Ok(ApplyResult::Success {
         new_head: new_state_id,

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -396,44 +396,38 @@ async fn pull_local(
     let track_to_update = local_thread.unwrap_or(remote_thread);
     let track_tn = ThreadName::new(track_to_update);
 
-    // Capture the local thread's pre-pull tip *before* mutating it
-    // (heddle#110). The materializing branch records an
-    // `OpRecord::FastForwardV2` whose `pre_target_id` must be the
-    // pre-pull state so undo restores both HEAD and the local thread
-    // ref. Reading the ref after `set_thread` would return the
-    // post-pull state and silently strand the thread on undo —
-    // exactly the bug we're closing.
     let pre_target = repo.refs().get_thread(&track_tn)?;
     let changed = pre_target.as_ref() != Some(&state_id) || objects_copied > 0;
-    repo.refs().set_thread(&track_tn, &state_id)?;
 
     // Preserve attached-HEAD semantics only when the pull target is the
     // current checkout. Pulling a remote into a side thread must not move
     // the operator's active thread or overwrite its worktree.
-    let should_materialize = match repo.head_ref()? {
+    let head_ref = repo.head_ref()?;
+    let should_materialize = match &head_ref {
         Head::Attached { thread } => thread == track_to_update,
         Head::Detached { .. } => local_thread.is_none(),
     };
     if should_materialize {
-        // First-time pull of this thread has no pre_target_id; the
-        // `set_thread` above effectively created the ref. Fall back to
-        // recording the generic `Goto` inverse — there's no pre-FF tip
-        // to restore on undo, only HEAD to rewind. Repeat pulls flow
-        // through the `FastForwardV2` arm so undo restores the local
-        // thread ref alongside HEAD.
-        match pre_target {
-            Some(pre) => {
-                super::super::ff_record::record_ff_advance_explicit(
-                    repo,
-                    remote_thread,
-                    &pre,
-                    &state_id,
-                )?;
+        // A dirty-refusal must NEVER leave a ref advanced without its
+        // corresponding worktree materialization. Run the refuse-able
+        // apply before publishing `track_tn`; `fast_forward_attached*`
+        // publishes the attached current thread only after the worktree
+        // apply succeeds, and the detached arm publishes `track_tn`
+        // explicitly below after the same guard has passed.
+        match (&head_ref, pre_target) {
+            (Head::Attached { .. }, Some(_)) => {
+                super::super::ff_record::record_ff_advance(repo, remote_thread, &state_id)?;
             }
-            None => {
+            (Head::Attached { .. }, None) => {
                 repo.fast_forward_attached_from_materialized_state(&state_id, None)?;
             }
+            (Head::Detached { .. }, _) => {
+                repo.goto(&state_id)?;
+                repo.refs().set_thread(&track_tn, &state_id)?;
+            }
         }
+    } else {
+        repo.refs().set_thread(&track_tn, &state_id)?;
     }
 
     if should_output_json(cli, Some(repo.config())) {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -431,7 +431,7 @@ async fn pull_local(
                 )?;
             }
             None => {
-                repo.fast_forward_attached(&state_id)?;
+                repo.fast_forward_attached_discard_local(&state_id)?;
             }
         }
     }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -431,7 +431,7 @@ async fn pull_local(
                 )?;
             }
             None => {
-                repo.fast_forward_attached_discard_local(&state_id)?;
+                repo.fast_forward_attached_from_materialized_state(&state_id, None)?;
             }
         }
     }

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -97,7 +97,7 @@ pub(crate) fn abort_merge_state(
     // that *does* move HEAD before aborting (e.g. a partial-apply
     // shape) would then get correct undo semantics for free without
     // a second migration.
-    super::ff_record::record_ff_advance(repo, "<abort>", &merge_state.ours)?;
+    super::ff_record::record_ff_advance_discard_local(repo, "<abort>", &merge_state.ours)?;
     merge_manager.abort()?;
     Ok(())
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2687,7 +2687,11 @@ pub(crate) fn cmd_thread_switch(
         // CWD and reattach HEAD to the thread. Intentional raw `goto`:
         // `fast_forward_attached` would re-attach to the previously
         // attached thread, which is the wrong behavior here.
-        repo.goto(&state)?;
+        if force {
+            repo.goto_discard_local(&state)?;
+        } else {
+            repo.goto(&state)?;
+        }
         repo.refs().write_head(&Head::Attached {
             thread: ThreadName::new(&name),
         })?;

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -530,7 +530,7 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
 fn restore_refresh_rebase_abort(repo: &Repository, rebase_state_path: &Path) -> Result<()> {
     let rebase_state = super::rebase::load_persisted_rebase_state(rebase_state_path)?;
     let head_before = repo.head_ref()?;
-    repo.goto_without_record(&rebase_state.original_head)?;
+    repo.goto_without_record_discard_local(&rebase_state.original_head)?;
     if let Head::Attached { thread } = head_before {
         repo.refs()
             .set_thread(&thread, &rebase_state.original_head)?;

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -220,7 +220,7 @@ fn fault_counter_trips(
 /// the worktree (if a state was captured), then restore the exact `Head` ref.
 fn restore_head(repo: &Repository, state: Option<ChangeId>, head_ref: &Head) -> HeddleResult<()> {
     if let Some(state) = state {
-        repo.goto_without_record(&state)?;
+        repo.goto_without_record_discard_local(&state)?;
     }
     repo.refs().write_head(head_ref)
 }
@@ -297,7 +297,7 @@ impl<'a> EntrySteps<'_, 'a> {
         self.step_nonatomic(
             move || Ok((repo.head()?, repo.head_ref()?)),
             move |(prev_state, prev_head_ref)| restore_head(repo, prev_state, &prev_head_ref),
-            move || repo.goto_without_record(&target),
+            move || repo.goto_without_record_discard_local(&target),
         )
     }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -374,6 +374,76 @@ fn test_cli_pull_local_updates_requested_track() {
 }
 
 #[test]
+fn test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged() {
+    let source = TempDir::new().unwrap();
+    let target_parent = TempDir::new().unwrap();
+    let target_path = target_parent.path().join("target");
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("shared.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "Base state"], Some(source.path())).unwrap();
+
+    let source_path = source.path().to_str().unwrap().to_string();
+    let target_path_arg = target_path.to_str().unwrap().to_string();
+    heddle(&["clone", &source_path, &target_path_arg], None).unwrap();
+
+    let target_repo = Repository::open(&target_path).unwrap();
+    let pre_pull_ref = target_repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .unwrap()
+        .expect("cloned main ref exists");
+
+    std::fs::write(source.path().join("shared.txt"), "remote\n").unwrap();
+    heddle(&["capture", "-m", "Remote state"], Some(source.path())).unwrap();
+    std::fs::write(target_path.join("shared.txt"), "local dirty\n").unwrap();
+
+    let pull = heddle_output(
+        &["--output", "json", "pull", &source_path],
+        Some(&target_path),
+    )
+    .expect("invoke dirty local pull");
+    assert!(
+        !pull.status.success(),
+        "dirty local pull should refuse before publishing the ref"
+    );
+    assert!(
+        pull.stdout.is_empty(),
+        "JSON refusal should keep stdout quiet: {}",
+        String::from_utf8_lossy(&pull.stdout)
+    );
+
+    let target_repo = Repository::open(&target_path).unwrap();
+    assert_eq!(
+        target_repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap(),
+        Some(pre_pull_ref),
+        "dirty pull refusal must leave main at the pre-pull state"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target_path.join("shared.txt")).unwrap(),
+        "local dirty\n",
+        "dirty pull refusal must preserve the user's edit"
+    );
+
+    let status_json =
+        heddle(&["--output", "json", "status"], Some(&target_path)).expect("status succeeds");
+    let status: Value = serde_json::from_str(&status_json).expect("status JSON parses");
+    assert_eq!(
+        status["state"]["change_id"],
+        pre_pull_ref.to_string(),
+        "status must continue attributing the dirty file against the pre-pull state: {status_json}"
+    );
+    assert_eq!(
+        status["changes"]["modified"],
+        serde_json::json!(["shared.txt"]),
+        "dirty edit should remain attributed to the pulled clone's original baseline: {status_json}"
+    );
+}
+
+#[test]
 fn test_cli_clone_help_hides_planned_lazy_flag() {
     let output = heddle(&["clone", "--help"], None).unwrap();
     assert!(

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -28,6 +28,25 @@ fn verify_json(cwd: &std::path::Path) -> Value {
     envelope["verification"].clone()
 }
 
+fn current_thread_state(cwd: &std::path::Path, thread: &str) -> String {
+    let repo = Repository::open(cwd).expect("open repository");
+    repo.refs()
+        .get_thread(&ThreadName::new(thread))
+        .expect("read thread ref")
+        .unwrap_or_else(|| panic!("{thread} should have a current state"))
+        .to_string()
+}
+
+fn log_head_state(cwd: &std::path::Path) -> String {
+    let log_json =
+        heddle(&["--output", "json", "log", "--limit", "1"], Some(cwd)).expect("log current state");
+    let log: Value = serde_json::from_str(&log_json).expect("log JSON parses");
+    log["states"][0]["change_id"]
+        .as_str()
+        .expect("log entry has change_id")
+        .to_string()
+}
+
 /// Mutation `--output json` replies no longer embed `verification`
 /// (the verification-claim gate still consults it in-memory, but it
 /// is omitted from the wire to keep mutation replies focused).
@@ -449,6 +468,169 @@ fn test_cli_clone_help_hides_planned_lazy_flag() {
     assert!(
         !output.contains("--lazy") && !output.contains("--filter"),
         "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
+    );
+}
+
+#[test]
+fn test_cli_pull_local_side_thread_updates_ref_without_materializing_checkout() {
+    let source = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("source.txt"), "from source\n").unwrap();
+    heddle(&["capture", "-m", "Source state"], Some(source.path())).unwrap();
+
+    heddle(&["init"], Some(target.path())).unwrap();
+    std::fs::write(target.path().join("target.txt"), "from target\n").unwrap();
+    heddle(&["capture", "-m", "Target state"], Some(target.path())).unwrap();
+    let main_before = current_thread_state(target.path(), "main");
+
+    let source_path = source.path().to_str().unwrap().to_string();
+    let pull_json = heddle(
+        &[
+            "--output",
+            "json",
+            "pull",
+            &source_path,
+            "--thread",
+            "main",
+            "--local-thread",
+            "imported",
+        ],
+        Some(target.path()),
+    )
+    .expect("side-thread pull succeeds");
+    let pull: Value = serde_json::from_str(&pull_json).expect("pull JSON parses");
+    assert_eq!(pull["thread"], "imported", "{pull}");
+
+    assert_eq!(
+        current_thread_state(target.path(), "main"),
+        main_before,
+        "side-thread pull must not advance the active main thread"
+    );
+    assert!(
+        !target.path().join("source.txt").exists(),
+        "side-thread pull must not materialize remote files into the active checkout"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target.path().join("target.txt")).unwrap(),
+        "from target\n",
+        "side-thread pull must leave active checkout content untouched"
+    );
+
+    heddle(&["thread", "switch", "imported"], Some(target.path()))
+        .expect("imported thread should be switchable after direct ref update");
+    assert_eq!(
+        std::fs::read_to_string(target.path().join("source.txt")).unwrap(),
+        "from source\n"
+    );
+}
+
+#[test]
+fn test_cli_pull_local_clean_active_checkout_materializes_before_publish() {
+    let source = TempDir::new().unwrap();
+    let target_parent = TempDir::new().unwrap();
+    let target_path = target_parent.path().join("target");
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("shared.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "Base state"], Some(source.path())).unwrap();
+
+    let source_path = source.path().to_str().unwrap().to_string();
+    let target_path_arg = target_path.to_str().unwrap().to_string();
+    heddle(&["clone", &source_path, &target_path_arg], None).unwrap();
+    let pre_pull_ref = current_thread_state(&target_path, "main");
+
+    std::fs::write(source.path().join("shared.txt"), "remote\n").unwrap();
+    heddle(&["capture", "-m", "Remote state"], Some(source.path())).unwrap();
+    let source_main = current_thread_state(source.path(), "main");
+
+    heddle(
+        &["--output", "json", "pull", &source_path],
+        Some(&target_path),
+    )
+    .expect("clean active-checkout pull succeeds");
+
+    assert_eq!(
+        current_thread_state(&target_path, "main"),
+        source_main,
+        "clean pull should publish main after materializing the worktree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target_path.join("shared.txt")).unwrap(),
+        "remote\n",
+        "clean pull should materialize the pulled content"
+    );
+    let status_json =
+        heddle(&["--output", "json", "status"], Some(&target_path)).expect("status JSON");
+    let status: Value = serde_json::from_str(&status_json).expect("status JSON parses");
+    assert_eq!(status["thread"], "main", "{status_json}");
+
+    heddle(&["undo"], Some(&target_path)).expect("pull fast-forward should be undoable");
+    assert_eq!(
+        current_thread_state(&target_path, "main"),
+        pre_pull_ref,
+        "undo should restore the pre-pull main ref recorded before publication"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target_path.join("shared.txt")).unwrap(),
+        "base\n",
+        "undo should restore the pre-pull materialized checkout"
+    );
+}
+
+#[test]
+fn test_cli_pull_local_detached_head_materializes_then_publishes_thread() {
+    let source = TempDir::new().unwrap();
+    let target_parent = TempDir::new().unwrap();
+    let target_path = target_parent.path().join("target");
+
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("shared.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "Base state"], Some(source.path())).unwrap();
+
+    let source_path = source.path().to_str().unwrap().to_string();
+    let target_path_arg = target_path.to_str().unwrap().to_string();
+    heddle(&["clone", &source_path, &target_path_arg], None).unwrap();
+    let base_state = current_thread_state(&target_path, "main");
+    heddle(&["goto", &base_state], Some(&target_path)).expect("detach target HEAD");
+    let head_before = std::fs::read_to_string(target_path.join(".heddle").join("HEAD"))
+        .expect("read detached HEAD");
+    assert!(
+        !head_before.trim().starts_with("ref:"),
+        "test setup should leave HEAD detached: {head_before}"
+    );
+
+    std::fs::write(source.path().join("shared.txt"), "remote\n").unwrap();
+    heddle(&["capture", "-m", "Remote state"], Some(source.path())).unwrap();
+    let source_main = current_thread_state(source.path(), "main");
+
+    heddle(
+        &["--output", "json", "pull", &source_path],
+        Some(&target_path),
+    )
+    .expect("detached local pull succeeds");
+
+    assert_eq!(
+        current_thread_state(&target_path, "main"),
+        source_main,
+        "detached pull should publish the local thread after materializing"
+    );
+    assert_eq!(
+        log_head_state(&target_path),
+        source_main,
+        "detached pull should move detached HEAD to the pulled state"
+    );
+    let head_after = std::fs::read_to_string(target_path.join(".heddle").join("HEAD"))
+        .expect("read detached HEAD after pull");
+    assert!(
+        !head_after.trim().starts_with("ref:"),
+        "detached pull should not attach HEAD to the published thread: {head_after}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target_path.join("shared.txt")).unwrap(),
+        "remote\n",
+        "detached pull should materialize the pulled content"
     );
 }
 

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -1779,6 +1779,64 @@ mod rebase {
             "HEAD must remain attached to the parent thread after fast-forward rebase"
         );
     }
+
+    #[test]
+    fn test_rebase_refuses_dirty_worktree_unless_force_discards_it() {
+        let temp = TempDir::new().unwrap();
+        heddle(&["init"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+        heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "create", "feature"], Some(temp.path())).unwrap();
+        heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("feature.txt"), "feature\n").unwrap();
+        heddle(&["capture", "-m", "Feature"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("main.txt"), "main\n").unwrap();
+        heddle(&["capture", "-m", "Main"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("feature.txt"), "unsnapped feature edit\n").unwrap();
+        fs::write(temp.path().join("scratch.txt"), "local only\n").unwrap();
+
+        let err = heddle(&["rebase", "main"], Some(temp.path()))
+            .expect_err("dirty rebase should refuse without --force");
+        assert!(
+            err.contains("rebase") && err.contains("unsaved") || err.contains("dirty"),
+            "dirty rebase refusal should explain the safety gate: {err}"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+            "unsnapped feature edit\n"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("scratch.txt")).unwrap(),
+            "local only\n"
+        );
+
+        let output = heddle(&["rebase", "main", "--force"], Some(temp.path()))
+            .expect("forced rebase should discard local edits and proceed");
+        assert!(
+            output.contains("Rebasing")
+                || output.contains("Rebase completed")
+                || output.contains("\"status\": \"started\"")
+                || output.contains("\"status\":\"started\""),
+            "forced rebase should run the replay path: {output}"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+            "feature\n"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("main.txt")).unwrap(),
+            "main\n"
+        );
+        assert!(
+            !temp.path().join("scratch.txt").exists(),
+            "--force must discard untracked local work during rebase materialization"
+        );
+    }
 }
 
 mod hooks {

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -17,6 +17,12 @@ use super::{
 };
 use crate::{thread_model::ThreadFreshness, thread_storage::ThreadManager};
 
+#[derive(Debug, Clone, Copy)]
+enum WorktreeBaseline {
+    Head,
+    Materialized(Option<ChangeId>),
+}
+
 impl Repository {
     /// Move worktree to a different state.
     pub fn goto(&self, target: &ChangeId) -> Result<()> {
@@ -25,6 +31,7 @@ impl Repository {
             true,
             false,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -35,6 +42,27 @@ impl Repository {
             true,
             false,
             WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+            WorktreeBaseline::Head,
+        )
+    }
+
+    /// Move worktree to `target` using the state that the worktree currently
+    /// represents as the dirty-check and incremental-apply baseline.
+    ///
+    /// This is for callers that must publish or import refs before they can
+    /// materialize the checkout. In those flows HEAD may already resolve to
+    /// `target`, even though the files on disk still represent `materialized`.
+    pub fn goto_from_materialized_state(
+        &self,
+        target: &ChangeId,
+        materialized: Option<&ChangeId>,
+    ) -> Result<()> {
+        self.goto_internal(
+            target,
+            true,
+            false,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Materialized(materialized.copied()),
         )
     }
 
@@ -51,7 +79,12 @@ impl Repository {
     /// pre-op state — this helper preserves attached-HEAD semantics so the
     /// thread's ref and metadata advance with the worktree.
     pub fn fast_forward_attached(&self, target: &ChangeId) -> Result<()> {
-        self.fast_forward_attached_internal(target, true, WorktreeApplyDirtyBehavior::RefuseOnDirty)
+        self.fast_forward_attached_internal(
+            target,
+            true,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
+        )
     }
 
     pub fn fast_forward_attached_discard_local(&self, target: &ChangeId) -> Result<()> {
@@ -59,6 +92,20 @@ impl Repository {
             target,
             true,
             WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+            WorktreeBaseline::Head,
+        )
+    }
+
+    pub fn fast_forward_attached_from_materialized_state(
+        &self,
+        target: &ChangeId,
+        materialized: Option<&ChangeId>,
+    ) -> Result<()> {
+        self.fast_forward_attached_internal(
+            target,
+            true,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Materialized(materialized.copied()),
         )
     }
 
@@ -75,6 +122,7 @@ impl Repository {
             target,
             false,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -86,6 +134,20 @@ impl Repository {
             target,
             false,
             WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+            WorktreeBaseline::Head,
+        )
+    }
+
+    pub fn fast_forward_attached_from_materialized_state_without_record(
+        &self,
+        target: &ChangeId,
+        materialized: Option<&ChangeId>,
+    ) -> Result<()> {
+        self.fast_forward_attached_internal(
+            target,
+            false,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Materialized(materialized.copied()),
         )
     }
 
@@ -94,12 +156,13 @@ impl Repository {
         target: &ChangeId,
         record: bool,
         dirty_behavior: WorktreeApplyDirtyBehavior,
+        baseline: WorktreeBaseline,
     ) -> Result<()> {
         let head_before = self.refs.read_head()?;
         if record {
-            self.goto_internal(target, true, false, dirty_behavior)?;
+            self.goto_internal(target, true, false, dirty_behavior, baseline)?;
         } else {
-            self.goto_internal(target, false, false, dirty_behavior)?;
+            self.goto_internal(target, false, false, dirty_behavior, baseline)?;
         }
         if let Head::Attached {
             thread: current_thread,
@@ -126,6 +189,7 @@ impl Repository {
             true,
             true,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -135,6 +199,7 @@ impl Repository {
             false,
             true,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -144,6 +209,7 @@ impl Repository {
             false,
             false,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -153,6 +219,7 @@ impl Repository {
             false,
             false,
             WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+            WorktreeBaseline::Head,
         )
     }
 
@@ -162,6 +229,7 @@ impl Repository {
         record: bool,
         current_worktree_verified_clean: bool,
         dirty_behavior: WorktreeApplyDirtyBehavior,
+        baseline: WorktreeBaseline,
     ) -> Result<()> {
         let total_start = Instant::now();
         let _lock = self
@@ -175,12 +243,17 @@ impl Repository {
             .ok_or(HeddleError::StateNotFound(*target))?;
 
         let prev_head_ref = self.refs.read_head()?;
-        let (prev_head, current_state) = match &prev_head_ref {
+        let (prev_head, head_state) = match &prev_head_ref {
             Head::Attached { thread } => match self.refs.get_thread(thread)? {
                 Some(change_id) => (Some(change_id), self.store.get_state(&change_id)?),
                 None => (None, None),
             },
             Head::Detached { state } => (Some(*state), self.store.get_state(state)?),
+        };
+        let current_state = match baseline {
+            WorktreeBaseline::Head => head_state,
+            WorktreeBaseline::Materialized(Some(change_id)) => self.store.get_state(&change_id)?,
+            WorktreeBaseline::Materialized(None) => None,
         };
         let same_state_verified_clean = current_worktree_verified_clean
             && current_state

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -338,3 +338,135 @@ impl Repository {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use objects::object::ThreadName;
+    use refs::Head;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn create_repo() -> (TempDir, Repository) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        (temp, repo)
+    }
+
+    fn write_snapshot(
+        repo: &Repository,
+        root: &std::path::Path,
+        path: &str,
+        content: &str,
+    ) -> ChangeId {
+        fs::write(root.join(path), content).unwrap();
+        repo.snapshot(Some(path.to_string()), None)
+            .unwrap()
+            .change_id
+    }
+
+    #[test]
+    fn goto_from_unknown_materialized_state_full_rematerializes_clean_checkout() {
+        let (temp, repo) = create_repo();
+        let target = write_snapshot(&repo, temp.path(), "target.txt", "target\n");
+        repo.clear_worktree().unwrap();
+
+        repo.goto_from_materialized_state(&target, None).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(temp.path().join("target.txt")).unwrap(),
+            "target\n"
+        );
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Detached { state } if state == target
+        ));
+    }
+
+    #[test]
+    fn goto_from_materialized_pre_target_uses_disk_baseline_when_head_already_moved() {
+        let (temp, repo) = create_repo();
+        let file = temp.path().join("tracked.txt");
+        let pre_target = write_snapshot(&repo, temp.path(), "tracked.txt", "before\n");
+        fs::write(&file, "after\n").unwrap();
+        fs::write(temp.path().join("added.txt"), "added\n").unwrap();
+        let target = repo
+            .snapshot(Some("target".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&pre_target).unwrap();
+        repo.refs()
+            .write_head(&Head::Detached { state: target })
+            .unwrap();
+
+        repo.goto_from_materialized_state(&target, Some(&pre_target))
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(&file).unwrap(), "after\n");
+        assert_eq!(
+            fs::read_to_string(temp.path().join("added.txt")).unwrap(),
+            "added\n"
+        );
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Detached { state } if state == target
+        ));
+    }
+
+    #[test]
+    fn discard_local_goto_variants_overwrite_unsnapped_edits() {
+        let (temp, repo) = create_repo();
+        let tracked = temp.path().join("tracked.txt");
+        let base = write_snapshot(&repo, temp.path(), "tracked.txt", "base\n");
+        fs::write(&tracked, "target\n").unwrap();
+        let target = repo
+            .snapshot(Some("target".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&base).unwrap();
+        fs::write(&tracked, "local edit\n").unwrap();
+        fs::write(temp.path().join("local.txt"), "local only\n").unwrap();
+
+        repo.goto_without_record_discard_local(&target).unwrap();
+
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "target\n");
+        assert!(!temp.path().join("local.txt").exists());
+    }
+
+    #[test]
+    fn attached_fast_forward_from_materialized_state_advances_thread_without_detaching() {
+        let (temp, repo) = create_repo();
+        let base = write_snapshot(&repo, temp.path(), "base.txt", "base\n");
+        fs::write(temp.path().join("next.txt"), "next\n").unwrap();
+        let target = repo
+            .snapshot(Some("target".to_string()), None)
+            .unwrap()
+            .change_id;
+
+        repo.goto(&base).unwrap();
+        let thread = ThreadName::new("main");
+        repo.refs().set_thread(&thread, &target).unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: thread.clone(),
+            })
+            .unwrap();
+
+        repo.fast_forward_attached_from_materialized_state(&target, Some(&base))
+            .unwrap();
+
+        assert_eq!(repo.refs().get_thread(&thread).unwrap(), Some(target));
+        assert!(matches!(
+            repo.refs().read_head().unwrap(),
+            Head::Attached { thread: current } if current == thread
+        ));
+        assert_eq!(
+            fs::read_to_string(temp.path().join("next.txt")).unwrap(),
+            "next\n"
+        );
+    }
+}

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -11,7 +11,8 @@ use tracing::debug;
 use super::{
     HeddleError, Repository, Result,
     repository_worktree_apply::{
-        WorktreeApplyPlan, WorktreeApplyReport, WorktreeApplyStats, WorktreeApplyStrategy,
+        WorktreeApplyDirtyBehavior, WorktreeApplyPlan, WorktreeApplyReport, WorktreeApplyStats,
+        WorktreeApplyStrategy,
     },
 };
 use crate::{thread_model::ThreadFreshness, thread_storage::ThreadManager};
@@ -19,7 +20,22 @@ use crate::{thread_model::ThreadFreshness, thread_storage::ThreadManager};
 impl Repository {
     /// Move worktree to a different state.
     pub fn goto(&self, target: &ChangeId) -> Result<()> {
-        self.goto_internal(target, true, false)
+        self.goto_internal(
+            target,
+            true,
+            false,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        )
+    }
+
+    /// Move worktree to a different state, discarding unsnapped local edits.
+    pub fn goto_discard_local(&self, target: &ChangeId) -> Result<()> {
+        self.goto_internal(
+            target,
+            true,
+            false,
+            WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+        )
     }
 
     /// Fast-forward the current checkout to `target`.
@@ -35,7 +51,15 @@ impl Repository {
     /// pre-op state — this helper preserves attached-HEAD semantics so the
     /// thread's ref and metadata advance with the worktree.
     pub fn fast_forward_attached(&self, target: &ChangeId) -> Result<()> {
-        self.fast_forward_attached_internal(target, true)
+        self.fast_forward_attached_internal(target, true, WorktreeApplyDirtyBehavior::RefuseOnDirty)
+    }
+
+    pub fn fast_forward_attached_discard_local(&self, target: &ChangeId) -> Result<()> {
+        self.fast_forward_attached_internal(
+            target,
+            true,
+            WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+        )
     }
 
     /// Variant of [`Self::fast_forward_attached`] that performs the
@@ -47,15 +71,35 @@ impl Repository {
     /// merged-into thread ref (heddle#99 r1); a name-resolved redo was
     /// also non-deterministic if the source thread moved (heddle#99 r2).
     pub fn fast_forward_attached_without_record(&self, target: &ChangeId) -> Result<()> {
-        self.fast_forward_attached_internal(target, false)
+        self.fast_forward_attached_internal(
+            target,
+            false,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        )
     }
 
-    fn fast_forward_attached_internal(&self, target: &ChangeId, record: bool) -> Result<()> {
+    pub fn fast_forward_attached_without_record_discard_local(
+        &self,
+        target: &ChangeId,
+    ) -> Result<()> {
+        self.fast_forward_attached_internal(
+            target,
+            false,
+            WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+        )
+    }
+
+    fn fast_forward_attached_internal(
+        &self,
+        target: &ChangeId,
+        record: bool,
+        dirty_behavior: WorktreeApplyDirtyBehavior,
+    ) -> Result<()> {
         let head_before = self.refs.read_head()?;
         if record {
-            self.goto(target)?;
+            self.goto_internal(target, true, false, dirty_behavior)?;
         } else {
-            self.goto_without_record(target)?;
+            self.goto_internal(target, false, false, dirty_behavior)?;
         }
         if let Head::Attached {
             thread: current_thread,
@@ -77,15 +121,39 @@ impl Repository {
     }
 
     pub fn goto_verified_clean(&self, target: &ChangeId) -> Result<()> {
-        self.goto_internal(target, true, true)
+        self.goto_internal(
+            target,
+            true,
+            true,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        )
     }
 
     pub fn goto_verified_clean_without_record(&self, target: &ChangeId) -> Result<()> {
-        self.goto_internal(target, false, true)
+        self.goto_internal(
+            target,
+            false,
+            true,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        )
     }
 
     pub fn goto_without_record(&self, target: &ChangeId) -> Result<()> {
-        self.goto_internal(target, false, false)
+        self.goto_internal(
+            target,
+            false,
+            false,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        )
+    }
+
+    pub fn goto_without_record_discard_local(&self, target: &ChangeId) -> Result<()> {
+        self.goto_internal(
+            target,
+            false,
+            false,
+            WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+        )
     }
 
     fn goto_internal(
@@ -93,6 +161,7 @@ impl Repository {
         target: &ChangeId,
         record: bool,
         current_worktree_verified_clean: bool,
+        dirty_behavior: WorktreeApplyDirtyBehavior,
     ) -> Result<()> {
         let total_start = Instant::now();
         let _lock = self
@@ -140,6 +209,7 @@ impl Repository {
                 tree,
                 &self.root,
                 current_worktree_verified_clean,
+                dirty_behavior,
             )?;
             let apply_report = self.execute_worktree_apply(&apply_plan, tree, &self.root)?;
             (apply_plan, apply_report)
@@ -147,6 +217,7 @@ impl Repository {
             (
                 WorktreeApplyPlan {
                     strategy: WorktreeApplyStrategy::Incremental,
+                    dirty_behavior: WorktreeApplyDirtyBehavior::RefuseOnDirty,
                     removals: Vec::new(),
                     directories: Vec::new(),
                     writes: Vec::new(),

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -347,7 +347,7 @@ fn test_goto_clears_non_empty_directories() {
 
     fs::write(temp_dir.path().join("new_file.txt"), "new").unwrap();
 
-    repo.goto(&state1.change_id).unwrap();
+    repo.goto_discard_local(&state1.change_id).unwrap();
 
     assert!(!temp_dir.path().join("new_file.txt").exists());
     assert!(temp_dir.path().join("subdir").exists());

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -43,6 +43,21 @@ impl WorktreeApplyStrategy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorktreeApplyDirtyBehavior {
+    RefuseOnDirty,
+    DiscardLocalChanges,
+}
+
+impl WorktreeApplyDirtyBehavior {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RefuseOnDirty => "refuse_on_dirty",
+            Self::DiscardLocalChanges => "discard_local_changes",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorktreeApplyFallbackReason {
     MissingCurrentTree,
     NonRootDirectory,
@@ -68,6 +83,7 @@ pub(crate) struct WorktreeApplyStats {
 #[derive(Debug)]
 pub(crate) struct WorktreeApplyPlan {
     pub(crate) strategy: WorktreeApplyStrategy,
+    pub(crate) dirty_behavior: WorktreeApplyDirtyBehavior,
     pub(crate) removals: Vec<PathBuf>,
     pub(crate) directories: Vec<PathBuf>,
     pub(crate) writes: Vec<WorktreeWriteOp>,
@@ -98,6 +114,7 @@ impl WorktreeApplyPlan {
     fn incremental() -> Self {
         Self {
             strategy: WorktreeApplyStrategy::Incremental,
+            dirty_behavior: WorktreeApplyDirtyBehavior::RefuseOnDirty,
             removals: Vec::new(),
             directories: Vec::new(),
             writes: Vec::new(),
@@ -106,9 +123,13 @@ impl WorktreeApplyPlan {
         }
     }
 
-    fn fallback(reason: WorktreeApplyFallbackReason) -> Self {
+    fn fallback(
+        reason: WorktreeApplyFallbackReason,
+        dirty_behavior: WorktreeApplyDirtyBehavior,
+    ) -> Self {
         Self {
             strategy: WorktreeApplyStrategy::FullRematerialize,
+            dirty_behavior,
             removals: Vec::new(),
             directories: Vec::new(),
             writes: Vec::new(),
@@ -129,35 +150,54 @@ impl Repository {
         to_tree: &Tree,
         dir: &Path,
         current_worktree_verified_clean: bool,
+        dirty_behavior: WorktreeApplyDirtyBehavior,
     ) -> Result<WorktreeApplyPlan> {
         let plan_start = Instant::now();
         let plan = match from_tree {
-            None => WorktreeApplyPlan::fallback(WorktreeApplyFallbackReason::MissingCurrentTree),
+            None => {
+                self.refuse_full_rematerialize_on_dirty(
+                    dirty_behavior,
+                    WorktreeApplyFallbackReason::MissingCurrentTree,
+                )?;
+                WorktreeApplyPlan::fallback(
+                    WorktreeApplyFallbackReason::MissingCurrentTree,
+                    dirty_behavior,
+                )
+            }
             Some(_) if dir != self.root() => {
-                WorktreeApplyPlan::fallback(WorktreeApplyFallbackReason::NonRootDirectory)
+                self.refuse_full_rematerialize_on_dirty(
+                    dirty_behavior,
+                    WorktreeApplyFallbackReason::NonRootDirectory,
+                )?;
+                WorktreeApplyPlan::fallback(
+                    WorktreeApplyFallbackReason::NonRootDirectory,
+                    dirty_behavior,
+                )
             }
             Some(from_tree) => {
-                // FOOTGUN: when the worktree is dirty we silently fall back to
-                // `FullRematerialize`, which calls `clear_worktree` on the way
-                // out — wiping any tracked-but-unsnapshotted edits and any
-                // untracked files on tracked paths. Callers cannot tell from
-                // the return value whether their tree-apply preserved or
-                // destroyed uncommitted work.
-                //
-                // Defense-in-depth lives at the CLI layer: `goto`, `revert`,
-                // `undo`, `redo`, `cherry-pick`, and `rebase` all refuse on a
-                // dirty worktree (with `--force` to bypass) before reaching
-                // here. The remaining direct callers of `goto_internal` are
-                // either internal (`fast_forward_attached`, rebase replay,
-                // operator continue) or already pass
-                // `current_worktree_verified_clean=true`.
-                //
-                // TODO: surface the strategy choice as an explicit parameter
-                // (e.g. `apply_strategy: AllowDirtyFallback | RefuseOnDirty`)
-                // so library callers cannot accidentally clobber a dirty
-                // worktree. That refactor is out of scope for this change.
-                if !current_worktree_verified_clean && !self.worktree_is_clean_cached(from_tree)? {
-                    WorktreeApplyPlan::fallback(WorktreeApplyFallbackReason::DirtyWorktree)
+                if !current_worktree_verified_clean {
+                    let detailed = self.compare_worktree_cached_detailed(from_tree)?;
+                    if !detailed.is_clean() {
+                        if dirty_behavior == WorktreeApplyDirtyBehavior::RefuseOnDirty {
+                            return Err(full_rematerialize_dirty_refusal_from_status(
+                                WorktreeApplyFallbackReason::DirtyWorktree,
+                                &detailed,
+                            ));
+                        }
+                        WorktreeApplyPlan::fallback(
+                            WorktreeApplyFallbackReason::DirtyWorktree,
+                            dirty_behavior,
+                        )
+                    } else {
+                        let mut plan = WorktreeApplyPlan::incremental();
+                        self.plan_tree_apply_recursive(
+                            Path::new(""),
+                            Some(from_tree),
+                            Some(to_tree),
+                            &mut plan,
+                        )?;
+                        plan
+                    }
                 } else {
                     let mut plan = WorktreeApplyPlan::incremental();
                     self.plan_tree_apply_recursive(
@@ -173,6 +213,7 @@ impl Repository {
 
         debug!(
             strategy = plan.strategy.as_str(),
+            dirty_behavior = plan.dirty_behavior.as_str(),
             changed_count = plan.stats.changed_count,
             unchanged_count = plan.stats.unchanged_count,
             fallback_reason = plan
@@ -197,6 +238,14 @@ impl Repository {
                 self.execute_incremental_worktree_apply(plan, tree)
             }
             WorktreeApplyStrategy::FullRematerialize => {
+                if plan.dirty_behavior == WorktreeApplyDirtyBehavior::RefuseOnDirty {
+                    self.refuse_full_rematerialize_on_dirty(
+                        plan.dirty_behavior,
+                        plan.fallback_reason
+                            .unwrap_or(WorktreeApplyFallbackReason::MissingCurrentTree),
+                    )?;
+                }
+
                 let delete_start = Instant::now();
                 if self.worktree_requires_clear()? {
                     self.clear_worktree()?;
@@ -519,6 +568,46 @@ impl Repository {
             return Ok(true);
         }
         Ok(false)
+    }
+
+    fn refuse_full_rematerialize_on_dirty(
+        &self,
+        dirty_behavior: WorktreeApplyDirtyBehavior,
+        reason: WorktreeApplyFallbackReason,
+    ) -> Result<()> {
+        if dirty_behavior == WorktreeApplyDirtyBehavior::DiscardLocalChanges {
+            return Ok(());
+        }
+        let at_risk_paths = self.full_rematerialize_at_risk_paths()?;
+        if at_risk_paths.is_empty() {
+            return Ok(());
+        }
+        Err(full_rematerialize_dirty_refusal(reason, at_risk_paths))
+    }
+
+    fn full_rematerialize_at_risk_paths(&self) -> Result<Vec<String>> {
+        let patterns = self.ignore_patterns()?;
+        let walker = ignore::WalkBuilder::new(&self.root)
+            .hidden(false)
+            .git_ignore(false)
+            .follow_links(false)
+            .build();
+
+        let mut paths = Vec::new();
+        for entry in walker {
+            let entry = entry.map_err(|e| HeddleError::Io(std::io::Error::other(e.to_string())))?;
+            let path = entry.path();
+            if path == self.root {
+                continue;
+            }
+            let rel_path = path.strip_prefix(&self.root).unwrap_or(path);
+            if should_ignore_path(rel_path, &patterns) {
+                continue;
+            }
+            paths.push(format!("existing: {}", rel_path.display()));
+        }
+        paths.sort();
+        Ok(paths)
     }
 
     fn invalidate_worktree_performance_state(&self) -> Result<()> {
@@ -934,6 +1023,56 @@ fn remove_existing_path(path: &Path) -> Result<()> {
     }
 }
 
+fn full_rematerialize_dirty_refusal_from_status(
+    reason: WorktreeApplyFallbackReason,
+    detailed: &crate::WorktreeStatusDetailed,
+) -> HeddleError {
+    let untracked = detailed.untracked.flatten_paths();
+    let at_risk_paths = detailed
+        .modified
+        .iter()
+        .map(|path| format!("modified: {}", path.display()))
+        .chain(
+            detailed
+                .deleted
+                .iter()
+                .map(|path| format!("deleted: {}", path.display())),
+        )
+        .chain(
+            untracked
+                .iter()
+                .map(|path| format!("untracked: {}", path.display())),
+        )
+        .collect();
+    full_rematerialize_dirty_refusal(reason, at_risk_paths)
+}
+
+fn full_rematerialize_dirty_refusal(
+    reason: WorktreeApplyFallbackReason,
+    at_risk_paths: Vec<String>,
+) -> HeddleError {
+    HeddleError::Conflict(format!(
+        "dirty worktree would be overwritten by full rematerialize ({reason}); unsnapped edits at risk: {paths}. Capture, commit, or stash them first, or rerun with --force to discard local changes.",
+        reason = reason.as_str(),
+        paths = format_at_risk_paths(&at_risk_paths),
+    ))
+}
+
+fn format_at_risk_paths(paths: &[String]) -> String {
+    const LIMIT: usize = 20;
+    let mut rendered = paths
+        .iter()
+        .take(LIMIT)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let remaining = paths.len().saturating_sub(LIMIT);
+    if remaining > 0 {
+        rendered.push_str(&format!(", ... and {remaining} more"));
+    }
+    rendered
+}
+
 /// Legacy ignore-driven walker — backs the deprecated
 /// [`Repository::remove_tracked_descendants`] entrypoint. Walks `dir`
 /// recursively, removing every entry whose worktree-relative path is
@@ -1099,7 +1238,13 @@ mod tests {
         let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
 
         let plan = repo
-            .plan_worktree_apply(Some(&tree), &tree, temp_dir.path(), true)
+            .plan_worktree_apply(
+                Some(&tree),
+                &tree,
+                temp_dir.path(),
+                true,
+                WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            )
             .unwrap();
 
         assert_eq!(plan.strategy, WorktreeApplyStrategy::Incremental);
@@ -1128,7 +1273,13 @@ mod tests {
 
         thread::sleep(Duration::from_millis(20));
         let plan = repo
-            .plan_worktree_apply(Some(&tree_one), &tree_two, temp_dir.path(), true)
+            .plan_worktree_apply(
+                Some(&tree_one),
+                &tree_two,
+                temp_dir.path(),
+                true,
+                WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            )
             .unwrap();
         let report = repo
             .execute_worktree_apply(&plan, &tree_two, temp_dir.path())
@@ -1145,6 +1296,81 @@ mod tests {
     }
 
     #[test]
+    fn full_rematerialize_refuses_dirty_worktree_and_preserves_edits() {
+        let (temp_dir, repo) = create_repo();
+        let tracked = temp_dir.path().join("tracked.txt");
+        let notes = temp_dir.path().join("notes.md");
+
+        fs::write(&tracked, "base\n").unwrap();
+        let state_one = repo.snapshot(Some("one".to_string()), None).unwrap();
+
+        fs::write(&tracked, "target\n").unwrap();
+        fs::write(temp_dir.path().join("target-only.txt"), "target file\n").unwrap();
+        let state_two = repo.snapshot(Some("two".to_string()), None).unwrap();
+
+        repo.goto(&state_one.change_id).unwrap();
+        fs::write(&tracked, "unsnapped edit\n").unwrap();
+        fs::write(&notes, "local notes\n").unwrap();
+
+        let err = repo.goto(&state_two.change_id).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("dirty worktree")
+                && msg.contains("full rematerialize")
+                && msg.contains("modified: tracked.txt")
+                && msg.contains("untracked: notes.md")
+                && msg.contains("--force"),
+            "refusal should name the destructive apply and at-risk edits: {msg}"
+        );
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "unsnapped edit\n");
+        assert_eq!(fs::read_to_string(&notes).unwrap(), "local notes\n");
+        assert!(!temp_dir.path().join("target-only.txt").exists());
+    }
+
+    #[test]
+    fn full_rematerialize_discard_opt_in_proceeds_on_dirty_worktree() {
+        let (temp_dir, repo) = create_repo();
+        let tracked = temp_dir.path().join("tracked.txt");
+        let notes = temp_dir.path().join("notes.md");
+
+        fs::write(&tracked, "base\n").unwrap();
+        let state_one = repo.snapshot(Some("one".to_string()), None).unwrap();
+
+        fs::write(&tracked, "target\n").unwrap();
+        fs::write(temp_dir.path().join("target-only.txt"), "target file\n").unwrap();
+        let state_two = repo.snapshot(Some("two".to_string()), None).unwrap();
+
+        repo.goto(&state_one.change_id).unwrap();
+        fs::write(&tracked, "unsnapped edit\n").unwrap();
+        fs::write(&notes, "local notes\n").unwrap();
+
+        repo.goto_discard_local(&state_two.change_id).unwrap();
+
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "target\n");
+        assert!(!notes.exists());
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("target-only.txt")).unwrap(),
+            "target file\n"
+        );
+    }
+
+    #[test]
+    fn clean_worktree_apply_still_succeeds_by_default() {
+        let (temp_dir, repo) = create_repo();
+        let tracked = temp_dir.path().join("tracked.txt");
+
+        fs::write(&tracked, "base\n").unwrap();
+        let state_one = repo.snapshot(Some("one".to_string()), None).unwrap();
+        fs::write(&tracked, "target\n").unwrap();
+        let state_two = repo.snapshot(Some("two".to_string()), None).unwrap();
+
+        repo.goto(&state_one.change_id).unwrap();
+        repo.goto(&state_two.change_id).unwrap();
+
+        assert_eq!(fs::read_to_string(&tracked).unwrap(), "target\n");
+    }
+
+    #[test]
     fn full_rematerialize_reseeds_worktree_index() {
         let (temp_dir, repo) = create_repo();
         let nested_dir = temp_dir.path().join("src/bin");
@@ -1156,7 +1382,10 @@ mod tests {
 
         repo.clear_worktree().unwrap();
 
-        let plan = WorktreeApplyPlan::fallback(WorktreeApplyFallbackReason::MissingCurrentTree);
+        let plan = WorktreeApplyPlan::fallback(
+            WorktreeApplyFallbackReason::MissingCurrentTree,
+            WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+        );
         let report = repo
             .execute_worktree_apply(&plan, &tree, temp_dir.path())
             .unwrap();

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -1355,6 +1355,103 @@ mod tests {
     }
 
     #[test]
+    fn non_root_full_rematerialize_refuses_existing_worktree_content() {
+        let (temp_dir, repo) = create_repo();
+        fs::write(temp_dir.path().join("tracked.txt"), "tracked\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
+        let non_root = temp_dir.path().join("checkout");
+
+        let err = repo
+            .plan_worktree_apply(
+                Some(&tree),
+                &tree,
+                &non_root,
+                false,
+                WorktreeApplyDirtyBehavior::RefuseOnDirty,
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non_root_directory") && msg.contains("existing: tracked.txt"),
+            "non-root fallback should refuse before overwriting existing checkout content: {msg}"
+        );
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("tracked.txt")).unwrap(),
+            "tracked\n"
+        );
+    }
+
+    #[test]
+    fn non_root_full_rematerialize_with_discard_clears_and_writes_target_tree() {
+        let (temp_dir, repo) = create_repo();
+        fs::write(temp_dir.path().join("tracked.txt"), "tracked\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
+        fs::write(temp_dir.path().join("local.txt"), "local\n").unwrap();
+        let non_root = temp_dir.path().join("checkout");
+
+        let plan = repo
+            .plan_worktree_apply(
+                Some(&tree),
+                &tree,
+                &non_root,
+                false,
+                WorktreeApplyDirtyBehavior::DiscardLocalChanges,
+            )
+            .unwrap();
+        assert_eq!(plan.strategy, WorktreeApplyStrategy::FullRematerialize);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(WorktreeApplyFallbackReason::NonRootDirectory)
+        );
+
+        repo.execute_worktree_apply(&plan, &tree, &non_root)
+            .unwrap();
+
+        assert!(!temp_dir.path().join("local.txt").exists());
+        assert_eq!(
+            fs::read_to_string(non_root.join("tracked.txt")).unwrap(),
+            "tracked\n"
+        );
+        assert!(
+            !temp_dir.path().join(".heddle/state/index.bin").exists(),
+            "non-root full rematerialize must invalidate the root worktree index"
+        );
+    }
+
+    #[test]
+    fn execute_full_rematerialize_regates_refuse_on_dirty_plans() {
+        let (temp_dir, repo) = create_repo();
+        fs::write(temp_dir.path().join("tracked.txt"), "tracked\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
+        fs::write(temp_dir.path().join("local.txt"), "local\n").unwrap();
+        let plan = WorktreeApplyPlan::fallback(
+            WorktreeApplyFallbackReason::MissingCurrentTree,
+            WorktreeApplyDirtyBehavior::RefuseOnDirty,
+        );
+
+        let err = repo
+            .execute_worktree_apply(&plan, &tree, temp_dir.path())
+            .unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("missing_current_tree") && msg.contains("existing: local.txt"),
+            "execute-time re-gate should refuse stale full-rematerialize plans: {msg}"
+        );
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("local.txt")).unwrap(),
+            "local\n"
+        );
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("tracked.txt")).unwrap(),
+            "tracked\n"
+        );
+    }
+
+    #[test]
     fn clean_worktree_apply_still_succeeds_by_default() {
         let (temp_dir, repo) = create_repo();
         let tracked = temp_dir.path().join("tracked.txt");


### PR DESCRIPTION
## Summary
Closes #368. `FullRematerialize` silently clobbered unsnapped worktree edits (data loss with no opt-in). Now **refuse-on-dirty is the default**; the destructive discard is reachable only via an explicit opt-in.

- Default dirty behavior: `RefuseOnDirty` (errors, names the at-risk edits, leaves them intact).
- Opt-in surface: CLI `heddle goto --force`; repo API `*_discard_local` methods + `WorktreeApplyDirtyBehavior::DiscardLocalChanges`.

## Close-the-class — all apply sites gated
- dirty fallback → `FullRematerialize`
- missing-current-tree full rematerialize
- non-root full rematerialize
- `execute_worktree_apply` re-gates before clearing
- goto / fast-forward / rebase callers routed through safe default or explicit discard

## Test evidence
- `cargo test -p heddle-repo`, `cargo test -p heddle-mount`
- dirty-goto integration test, rebase regression subset, full `undo_and_special::` module
- `bash scripts/check-no-silent-default-tree-load.sh`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo build -p heddle-cli`

🤖 codex-authored; cross-engine Claude review pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783009252&installation_id=132405951&pr_number=442&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F442&signature=5108f2a8d6ee8a490b784585980001a734345ce2c9b2af65ceb7e1c070feb2ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->