### PR TITLE
fix(config): fail closed on TLS/auth config read failure (#437)

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
     collections::BTreeMap,
-    fs,
+    env, fs,
     io::Read,
     path::{Path, PathBuf},
 };
@@ -329,21 +329,29 @@ impl UserConfig {
         });
     }
 
-    pub fn remote_token(&self) -> Option<AuthToken> {
-        std::env::var("HEDDLE_REMOTE_TOKEN")
-            .ok()
-            .filter(|token| !token.is_empty())
-            .map(|token| AuthToken::new(token, "env"))
-            .or_else(|| {
-                self.remote
-                    .token
-                    .clone()
-                    .map(|token| AuthToken::new(token, "user-config"))
-            })
+    pub fn remote_token(&self) -> anyhow::Result<Option<AuthToken>> {
+        match env::var("HEDDLE_REMOTE_TOKEN") {
+            Ok(token) if !token.is_empty() => Ok(Some(AuthToken::new(token, "env"))),
+            Ok(_) | Err(env::VarError::NotPresent) => Ok(self
+                .remote
+                .token
+                .clone()
+                .map(|token| AuthToken::new(token, "user-config"))),
+            Err(err @ env::VarError::NotUnicode(_)) => Err(security_config_error(
+                "HEDDLE_REMOTE_TOKEN",
+                format!("read environment value: {err}"),
+            )),
+        }
     }
 
-    pub fn heddle_client_config(&self, token_override: Option<AuthToken>) -> ClientConfig {
-        let token = token_override.or_else(|| self.remote_token());
+    pub fn heddle_client_config(
+        &self,
+        token_override: Option<AuthToken>,
+    ) -> anyhow::Result<ClientConfig> {
+        let token = match token_override {
+            Some(token) => Some(token),
+            None => self.remote_token()?,
+        };
         let mut config = token
             .map(|token| ClientConfig::default().with_token(token))
             .unwrap_or_default();
@@ -354,37 +362,43 @@ impl UserConfig {
         if let Some(domain) = &self.remote.tls_domain_name {
             config = config.with_tls_domain_name(domain.clone());
         }
-        if let Some(path) = &self.remote.tls_ca_certificate_path
-            && let Ok(pem) = fs::read_to_string(path)
-        {
+        if let Some(path) = &self.remote.tls_ca_certificate_path {
+            let pem = read_security_config_file("remote.tls_ca_certificate_path", path)?;
             config = config.with_tls_ca_certificate_pem(pem);
         }
-        if let Some(path) = &self.remote.auth_proof_key_pem_path
-            && let Ok(pem) = fs::read_to_string(path)
-        {
+        if let Some(path) = &self.remote.auth_proof_key_pem_path {
+            let pem = read_security_config_file("remote.auth_proof_key_pem_path", path)?;
             config = config.with_auth_proof_key_pem(pem);
         }
 
-        if std::env::var("HEDDLE_REMOTE_TLS")
-            .ok()
-            .is_some_and(|value| {
-                matches!(
-                    value.to_ascii_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on"
-                )
-            })
-        {
+        if env_bool("HEDDLE_REMOTE_TLS")? {
             config = config.with_tls(false);
         }
-        if let Ok(domain) = std::env::var("HEDDLE_REMOTE_TLS_DOMAIN") {
-            config = config.with_tls_domain_name(domain);
+        match env::var("HEDDLE_REMOTE_TLS_DOMAIN") {
+            Ok(domain) => config = config.with_tls_domain_name(domain),
+            Err(env::VarError::NotPresent) => {}
+            Err(err @ env::VarError::NotUnicode(_)) => {
+                return Err(security_config_error(
+                    "HEDDLE_REMOTE_TLS_DOMAIN",
+                    format!("read environment value: {err}"),
+                ));
+            }
         }
-        if let Ok(path) = std::env::var("HEDDLE_REMOTE_TLS_CA_CERT")
-            && let Ok(pem) = fs::read_to_string(path)
-        {
-            config = config.with_tls_ca_certificate_pem(pem);
+        match env::var("HEDDLE_REMOTE_TLS_CA_CERT") {
+            Ok(path) => {
+                let pem =
+                    read_security_config_file("HEDDLE_REMOTE_TLS_CA_CERT", &PathBuf::from(path))?;
+                config = config.with_tls_ca_certificate_pem(pem);
+            }
+            Err(env::VarError::NotPresent) => {}
+            Err(err @ env::VarError::NotUnicode(_)) => {
+                return Err(security_config_error(
+                    "HEDDLE_REMOTE_TLS_CA_CERT",
+                    format!("read environment value: {err}"),
+                ));
+            }
         }
-        config
+        Ok(config)
     }
 
     pub fn worktree_status_options(
@@ -409,6 +423,44 @@ impl UserConfig {
     }
 }
 
+fn read_security_config_file(setting: &str, path: &Path) -> anyhow::Result<String> {
+    fs::read_to_string(path).map_err(|err| {
+        security_config_error(
+            setting,
+            format!("read configured file {}: {err}", path.display()),
+        )
+    })
+}
+
+fn env_bool(name: &str) -> anyhow::Result<bool> {
+    let value = match env::var(name) {
+        Ok(value) => value,
+        Err(env::VarError::NotPresent) => return Ok(false),
+        Err(err @ env::VarError::NotUnicode(_)) => {
+            return Err(security_config_error(
+                name,
+                format!("read environment value: {err}"),
+            ));
+        }
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(security_config_error(
+            name,
+            format!(
+                "parse boolean value {value:?}; expected one of 1/0, true/false, yes/no, or on/off"
+            ),
+        )),
+    }
+}
+
+fn security_config_error(setting: &str, reason: String) -> anyhow::Error {
+    anyhow::anyhow!(
+        "fatal TLS/auth configuration error for `{setting}`: {reason}; refusing to proceed with an ambiguous security posture"
+    )
+}
+
 fn path_missing(err: &anyhow::Error) -> bool {
     err.downcast_ref::<std::io::Error>()
         .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
@@ -416,9 +468,77 @@ fn path_missing(err: &anyhow::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        ffi::OsString,
+        fs,
+        path::PathBuf,
+        sync::MutexGuard,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use repo::{FsMonitorMode, RepoConfig};
 
-    use super::{HarnessMode, HarnessTranscriptMode, HarnessTransport, UserConfig};
+    use super::{
+        HarnessMode, HarnessTranscriptMode, HarnessTransport, UserConfig, UserRemoteConfig,
+    };
+
+    static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    const REMOTE_ENV_KEYS: &[&str] = &[
+        "HEDDLE_REMOTE_TOKEN",
+        "HEDDLE_REMOTE_TLS",
+        "HEDDLE_REMOTE_TLS_DOMAIN",
+        "HEDDLE_REMOTE_TLS_CA_CERT",
+    ];
+
+    struct RemoteEnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl RemoteEnvGuard {
+        fn clean() -> Self {
+            let guard = TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let saved = REMOTE_ENV_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var_os(key)))
+                .collect();
+            for key in REMOTE_ENV_KEYS {
+                unsafe { std::env::remove_var(key) };
+            }
+            Self {
+                _guard: guard,
+                saved,
+            }
+        }
+
+        fn set(&self, key: &str, value: impl AsRef<std::ffi::OsStr>) {
+            unsafe { std::env::set_var(key, value) };
+        }
+    }
+
+    impl Drop for RemoteEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                unsafe {
+                    if let Some(value) = value {
+                        std::env::set_var(key, value);
+                    } else {
+                        std::env::remove_var(key);
+                    }
+                }
+            }
+        }
+    }
+
+    fn unique_temp_path(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()))
+    }
 
     #[test]
     fn user_worktree_status_options_fall_back_to_repo_config() {
@@ -439,5 +559,122 @@ mod tests {
         assert_eq!(config.harness.transcript, HarnessTranscriptMode::Off);
         assert!(config.harness.auto_infer);
         assert!(config.harness.harnesses.is_empty());
+    }
+
+    #[test]
+    fn heddle_client_config_absent_security_settings_uses_defaults() {
+        let _env = RemoteEnvGuard::clean();
+        let config = UserConfig::default()
+            .heddle_client_config(None)
+            .expect("absent optional settings should not error");
+
+        assert!(!config.tls_enabled);
+        assert!(!config.tls_skip_verify);
+        assert!(config.tls_ca_certificate_pem.is_none());
+        assert!(config.auth_proof_key_pem.is_none());
+        assert!(config.token.is_none());
+    }
+
+    #[test]
+    fn heddle_client_config_valid_security_files_are_applied() {
+        let _env = RemoteEnvGuard::clean();
+        let dir = unique_temp_path("heddle-user-config-valid-security");
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let ca_path = dir.join("ca.pem");
+        let key_path = dir.join("proof-key.pem");
+        fs::write(&ca_path, "test ca pem").expect("write ca pem");
+        fs::write(&key_path, "test key pem").expect("write key pem");
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                tls_ca_certificate_path: Some(ca_path),
+                auth_proof_key_pem_path: Some(key_path),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+
+        let config = user
+            .heddle_client_config(None)
+            .expect("valid TLS/auth files should load");
+
+        assert!(config.tls_enabled);
+        assert_eq!(
+            config.tls_ca_certificate_pem.as_deref(),
+            Some("test ca pem")
+        );
+        assert_eq!(config.auth_proof_key_pem.as_deref(), Some("test key pem"));
+
+        fs::remove_dir_all(dir).expect("remove temp dir");
+    }
+
+    #[test]
+    fn heddle_client_config_missing_tls_ca_path_fails_closed() {
+        let _env = RemoteEnvGuard::clean();
+        let missing = unique_temp_path("heddle-user-config-missing-ca").join("ca.pem");
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                tls_ca_certificate_path: Some(missing),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+
+        let err = user
+            .heddle_client_config(None)
+            .expect_err("missing configured CA path must fail closed");
+        let message = err.to_string();
+
+        assert!(message.contains("fatal TLS/auth configuration error"));
+        assert!(message.contains("remote.tls_ca_certificate_path"));
+    }
+
+    #[test]
+    fn heddle_client_config_missing_auth_proof_key_path_fails_closed() {
+        let _env = RemoteEnvGuard::clean();
+        let missing = unique_temp_path("heddle-user-config-missing-key").join("proof-key.pem");
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                auth_proof_key_pem_path: Some(missing),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+
+        let err = user
+            .heddle_client_config(None)
+            .expect_err("missing configured proof key path must fail closed");
+        let message = err.to_string();
+
+        assert!(message.contains("fatal TLS/auth configuration error"));
+        assert!(message.contains("remote.auth_proof_key_pem_path"));
+    }
+
+    #[test]
+    fn heddle_client_config_missing_env_tls_ca_path_fails_closed() {
+        let env = RemoteEnvGuard::clean();
+        let missing = unique_temp_path("heddle-user-config-missing-env-ca").join("ca.pem");
+        env.set("HEDDLE_REMOTE_TLS_CA_CERT", missing);
+
+        let err = UserConfig::default()
+            .heddle_client_config(None)
+            .expect_err("missing env CA path must fail closed");
+        let message = err.to_string();
+
+        assert!(message.contains("fatal TLS/auth configuration error"));
+        assert!(message.contains("HEDDLE_REMOTE_TLS_CA_CERT"));
+    }
+
+    #[test]
+    fn heddle_client_config_invalid_env_tls_value_fails_closed() {
+        let env = RemoteEnvGuard::clean();
+        env.set("HEDDLE_REMOTE_TLS", "enabled");
+
+        let err = UserConfig::default()
+            .heddle_client_config(None)
+            .expect_err("invalid TLS env value must fail closed");
+        let message = err.to_string();
+
+        assert!(message.contains("fatal TLS/auth configuration error"));
+        assert!(message.contains("HEDDLE_REMOTE_TLS"));
     }
 }

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1215,10 +1215,10 @@ async fn clone_network(
     // Initialize the local repository
     let local_repo = Repository::init(local_path)?;
 
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
 
     // Connect to remote
-    let mut config = user_config.heddle_client_config(None);
+    let mut config = user_config.heddle_client_config(None)?;
     if let Some(key) = server_key {
         config = config.with_server_key(key);
     }

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1187,6 +1187,35 @@ fn hosted_endpoint_spec(remote: &str) -> String {
 }
 
 #[cfg(feature = "client")]
+struct CloneDestinationCleanup<'a> {
+    path: &'a Path,
+    armed: bool,
+}
+
+#[cfg(feature = "client")]
+impl<'a> CloneDestinationCleanup<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self {
+            path,
+            armed: !path.exists(),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(feature = "client")]
+impl Drop for CloneDestinationCleanup<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_dir_all(self.path);
+        }
+    }
+}
+
+#[cfg(feature = "client")]
 async fn clone_network(
     cli: &Cli,
     addr: std::net::SocketAddr,
@@ -1209,20 +1238,25 @@ async fn clone_network(
     // remotes; both produce a clone whose blob content is hydrated on demand.
     let lazy = *lazy || filter.is_some();
 
-    // Create the local directory
-    fs::create_dir_all(local_path)?;
-
-    // Initialize the local repository
-    let local_repo = Repository::init(local_path)?;
-
     let user_config = UserConfig::load_default()?;
-
-    // Connect to remote
+    // On every network-connecting command, TLS/auth config validation
+    // (`heddle_client_config`) must succeed before any irreversible
+    // filesystem/repo mutation such as `create_dir_all`, `Repository::init`,
+    // state writes, or ref publishes. A rejected security config must leave
+    // no partial on-disk artifact.
     let mut config = user_config.heddle_client_config(None)?;
     if let Some(key) = server_key {
         config = config.with_server_key(key);
     }
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
+
+    let mut cleanup = CloneDestinationCleanup::new(local_path);
+
+    // Create the local directory only after TLS/auth prevalidation.
+    fs::create_dir_all(local_path)?;
+
+    // Initialize the local repository only after TLS/auth prevalidation.
+    let local_repo = Repository::init(local_path)?;
 
     let mut client = HostedGrpcClient::connect(addr, &config).await?;
     client.auto_rotate_if_needed().await;
@@ -1306,6 +1340,7 @@ async fn clone_network(
         )));
     }
 
