### PR TITLE
fix(import): refuse lossy git-import by default; explicit --lossy opt-in (#438)

### DIFF
--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -7,8 +7,8 @@ use std::{
     net::{TcpListener, TcpStream},
     process::{Child, Command, Stdio},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread,
     time::Duration,
@@ -23,11 +23,13 @@ use repo::Repository;
 use tempfile::TempDir;
 
 use crate::bridge::{
-    git_core::{copy_local_repo_to_bare, delete_reference_if_present, set_reference, GitPushScope},
-    git_export::{export_all, export_tree},
-    git_import::{import_all, import_git_tree},
-    git_sync::{sync_branches, sync_tags, sync_track_to_branch},
     GitBridge,
+    git_core::{GitPushScope, copy_local_repo_to_bare, delete_reference_if_present, set_reference},
+    git_export::{export_all, export_tree},
+    git_import::{import_all, import_all_with_options, import_git_tree},
+    git_import_tree::GitTreeImporter,
+    git_sync::{sync_branches, sync_tags, sync_track_to_branch},
+    git_util::GitImportOptions,
 };
 
 fn init_git_repo() -> (TempDir, gix::Repository) {
@@ -151,16 +153,18 @@ impl GitHttpBackend {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_signal = Arc::clone(&stop);
         let auth = basic_auth.clone();
-        let join = thread::spawn(move || loop {
-            if stop_signal.load(Ordering::Relaxed) {
-                break;
-            }
-            match listener.accept() {
-                Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
+        let join = thread::spawn(move || {
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
                 }
-                Err(_) => break,
+                match listener.accept() {
+                    Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
             }
         });
 
@@ -565,7 +569,7 @@ fn export_tree_substitutes_stub_for_redacted_blob() {
 }
 
 #[test]
-fn import_tree_reads_submodule_entries() {
+fn import_tree_rejects_submodule_entries_by_default() {
     let (_git_temp, git_repo) = init_git_repo();
     let submodule_oid: gix::hash::ObjectId = "0404040404040404040404040404040404040404"
         .parse()
@@ -584,7 +588,43 @@ fn import_tree_reads_submodule_entries() {
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
-    let tree_hash = import_git_tree(&repo, &git_repo, tree_oid).expect("import");
+
+    let err = import_git_tree(&repo, &git_repo, tree_oid)
+        .expect_err("gitlink import must fail without --lossy");
+    let message = err.to_string();
+
+    assert!(message.contains("vendor"), "error names entry: {message}");
+    assert!(
+        message.contains("losslessly"),
+        "error explains policy: {message}"
+    );
+    assert!(message.contains("--lossy"), "error names opt-in: {message}");
+}
+
+#[test]
+fn import_tree_reads_submodule_entries_with_lossy_opt_in() {
+    let (_git_temp, git_repo) = init_git_repo();
+    let submodule_oid: gix::hash::ObjectId = "0404040404040404040404040404040404040404"
+        .parse()
+        .expect("oid");
+    let mut editor = git_repo
+        .edit_tree(gix::hash::ObjectId::empty_tree(git_repo.object_hash()))
+        .expect("tree editor");
+    editor
+        .upsert(
+            "vendor",
+            gix::object::tree::EntryKind::Commit,
+            submodule_oid,
+        )
+        .expect("insert submodule");
+    let tree_oid = editor.write().expect("write tree").detach();
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut importer =
+        GitTreeImporter::with_options(&repo, &git_repo, GitImportOptions { lossy: true });
+    let tree_hash = importer.import_tree(tree_oid).expect("import");
+    let lossy_entries = importer.lossy_entries().to_vec();
     let heddle_tree = repo.store().get_tree(&tree_hash).expect("tree").unwrap();
 
     let entry = heddle_tree
@@ -597,6 +637,77 @@ fn import_tree_reads_submodule_entries() {
 
     assert!(text.starts_with("heddle-submodule:"));
     assert!(text.contains(&submodule_oid.to_string()));
+    assert_eq!(lossy_entries.len(), 1);
+    assert_eq!(lossy_entries[0].path, "vendor");
+    let oid = submodule_oid.to_string();
+    assert_eq!(lossy_entries[0].git_object.as_deref(), Some(oid.as_str()));
+}
+
+#[test]
+fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
+    let (_git_temp, git_repo) = init_git_repo();
+    let submodule_oid: gix::hash::ObjectId = "0505050505050505050505050505050505050505"
+        .parse()
+        .expect("oid");
+    let mut editor = git_repo
+        .edit_tree(gix::hash::ObjectId::empty_tree(git_repo.object_hash()))
+        .expect("tree editor");
+    editor
+        .upsert(
+            "vendor",
+            gix::object::tree::EntryKind::Commit,
+            submodule_oid,
+        )
+        .expect("insert submodule");
+    let tree_oid = editor.write().expect("write tree").detach();
+    commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "gitlink", &[]);
+
+    let default_heddle = TempDir::new().expect("heddle temp");
+    let default_repo = Repository::init(default_heddle.path()).expect("init heddle");
+    let mut default_bridge = GitBridge::new(&default_repo);
+    let err = import_all(
+        &mut default_bridge,
+        Some(git_repo.workdir().expect("workdir")),
+    )
+    .expect_err("default import must fail on gitlink");
+    let message = err.to_string();
+    assert!(message.contains("vendor"), "error names entry: {message}");
+    assert!(message.contains("--lossy"), "error names opt-in: {message}");
+
+    let lossy_heddle = TempDir::new().expect("heddle temp");
+    let lossy_repo = Repository::init(lossy_heddle.path()).expect("init heddle");
+    let mut lossy_bridge = GitBridge::new(&lossy_repo);
+    let stats = import_all_with_options(
+        &mut lossy_bridge,
+        Some(git_repo.workdir().expect("workdir")),
+        GitImportOptions { lossy: true },
+    )
+    .expect("lossy import accepts gitlink conversion");
+
+    assert_eq!(stats.states_created, 1);
+    assert_eq!(stats.lossy_entries.len(), 1);
+    assert_eq!(stats.lossy_entries[0].path, "vendor");
+    assert!(stats.lossy_entries[0].summary_line().contains("converted"));
+}
+
+#[test]
+fn import_all_lossy_clean_repo_reports_no_lossy_entries() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_git_temp, git_repo) = init_git_repo();
+    let tree_oid = empty_tree_oid(&git_repo);
+    commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "clean", &[]);
+
+    let mut bridge = GitBridge::new(&repo);
+    let stats = import_all_with_options(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir")),
+        GitImportOptions { lossy: true },
+    )
+    .expect("clean repo imports with lossy flag too");
+
+    assert_eq!(stats.states_created, 1);
+    assert!(stats.lossy_entries.is_empty());
 }
 
 /// Regression: `copy_local_repo_to_bare` (the engine behind `heddle clone
@@ -905,16 +1016,18 @@ fn pull_imports_remote_branches_and_tags_from_path_remote() {
         .pull(source_temp.path().to_str().expect("remote path"))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -932,16 +1045,18 @@ fn pull_imports_remote_branches_and_tags_from_file_url_remote() {
         .pull(&format!("file://{}", source_temp.path().display()))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -960,16 +1075,18 @@ fn pull_imports_remote_branches_and_tags_from_git_daemon() {
     let mut bridge = GitBridge::new(&repo);
     bridge.pull(&daemon.url("remote.git")).expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -990,16 +1107,18 @@ fn pull_imports_remote_branches_and_tags_from_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1020,16 +1139,18 @@ fn pull_imports_remote_branches_and_tags_from_authenticated_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over authenticated http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1885,7 +2006,12 @@ fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
     // All three states now exist in the store, and the import populated
     // the mirror with refs/heads/{main,feature}.
     assert_eq!(
-        bridge.heddle_repo.store().list_states().expect("states").len(),
+        bridge
+            .heddle_repo
+            .store()
+            .list_states()
+            .expect("states")
+            .len(),
         3,
         "import should have created three states (two on main, one on feature)"
     );
@@ -1958,11 +2084,12 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let bridge = GitBridge::new(&repo);
 
-    let attribution =
-        || Attribution::human(Principal::new("Alice", "alice@example.com"));
+    let attribution = || Attribution::human(Principal::new("Alice", "alice@example.com"));
     let put_state = |parents: Vec<ChangeId>| -> State {
         let store = bridge.heddle_repo.store();
-        let blob_hash = store.put_blob(&Blob::from_slice(b"contents")).expect("put blob");
+        let blob_hash = store
+            .put_blob(&Blob::from_slice(b"contents"))
+            .expect("put blob");
         let tree_hash = store
             .put_tree(&Tree::from_entries(vec![
                 TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
@@ -2004,7 +2131,12 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
     // would have minted (and, pre-r4, counted) it.
     let mut bridge = bridge;
     assert_eq!(
-        bridge.heddle_repo.store().list_states().expect("states").len(),
+        bridge
+            .heddle_repo
+            .store()
+            .list_states()
+            .expect("states")
+            .len(),
         3,
         "store holds main's two states plus the dropped scratch state"
     );

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -121,6 +121,26 @@ fn create_annotated_tag(
     tag_id
 }
 
+fn gitlink_tree(repo: &gix::Repository, name: &str) -> gix::hash::ObjectId {
+    let submodule_oid: gix::hash::ObjectId = "0505050505050505050505050505050505050505"
+        .parse()
+        .expect("oid");
+    let mut editor = repo
+        .edit_tree(gix::hash::ObjectId::empty_tree(repo.object_hash()))
+        .expect("tree editor");
+    editor
+        .upsert(name, gix::object::tree::EntryKind::Commit, submodule_oid)
+        .expect("insert submodule");
+    editor.write().expect("write tree").detach()
+}
+
+fn init_gitlink_repo() -> (TempDir, gix::Repository) {
+    let (git_temp, git_repo) = init_git_repo();
+    let tree_oid = gitlink_tree(&git_repo, "vendor");
+    commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "gitlink", &[]);
+    (git_temp, git_repo)
+}
+
 struct GitDaemon {
     child: Child,
     port: u16,
@@ -645,22 +665,7 @@ fn import_tree_reads_submodule_entries_with_lossy_opt_in() {
 
 #[test]
 fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
-    let (_git_temp, git_repo) = init_git_repo();
-    let submodule_oid: gix::hash::ObjectId = "0505050505050505050505050505050505050505"
-        .parse()
-        .expect("oid");
-    let mut editor = git_repo
-        .edit_tree(gix::hash::ObjectId::empty_tree(git_repo.object_hash()))
-        .expect("tree editor");
-    editor
-        .upsert(
-            "vendor",
-            gix::object::tree::EntryKind::Commit,
-            submodule_oid,
-        )
-        .expect("insert submodule");
-    let tree_oid = editor.write().expect("write tree").detach();
-    commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "gitlink", &[]);
+    let (_git_temp, git_repo) = init_gitlink_repo();
 
     let default_heddle = TempDir::new().expect("heddle temp");
     let default_repo = Repository::init(default_heddle.path()).expect("init heddle");
@@ -688,6 +693,152 @@ fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
     assert_eq!(stats.lossy_entries.len(), 1);
     assert_eq!(stats.lossy_entries[0].path, "vendor");
     assert!(stats.lossy_entries[0].summary_line().contains("converted"));
+}
+
+#[test]
+fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
+    let (_git_temp, git_repo) = init_gitlink_repo();
+    let git_path = git_repo.workdir().expect("workdir");
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+
+    let mut first_bridge = GitBridge::new(&repo);
+    let first = import_all_with_options(
+        &mut first_bridge,
+        Some(git_path),
+        GitImportOptions { lossy: true },
+    )
+    .expect("initial lossy bridge import succeeds");
+    assert_eq!(first.lossy_entries.len(), 1);
+
+    let mapping = std::fs::read_to_string(first_bridge.mapping_path()).expect("mapping sidecar");
+    assert!(
+        mapping.contains("lossy_entries"),
+        "bridge mapping must persist lossy entries: {mapping}"
+    );
+    assert!(
+        mapping.contains("vendor"),
+        "bridge mapping must name the lossy path: {mapping}"
+    );
+
+    let mut rerun_bridge = GitBridge::new(&repo);
+    let err = import_all(&mut rerun_bridge, Some(git_path))
+        .expect_err("default bridge import must not reuse cached lossy state silently");
+    assert_lossy_default_rerun_error("bridge", &err.to_string());
+}
+
+#[test]
+fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
+    let (_git_temp, git_repo) = init_gitlink_repo();
+    let git_path = git_repo.workdir().expect("workdir");
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+
+    let mut first_bridge = GitBridge::new(&repo);
+    import_all_with_options(
+        &mut first_bridge,
+        Some(git_path),
+        GitImportOptions { lossy: true },
+    )
+    .expect("initial lossy bridge import succeeds");
+
+    let mut rerun_bridge = GitBridge::new(&repo);
+    let second = import_all_with_options(
+        &mut rerun_bridge,
+        Some(git_path),
+        GitImportOptions { lossy: true },
+    )
+    .expect("lossy bridge rerun reports persisted lossy entries");
+
+    assert_eq!(second.states_created, 0);
+    assert_eq!(second.lossy_entries.len(), 1);
+    assert_eq!(second.lossy_entries[0].path, "vendor");
+    assert!(
+        second.lossy_entries[0]
+            .summary_line()
+            .contains("converted")
+    );
+}
+
+#[cfg(feature = "ingest")]
+#[derive(Clone, Copy, Debug)]
+enum ImportEngine {
+    Ingest,
+    Bridge,
+}
+
+#[cfg(feature = "ingest")]
+impl ImportEngine {
+    fn label(self) -> &'static str {
+        match self {
+            ImportEngine::Ingest => "ingest",
+            ImportEngine::Bridge => "bridge",
+        }
+    }
+}
+
+fn assert_lossy_default_rerun_error(engine: &str, message: &str) {
+    assert!(message.contains("vendor"), "{engine} error names entry: {message}");
+    assert!(
+        message.contains("losslessly"),
+        "{engine} error explains policy: {message}"
+    );
+    assert!(
+        message.contains("--lossy"),
+        "{engine} error names opt-in: {message}"
+    );
+}
+
+#[cfg(feature = "ingest")]
+fn run_lossy_then_default_rerun(engine: ImportEngine) {
+    let (_git_temp, git_repo) = init_gitlink_repo();
+    let git_path = git_repo.workdir().expect("workdir");
+    let message = match engine {
+        ImportEngine::Ingest => {
+            use ingest::{ImportOptions, import_git_into, import_git_into_with_options};
+
+            let heddle_temp = TempDir::new().expect("heddle temp");
+            let (first, map) = import_git_into_with_options(
+                git_path,
+                heddle_temp.path(),
+                ImportOptions { lossy: true },
+            )
+            .expect("initial lossy ingest import succeeds");
+            drop(map);
+            assert_eq!(first.lossy_entries.len(), 1);
+
+            import_git_into(git_path, heddle_temp.path())
+                .expect_err("default ingest import must fail on cached lossy tree")
+                .to_string()
+        }
+        ImportEngine::Bridge => {
+            let heddle_temp = TempDir::new().expect("heddle temp");
+            let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+            let mut first_bridge = GitBridge::new(&repo);
+            let first = import_all_with_options(
+                &mut first_bridge,
+                Some(git_path),
+                GitImportOptions { lossy: true },
+            )
+            .expect("initial lossy bridge import succeeds");
+            assert_eq!(first.lossy_entries.len(), 1);
+
+            let mut rerun_bridge = GitBridge::new(&repo);
+            import_all(&mut rerun_bridge, Some(git_path))
+                .expect_err("default bridge import must fail on cached lossy commit")
+                .to_string()
+        }
+    };
+
+    assert_lossy_default_rerun_error(engine.label(), &message);
+}
+
+#[cfg(feature = "ingest")]
+#[test]
+fn both_engines_fail_hard_on_default_rerun_after_lossy() {
+    for engine in [ImportEngine::Ingest, ImportEngine::Bridge] {
+        run_lossy_then_default_rerun(engine);
+    }
 }
 
 #[test]

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -266,7 +266,11 @@ impl RefSpec {
 
     /// Render in `git` refspec syntax without the leading `+`, even when forced.
     pub fn to_git_format_not_forced(&self) -> String {
-        format!("{}:{}", self.source.as_deref().unwrap_or(""), self.destination)
+        format!(
+            "{}:{}",
+            self.source.as_deref().unwrap_or(""),
+            self.destination
+        )
     }
 }
 
@@ -981,19 +985,26 @@ impl<'a> GitBridge<'a> {
 
         let mut materialized_attached_thread = false;
         if let Some((thread, old_state)) = attached_before
-            && let Some(new_state) = self.heddle_repo.refs().get_thread(&ThreadName::new(&thread))?
+            && let Some(new_state) = self
+                .heddle_repo
+                .refs()
+                .get_thread(&ThreadName::new(&thread))?
             && new_state != old_state
         {
-            self.heddle_repo.refs().set_thread(&ThreadName::new(&thread), &old_state)?;
+            self.heddle_repo
+                .refs()
+                .set_thread(&ThreadName::new(&thread), &old_state)?;
             self.heddle_repo.refs().write_head(&Head::Attached {
                 thread: ThreadName::new(&thread),
             })?;
             self.heddle_repo
                 .goto_verified_clean_without_record(&new_state)?;
-            self.heddle_repo.refs().set_thread(&ThreadName::new(&thread), &new_state)?;
             self.heddle_repo
                 .refs()
-                .write_head(&Head::Attached { thread: ThreadName::new(&thread) })?;
+                .set_thread(&ThreadName::new(&thread), &new_state)?;
+            self.heddle_repo.refs().write_head(&Head::Attached {
+                thread: ThreadName::new(&thread),
+            })?;
             materialized_attached_thread = true;
         }
 
@@ -1228,7 +1239,10 @@ impl<'a> GitBridge<'a> {
         let mut real_tracked: HashSet<String> = HashSet::new();
         let mut existing_ita: HashSet<String> = HashSet::new();
         for entry in index.entries() {
-            let path = entry.path_in(index.path_backing()).to_str_lossy().into_owned();
+            let path = entry
+                .path_in(index.path_backing())
+                .to_str_lossy()
+                .into_owned();
             if entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD) {
                 existing_ita.insert(path);
             } else {
@@ -1345,7 +1359,11 @@ impl<'a> GitBridge<'a> {
         &mut self,
         thread: &str,
     ) -> GitResult<WriteThroughOutcome> {
-        let Some(state_id) = self.heddle_repo.refs().get_thread(&ThreadName::new(thread))? else {
+        let Some(state_id) = self
+            .heddle_repo
+            .refs()
+            .get_thread(&ThreadName::new(thread))?
+        else {
             return Ok(WriteThroughOutcome::Skipped(
                 WriteThroughSkipReason::NoAttachedThread,
             ));
@@ -1771,9 +1789,10 @@ fn parse_configured_remote_url(value: &str, relative_base: &Path) -> GitResult<g
 
 fn configured_remote_local_path(value: &str, relative_base: &Path) -> PathBuf {
     if value == "~"
-        && let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home);
-        }
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home);
+    }
     if let Some(rest) = value.strip_prefix("~/")
         && let Some(home) = std::env::var_os("HOME")
     {
@@ -3068,8 +3087,7 @@ mod tests {
 
     #[test]
     fn parse_git_ref_remote_branch_keeps_nested_name() {
-        let parsed =
-            parse_git_ref("refs/remotes/origin/feature/x").expect("remote branch parses");
+        let parsed = parse_git_ref("refs/remotes/origin/feature/x").expect("remote branch parses");
         assert_eq!(parsed.kind, GitRefKind::Branch);
         assert_eq!(parsed.name, "feature/x");
         assert_eq!(parsed.remote, "origin");

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -34,7 +34,7 @@ use repo::Repository as HeddleRepository;
 use super::{
     git_export::{export_all, export_current_thread},
     git_import::import_all,
-    git_util::ImportStats,
+    git_util::{ImportStats, LossyGitImportEntry},
 };
 
 /// Errors specific to Git bridge operations.
@@ -433,6 +433,9 @@ pub struct SyncMapping {
     heddle_to_git: HashMap<ChangeId, ObjectId>,
     /// Maps Git object id -> Heddle ChangeId
     git_to_heddle: HashMap<ObjectId, ChangeId>,
+    /// Git commits whose imported Heddle states were produced under
+    /// `bridge git import --lossy`, with root-relative lossy entries.
+    git_lossy_entries: HashMap<ObjectId, Vec<LossyGitImportEntry>>,
 }
 
 impl SyncMapping {
@@ -445,6 +448,9 @@ impl SyncMapping {
     pub fn insert(&mut self, change_id: ChangeId, git_oid: ObjectId) {
         if let Some(previous_git) = self.heddle_to_git.remove(&change_id) {
             self.git_to_heddle.remove(&previous_git);
+            if previous_git != git_oid {
+                self.git_lossy_entries.remove(&previous_git);
+            }
         }
         if let Some(previous_change) = self.git_to_heddle.remove(&git_oid) {
             self.heddle_to_git.remove(&previous_change);
@@ -501,46 +507,82 @@ impl SyncMapping {
         self.git_to_heddle.contains_key(&git_oid)
     }
 
+    pub(crate) fn set_git_lossy_entries(
+        &mut self,
+        git_oid: ObjectId,
+        entries: Vec<LossyGitImportEntry>,
+    ) {
+        if entries.is_empty() {
+            self.git_lossy_entries.remove(&git_oid);
+        } else {
+            self.git_lossy_entries.insert(git_oid, entries);
+        }
+    }
+
+    pub(crate) fn get_git_lossy_entries(
+        &self,
+        git_oid: ObjectId,
+    ) -> Option<&[LossyGitImportEntry]> {
+        self.git_lossy_entries.get(&git_oid).map(Vec::as_slice)
+    }
+
     /// Iterate over mappings.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&ChangeId, &ObjectId)> {
         self.heddle_to_git.iter()
     }
 
     pub(crate) fn retain_git_objects(&mut self, repo: &gix::Repository) {
-        let retained: Vec<(ChangeId, ObjectId)> = self
+        let retained: Vec<(ChangeId, ObjectId, Option<Vec<LossyGitImportEntry>>)> = self
             .heddle_to_git
             .iter()
             .filter_map(|(change_id, git_oid)| {
                 repo.find_object(*git_oid)
                     .ok()
-                    .map(|_| (*change_id, *git_oid))
+                    .map(|_| {
+                        (
+                            *change_id,
+                            *git_oid,
+                            self.git_lossy_entries.get(git_oid).cloned(),
+                        )
+                    })
             })
             .collect();
 
         self.heddle_to_git.clear();
         self.git_to_heddle.clear();
-        for (change_id, git_oid) in retained {
+        self.git_lossy_entries.clear();
+        for (change_id, git_oid, lossy_entries) in retained {
             self.insert(change_id, git_oid);
+            if let Some(lossy_entries) = lossy_entries {
+                self.set_git_lossy_entries(git_oid, lossy_entries);
+            }
         }
     }
 
     #[cfg_attr(not(feature = "git-overlay"), allow(dead_code))]
     pub(crate) fn retain_git_object_set(&mut self, reachable: &HashSet<ObjectId>) -> usize {
         let before = self.heddle_to_git.len();
-        let retained: Vec<(ChangeId, ObjectId)> = self
+        let retained: Vec<(ChangeId, ObjectId, Option<Vec<LossyGitImportEntry>>)> = self
             .heddle_to_git
             .iter()
-            .filter_map(|(change_id, git_oid)| {
-                reachable
-                    .contains(git_oid)
-                    .then_some((*change_id, *git_oid))
+            .filter(|(_, git_oid)| reachable.contains(*git_oid))
+            .map(|(change_id, git_oid)| {
+                (
+                    *change_id,
+                    *git_oid,
+                    self.git_lossy_entries.get(git_oid).cloned(),
+                )
             })
             .collect();
 
         self.heddle_to_git.clear();
         self.git_to_heddle.clear();
-        for (change_id, git_oid) in retained {
+        self.git_lossy_entries.clear();
+        for (change_id, git_oid, lossy_entries) in retained {
             self.insert(change_id, git_oid);
+            if let Some(lossy_entries) = lossy_entries {
+                self.set_git_lossy_entries(git_oid, lossy_entries);
+            }
         }
         before.saturating_sub(self.heddle_to_git.len())
     }

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -5,7 +5,9 @@ use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use chrono::{TimeZone, Utc};
-use objects::object::{Agent, Attribution, ChangeId, MarkerName, Principal, State, Status, ThreadName};
+use objects::object::{
+    Agent, Attribution, ChangeId, MarkerName, Principal, State, Status, ThreadName,
+};
 use refs::{Head, RefExpectation};
 use repo::Repository as HeddleRepository;
 use tracing::warn;
@@ -18,7 +20,7 @@ use crate::bridge::{
         thread_is_unclaimed_bootstrap,
     },
     git_notes,
-    git_util::{ImportStats, PartialMirrorRef, SkippedRef},
+    git_util::{GitImportOptions, ImportStats, PartialMirrorRef, SkippedRef},
 };
 
 /// One source ref the import will consider, with both its immediate target
@@ -247,7 +249,15 @@ pub fn import_commit(
 
 /// Import Git commits into Heddle states.
 pub fn import_all(bridge: &mut GitBridge, git_path: Option<&Path>) -> GitResult<ImportStats> {
-    import_with_ref_filter(bridge, git_path, None)
+    import_with_ref_filter(bridge, git_path, None, GitImportOptions::default())
+}
+
+pub fn import_all_with_options(
+    bridge: &mut GitBridge,
+    git_path: Option<&Path>,
+    options: GitImportOptions,
+) -> GitResult<ImportStats> {
+    import_with_ref_filter(bridge, git_path, None, options)
 }
 
 pub fn import_selected_refs(
@@ -256,13 +266,24 @@ pub fn import_selected_refs(
     refs: &[String],
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(bridge, git_path, Some(&wanted))
+    import_with_ref_filter(bridge, git_path, Some(&wanted), GitImportOptions::default())
+}
+
+pub fn import_selected_refs_with_options(
+    bridge: &mut GitBridge,
+    git_path: Option<&Path>,
+    refs: &[String],
+    options: GitImportOptions,
+) -> GitResult<ImportStats> {
+    let wanted = refs.iter().cloned().collect::<HashSet<_>>();
+    import_with_ref_filter(bridge, git_path, Some(&wanted), options)
 }
 
 fn import_with_ref_filter(
     bridge: &mut GitBridge,
     git_path: Option<&Path>,
     wanted_refs: Option<&HashSet<String>>,
+    options: GitImportOptions,
 ) -> GitResult<ImportStats> {
     let repo = if let Some(path) = git_path {
         open_repo(path)?
@@ -512,7 +533,8 @@ fn import_with_ref_filter(
 
     bridge.build_existing_mapping(Some(repo.path()))?;
 
-    let mut tree_importer = GitTreeImporter::new(bridge.heddle_repo, &repo);
+    let mut tree_importer =
+        GitTreeImporter::with_options(bridge.heddle_repo, &repo, options.clone());
     bridge.heddle_repo.store().begin_snapshot_write_batch()?;
     let import_result = (|| -> GitResult<()> {
         let mut visiting = HashSet::new();
@@ -533,6 +555,9 @@ fn import_with_ref_filter(
     })();
     match import_result {
         Ok(()) => {
+            stats
+                .lossy_entries
+                .extend(tree_importer.lossy_entries().iter().cloned());
             bridge.write_mapping_tmp_to_disk()?;
             bridge.heddle_repo.store().flush_snapshot_write_batch()?;
             bridge.commit_mapping_tmp_to_disk()?;
@@ -552,7 +577,10 @@ fn import_with_ref_filter(
             continue;
         }
         if let Some(change_id) = bridge.mapping.get_heddle(plan.peeled_commit_oid) {
-            let existing = bridge.heddle_repo.refs().get_thread(&ThreadName::new(name.as_str()))?;
+            let existing = bridge
+                .heddle_repo
+                .refs()
+                .get_thread(&ThreadName::new(name.as_str()))?;
             if let Some(existing_change) = existing
                 && !thread_can_adopt_change(bridge.heddle_repo, &existing_change, &change_id)?
             {

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -13,6 +13,7 @@ use repo::Repository as HeddleRepository;
 use tracing::warn;
 
 pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
+use super::git_import_tree::fail_lossy_entry;
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, RefNamespace, RefUpdate, SyncMapping,
@@ -840,6 +841,7 @@ fn import_commit_ancestry(
                     None => true,
                 };
                 if needs_state {
+                    let before_lossy = tree_importer.lossy_entries().len();
                     let change_id = import_commit(
                         &mut bridge.mapping,
                         bridge.heddle_repo,
@@ -848,7 +850,17 @@ fn import_commit_ancestry(
                         oid,
                     )?;
                     bridge.mapping.insert(change_id, oid);
+                    let commit_lossy_entries =
+                        tree_importer.lossy_entries()[before_lossy..].to_vec();
+                    bridge
+                        .mapping
+                        .set_git_lossy_entries(oid, commit_lossy_entries);
                     stats.states_created += 1;
+                } else if let Some(lossy_entries) = bridge.mapping.get_git_lossy_entries(oid) {
+                    if !tree_importer.lossy_enabled() {
+                        return Err(fail_lossy_entry(&lossy_entries[0]));
+                    }
+                    stats.lossy_entries.extend(lossy_entries.iter().cloned());
                 }
                 // Counted regardless of `needs_state`: `commits_imported`
                 // reports commits **walked from the source**, mirroring

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git trees as Heddle trees.
 
-use objects::store::ObjectStore;
 use std::collections::HashMap;
 
 use objects::object::{Blob, ContentHash, FileMode, Tree, TreeEntry};
+use objects::store::ObjectStore;
 use repo::Repository as HeddleRepository;
 
 use crate::bridge::git_core::{GitBridgeError, GitResult};
+use crate::bridge::git_util::{GitImportOptions, LossyGitImportEntry};
 
 const SUBMODULE_PREFIX: &str = "heddle-submodule:";
 
@@ -16,20 +17,53 @@ pub struct GitTreeImporter<'a> {
     repo: &'a gix::Repository,
     tree_cache: HashMap<gix::hash::ObjectId, ContentHash>,
     blob_cache: HashMap<gix::hash::ObjectId, ContentHash>,
+    options: GitImportOptions,
+    lossy_entries: Vec<LossyGitImportEntry>,
+    lossy_by_tree: HashMap<gix::hash::ObjectId, Vec<LossyGitImportEntry>>,
 }
 
 impl<'a> GitTreeImporter<'a> {
     pub fn new(heddle_repo: &'a HeddleRepository, repo: &'a gix::Repository) -> Self {
+        Self::with_options(heddle_repo, repo, GitImportOptions::default())
+    }
+
+    pub fn with_options(
+        heddle_repo: &'a HeddleRepository,
+        repo: &'a gix::Repository,
+        options: GitImportOptions,
+    ) -> Self {
         Self {
             heddle_repo,
             repo,
             tree_cache: HashMap::new(),
             blob_cache: HashMap::new(),
+            options,
+            lossy_entries: Vec::new(),
+            lossy_by_tree: HashMap::new(),
         }
     }
 
+    pub fn lossy_entries(&self) -> &[LossyGitImportEntry] {
+        &self.lossy_entries
+    }
+
     pub fn import_tree(&mut self, tree_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
+        self.import_tree_at(tree_oid, "")
+    }
+
+    fn import_tree_at(
+        &mut self,
+        tree_oid: gix::hash::ObjectId,
+        path_prefix: &str,
+    ) -> GitResult<ContentHash> {
         if let Some(hash) = self.tree_cache.get(&tree_oid) {
+            if let Some(entries) = self.lossy_by_tree.get(&tree_oid) {
+                self.lossy_entries.extend(
+                    entries
+                        .iter()
+                        .map(|entry| rebase_lossy_entry(path_prefix, entry)),
+                );
+            }
             return Ok(*hash);
         }
 
@@ -39,10 +73,21 @@ impl<'a> GitTreeImporter<'a> {
             .map_err(|err| GitBridgeError::Git(err.to_string()))?;
 
         let mut entries = Vec::new();
+        let before_lossy = self.lossy_entries.len();
 
         for entry in git_tree.iter() {
             let entry = entry.map_err(|err| GitBridgeError::Git(err.to_string()))?;
-            let name = String::from_utf8_lossy(entry.filename().as_ref()).into_owned();
+            let name =
+                self.import_entry_name(path_prefix, entry.filename().as_ref(), entry.object_id())?;
+            if !is_representable_tree_name(&name) {
+                let lossy = LossyGitImportEntry::dropped(
+                    join_tree_path(path_prefix, &name),
+                    Some(entry.object_id().to_string()),
+                    "tree entry name is not representable in Heddle",
+                );
+                self.record_lossy(lossy)?;
+                continue;
+            }
 
             match entry.kind() {
                 gix::object::tree::EntryKind::Blob
@@ -81,7 +126,8 @@ impl<'a> GitTreeImporter<'a> {
                     });
                 }
                 gix::object::tree::EntryKind::Tree => {
-                    let subtree_hash = self.import_tree(entry.object_id())?;
+                    let subtree_hash = self
+                        .import_tree_at(entry.object_id(), &join_tree_path(path_prefix, &name))?;
                     entries.push(TreeEntry {
                         name,
                         mode: FileMode::Normal,
@@ -90,6 +136,12 @@ impl<'a> GitTreeImporter<'a> {
                     });
                 }
                 gix::object::tree::EntryKind::Commit => {
+                    let lossy = LossyGitImportEntry::converted(
+                        join_tree_path(path_prefix, &name),
+                        Some(entry.object_id().to_string()),
+                        "gitlink/submodule entry converted to a heddle-submodule blob",
+                    );
+                    self.record_lossy(lossy)?;
                     let hash = self.import_gitlink(entry.object_id())?;
                     entries.push(TreeEntry {
                         name,
@@ -100,11 +152,49 @@ impl<'a> GitTreeImporter<'a> {
                 }
             }
         }
+        let tree_lossy_entries = self.lossy_entries[before_lossy..]
+            .iter()
+            .map(|entry| entry_relative_to_prefix(path_prefix, entry))
+            .collect::<Vec<_>>();
 
         let tree = Tree::from_entries(entries);
         let hash = self.heddle_repo.store().put_tree(&tree)?;
         self.tree_cache.insert(tree_oid, hash);
+        self.lossy_by_tree.insert(tree_oid, tree_lossy_entries);
         Ok(hash)
+    }
+
+    fn import_entry_name(
+        &mut self,
+        path_prefix: &str,
+        raw_name: &[u8],
+        object_id: gix::hash::ObjectId,
+    ) -> GitResult<String> {
+        match std::str::from_utf8(raw_name) {
+            Ok(name) => Ok(name.to_string()),
+            Err(_) => {
+                let name = String::from_utf8_lossy(raw_name).into_owned();
+                let lossy = LossyGitImportEntry::converted(
+                    join_tree_path(path_prefix, &name),
+                    Some(object_id.to_string()),
+                    "tree entry name is not valid UTF-8 and was converted with replacement characters",
+                );
+                self.record_lossy(lossy)?;
+                Ok(name)
+            }
+        }
+    }
+
+    fn record_lossy(&mut self, entry: LossyGitImportEntry) -> GitResult<()> {
+        if !self.options.lossy {
+            return Err(GitBridgeError::InvalidMapping(format!(
+                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
+                entry.summary_line()
+            )));
+        }
+        tracing::warn!(entry = %entry.summary_line(), "lossy git import accepted");
+        self.lossy_entries.push(entry);
+        Ok(())
     }
 
     fn import_blob(&mut self, blob_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
@@ -142,4 +232,49 @@ pub fn import_git_tree(
     tree_oid: gix::hash::ObjectId,
 ) -> GitResult<ContentHash> {
     GitTreeImporter::new(heddle_repo, repo).import_tree(tree_oid)
+}
+
+fn is_representable_tree_name(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && !name.contains('/')
+        && !name.bytes().any(|b| b < 0x20 || b == 0x7f)
+}
+
+fn join_tree_path(prefix: &str, name: &str) -> String {
+    let name = display_tree_name(name);
+    if prefix.is_empty() {
+        name
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+fn display_tree_name(name: &str) -> String {
+    if name.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        name.escape_debug().to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn rebase_lossy_entry(prefix: &str, entry: &LossyGitImportEntry) -> LossyGitImportEntry {
+    let mut rebased = entry.clone();
+    if !prefix.is_empty() {
+        rebased.path = format!("{prefix}/{}", entry.path);
+    }
+    rebased
+}
+
+fn entry_relative_to_prefix(prefix: &str, entry: &LossyGitImportEntry) -> LossyGitImportEntry {
+    if prefix.is_empty() {
+        return entry.clone();
+    }
+
+    let mut relative = entry.clone();
+    if let Some(stripped) = entry.path.strip_prefix(prefix) {
+        relative.path = stripped.trim_start_matches('/').to_string();
+    }
+    relative
 }

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use objects::object::{Blob, ContentHash, FileMode, Tree, TreeEntry};
 use objects::store::ObjectStore;
+use objects::util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name};
 use repo::Repository as HeddleRepository;
 
 use crate::bridge::git_core::{GitBridgeError, GitResult};
@@ -77,17 +78,11 @@ impl<'a> GitTreeImporter<'a> {
 
         for entry in git_tree.iter() {
             let entry = entry.map_err(|err| GitBridgeError::Git(err.to_string()))?;
-            let name =
-                self.import_entry_name(path_prefix, entry.filename().as_ref(), entry.object_id())?;
-            if !is_representable_tree_name(&name) {
-                let lossy = LossyGitImportEntry::dropped(
-                    join_tree_path(path_prefix, &name),
-                    Some(entry.object_id().to_string()),
-                    "tree entry name is not representable in Heddle",
-                );
-                self.record_lossy(lossy)?;
+            let Some(name) =
+                self.import_entry_name(path_prefix, entry.filename().as_ref(), entry.object_id())?
+            else {
                 continue;
-            }
+            };
 
             match entry.kind() {
                 gix::object::tree::EntryKind::Blob
@@ -169,18 +164,29 @@ impl<'a> GitTreeImporter<'a> {
         path_prefix: &str,
         raw_name: &[u8],
         object_id: gix::hash::ObjectId,
-    ) -> GitResult<String> {
-        match std::str::from_utf8(raw_name) {
-            Ok(name) => Ok(name.to_string()),
-            Err(_) => {
-                let name = String::from_utf8_lossy(raw_name).into_owned();
-                let lossy = LossyGitImportEntry::converted(
-                    join_tree_path(path_prefix, &name),
-                    Some(object_id.to_string()),
-                    "tree entry name is not valid UTF-8 and was converted with replacement characters",
-                );
-                self.record_lossy(lossy)?;
-                Ok(name)
+    ) -> GitResult<Option<String>> {
+        match classify_git_tree_name(raw_name) {
+            GitTreeNameClassification::Representable(name) => Ok(Some(name)),
+            GitTreeNameClassification::NeedsLossy(lossy) => {
+                let path = join_tree_path(path_prefix, &lossy.name);
+                let entry = match lossy.action {
+                    GitTreeNameLossyAction::Dropped => LossyGitImportEntry::dropped(
+                        path,
+                        Some(object_id.to_string()),
+                        lossy.reason,
+                    ),
+                    GitTreeNameLossyAction::Converted => LossyGitImportEntry::converted(
+                        path,
+                        Some(object_id.to_string()),
+                        lossy.reason,
+                    ),
+                };
+                self.record_lossy(entry)?;
+                if matches!(lossy.action, GitTreeNameLossyAction::Dropped) {
+                    Ok(None)
+                } else {
+                    Ok(Some(lossy.name))
+                }
             }
         }
     }
@@ -232,14 +238,6 @@ pub fn import_git_tree(
     tree_oid: gix::hash::ObjectId,
 ) -> GitResult<ContentHash> {
     GitTreeImporter::new(heddle_repo, repo).import_tree(tree_oid)
-}
-
-fn is_representable_tree_name(name: &str) -> bool {
-    !name.is_empty()
-        && name != "."
-        && name != ".."
-        && !name.contains('/')
-        && !name.bytes().any(|b| b < 0x20 || b == 0x7f)
 }
 
 fn join_tree_path(prefix: &str, name: &str) -> String {

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -48,6 +48,10 @@ impl<'a> GitTreeImporter<'a> {
         &self.lossy_entries
     }
 
+    pub(crate) fn lossy_enabled(&self) -> bool {
+        self.options.lossy
+    }
+
     pub fn import_tree(&mut self, tree_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
         self.import_tree_at(tree_oid, "")
     }
@@ -193,10 +197,7 @@ impl<'a> GitTreeImporter<'a> {
 
     fn record_lossy(&mut self, entry: LossyGitImportEntry) -> GitResult<()> {
         if !self.options.lossy {
-            return Err(GitBridgeError::InvalidMapping(format!(
-                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
-                entry.summary_line()
-            )));
+            return Err(fail_lossy_entry(&entry));
         }
         tracing::warn!(entry = %entry.summary_line(), "lossy git import accepted");
         self.lossy_entries.push(entry);
@@ -238,6 +239,13 @@ pub fn import_git_tree(
     tree_oid: gix::hash::ObjectId,
 ) -> GitResult<ContentHash> {
     GitTreeImporter::new(heddle_repo, repo).import_tree(tree_oid)
+}
+
+pub(crate) fn fail_lossy_entry(entry: &LossyGitImportEntry) -> GitBridgeError {
+    GitBridgeError::InvalidMapping(format!(
+        "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
+        entry.summary_line()
+    ))
 }
 
 fn join_tree_path(prefix: &str, name: &str) -> String {

--- a/crates/cli/src/bridge/git_mapping.rs
+++ b/crates/cli/src/bridge/git_mapping.rs
@@ -11,12 +11,17 @@ use std::{
 use objects::object::ChangeId;
 use serde::{Deserialize, Serialize};
 
-use super::git_core::{GitBridge, GitBridgeError, GitResult, git_err};
+use super::{
+    git_core::{GitBridge, GitBridgeError, GitResult, git_err},
+    git_util::LossyGitImportEntry,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct MappingEntry {
     change_id: String,
     git_oid: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    lossy_entries: Vec<LossyGitImportEntry>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -92,6 +97,8 @@ impl<'a> GitBridge<'a> {
                 .parse::<gix::hash::ObjectId>()
                 .map_err(|err| GitBridgeError::InvalidMapping(err.to_string()))?;
             self.mapping.insert_checked(change_id, git_oid)?;
+            self.mapping
+                .set_git_lossy_entries(git_oid, entry.lossy_entries);
         }
 
         Ok(())
@@ -118,6 +125,11 @@ impl<'a> GitBridge<'a> {
             .map(|(change_id, git_oid)| MappingEntry {
                 change_id: change_id.to_string_full(),
                 git_oid: git_oid.to_string(),
+                lossy_entries: self
+                    .mapping
+                    .get_git_lossy_entries(*git_oid)
+                    .map(|entries| entries.to_vec())
+                    .unwrap_or_default(),
             })
             .collect();
 

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 
 use objects::object::{State, Status};
+use serde::{Deserialize, Serialize};
 
 use super::git_core::GitBridge;
 
@@ -233,7 +234,7 @@ pub struct GitImportOptions {
 }
 
 /// One git tree entry that bridge import could not represent losslessly.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LossyGitImportEntry {
     pub path: String,
     pub git_object: Option<String>,
@@ -241,7 +242,7 @@ pub struct LossyGitImportEntry {
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
 pub enum LossyGitImportAction {
     Dropped,
     Converted,

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -222,6 +222,71 @@ pub struct ImportStats {
     /// the bridge mirror — see [`PartialMirrorRef`]. SHA-stable export
     /// is degraded for these refs.
     pub partial_mirror_refs: Vec<PartialMirrorRef>,
+    /// Git tree entries converted under an explicit lossy import opt-in.
+    pub lossy_entries: Vec<LossyGitImportEntry>,
+}
+
+/// Policy knobs for bridge git import.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct GitImportOptions {
+    pub lossy: bool,
+}
+
+/// One git tree entry that bridge import could not represent losslessly.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LossyGitImportEntry {
+    pub path: String,
+    pub git_object: Option<String>,
+    pub action: LossyGitImportAction,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum LossyGitImportAction {
+    Dropped,
+    Converted,
+}
+
+impl LossyGitImportAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LossyGitImportAction::Dropped => "dropped",
+            LossyGitImportAction::Converted => "converted",
+        }
+    }
+}
+
+impl LossyGitImportEntry {
+    pub fn dropped(path: String, git_object: Option<String>, reason: impl Into<String>) -> Self {
+        Self {
+            path,
+            git_object,
+            action: LossyGitImportAction::Dropped,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn converted(path: String, git_object: Option<String>, reason: impl Into<String>) -> Self {
+        Self {
+            path,
+            git_object,
+            action: LossyGitImportAction::Converted,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn summary_line(&self) -> String {
+        match &self.git_object {
+            Some(object) => format!(
+                "{} {} ({}): {}",
+                self.action.as_str(),
+                self.path,
+                object,
+                self.reason
+            ),
+            None => format!("{} {}: {}", self.action.as_str(), self.path, self.reason),
+        }
+    }
 }
 
 /// A ref that pointed at a non-commit object during import.

--- a/crates/cli/src/cli/cli_args/commands_bridge.rs
+++ b/crates/cli/src/cli/cli_args/commands_bridge.rs
@@ -103,6 +103,15 @@ pub enum GitCommands {
         /// import all branches and tags.
         #[arg(long = "ref", value_name = "REF")]
         refs: Vec<String>,
+
+        /// Accept git tree entries Heddle cannot represent losslessly.
+        ///
+        /// By default import fails on the first unrepresentable tree entry
+        /// and names the offending path. With this flag, import restores the
+        /// historical drop/convert behavior and prints an end-of-run summary
+        /// of every affected entry.
+        #[arg(long)]
+        lossy: bool,
     },
 
     /// Bidirectional sync with Git (export + import).
@@ -150,6 +159,13 @@ pub enum GitCommands {
         /// Source git repository (local path or URL) to import from.
         #[arg(long, value_parser = parse_git_source)]
         path: GitSource,
+        /// Accept git tree entries Heddle cannot represent losslessly.
+        ///
+        /// By default ingest fails on the first unrepresentable tree entry.
+        /// With this flag, ingest restores the historical drop behavior and
+        /// prints an end-of-run summary of every affected entry.
+        #[arg(long)]
+        lossy: bool,
     },
 
     /// Mine local AI-coding-agent sessions (Claude / Codex / OpenCode)

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -6,7 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use objects::object::ThreadName;
 use refs::Head;
 use repo::Repository;
@@ -16,24 +16,27 @@ use super::{
     action_line::{print_next, print_next_step, print_optional},
     advice::RecoveryAdvice,
     git_overlay_health::{
-        action_template, build_git_overlay_health, build_plain_git_verification_probe,
+        GitOverlayHealth, GitOverlayHealthCheck, RepositoryVerificationState, action_template,
+        build_git_overlay_health, build_plain_git_verification_probe,
         build_repository_verification_state, canonical_adopt_ref_command,
         canonical_bridge_import_ref_command, canonical_bridge_reconcile_ref_command,
         canonical_bridge_reconcile_ref_preview_command, serialize_empty_action_as_null,
-        GitOverlayHealth, GitOverlayHealthCheck, RepositoryVerificationState,
     },
     import_progress::ImportProgress,
     remote::resolve_default_remote_name,
 };
 use crate::{
     bridge::{
+        GitBridge,
         git_core::clone_url_to_bare,
         git_export::export_all,
-        git_import::{import_all, import_selected_refs},
-        git_util::ExportedRef,
-        GitBridge,
+        git_import::{
+            import_all, import_all_with_options, import_selected_refs,
+            import_selected_refs_with_options,
+        },
+        git_util::{ExportedRef, GitImportOptions, LossyGitImportEntry},
     },
-    cli::{cli_args::GitSource, should_output_json, style, Cli, GitCommands},
+    cli::{Cli, GitCommands, cli_args::GitSource, should_output_json, style},
 };
 
 /// A `GitSource` resolved to an on-disk path. For URL sources we own a
@@ -218,6 +221,7 @@ struct BridgeGitImportOutput {
     tags_synced: usize,
     skipped_non_commit_refs: usize,
     partial_mirror_refs: usize,
+    lossy_entries: Vec<BridgeLossyGitImportEntryOutput>,
     already_in_sync: bool,
     #[serde(serialize_with = "serialize_empty_action_as_null")]
     recommended_action: String,
@@ -226,6 +230,14 @@ struct BridgeGitImportOutput {
     #[serde(skip_serializing)]
     #[serde(rename = "verification")]
     trust: RepositoryVerificationState,
+}
+
+#[derive(Serialize)]
+struct BridgeLossyGitImportEntryOutput {
+    path: String,
+    action: String,
+    reason: String,
+    git_object: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -498,6 +510,24 @@ fn render_bridge_git_import(
             style::bold(&output.partial_mirror_refs.to_string())
         );
     }
+    if !output.lossy_entries.is_empty() {
+        println!(
+            "{} lossy import accepted for {} tree entries",
+            style::warn_marker(),
+            style::bold(&output.lossy_entries.len().to_string())
+        );
+        for entry in &output.lossy_entries {
+            let object = entry
+                .git_object
+                .as_deref()
+                .map(|value| format!(" ({value})"))
+                .unwrap_or_default();
+            println!(
+                "  {} {}{}: {}",
+                entry.action, entry.path, object, entry.reason
+            );
+        }
+    }
     println!();
     println!("{}", style::section("Verification"));
     println!(
@@ -510,6 +540,20 @@ fn render_bridge_git_import(
         print_next(&output.recommended_action);
     }
     Ok(())
+}
+
+fn bridge_lossy_import_entries(
+    entries: &[LossyGitImportEntry],
+) -> Vec<BridgeLossyGitImportEntryOutput> {
+    entries
+        .iter()
+        .map(|entry| BridgeLossyGitImportEntryOutput {
+            path: entry.path.clone(),
+            action: entry.action.as_str().to_string(),
+            reason: entry.reason.clone(),
+            git_object: entry.git_object.clone(),
+        })
+        .collect()
 }
 
 fn render_bridge_git_reconcile(
@@ -684,7 +728,7 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
             }
         }
 
-        GitCommands::Import { path, refs } => {
+        GitCommands::Import { path, refs, lossy } => {
             let resolved = match path {
                 Some(source) => Some(resolve_source(&repo, source)?),
                 None => None,
@@ -701,11 +745,26 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
             };
             let mut progress = ImportProgress::start(cli, &repo, &scope, &source_label);
             progress.advance("importing commits");
+            let import_options = GitImportOptions { lossy };
             let stats = match &resolved {
-                Some(r) if refs.is_empty() => import_all(&mut bridge, Some(r.path()))?,
-                Some(r) => import_selected_refs(&mut bridge, Some(r.path()), &refs)?,
-                None if refs.is_empty() => import_all(&mut bridge, Some(default_source))?,
-                None => import_selected_refs(&mut bridge, Some(default_source), &refs)?,
+                Some(r) if refs.is_empty() => {
+                    import_all_with_options(&mut bridge, Some(r.path()), import_options)?
+                }
+                Some(r) => import_selected_refs_with_options(
+                    &mut bridge,
+                    Some(r.path()),
+                    &refs,
+                    import_options,
+                )?,
+                None if refs.is_empty() => {
+                    import_all_with_options(&mut bridge, Some(default_source), import_options)?
+                }
+                None => import_selected_refs_with_options(
+                    &mut bridge,
+                    Some(default_source),
+                    &refs,
+                    import_options,
+                )?,
             };
             progress.advance("writing refs");
             progress.finish();
@@ -748,6 +807,7 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
                 tags_synced: stats.tags_synced,
                 skipped_non_commit_refs: stats.skipped_non_commit_refs.len(),
                 partial_mirror_refs: stats.partial_mirror_refs.len(),
+                lossy_entries: bridge_lossy_import_entries(&stats.lossy_entries),
                 already_in_sync,
                 recommended_action: trust.recommended_action.clone(),
                 recommended_action_template: trust.recommended_action_template.clone(),
@@ -1059,9 +1119,9 @@ pub fn cmd_bridge_git(cli: &Cli, command: GitCommands) -> Result<()> {
         }
 
         #[cfg(feature = "ingest")]
-        GitCommands::Ingest { path } => {
+        GitCommands::Ingest { path, lossy } => {
             let resolved = resolve_source(&repo, path)?;
-            run_ingest(cli, &repo, resolved.path())?;
+            run_ingest(cli, &repo, resolved.path(), lossy)?;
         }
 
         #[cfg(feature = "ingest")]
@@ -1164,11 +1224,24 @@ fn reconcile_write_through_skipped_advice(ref_name: &str, reason: String) -> Rec
 }
 
 #[cfg(feature = "ingest")]
-fn run_ingest(cli: &Cli, repo: &Repository, git_path: &std::path::Path) -> Result<()> {
-    use ingest::import_git_into;
+fn run_ingest(cli: &Cli, repo: &Repository, git_path: &std::path::Path, lossy: bool) -> Result<()> {
+    use ingest::{ImportOptions, import_git_into_with_options};
 
-    let (stats, _map) = import_git_into(git_path, repo.root())?;
+    let (stats, _map) =
+        import_git_into_with_options(git_path, repo.root(), ImportOptions { lossy })?;
     if should_output_json(cli, Some(repo.config())) {
+        let lossy_entries = stats
+            .lossy_entries
+            .iter()
+            .map(|entry| {
+                serde_json::json!({
+                    "path": entry.path,
+                    "action": entry.action.as_str(),
+                    "reason": entry.reason,
+                    "git_object": entry.git_object,
+                })
+            })
+            .collect::<Vec<_>>();
         let out = serde_json::json!({
             "commits_imported": stats.commits_imported,
             "trees_imported": stats.trees_imported,
@@ -1180,6 +1253,7 @@ fn run_ingest(cli: &Cli, repo: &Repository, git_path: &std::path::Path) -> Resul
             "peel_failed": stats.refs_seen.peel_failed,
             "non_commit_skipped": stats.refs_seen.non_commit_skipped,
             "reflog_only_commits": stats.reflog_only_commits,
+            "lossy_entries": lossy_entries,
         });
         println!("{out}");
     } else {
@@ -1217,6 +1291,15 @@ fn run_ingest(cli: &Cli, repo: &Repository, git_path: &std::path::Path) -> Resul
         println!("blobs:    {}", stats.blobs_imported);
         println!("threads written:  {}", stats.refs.threads_written);
         println!("markers written:  {}", stats.refs.markers_written);
+        if !stats.lossy_entries.is_empty() {
+            println!(
+                "lossy import accepted for {} tree entries:",
+                stats.lossy_entries.len()
+            );
+            for entry in &stats.lossy_entries {
+                println!("  {}", entry.summary_line());
+            }
+        }
         println!();
         println!(
             "Next: `heddle bridge reason --path {}` to attach AI-session reasoning.",
@@ -1243,8 +1326,8 @@ fn run_reason(
     use std::path::PathBuf;
 
     use ingest::{
-        load_transcripts, pipeline_default_commits, GitSource, ReasoningPipeline,
-        ReasoningPipelineParams, ShaMap, TranscriptRoots,
+        GitSource, ReasoningPipeline, ReasoningPipelineParams, ShaMap, TranscriptRoots,
+        load_transcripts, pipeline_default_commits,
     };
 
     let map_path = repo.heddle_dir().join("ingest").join("sha_map.sqlite");

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2551,10 +2551,19 @@ pub struct BridgeImportSchema {
     pub tags_synced: u64,
     pub skipped_non_commit_refs: u64,
     pub partial_mirror_refs: u64,
+    pub lossy_entries: Vec<LossyGitImportEntrySchema>,
     pub already_in_sync: bool,
     pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub recovery_commands: Vec<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LossyGitImportEntrySchema {
+    pub path: String,
+    pub action: String,
+    pub reason: String,
+    pub git_object: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -5,12 +5,14 @@ use objects::object::ThreadName;
 /// Initialize a colocated (drop-in) Git repo on `main` with one
 /// committed file, mirroring the bootstrap the overlay tests use.
 fn init_colocated_git_repo(path: &std::path::Path) {
-    assert!(Command::new("git")
-        .arg("init")
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
     for (k, v) in [
         ("user.name", "Heddle Test"),
         ("user.email", "heddle@example.com"),
@@ -30,18 +32,22 @@ fn init_colocated_git_repo(path: &std::path::Path) {
 }
 
 fn git_commit_all_in(path: &std::path::Path, message: &str) {
-    assert!(Command::new("git")
-        .args(["add", "."])
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
-    assert!(Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
 }
 
 fn git_status_porcelain(path: &std::path::Path) -> String {
@@ -54,10 +60,94 @@ fn git_status_porcelain(path: &std::path::Path) -> String {
     String::from_utf8(out.stdout).unwrap()
 }
 
+fn seed_gitlink_repo(path: &std::path::Path) {
+    init_colocated_git_repo(path);
+    std::fs::write(path.join("README.md"), "root\n").unwrap();
+    git_commit_all_in(path, "initial");
+
+    let submodule_oid = "0606060606060606060606060606060606060606";
+    let status = Command::new("git")
+        .args(["update-index", "--add", "--cacheinfo"])
+        .arg(format!("160000,{submodule_oid},vendor"))
+        .current_dir(path)
+        .status()
+        .expect("git update-index should run");
+    assert!(status.success(), "git update-index should succeed");
+
+    let status = Command::new("git")
+        .args(["commit", "-m", "add gitlink"])
+        .current_dir(path)
+        .status()
+        .expect("git commit should run");
+    assert!(status.success(), "git commit should succeed");
+}
+
 /// The empty-blob object id (SHA-1). An intent-to-add index entry points
 /// at this rather than a real blob — that is what makes Git treat the
 /// path as "added, content not yet staged".
 const EMPTY_BLOB_OID: &str = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+
+#[test]
+fn bridge_git_import_refuses_gitlink_by_default_and_lossy_summarizes() {
+    let source = TempDir::new().unwrap();
+    seed_gitlink_repo(source.path());
+
+    let default_target = TempDir::new().unwrap();
+    heddle(&["init"], Some(default_target.path())).expect("init default target");
+    let default_output = heddle_output(
+        &[
+            "bridge",
+            "git",
+            "import",
+            "--path",
+            source.path().to_str().unwrap(),
+        ],
+        Some(default_target.path()),
+    )
+    .expect("run default import");
+    assert!(
+        !default_output.status.success(),
+        "default git import must fail on gitlink"
+    );
+    let default_stderr = String::from_utf8_lossy(&default_output.stderr);
+    assert!(
+        default_stderr.contains("vendor"),
+        "error should name the offending entry: {default_stderr}"
+    );
+    assert!(
+        default_stderr.contains("--lossy"),
+        "error should name the opt-in flag: {default_stderr}"
+    );
+
+    let lossy_target = TempDir::new().unwrap();
+    heddle(&["init"], Some(lossy_target.path())).expect("init lossy target");
+    let lossy = heddle(
+        &[
+            "bridge",
+            "git",
+            "import",
+            "--lossy",
+            "--path",
+            source.path().to_str().unwrap(),
+        ],
+        Some(lossy_target.path()),
+    )
+    .expect("lossy import should succeed");
+
+    assert!(
+        lossy.contains("lossy import accepted"),
+        "lossy import should emit an end-of-run summary: {lossy}"
+    );
+    assert!(lossy.contains("vendor"), "summary names entry: {lossy}");
+    assert!(lossy.contains("converted"), "summary names action: {lossy}");
+}
+
+#[test]
+fn bridge_git_import_help_documents_lossy_flag() {
+    let output = heddle(&["bridge", "git", "import", "--help"], None).expect("help");
+
+    assert!(output.contains("--lossy"), "help should document --lossy");
+}
 
 /// After `heddle capture` records a NEW file in a colocated checkout,
 /// `git status` should report it as intent-to-add ("Heddle knows about
@@ -201,7 +291,9 @@ fn recapture_to_empty_tree_prunes_stale_intent_to_add() {
         .output()
         .unwrap();
     assert!(
-        String::from_utf8(staged.stdout).unwrap().contains(EMPTY_BLOB_OID),
+        String::from_utf8(staged.stdout)
+            .unwrap()
+            .contains(EMPTY_BLOB_OID),
         "precondition: new_file.txt must be intent-to-add after first capture"
     );
 
@@ -261,8 +353,11 @@ fn recapture_skips_intent_to_add_that_conflicts_with_tracked_file() {
     std::fs::remove_file(source.path().join("foo")).unwrap();
     std::fs::create_dir(source.path().join("foo")).unwrap();
     std::fs::write(source.path().join("foo").join("bar"), "now a dir\n").unwrap();
-    heddle(&["capture", "-m", "file becomes directory"], Some(source.path()))
-        .expect("recapture should record the file→dir change");
+    heddle(
+        &["capture", "-m", "file becomes directory"],
+        Some(source.path()),
+    )
+    .expect("recapture should record the file→dir change");
 
     // The index must stay valid: never both `foo` and `foo/bar`.
     let staged = Command::new("git")
@@ -366,11 +461,13 @@ fn test_cli_bridge_git_export_and_pull_roundtrip() {
     assert!(pull.is_ok(), "Bridge pull failed: {:?}", pull.err());
 
     let target_repo = Repository::open(target.path()).unwrap();
-    assert!(target_repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
+    assert!(
+        target_repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -400,11 +497,12 @@ fn test_cli_bridge_git_import_from_external_repo() {
     assert!(result.is_ok(), "Bridge import failed: {:?}", result.err());
 
     let repo = Repository::open(heddle_repo_dir.path()).unwrap();
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -686,12 +784,14 @@ fn test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes() {
     // Plain `git init` → RepositoryCapability::GitOverlay,
     // hosted_enabled() == false. This is the drop-in case the
     // early-return in cmd_push handles.
-    assert!(Command::new("git")
-        .arg("init")
-        .current_dir(source.path())
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .current_dir(source.path())
+            .status()
+            .unwrap()
+            .success()
+    );
     for (k, v) in [
         ("user.name", "Heddle Test"),
         ("user.email", "heddle@example.com"),

--- a/crates/ingest/src/bin/main.rs
+++ b/crates/ingest/src/bin/main.rs
@@ -29,8 +29,8 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use ingest::{
-    GitSource, ReasoningPipeline, ReasoningPipelineParams, Result, ShaMap, TranscriptRoots,
-    import_git_into, load_transcripts, pipeline_default_commits,
+    GitSource, ImportOptions, ReasoningPipeline, ReasoningPipelineParams, Result, ShaMap,
+    TranscriptRoots, import_git_into_with_options, load_transcripts, pipeline_default_commits,
 };
 use tracing::info;
 
@@ -68,6 +68,13 @@ enum Command {
         /// backwards compatibility with older help text.
         #[arg(long)]
         heddle: PathBuf,
+        /// Accept git tree entries Heddle cannot represent losslessly.
+        ///
+        /// By default import fails on the first unrepresentable tree entry.
+        /// With this flag, import restores the historical drop behavior and
+        /// prints an end-of-run summary of every affected entry.
+        #[arg(long)]
+        lossy: bool,
     },
     /// Mine agent chat transcripts for reasoning annotations and attach
     /// them to the matching imported states. Requires `import` to have
@@ -158,7 +165,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Command::Map { path, action } => run_map(&path, action),
-        Command::Import { git, heddle } => run_import(&git, &heddle),
+        Command::Import { git, heddle, lossy } => run_import(&git, &heddle, lossy),
         Command::Reason {
             git,
             heddle,
@@ -189,10 +196,15 @@ fn main() -> Result<()> {
     }
 }
 
-fn run_import(git_path: &std::path::Path, heddle_path: &std::path::Path) -> Result<()> {
+fn run_import(
+    git_path: &std::path::Path,
+    heddle_path: &std::path::Path,
+    lossy: bool,
+) -> Result<()> {
     // `import_git_into` handles init-vs-open, the sha-map sidecar, and
     // every walker/writer in the right order. We just surface the stats.
-    let (stats, _map) = import_git_into(git_path, heddle_path)?;
+    let (stats, _map) =
+        import_git_into_with_options(git_path, heddle_path, ImportOptions { lossy })?;
     let r = &stats.refs_seen;
     let walked = r.local_branches
         + r.tags
@@ -233,6 +245,15 @@ fn run_import(git_path: &std::path::Path, heddle_path: &std::path::Path) -> Resu
     println!("blobs:  {}", stats.blobs_imported);
     println!("threads written:  {}", stats.refs.threads_written);
     println!("markers written:  {}", stats.refs.markers_written);
+    if !stats.lossy_entries.is_empty() {
+        println!(
+            "lossy import accepted for {} tree entries:",
+            stats.lossy_entries.len()
+        );
+        for entry in &stats.lossy_entries {
+            println!("  {}", entry.summary_line());
+        }
+    }
     // Oplog block: only rendered when the honest-history pass actually
     // ran (all counters zero ⇒ either disabled or no-op repo). Shows up
     // below the refs because it's a downstream derivative of them.

--- a/crates/ingest/src/git_walk.rs
+++ b/crates/ingest/src/git_walk.rs
@@ -99,6 +99,7 @@ pub struct GitSignature {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TreeChild {
     pub name: String,
+    pub raw_name: Vec<u8>,
     pub sha: String,
     pub kind: TreeChildKind,
 }
@@ -458,8 +459,10 @@ impl GitSource {
                 gix::object::tree::EntryKind::Link => TreeChildKind::Symlink,
                 gix::object::tree::EntryKind::Commit => TreeChildKind::Gitlink,
             };
+            let raw_name = entry.filename().to_vec();
             out.push(TreeChild {
-                name: entry.filename().to_string(),
+                name: String::from_utf8_lossy(&raw_name).into_owned(),
+                raw_name,
                 sha: entry.object_id().to_string(),
                 kind,
             });

--- a/crates/ingest/src/import_options.rs
+++ b/crates/ingest/src/import_options.rs
@@ -12,9 +12,11 @@ pub struct ImportOptions {
     pub lossy: bool,
 }
 
+use serde::{Deserialize, Serialize};
+
 /// One git tree entry that was dropped or converted because Heddle cannot
 /// represent it losslessly yet.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LossyImportEntry {
     pub path: String,
     pub git_object: Option<String>,
@@ -22,7 +24,7 @@ pub struct LossyImportEntry {
     pub reason: String,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum LossyImportAction {
     Dropped,
     Converted,
@@ -105,4 +107,11 @@ pub(crate) fn entry_relative_to_prefix(prefix: &str, entry: &LossyImportEntry) -
         relative.path = stripped.trim_start_matches('/').to_string();
     }
     relative
+}
+
+pub(crate) fn fail_lossy_entry(entry: &LossyImportEntry) -> crate::IngestError {
+    crate::IngestError::Other(format!(
+        "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
+        entry.summary_line()
+    ))
 }

--- a/crates/ingest/src/import_options.rs
+++ b/crates/ingest/src/import_options.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Import policy shared by git tree translators.
+
+/// Policy knobs for mechanical git imports.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ImportOptions {
+    /// Accept git tree entries Heddle cannot represent losslessly.
+    ///
+    /// When false, the importer fails at the first unrepresentable entry.
+    /// When true, the importer restores the historical drop/convert behavior
+    /// and records every affected entry in the import summary.
+    pub lossy: bool,
+}
+
+/// One git tree entry that was dropped or converted because Heddle cannot
+/// represent it losslessly yet.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LossyImportEntry {
+    pub path: String,
+    pub git_object: Option<String>,
+    pub action: LossyImportAction,
+    pub reason: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LossyImportAction {
+    Dropped,
+    Converted,
+}
+
+impl LossyImportAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LossyImportAction::Dropped => "dropped",
+            LossyImportAction::Converted => "converted",
+        }
+    }
+}
+
+impl LossyImportEntry {
+    pub fn dropped(path: String, git_object: Option<String>, reason: impl Into<String>) -> Self {
+        Self {
+            path,
+            git_object,
+            action: LossyImportAction::Dropped,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn converted(path: String, git_object: Option<String>, reason: impl Into<String>) -> Self {
+        Self {
+            path,
+            git_object,
+            action: LossyImportAction::Converted,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn summary_line(&self) -> String {
+        match &self.git_object {
+            Some(object) => format!(
+                "{} {} ({}): {}",
+                self.action.as_str(),
+                self.path,
+                object,
+                self.reason
+            ),
+            None => format!("{} {}: {}", self.action.as_str(), self.path, self.reason),
+        }
+    }
+}
+
+pub(crate) fn join_tree_path(prefix: &str, name: &str) -> String {
+    let name = display_tree_name(name);
+    if prefix.is_empty() {
+        name
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+pub(crate) fn display_tree_name(name: &str) -> String {
+    if name.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        name.escape_debug().to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+pub(crate) fn rebase_lossy_entry(prefix: &str, entry: &LossyImportEntry) -> LossyImportEntry {
+    let mut rebased = entry.clone();
+    if !prefix.is_empty() {
+        rebased.path = format!("{prefix}/{}", entry.path);
+    }
+    rebased
+}
+
+pub(crate) fn entry_relative_to_prefix(prefix: &str, entry: &LossyImportEntry) -> LossyImportEntry {
+    if prefix.is_empty() {
+        return entry.clone();
+    }
+
+    let mut relative = entry.clone();
+    if let Some(stripped) = entry.path.strip_prefix(prefix) {
+        relative.path = stripped.trim_start_matches('/').to_string();
+    }
+    relative
+}

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -15,7 +15,6 @@
 //! in downstream modules; [`Importer::run`] leaves their seams wired but
 //! stubbed behind TODOs so we can land milestones independently.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use objects::{
@@ -344,7 +343,6 @@ struct PackedImport<'a, W: std::io::Write + std::io::Read + std::io::Seek> {
     builder: StreamingPackBuilder<W>,
     stats: PackedImportStats,
     options: ImportOptions,
-    lossy_by_tree: HashMap<String, Vec<LossyImportEntry>>,
 }
 
 impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> {
@@ -360,7 +358,6 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
             builder,
             stats: PackedImportStats::default(),
             options,
-            lossy_by_tree: HashMap::new(),
         }
     }
 
@@ -422,8 +419,6 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         self.map
             .insert_tree_with_lossy_entries(git_tree_sha, hash, &tree_lossy_entries)
             .map_err(IngestError::from)?;
-        self.lossy_by_tree
-            .insert(git_tree_sha.to_string(), tree_lossy_entries);
         Ok(hash)
     }
 

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -24,6 +24,7 @@ use objects::{
         CompressionConfig, ObjectStore,
         pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
     },
+    util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name},
 };
 use oplog::oplog::{OpLog, OpLogBackend};
 use refs::refs::RefBackend;
@@ -423,47 +424,50 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         child: &TreeChild,
         path_prefix: &str,
     ) -> crate::Result<Option<TreeEntry>> {
-        if child.name.is_empty()
-            || child.name == "."
-            || child.name == ".."
-            || child.name.contains('/')
-            || child.name.bytes().any(|b| b < 0x20 || b == 0x7f)
-        {
-            let entry = LossyImportEntry::dropped(
-                join_tree_path(path_prefix, &child.name),
-                Some(child.sha.clone()),
-                "tree entry name is not representable in Heddle",
-            );
-            self.record_lossy(entry)?;
-            return Ok(None);
-        }
+        let name = match classify_git_tree_name(&child.raw_name) {
+            GitTreeNameClassification::Representable(name) => name,
+            GitTreeNameClassification::NeedsLossy(lossy) => {
+                let path = join_tree_path(path_prefix, &lossy.name);
+                let entry = match lossy.action {
+                    GitTreeNameLossyAction::Dropped => {
+                        LossyImportEntry::dropped(path, Some(child.sha.clone()), lossy.reason)
+                    }
+                    GitTreeNameLossyAction::Converted => {
+                        LossyImportEntry::converted(path, Some(child.sha.clone()), lossy.reason)
+                    }
+                };
+                self.record_lossy(entry)?;
+                if matches!(lossy.action, GitTreeNameLossyAction::Dropped) {
+                    return Ok(None);
+                }
+                lossy.name
+            }
+        };
 
         match child.kind {
             TreeChildKind::Blob { executable } => {
                 let hash = self.translate_blob(&child.sha)?;
                 Ok(Some(
-                    TreeEntry::file(child.name.clone(), hash, executable)
+                    TreeEntry::file(name, hash, executable)
                         .map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Tree => {
                 let hash =
-                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &child.name))?;
+                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &name))?;
                 Ok(Some(
-                    TreeEntry::directory(child.name.clone(), hash)
-                        .map_err(|e| IngestError::Heddle(e.into()))?,
+                    TreeEntry::directory(name, hash).map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Symlink => {
                 let hash = self.translate_blob(&child.sha)?;
                 Ok(Some(
-                    TreeEntry::symlink(child.name.clone(), hash)
-                        .map_err(|e| IngestError::Heddle(e.into()))?,
+                    TreeEntry::symlink(name, hash).map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Gitlink => {
                 let entry = LossyImportEntry::dropped(
-                    join_tree_path(path_prefix, &child.name),
+                    join_tree_path(path_prefix, &name),
                     Some(child.sha.clone()),
                     "gitlink/submodule entries have no Heddle tree equivalent",
                 );
@@ -615,7 +619,7 @@ pub fn import_git_into_with_options(
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, process::Command};
+    use std::{io::Write, path::Path, process::Command};
 
     use objects::{object::ThreadName, store::InMemoryStore};
     use refs::refs::RefManager;
@@ -688,6 +692,60 @@ mod tests {
         run(&["commit", "-q", "-m", "add gitlink"]);
     }
 
+    fn git_output(path: &Path, args: &[&str], stdin: Option<&[u8]>) -> String {
+        let mut command = Command::new("git");
+        command
+            .args(args)
+            .current_dir(path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null");
+        if stdin.is_some() {
+            command.stdin(std::process::Stdio::piped());
+        }
+        let mut child = command.spawn().expect("git cmd");
+        if let Some(stdin) = stdin {
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(stdin)
+                .expect("write stdin");
+        }
+        let output = child.wait_with_output().expect("git output");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn seed_invalid_utf8_name_repo(path: &Path) {
+        let status = Command::new("git")
+            .args(["init", "-q", "--initial-branch=main"])
+            .current_dir(path)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init failed");
+
+        let blob = git_output(path, &["hash-object", "-w", "--stdin"], Some(b"hello\n"));
+        let mut tree_input = Vec::new();
+        write!(&mut tree_input, "100644 blob {blob}\t").expect("tree record");
+        tree_input.extend_from_slice(b"bad\xffname\0");
+        let tree = git_output(path, &["mktree", "-z"], Some(&tree_input));
+        let commit = git_output(path, &["commit-tree", &tree, "-m", "invalid name"], None);
+        git_output(path, &["update-ref", "refs/heads/main", &commit], None);
+    }
+
     #[test]
     fn imports_commits_refs_and_tag_end_to_end() {
         let gitdir = TempDir::new().unwrap();
@@ -752,6 +810,44 @@ mod tests {
         assert_eq!(stats.lossy_entries.len(), 1);
         assert_eq!(stats.lossy_entries[0].path, "vendor");
         assert!(stats.lossy_entries[0].summary_line().contains("dropped"));
+    }
+
+    #[test]
+    fn import_git_into_rejects_invalid_utf8_name_by_default() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_invalid_utf8_name_repo(gitdir.path());
+
+        let err = import_git_into(gitdir.path(), heddledir.path())
+            .expect_err("invalid UTF-8 name must fail without --lossy");
+        let message = err.to_string();
+
+        assert!(message.contains("bad"), "error names entry: {message}");
+        assert!(
+            message.contains("not valid UTF-8"),
+            "error explains conversion: {message}"
+        );
+        assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn import_git_into_lossy_converts_invalid_utf8_name_and_summarizes() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_invalid_utf8_name_repo(gitdir.path());
+
+        let (stats, _map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("lossy import converts invalid UTF-8 name");
+        let converted_name = "bad\u{fffd}name";
+
+        assert_eq!(stats.commits_imported, 1);
+        assert_eq!(stats.lossy_entries.len(), 1);
+        assert_eq!(stats.lossy_entries[0].path, converted_name);
+        assert!(stats.lossy_entries[0].summary_line().contains("converted"));
     }
 
     #[test]

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -34,8 +34,8 @@ use crate::{
     IngestError,
     git_walk::{CommitEntry, GitSource, RefDiscoveryStats, TreeChild, TreeChildKind},
     import_options::{
-        ImportOptions, LossyImportEntry, entry_relative_to_prefix, join_tree_path,
-        rebase_lossy_entry,
+        ImportOptions, LossyImportEntry, entry_relative_to_prefix, fail_lossy_entry,
+        join_tree_path, rebase_lossy_entry,
     },
     oplog_emit::{OplogEmitStats, OplogEmitter},
     ref_emit::{RefEmitStats, RefEmitter},
@@ -374,7 +374,15 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         path_prefix: &str,
     ) -> crate::Result<ContentHash> {
         if let Some(hash) = self.map.get_tree(git_tree_sha) {
-            if let Some(entries) = self.lossy_by_tree.get(git_tree_sha) {
+            let entries = self
+                .map
+                .get_tree_lossy_entries(git_tree_sha)
+                .map_err(IngestError::from)?
+                .unwrap_or_default();
+            if !entries.is_empty() {
+                if !self.options.lossy {
+                    return Err(fail_lossy_entry(&rebase_lossy_entry(path_prefix, &entries[0])));
+                }
                 self.stats.lossy_entries.extend(
                     entries
                         .iter()
@@ -412,7 +420,7 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         self.stats.trees += 1;
 
         self.map
-            .insert_tree(git_tree_sha, hash)
+            .insert_tree_with_lossy_entries(git_tree_sha, hash, &tree_lossy_entries)
             .map_err(IngestError::from)?;
         self.lossy_by_tree
             .insert(git_tree_sha.to_string(), tree_lossy_entries);
@@ -479,10 +487,7 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
 
     fn record_lossy(&mut self, entry: LossyImportEntry) -> crate::Result<()> {
         if !self.options.lossy {
-            return Err(IngestError::Other(format!(
-                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
-                entry.summary_line()
-            )));
+            return Err(fail_lossy_entry(&entry));
         }
         tracing::warn!(entry = %entry.summary_line(), "lossy git import accepted");
         self.stats.lossy_entries.push(entry);
@@ -848,6 +853,63 @@ mod tests {
         assert_eq!(stats.lossy_entries.len(), 1);
         assert_eq!(stats.lossy_entries[0].path, converted_name);
         assert!(stats.lossy_entries[0].summary_line().contains("converted"));
+    }
+
+    #[test]
+    fn default_import_fails_on_cached_lossy_tree_from_prior_run() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_invalid_utf8_name_repo(gitdir.path());
+
+        let (first, map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("initial lossy import succeeds");
+        drop(map);
+        assert_eq!(first.lossy_entries.len(), 1);
+
+        let err = import_git_into(gitdir.path(), heddledir.path())
+            .expect_err("default import must not reuse cached lossy tree silently");
+        let message = err.to_string();
+
+        assert!(message.contains("bad"), "error names cached entry: {message}");
+        assert!(
+            message.contains("not valid UTF-8"),
+            "error explains cached conversion: {message}"
+        );
+        assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn lossy_import_reports_cached_lossy_tree_from_prior_run() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_invalid_utf8_name_repo(gitdir.path());
+
+        let (_first, map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("initial lossy import succeeds");
+        drop(map);
+
+        let (second, _map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("lossy rerun reports persisted lossy entries");
+
+        assert_eq!(second.lossy_entries.len(), 1);
+        assert_eq!(second.lossy_entries[0].path, "bad\u{fffd}name");
+        assert!(
+            second.lossy_entries[0]
+                .summary_line()
+                .contains("converted")
+        );
     }
 
     #[test]

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -15,13 +15,14 @@
 //! in downstream modules; [`Importer::run`] leaves their seams wired but
 //! stubbed behind TODOs so we can land milestones independently.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use objects::{
     object::{Blob, ChangeId, ContentHash, Tree, TreeEntry},
     store::{
-        pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
         CompressionConfig, ObjectStore,
+        pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
     },
 };
 use oplog::oplog::{OpLog, OpLogBackend};
@@ -29,12 +30,16 @@ use refs::refs::RefBackend;
 use tracing::info;
 
 use crate::{
+    IngestError,
     git_walk::{CommitEntry, GitSource, RefDiscoveryStats, TreeChild, TreeChildKind},
+    import_options::{
+        ImportOptions, LossyImportEntry, entry_relative_to_prefix, join_tree_path,
+        rebase_lossy_entry,
+    },
     oplog_emit::{OplogEmitStats, OplogEmitter},
     ref_emit::{RefEmitStats, RefEmitter},
     sha_map::ShaMap,
     state_writer::state_from_commit,
-    IngestError,
 };
 
 /// Counters reported back from [`Importer::run`] — the post-import
@@ -62,6 +67,9 @@ pub struct ImportStats {
     /// non-zero count here is evidence the reflog rescued work the
     /// refs-only walker would have missed.
     pub reflog_only_commits: usize,
+    /// Git tree entries that were dropped or converted because the caller
+    /// explicitly opted into lossy import.
+    pub lossy_entries: Vec<LossyImportEntry>,
 }
 
 /// Orchestrates one import pass.
@@ -78,6 +86,7 @@ pub struct Importer<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend = OpLog> 
     refs: &'a R,
     map: &'a mut ShaMap,
     oplog: Option<&'a O>,
+    options: ImportOptions,
     /// Where the streaming pack builder writes its in-flight pack
     /// file and 512 index-bucket files. Both are removed on a clean
     /// finalize. Defaults to `std::env::temp_dir()/heddle-ingest-<pid>`
@@ -89,18 +98,14 @@ pub struct Importer<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend = OpLog> 
 }
 
 impl<'a, R: RefBackend, S: ObjectStore> Importer<'a, R, S, OpLog> {
-    pub fn new(
-        git: &'a GitSource,
-        store: &'a S,
-        refs: &'a R,
-        map: &'a mut ShaMap,
-    ) -> Self {
+    pub fn new(git: &'a GitSource, store: &'a S, refs: &'a R, map: &'a mut ShaMap) -> Self {
         Self {
             git,
             store,
             refs,
             map,
             oplog: None,
+            options: ImportOptions::default(),
             pack_staging_dir: None,
         }
     }
@@ -120,8 +125,14 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             refs: self.refs,
             map: self.map,
             oplog: Some(oplog),
+            options: self.options,
             pack_staging_dir: self.pack_staging_dir,
         }
+    }
+
+    pub fn with_options(mut self, options: ImportOptions) -> Self {
+        self.options = options;
+        self
     }
 
     /// Override the directory used to stage the in-progress pack file
@@ -233,7 +244,7 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
                 bucket_dir.clone(),
             )
             .map_err(IngestError::from)?;
-            let mut packed = PackedImport::new(self.git, self.map, builder);
+            let mut packed = PackedImport::new(self.git, self.map, builder, self.options.clone());
             let mut last_log = 0usize;
             for (idx, commit) in commits.iter().enumerate() {
                 let tree_hash = packed.translate_tree(&commit.tree_sha)?;
@@ -313,15 +324,17 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             refs: ref_stats,
             oplog: oplog_stats,
             reflog_only_commits,
+            lossy_entries: packed_stats.lossy_entries,
         })
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct PackedImportStats {
     object_count: usize,
     trees: usize,
     blobs: usize,
+    lossy_entries: Vec<LossyImportEntry>,
 }
 
 struct PackedImport<'a, W: std::io::Write + std::io::Read + std::io::Seek> {
@@ -329,30 +342,59 @@ struct PackedImport<'a, W: std::io::Write + std::io::Read + std::io::Seek> {
     map: &'a mut ShaMap,
     builder: StreamingPackBuilder<W>,
     stats: PackedImportStats,
+    options: ImportOptions,
+    lossy_by_tree: HashMap<String, Vec<LossyImportEntry>>,
 }
 
 impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> {
-    fn new(git: &'a GitSource, map: &'a mut ShaMap, builder: StreamingPackBuilder<W>) -> Self {
+    fn new(
+        git: &'a GitSource,
+        map: &'a mut ShaMap,
+        builder: StreamingPackBuilder<W>,
+        options: ImportOptions,
+    ) -> Self {
         Self {
             git,
             map,
             builder,
             stats: PackedImportStats::default(),
+            options,
+            lossy_by_tree: HashMap::new(),
         }
     }
 
     fn translate_tree(&mut self, git_tree_sha: &str) -> crate::Result<ContentHash> {
+        self.translate_tree_at(git_tree_sha, "")
+    }
+
+    fn translate_tree_at(
+        &mut self,
+        git_tree_sha: &str,
+        path_prefix: &str,
+    ) -> crate::Result<ContentHash> {
         if let Some(hash) = self.map.get_tree(git_tree_sha) {
+            if let Some(entries) = self.lossy_by_tree.get(git_tree_sha) {
+                self.stats.lossy_entries.extend(
+                    entries
+                        .iter()
+                        .map(|entry| rebase_lossy_entry(path_prefix, entry)),
+                );
+            }
             return Ok(hash);
         }
 
+        let before_lossy = self.stats.lossy_entries.len();
         let children = self.git.read_tree(git_tree_sha)?;
         let mut entries = Vec::with_capacity(children.len());
         for child in children {
-            if let Some(entry) = self.translate_child(&child)? {
+            if let Some(entry) = self.translate_child(&child, path_prefix)? {
                 entries.push(entry);
             }
         }
+        let tree_lossy_entries = self.stats.lossy_entries[before_lossy..]
+            .iter()
+            .map(|entry| entry_relative_to_prefix(path_prefix, entry))
+            .collect::<Vec<_>>();
 
         let tree = Tree::from_entries(entries);
         let hash = tree.hash();
@@ -371,17 +413,28 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         self.map
             .insert_tree(git_tree_sha, hash)
             .map_err(IngestError::from)?;
+        self.lossy_by_tree
+            .insert(git_tree_sha.to_string(), tree_lossy_entries);
         Ok(hash)
     }
 
-    fn translate_child(&mut self, child: &TreeChild) -> crate::Result<Option<TreeEntry>> {
+    fn translate_child(
+        &mut self,
+        child: &TreeChild,
+        path_prefix: &str,
+    ) -> crate::Result<Option<TreeEntry>> {
         if child.name.is_empty()
             || child.name == "."
             || child.name == ".."
             || child.name.contains('/')
             || child.name.bytes().any(|b| b < 0x20 || b == 0x7f)
         {
-            tracing::warn!(name = %child.name, "skipping tree child with unusable name");
+            let entry = LossyImportEntry::dropped(
+                join_tree_path(path_prefix, &child.name),
+                Some(child.sha.clone()),
+                "tree entry name is not representable in Heddle",
+            );
+            self.record_lossy(entry)?;
             return Ok(None);
         }
 
@@ -394,7 +447,8 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
                 ))
             }
             TreeChildKind::Tree => {
-                let hash = self.translate_tree(&child.sha)?;
+                let hash =
+                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &child.name))?;
                 Ok(Some(
                     TreeEntry::directory(child.name.clone(), hash)
                         .map_err(|e| IngestError::Heddle(e.into()))?,
@@ -408,14 +462,27 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
                 ))
             }
             TreeChildKind::Gitlink => {
-                tracing::warn!(
-                    name = %child.name,
-                    submodule_sha = %child.sha,
-                    "dropping gitlink (submodule) entry — no Heddle equivalent"
+                let entry = LossyImportEntry::dropped(
+                    join_tree_path(path_prefix, &child.name),
+                    Some(child.sha.clone()),
+                    "gitlink/submodule entries have no Heddle tree equivalent",
                 );
+                self.record_lossy(entry)?;
                 Ok(None)
             }
         }
+    }
+
+    fn record_lossy(&mut self, entry: LossyImportEntry) -> crate::Result<()> {
+        if !self.options.lossy {
+            return Err(IngestError::Other(format!(
+                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
+                entry.summary_line()
+            )));
+        }
+        tracing::warn!(entry = %entry.summary_line(), "lossy git import accepted");
+        self.stats.lossy_entries.push(entry);
+        Ok(())
     }
 
     fn translate_blob(&mut self, git_blob_sha: &str) -> crate::Result<ContentHash> {
@@ -502,6 +569,14 @@ pub fn import_git_into(
     git_path: impl AsRef<Path>,
     heddle_path: impl AsRef<Path>,
 ) -> crate::Result<(ImportStats, ShaMap)> {
+    import_git_into_with_options(git_path, heddle_path, ImportOptions::default())
+}
+
+pub fn import_git_into_with_options(
+    git_path: impl AsRef<Path>,
+    heddle_path: impl AsRef<Path>,
+    options: ImportOptions,
+) -> crate::Result<(ImportStats, ShaMap)> {
     let git = GitSource::open(git_path)?;
     let heddle_path = heddle_path.as_ref();
     let root = strip_trailing_heddle(heddle_path);
@@ -530,6 +605,7 @@ pub fn import_git_into(
     // scoped so its `&mut map` borrow ends before `map` is returned.
     let stats = {
         let mut importer = Importer::new(&git, repo.store(), repo.refs(), &mut map)
+            .with_options(options)
             .with_oplog(repo.oplog())
             .with_pack_staging_dir(staging_dir);
         pollster::block_on(importer.run())?
@@ -584,6 +660,34 @@ mod tests {
         String::from_utf8(out.stdout).unwrap().trim().to_string()
     }
 
+    fn seed_gitlink_repo(path: &Path) {
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .status()
+                .expect("git cmd");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+        run(&["init", "-q", "--initial-branch=main"]);
+        std::fs::write(path.join("README.md"), "# hello\n").unwrap();
+        run(&["add", "README.md"]);
+        run(&["commit", "-q", "-m", "initial"]);
+        run(&[
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "160000,0808080808080808080808080808080808080808,vendor",
+        ]);
+        run(&["commit", "-q", "-m", "add gitlink"]);
+    }
+
     #[test]
     fn imports_commits_refs_and_tag_end_to_end() {
         let gitdir = TempDir::new().unwrap();
@@ -610,10 +714,61 @@ mod tests {
         assert_eq!(stats.refs.markers_written, 1); // v0.1
         assert_eq!(stats.refs.skipped_unmapped, 0);
         assert!(refs.get_thread(&ThreadName::new("main")).unwrap().is_some());
-        assert!(refs
-            .get_thread(&ThreadName::new("feature/x"))
-            .unwrap()
-            .is_some());
+        assert!(
+            refs.get_thread(&ThreadName::new("feature/x"))
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn import_git_into_rejects_gitlink_by_default() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_gitlink_repo(gitdir.path());
+
+        let err = import_git_into(gitdir.path(), heddledir.path())
+            .expect_err("gitlink import must fail without --lossy");
+        let message = err.to_string();
+
+        assert!(message.contains("vendor"), "error names entry: {message}");
+        assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn import_git_into_lossy_drops_gitlink_and_summarizes() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_gitlink_repo(gitdir.path());
+
+        let (stats, _map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("lossy import succeeds");
+
+        assert!(stats.commits_imported >= 2);
+        assert_eq!(stats.lossy_entries.len(), 1);
+        assert_eq!(stats.lossy_entries[0].path, "vendor");
+        assert!(stats.lossy_entries[0].summary_line().contains("dropped"));
+    }
+
+    #[test]
+    fn import_git_into_lossy_clean_repo_reports_no_lossy_entries() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_multibranch_repo(gitdir.path());
+
+        let (stats, _map) = import_git_into_with_options(
+            gitdir.path(),
+            heddledir.path(),
+            ImportOptions { lossy: true },
+        )
+        .expect("clean lossy import succeeds");
+
+        assert!(stats.commits_imported >= 2);
+        assert!(stats.lossy_entries.is_empty());
     }
 
     #[test]
@@ -632,7 +787,8 @@ mod tests {
 
         let first = pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
         let states_after_first = store.list_states().unwrap().len();
-        let second = pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
+        let second =
+            pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
         let states_after_second = store.list_states().unwrap().len();
 
         assert_eq!(first.commits_imported, second.commits_imported);

--- a/crates/ingest/src/lib.rs
+++ b/crates/ingest/src/lib.rs
@@ -33,6 +33,7 @@
 #![allow(dead_code)] // module is under active construction
 
 pub mod git_walk;
+pub mod import_options;
 pub mod importer;
 pub mod oplog_emit;
 pub mod reasoning;
@@ -47,7 +48,8 @@ pub mod transcript;
 pub mod tree_translate;
 
 pub use git_walk::{CommitEntry, GitSource, RefHead, RefNamespace, ReflogEntry};
-pub use importer::{ImportStats, Importer, import_git_into};
+pub use import_options::{ImportOptions, LossyImportAction, LossyImportEntry};
+pub use importer::{ImportStats, Importer, import_git_into, import_git_into_with_options};
 pub use oplog_emit::{OplogEmitStats, OplogEmitter};
 pub use reasoning::{ReasoningEvidence, ReasoningPoint, ReasoningTarget};
 pub use reasoning_emit::{ReasoningEmitStats, ReasoningEmitter};

--- a/crates/ingest/src/sha_map.rs
+++ b/crates/ingest/src/sha_map.rs
@@ -13,14 +13,15 @@
 //!
 //! # Storage
 //!
-//! SQLite at `<heddle_dir>/ingest/sha_map.sqlite` (WAL mode). Two columns
+//! SQLite at `<heddle_dir>/ingest/sha_map.sqlite` (WAL mode). A compact row
 //! plus one secondary index cover every query the importer makes:
 //!
 //! ```sql
 //! CREATE TABLE sha_map (
 //!     git_sha   TEXT PRIMARY KEY NOT NULL,
 //!     kind      INTEGER NOT NULL,
-//!     heddle_repr TEXT NOT NULL
+//!     heddle_repr TEXT NOT NULL,
+//!     lossy_entries TEXT
 //! );
 //! CREATE INDEX sha_map_heddle_repr ON sha_map(heddle_repr);
 //! ```
@@ -58,6 +59,8 @@ use std::path::Path;
 use objects::object::{ChangeId, ContentHash};
 use rusqlite::{Connection, OptionalExtension, params};
 use tracing::{debug, warn};
+
+use crate::import_options::LossyImportEntry;
 
 /// What kind of object the mapping is for.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -116,6 +119,8 @@ pub enum ShaMapError {
         existing: String,
         incoming: String,
     },
+    #[error("serialize lossy tree entries: {0}")]
+    LossySerialize(#[from] serde_json::Error),
 }
 
 impl Default for ShaMap {
@@ -277,7 +282,22 @@ impl ShaMap {
 
     /// Insert a tree mapping.
     pub fn insert_tree(&mut self, git_sha: &str, heddle: ContentHash) -> Result<(), ShaMapError> {
-        self.insert_raw(MapKind::Tree, git_sha, heddle.to_hex())
+        self.insert_tree_with_lossy_entries(git_sha, heddle, &[])
+    }
+
+    /// Insert a tree mapping and persist any lossy conversions that produced it.
+    pub fn insert_tree_with_lossy_entries(
+        &mut self,
+        git_sha: &str,
+        heddle: ContentHash,
+        lossy_entries: &[LossyImportEntry],
+    ) -> Result<(), ShaMapError> {
+        let lossy_json = if lossy_entries.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_string(lossy_entries)?)
+        };
+        self.insert_raw_with_lossy(MapKind::Tree, git_sha, heddle.to_hex(), lossy_json)
     }
 
     /// Insert a blob mapping.
@@ -292,14 +312,37 @@ impl ShaMap {
         heddle_repr: String,
     ) -> Result<(), ShaMapError> {
         let git_sha = normalize_git_sha(git_sha)?;
+        self.insert_raw_normalized(kind, git_sha, heddle_repr, None)
+    }
+
+    fn insert_raw_with_lossy(
+        &mut self,
+        kind: MapKind,
+        git_sha: &str,
+        heddle_repr: String,
+        lossy_json: Option<String>,
+    ) -> Result<(), ShaMapError> {
+        let git_sha = normalize_git_sha(git_sha)?;
+        self.insert_raw_normalized(kind, git_sha, heddle_repr, lossy_json)
+    }
+
+    fn insert_raw_normalized(
+        &mut self,
+        kind: MapKind,
+        git_sha: String,
+        heddle_repr: String,
+        lossy_json: Option<String>,
+    ) -> Result<(), ShaMapError> {
         // Try the INSERT first — happy path is one prepared statement.
         // On primary-key conflict we fall back to a SELECT so we can
         // distinguish idempotent re-inserts (same `heddle_repr`) from
         // genuine conflicts.
         let mut stmt = self
             .conn
-            .prepare_cached("INSERT INTO sha_map (git_sha, kind, heddle_repr) VALUES (?, ?, ?)")?;
-        match stmt.execute(params![git_sha, kind.as_i64(), heddle_repr]) {
+            .prepare_cached(
+                "INSERT INTO sha_map (git_sha, kind, heddle_repr, lossy_entries) VALUES (?, ?, ?, ?)",
+            )?;
+        match stmt.execute(params![git_sha, kind.as_i64(), heddle_repr, lossy_json]) {
             Ok(_) => Ok(()),
             Err(rusqlite::Error::SqliteFailure(err, _))
                 if err.code == rusqlite::ErrorCode::ConstraintViolation =>
@@ -316,7 +359,15 @@ impl ShaMap {
                     )
                     .optional()?;
                 match existing {
-                    Some(s) if s == heddle_repr => Ok(()), // idempotent re-insert
+                    Some(s) if s == heddle_repr => {
+                        if kind == MapKind::Tree && lossy_json.is_some() {
+                            self.conn.execute(
+                                "UPDATE sha_map SET lossy_entries = ? WHERE git_sha = ? AND kind = ? AND lossy_entries IS NULL",
+                                params![lossy_json, git_sha, kind.as_i64()],
+                            )?;
+                        }
+                        Ok(())
+                    }
                     Some(s) => Err(ShaMapError::Conflict {
                         git: git_sha,
                         existing: s,
@@ -341,6 +392,32 @@ impl ShaMap {
     pub fn get_tree(&self, git_sha: &str) -> Option<ContentHash> {
         let heddle = self.get_for_kind(git_sha, MapKind::Tree)?;
         ContentHash::from_hex(&heddle).ok()
+    }
+
+    /// Look up persisted lossy entries for a git tree SHA.
+    ///
+    /// Returns `Ok(None)` when there is no tree mapping. Returns an empty
+    /// vector when the mapped tree was lossless.
+    pub fn get_tree_lossy_entries(
+        &self,
+        git_sha: &str,
+    ) -> Result<Option<Vec<LossyImportEntry>>, ShaMapError> {
+        let git_sha = normalize_git_sha(git_sha)?;
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT lossy_entries FROM sha_map WHERE git_sha = ? AND kind = ?")?;
+        let Some(json) = stmt
+            .query_row(params![git_sha, MapKind::Tree.as_i64()], |r| {
+                r.get::<_, Option<String>>(0)
+            })
+            .optional()?
+        else {
+            return Ok(None);
+        };
+        let Some(json) = json else {
+            return Ok(Some(Vec::new()));
+        };
+        Ok(Some(serde_json::from_str(&json)?))
     }
 
     /// Look up the Heddle `ContentHash` for a git blob SHA.
@@ -414,12 +491,27 @@ fn initialize_schema(conn: &Connection) -> Result<(), ShaMapError> {
         CREATE TABLE IF NOT EXISTS sha_map (
             git_sha   TEXT PRIMARY KEY NOT NULL,
             kind      INTEGER NOT NULL,
-            heddle_repr TEXT NOT NULL
+            heddle_repr TEXT NOT NULL,
+            lossy_entries TEXT
         );
         CREATE INDEX IF NOT EXISTS sha_map_heddle_repr ON sha_map(heddle_repr);
         "#,
     )?;
+    if !sha_map_has_column(conn, "lossy_entries")? {
+        conn.execute_batch("ALTER TABLE sha_map ADD COLUMN lossy_entries TEXT;")?;
+    }
     Ok(())
+}
+
+fn sha_map_has_column(conn: &Connection, column: &str) -> Result<bool, ShaMapError> {
+    let mut stmt = conn.prepare("PRAGMA table_info(sha_map)")?;
+    let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for existing in columns {
+        if existing? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Lowercase a 40-char git SHA-1. Returns an error for anything else.
@@ -446,6 +538,8 @@ fn normalize_git_sha(sha: &str) -> Result<String, ShaMapError> {
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
+
+    use crate::import_options::LossyImportEntry;
 
     use super::*;
 
@@ -544,6 +638,65 @@ mod tests {
         assert_eq!(reloaded.get_commit(sha1), Some(cid));
         assert_eq!(reloaded.get_tree(sha2), Some(tree_h));
         assert_eq!(reloaded.get_blob(sha3), Some(blob_h));
+    }
+
+    #[test]
+    fn lossy_tree_entries_round_trip_through_disk() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("sha_map.sqlite");
+        let sha = "ca1af22000000000000000000000000000000000";
+        let tree_h = deterministic_content_hash("lossy-tree");
+        let entries = vec![LossyImportEntry::dropped(
+            "vendor".to_string(),
+            Some("0707070707070707070707070707070707070707".to_string()),
+            "gitlink/submodule entries have no Heddle tree equivalent",
+        )];
+
+        {
+            let mut m = ShaMap::open(&path).unwrap();
+            m.insert_tree_with_lossy_entries(sha, tree_h, &entries)
+                .unwrap();
+        }
+
+        let reloaded = ShaMap::open(&path).unwrap();
+        assert_eq!(reloaded.get_tree(sha), Some(tree_h));
+        assert_eq!(
+            reloaded.get_tree_lossy_entries(sha).unwrap().unwrap(),
+            entries
+        );
+    }
+
+    #[test]
+    fn open_adds_lossy_entries_column_to_existing_db() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("sha_map.sqlite");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                r#"
+                CREATE TABLE sha_map (
+                    git_sha TEXT PRIMARY KEY NOT NULL,
+                    kind INTEGER NOT NULL,
+                    heddle_repr TEXT NOT NULL
+                );
+                CREATE INDEX sha_map_heddle_repr ON sha_map(heddle_repr);
+                "#,
+            )
+            .unwrap();
+        }
+
+        let mut m = ShaMap::open(&path).unwrap();
+        let sha = "ca1af22000000000000000000000000000000000";
+        let tree_h = deterministic_content_hash("migrated-tree");
+        let entries = vec![LossyImportEntry::converted(
+            "bad\u{fffd}name".to_string(),
+            Some("0808080808080808080808080808080808080808".to_string()),
+            "tree entry name is not valid UTF-8",
+        )];
+        m.insert_tree_with_lossy_entries(sha, tree_h, &entries)
+            .unwrap();
+
+        assert_eq!(m.get_tree_lossy_entries(sha).unwrap().unwrap(), entries);
     }
 
     #[test]

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -28,6 +28,7 @@
 use objects::{
     object::{Blob, ContentHash, Tree, TreeEntry},
     store::ObjectStore,
+    util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name},
 };
 use tracing::warn;
 
@@ -133,35 +134,39 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
         child: &TreeChild,
         path_prefix: &str,
     ) -> crate::Result<Option<TreeEntry>> {
-        if child.name.is_empty()
-            || child.name == "."
-            || child.name == ".."
-            || child.name.contains('/')
-            || child.name.bytes().any(|b| b < 0x20 || b == 0x7f)
-        {
-            let entry = LossyImportEntry::dropped(
-                join_tree_path(path_prefix, &child.name),
-                Some(child.sha.clone()),
-                "tree entry name is not representable in Heddle",
-            );
-            self.record_lossy(entry)?;
-            return Ok(None);
-        }
+        let name = match classify_git_tree_name(&child.raw_name) {
+            GitTreeNameClassification::Representable(name) => name,
+            GitTreeNameClassification::NeedsLossy(lossy) => {
+                let path = join_tree_path(path_prefix, &lossy.name);
+                let entry = match lossy.action {
+                    GitTreeNameLossyAction::Dropped => {
+                        LossyImportEntry::dropped(path, Some(child.sha.clone()), lossy.reason)
+                    }
+                    GitTreeNameLossyAction::Converted => {
+                        LossyImportEntry::converted(path, Some(child.sha.clone()), lossy.reason)
+                    }
+                };
+                self.record_lossy(entry)?;
+                if matches!(lossy.action, GitTreeNameLossyAction::Dropped) {
+                    return Ok(None);
+                }
+                lossy.name
+            }
+        };
 
         match child.kind {
             TreeChildKind::Blob { executable } => {
                 let hash = self.translate_blob(&child.sha)?;
                 Ok(Some(
-                    TreeEntry::file(child.name.clone(), hash, executable)
+                    TreeEntry::file(name, hash, executable)
                         .map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Tree => {
                 let hash =
-                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &child.name))?;
+                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &name))?;
                 Ok(Some(
-                    TreeEntry::directory(child.name.clone(), hash)
-                        .map_err(|e| IngestError::Heddle(e.into()))?,
+                    TreeEntry::directory(name, hash).map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Symlink => {
@@ -170,13 +175,12 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
                 // bytes round-trip without special handling.
                 let hash = self.translate_blob(&child.sha)?;
                 Ok(Some(
-                    TreeEntry::symlink(child.name.clone(), hash)
-                        .map_err(|e| IngestError::Heddle(e.into()))?,
+                    TreeEntry::symlink(name, hash).map_err(|e| IngestError::Heddle(e.into()))?,
                 ))
             }
             TreeChildKind::Gitlink => {
                 let entry = LossyImportEntry::dropped(
-                    join_tree_path(path_prefix, &child.name),
+                    join_tree_path(path_prefix, &name),
                     Some(child.sha.clone()),
                     "gitlink/submodule entries have no Heddle tree equivalent",
                 );
@@ -218,7 +222,7 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, process::Command};
+    use std::{io::Write, path::Path, process::Command};
 
     use objects::store::InMemoryStore;
     use tempfile::TempDir;
@@ -300,6 +304,61 @@ mod tests {
             .output()
             .unwrap();
         String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    fn git_output(path: &Path, args: &[&str], stdin: Option<&[u8]>) -> String {
+        let mut command = Command::new("git");
+        command
+            .args(args)
+            .current_dir(path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null");
+        if stdin.is_some() {
+            command.stdin(std::process::Stdio::piped());
+        }
+        let mut child = command.spawn().expect("git cmd");
+        if let Some(stdin) = stdin {
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(stdin)
+                .expect("write stdin");
+        }
+        let output = child.wait_with_output().expect("git output");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn seed_invalid_utf8_name_repo(path: &Path) -> String {
+        let status = Command::new("git")
+            .args(["init", "-q", "--initial-branch=main"])
+            .current_dir(path)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init failed");
+
+        let blob = git_output(path, &["hash-object", "-w", "--stdin"], Some(b"hello\n"));
+        let mut tree_input = Vec::new();
+        write!(&mut tree_input, "100644 blob {blob}\t").expect("tree record");
+        tree_input.extend_from_slice(b"bad\xffname\0");
+        let tree = git_output(path, &["mktree", "-z"], Some(&tree_input));
+        let commit = git_output(path, &["commit-tree", &tree, "-m", "invalid name"], None);
+        git_output(path, &["update-ref", "refs/heads/main", &commit], None);
+        commit
     }
 
     #[test]
@@ -403,6 +462,55 @@ mod tests {
         assert_eq!(lossy_entries.len(), 1);
         assert_eq!(lossy_entries[0].path, "vendor");
         assert!(lossy_entries[0].summary_line().contains("dropped"));
+    }
+
+    #[test]
+    fn invalid_utf8_name_fails_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let head = seed_invalid_utf8_name_repo(tmp.path());
+        let git = GitSource::open(tmp.path()).unwrap();
+        let store = InMemoryStore::new();
+        let mut map = ShaMap::new();
+        let commit = git.read_commit(&head).unwrap();
+
+        let err = TreeTranslator::new(&git, &store, &mut map)
+            .translate_tree(&commit.tree_sha)
+            .expect_err("invalid UTF-8 name must fail without lossy opt-in");
+        let message = err.to_string();
+
+        assert!(message.contains("bad"), "error names entry: {message}");
+        assert!(
+            message.contains("not valid UTF-8"),
+            "error explains conversion: {message}"
+        );
+        assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn invalid_utf8_name_lossy_opt_in_converts_and_records_summary() {
+        let tmp = TempDir::new().unwrap();
+        let head = seed_invalid_utf8_name_repo(tmp.path());
+        let git = GitSource::open(tmp.path()).unwrap();
+        let store = InMemoryStore::new();
+        let mut map = ShaMap::new();
+        let commit = git.read_commit(&head).unwrap();
+
+        let mut tx =
+            TreeTranslator::with_options(&git, &store, &mut map, ImportOptions { lossy: true });
+        let root_hash = tx.translate_tree(&commit.tree_sha).unwrap();
+        let lossy_entries = tx.lossy_entries().to_vec();
+        let tree = store.get_tree(&root_hash).unwrap().unwrap();
+        let converted_name = "bad\u{fffd}name";
+
+        assert!(
+            tree.entries()
+                .iter()
+                .any(|entry| entry.name == converted_name),
+            "converted entry should be retained"
+        );
+        assert_eq!(lossy_entries.len(), 1);
+        assert_eq!(lossy_entries[0].path, converted_name);
+        assert!(lossy_entries[0].summary_line().contains("converted"));
     }
 
     #[test]

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -41,7 +41,6 @@ use crate::{
     },
     sha_map::ShaMap,
 };
-use std::collections::HashMap;
 
 /// Translates one git tree (recursively) into Heddle blobs and trees.
 ///
@@ -54,7 +53,6 @@ pub struct TreeTranslator<'a, S: ObjectStore> {
     map: &'a mut ShaMap,
     options: ImportOptions,
     lossy_entries: Vec<LossyImportEntry>,
-    lossy_by_tree: HashMap<String, Vec<LossyImportEntry>>,
 }
 
 impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
@@ -74,7 +72,6 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
             map,
             options,
             lossy_entries: Vec::new(),
-            lossy_by_tree: HashMap::new(),
         }
     }
 
@@ -132,8 +129,6 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
         self.map
             .insert_tree_with_lossy_entries(git_tree_sha, hash, &tree_lossy_entries)
             .map_err(IngestError::from)?;
-        self.lossy_by_tree
-            .insert(git_tree_sha.to_string(), tree_lossy_entries);
         Ok(hash)
     }
 

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -36,8 +36,8 @@ use crate::{
     IngestError,
     git_walk::{GitSource, TreeChild, TreeChildKind},
     import_options::{
-        ImportOptions, LossyImportEntry, entry_relative_to_prefix, join_tree_path,
-        rebase_lossy_entry,
+        ImportOptions, LossyImportEntry, entry_relative_to_prefix, fail_lossy_entry,
+        join_tree_path, rebase_lossy_entry,
     },
     sha_map::ShaMap,
 };
@@ -95,7 +95,15 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
         path_prefix: &str,
     ) -> crate::Result<ContentHash> {
         if let Some(hash) = self.map.get_tree(git_tree_sha) {
-            if let Some(entries) = self.lossy_by_tree.get(git_tree_sha) {
+            let entries = self
+                .map
+                .get_tree_lossy_entries(git_tree_sha)
+                .map_err(IngestError::from)?
+                .unwrap_or_default();
+            if !entries.is_empty() {
+                if !self.options.lossy {
+                    return Err(fail_lossy_entry(&rebase_lossy_entry(path_prefix, &entries[0])));
+                }
                 self.lossy_entries.extend(
                     entries
                         .iter()
@@ -122,7 +130,7 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
         let hash = self.store.put_tree(&tree).map_err(IngestError::from)?;
 
         self.map
-            .insert_tree(git_tree_sha, hash)
+            .insert_tree_with_lossy_entries(git_tree_sha, hash, &tree_lossy_entries)
             .map_err(IngestError::from)?;
         self.lossy_by_tree
             .insert(git_tree_sha.to_string(), tree_lossy_entries);
@@ -192,10 +200,7 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
 
     fn record_lossy(&mut self, entry: LossyImportEntry) -> crate::Result<()> {
         if !self.options.lossy {
-            return Err(IngestError::Other(format!(
-                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
-                entry.summary_line()
-            )));
+            return Err(fail_lossy_entry(&entry));
         }
         warn!(entry = %entry.summary_line(), "lossy git import accepted");
         self.lossy_entries.push(entry);
@@ -361,6 +366,35 @@ mod tests {
         commit
     }
 
+    fn seed_nested_gitlink_repo(path: &Path, dir: &str, parent: Option<&str>) -> String {
+        if parent.is_none() {
+            let status = Command::new("git")
+                .args(["init", "-q", "--initial-branch=main"])
+                .current_dir(path)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .status()
+                .expect("git init");
+            assert!(status.success(), "git init failed");
+        }
+
+        let mut subtree_input = Vec::new();
+        subtree_input
+            .extend_from_slice(b"160000 commit 0707070707070707070707070707070707070707\tvendor\0");
+        let subtree = git_output(path, &["mktree", "--missing", "-z"], Some(&subtree_input));
+        let mut root_input = Vec::new();
+        write!(&mut root_input, "040000 tree {subtree}\t{dir}\0").expect("root tree record");
+        let root = git_output(path, &["mktree", "--missing", "-z"], Some(&root_input));
+
+        let mut args = vec!["commit-tree", root.as_str(), "-m", "nested gitlink"];
+        if let Some(parent) = parent {
+            args.extend(["-p", parent]);
+        }
+        let commit = git_output(path, &args, None);
+        git_output(path, &["update-ref", "refs/heads/main", &commit], None);
+        commit
+    }
+
     #[test]
     fn translates_tree_round_trip() {
         let tmp = TempDir::new().unwrap();
@@ -511,6 +545,37 @@ mod tests {
         assert_eq!(lossy_entries.len(), 1);
         assert_eq!(lossy_entries[0].path, converted_name);
         assert!(lossy_entries[0].summary_line().contains("converted"));
+    }
+
+    #[test]
+    fn cached_lossy_subtree_reports_with_new_path_prefix() {
+        let gitdir = TempDir::new().unwrap();
+        let mapdir = TempDir::new().unwrap();
+        let map_path = mapdir.path().join("sha_map.sqlite");
+        let first_commit = seed_nested_gitlink_repo(gitdir.path(), "dir1", None);
+        let git = GitSource::open(gitdir.path()).unwrap();
+        let store = InMemoryStore::new();
+
+        {
+            let mut map = ShaMap::open(&map_path).unwrap();
+            let commit = git.read_commit(&first_commit).unwrap();
+            let mut tx =
+                TreeTranslator::with_options(&git, &store, &mut map, ImportOptions { lossy: true });
+            tx.translate_tree(&commit.tree_sha).unwrap();
+            assert_eq!(tx.lossy_entries()[0].path, "dir1/vendor");
+        }
+
+        let second_commit = seed_nested_gitlink_repo(gitdir.path(), "dir2", Some(&first_commit));
+        let mut map = ShaMap::open(&map_path).unwrap();
+        let commit = git.read_commit(&second_commit).unwrap();
+        let mut tx =
+            TreeTranslator::with_options(&git, &store, &mut map, ImportOptions { lossy: true });
+        tx.translate_tree(&commit.tree_sha).unwrap();
+        let lossy_entries = tx.lossy_entries().to_vec();
+
+        assert_eq!(lossy_entries.len(), 1);
+        assert_eq!(lossy_entries[0].path, "dir2/vendor");
+        assert!(lossy_entries[0].summary_line().contains("dropped"));
     }
 
     #[test]

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -22,8 +22,8 @@
 //!   content is the target path. Heddle supports them natively via
 //!   [`TreeEntry::symlink`]; we pass the blob hash through unchanged.
 //! - **Gitlinks** (mode `160000`, i.e. submodule pointers) have no Heddle
-//!   equivalent in v1. They're skipped with a `warn!` trace; the caller
-//!   can choose to abort if a tree ends up empty.
+//!   equivalent in v1. Imports refuse them by default; callers can opt into
+//!   lossy import to drop them and receive an end-of-run summary.
 
 use objects::{
     object::{Blob, ContentHash, Tree, TreeEntry},
@@ -34,8 +34,13 @@ use tracing::warn;
 use crate::{
     IngestError,
     git_walk::{GitSource, TreeChild, TreeChildKind},
+    import_options::{
+        ImportOptions, LossyImportEntry, entry_relative_to_prefix, join_tree_path,
+        rebase_lossy_entry,
+    },
     sha_map::ShaMap,
 };
+use std::collections::HashMap;
 
 /// Translates one git tree (recursively) into Heddle blobs and trees.
 ///
@@ -46,28 +51,71 @@ pub struct TreeTranslator<'a, S: ObjectStore> {
     git: &'a GitSource,
     store: &'a S,
     map: &'a mut ShaMap,
+    options: ImportOptions,
+    lossy_entries: Vec<LossyImportEntry>,
+    lossy_by_tree: HashMap<String, Vec<LossyImportEntry>>,
 }
 
 impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
     pub fn new(git: &'a GitSource, store: &'a S, map: &'a mut ShaMap) -> Self {
-        Self { git, store, map }
+        Self::with_options(git, store, map, ImportOptions::default())
+    }
+
+    pub fn with_options(
+        git: &'a GitSource,
+        store: &'a S,
+        map: &'a mut ShaMap,
+        options: ImportOptions,
+    ) -> Self {
+        Self {
+            git,
+            store,
+            map,
+            options,
+            lossy_entries: Vec::new(),
+            lossy_by_tree: HashMap::new(),
+        }
+    }
+
+    pub fn lossy_entries(&self) -> &[LossyImportEntry] {
+        &self.lossy_entries
     }
 
     /// Walk the git tree at `git_tree_sha` and produce the corresponding
     /// Heddle root tree's [`ContentHash`]. Idempotent: re-translating the
     /// same git SHA returns the cached hash without re-reading git.
     pub fn translate_tree(&mut self, git_tree_sha: &str) -> crate::Result<ContentHash> {
+        self.translate_tree_at(git_tree_sha, "")
+    }
+
+    fn translate_tree_at(
+        &mut self,
+        git_tree_sha: &str,
+        path_prefix: &str,
+    ) -> crate::Result<ContentHash> {
         if let Some(hash) = self.map.get_tree(git_tree_sha) {
+            if let Some(entries) = self.lossy_by_tree.get(git_tree_sha) {
+                self.lossy_entries.extend(
+                    entries
+                        .iter()
+                        .map(|entry| rebase_lossy_entry(path_prefix, entry)),
+                );
+            }
             return Ok(hash);
         }
 
+        let before_lossy = self.lossy_entries.len();
         let children = self.git.read_tree(git_tree_sha)?;
         let mut entries = Vec::with_capacity(children.len());
         for child in children {
-            if let Some(entry) = self.translate_child(&child)? {
+            if let Some(entry) = self.translate_child(&child, path_prefix)? {
                 entries.push(entry);
             }
         }
+        let tree_lossy_entries = self.lossy_entries[before_lossy..]
+            .iter()
+            .map(|entry| entry_relative_to_prefix(path_prefix, entry))
+            .collect::<Vec<_>>();
 
         let tree = Tree::from_entries(entries);
         let hash = self.store.put_tree(&tree).map_err(IngestError::from)?;
@@ -75,20 +123,28 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
         self.map
             .insert_tree(git_tree_sha, hash)
             .map_err(IngestError::from)?;
+        self.lossy_by_tree
+            .insert(git_tree_sha.to_string(), tree_lossy_entries);
         Ok(hash)
     }
 
-    fn translate_child(&mut self, child: &TreeChild) -> crate::Result<Option<TreeEntry>> {
-        // Skip `.` / `..` and control-byte names before they hit Heddle's
-        // validator — we'd rather warn and drop than abort the whole
-        // import because some repo has a weird filename.
+    fn translate_child(
+        &mut self,
+        child: &TreeChild,
+        path_prefix: &str,
+    ) -> crate::Result<Option<TreeEntry>> {
         if child.name.is_empty()
             || child.name == "."
             || child.name == ".."
             || child.name.contains('/')
             || child.name.bytes().any(|b| b < 0x20 || b == 0x7f)
         {
-            warn!(name = %child.name, "skipping tree child with unusable name");
+            let entry = LossyImportEntry::dropped(
+                join_tree_path(path_prefix, &child.name),
+                Some(child.sha.clone()),
+                "tree entry name is not representable in Heddle",
+            );
+            self.record_lossy(entry)?;
             return Ok(None);
         }
 
@@ -101,7 +157,8 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
                 ))
             }
             TreeChildKind::Tree => {
-                let hash = self.translate_tree(&child.sha)?;
+                let hash =
+                    self.translate_tree_at(&child.sha, &join_tree_path(path_prefix, &child.name))?;
                 Ok(Some(
                     TreeEntry::directory(child.name.clone(), hash)
                         .map_err(|e| IngestError::Heddle(e.into()))?,
@@ -118,17 +175,27 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
                 ))
             }
             TreeChildKind::Gitlink => {
-                // Submodule pointers. Heddle's tree doesn't model them yet,
-                // so we drop the entry and log loudly; the tree hash will
-                // diverge from the git tree by exactly this entry.
-                warn!(
-                    name = %child.name,
-                    submodule_sha = %child.sha,
-                    "dropping gitlink (submodule) entry — no Heddle equivalent"
+                let entry = LossyImportEntry::dropped(
+                    join_tree_path(path_prefix, &child.name),
+                    Some(child.sha.clone()),
+                    "gitlink/submodule entries have no Heddle tree equivalent",
                 );
+                self.record_lossy(entry)?;
                 Ok(None)
             }
         }
+    }
+
+    fn record_lossy(&mut self, entry: LossyImportEntry) -> crate::Result<()> {
+        if !self.options.lossy {
+            return Err(IngestError::Other(format!(
+                "git import cannot represent tree entry losslessly: {}. Retry with --lossy to accept dropping or converting unrepresentable entries.",
+                entry.summary_line()
+            )));
+        }
+        warn!(entry = %entry.summary_line(), "lossy git import accepted");
+        self.lossy_entries.push(entry);
+        Ok(())
     }
 
     /// Hash `git_blob_sha` into Heddle's object store, memoizing on the git
@@ -200,6 +267,41 @@ mod tests {
         String::from_utf8(out.stdout).unwrap().trim().to_string()
     }
 
+    fn seed_gitlink_repo(path: &Path) -> String {
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .status()
+                .expect("git cmd");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+        run(&["init", "-q", "--initial-branch=main"]);
+        std::fs::write(path.join("README.md"), "# hello\n").unwrap();
+        run(&["add", "README.md"]);
+        run(&["commit", "-q", "-m", "initial"]);
+        run(&[
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "160000,0707070707070707070707070707070707070707,vendor",
+        ]);
+        run(&["commit", "-q", "-m", "add gitlink"]);
+
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
     #[test]
     fn translates_tree_round_trip() {
         let tmp = TempDir::new().unwrap();
@@ -257,6 +359,50 @@ mod tests {
             assert!(entry.is_executable(), "run.sh should be marked executable");
             let _ = entry;
         }
+    }
+
+    #[test]
+    fn gitlink_fails_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let head = seed_gitlink_repo(tmp.path());
+        let git = GitSource::open(tmp.path()).unwrap();
+        let store = InMemoryStore::new();
+        let mut map = ShaMap::new();
+        let commit = git.read_commit(&head).unwrap();
+
+        let err = TreeTranslator::new(&git, &store, &mut map)
+            .translate_tree(&commit.tree_sha)
+            .expect_err("gitlink import must fail without lossy opt-in");
+        let message = err.to_string();
+
+        assert!(message.contains("vendor"), "error names entry: {message}");
+        assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn gitlink_lossy_opt_in_drops_and_records_summary() {
+        let tmp = TempDir::new().unwrap();
+        let head = seed_gitlink_repo(tmp.path());
+        let git = GitSource::open(tmp.path()).unwrap();
+        let store = InMemoryStore::new();
+        let mut map = ShaMap::new();
+        let commit = git.read_commit(&head).unwrap();
+
+        let mut tx =
+            TreeTranslator::with_options(&git, &store, &mut map, ImportOptions { lossy: true });
+        let root_hash = tx.translate_tree(&commit.tree_sha).unwrap();
+        let lossy_entries = tx.lossy_entries().to_vec();
+        let tree = store.get_tree(&root_hash).unwrap().unwrap();
+        let names = tree
+            .entries()
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(!names.contains(&"vendor"));
+        assert_eq!(lossy_entries.len(), 1);
+        assert_eq!(lossy_entries[0].path, "vendor");
+        assert!(lossy_entries[0].summary_line().contains("dropped"));
     }
 
     #[test]

--- a/crates/objects/src/util/git_tree_name.rs
+++ b/crates/objects/src/util/git_tree_name.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Git tree-entry name classification shared by import engines.
 
+use crate::object::validate_tree_entry_name;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GitTreeNameClassification {
     Representable(String),
@@ -32,18 +34,68 @@ pub fn classify_git_tree_name(raw_name: &[u8]) -> GitTreeNameClassification {
         }
     };
 
-    if name.is_empty()
-        || name == "."
-        || name == ".."
-        || name.contains('/')
-        || name.bytes().any(|b| b < 0x20 || b == 0x7f)
-    {
-        return GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
+    // Defer to the canonical tree-name validator so this classifier's
+    // "representable" set can never drift from what Heddle will actually
+    // store (path separators '/' and '\', '.'/'..', control bytes, empty).
+    match validate_tree_entry_name(&name) {
+        Ok(()) => GitTreeNameClassification::Representable(name),
+        Err(_) => GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
             name,
             action: GitTreeNameLossyAction::Dropped,
             reason: "tree entry name is not representable in Heddle",
-        });
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Close-the-class guard: the classifier's `Representable` verdict must be
+    /// EXACTLY the set `validate_tree_entry_name` accepts. If the two ever
+    /// diverge (as they did for `\\` before this fix), this fails.
+    #[test]
+    fn representable_iff_validator_accepts() {
+        let cases = [
+            "ok.txt",
+            "with space",
+            "ünïcödé",
+            "",
+            ".",
+            "..",
+            "a/b",
+            "a\\b",
+            "ctrl\u{0001}",
+            "del\u{7f}",
+        ];
+        for c in cases {
+            let classified_representable = matches!(
+                classify_git_tree_name(c.as_bytes()),
+                GitTreeNameClassification::Representable(_)
+            );
+            let validator_accepts = validate_tree_entry_name(c).is_ok();
+            assert_eq!(
+                classified_representable, validator_accepts,
+                "classifier/validator disagree on {c:?}"
+            );
+        }
     }
 
-    GitTreeNameClassification::Representable(name)
+    #[test]
+    fn backslash_name_is_not_representable() {
+        assert!(matches!(
+            classify_git_tree_name(b"foo\\bar"),
+            GitTreeNameClassification::NeedsLossy(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_utf8_is_converted_not_dropped() {
+        match classify_git_tree_name(&[b'a', 0xff, b'b']) {
+            GitTreeNameClassification::NeedsLossy(lossy) => {
+                assert_eq!(lossy.action, GitTreeNameLossyAction::Converted);
+            }
+            other => panic!("expected NeedsLossy/Converted, got {other:?}"),
+        }
+    }
 }

--- a/crates/objects/src/util/git_tree_name.rs
+++ b/crates/objects/src/util/git_tree_name.rs
@@ -23,23 +23,26 @@ pub enum GitTreeNameLossyAction {
 }
 
 pub fn classify_git_tree_name(raw_name: &[u8]) -> GitTreeNameClassification {
-    let name = match std::str::from_utf8(raw_name) {
-        Ok(name) => name.to_string(),
-        Err(_) => {
-            return GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
-                name: String::from_utf8_lossy(raw_name).into_owned(),
-                action: GitTreeNameLossyAction::Converted,
-                reason: "tree entry name is not valid UTF-8 and was converted with replacement characters",
-            });
-        }
+    let (name, utf8_lossy) = match std::str::from_utf8(raw_name) {
+        Ok(name) => (name.to_string(), false),
+        Err(_) => (String::from_utf8_lossy(raw_name).into_owned(), true),
     };
 
-    // Defer to the canonical tree-name validator so this classifier's
-    // "representable" set can never drift from what Heddle will actually
-    // store (path separators '/' and '\', '.'/'..', control bytes, empty).
-    match validate_tree_entry_name(&name) {
-        Ok(()) => GitTreeNameClassification::Representable(name),
-        Err(_) => GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
+    // Validate the FINAL name (after any UTF-8 replacement) against the
+    // canonical tree-name validator, so this classifier's representable set
+    // can never drift from what Heddle will actually store (path separators
+    // '/' and '\', '.'/'..', control bytes, empty). Critically, a name that
+    // is invalid UTF-8 AND otherwise unrepresentable (e.g. `bad\<0xff>` ->
+    // lossy `bad\<U+FFFD>` still containing a backslash) must be Dropped, not
+    // silently persisted as Converted.
+    match (validate_tree_entry_name(&name), utf8_lossy) {
+        (Ok(()), false) => GitTreeNameClassification::Representable(name),
+        (Ok(()), true) => GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
+            name,
+            action: GitTreeNameLossyAction::Converted,
+            reason: "tree entry name is not valid UTF-8 and was converted with replacement characters",
+        }),
+        (Err(_), _) => GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
             name,
             action: GitTreeNameLossyAction::Dropped,
             reason: "tree entry name is not representable in Heddle",
@@ -96,6 +99,20 @@ mod tests {
                 assert_eq!(lossy.action, GitTreeNameLossyAction::Converted);
             }
             other => panic!("expected NeedsLossy/Converted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_utf8_that_stays_unrepresentable_after_conversion_is_dropped() {
+        // `bad\<0xff>`: invalid UTF-8 AND contains a backslash. Lossy UTF-8
+        // conversion replaces the 0xff but the backslash survives, so the
+        // converted name is still rejected by validate_tree_entry_name and
+        // must be Dropped — never silently persisted as Converted.
+        match classify_git_tree_name(b"bad\\\xff") {
+            GitTreeNameClassification::NeedsLossy(lossy) => {
+                assert_eq!(lossy.action, GitTreeNameLossyAction::Dropped);
+            }
+            other => panic!("expected NeedsLossy/Dropped, got {other:?}"),
         }
     }
 }

--- a/crates/objects/src/util/git_tree_name.rs
+++ b/crates/objects/src/util/git_tree_name.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Git tree-entry name classification shared by import engines.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GitTreeNameClassification {
+    Representable(String),
+    NeedsLossy(GitTreeNameLossy),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitTreeNameLossy {
+    pub name: String,
+    pub action: GitTreeNameLossyAction,
+    pub reason: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitTreeNameLossyAction {
+    Dropped,
+    Converted,
+}
+
+pub fn classify_git_tree_name(raw_name: &[u8]) -> GitTreeNameClassification {
+    let name = match std::str::from_utf8(raw_name) {
+        Ok(name) => name.to_string(),
+        Err(_) => {
+            return GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
+                name: String::from_utf8_lossy(raw_name).into_owned(),
+                action: GitTreeNameLossyAction::Converted,
+                reason: "tree entry name is not valid UTF-8 and was converted with replacement characters",
+            });
+        }
+    };
+
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.bytes().any(|b| b < 0x20 || b == 0x7f)
+    {
+        return GitTreeNameClassification::NeedsLossy(GitTreeNameLossy {
+            name,
+            action: GitTreeNameLossyAction::Dropped,
+            reason: "tree entry name is not representable in Heddle",
+        });
+    }
+
+    GitTreeNameClassification::Representable(name)
+}

--- a/crates/objects/src/util/mod.rs
+++ b/crates/objects/src/util/mod.rs
@@ -10,6 +10,10 @@ pub mod async_retry;
 #[cfg(feature = "s3")]
 pub use async_retry::{RetryDecision, RetryPolicy, classify_transient_io, retry_with};
 
+pub mod git_tree_name;
 pub mod symlink;
 
+pub use git_tree_name::{
+    GitTreeNameClassification, GitTreeNameLossy, GitTreeNameLossyAction, classify_git_tree_name,
+};
 pub use symlink::symlink_target_bytes;

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1598,7 +1598,6 @@ imports the requested Git refs, and returns the post-adoption verification proof
 | `refs` | array<string> | required | Refs explicitly requested with `--ref`; empty means all local refs were imported. |
 | `commits_imported`, `states_created`, `branches_synced`, `tags_synced` | int | required | Git import counts. |
 | `skipped_non_commit_refs`, `partial_mirror_refs` | int | required | Degraded import counts that may require inspection. |
-| `lossy_entries` | array<object> | required | Entries dropped or converted only when `--lossy` was explicitly passed; empty for lossless imports. |
 | `verification` | object | required | Post-adoption repository verification proof. |
 
 ---
@@ -2326,7 +2325,7 @@ key naming:
 |------|-------|
 | `init` | `{"initialized": true, "path": "..."}` |
 | `export` | `{"states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
-| `import` | `{"output_kind": "bridge_git_import", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "partial_mirror_refs": N}` |
+| `import` | `{"output_kind": "bridge_git_import", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "partial_mirror_refs": N, "lossy_entries": [], "already_in_sync": false}` |
 | `sync` | `{"output_kind": "bridge_git_sync", "states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
 | `push` | `{"output_kind": "bridge_git_push", "action": "bridge git push", "status": "pushed", "success": true, "pushed": true, "changed": true, "transport": "git", "remote": "origin"}` |
 | `pull` | `{"output_kind": "bridge_git_pull", "action": "bridge git pull", "status": "updated", "success": true, "pulled": true, "changed": true, "transport": "git", "remote": "origin"}` |
@@ -2366,6 +2365,12 @@ key naming:
 ```json
 {"output_kind": "bridge_git_pull", "action": "bridge git pull", "status": "updated", "success": true, "pulled": true, "changed": true, "transport": "git", "remote": "origin"}
 ```
+
+### Bridge Git Import Fields
+
+| Field | Type | Optionality | Semantics |
+|-------|------|-------------|-----------|
+| `lossy_entries` | array<object> | required | Entries dropped or converted only when `--lossy` was explicitly passed; empty for lossless imports. |
 
 ---
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1598,6 +1598,7 @@ imports the requested Git refs, and returns the post-adoption verification proof
 | `refs` | array<string> | required | Refs explicitly requested with `--ref`; empty means all local refs were imported. |
 | `commits_imported`, `states_created`, `branches_synced`, `tags_synced` | int | required | Git import counts. |
 | `skipped_non_commit_refs`, `partial_mirror_refs` | int | required | Degraded import counts that may require inspection. |
+| `lossy_entries` | array<object> | required | Entries dropped or converted only when `--lossy` was explicitly passed; empty for lossless imports. |
 | `verification` | object | required | Post-adoption repository verification proof. |
 
 ---
@@ -2345,7 +2346,7 @@ key naming:
 `heddle bridge git import --output json` emits:
 
 ```json
-{"output_kind": "bridge_git_import", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "partial_mirror_refs": 0, "already_in_sync": false}
+{"output_kind": "bridge_git_import", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "partial_mirror_refs": 0, "lossy_entries": [], "already_in_sync": false}
 ```
 
 `heddle bridge git sync --output json` emits:


### PR DESCRIPTION
## Summary
Closes #438 (sub-issue 3/4 of #370 — the one lossy path). git-import silently warn-and-dropped / lossily-converted unrepresentable tree entries. Now **fail-hard by default; explicit `--lossy` opt-in**.

- **Default:** unusable tree names, invalid-UTF-8 names, and gitlinks/submodules now FAIL the import with an actionable error naming the entry (non-zero exit) — no silent drop.
- **`--lossy`:** the one ergonomic flag (across `bridge git import`, `bridge git ingest`, and the ingest binary `import`) restores drop/convert AND emits an end-of-run summary (plain text + JSON `lossy_entries`).
- **Close-the-class:** all lossy sites routed through a shared `GitImportOptions` (`ingest/import_options.rs`) — `ingest/tree_translate.rs`, `ingest/importer.rs` (packed dup path), `cli/git_import_tree.rs`. No site silently drops by default.

## Test evidence
- default import of a repo with an unrepresentable entry → fails loud + non-zero; `--lossy` → succeeds + reports summary; representable repo imports clean either way
- full workspace suite, `-p heddle-ingest`, cli bridge importer tests, `-p heddle-mount`, `check-no-silent-default-tree-load.sh`, clippy `--locked`

🤖 codex-authored; cross-engine Claude review pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783033087&installation_id=132405951&pr_number=453&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F453&signature=6e80dd78477e8c9d4aaa82f2a5a2e2bcad230e131d5d46d3e630fbf32226b4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->