### PR TITLE
fix(refs): replace age-based stale-lock reaper with fs2 advisory lock (#372)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ version = "0.2.4"
 dependencies = [
  "chrono",
  "criterion",
+ "fs2",
  "heddle-objects",
  "heddle-runtime-bridge",
  "pollster",

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
+fs2.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 rand.workspace = true
 rmp-serde.workspace = true

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -3,14 +3,13 @@
 
 use std::{
     fs::{self, File, OpenOptions},
-    io::{Read, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
-    process,
     thread::{self},
     time::{Duration, Instant},
 };
 
-use chrono::Utc;
+use fs2::FileExt;
 use objects::{
     error::{HeddleError, Result},
     object::ThreadName,
@@ -19,20 +18,20 @@ use objects::{
 use super::{RefManager, name::validate_ref_name};
 use crate::fs_atomic::write_file_atomic;
 
-const STALE_LOCK_TIMEOUT_SECS: i64 = 300;
 const MAX_LOCK_WAIT_SECS: u64 = 10;
 const FLAT_THREADS_DIR_NAME: &str = "__heddle_flat";
 const FLAT_THREAD_SUFFIX: &str = ".ref";
 
 pub(super) struct RefsLock {
+    file: File,
     path: PathBuf,
 }
 
 impl Drop for RefsLock {
     fn drop(&mut self) {
-        if let Err(err) = fs::remove_file(&self.path) {
+        if let Err(err) = self.file.unlock() {
             eprintln!(
-                "Warning: failed to remove refs lock file {}: {}",
+                "Warning: failed to unlock refs lock file {}: {}",
                 self.path.display(),
                 err
             );
@@ -153,7 +152,7 @@ impl RefManager {
     pub(super) fn lock_refs(&self) -> Result<RefsLock> {
         std::fs::create_dir_all(self.refs_dir())?;
         let path = self.lock_path();
-        let current_pid = process::id();
+        let file = Self::open_lock_file(&path)?;
         let start_time = Instant::now();
         let mut delay = Duration::from_millis(5);
 
@@ -165,30 +164,9 @@ impl RefManager {
                 )));
             }
 
-            if let Ok(content) = self.read_string(&path)
-                && let Some((pid, ts)) = Self::parse_lock_content(&content)
-            {
-                let now = Utc::now().timestamp();
-                if pid != current_pid && now - ts > STALE_LOCK_TIMEOUT_SECS {
-                    let _ = fs::remove_file(&path);
-                }
-            }
-
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(file) => {
-                    let now = Utc::now().timestamp();
-                    let content = format!("{} {}", current_pid, now);
-                    let file = write_lock_body_or_cleanup(file, content.as_bytes(), &path)?;
-                    if let Err(err) = file.sync_all() {
-                        // Drop-before-remove is load-bearing on Windows.
-                        // See `write_lock_body_or_cleanup` doc-comment.
-                        drop(file);
-                        let _ = fs::remove_file(&path);
-                        return Err(err.into());
-                    }
-                    return Ok(RefsLock { path });
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(RefsLock { file, path }),
+                Err(err) if is_lock_contended(&err) => {
                     let jitter_window = (delay.as_millis() as u64 / 2).max(1);
                     let jitter = rand::random::<u64>() % jitter_window;
                     thread::sleep(delay + Duration::from_millis(jitter));
@@ -198,18 +176,30 @@ impl RefManager {
             }
         }
     }
-    fn parse_lock_content(content: &str) -> Option<(u32, i64)> {
-        let parts: Vec<&str> = content.split_whitespace().collect();
-        if parts.len() == 2 {
-            if let (Ok(pid), Ok(ts)) = (parts[0].parse::<u32>(), parts[1].parse::<i64>()) {
-                Some((pid, ts))
-            } else {
-                None
-            }
-        } else {
-            None
+
+    fn open_lock_file(path: &Path) -> Result<File> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(Into::into)
+    }
+
+    #[cfg(test)]
+    fn try_lock_refs_for_test(&self) -> Result<Option<RefsLock>> {
+        std::fs::create_dir_all(self.refs_dir())?;
+        let path = self.lock_path();
+        let file = Self::open_lock_file(&path)?;
+
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(Some(RefsLock { file, path })),
+            Err(err) if is_lock_contended(&err) => Ok(None),
+            Err(err) => Err(err.into()),
         }
     }
+
     pub(super) fn write_string(&self, path: &Path, contents: &str) -> Result<()> {
         Ok(write_file_atomic(path, contents.as_bytes())?)
     }
@@ -259,33 +249,11 @@ impl RefManager {
     }
 }
 
-/// Write `body` to `writer`; on failure drop the writer (closing any
-/// underlying OS handle) and remove the orphan at `cleanup_path`,
-/// returning the original write error. On success, return the writer
-/// so the caller can continue using it (e.g. for `sync_all`).
-///
-/// Generic over `Write` so tests can inject a failing writer to
-/// exercise the cleanup branch — the production caller passes the
-/// freshly-`create_new`'d lock file by value.
-///
-/// **Drop-before-remove is load-bearing on Windows.** Without
-/// `FILE_SHARE_DELETE`, `DeleteFile` against a still-open handle fails
-/// with `ERROR_SHARING_VIOLATION`. Taking the writer by value makes
-/// ownership obvious at the call site and forces the close to happen
-/// before `remove_file`. Lifted from the heddle#86 r2 helper in
-/// `shared_target.rs`.
-fn write_lock_body_or_cleanup<W: Write>(
-    mut writer: W,
-    body: &[u8],
-    cleanup_path: &Path,
-) -> Result<W> {
-    match writer.write_all(body) {
-        Ok(()) => Ok(writer),
-        Err(err) => {
-            drop(writer);
-            let _ = fs::remove_file(cleanup_path);
-            Err(err.into())
-        }
+fn is_lock_contended(err: &io::Error) -> bool {
+    let lock_error = fs2::lock_contended_error();
+    match lock_error.raw_os_error() {
+        Some(code) => err.raw_os_error() == Some(code),
+        None => err.kind() == lock_error.kind(),
     }
 }
 
@@ -314,23 +282,11 @@ fn decode_flat_thread_name(file_name: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::mpsc, time::Duration};
+
     use tempfile::TempDir;
 
     use super::*;
-
-    #[test]
-    fn test_parse_lock_content_valid() {
-        let content = "1234 1640995200";
-        let result = RefManager::parse_lock_content(content);
-        assert_eq!(result, Some((1234, 1640995200)));
-    }
-
-    #[test]
-    fn test_parse_lock_content_invalid() {
-        assert_eq!(RefManager::parse_lock_content("invalid"), None);
-        assert_eq!(RefManager::parse_lock_content("1234"), None);
-        assert_eq!(RefManager::parse_lock_content("abc 123"), None);
-    }
 
     #[test]
     fn test_lock_refs_basic() {
@@ -338,74 +294,60 @@ mod tests {
         let repo = RefManager::new(temp_dir.path());
         let lock = repo.lock_refs().unwrap();
         assert!(repo.lock_path().exists());
+        assert!(repo.try_lock_refs_for_test().unwrap().is_none());
         drop(lock);
-        assert!(!repo.lock_path().exists());
-    }
-
-    /// `Write` wrapper that flips a flag from its `Drop` impl. The
-    /// regression test below uses this to assert the writer is closed
-    /// before the helper's `remove_file` call — load-bearing on Windows,
-    /// where `DeleteFile` against a still-open handle fails with
-    /// `ERROR_SHARING_VIOLATION` and the orphan would otherwise survive.
-    /// Mirrors `DropTrackingFailingWriter` from
-    /// `shared_target.rs` (heddle#86 r2).
-    struct DropTrackingFailingWriter<'a> {
-        dropped: &'a std::cell::Cell<bool>,
-    }
-    impl Write for DropTrackingFailingWriter<'_> {
-        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::other("simulated write failure"))
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-    impl Drop for DropTrackingFailingWriter<'_> {
-        fn drop(&mut self) {
-            self.dropped.set(true);
-        }
+        assert!(repo.lock_path().exists());
+        assert!(repo.try_lock_refs_for_test().unwrap().is_some());
     }
 
     #[test]
-    fn write_lock_body_or_cleanup_drops_writer_before_returning_on_failure() {
-        // Regression for heddle#95 (sweep follow-up to heddle#86 r2). On
-        // Windows, `remove_file` against a still-open handle fails with
-        // `ERROR_SHARING_VIOLATION`; the lock file stays, and the next
-        // operation waits the full 5-minute stale-lock timeout. The
-        // helper must take the writer by value and drop it before
-        // `remove_file`. POSIX would let the unlink succeed against an
-        // open handle, so this test asserts the ownership-transfer
-        // guarantee directly: by the time the helper returns on the
-        // failure path, the writer has been dropped (i.e. on a real
-        // `File`, the OS handle is closed).
-        let temp = TempDir::new().unwrap();
-        let orphan = temp.path().join("LOCK");
-        fs::write(&orphan, b"").unwrap();
-
-        let dropped = std::cell::Cell::new(false);
-        let writer = DropTrackingFailingWriter { dropped: &dropped };
-        let result = write_lock_body_or_cleanup(writer, b"would-be body", &orphan);
-
-        assert!(result.is_err());
-        assert!(
-            dropped.get(),
-            "writer must be dropped before the helper returns on failure — \
-             on Windows, the file handle must be closed before remove_file"
-        );
-        assert!(!orphan.exists());
-    }
-
-    #[test]
-    fn test_lock_refs_stale_removal() {
+    fn lock_refs_does_not_reap_old_lock_body_while_holder_is_alive() {
         let temp_dir = TempDir::new().unwrap();
         let repo = RefManager::new(temp_dir.path());
         let lock_path = repo.lock_path();
         fs::create_dir_all(repo.refs_dir()).unwrap();
-        let fake_pid = 99999;
-        let old_ts = Utc::now().timestamp() - STALE_LOCK_TIMEOUT_SECS - 1;
-        let content = format!("{} {}", fake_pid, old_ts);
-        fs::write(&lock_path, content).unwrap();
-        let _lock = repo.lock_refs().unwrap();
+        let old_lock_body = "99999 0";
+        fs::write(&lock_path, old_lock_body).unwrap();
+
+        let holder = repo.lock_refs().unwrap();
+        assert!(repo.try_lock_refs_for_test().unwrap().is_none());
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let root = temp_dir.path().to_path_buf();
+        let waiter = thread::spawn(move || {
+            let repo = RefManager::new(&root);
+            started_tx.send(()).unwrap();
+            let _lock = repo.lock_refs().unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
         assert!(lock_path.exists());
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), old_lock_body);
+
+        drop(holder);
+        acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        waiter.join().unwrap();
+        assert!(lock_path.exists());
+    }
+
+    #[test]
+    fn lock_refs_reclaims_when_owner_fd_closes() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = RefManager::new(temp_dir.path());
+
+        let holder = repo.lock_refs().unwrap();
+        assert!(repo.try_lock_refs_for_test().unwrap().is_none());
+
+        drop(holder);
+        let successor = repo.try_lock_refs_for_test().unwrap();
+        assert!(successor.is_some());
+        assert!(repo.lock_path().exists());
     }
 }


### PR DESCRIPTION
## Summary
Closes #372 (spike #413 decided Option A). The refs `refs/LOCK` was an existence-based lockfile reaped purely on age (`STALE_LOCK_TIMEOUT_SECS = 300`) with **no liveness check** — a long operation holding the lock past 300s could have it reaped out from under it, losing mutual exclusion.

**Fix (fs2 advisory lock):** `refs/LOCK` is now a persistent `fs2` advisory-lock file; `RefsLock` holds the locked `File` FD and unlocks on drop. Kernel releases the lock on FD close / process death (`kill -9`/panic/exit leave **no** stale lock), so the age-based reaper is removed entirely (`STALE_LOCK_TIMEOUT_SECS`, `parse_lock_content`, the PID/timestamp body, the `remove_file` reaper — all gone). No delete-on-drop (avoids the Unix locked-inode split hazard). One-lock critical-section shape preserved. Windows gets real exclusive locking.

Net **−140/+84** in `refs_storage.rs` (simplification).

## Test evidence
- stable-lockfile behavior, long-holder exclusion (even with an old legacy lock body present), reclaim-after-owner-FD-close
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd`, `cargo test -p heddle-refs`, `-p heddle-mount`
- `bash scripts/check-no-silent-default-tree-load.sh`, `cargo clippy --locked --workspace --all-targets -- -D warnings`

🤖 codex-authored; cross-engine Claude review pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783015926&installation_id=132405951&pr_number=447&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F447&signature=4fa921c2023d36170056eb052c7bae7f3b6b287e13d23c27470407007dd45022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->