+    cleanup.disarm();
     Ok(())
 }
 
@@ -1661,6 +1696,41 @@ mod tests {
         assert_eq!(
             hosted_endpoint_spec("heddle://example.heddle.cloud:443/org/acme/repo"),
             "example.heddle.cloud:443",
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn clone_destination_cleanup_removes_armed_destination() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let path = temp.path().join("partial-clone");
+
+        {
+            let _cleanup = CloneDestinationCleanup::new(&path);
+            std::fs::create_dir_all(&path).expect("create partial destination");
+        }
+
+        assert!(
+            !path.exists(),
+            "armed clone cleanup must remove the partial destination"
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn clone_destination_cleanup_disarm_preserves_destination() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let path = temp.path().join("successful-clone");
+
+        {
+            let mut cleanup = CloneDestinationCleanup::new(&path);
+            std::fs::create_dir_all(&path).expect("create successful destination");
+            cleanup.disarm();
+        }
+
+        assert!(
+            path.exists(),
+            "disarmed clone cleanup must preserve the successful destination"
         );
     }
 

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -119,10 +119,10 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
 
     let mut total_refs = 0;
     let mut total_objects = 0;
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
 
     for remote_name in &remotes {
-        let token = user_config.remote_token();
+        let token = user_config.remote_token()?;
         #[cfg(feature = "client")]
         let (target, server_key) = resolve_remote_with_key(&repo, Some(remote_name.as_str()))
             .map_err(anyhow::Error::msg)?;
@@ -269,7 +269,7 @@ async fn fetch_network(
         .repo_path
         .context("network remotes must include a hosted repository path")?;
 
-    let mut config = options.user_config.heddle_client_config(options.token);
+    let mut config = options.user_config.heddle_client_config(options.token)?;
     if let Some(key) = options.server_key {
         config = config.with_server_key(key);
     }

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -37,6 +37,7 @@ struct ForkOutput {
 /// If `--name` is provided, a new thread is created pointing to the new state.
 pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let user_config = UserConfig::load_default()?;
 
     // Determine the source state
     let source_state = if let Some(ref state_spec) = from {
@@ -46,7 +47,7 @@ pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result
         // Use current HEAD
         let change_id = ensure_current_state(
             &repo,
-            &UserConfig::load_default().unwrap_or_default(),
+            &user_config,
             Some("Bootstrap git-overlay before forking".to_string()),
         )?;
         require_resolved_state(&repo, &change_id)?
@@ -54,7 +55,6 @@ pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result
 
     // Create a new state with the same tree but a new change ID
     // The new state has the source state as its parent
-    let user_config = UserConfig::load_default()?;
     let attribution = resolve_attribution(&repo, &user_config)?;
     let mut new_state =
         State::new_fork_of(source_state.tree, vec![source_state.change_id], attribution);

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -25,7 +25,7 @@ use super::{
     snapshot::ensure_current_state,
 };
 #[cfg(feature = "client")]
-use crate::client::HostedGrpcClient;
+use crate::client::{ClientConfig, HostedGrpcClient};
 use crate::{
     bridge::{
         GitBridge,
@@ -194,6 +194,8 @@ pub async fn cmd_push(
         )));
     }
 
+    let user_config = UserConfig::load_default()?;
+
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let default_remote_name = if remote.is_none() {
             resolved_default_remote_name(&repo)?
@@ -206,7 +208,7 @@ pub async fn cmd_push(
                 if matches!(state_str.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {
                     ensure_current_state(
                         &repo,
-                        &UserConfig::load_default().unwrap_or_default(),
+                        &user_config,
                         Some("Bootstrap git-overlay before push".to_string()),
                     )?;
                 }
@@ -214,7 +216,7 @@ pub async fn cmd_push(
             } else {
                 ensure_current_state(
                     &repo,
-                    &UserConfig::load_default().unwrap_or_default(),
+                    &user_config,
                     Some("Bootstrap git-overlay before push".to_string()),
                 )?
             };
@@ -332,38 +334,17 @@ pub async fn cmd_push(
 
     preflight_native_remote_transport(&repo, remote.as_deref(), "push")?;
 
-    let state_id = if let Some(state_str) = state {
-        if matches!(state_str.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {
-            ensure_current_state(
-                &repo,
-                &UserConfig::load_default().unwrap_or_default(),
-                Some("Bootstrap git-overlay before push".to_string()),
-            )?;
-        }
-        repo.resolve_state(&state_str)?.context("State not found")?
-    } else {
-        ensure_current_state(
-            &repo,
-            &UserConfig::load_default().unwrap_or_default(),
-            Some("Bootstrap git-overlay before push".to_string()),
-        )?
-    };
-
-    let user_config = UserConfig::load_default()?;
-    #[cfg(feature = "client")]
-    let mut token = user_config.remote_token()?;
-    #[cfg(not(feature = "client"))]
     let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
+    let mut token = token;
     let (target, server_key) =
-        resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
-    #[cfg(not(feature = "client"))]
-    let (target, _server_key) =
         resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
 
     // Fall back to the credential store if no token was provided via env/config.
     #[cfg(feature = "client")]
     let mut credential_proof_key: Option<String> = None;
+    #[cfg(not(feature = "client"))]
+    let credential_proof_key: Option<String> = None;
     #[cfg(feature = "client")]
     if token.is_none()
         && let Some(ref key) = server_key
@@ -372,6 +353,38 @@ pub async fn cmd_push(
         token = Some(AuthToken::new(cred.token, "credential-store"));
         credential_proof_key = cred.private_key_pem;
     }
+
+    let network_client_config = if matches!(target, RemoteTarget::Network { .. }) {
+        let mut config = user_config.heddle_client_config(token.clone())?;
+        if let Some(ref key) = server_key {
+            config = config.with_server_key(key.clone());
+        }
+        if let Some(ref pem) = credential_proof_key
+            && config.auth_proof_key_pem.is_none()
+        {
+            config = config.with_auth_proof_key_pem(pem.clone());
+        }
+        Some(config)
+    } else {
+        None
+    };
+
+    let state_id = if let Some(state_str) = state {
+        if matches!(state_str.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {
+            ensure_current_state(
+                &repo,
+                &user_config,
+                Some("Bootstrap git-overlay before push".to_string()),
+            )?;
+        }
+        repo.resolve_state(&state_str)?.context("State not found")?
+    } else {
+        ensure_current_state(
+            &repo,
+            &user_config,
+            Some("Bootstrap git-overlay before push".to_string()),
+        )?
+    };
 
     let track_name = resolve_default_push_thread(&repo, thread.as_deref())?;
 
@@ -386,10 +399,9 @@ pub async fn cmd_push(
                 PushNetworkOptions {
                     addr,
                     repo_path: repo_path.as_deref(),
-                    user_config: &user_config,
-                    token,
-                    server_key,
-                    credential_proof_key,
+                    client_config: network_client_config
+                        .as_ref()
+                        .context("network client config was not prevalidated")?,
                     state_id: &state_id,
                     track_name: &track_name,
                     force,
@@ -398,7 +410,7 @@ pub async fn cmd_push(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, token);
+            let _ = (addr, repo_path, token, network_client_config);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("push"));
         }
@@ -1145,16 +1157,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         .repo_path
         .context("network remotes must include a hosted repository path")?;
 
-    let mut config = options.user_config.heddle_client_config(options.token)?;
-    if let Some(key) = options.server_key {
-        config = config.with_server_key(key);
-    }
-    if let Some(pem) = options.credential_proof_key
-        && config.auth_proof_key_pem.is_none()
-    {
-        config = config.with_auth_proof_key_pem(pem);
-    }
-    let mut client = HostedGrpcClient::connect(options.addr, &config).await?;
+    let mut client = HostedGrpcClient::connect(options.addr, options.client_config).await?;
     client.auto_rotate_if_needed().await;
 
     if !should_output_json(options.cli, Some(repo.config())) {
@@ -1208,10 +1211,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
 struct PushNetworkOptions<'a> {
     addr: SocketAddr,
     repo_path: Option<&'a str>,
-    user_config: &'a UserConfig,
-    token: Option<AuthToken>,
-    server_key: Option<String>,
-    credential_proof_key: Option<String>,
+    client_config: &'a ClientConfig,
     state_id: &'a objects::object::ChangeId,
     track_name: &'a str,
     force: bool,

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -349,11 +349,11 @@ pub async fn cmd_push(
         )?
     };
 
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
     #[cfg(feature = "client")]
-    let mut token = user_config.remote_token();
+    let mut token = user_config.remote_token()?;
     #[cfg(not(feature = "client"))]
-    let token = user_config.remote_token();
+    let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
     let (target, server_key) =
         resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
@@ -1145,7 +1145,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         .repo_path
         .context("network remotes must include a hosted repository path")?;
 
-    let mut config = options.user_config.heddle_client_config(options.token);
+    let mut config = options.user_config.heddle_client_config(options.token)?;
     if let Some(key) = options.server_key {
         config = config.with_server_key(key);
     }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -295,11 +295,11 @@ pub async fn cmd_pull(
 
     super::preflight_native_remote_transport(&repo, remote.as_deref(), "pull")?;
 
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
     #[cfg(feature = "client")]
-    let mut token = user_config.remote_token();
+    let mut token = user_config.remote_token()?;
     #[cfg(not(feature = "client"))]
-    let token = user_config.remote_token();
+    let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
     let (target, server_key) =
         resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
@@ -506,7 +506,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     let repo_path = options
         .repo_path
         .context("network remotes must include a hosted repository path")?;
-    let mut config = options.user_config.heddle_client_config(options.token);
+    let mut config = options.user_config.heddle_client_config(options.token)?;
     if let Some(key) = options.server_key {
         config = config.with_server_key(key);
     }

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -2271,7 +2271,7 @@ impl HostedPresenceWatch {
             return None;
         }
 
-        let token = UserConfig::load_default().ok()?.remote_token()?;
+        let token = UserConfig::load_default().ok()?.remote_token().ok()??;
         let mut request = normalize_presence_ws_url(upstream)
             .ok()?
             .into_client_request()

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -15,6 +15,7 @@
 #![cfg(feature = "client")]
 
 use anyhow::{Context, Result, anyhow};
+use objects::object::ThreadName;
 use repo::Repository;
 use serde::Serialize;
 
@@ -129,7 +130,7 @@ async fn open_heddle_client(
 /// will invalidate the prior approval.
 fn thread_head_state(repo: &Repository, thread: &str) -> Result<String> {
     repo.refs()
-        .get_thread(thread)?
+        .get_thread(&ThreadName::new(thread))?
         .map(|change_id| change_id.to_string())
         .ok_or_else(|| anyhow!("thread '{thread}' has no head state"))
 }

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -109,13 +109,13 @@ async fn open_heddle_client(
         }
     };
 
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
     // If a token isn't in the user-level config, the per-server
     // credential file (looked up via `server_key`) supplies it. Pass
     // whatever the user-level config has and let `with_server_key`
     // resolve the rest.
-    let token = user_config.remote_token();
-    let mut config = user_config.heddle_client_config(token);
+    let token = user_config.remote_token()?;
+    let mut config = user_config.heddle_client_config(token)?;
     if let Some(key) = server_key {
         config = config.with_server_key(key);
     }

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2010,6 +2010,8 @@ fn decode_token_claims(token: &str) -> Option<TokenClaims> {
 fn user_config_token_claims(user_config: &UserConfig) -> Option<TokenClaims> {
     user_config
         .remote_token()
+        .ok()
+        .flatten()
         .and_then(|token| decode_token_claims(&token.id))
 }
 

--- a/crates/cli/tests/cli_integration/refs_and_history.rs
+++ b/crates/cli/tests/cli_integration/refs_and_history.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use objects::object::ThreadName;
 
 #[test]
 fn test_cli_track_operations() {
@@ -295,6 +296,65 @@ fn test_cli_fork_creates_exploration_branch() {
         output.contains("Created fork") || output.contains("experiment"),
         "Should show fork created: {}",
         output
+    );
+}
+
+#[test]
+fn test_cli_fork_bootstraps_current_state_with_user_config() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init repo");
+
+    let before = Repository::open(temp.path()).expect("open repo");
+    before
+        .refs()
+        .delete_thread(&ThreadName::new("main"))
+        .expect("clear current thread ref");
+    assert!(
+        before.current_state().unwrap().is_none(),
+        "fresh repo should have no current state after clearing main"
+    );
+
+    let config_path = temp.path().join("fork-config.toml");
+    std::fs::write(
+        &config_path,
+        "[principal]\nname = \"Fork Tester\"\nemail = \"fork@example.com\"\n",
+    )
+    .unwrap();
+    let config = config_path.to_string_lossy().to_string();
+
+    let output = heddle_output_with_env(
+        &["fork", "--name", "bootstrap-fork"],
+        Some(temp.path()),
+        &[("HEDDLE_CONFIG", &config)],
+    )
+    .expect("invoke fork");
+    assert!(
+        output.status.success(),
+        "fork should succeed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let repo = Repository::open(temp.path()).expect("reopen repo");
+    let bootstrapped = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .unwrap()
+        .expect("fork should bootstrap main before creating fork");
+    let forked = repo
+        .refs()
+        .get_thread(&ThreadName::new("bootstrap-fork"))
+        .unwrap()
+        .expect("fork should create named thread");
+    let fork_state = repo
+        .store()
+        .get_state(&forked)
+        .unwrap()
+        .expect("fork state should be stored");
+    assert_eq!(
+        fork_state.first_parent(),
+        Some(&bootstrapped),
+        "fork should be based on the bootstrapped current state"
     );
 }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -2837,3 +2837,100 @@ fn test_cli_git_overlay_push_to_native_heddle_local_path_uses_heddle_sync() {
         "push to a native Heddle path must not turn the target into a Git remote"
     );
 }
+
+#[test]
+fn push_bootstrap_validates_tls_config_before_creating_state() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).expect("init source");
+
+    let repo = Repository::open(source.path()).expect("open source");
+    repo.refs()
+        .delete_thread(&ThreadName::new("main"))
+        .expect("clear current thread ref");
+    assert!(
+        repo.current_state().unwrap().is_none(),
+        "fresh source should have no current state before push"
+    );
+    let states_before = repo.store().list_states().unwrap();
+
+    let config_path = source.path().join("bad-tls-config.toml");
+    let missing_ca = source.path().join("missing-ca.pem");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+            missing_ca.display()
+        ),
+    )
+    .unwrap();
+
+    let config = config_path.to_string_lossy().to_string();
+    let output = heddle_output_with_env(
+        &["push", "heddle://127.0.0.1:1/owner/repo"],
+        Some(source.path()),
+        &[("HEDDLE_CONFIG", &config)],
+    )
+    .expect("invoke push");
+    assert!(!output.status.success(), "push should fail closed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.is_empty(),
+        "failed push should not write stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("fatal TLS/auth configuration error")
+            && stderr.contains("remote.tls_ca_certificate_path"),
+        "push should fail on TLS config before transport: {stderr}"
+    );
+
+    let repo = Repository::open(source.path()).expect("reopen source");
+    assert!(
+        repo.current_state().unwrap().is_none(),
+        "TLS config failure must not bootstrap a current state"
+    );
+    assert_eq!(
+        repo.store().list_states().unwrap(),
+        states_before,
+        "TLS config failure must not record a default-attributed state"
+    );
+}
+
+#[test]
+fn push_bootstrap_with_valid_config_still_creates_state() {
+    let source = TempDir::new().unwrap();
+    let remote = TempDir::new().unwrap();
+
+    heddle(&["init"], Some(source.path())).expect("init source");
+    heddle(&["init"], Some(remote.path())).expect("init target");
+
+    let before = Repository::open(source.path()).expect("open source");
+    before
+        .refs()
+        .delete_thread(&ThreadName::new("main"))
+        .expect("clear current thread ref");
+    assert!(
+        before.current_state().unwrap().is_none(),
+        "fresh source should start without current state"
+    );
+
+    let remote_path = remote.path().to_str().expect("remote path utf8");
+    heddle(&["push", remote_path], Some(source.path())).expect("bootstrap push succeeds");
+
+    let source_repo = Repository::open(source.path()).expect("reopen source");
+    let source_state = source_repo
+        .current_state()
+        .unwrap()
+        .expect("valid push should bootstrap source state")
+        .change_id;
+    let remote_repo = Repository::open(remote.path()).expect("open target");
+    let remote_state = remote_repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .unwrap()
+        .expect("valid push should update target main");
+    assert_eq!(
+        remote_state, source_state,
+        "bootstrap push should send the newly created state"
+    );
+}

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -940,6 +940,87 @@ fn test_cli_clone_missing_local_remote_uses_typed_advice() {
 }
 
 #[test]
+#[cfg(feature = "client")]
+fn clone_network_validates_tls_config_before_creating_destination() {
+    let temp = TempDir::new().unwrap();
+    let local = temp.path().join("network-clone");
+    let config_path = temp.path().join("bad-tls-config.toml");
+    let missing_ca = temp.path().join("missing-ca.pem");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+            missing_ca.display()
+        ),
+    )
+    .unwrap();
+
+    let config = config_path.to_string_lossy().to_string();
+    let local_arg = local.to_string_lossy().to_string();
+    let output = heddle_output_with_env(
+        &[
+            "clone",
+            "heddle://127.0.0.1:1/owner/repo",
+            local_arg.as_str(),
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_CONFIG", &config)],
+    )
+    .expect("invoke network clone");
+
+    assert!(!output.status.success(), "clone should fail closed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.is_empty(),
+        "failed clone should not write stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("fatal TLS/auth configuration error")
+            && stderr.contains("remote.tls_ca_certificate_path"),
+        "clone should fail on TLS config before transport: {stderr}"
+    );
+    assert!(
+        !local.exists(),
+        "TLS config failure must not create a partial clone destination at {}",
+        local.display()
+    );
+}
+
+#[test]
+#[cfg(feature = "client")]
+fn clone_network_removes_self_created_destination_after_later_failure() {
+    let temp = TempDir::new().unwrap();
+    let local = temp.path().join("network-clone-cleanup");
+    let local_arg = local.to_string_lossy().to_string();
+
+    let output = heddle_output(
+        &[
+            "clone",
+            "heddle://127.0.0.1:1/owner/repo",
+            local_arg.as_str(),
+        ],
+        Some(temp.path()),
+    )
+    .expect("invoke network clone");
+
+    assert!(
+        !output.status.success(),
+        "clone should fail against a closed local port"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("fatal TLS/auth configuration error"),
+        "default TLS/auth config should pass before the transport failure: {stderr}"
+    );
+    assert!(
+        !local.exists(),
+        "later network clone failure must remove the self-created destination at {}",
+        local.display()
+    );
+}
+
+#[test]
 fn test_cli_clone_git_overlay_depth_is_rejected() {
     // Issue 49 / 20b: `--depth` is wired through to gix at the wire
     // layer (`clone_url_to_bare` honours it), but the import step

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -2934,3 +2934,55 @@ fn push_bootstrap_with_valid_config_still_creates_state() {
         "bootstrap push should send the newly created state"
     );
 }
+
+#[test]
+fn push_network_validates_valid_config_before_bootstrapping_state() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).expect("init source");
+
+    let before = Repository::open(source.path()).expect("open source");
+    before
+        .refs()
+        .delete_thread(&ThreadName::new("main"))
+        .expect("clear current thread ref");
+    assert!(
+        before.current_state().unwrap().is_none(),
+        "fresh source should start without current state"
+    );
+
+    let ca_path = source.path().join("ca.pem");
+    std::fs::write(
+        &ca_path,
+        "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
+    let config_path = source.path().join("valid-network-config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+            ca_path.display()
+        ),
+    )
+    .unwrap();
+
+    let config = config_path.to_string_lossy().to_string();
+    let output = heddle_output_with_env(
+        &["push", "heddle://127.0.0.1:1/owner/repo"],
+        Some(source.path()),
+        &[("HEDDLE_CONFIG", &config)],
+    )
+    .expect("invoke push");
+    assert!(!output.status.success(), "push should fail at transport");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("fatal TLS/auth configuration error"),
+        "valid TLS config should pass prevalidation before transport failure: {stderr}"
+    );
+
+    let repo = Repository::open(source.path()).expect("reopen source");
+    assert!(
+        repo.current_state().unwrap().is_some(),
+        "valid network config should allow push bootstrap before transport failure"
+    );
+}

--- a/crates/client/src/grpc_hosted/hydration.rs
+++ b/crates/client/src/grpc_hosted/hydration.rs
@@ -214,8 +214,14 @@ impl HydrationBridge {
                 ))
             })?;
 
-        let user_config = cli_shared::UserConfig::load_default().unwrap_or_default();
-        let client_config = user_config.heddle_client_config(None);
+        let user_config = cli_shared::UserConfig::load_default().map_err(|err| {
+            HeddleError::Config(format!("lazy hosted hydrator: load user config: {err}"))
+        })?;
+        let client_config = user_config.heddle_client_config(None).map_err(|err| {
+            HeddleError::Config(format!(
+                "lazy hosted hydrator: load TLS/auth client config: {err}"
+            ))
+        })?;
 
         // Build the worker thread first so the bridge can store the
         // tx side immediately. The worker's runtime + client are

--- a/crates/client/src/presence.rs
+++ b/crates/client/src/presence.rs
@@ -152,7 +152,7 @@ pub async fn cmd_presence_publish(
     let hosted = repo.config().hosted.clone();
     let agent = load_agent_entry(repo.heddle_dir(), &session)?;
 
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let user_config = UserConfig::load_default()?;
 
     match resolve_publisher_config(
         &hosted,
@@ -201,7 +201,7 @@ pub fn resolve_publisher_config(
         return Ok(None);
     };
 
-    let (token, credential_subject) = if let Some(token) = user_config.remote_token() {
+    let (token, credential_subject) = if let Some(token) = user_config.remote_token()? {
         (token.id, None)
     } else {
         let stored_credential = credentials::resolve_credential_for_server(upstream)

--- a/crates/client/src/support.rs
+++ b/crates/client/src/support.rs
@@ -116,9 +116,9 @@ async fn open_client(repo: &Repository, remote: &str) -> Result<HostedGrpcClient
             )));
         }
     };
-    let user_config = UserConfig::load_default().unwrap_or_default();
-    let token = user_config.remote_token();
-    let mut config = user_config.heddle_client_config(token);
+    let user_config = UserConfig::load_default()?;
+    let token = user_config.remote_token()?;
+    let mut config = user_config.heddle_client_config(token)?;
     if let Some(key) = server_key {
         config = config.with_server_key(key);
     }


### PR DESCRIPTION
## Summary
Closes #437 (sub-issue 2/4 of #370). TLS/auth config reads silently ignored failures and could downgrade to a default `ClientConfig` (no TLS CA, no auth proof key, possibly no TLS enablement) — a fail-OPEN security bug.

**Fix (fail closed, at the shared chokepoint):** `UserConfig::heddle_client_config` now hard-errors on TLS/auth config read/parse failures instead of degrading. Strict handling added for `HEDDLE_REMOTE_TLS`, `HEDDLE_REMOTE_TLS_DOMAIN`, `HEDDLE_REMOTE_TLS_CA_CERT`, and non-Unicode `HEDDLE_REMOTE_TOKEN`. Callers (CLI push/pull/fetch/clone/thread-approval, client support, hosted hydration, presence) propagate the failure. **Absent optional settings still use their documented defaults** — only read/parse *failures* error. No `--lossy` opt-in (security path).

## Test evidence
- `cargo test --locked --workspace`, `cargo test -p heddle-cli-shared`, `cargo test -p heddle-mount`
- `bash scripts/check-no-silent-default-tree-load.sh`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, both no-default-feature checks

🤖 codex-authored; cross-engine Claude review pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783013487&installation_id=132405951&pr_number=446&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F446&signature=d8a5e9f71b4845775a1bed92303959fb507e3cb407123ffd6938b09d4bb96aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->