### PR TITLE
chore: normalize formatting (cargo +nightly fmt --all)

### DIFF
--- a/crates/cli-macro-poc/tests/measure.rs
+++ b/crates/cli-macro-poc/tests/measure.rs
@@ -48,8 +48,9 @@ fn serialized_example_keys() -> BTreeSet<String> {
 fn both_emitters_cover_the_documented_sample_keys() {
     let documented: BTreeSet<&str> = documented_sample_keys().into_iter().collect();
 
-    let schemars_keys: BTreeSet<String> =
-        property_keys(&schemars_path::schema()).into_iter().collect();
+    let schemars_keys: BTreeSet<String> = property_keys(&schemars_path::schema())
+        .into_iter()
+        .collect();
     let custom_keys: BTreeSet<String> = property_keys(&custom_path::schema()).into_iter().collect();
 
     for key in &documented {
@@ -150,8 +151,7 @@ fn discriminator_gap_is_real_schemars_unpinned_custom_pinned() {
 #[test]
 fn schemars_re_exposes_skip_serialized_verification_field() {
     let schemars_schema = schemars_path::schema();
-    let schemars_props: BTreeSet<String> =
-        property_keys(&schemars_schema).into_iter().collect();
+    let schemars_props: BTreeSet<String> = property_keys(&schemars_schema).into_iter().collect();
     let custom_props: BTreeSet<String> =
         property_keys(&custom_path::schema()).into_iter().collect();
     let wire_keys = serialized_example_keys();
@@ -164,7 +164,11 @@ fn schemars_re_exposes_skip_serialized_verification_field() {
     let required: BTreeSet<String> = schemars_schema
         .get("required")
         .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
         .unwrap_or_default();
     assert!(
         required.contains("verification"),
@@ -274,7 +278,10 @@ fn print_measurement_table() {
         "phantom `verification` property", s_has_verification, false
     );
     println!("{:<36} | {:>10} | {:>10}", "carries example", true, true);
-    println!("{:<36} | {:>10} | {:>10}", "needs schemars dep", true, false);
+    println!(
+        "{:<36} | {:>10} | {:>10}",
+        "needs schemars dep", true, false
+    );
     println!("===========================================================\n");
 
     println!("--- schemars schema ---\n{s_pretty}\n");

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
@@ -7,8 +6,8 @@ use std::{
     net::{TcpListener, TcpStream},
     process::{Child, Command, Stdio},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread,
     time::Duration,
@@ -16,18 +15,19 @@ use std::{
 
 use base64::Engine;
 use gix::refs::transaction::PreviousValue;
-use objects::object::{
-    Blob, ChangeId, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry,
+use objects::{
+    object::{Blob, ChangeId, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry},
+    store::ObjectStore,
 };
 use repo::Repository;
 use tempfile::TempDir;
 
 use crate::bridge::{
-    git_core::{copy_local_repo_to_bare, delete_reference_if_present, set_reference, GitPushScope},
+    GitBridge,
+    git_core::{GitPushScope, copy_local_repo_to_bare, delete_reference_if_present, set_reference},
     git_export::{export_all, export_tree},
     git_import::{import_all, import_git_tree},
     git_sync::{sync_branches, sync_tags, sync_track_to_branch},
-    GitBridge,
 };
 
 fn init_git_repo() -> (TempDir, gix::Repository) {
@@ -151,16 +151,18 @@ impl GitHttpBackend {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_signal = Arc::clone(&stop);
         let auth = basic_auth.clone();
-        let join = thread::spawn(move || loop {
-            if stop_signal.load(Ordering::Relaxed) {
-                break;
-            }
-            match listener.accept() {
-                Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
+        let join = thread::spawn(move || {
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
                 }
-                Err(_) => break,
+                match listener.accept() {
+                    Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
             }
         });
 
@@ -905,16 +907,18 @@ fn pull_imports_remote_branches_and_tags_from_path_remote() {
         .pull(source_temp.path().to_str().expect("remote path"))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -932,16 +936,18 @@ fn pull_imports_remote_branches_and_tags_from_file_url_remote() {
         .pull(&format!("file://{}", source_temp.path().display()))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -960,16 +966,18 @@ fn pull_imports_remote_branches_and_tags_from_git_daemon() {
     let mut bridge = GitBridge::new(&repo);
     bridge.pull(&daemon.url("remote.git")).expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -990,16 +998,18 @@ fn pull_imports_remote_branches_and_tags_from_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1020,16 +1030,18 @@ fn pull_imports_remote_branches_and_tags_from_authenticated_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over authenticated http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1885,7 +1897,12 @@ fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
     // All three states now exist in the store, and the import populated
     // the mirror with refs/heads/{main,feature}.
     assert_eq!(
-        bridge.heddle_repo.store().list_states().expect("states").len(),
+        bridge
+            .heddle_repo
+            .store()
+            .list_states()
+            .expect("states")
+            .len(),
         3,
         "import should have created three states (two on main, one on feature)"
     );
@@ -1958,11 +1975,12 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let bridge = GitBridge::new(&repo);
 
-    let attribution =
-        || Attribution::human(Principal::new("Alice", "alice@example.com"));
+    let attribution = || Attribution::human(Principal::new("Alice", "alice@example.com"));
     let put_state = |parents: Vec<ChangeId>| -> State {
         let store = bridge.heddle_repo.store();
-        let blob_hash = store.put_blob(&Blob::from_slice(b"contents")).expect("put blob");
+        let blob_hash = store
+            .put_blob(&Blob::from_slice(b"contents"))
+            .expect("put blob");
         let tree_hash = store
             .put_tree(&Tree::from_entries(vec![
                 TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
@@ -2004,7 +2022,12 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
     // would have minted (and, pre-r4, counted) it.
     let mut bridge = bridge;
     assert_eq!(
-        bridge.heddle_repo.store().list_states().expect("states").len(),
+        bridge
+            .heddle_repo
+            .store()
+            .list_states()
+            .expect("states")
+            .len(),
         3,
         "store holds main's two states plus the dropped scratch state"
     );

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -266,7 +266,11 @@ impl RefSpec {
 
     /// Render in `git` refspec syntax without the leading `+`, even when forced.
     pub fn to_git_format_not_forced(&self) -> String {
-        format!("{}:{}", self.source.as_deref().unwrap_or(""), self.destination)
+        format!(
+            "{}:{}",
+            self.source.as_deref().unwrap_or(""),
+            self.destination
+        )
     }
 }
 
@@ -981,19 +985,26 @@ impl<'a> GitBridge<'a> {
 
         let mut materialized_attached_thread = false;
         if let Some((thread, old_state)) = attached_before
-            && let Some(new_state) = self.heddle_repo.refs().get_thread(&ThreadName::new(&thread))?
+            && let Some(new_state) = self
+                .heddle_repo
+                .refs()
+                .get_thread(&ThreadName::new(&thread))?
             && new_state != old_state
         {
-            self.heddle_repo.refs().set_thread(&ThreadName::new(&thread), &old_state)?;
+            self.heddle_repo
+                .refs()
+                .set_thread(&ThreadName::new(&thread), &old_state)?;
             self.heddle_repo.refs().write_head(&Head::Attached {
                 thread: ThreadName::new(&thread),
             })?;
             self.heddle_repo
                 .goto_verified_clean_without_record(&new_state)?;
-            self.heddle_repo.refs().set_thread(&ThreadName::new(&thread), &new_state)?;
             self.heddle_repo
                 .refs()
-                .write_head(&Head::Attached { thread: ThreadName::new(&thread) })?;
+                .set_thread(&ThreadName::new(&thread), &new_state)?;
+            self.heddle_repo.refs().write_head(&Head::Attached {
+                thread: ThreadName::new(&thread),
+            })?;
             materialized_attached_thread = true;
         }
 
@@ -1228,7 +1239,10 @@ impl<'a> GitBridge<'a> {
         let mut real_tracked: HashSet<String> = HashSet::new();
         let mut existing_ita: HashSet<String> = HashSet::new();
         for entry in index.entries() {
-            let path = entry.path_in(index.path_backing()).to_str_lossy().into_owned();
+            let path = entry
+                .path_in(index.path_backing())
+                .to_str_lossy()
+                .into_owned();
             if entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD) {
                 existing_ita.insert(path);
             } else {
@@ -1345,7 +1359,11 @@ impl<'a> GitBridge<'a> {
         &mut self,
         thread: &str,
     ) -> GitResult<WriteThroughOutcome> {
-        let Some(state_id) = self.heddle_repo.refs().get_thread(&ThreadName::new(thread))? else {
+        let Some(state_id) = self
+            .heddle_repo
+            .refs()
+            .get_thread(&ThreadName::new(thread))?
+        else {
             return Ok(WriteThroughOutcome::Skipped(
                 WriteThroughSkipReason::NoAttachedThread,
             ));
@@ -1771,9 +1789,10 @@ fn parse_configured_remote_url(value: &str, relative_base: &Path) -> GitResult<g
 
 fn configured_remote_local_path(value: &str, relative_base: &Path) -> PathBuf {
     if value == "~"
-        && let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home);
-        }
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home);
+    }
     if let Some(rest) = value.strip_prefix("~/")
         && let Some(home) = std::env::var_os("HOME")
     {
@@ -3068,8 +3087,7 @@ mod tests {
 
     #[test]
     fn parse_git_ref_remote_branch_keeps_nested_name() {
-        let parsed =
-            parse_git_ref("refs/remotes/origin/feature/x").expect("remote branch parses");
+        let parsed = parse_git_ref("refs/remotes/origin/feature/x").expect("remote branch parses");
         assert_eq!(parsed.kind, GitRefKind::Branch);
         assert_eq!(parsed.name, "feature/x");
         assert_eq!(parsed.remote, "origin");

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Export Heddle states to Git commits functionality.
 
-use objects::store::ObjectStore;
 use std::collections::HashSet;
 
 use gix::bstr::ByteSlice;
 use objects::{
     error::HeddleError,
     object::{ChangeId, ContentHash, FileMode, ThreadName},
+    store::ObjectStore,
 };
 use repo::Repository as HeddleRepository;
 
@@ -184,7 +184,11 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
 
     let states = match thread {
         Some(thread) => {
-            let Some(state_id) = bridge.heddle_repo.refs().get_thread(&ThreadName::new(thread))? else {
+            let Some(state_id) = bridge
+                .heddle_repo
+                .refs()
+                .get_thread(&ThreadName::new(thread))?
+            else {
                 return Err(GitBridgeError::Git(format!(
                     "thread '{thread}' has no state to export"
                 )));
@@ -275,7 +279,10 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
         }
     };
     for track_name in threads {
-        if let Some(state_id) = bridge.heddle_repo.refs().get_thread(&ThreadName::new(&track_name))?
+        if let Some(state_id) = bridge
+            .heddle_repo
+            .refs()
+            .get_thread(&ThreadName::new(&track_name))?
             && let Some(git_oid) = bridge.mapping.get_git(&state_id)
         {
             sync_track_to_branch(&repo, &track_name, git_oid)?;

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git commits into Heddle states functionality.
 
-use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use chrono::{TimeZone, Utc};
-use objects::object::{Agent, Attribution, ChangeId, MarkerName, Principal, State, Status, ThreadName};
+use objects::{
+    object::{Agent, Attribution, ChangeId, MarkerName, Principal, State, Status, ThreadName},
+    store::ObjectStore,
+};
 use refs::{Head, RefExpectation};
 use repo::Repository as HeddleRepository;
 use tracing::warn;
@@ -552,7 +554,10 @@ fn import_with_ref_filter(
             continue;
         }
         if let Some(change_id) = bridge.mapping.get_heddle(plan.peeled_commit_oid) {
-            let existing = bridge.heddle_repo.refs().get_thread(&ThreadName::new(name.as_str()))?;
+            let existing = bridge
+                .heddle_repo
+                .refs()
+                .get_thread(&ThreadName::new(name.as_str()))?;
             if let Some(existing_change) = existing
                 && !thread_can_adopt_change(bridge.heddle_repo, &existing_change, &change_id)?
             {

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git trees as Heddle trees.
 
-use objects::store::ObjectStore;
 use std::collections::HashMap;
 
-use objects::object::{Blob, ContentHash, FileMode, Tree, TreeEntry};
+use objects::{
+    object::{Blob, ContentHash, FileMode, Tree, TreeEntry},
+    store::ObjectStore,
+};
 use repo::Repository as HeddleRepository;
 
 use crate::bridge::git_core::{GitBridgeError, GitResult};

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -7,8 +7,10 @@
 
 use anyhow::{Result, anyhow};
 use chrono::Utc;
-use objects::object::ThreadName;
-use objects::store::{ActorChainNode, AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary};
+use objects::{
+    object::ThreadName,
+    store::{ActorChainNode, AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary},
+};
 use repo::Repository;
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stable JSON-first agent reservation API.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use chrono::Utc;
-use objects::object::ThreadName;
-use objects::store::{
-    AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary, ReserveOutcome, current_boot_id,
+use objects::{
+    object::ThreadName,
+    store::{
+        AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary, ObjectStore, ReserveOutcome,
+        current_boot_id,
+    },
 };
 use refs::{Head, RefExpectation};
 use repo::{
@@ -318,12 +320,8 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
             // manager snapshot. Reservations are an agent-internal API
             // that aren't expected to participate in human undo/redo
             // flows in 0.3. heddle#23 r2.
-            repo.oplog().record_thread_create(
-                &tn,
-                &anchor,
-                None,
-                Some(&repo.op_scope()),
-            )?;
+            repo.oplog()
+                .record_thread_create(&tn, &anchor, None, Some(&repo.op_scope()))?;
         }
 
         // Ensure a Thread record exists so downstream commands

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -902,8 +902,9 @@ mod tests {
         let patterns = vec!["node_modules".to_string(), "target".to_string()];
         let matcher = build_worktree_ignore(&patterns);
 
-        let ignored: Vec<String> =
-            (0..5_000).map(|i| format!("node_modules/pkg-{i}/index.js")).collect();
+        let ignored: Vec<String> = (0..5_000)
+            .map(|i| format!("node_modules/pkg-{i}/index.js"))
+            .collect();
         let sources: Vec<String> = (0..7).map(|i| format!("src/mod-{i}.rs")).collect();
         let all: Vec<&str> = ignored
             .iter()
@@ -929,7 +930,9 @@ mod tests {
         // path could later drop it.
         let (_temp, repo) = init_repo();
         let id = ChangeId::generate();
-        repo.refs().set_thread(&ThreadName::new("attempt-fixed-1"), &id).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("attempt-fixed-1"), &id)
+            .unwrap();
 
         let make_args = || AttemptArgs {
             n: 3,
@@ -970,15 +973,24 @@ mod tests {
         // created. attempt-fixed-1 still exists (the one we planted),
         // attempt-fixed-2 and attempt-fixed-3 must not.
         assert!(
-            repo.refs().get_thread(&ThreadName::new("attempt-fixed-1")).unwrap().is_some(),
+            repo.refs()
+                .get_thread(&ThreadName::new("attempt-fixed-1"))
+                .unwrap()
+                .is_some(),
             "the planted ref must still be there"
         );
         assert!(
-            repo.refs().get_thread(&ThreadName::new("attempt-fixed-2")).unwrap().is_none(),
+            repo.refs()
+                .get_thread(&ThreadName::new("attempt-fixed-2"))
+                .unwrap()
+                .is_none(),
             "preflight must refuse before any new threads are spawned"
         );
         assert!(
-            repo.refs().get_thread(&ThreadName::new("attempt-fixed-3")).unwrap().is_none(),
+            repo.refs()
+                .get_thread(&ThreadName::new("attempt-fixed-3"))
+                .unwrap()
+                .is_none(),
             "preflight must refuse before any new threads are spawned"
         );
     }
@@ -990,7 +1002,9 @@ mod tests {
         // `<prefix>-1`.
         let (_temp, repo) = init_repo();
         let id = ChangeId::generate();
-        repo.refs().set_thread(&ThreadName::new("attempt-mid-2"), &id).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("attempt-mid-2"), &id)
+            .unwrap();
 
         let make_args = || AttemptArgs {
             n: 3,
@@ -1024,7 +1038,10 @@ mod tests {
         // Crucially attempt-mid-1 was NOT created — preflight ran
         // before any spawn.
         assert!(
-            repo.refs().get_thread(&ThreadName::new("attempt-mid-1")).unwrap().is_none(),
+            repo.refs()
+                .get_thread(&ThreadName::new("attempt-mid-1"))
+                .unwrap()
+                .is_none(),
             "all-or-nothing: no new threads spawn on preflight failure"
         );
     }

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Blame command - show line-by-line attribution for files.
 
-use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
 use anyhow::{Result, anyhow};
-use objects::object::{
-    AnnotationStatus, Attribution, ChangeId, ContentHash, ContextTarget, FileProvenance,
-    ProvenanceError, Tree,
+use objects::{
+    object::{
+        AnnotationStatus, Attribution, ChangeId, ContentHash, ContextTarget, FileProvenance,
+        ProvenanceError, Tree,
+    },
+    store::ObjectStore,
 };
 use repo::Repository;
 use serde::Serialize;
@@ -438,8 +440,9 @@ fn fit_author(s: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use objects::object::{Agent, Attribution, Principal, State};
+
+    use super::*;
 
     fn human() -> Attribution {
         Attribution::human(Principal::new("Ada Lovelace", "ada@example.com"))
@@ -470,7 +473,10 @@ mod tests {
     fn attribution_parts_omits_agent_for_human_only() {
         let (principal, agent) = attribution_parts(&human());
         assert_eq!(principal.name, "Ada Lovelace");
-        assert!(agent.is_none(), "human-only attribution must not synthesize an agent");
+        assert!(
+            agent.is_none(),
+            "human-only attribution must not synthesize an agent"
+        );
     }
 
     #[test]
@@ -484,8 +490,14 @@ mod tests {
         let json = serde_json::to_value(agent.unwrap()).unwrap();
         assert_eq!(json["provider"], "openai");
         assert_eq!(json["model"], "gpt-5");
-        assert!(json.get("session_id").is_none(), "absent session_id must be omitted, not null");
-        assert!(json.get("policy_id").is_none(), "absent policy_id must be omitted, not null");
+        assert!(
+            json.get("session_id").is_none(),
+            "absent session_id must be omitted, not null"
+        );
+        assert!(
+            json.get("policy_id").is_none(),
+            "absent policy_id must be omitted, not null"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -6,7 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use objects::object::ThreadName;
 use refs::Head;
 use repo::Repository;
@@ -16,24 +16,24 @@ use super::{
     action_line::{print_next, print_next_step, print_optional},
     advice::RecoveryAdvice,
     git_overlay_health::{
-        action_template, build_git_overlay_health, build_plain_git_verification_probe,
+        GitOverlayHealth, GitOverlayHealthCheck, RepositoryVerificationState, action_template,
+        build_git_overlay_health, build_plain_git_verification_probe,
         build_repository_verification_state, canonical_adopt_ref_command,
         canonical_bridge_import_ref_command, canonical_bridge_reconcile_ref_command,
         canonical_bridge_reconcile_ref_preview_command, serialize_empty_action_as_null,
-        GitOverlayHealth, GitOverlayHealthCheck, RepositoryVerificationState,
     },
     import_progress::ImportProgress,
     remote::resolve_default_remote_name,
 };
 use crate::{
     bridge::{
+        GitBridge,
         git_core::clone_url_to_bare,
         git_export::export_all,
         git_import::{import_all, import_selected_refs},
         git_util::ExportedRef,
-        GitBridge,
     },
-    cli::{cli_args::GitSource, should_output_json, style, Cli, GitCommands},
+    cli::{Cli, GitCommands, cli_args::GitSource, should_output_json, style},
 };
 
 /// A `GitSource` resolved to an on-disk path. For URL sources we own a
@@ -1243,8 +1243,8 @@ fn run_reason(
     use std::path::PathBuf;
 
     use ingest::{
-        load_transcripts, pipeline_default_commits, GitSource, ReasoningPipeline,
-        ReasoningPipelineParams, ShaMap, TranscriptRoots,
+        GitSource, ReasoningPipeline, ReasoningPipelineParams, ShaMap, TranscriptRoots,
+        load_transcripts, pipeline_default_commits,
     };
 
     let map_path = repo.heddle_dir().join("ingest").join("sha_map.sqlite");

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -12,9 +12,8 @@
 //! to match main's `pub use checkpoint::run as cmd_checkpoint;`
 //! convention.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 use oplog::OpRecord;
 use repo::{CommitGraphIndex, GitCheckpointRecord, Repository, RepositoryCapability};
 use serde::Serialize;

--- a/crates/cli/src/cli/commands/cherry_pick.rs
+++ b/crates/cli/src/cli/commands/cherry_pick.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Cherry-pick command - apply specific commits.
 
-use objects::store::ObjectStore;
 use anyhow::Result;
-use objects::object::Attribution;
+use objects::{object::Attribution, store::ObjectStore};
 use repo::Repository;
 
 use super::{advice::RecoveryAdvice, worktree_safety::ensure_worktree_clean};

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Clone command - clone from remote.
 
-use objects::store::ObjectStore;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -16,6 +15,7 @@ use heddle_client::grpc_hosted::PullMaterialization;
 use objects::{
     error::{HeddleError, Result as HeddleResult},
     object::{Blob, ContentHash, ThreadName},
+    store::ObjectStore,
 };
 use refs::Head;
 use repo::{BlobHydrator, Repository};

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Collapse command: squash multiple states into one.
 
-use objects::store::ObjectStore;
 use std::time::Instant;
 
 use anyhow::Result;
-use objects::object::State;
+use objects::{object::State, store::ObjectStore};
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
 use repo::Repository;

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -2608,8 +2608,7 @@ fn apply_command_catalog_filters(output: &mut CommandCatalogOutput, args: &Comma
             || command_filters
                 .iter()
                 .any(|filter| command_matches_filter(command, filter)))
-            && (tier_filters.is_empty()
-                || tier_filters.contains(&command.tier.as_str()))
+            && (tier_filters.is_empty() || tier_filters.contains(&command.tier.as_str()))
             && (!args.mutating || command.mutates)
             && (!args.supports_op_id || command.supports_op_id)
     });
@@ -2734,9 +2733,10 @@ fn catalog_entry(
 
     let contract = command_contract(path);
     if contract.supports_op_id
-        && let Some(op_id_option) = op_id_option {
-            options.push(op_id_option.clone());
-        }
+        && let Some(op_id_option) = op_id_option
+    {
+        options.push(op_id_option.clone());
+    }
     CommandCatalogEntry {
         path: path.to_vec(),
         display: path.join(" "),

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -7,11 +7,13 @@
 //! active merge first so the command users see during recovery is the same
 //! command that can show the conflict they just listed.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Context, Result};
-use objects::object::{ConflictSymbol, StructuredConflict};
+use objects::{
+    object::{ConflictSymbol, StructuredConflict},
+    store::ObjectStore,
+};
 use repo::{MergeState, Repository};
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -4,13 +4,15 @@
 mod context_mutate;
 mod context_query;
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 pub use context_mutate::*;
 pub use context_query::*;
-use objects::object::{
-    Annotation, AnnotationKind, AnnotationScope, AnnotationStatus, ContentHash, ContextTarget,
-    State,
+use objects::{
+    object::{
+        Annotation, AnnotationKind, AnnotationScope, AnnotationStatus, ContentHash, ContextTarget,
+        State,
+    },
+    store::ObjectStore,
 };
 use refs::Head;
 use repo::Repository;

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Core diff command logic.
 
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     path::{Path, PathBuf},
@@ -13,6 +12,7 @@ use objects::{
         AnnotationStatus, Blob, ChangeId, ContextTarget, DiffKind, EntryType, FileChangeSet,
         FileMode, State, Tree, TreeEntry,
     },
+    store::ObjectStore,
     worktree::diff_blobs,
 };
 use repo::Repository;
@@ -282,14 +282,17 @@ pub fn cmd_diff(
                     change.kind
                 };
                 let diff_result = if let Some(ref tree) = to_tree {
-                    get_state_diff(&repo, from_tree.as_ref(), tree, &change.path, &effective_kind)
+                    get_state_diff(
+                        &repo,
+                        from_tree.as_ref(),
+                        tree,
+                        &change.path,
+                        &effective_kind,
+                    )
                 } else {
                     get_worktree_diff(&repo, from_tree.as_ref(), &change.path, &effective_kind)
                 };
-                let binary = diff_result
-                    .as_ref()
-                    .err()
-                    .is_some_and(is_binary_diff_error);
+                let binary = diff_result.as_ref().err().is_some_and(is_binary_diff_error);
                 let (raw_lines, eol) = match diff_result {
                     Ok((lines, eol)) => (Some(lines), eol),
                     Err(_) => (None, FileEolState::default()),
@@ -623,8 +626,7 @@ fn plain_git_file_changes_with_hunks(
     // state as a single modify (HEAD content -> worktree content), so we
     // coalesce here.
     let added_set: BTreeSet<&Path> = probe.changes.added.iter().map(PathBuf::as_path).collect();
-    let deleted_set: BTreeSet<&Path> =
-        probe.changes.deleted.iter().map(PathBuf::as_path).collect();
+    let deleted_set: BTreeSet<&Path> = probe.changes.deleted.iter().map(PathBuf::as_path).collect();
 
     let mut changes = Vec::with_capacity(probe.changes.change_count());
     for path in &probe.changes.modified {
@@ -718,14 +720,15 @@ fn plain_git_file_change(
         DiffKind::Modified => (old_mode, worktree_file_mode(&root.join(path))),
         DiffKind::Unchanged => (None, None),
     };
-    let (lines, eol, binary) = compute_plain_git_hunks(
+    let (lines, eol, binary) =
+        compute_plain_git_hunks(old_blob.as_ref(), new_blob.as_ref(), &diff_kind, unified);
+    let symlink = symlink_change_from_blobs(
+        kind,
         old_blob.as_ref(),
+        old_mode_field,
         new_blob.as_ref(),
-        &diff_kind,
-        unified,
+        mode,
     );
-    let symlink =
-        symlink_change_from_blobs(kind, old_blob.as_ref(), old_mode_field, new_blob.as_ref(), mode);
     Ok(FileChange {
         path: path.display().to_string(),
         kind: kind.to_string(),
@@ -885,9 +888,7 @@ fn compute_plain_git_hunks(
     };
     match attempt() {
         Ok((lines, eol)) => (Some(unified_hunks(lines, unified, &eol)), eol, false),
-        Err(error) if is_binary_diff_error(&error) => {
-            (None, FileEolState::default(), true)
-        }
+        Err(error) if is_binary_diff_error(&error) => (None, FileEolState::default(), true),
         Err(_) => (None, FileEolState::default(), false),
     }
 }
@@ -1104,8 +1105,9 @@ fn build_worktree_change(
         // body, matching git's behaviour for transient races.
         Err(_) => (None, FileEolState::default(), false),
     };
-    let symlink =
-        symlink_change_for_paths(repo, from_tree, None, kind, path_str, path_str, old_mode, mode);
+    let symlink = symlink_change_for_paths(
+        repo, from_tree, None, kind, path_str, path_str, old_mode, mode,
+    );
     FileChange {
         path: path_str.to_string(),
         kind: kind.to_string(),
@@ -1321,9 +1323,9 @@ fn make_type_change_part(
         return make_status_only_change(Some(repo), from_tree, to_tree, path_str, &kind);
     }
     match to_tree {
-        Some(to_tree) => {
-            build_state_change(repo, from_tree, to_tree, path_str, &kind, diff_kind, unified)
-        }
+        Some(to_tree) => build_state_change(
+            repo, from_tree, to_tree, path_str, &kind, diff_kind, unified,
+        ),
         None => build_worktree_change(repo, from_tree, path_str, &kind, diff_kind, unified),
     }
 }
@@ -1341,7 +1343,8 @@ fn build_state_change(
     unified: usize,
 ) -> FileChange {
     let (old_mode, mode) = change_file_modes(repo, from_tree, Some(to_tree), path_str, kind);
-    let (lines, eol, binary) = match get_state_diff(repo, from_tree, to_tree, path_str, &diff_kind) {
+    let (lines, eol, binary) = match get_state_diff(repo, from_tree, to_tree, path_str, &diff_kind)
+    {
         Ok((raw, eol)) => (Some(unified_hunks(raw, unified, &eol)), eol, false),
         Err(error) if is_binary_diff_error(&error) => (None, FileEolState::default(), true),
         Err(_) => (None, FileEolState::default(), false),
@@ -2113,7 +2116,14 @@ fn detect_clear_renames_for_worktree_status(
     } else {
         None
     };
-    detect_clear_renames(&repo, from_tree.as_ref(), None, changes, include_lines, unified)
+    detect_clear_renames(
+        &repo,
+        from_tree.as_ref(),
+        None,
+        changes,
+        include_lines,
+        unified,
+    )
 }
 
 fn detect_clear_renames(
@@ -2316,7 +2326,10 @@ fn rename_lines(
         .iter()
         .map(|line| LineDiff::new(line.prefix(), line.content()))
         .collect();
-    Ok(Some((unified_hunks(number_lines(lines), unified, &eol), eol)))
+    Ok(Some((
+        unified_hunks(number_lines(lines), unified, &eol),
+        eol,
+    )))
 }
 
 fn blob_from_tree(repo: &Repository, tree: Option<&Tree>, path: &str) -> Result<Option<Blob>> {
@@ -2842,7 +2855,10 @@ mod tests {
             "added function body should remain after display trim: {display:?}"
         );
         assert_eq!(
-            display.iter().find(|line| line.prefix == "@").map(|l| l.content.as_str()),
+            display
+                .iter()
+                .find(|line| line.prefix == "@")
+                .map(|l| l.content.as_str()),
             Some("@ -1,2 +1,4 @@"),
             "display trim must not rewrite the `@@` header: {display:?}"
         );

--- a/crates/cli/src/cli/commands/diff/diff_output.rs
+++ b/crates/cli/src/cli/commands/diff/diff_output.rs
@@ -9,9 +9,11 @@ use std::{
 
 use objects::object::FileMode;
 
-use super::diff_compute::trim_added_decorations_for_display;
-use super::diff_types::{
-    DiffOutput, FileChange, LineDiff, SemanticChangeEntry, should_render_modified_pair,
+use super::{
+    diff_compute::trim_added_decorations_for_display,
+    diff_types::{
+        DiffOutput, FileChange, LineDiff, SemanticChangeEntry, should_render_modified_pair,
+    },
 };
 use crate::cli::style;
 
@@ -161,10 +163,12 @@ pub(crate) fn render_diff_patch(output: &DiffOutput) -> String {
 /// cannot populate) or `render_binary_change`.
 fn render_text_change(change: &FileChange, buf: &mut String) {
     let lines_ref = change.lines.as_deref();
-    let has_hunk_body = lines_ref
-        .is_some_and(|lines| lines.iter().any(|line| line.prefix != " "));
+    let has_hunk_body = lines_ref.is_some_and(|lines| lines.iter().any(|line| line.prefix != " "));
     let old_path = change.old_path.as_deref().unwrap_or(&change.path);
-    let is_rename = change.old_path.as_deref().is_some_and(|old| old != change.path);
+    let is_rename = change
+        .old_path
+        .as_deref()
+        .is_some_and(|old| old != change.path);
     let is_added = change.kind == "added";
     let is_deleted = change.kind == "deleted";
     let is_modified = !is_rename && !is_added && !is_deleted;
@@ -236,15 +240,16 @@ fn render_text_change(change: &FileChange, buf: &mut String) {
             buf.push_str(&format!("old mode {}\n", mode_str(change.old_mode)));
             buf.push_str(&format!("new mode {}\n", mode_str(change.mode)));
         }
-        let pct = (change
-            .similarity_score
-            .unwrap_or(1.0)
-            .clamp(0.0, 1.0)
-            * 100.0)
-            .round() as u32;
+        let pct = (change.similarity_score.unwrap_or(1.0).clamp(0.0, 1.0) * 100.0).round() as u32;
         buf.push_str(&format!("similarity index {pct}%\n"));
-        buf.push_str(&format!("rename from {}\n", quote_path_for_patch("", old_path)));
-        buf.push_str(&format!("rename to {}\n", quote_path_for_patch("", &change.path)));
+        buf.push_str(&format!(
+            "rename from {}\n",
+            quote_path_for_patch("", old_path)
+        ));
+        buf.push_str(&format!(
+            "rename to {}\n",
+            quote_path_for_patch("", &change.path)
+        ));
         // Pure rename — extended headers alone suffice; emitting
         // `--- a/old / +++ b/new` without hunks would tell git to
         // apply an empty patch and warn about a stray header.
@@ -317,7 +322,10 @@ fn render_text_change(change: &FileChange, buf: &mut String) {
     if is_deleted {
         buf.push_str("+++ /dev/null\n");
     } else {
-        buf.push_str(&format!("+++ {}\n", quote_path_for_patch("b/", &change.path)));
+        buf.push_str(&format!(
+            "+++ {}\n",
+            quote_path_for_patch("b/", &change.path)
+        ));
     }
     if let Some(lines) = lines_ref {
         render_patch_hunks(change, lines, buf);
@@ -342,7 +350,10 @@ fn render_symlink_change(change: &FileChange, buf: &mut Vec<u8>) {
     };
     let push = |buf: &mut Vec<u8>, text: &str| buf.extend_from_slice(text.as_bytes());
     let old_path = change.old_path.as_deref().unwrap_or(&change.path);
-    let is_rename = change.old_path.as_deref().is_some_and(|old| old != change.path);
+    let is_rename = change
+        .old_path
+        .as_deref()
+        .is_some_and(|old| old != change.path);
     let is_added = change.kind == "added";
     let is_deleted = change.kind == "deleted";
 
@@ -363,15 +374,27 @@ fn render_symlink_change(change: &FileChange, buf: &mut Vec<u8>) {
         }
         let pct = (change.similarity_score.unwrap_or(1.0).clamp(0.0, 1.0) * 100.0).round() as u32;
         push(buf, &format!("similarity index {pct}%\n"));
-        push(buf, &format!("rename from {}\n", quote_path_for_patch("", old_path)));
-        push(buf, &format!("rename to {}\n", quote_path_for_patch("", &change.path)));
+        push(
+            buf,
+            &format!("rename from {}\n", quote_path_for_patch("", old_path)),
+        );
+        push(
+            buf,
+            &format!("rename to {}\n", quote_path_for_patch("", &change.path)),
+        );
         // Pure rename (identical target) — the extended headers alone carry
         // the move, exactly like a text rename with no hunk body.
         if sym.old == sym.new {
             return;
         }
-        push(buf, &format!("--- {}\n", quote_path_for_patch("a/", old_path)));
-        push(buf, &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)));
+        push(
+            buf,
+            &format!("--- {}\n", quote_path_for_patch("a/", old_path)),
+        );
+        push(
+            buf,
+            &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)),
+        );
     } else if is_added {
         push(
             buf,
@@ -383,7 +406,10 @@ fn render_symlink_change(change: &FileChange, buf: &mut Vec<u8>) {
         );
         push(buf, &format!("new file mode {}\n", mode_str(change.mode)));
         push(buf, "--- /dev/null\n");
-        push(buf, &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)));
+        push(
+            buf,
+            &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)),
+        );
     } else if is_deleted {
         push(
             buf,
@@ -393,8 +419,14 @@ fn render_symlink_change(change: &FileChange, buf: &mut Vec<u8>) {
                 quote_path_for_patch("b/", &change.path)
             ),
         );
-        push(buf, &format!("deleted file mode {}\n", mode_str(change.mode)));
-        push(buf, &format!("--- {}\n", quote_path_for_patch("a/", &change.path)));
+        push(
+            buf,
+            &format!("deleted file mode {}\n", mode_str(change.mode)),
+        );
+        push(
+            buf,
+            &format!("--- {}\n", quote_path_for_patch("a/", &change.path)),
+        );
         push(buf, "+++ /dev/null\n");
     } else {
         // A symlink target-edit. The mode is unchanged (`120000` → `120000`),
@@ -412,8 +444,14 @@ fn render_symlink_change(change: &FileChange, buf: &mut Vec<u8>) {
                 quote_path_for_patch("b/", &change.path)
             ),
         );
-        push(buf, &format!("--- {}\n", quote_path_for_patch("a/", &change.path)));
-        push(buf, &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)));
+        push(
+            buf,
+            &format!("--- {}\n", quote_path_for_patch("a/", &change.path)),
+        );
+        push(
+            buf,
+            &format!("+++ {}\n", quote_path_for_patch("b/", &change.path)),
+        );
     }
 
     render_symlink_hunk(sym.old.as_deref(), sym.new.as_deref(), buf);
@@ -517,7 +555,10 @@ fn render_binary_change(
     } else {
         // Plain binary modify: git stamps the mode at the end of the
         // index line (`index <old>..<new> 100644`).
-        buf.push_str(&format!("index 0000000..0000000 {}\n", mode_str(change.mode)));
+        buf.push_str(&format!(
+            "index 0000000..0000000 {}\n",
+            mode_str(change.mode)
+        ));
     }
     let (a, b) = if is_added {
         ("/dev/null".to_string(), quote_path_for_patch("b/", path))
@@ -1411,11 +1452,7 @@ mod tests {
         should_render_modified_pair,
     };
 
-    fn modified_change_with_eol(
-        path: &str,
-        lines: Vec<LineDiff>,
-        eol: FileEolState,
-    ) -> FileChange {
+    fn modified_change_with_eol(path: &str, lines: Vec<LineDiff>, eol: FileEolState) -> FileChange {
         FileChange {
             path: path.to_string(),
             kind: "modified".to_string(),
@@ -1803,9 +1840,15 @@ mod tests {
         // Tab/newline/quote/backslash force quoting; the prefix is escaped
         // inside the quotes, matching git's `quote_two`.
         assert_eq!(quote_path_for_patch("a/", "tab\there"), "\"a/tab\\there\"");
-        assert_eq!(quote_path_for_patch("b/", "line\nbreak"), "\"b/line\\nbreak\"");
+        assert_eq!(
+            quote_path_for_patch("b/", "line\nbreak"),
+            "\"b/line\\nbreak\""
+        );
         assert_eq!(quote_path_for_patch("a/", "quo\"te"), "\"a/quo\\\"te\"");
-        assert_eq!(quote_path_for_patch("a/", "back\\slash"), "\"a/back\\\\slash\"");
+        assert_eq!(
+            quote_path_for_patch("a/", "back\\slash"),
+            "\"a/back\\\\slash\""
+        );
         // Non-ASCII (UTF-8 é = 0xC3 0xA9) → per-byte octal.
         assert_eq!(quote_path_for_patch("a/", "café"), "\"a/caf\\303\\251\"");
         // `rename from`/`rename to` quote the bare path (empty prefix).

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -344,10 +344,7 @@ fn classify_error(err: &anyhow::Error) -> ErrorClassification {
     classify_error_with_verb(err, None)
 }
 
-fn classify_error_with_verb(
-    err: &anyhow::Error,
-    verb_help: Option<&str>,
-) -> ErrorClassification {
+fn classify_error_with_verb(err: &anyhow::Error, verb_help: Option<&str>) -> ErrorClassification {
     let mut classification = classify_error_inner(err);
     if classification.kind == "runtime_error"
         && let Some(help) = verb_help
@@ -378,9 +375,10 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
             };
         }
         if let Some(git_error) = cause.downcast_ref::<crate::bridge::git_core::GitBridgeError>()
-            && let Some(advice) = RecoveryAdvice::from_git_bridge_error(git_error) {
-                return ErrorClassification::from_advice(&advice);
-            }
+            && let Some(advice) = RecoveryAdvice::from_git_bridge_error(git_error)
+        {
+            return ErrorClassification::from_advice(&advice);
+        }
         if let Some(heddle_err) = cause.downcast_ref::<HeddleError>() {
             // `output.format = "auto"` is rejected at config-parse time by
             // the hand-rolled `OutputFormat` deserializer (see

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -2,16 +2,16 @@
 //! Fetch command - download objects and refs from remote.
 
 #[cfg(feature = "client")]
-use objects::store::ObjectStore;
-#[cfg(feature = "client")]
 use std::collections::HashSet;
 
 #[cfg(feature = "client")]
 use anyhow::Context;
 use anyhow::Result;
-use objects::object::{MarkerName, ThreadName};
 #[cfg(feature = "client")]
 use objects::object::ChangeId;
+use objects::object::{MarkerName, ThreadName};
+#[cfg(feature = "client")]
+use objects::store::ObjectStore;
 #[cfg(feature = "client")]
 use proto::AuthToken;
 use repo::{Repository, RepositoryCapability};
@@ -317,8 +317,11 @@ async fn fetch_network(
     // Update remote refs
     let refs_fetched = refs_to_update.len();
     for (track_name, change_id) in refs_to_update {
-        repo.refs()
-            .set_remote_thread(options.remote_name, &ThreadName::new(&track_name), &change_id)?;
+        repo.refs().set_remote_thread(
+            options.remote_name,
+            &ThreadName::new(&track_name),
+            &change_id,
+        )?;
     }
 
     for (marker_name, change_id) in markers_to_create {

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Fork command: create exploration branch.
 
-use objects::store::ObjectStore;
 use anyhow::Result;
-use objects::object::{State, ThreadName};
+use objects::{
+    object::{State, ThreadName},
+    store::ObjectStore,
+};
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
 use repo::Repository;
@@ -14,7 +16,7 @@ use super::{
     snapshot::{ensure_current_state, resolve_attribution},
 };
 use crate::{
-    cli::{should_output_json, Cli},
+    cli::{Cli, should_output_json},
     config::UserConfig,
 };
 

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Fsck command - verify repository integrity.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
+use objects::store::ObjectStore;
 use repo::Repository;
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/fsck_checks/objects.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/objects.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::collections::HashSet;
 
 use anyhow::Result;
-use objects::object::{ContentHash, Tree};
+use objects::{
+    object::{ContentHash, Tree},
+    store::ObjectStore,
+};
 use repo::Repository;
 
 use super::{FsckError, make_error};

--- a/crates/cli/src/cli/commands/fsck_checks/refs.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/refs.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use anyhow::Result;
-use objects::object::ContentHash;
+use objects::{object::ContentHash, store::ObjectStore};
 use repo::Repository;
 
 use super::{FsckError, make_error};

--- a/crates/cli/src/cli/commands/fsck_checks/state.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/state.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
@@ -7,7 +6,10 @@ use std::{
 
 use anyhow::Result;
 use crypto::StateSigningExt;
-use objects::object::{ContentHash, State, Tree};
+use objects::{
+    object::{ContentHash, State, Tree},
+    store::ObjectStore,
+};
 use repo::Repository;
 
 use super::{FsckError, make_error};

--- a/crates/cli/src/cli/commands/fsck_checks/tests.rs
+++ b/crates/cli/src/cli/commands/fsck_checks/tests.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use crypto::{Ed25519Signer, StateSigningExt};
-use objects::object::{
-    Attribution, Blob, FileProvenance, LineSpan, Origin, OriginSet, Principal, State, Tree,
+use objects::{
+    object::{
+        Attribution, Blob, FileProvenance, LineSpan, Origin, OriginSet, Principal, State, Tree,
+    },
+    store::ObjectStore,
 };
 use repo::Repository;
 use tempfile::TempDir;

--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -11,8 +11,8 @@
 //! pass. We report the pinned count so the audit trail in `heddle gc`
 //! output makes the invariant visible to operators.
 
-use objects::store::ObjectStore;
 use anyhow::Result;
+use objects::store::ObjectStore;
 use repo::Repository;
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Git-muscle-memory compatibility shims.
 
-use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
@@ -12,7 +11,11 @@ use anyhow::{Context, Result, anyhow};
 use gix::bstr::{BStr, ByteSlice};
 use gix_index::entry::{Mode, Stage};
 use objects::{
-    object::{Agent, Blob, ChangeId, ContentHash, EntryType, FileMode, Principal, ThreadName, Tree, TreeEntry},
+    object::{
+        Agent, Blob, ChangeId, ContentHash, EntryType, FileMode, Principal, ThreadName, Tree,
+        TreeEntry,
+    },
+    store::ObjectStore,
     worktree::should_ignore as should_ignore_path,
 };
 use oplog::{OpBatch, OpRecord};
@@ -1265,7 +1268,11 @@ pub async fn cmd_switch_compat(cli: &Cli, args: SwitchArgs) -> Result<()> {
         )));
     }
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
-    if repo.refs().get_thread(&ThreadName::new(&args.target))?.is_some() {
+    if repo
+        .refs()
+        .get_thread(&ThreadName::new(&args.target))?
+        .is_some()
+    {
         return cmd_thread(
             cli,
             ThreadCommands::Switch {

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -8,8 +8,7 @@ use std::{
 };
 
 use gix::bstr::{BStr, ByteSlice};
-use objects::object::ThreadName;
-use objects::worktree::WorktreeStatus;
+use objects::{object::ThreadName, worktree::WorktreeStatus};
 use refs::Head;
 use repo::{
     CommitGraphIndex, GitOverlayBranchTip, GitOverlayImportHint, GitRemoteTrackingStatus,
@@ -2451,7 +2450,12 @@ pub(crate) fn remote_drift_decision(
             }
             let import = canonical_bridge_import_ref_command(upstream);
             let merge_preview = super::thread_landing::merge_preview_command(upstream);
-            let imported = repo.refs().get_thread(&ThreadName::new(upstream)).ok().flatten().is_some();
+            let imported = repo
+                .refs()
+                .get_thread(&ThreadName::new(upstream))
+                .ok()
+                .flatten()
+                .is_some();
             RemoteDriftDecision {
                 status,
                 verified_as_clean: false,
@@ -2929,7 +2933,9 @@ fn tag_mapping_check(repo: &Repository) -> anyhow::Result<Option<GitOverlayHealt
     let mut unmapped = Vec::new();
 
     for tip in repo.git_overlay_tag_tips()? {
-        let marker = repo.refs().get_marker(&objects::object::MarkerName::new(&tip.tag))?;
+        let marker = repo
+            .refs()
+            .get_marker(&objects::object::MarkerName::new(&tip.tag))?;
         match (marker, tip.mapped_change) {
             (Some(existing), Some(mapped)) if existing == mapped => {}
             (Some(existing), Some(mapped)) => mismatched.push(format!(
@@ -3051,7 +3057,12 @@ fn stale_integration_metadata_check(
             .as_deref()
             .or(thread.merged_state.as_deref())
             .and_then(|state| repo.resolve_state(state).ok().flatten())
-            .or_else(|| repo.refs().get_thread(&ThreadName::new(&thread.thread)).ok().flatten());
+            .or_else(|| {
+                repo.refs()
+                    .get_thread(&ThreadName::new(&thread.thread))
+                    .ok()
+                    .flatten()
+            });
         let Some(candidate) = candidate else {
             continue;
         };
@@ -3692,7 +3703,9 @@ mod tests {
         );
 
         let head = repo.head().unwrap().expect("test repo should have a head");
-        repo.refs().set_thread(&ThreadName::new("origin/main"), &head).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("origin/main"), &head)
+            .unwrap();
         let imported = remote_drift_decision(&repo, &diverged);
         assert_eq!(
             imported.primary_action.as_deref(),
@@ -3750,8 +3763,7 @@ mod tests {
     /// new file.
     #[test]
     fn plain_git_worktree_status_preserves_staged_removal_alongside_untracked() {
-        use std::path::PathBuf;
-        use std::process::Command;
+        use std::{path::PathBuf, process::Command};
 
         let dir = TempDir::new().expect("tempdir");
         let root = dir.path();

--- a/crates/cli/src/cli/commands/history_target.rs
+++ b/crates/cli/src/cli/commands/history_target.rs
@@ -23,11 +23,11 @@
 //! [`resolve_state_id_bytes`] when you need the wire-form 16-byte
 //! representation (e.g. when handing it to a gRPC service stub).
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::{
     error::HeddleError,
     object::{ChangeId, State},
+    store::ObjectStore,
 };
 use repo::Repository;
 

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -861,9 +861,7 @@ fn resolve_quickstart_principal(root: &Path, is_git_overlay: bool) -> Principal 
     }
     // Git config: `resolve_principal` falls through when Git's identity is the
     // sentinel, so only a non-sentinel Git identity stops here.
-    if is_git_overlay
-        && let Ok(Some(identity)) = git_config_identity_with_global_fallback(root)
-    {
+    if is_git_overlay && let Ok(Some(identity)) = git_config_identity_with_global_fallback(root) {
         let principal = Principal::new(&identity.name, &identity.email);
         if !principal_is_unconfigured(&principal) {
             return principal;
@@ -1177,9 +1175,7 @@ fn ensure_quickstart_thread(repo: &Repository, name: &str) -> Result<()> {
     let target = ThreadName::new(name);
     let already_attached =
         matches!(repo.head_ref()?, Head::Attached { thread } if thread == target);
-    if !already_attached
-        && let Some(state) = repo.current_state()?
-    {
+    if !already_attached && let Some(state) = repo.current_state()? {
         repo.refs().set_thread(&target, &state.change_id)?;
     }
     if !already_attached {
@@ -1224,10 +1220,18 @@ fn quickstart_needs_confirmation_advice() -> RecoveryAdvice {
 fn quickstart_thread_branch_collision_advice(thread: &str) -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "quickstart_thread_branch_collision",
-        format!("Refusing to run --quickstart: a Git branch named '{thread}' already exists at a different commit than the current checkout"),
-        format!("Pass `--quickstart-thread <name>` to use a different thread name, or switch to '{thread}' (`git switch {thread}`) and run the normal capture flow."),
-        format!("a Git branch '{thread}' already exists and points at history unrelated to the current branch"),
-        format!("quickstart would attach the '{thread}' thread to the current branch's state and move refs/heads/{thread} onto it, silently discarding the existing branch's history"),
+        format!(
+            "Refusing to run --quickstart: a Git branch named '{thread}' already exists at a different commit than the current checkout"
+        ),
+        format!(
+            "Pass `--quickstart-thread <name>` to use a different thread name, or switch to '{thread}' (`git switch {thread}`) and run the normal capture flow."
+        ),
+        format!(
+            "a Git branch '{thread}' already exists and points at history unrelated to the current branch"
+        ),
+        format!(
+            "quickstart would attach the '{thread}' thread to the current branch's state and move refs/heads/{thread} onto it, silently discarding the existing branch's history"
+        ),
         "no repository objects, refs, metadata, or worktree files were changed",
         "heddle init --quickstart --quickstart-thread <name>",
         vec![

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -639,14 +639,12 @@ fn target_harnesses(manifest: &IntegrationManifest, requested: Vec<String>) -> R
 /// must fail in the preflight, not after `.heddle/`/capture/checkpoint exist.
 fn validate_harness_scope(harness: &str, scope: &IntegrationScope) -> Result<()> {
     match harness {
-        "codex" if *scope != IntegrationScope::User => {
-            Err(anyhow!(RecoveryAdvice::invalid_usage(
-                "integration_codex_scope_invalid",
-                "codex integration currently requires --scope user",
-                "Rerun the install with `--scope user`.",
-                "heddle integration install codex --scope user",
-            )))
-        }
+        "codex" if *scope != IntegrationScope::User => Err(anyhow!(RecoveryAdvice::invalid_usage(
+            "integration_codex_scope_invalid",
+            "codex integration currently requires --scope user",
+            "Rerun the install with `--scope user`.",
+            "heddle integration install codex --scope user",
+        ))),
         _ => Ok(()),
     }
 }

--- a/crates/cli/src/cli/commands/marker.rs
+++ b/crates/cli/src/cli/commands/marker.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Marker commands.
 
-use objects::store::ObjectStore;
-use anyhow::{anyhow, Result};
-use objects::object::MarkerName;
+use anyhow::{Result, anyhow};
+use objects::{object::MarkerName, store::ObjectStore};
 use repo::Repository;
 use serde::Serialize;
 
 use super::{advice::RecoveryAdvice, snapshot::ensure_current_state};
 use crate::{
-    cli::{should_output_json, Cli, MarkerCommands},
+    cli::{Cli, MarkerCommands, should_output_json},
     config::UserConfig,
 };
 

--- a/crates/cli/src/cli/commands/merge/git_commit.rs
+++ b/crates/cli/src/cli/commands/merge/git_commit.rs
@@ -7,7 +7,6 @@
 //! merge introduced. The default (`--git-commit` not set) is preserved
 //! — heddle state advances and git is unaware.
 
-use objects::store::ObjectStore;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result, anyhow};
@@ -18,7 +17,10 @@ use gix::{
         transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
     },
 };
-use objects::object::{Attribution, ChangeId};
+use objects::{
+    object::{Attribution, ChangeId},
+    store::ObjectStore,
+};
 use repo::Repository;
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/merge/merge_algo/apply.rs
+++ b/crates/cli/src/cli/commands/merge/merge_algo/apply.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{collections::HashMap, fs, path::Path};
 
 use anyhow::{Result, anyhow};
-use objects::object::{Tree, TreeEntry};
+use objects::{
+    object::{Tree, TreeEntry},
+    store::ObjectStore,
+};
 use repo::Repository;
 
 use super::super::prepare_dir_for_file_replacement;

--- a/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
+++ b/crates/cli/src/cli/commands/merge/merge_algo/executor.rs
@@ -414,7 +414,10 @@ fn format_conflict_content(
     .into_bytes()
 }
 
-fn build_nested_tree(store: &impl ObjectStore, flat: &HashMap<String, ContentHash>) -> Result<Tree> {
+fn build_nested_tree(
+    store: &impl ObjectStore,
+    flat: &HashMap<String, ContentHash>,
+) -> Result<Tree> {
     let mut top_files = Vec::new();
     let mut subdirs: HashMap<String, HashMap<String, ContentHash>> = HashMap::new();
 

--- a/crates/cli/src/cli/commands/merge/merge_plan.rs
+++ b/crates/cli/src/cli/commands/merge/merge_plan.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared merge planning seam for preview and apply flows.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::ChangeId;
+use objects::{object::ChangeId, store::ObjectStore};
 use repo::{CommitGraphIndex, Repository};
 
 use super::{

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -24,8 +24,7 @@ use super::{
     diff::{DiffOutput, SemanticChangeEntry, compute_state_diff, compute_tree_diff},
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
-        override_trust_recommended_action,
-        repository_verification_blocked_advice,
+        override_trust_recommended_action, repository_verification_blocked_advice,
     },
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
     ready_cmd::{worktree_dirty, worktree_dirty_paths},
@@ -891,9 +890,10 @@ pub(crate) fn merge_thread_into_current(
             && thread
                 .as_ref()
                 .is_some_and(|thread| thread.state == ThreadState::Ready)
-            && let Some(thread) = thread.as_ref() {
-                mark_merge_previewed(repo, &thread.id)?;
-            }
+            && let Some(thread) = thread.as_ref()
+        {
+            mark_merge_previewed(repo, &thread.id)?;
+        }
         return Ok(merge_output_from_report(MergeOutputInput {
             repo,
             thread: &thread,
@@ -1858,7 +1858,10 @@ fn build_thread_preview_report_with_graph(
         advice.thread_health = "clean".to_string();
     }
 
-    let thread_tip = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.map(|id| id.short());
+    let thread_tip = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .map(|id| id.short());
     let manual_resolution_current = thread
         .integration_policy_result
         .manual_resolution_state

--- a/crates/cli/src/cli/commands/merge/rename_matcher.rs
+++ b/crates/cli/src/cli/commands/merge/rename_matcher.rs
@@ -92,7 +92,11 @@ struct AddedIndex<'a> {
     sorted_by_size: Vec<usize>,
 }
 
-pub(crate) fn flatten_tree(store: &impl ObjectStore, tree: &Tree, prefix: &str) -> Result<FlatTree> {
+pub(crate) fn flatten_tree(
+    store: &impl ObjectStore,
+    tree: &Tree,
+    prefix: &str,
+) -> Result<FlatTree> {
     let mut result = HashMap::new();
 
     for entry in tree.entries() {

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -118,9 +118,10 @@ fn default_next_action(input: NextActionInput<'_>) -> String {
         return operation.next_action.clone();
     }
     if let Some(remote_tracking) = input.remote_tracking
-        && let Some(action) = remote_tracking_next_action(remote_tracking) {
-            return action;
-        }
+        && let Some(action) = remote_tracking_next_action(remote_tracking)
+    {
+        return action;
+    }
     if let Some(action) = non_empty_action(input.fallback) {
         return action.to_string();
     }

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -1,31 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{collections::BTreeSet, path::Path};
 
 use anyhow::Result;
 use chrono::Utc;
 use gix::bstr::ByteSlice;
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 use repo::{
-    update_thread_state_from_state, GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind,
-    OperationScope, Repository, RepositoryOperationStatus, ThreadFreshness,
-    ThreadIntegrationPolicy, ThreadManager, ThreadState,
+    GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind, OperationScope, Repository,
+    RepositoryOperationStatus, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
+    ThreadState, update_thread_state_from_state,
 };
-use serde::{ser::SerializeStruct, Serialize, Serializer};
+use serde::{Serialize, Serializer, ser::SerializeStruct};
 
 use super::{
     bisect::reset_bisect_state,
     git_overlay_health::{
-        action_template, repository_verification_blockers,
-        repository_verification_primary_command, RepositoryVerificationState,
+        RepositoryVerificationState, action_template, repository_verification_blockers,
+        repository_verification_primary_command,
     },
-    next_action::{effective_next_action, NextActionInput},
+    next_action::{NextActionInput, effective_next_action},
     rebase::{
-        cmd_rebase_silent, continue_rebase_for_operator, has_persisted_rebase_state,
-        OperatorContinueStatus,
+        OperatorContinueStatus, cmd_rebase_silent, continue_rebase_for_operator,
+        has_persisted_rebase_state,
     },
     resolve::abort_merge_state,
-    snapshot::{create_snapshot, SnapshotAgentOverrides},
+    snapshot::{SnapshotAgentOverrides, create_snapshot},
 };
 use crate::config::UserConfig;
 
@@ -545,7 +544,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::cli::commands::git_overlay_health::{machine_contract_coverage, VerificationCheck};
+    use crate::cli::commands::git_overlay_health::{VerificationCheck, machine_contract_coverage};
 
     #[test]
     fn raw_git_operation_handoff_recommends_heddle_preservation_not_git_cli() {
@@ -566,14 +565,18 @@ mod tests {
         );
         assert!(output.message.contains("no-git runtime"));
         assert!(output.message.contains("conflict.txt"));
-        assert!(output
-            .blockers
-            .iter()
-            .any(|path| path == "unresolved: conflict.txt"));
-        assert!(!output
-            .recommended_action
-            .as_deref()
-            .is_some_and(|action| action.starts_with("git ")));
+        assert!(
+            output
+                .blockers
+                .iter()
+                .any(|path| path == "unresolved: conflict.txt")
+        );
+        assert!(
+            !output
+                .recommended_action
+                .as_deref()
+                .is_some_and(|action| action.starts_with("git "))
+        );
     }
 
     #[test]
@@ -600,9 +603,11 @@ mod tests {
             output.recommended_action.as_deref(),
             Some("heddle checkpoint -m \"...\"")
         );
-        assert!(output
-            .message
-            .contains("repository verification is blocked"));
+        assert!(
+            output
+                .message
+                .contains("repository verification is blocked")
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase command - replay commits onto another thread.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 use refs::Head;
 use repo::Repository;
 use serde_json::json;
@@ -32,13 +31,13 @@ mod rebase_state;
 use rebase_ops::{
     flush_rebase_batch, mint_rebase_transaction_id, replay_commits, replay_commits_silent,
 };
-
-use super::ff_record::ff_advance_deferred;
 pub(crate) use rebase_state::load_rebase_state as load_persisted_rebase_state;
 use rebase_state::{
     RebaseState, collect_commits_to_rebase, is_ancestor_of, load_rebase_state,
     load_rebase_state_for_abort, save_rebase_state,
 };
+
+use super::ff_record::ff_advance_deferred;
 
 const REBASE_STATE_FILE: &str = "REBASE_STATE";
 

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase operation execution — applying commits onto a new base.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};
-use objects::object::{Blob, ChangeId, ContentHash, EntryType, State};
+use objects::{
+    object::{Blob, ChangeId, ContentHash, EntryType, State},
+    store::ObjectStore,
+};
 use oplog::OpRecord;
 use refs::Head;
 use repo::Repository;
@@ -71,15 +73,12 @@ fn replay_commits_internal(
 
     while state.current_index < state.commits_to_replay.len() {
         let commit_id = state.commits_to_replay[state.current_index];
-        let commit_state = repo
-            .store()
-            .get_state(&commit_id)?
-            .ok_or_else(|| {
-                anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                    &commit_id.to_string(),
-                    "commit",
-                ))
-            })?;
+        let commit_state = repo.store().get_state(&commit_id)?.ok_or_else(|| {
+            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+                &commit_id.to_string(),
+                "commit",
+            ))
+        })?;
 
         if let Some(cli) = cli
             && should_output_json(cli, Some(repo.config()))
@@ -92,12 +91,7 @@ fn replay_commits_internal(
             println!("Applying {}...", commit_id.short());
         }
 
-        let result = apply_commit(
-            repo,
-            &commit_state,
-            &current_head,
-            discard_local_changes,
-        )?;
+        let result = apply_commit(repo, &commit_state, &current_head, discard_local_changes)?;
 
         match result {
             ApplyResult::Success { new_head, advance } => {
@@ -227,14 +221,12 @@ fn resume_manual_resolution_if_present(
         return Ok(());
     };
 
-    let current_state = repo
-        .current_state()?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                "<current>",
-                "current state",
-            ))
-        })?;
+    let current_state = repo.current_state()?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            "<current>",
+            "current state",
+        ))
+    })?;
 
     if current_state.change_id == pre_conflict_head || current_state.change_id == pending_commit {
         if let Some(cli) = cli
@@ -324,25 +316,19 @@ fn apply_commit(
     let current_tree_hash = get_tree_for_state(repo, current_head)?;
     let commit_tree_hash = commit_state.tree;
 
-    let current_tree = repo
-        .store()
-        .get_tree(&current_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &current_tree_hash.to_string(),
-                "current tree",
-            ))
-        })?;
+    let current_tree = repo.store().get_tree(&current_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &current_tree_hash.to_string(),
+            "current tree",
+        ))
+    })?;
 
-    let commit_tree = repo
-        .store()
-        .get_tree(&commit_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &commit_tree_hash.to_string(),
-                "commit tree",
-            ))
-        })?;
+    let commit_tree = repo.store().get_tree(&commit_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &commit_tree_hash.to_string(),
+            "commit tree",
+        ))
+    })?;
 
     let parent_tree_hash = if let Some(parent_id) = commit_state.parents.first() {
         get_tree_for_state(repo, parent_id)?
@@ -356,15 +342,12 @@ fn apply_commit(
         );
     };
 
-    let parent_tree = repo
-        .store()
-        .get_tree(&parent_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &parent_tree_hash.to_string(),
-                "parent tree",
-            ))
-        })?;
+    let parent_tree = repo.store().get_tree(&parent_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &parent_tree_hash.to_string(),
+            "parent tree",
+        ))
+    })?;
 
     let changes = compute_tree_diff(&parent_tree, &commit_tree);
 
@@ -597,15 +580,12 @@ fn copy_state_metadata(
 }
 
 fn get_tree_for_state(repo: &Repository, state_id: &ChangeId) -> Result<ContentHash> {
-    let state = repo
-        .store()
-        .get_state(state_id)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &state_id.to_string(),
-                "state",
-            ))
-        })?;
+    let state = repo.store().get_state(state_id)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &state_id.to_string(),
+            "state",
+        ))
+    })?;
     Ok(state.tree)
 }
 
@@ -914,9 +894,11 @@ mod tests {
     /// barrier to maximise the chance of concurrent clock reads.
     #[test]
     fn mint_rebase_transaction_id_is_unique_under_thread_contention() {
-        use std::collections::HashSet;
-        use std::sync::{Arc, Barrier};
-        use std::thread;
+        use std::{
+            collections::HashSet,
+            sync::{Arc, Barrier},
+            thread,
+        };
 
         const N_THREADS: usize = 32;
         const N_PER_THREAD: usize = 64;
@@ -980,8 +962,10 @@ mod tests {
     /// so exactly one batch lands regardless of contention.
     #[test]
     fn flush_rebase_batch_is_atomic_across_concurrent_continues() {
-        use std::sync::{Arc, Barrier};
-        use std::thread;
+        use std::{
+            sync::{Arc, Barrier},
+            thread,
+        };
 
         const N_THREADS: usize = 8;
 

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebase state persistence and commit-graph traversal.
 
-use objects::store::ObjectStore;
 use std::{fs, io::Write};
 
-use anyhow::{anyhow, Result};
-use objects::object::ChangeId;
+use anyhow::{Result, anyhow};
+use objects::{object::ChangeId, store::ObjectStore};
 use oplog::OpRecord;
 use repo::Repository;
 

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -15,7 +15,6 @@
 //! path) so a leaked secret is scrubbed everywhere it appears — across
 //! renames, copies, and parallel branches.
 
-use objects::store::ObjectStore;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, anyhow};
@@ -23,6 +22,7 @@ use chrono::Utc;
 use crypto::{Signer, load_signer, verify_payload_signature};
 use objects::{
     object::{ChangeId, ContentHash, Redaction, RedactionsBlob, StateSignature},
+    store::ObjectStore,
     worktree::should_ignore,
 };
 use repo::{Repository, RepositoryCapability};

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -40,9 +40,7 @@ use crate::{
 mod remote_ops;
 
 pub use remote_ops::{cmd_pull, cmd_remote};
-pub(crate) use remote_ops::{
-    resolve_default_remote_name, resolved_default_remote_name,
-};
+pub(crate) use remote_ops::{resolve_default_remote_name, resolved_default_remote_name};
 
 #[allow(clippy::type_complexity)]
 pub(crate) fn push_git_overlay_refs(
@@ -237,9 +235,7 @@ pub async fn cmd_push(
         // thread explicitly (positional or `--thread`) we must NOT
         // silently push the wrong branch — refuse and tell them to
         // switch first or use `--all-threads`.
-        if !all_threads
-            && let Some(requested) = thread.as_deref()
-        {
+        if !all_threads && let Some(requested) = thread.as_deref() {
             let attached = match repo.head_ref()? {
                 Head::Attached { thread } => Some(thread.to_string()),
                 Head::Detached { .. } => None,
@@ -1132,7 +1128,9 @@ async fn push_local(
     let sync = LocalSync::open(repo.root())?;
     let objects_copied = sync.fetch_state(&target_repo, state_id)?;
 
-    target_repo.refs().set_thread(&ThreadName::new(track_name), state_id)?;
+    target_repo
+        .refs()
+        .set_thread(&ThreadName::new(track_name), state_id)?;
 
     if should_output_json(cli, Some(repo.config())) {
         let trust = build_repository_verification_state(repo);
@@ -1228,8 +1226,9 @@ mod git_overlay_config_atomic_tests {
     //! after the helper returns, the file is the full new content; a
     //! prior interrupted write that left the file partially-written
     //! must not leak back into the result.
-    use super::*;
     use tempfile::TempDir;
+
+    use super::*;
 
     fn init_dot_git(root: &Path) {
         fs::create_dir_all(root.join(".git")).unwrap();
@@ -1303,10 +1302,7 @@ mod git_overlay_config_atomic_tests {
         let recovered = fs::read_to_string(&config).unwrap();
         assert!(recovered.contains("[branch \"main\"]"), "{recovered}");
         assert!(recovered.contains("upstream"), "{recovered}");
-        assert!(
-            recovered.contains("merge = refs/heads/main"),
-            "{recovered}"
-        );
+        assert!(recovered.contains("merge = refs/heads/main"), "{recovered}");
         assert!(
             !recovered.trim_end().ends_with("rem"),
             "partial bytes from prior crash leaked into result: {recovered}"

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pull, remote management, and serve commands.
 
-use objects::store::ObjectStore;
 #[cfg(feature = "client")]
 use std::net::SocketAddr;
 use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
@@ -13,6 +12,7 @@ use heddle_client::grpc_hosted::PullMaterialization;
 use objects::{
     fs_atomic::write_file_atomic,
     object::{ChangeId, ThreadName, Tree},
+    store::ObjectStore,
 };
 #[cfg(feature = "client")]
 use proto::AuthToken;
@@ -203,7 +203,9 @@ pub async fn cmd_pull(
 ) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
-        return Err(anyhow::anyhow!(RecoveryAdvice::remote_not_configured("pull")));
+        return Err(anyhow::anyhow!(RecoveryAdvice::remote_not_configured(
+            "pull"
+        )));
     }
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         ensure_worktree_clean(&repo, "pull")?;
@@ -732,8 +734,7 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
             // readers (including `resolve_remote_with_key`) can resolve
             // it, then set the default explicitly.
             if cfg.get(&name).is_err() {
-                cfg.add(&name, Remote { url })
-                    .map_err(anyhow::Error::msg)?;
+                cfg.add(&name, Remote { url }).map_err(anyhow::Error::msg)?;
             }
             cfg.set_default(&name).map_err(anyhow::Error::msg)?;
             render_remote_mutation(
@@ -843,9 +844,10 @@ pub(crate) fn resolve_default_remote_name(
         return Ok(default.to_string());
     }
     if repo.capability() == RepositoryCapability::GitOverlay
-        && let Some(default) = git_overlay_default_remote_name(repo) {
-            return Ok(default);
-        }
+        && let Some(default) = git_overlay_default_remote_name(repo)
+    {
+        return Ok(default);
+    }
     Ok("origin".to_string())
 }
 
@@ -885,7 +887,6 @@ fn git_upstream_remote_name(repo: &Repository) -> Option<String> {
         .and_then(|name| name.as_symbol().map(str::to_string))
         .filter(|remote| !remote.is_empty())
 }
-
 
 fn merged_remote_items(repo: &Repository) -> Result<BTreeMap<String, (String, String)>> {
     let cfg = RemoteConfig::open(repo).map_err(anyhow::Error::msg)?;
@@ -1324,11 +1325,7 @@ mod tests {
             "[remote \"upstream\"]\n\turl = https://example.com/upstream\n",
         )
         .unwrap();
-        fs::write(
-            git_dir.join("config"),
-            "[include]\n\tpath = extra.config\n",
-        )
-        .unwrap();
+        fs::write(git_dir.join("config"), "[include]\n\tpath = extra.config\n").unwrap();
 
         let remotes = plain_git_remote_items(tmp.path());
 
@@ -1442,7 +1439,9 @@ mod tests {
         // lives and wins on read); writing to common would leave the
         // stale per-worktree url winning, a silent read/write divergence.
         assert_eq!(
-            plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
+            plain_git_remote_items(tmp.path())
+                .get("origin")
+                .map(String::as_str),
             Some("https://example.com/new"),
         );
     }
@@ -1534,7 +1533,10 @@ mod tests {
         let ctx = GitConfigContext::discover(tmp.path()).unwrap();
         // A brand-new remote (no layer defines it yet) follows git's
         // default: the common config.
-        assert_eq!(ctx.write_file_for("origin").unwrap(), git_dir.join("config"));
+        assert_eq!(
+            ctx.write_file_for("origin").unwrap(),
+            git_dir.join("config")
+        );
         upsert_git_remote_config(
             &ctx.write_file_for("origin").unwrap(),
             "origin",
@@ -1542,7 +1544,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            plain_git_remote_items(tmp.path()).get("origin").map(String::as_str),
+            plain_git_remote_items(tmp.path())
+                .get("origin")
+                .map(String::as_str),
             Some("https://example.com/new"),
         );
     }

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Resolve command implementation.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Context, Result, anyhow};
+use objects::store::ObjectStore;
 use repo::{MergeState, Repository};
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -17,14 +17,13 @@
 //! intentionally biases toward "what happened in this turn" rather than
 //! a long backlog, because retros surface most often at end-of-turn.
 
-use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use objects::{
     object::{ChangeId, State},
-    store::AgentRegistry,
+    store::{AgentRegistry, ObjectStore},
 };
 use oplog::OpRecord;
 use repo::Repository;

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -398,8 +398,7 @@ async fn run_next(cli: &Cli, args: &ReviewNextArgs) -> Result<()> {
         };
         println!(
             "{}",
-            serde_json::to_string(&envelope)
-                .context("serialize review next envelope")?
+            serde_json::to_string(&envelope).context("serialize review next envelope")?
         );
     } else {
         match &next_state {

--- a/crates/cli/src/cli/commands/stack.rs
+++ b/crates/cli/src/cli/commands/stack.rs
@@ -5,12 +5,12 @@
 //! cover `ready` (next-action verdict) and `snapshot` (JSON projection
 //! for agentic tooling). All commands are read-only.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use refs::Head;
 use repo::{Repository, RepositorySnapshot, StackNextAction, StackNode, ThreadStack};
 use serde::Serialize;
 
-use crate::cli::{should_output_json, Cli, StackArgs, StackCommands};
+use crate::cli::{Cli, StackArgs, StackCommands, should_output_json};
 
 pub fn cmd_stack(cli: &Cli, args: StackArgs) -> Result<()> {
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -38,15 +38,19 @@
 //! checkout. No thread/ref/git domain knowledge leaks into the primitive — it
 //! all lives here, exactly like undo/redo's `EntrySteps`.
 
-use std::cell::Cell;
-use std::collections::BTreeSet;
 #[cfg(unix)]
 use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::{
+    cell::Cell,
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
-use objects::error::{HeddleError, Result as HeddleResult};
-use objects::object::{ChangeId, ThreadName};
+use objects::{
+    error::{HeddleError, Result as HeddleResult},
+    object::{ChangeId, ThreadName},
+};
 use oplog::{IsolationKey, OpRecord};
 use refs::RefExpectation;
 use repo::{
@@ -54,9 +58,9 @@ use repo::{
     atomic::{AtomicMutation, StagedCommit, Tx},
 };
 
-use super::mount_lifecycle::{self, MountOwnership};
-use super::worktree_cmd::{
-    helpers::write_isolated_checkout, hydrate, shared_target::write_cargo_config,
+use super::{
+    mount_lifecycle::{self, MountOwnership},
+    worktree_cmd::{helpers::write_isolated_checkout, hydrate, shared_target::write_cargo_config},
 };
 
 /// Wrap an `anyhow` error from a materialize/hydrate helper into the
@@ -1070,15 +1074,20 @@ fn symlink_unsupported_error(link: &str) -> HeddleError {
 
 #[cfg(test)]
 mod tests {
-    use super::super::thread::{
-        find_active_thread_entry, resolve_start_epoch, start_thread, start_transaction_id,
-    };
-    use super::super::thread_cmd::drop_thread_silent;
-    use super::super::worktree_cmd::helpers::plan_worktree_target;
-    use super::*;
-    use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
     use repo::Repository;
     use tempfile::TempDir;
+
+    use super::{
+        super::{
+            thread::{
+                find_active_thread_entry, resolve_start_epoch, start_thread, start_transaction_id,
+            },
+            thread_cmd::drop_thread_silent,
+            worktree_cmd::helpers::plan_worktree_target,
+        },
+        *,
+    };
+    use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
 
     /// A `--path` solid-thread start that pins its base on `from` (no current-
     /// state bootstrap) and never spawns a daemon — minimal machinery for the

--- a/crates/cli/src/cli/commands/stash.rs
+++ b/crates/cli/src/cli/commands/stash.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stash command implementation.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::ContentHash;
+use objects::{object::ContentHash, store::ObjectStore};
 use repo::{DiffKind, Repository};
 use serde::Serialize;
 

--- a/crates/cli/src/cli/commands/stash_ops.rs
+++ b/crates/cli/src/cli/commands/stash_ops.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stash worktree helper operations.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use anyhow::{Result, anyhow};
 use objects::{
     fs_ops::remove_path_recursively,
     object::{Blob, ContentHash, Tree, TreeEntry},
+    store::ObjectStore,
     worktree::WorktreeStatus,
 };
 use repo::{Repository, StashEntry};

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -508,9 +508,8 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         } else {
             trust.recommended_action.clone()
         };
-        let worktree_clean = changes.modified.is_empty()
-            && changes.added.is_empty()
-            && changes.deleted.is_empty();
+        let worktree_clean =
+            changes.modified.is_empty() && changes.added.is_empty() && changes.deleted.is_empty();
         let recommended_action =
             quickstart_init_recommendation(&repo, current_state.as_ref(), worktree_clean)
                 .unwrap_or(recommended_action);
@@ -1335,15 +1334,15 @@ fn render_status_operation(output: &StatusOutput) {
             .missing_branches
             .iter()
             .any(|branch| branch == &hint.current_branch)
-        {
-            println!(
-                "{}",
-                crate::cli::render::git_only_branch_summary(
-                    &hint.missing_branches,
-                    hint.missing_branch_count,
-                )
-            );
-        }
+    {
+        println!(
+            "{}",
+            crate::cli::render::git_only_branch_summary(
+                &hint.missing_branches,
+                hint.missing_branch_count,
+            )
+        );
+    }
     if !output.git_overlay_health.clean {
         let label = if matches!(
             output.git_overlay_health.status.as_str(),
@@ -1872,7 +1871,10 @@ fn assess_materialized_threads(repo: &Repository) -> Vec<MaterializedThreadInfo>
     summaries
         .into_iter()
         .map(|summary| {
-            let stale = match repo.refs().get_thread(&objects::object::ThreadName::new(&summary.thread)) {
+            let stale = match repo
+                .refs()
+                .get_thread(&objects::object::ThreadName::new(&summary.thread))
+            {
                 Ok(Some(head)) => head != summary.state_id,
                 _ => false,
             };
@@ -2656,24 +2658,31 @@ mod tests {
                 // `blocked_by_trust = !trust.verified`; a dirty/unverified
                 // worktree (trust_verified == false) drives the override.
                 let blocked_by_trust = !trust_verified;
-                let (coordination, blocked_by_trust_only) = resolve_coordination_with_trust(
-                    pre_override.clone(),
-                    blocked_by_trust,
-                    false,
-                );
-                let health = if trust_verified { "clean" } else { "dirty_worktree" };
+                let (coordination, blocked_by_trust_only) =
+                    resolve_coordination_with_trust(pre_override.clone(), blocked_by_trust, false);
+                let health = if trust_verified {
+                    "clean"
+                } else {
+                    "dirty_worktree"
+                };
                 let (health_clean, coordination_clean, reason) =
                     combined_verdict_axes(health, &coordination, blocked_by_trust_only);
                 let label = coordination_label(&coordination, blocked_by_trust_only);
                 let ctx = format!("{pre_override:?} / trust_verified={trust_verified}");
 
-                assert_eq!(health_clean, trust_verified, "{ctx}: health axis cleanliness");
+                assert_eq!(
+                    health_clean, trust_verified,
+                    "{ctx}: health axis cleanliness"
+                );
 
                 if genuinely_clean {
                     // Genuinely-clean axis: any override is its SOLE source, so
                     // the axis masks as work-in-progress (the health axis owns
                     // the blocker) — this cell must STAY masked.
-                    assert!(coordination_clean, "{ctx}: a genuinely-clean axis stays effectively clean");
+                    assert!(
+                        coordination_clean,
+                        "{ctx}: a genuinely-clean axis stays effectively clean"
+                    );
                     if trust_verified {
                         assert_eq!(reason, None, "{ctx}: all-clean → no reason");
                         assert_eq!(label, "clean", "{ctx}: clean axis renders as clean");
@@ -2735,11 +2744,17 @@ mod tests {
         let (coordination, blocked_by_trust_only) =
             resolve_coordination_with_trust(CoordinationStatus::Blocked, true, true);
         assert!(matches!(coordination, CoordinationStatus::Blocked));
-        assert!(!blocked_by_trust_only, "needs_checkpoint suppresses the override; genuine block wins");
+        assert!(
+            !blocked_by_trust_only,
+            "needs_checkpoint suppresses the override; genuine block wins"
+        );
 
         let (coordination, blocked_by_trust_only) =
             resolve_coordination_with_trust(CoordinationStatus::Clean, true, true);
-        assert!(matches!(coordination, CoordinationStatus::Clean), "no override → axis stays clean");
+        assert!(
+            matches!(coordination, CoordinationStatus::Clean),
+            "no override → axis stays clean"
+        );
         assert!(!blocked_by_trust_only);
     }
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread commands.
 
-use objects::store::ObjectStore;
 use std::{
     collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},
@@ -13,7 +12,7 @@ use chrono::{DateTime, Utc};
 use gix::bstr::ByteSlice;
 use objects::{
     object::{ChangeId, State, ThreadName, Tree},
-    store::{AgentEntry, AgentRegistry, AgentStatus, current_boot_id},
+    store::{AgentEntry, AgentRegistry, AgentStatus, ObjectStore, current_boot_id},
 };
 use refs::{Head, RefExpectation, RefUpdate};
 use repo::{
@@ -528,7 +527,10 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadSummary>>
     }
     for mut thread in thread_manager.list()? {
         if thread.state == ThreadState::Abandoned
-            && repo.refs().get_thread(&ThreadName::new(&thread.thread))?.is_none()
+            && repo
+                .refs()
+                .get_thread(&ThreadName::new(&thread.thread))?
+                .is_none()
         {
             continue;
         }
@@ -1669,7 +1671,9 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     let base_state = match (&args.from, existing_thread_state) {
         (Some(spec), Some(existing)) => {
             let requested = repo.resolve_state(spec)?.ok_or_else(|| {
-                anyhow!(RecoveryAdvice::thread_referenced_state_missing(spec, "State"))
+                anyhow!(RecoveryAdvice::thread_referenced_state_missing(
+                    spec, "State"
+                ))
             })?;
             if requested != existing {
                 return Err(anyhow!(thread_anchor_mismatch_advice(
@@ -1680,7 +1684,9 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         }
         (None, Some(existing)) => existing,
         (Some(spec), None) => repo.resolve_state(spec)?.ok_or_else(|| {
-            anyhow!(RecoveryAdvice::thread_referenced_state_missing(spec, "State"))
+            anyhow!(RecoveryAdvice::thread_referenced_state_missing(
+                spec, "State"
+            ))
         })?,
         (None, None) => ensure_current_state(
             repo,
@@ -1893,8 +1899,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     // precise directory + symlink rewind, back to the exact pre-start state;
     // the oplog `ThreadCreateV2` is the staged commit record appended once at
     // the single commit point. See `start_atomic::StartThread`.
-    let mount_ownership =
-        mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
+    let mount_ownership = mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
     // `scope` + `transaction_id` were resolved above the commit-detection gate.
     let hydrate_requested =
         args.hydrate && matches!(thread_mode, ThreadMode::Solid | ThreadMode::Materialized);
@@ -2406,8 +2411,12 @@ pub(crate) fn cmd_thread_create(
     // round-trip-encode that can't read its own write is a serde
     // contract bug, not a runtime condition.
     let manager_snapshot = thread_manager.snapshot_thread_record(&name)?;
-    repo.oplog()
-        .record_thread_create(&ThreadName::new(&name), &current, manager_snapshot, Some(&repo.op_scope()))?;
+    repo.oplog().record_thread_create(
+        &ThreadName::new(&name),
+        &current,
+        manager_snapshot,
+        Some(&repo.op_scope()),
+    )?;
 
     let output = thread_op_output(
         "thread_create",

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread command implementation.
 
-use objects::store::ObjectStore;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -9,7 +8,11 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use chrono::Utc;
-use objects::{fs_ops::remove_path_recursively, object::ThreadName, store::AgentRegistry};
+use objects::{
+    fs_ops::remove_path_recursively,
+    object::ThreadName,
+    store::{AgentRegistry, ObjectStore},
+};
 use refs::Head;
 use repo::{
     Repository, Thread, ThreadFreshness, ThreadManager, ThreadMode, ThreadState,
@@ -141,9 +144,15 @@ pub(crate) fn current_thread(repo: &Repository) -> Result<Option<Thread>> {
 pub(crate) fn load_thread(repo: &Repository, thread_id: &str) -> Result<Thread> {
     match thread_manager(repo).load(thread_id)? {
         Some(thread) => Ok(thread),
-        None if repo.refs().get_thread(&ThreadName::new(thread_id))?.is_some() => Err(anyhow!(
-            imported_git_ref_not_managed_thread_advice(thread_id)
-        )),
+        None if repo
+            .refs()
+            .get_thread(&ThreadName::new(thread_id))?
+            .is_some() =>
+        {
+            Err(anyhow!(imported_git_ref_not_managed_thread_advice(
+                thread_id
+            )))
+        }
         None => Err(anyhow!(thread_not_found_advice(thread_id, "load thread"))),
     }
 }
@@ -383,10 +392,12 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
     let mut thread = manager
         .load(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "refresh thread")))?;
-    let target_thread = thread
-        .target_thread
-        .clone()
-        .ok_or_else(|| anyhow!(RecoveryAdvice::missing_target_thread(thread_id, "refresh thread")))?;
+    let target_thread = thread.target_thread.clone().ok_or_else(|| {
+        anyhow!(RecoveryAdvice::missing_target_thread(
+            thread_id,
+            "refresh thread"
+        ))
+    })?;
 
     refresh_thread_freshness(repo, &mut thread)?;
     if thread.freshness == ThreadFreshness::Current {
@@ -811,11 +822,8 @@ fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice
 }
 
 fn current_thread_drop_advice(repo: &Repository, thread_id: &str) -> RecoveryAdvice {
-    let (primary, recovery, hint) = super::thread::current_thread_drop_recovery(
-        repo,
-        thread_id,
-        super::thread::DropMode::Drop,
-    );
+    let (primary, recovery, hint) =
+        super::thread::current_thread_drop_recovery(repo, thread_id, super::thread::DropMode::Drop);
     RecoveryAdvice::safety_refusal(
         "current_thread_not_droppable",
         format!("Thread '{thread_id}' is the current checkout thread and cannot be dropped"),
@@ -1029,7 +1037,9 @@ fn try_three_way_merge_refresh(
             // Thread is strictly behind target — fast-forward the
             // thread ref. We do this against the parent repo so the
             // ref move is visible to the caller's bookkeeping.
-            parent_repo.refs().set_thread(&ThreadName::new(&thread.thread), &target)?;
+            parent_repo
+                .refs()
+                .set_thread(&ThreadName::new(&thread.thread), &target)?;
             // Materialize the target tree to the thread's worktree.
             // Without this, HEAD metadata advances while the files on
             // disk stay stale and subsequent operations run against a
@@ -1092,12 +1102,15 @@ fn cmd_thread_promote(
     let mut thread = manager
         .load(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "promote thread")))?;
-    let state_id = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.ok_or_else(|| {
-        anyhow!(
-            "managed thread '{}' is missing its ref during promote",
-            thread.thread
-        )
-    })?;
+    let state_id = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .ok_or_else(|| {
+            anyhow!(
+                "managed thread '{}' is missing its ref during promote",
+                thread.thread
+            )
+        })?;
     if !force {
         if thread.execution_path.exists()
             && thread.execution_path != *repo.root()

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Heddle-native thread shaping helpers.
 
-use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
 use anyhow::{Result, anyhow};
-use objects::{fs_ops::remove_path_recursively, object::{ChangeId, ThreadName}};
+use objects::{
+    fs_ops::remove_path_recursively,
+    object::{ChangeId, ThreadName},
+    store::ObjectStore,
+};
 use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus};
 use serde::Serialize;
 
@@ -390,8 +393,10 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
         thread.integration_policy_result.status = Some("manual_resolved".to_string());
         thread.integration_policy_result.reason =
             Some("manual integration resolution captured".to_string());
-        thread.integration_policy_result.manual_resolution_state =
-            repo.refs().get_thread(&ThreadName::new(&thread.thread))?.map(|id| id.short());
+        thread.integration_policy_result.manual_resolution_state = repo
+            .refs()
+            .get_thread(&ThreadName::new(&thread.thread))?
+            .map(|id| id.short());
         manager.save(&thread)?;
     }
     let recommended_action = if blockers.is_empty() {
@@ -475,7 +480,8 @@ fn thread_resolve_rebase_followup_operator(
     let next_action = "heddle continue".to_string();
     let mut blockers = Vec::new();
     if rebase_state
-        .pre_conflict_head.is_none_or(|head| head == current_state.change_id)
+        .pre_conflict_head
+        .is_none_or(|head| head == current_state.change_id)
     {
         blockers.push(
             "refresh has a rebase in progress; capture a manual resolution in the thread checkout, then run `heddle rebase --continue`".to_string(),

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -36,7 +36,7 @@ use std::{
     time::Instant,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use repo::{Repository, ThreadManager};
 use serde::Serialize;
 
@@ -46,12 +46,12 @@ use super::{
     command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::action_templates,
     merge::merge_thread_into_current,
-    snapshot::{create_snapshot, SnapshotAgentOverrides},
+    snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread::start_thread,
-    thread_cmd::{drop_thread_silent, DropOutcome},
+    thread_cmd::{DropOutcome, drop_thread_silent},
 };
 use crate::{
-    cli::{should_output_json, style, Cli, ThreadStartArgs, TryArgs, WorkspaceModeArg},
+    cli::{Cli, ThreadStartArgs, TryArgs, WorkspaceModeArg, should_output_json, style},
     config::UserConfig,
 };
 

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Undo and redo commands.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
-use objects::object::{ChangeId, ContentHash};
+use objects::{
+    object::{ChangeId, ContentHash},
+    store::ObjectStore,
+};
 use oplog::{OpBatch, OpRecord};
 use refs::UNDO_RECOVERY_HANDLE;
 use repo::{Repository, ThreadManager};
@@ -216,11 +218,9 @@ pub fn cmd_undo(
     let recovery_state = repo.head()?;
     let generation = repo.oplog().head_id()?;
     let transaction_id = undo_redo_transaction_id("undo", &scope, generation, &batches);
-    let updated_batches = repo::atomic::execute(
-        &repo,
-        UndoOp::new(batches, recovery_state, transaction_id),
-    )
-    .map_err(|e| anyhow!(e))?;
+    let updated_batches =
+        repo::atomic::execute(&repo, UndoOp::new(batches, recovery_state, transaction_id))
+            .map_err(|e| anyhow!(e))?;
 
     let post_undo_repo = Repository::open(repo.root())?;
     let post_undo_trust = build_repository_verification_state(&post_undo_repo);
@@ -338,8 +338,8 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     // failure mid-redo rewinds every applied step (mirror of `cmd_undo`).
     let generation = repo.oplog().head_id()?;
     let transaction_id = undo_redo_transaction_id("redo", &scope, generation, &batches);
-    let updated_batches =
-        repo::atomic::execute(&repo, RedoOp::new(batches, transaction_id)).map_err(|e| anyhow!(e))?;
+    let updated_batches = repo::atomic::execute(&repo, RedoOp::new(batches, transaction_id))
+        .map_err(|e| anyhow!(e))?;
 
     let post_redo_trust = build_repository_verification_state(&repo);
     let recommended_action = ActionFields::from_action(&post_redo_trust.recommended_action);
@@ -661,8 +661,12 @@ fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
         // wildcard) so a new state-carrying variant must declare what its undo
         // needs to load, instead of silently skipping the reachability check
         // (heddle#354 r9).
-        OpRecord::Snapshot { prev_head: None, .. }
-        | OpRecord::Goto { prev_head: None, .. }
+        OpRecord::Snapshot {
+            prev_head: None, ..
+        }
+        | OpRecord::Goto {
+            prev_head: None, ..
+        }
         | OpRecord::ThreadCreate { .. }
         | OpRecord::ThreadCreateV2 { .. }
         | OpRecord::Fork { .. }
@@ -1093,8 +1097,9 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tempfile::TempDir;
+
+    use super::*;
 
     fn record(
         id: &str,
@@ -1177,7 +1182,10 @@ mod tests {
         // Record a `ThreadCreateV2` for the name; its undo converges the name to
         // empty, removing BOTH same-name records.
         std::fs::write(temp.path().join("f.txt"), "x").unwrap();
-        let state = repo.snapshot(Some("s".to_string()), None).unwrap().change_id;
+        let state = repo
+            .snapshot(Some("s".to_string()), None)
+            .unwrap()
+            .change_id;
         let scope = repo.op_scope();
         repo.oplog()
             .record_batch_scoped(

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -16,9 +16,11 @@ use gix::{
         transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
     },
 };
-use objects::error::{HeddleError, Result as HeddleResult};
-use objects::lock::{RepoLock, WriteLockGuard};
-use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName};
+use objects::{
+    error::{HeddleError, Result as HeddleResult},
+    lock::{RepoLock, WriteLockGuard},
+    object::{ChangeId, ContentHash, MarkerName, ThreadName},
+};
 use oplog::{IsolationKey, OpBatch, OpEntry, OpRecord, isolation_keys_for_record};
 use refs::Head;
 use repo::{
@@ -1933,8 +1935,9 @@ impl AtomicMutation for RedoOp {
 
 #[cfg(test)]
 mod atomic_tests {
-    use super::*;
     use tempfile::TempDir;
+
+    use super::*;
 
     /// Init a repo and create two snapshots on `main`. The worktree at `s2`
     /// holds both `a.txt` (from `s1`) and `b.txt` (from `s2`); `s1` holds only

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -32,7 +32,6 @@
 //! the print sites short-circuit on JSON mode before any styled
 //! helper runs.
 
-use objects::store::ObjectStore;
 use std::{
     path::{Path, PathBuf},
     sync::{
@@ -46,7 +45,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use objects::object::ChangeId;
+use objects::{object::ChangeId, store::ObjectStore};
 use oplog::{OpEntry, OpLog, OpRecord};
 use repo::Repository;
 use serde::Serialize;
@@ -499,8 +498,9 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::GitCheckpoint { state, .. } => Some(*state),
         OpRecord::EphemeralThreadCollapse { final_state, .. } => Some(*final_state),
         OpRecord::Redact { state, .. } => Some(*state),
-        OpRecord::RemoteThreadUpdate { state, .. }
-        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. } | OpRecord::RemoteThreadDelete { state, .. } => {
+            Some(*state)
+        }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
-use objects::object::{ChangeId, ThreadName};
+use objects::{
+    object::{ChangeId, ThreadName},
+    store::ObjectStore,
+};
 use oplog::{OpBatch, OpRecord};
 use repo::{Repository, Thread, ThreadIntegrationPolicy};
 use serde::Serialize;
@@ -685,7 +687,8 @@ fn ship_performed_steps(
         (pushed, "push"),
     ]
     .into_iter()
-    .filter(|&(done, _step)| done).map(|(_done, step)| step.to_string())
+    .filter(|&(done, _step)| done)
+    .map(|(_done, step)| step.to_string())
     .collect()
 }
 
@@ -706,7 +709,8 @@ fn ship_skipped_steps(
         (!pushed && !integrated, "push(not reached)"),
     ]
     .into_iter()
-    .filter(|&(skipped, _step)| skipped).map(|(_skipped, step)| step.to_string())
+    .filter(|&(skipped, _step)| skipped)
+    .map(|(_skipped, step)| step.to_string())
     .collect()
 }
 
@@ -1173,12 +1177,15 @@ fn adopt_manual_resolution(repo: &Repository, thread_id: &str) -> Result<String>
             "adopt manual resolution"
         ))
     })?;
-    let target = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.ok_or_else(|| {
-        anyhow!(
-            "Thread '{}' has no current state to integrate",
-            thread.thread
-        )
-    })?;
+    let target = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Thread '{}' has no current state to integrate",
+                thread.thread
+            )
+        })?;
     super::ff_record::record_ff_advance(repo, &thread.thread, &target)?;
     thread.state = repo::ThreadState::Merged;
     thread.merged_state = Some(target.short());
@@ -1213,13 +1220,13 @@ pub(crate) fn auto_ship_policy_blockers(repo: &Repository, thread: &Thread) -> V
     let agent_authored = thread_is_agent_authored(repo, thread);
     if agent_authored
         && let Some(confidence) = thread.confidence_summary.value
-            && confidence < AUTO_SHIP_CONFIDENCE_THRESHOLD
-        {
-            blockers.push(format!(
-                "confidence {:.2} is below the auto-ship threshold of 0.75",
-                confidence
-            ));
-        }
+        && confidence < AUTO_SHIP_CONFIDENCE_THRESHOLD
+    {
+        blockers.push(format!(
+            "confidence {:.2} is below the auto-ship threshold of 0.75",
+            confidence
+        ));
+    }
     if matches!(thread.verification_summary.tests_passed, Some(false)) {
         blockers.push("verification summary reports failing tests".to_string());
     }
@@ -1279,7 +1286,12 @@ fn thread_is_agent_authored(repo: &Repository, thread: &Thread) -> bool {
         .current_state
         .as_deref()
         .and_then(|state| repo.resolve_state(state).ok().flatten())
-        .or_else(|| repo.refs().get_thread(&ThreadName::new(&thread.thread)).ok().flatten());
+        .or_else(|| {
+            repo.refs()
+                .get_thread(&ThreadName::new(&thread.thread))
+                .ok()
+                .flatten()
+        });
     current_state
         .and_then(|id| repo.store().get_state(&id).ok().flatten())
         .map(|state| state.attribution.agent.is_some())

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use objects::object::ChangeId;
+use objects::{object::ChangeId, store::ObjectStore};
 use repo::Repository;
 
 use super::super::advice::RecoveryAdvice;

--- a/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/hydrate.rs
@@ -307,7 +307,10 @@ mod tests {
                 .is_symlink(),
             "node_modules should be a symlink"
         );
-        assert_eq!(std::fs::read_link(&nm).unwrap(), origin.join("node_modules"));
+        assert_eq!(
+            std::fs::read_link(&nm).unwrap(),
+            origin.join("node_modules")
+        );
         // The pre-existing .venv stayed a real directory (not clobbered).
         assert!(
             !std::fs::symlink_metadata(checkout.join(".venv"))
@@ -365,6 +368,9 @@ mod tests {
             std::fs::symlink_metadata(checkout.join("node_modules")).is_err(),
             "a directory symlink must be removed on rollback (remove_dir, not remove_file)"
         );
-        assert!(origin.join("node_modules").is_dir(), "the link target must survive");
+        assert!(
+            origin.join("node_modules").is_dir(),
+            "the link target must survive"
+        );
     }
 }

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -290,7 +290,8 @@ fn global_option_takes_value(command: &clap::Command, token: &str) -> Option<boo
     command
         .get_arguments()
         .find(|arg| {
-            arg.get_long().is_some_and(|long| token == format!("--{long}"))
+            arg.get_long()
+                .is_some_and(|long| token == format!("--{long}"))
                 || arg
                     .get_short()
                     .is_some_and(|short| token == format!("-{short}"))
@@ -939,7 +940,10 @@ mod tests {
                 .get_arguments()
                 .find(|arg| arg.get_id().as_str() == *id)
                 .expect("revealed arg present");
-            assert!(!arg.is_hide_set(), "`{id}` should be revealed by --help-agent");
+            assert!(
+                !arg.is_hide_set(),
+                "`{id}` should be revealed by --help-agent"
+            );
         }
     }
 
@@ -954,8 +958,9 @@ mod tests {
     /// `main.rs` makes (`matches!(cli.command, Commands::Capture(a) if
     /// a.help_agent)`), driven entirely by clap's parse.
     fn wants_reveal(args: &[&str]) -> bool {
-        use crate::cli::cli_args::{Cli, Commands};
         use clap::Parser;
+
+        use crate::cli::cli_args::{Cli, Commands};
         let argv = std::iter::once("heddle").chain(args.iter().copied());
         match Cli::try_parse_from(argv) {
             Ok(cli) => matches!(&cli.command, Commands::Capture(a) if a.help_agent),

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -3,11 +3,13 @@
 //!
 //! Direct access to local repositories without network protocol overhead.
 
-use objects::store::ObjectStore;
 use std::{collections::HashSet, path::Path};
 
-use anyhow::{anyhow, Result};
-use objects::object::{ChangeId, ContentHash};
+use anyhow::{Result, anyhow};
+use objects::{
+    object::{ChangeId, ContentHash},
+    store::ObjectStore,
+};
 use repo::Repository;
 
 /// Synchronize objects from a local source repository to a target repository.

--- a/crates/cli/src/harness/claude_hook.rs
+++ b/crates/cli/src/harness/claude_hook.rs
@@ -23,13 +23,12 @@
 //! All handlers are best-effort. Errors are logged via `tracing` and
 //! swallowed so a transient failure cannot block the harness.
 
-use objects::store::ObjectStore;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use objects::{
     object::{AnnotationKind, AnnotationScope, AnnotationStatus, ContextTarget},
-    store::{AgentRegistry, AgentStatus},
+    store::{AgentRegistry, AgentStatus, ObjectStore},
 };
 use refs::Head;
 use repo::{Repository, RepositorySnapshot, SessionManager, StackNextAction};

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
@@ -13,7 +12,7 @@ use chrono::Utc;
 use objects::{
     fs_atomic::write_file_atomic,
     object::{DiffKind, Session, ThreadName, Tree},
-    store::{AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary},
+    store::{AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary, ObjectStore},
 };
 use proto::{
     HarnessIdentity, ProgressCheckpoint, SessionDiffSummary, SessionReportEnvelope,
@@ -2142,7 +2141,10 @@ fn allocate_thread_name(repo: &Repository, base: &str) -> Result<String> {
         if ThreadManager::new(repo.heddle_dir())
             .load(&candidate)?
             .is_none()
-            && repo.refs().get_thread(&ThreadName::new(&candidate))?.is_none()
+            && repo
+                .refs()
+                .get_thread(&ThreadName::new(&candidate))?
+                .is_none()
         {
             return Ok(candidate);
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -474,7 +474,12 @@ async fn async_main() -> Result<()> {
             }
             let repo = repo::Repository::open(start)?;
             match target {
-                Some(name) if repo.refs().get_thread(&objects::object::ThreadName::new(name.as_str()))?.is_some() => {
+                Some(name)
+                    if repo
+                        .refs()
+                        .get_thread(&objects::object::ThreadName::new(name.as_str()))?
+                        .is_some() =>
+                {
                     cmd_thread_show(&cli, &repo, Some(name.clone()))
                 }
                 Some(state) => cmd_show(&cli, Some(state.clone())),
@@ -940,10 +945,9 @@ fn raw_wants_json(raw: &[String]) -> bool {
             index += 1;
             continue;
         };
-        if arg.get_id().as_str() == "output"
-            && value.is_some_and(|value| value == "json") {
-                wants_json = true;
-            }
+        if arg.get_id().as_str() == "output" && value.is_some_and(|value| value == "json") {
+            wants_json = true;
+        }
         index += consumed;
     }
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -6,7 +6,6 @@
 //! NOTE: These tests run the built binary via CARGO_BIN_EXE_heddle so they can
 //! execute from temporary directories without relying on `cargo run`.
 
-use objects::store::ObjectStore;
 use std::{
     io::Write,
     process::{Command, Output, Stdio},
@@ -14,6 +13,7 @@ use std::{
 };
 
 use gix::refs::transaction::PreviousValue;
+use objects::store::ObjectStore;
 use repo::Repository;
 use serde_json::Value;
 use tempfile::TempDir;

--- a/crates/cli/tests/cli_integration/attempt.rs
+++ b/crates/cli/tests/cli_integration/attempt.rs
@@ -108,7 +108,8 @@ fn attempt_n_one_is_degenerate_try() {
         "attempt's concrete preview action template should need no inputs to run: {raw}"
     );
     assert_eq!(
-        value["recommended_action_template"]["argv_template"], value["next_action_template"]["argv_template"],
+        value["recommended_action_template"]["argv_template"],
+        value["next_action_template"]["argv_template"],
         "recommended action argv_template should mirror next_action argv_template: {raw}"
     );
     assert_eq!(

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use cli::config::UserConfig;
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 
 use super::*;
 
@@ -1055,11 +1054,7 @@ fn test_cli_diff_head_to_worktree_in_plain_git_repo_uses_git_overlay_baseline() 
 
     std::fs::write(temp.path().join("tracked.txt"), "tracked but modified").unwrap();
 
-    let output = heddle(
-        &["--output", "json", "diff", "HEAD"],
-        Some(temp.path()),
-    )
-    .unwrap();
+    let output = heddle(&["--output", "json", "diff", "HEAD"], Some(temp.path())).unwrap();
     let parsed: Value = serde_json::from_str(&output).unwrap();
     assert!(
         !temp.path().join(".heddle").exists(),
@@ -1515,15 +1510,7 @@ fn test_cli_bridge_git_import_ref_imports_only_selected_tag() {
 
     let import_output = heddle(
         &[
-            "--output",
-            "json",
-            "bridge",
-            "git",
-            "import",
-            "--path",
-            ".",
-            "--ref",
-            "v1.0.0",
+            "--output", "json", "bridge", "git", "import", "--path", ".", "--ref", "v1.0.0",
         ],
         Some(temp.path()),
     )
@@ -4050,7 +4037,11 @@ fn test_cli_diff_patch_nested_deleted_file_round_trips() {
     let apply_dir = TempDir::new().unwrap();
     init_git_repo(apply_dir.path());
     std::fs::create_dir_all(apply_dir.path().join("src/nested")).unwrap();
-    std::fs::write(apply_dir.path().join("src/nested/file.txt"), "alpha\nbeta\n").unwrap();
+    std::fs::write(
+        apply_dir.path().join("src/nested/file.txt"),
+        "alpha\nbeta\n",
+    )
+    .unwrap();
     std::fs::write(apply_dir.path().join("keep.txt"), "keep\n").unwrap();
     git_commit_all(apply_dir.path(), "seed");
     git_apply(apply_dir.path(), &patch);
@@ -4265,8 +4256,7 @@ fn test_cli_diff_patch_plain_git_delete_executable_and_symlink_modes() {
     git_commit_all(apply_dir.path(), "seed");
     git_apply(apply_dir.path(), &patch);
     assert!(
-        !apply_dir.path().join("oldlink").exists()
-            && !apply_dir.path().join("old.sh").exists(),
+        !apply_dir.path().join("oldlink").exists() && !apply_dir.path().join("old.sh").exists(),
         "applying the delete patch must unlink both special files:\n{patch}"
     );
 }

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::*;
 use objects::object::ThreadName;
+
+use super::*;
 
 /// Initialize a colocated (drop-in) Git repo on `main` with one
 /// committed file, mirroring the bootstrap the overlay tests use.
 fn init_colocated_git_repo(path: &std::path::Path) {
-    assert!(Command::new("git")
-        .arg("init")
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
     for (k, v) in [
         ("user.name", "Heddle Test"),
         ("user.email", "heddle@example.com"),
@@ -30,18 +33,22 @@ fn init_colocated_git_repo(path: &std::path::Path) {
 }
 
 fn git_commit_all_in(path: &std::path::Path, message: &str) {
-    assert!(Command::new("git")
-        .args(["add", "."])
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
-    assert!(Command::new("git")
-        .args(["commit", "-m", message])
-        .current_dir(path)
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
 }
 
 fn git_status_porcelain(path: &std::path::Path) -> String {
@@ -201,7 +208,9 @@ fn recapture_to_empty_tree_prunes_stale_intent_to_add() {
         .output()
         .unwrap();
     assert!(
-        String::from_utf8(staged.stdout).unwrap().contains(EMPTY_BLOB_OID),
+        String::from_utf8(staged.stdout)
+            .unwrap()
+            .contains(EMPTY_BLOB_OID),
         "precondition: new_file.txt must be intent-to-add after first capture"
     );
 
@@ -261,8 +270,11 @@ fn recapture_skips_intent_to_add_that_conflicts_with_tracked_file() {
     std::fs::remove_file(source.path().join("foo")).unwrap();
     std::fs::create_dir(source.path().join("foo")).unwrap();
     std::fs::write(source.path().join("foo").join("bar"), "now a dir\n").unwrap();
-    heddle(&["capture", "-m", "file becomes directory"], Some(source.path()))
-        .expect("recapture should record the file→dir change");
+    heddle(
+        &["capture", "-m", "file becomes directory"],
+        Some(source.path()),
+    )
+    .expect("recapture should record the file→dir change");
 
     // The index must stay valid: never both `foo` and `foo/bar`.
     let staged = Command::new("git")
@@ -366,11 +378,13 @@ fn test_cli_bridge_git_export_and_pull_roundtrip() {
     assert!(pull.is_ok(), "Bridge pull failed: {:?}", pull.err());
 
     let target_repo = Repository::open(target.path()).unwrap();
-    assert!(target_repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
+    assert!(
+        target_repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -400,11 +414,12 @@ fn test_cli_bridge_git_import_from_external_repo() {
     assert!(result.is_ok(), "Bridge import failed: {:?}", result.err());
 
     let repo = Repository::open(heddle_repo_dir.path()).unwrap();
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -686,12 +701,14 @@ fn test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes() {
     // Plain `git init` → RepositoryCapability::GitOverlay,
     // hosted_enabled() == false. This is the drop-in case the
     // early-return in cmd_push handles.
-    assert!(Command::new("git")
-        .arg("init")
-        .current_dir(source.path())
-        .status()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .current_dir(source.path())
+            .status()
+            .unwrap()
+            .success()
+    );
     for (k, v) in [
         ("user.name", "Heddle Test"),
         ("user.email", "heddle@example.com"),

--- a/crates/cli/tests/cli_integration/diff_patch_conformance.rs
+++ b/crates/cli/tests/cli_integration/diff_patch_conformance.rs
@@ -558,7 +558,10 @@ fn add_symlink_round_trips() {
 #[test]
 fn delete_nonempty_round_trips() {
     native_cell(
-        &[normal("doomed.txt", "gamma\ndelta\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("doomed.txt", "gamma\ndelta\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| std::fs::remove_file(dir.join("doomed.txt")).unwrap(),
         &[
             Expect::Absent("doomed.txt"),
@@ -722,11 +725,7 @@ fn capturable_quoting_paths() -> Vec<&'static str> {
 /// the plain-Git surface, where git — not heddle — owns the tree). The add
 /// path never validates a tree name, so these must still quote correctly.
 fn worktree_only_quoting_paths() -> Vec<&'static str> {
-    vec![
-        "tab\tname.txt",
-        "new\nline.txt",
-        "back\\slash.txt",
-    ]
+    vec!["tab\tname.txt", "new\nline.txt", "back\\slash.txt"]
 }
 
 #[test]
@@ -757,7 +756,10 @@ fn special_char_path_modify_round_trips() {
 fn special_char_path_delete_round_trips() {
     for path in capturable_quoting_paths() {
         native_cell(
-            &[normal(path, "doomed\ncontent\n"), normal("keep.txt", "keep\n")],
+            &[
+                normal(path, "doomed\ncontent\n"),
+                normal("keep.txt", "keep\n"),
+            ],
             move |dir| std::fs::remove_file(dir.join(path)).unwrap(),
             &[
                 Expect::Absent(path),
@@ -981,7 +983,10 @@ const NON_UTF8_TARGET: &[u8] = b"dest/\xff\xfe/link-target";
 #[test]
 fn native_non_utf8_symlink_rename_round_trips() {
     native_cell(
-        &[symlink_bytes("from-link", NON_UTF8_TARGET), normal("anchor.txt", "anchor\n")],
+        &[
+            symlink_bytes("from-link", NON_UTF8_TARGET),
+            normal("anchor.txt", "anchor\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("from-link")).unwrap();
             write_entry(dir, &symlink_bytes("to-link", NON_UTF8_TARGET));
@@ -1000,7 +1005,10 @@ fn native_non_utf8_symlink_rename_round_trips() {
 #[test]
 fn state_non_utf8_symlink_rename_round_trips() {
     state_cell(
-        &[symlink_bytes("from-link", NON_UTF8_TARGET), normal("keep.txt", "keep\n")],
+        &[
+            symlink_bytes("from-link", NON_UTF8_TARGET),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("from-link")).unwrap();
             write_entry(dir, &symlink_bytes("to-link", NON_UTF8_TARGET));
@@ -1136,17 +1144,16 @@ fn state_cell_bytes(pre: &[Entry], mutate: impl Fn(&Path), expect: &[Expect]) {
     heddle(&["capture", "-m", "v2"], Some(h.path())).unwrap();
 
     let patch = patch_bytes(&["diff", "HEAD~1", "HEAD", "--patch"], h.path());
-    assert_modes_consistent(h.path(), &["HEAD~1", "HEAD"], &String::from_utf8_lossy(&patch));
+    assert_modes_consistent(
+        h.path(),
+        &["HEAD~1", "HEAD"],
+        &String::from_utf8_lossy(&patch),
+    );
     apply_oracle_bytes(pre, &patch, expect);
 }
 
 /// Plain-Git fast-path byte cell: no `heddle init`; HEAD read via gix.
-fn plain_git_cell_bytes(
-    pre: &[Entry],
-    stage: bool,
-    mutate: impl Fn(&Path),
-    expect: &[Expect],
-) {
+fn plain_git_cell_bytes(pre: &[Entry], stage: bool, mutate: impl Fn(&Path), expect: &[Expect]) {
     let h = TempDir::new().unwrap();
     git_init(h.path());
     for entry in pre {
@@ -1203,7 +1210,10 @@ fn plain_git_non_utf8_symlink_add_round_trips() {
 #[test]
 fn native_non_utf8_symlink_delete_round_trips() {
     native_cell_bytes(
-        &[symlink_bytes("doomed", NON_UTF8_TARGET), normal("keep.txt", "keep\n")],
+        &[
+            symlink_bytes("doomed", NON_UTF8_TARGET),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| std::fs::remove_file(dir.join("doomed")).unwrap(),
         &[
             Expect::Absent("doomed"),
@@ -1216,7 +1226,10 @@ fn native_non_utf8_symlink_delete_round_trips() {
 #[test]
 fn state_non_utf8_symlink_delete_round_trips() {
     state_cell_bytes(
-        &[symlink_bytes("doomed", NON_UTF8_TARGET), normal("keep.txt", "keep\n")],
+        &[
+            symlink_bytes("doomed", NON_UTF8_TARGET),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| std::fs::remove_file(dir.join("doomed")).unwrap(),
         &[
             Expect::Absent("doomed"),
@@ -1229,7 +1242,10 @@ fn state_non_utf8_symlink_delete_round_trips() {
 #[test]
 fn plain_git_non_utf8_symlink_delete_round_trips() {
     plain_git_cell_bytes(
-        &[symlink_bytes("doomed", NON_UTF8_TARGET), normal("keep.txt", "keep\n")],
+        &[
+            symlink_bytes("doomed", NON_UTF8_TARGET),
+            normal("keep.txt", "keep\n"),
+        ],
         true,
         |dir| std::fs::remove_file(dir.join("doomed")).unwrap(),
         &[
@@ -1341,7 +1357,10 @@ fn native_regular_to_symlink_rename_candidate_stays_split() {
 #[test]
 fn state_regular_to_symlink_rename_candidate_stays_split() {
     state_cell(
-        &[normal("mover.txt", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            normal("mover.txt", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover.txt")).unwrap();
             write_entry(dir, &symlink("linked", "dest/dir/file"));
@@ -1361,7 +1380,10 @@ fn state_regular_to_symlink_rename_candidate_stays_split() {
 #[test]
 fn state_symlink_to_regular_rename_candidate_stays_split() {
     state_cell(
-        &[symlink("mover", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover")).unwrap();
             write_entry(dir, &normal("landed.txt", "dest/dir/file"));
@@ -1436,7 +1458,10 @@ fn cross_type_rename_candidate_renders_as_split_not_rename() {
         "cross-type move must render as delete(100644) + add(120000):\n{patch}"
     );
     apply_oracle(
-        &[normal("mover.txt", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            normal("mover.txt", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         &patch,
         &[
             Expect::Absent("mover.txt"),
@@ -1453,7 +1478,10 @@ fn cross_type_rename_candidate_renders_as_split_not_rename() {
 #[test]
 fn plain_git_regular_to_symlink_rename_candidate_stays_split() {
     plain_git_cell(
-        &[normal("mover.txt", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            normal("mover.txt", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         true,
         |dir| {
             std::fs::remove_file(dir.join("mover.txt")).unwrap();
@@ -1560,7 +1588,10 @@ fn native_symlink_to_symlink_same_target_round_trips() {
 #[test]
 fn state_symlink_to_symlink_same_target_round_trips() {
     state_cell(
-        &[symlink("mover", "shared/target/path"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover", "shared/target/path"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover")).unwrap();
             write_entry(dir, &symlink("moved", "shared/target/path"));
@@ -1582,7 +1613,10 @@ fn state_symlink_to_symlink_same_target_round_trips() {
 #[test]
 fn native_symlink_to_regular_rename_candidate_stays_split() {
     native_cell(
-        &[symlink("mover", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover")).unwrap();
             write_entry(dir, &normal("landed.txt", "dest/dir/file"));
@@ -1699,7 +1733,10 @@ fn status_regular_to_symlink_rename_candidate_stays_split() {
 #[test]
 fn state_status_regular_to_symlink_rename_candidate_stays_split() {
     let renders = state_status_renders(
-        &[normal("mover.txt", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            normal("mover.txt", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover.txt")).unwrap();
             write_entry(dir, &symlink("linked", "dest/dir/file"));
@@ -1718,7 +1755,10 @@ fn state_status_regular_to_symlink_rename_candidate_stays_split() {
 #[test]
 fn status_symlink_to_regular_rename_candidate_stays_split() {
     let renders = status_renders(
-        &[symlink("mover_link", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover_link", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover_link")).unwrap();
             write_entry(dir, &normal("newreg.txt", "dest/dir/file"));
@@ -1732,7 +1772,10 @@ fn status_symlink_to_regular_rename_candidate_stays_split() {
 #[test]
 fn state_status_symlink_to_regular_rename_candidate_stays_split() {
     let renders = state_status_renders(
-        &[symlink("mover_link", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover_link", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover_link")).unwrap();
             write_entry(dir, &normal("newreg.txt", "dest/dir/file"));
@@ -1749,13 +1792,10 @@ fn state_status_symlink_to_regular_rename_candidate_stays_split() {
 #[test]
 fn status_regular_to_exec_move_still_collapses_to_rename() {
     let body = "alpha\nbeta\ngamma\ndelta\nepsilon\n";
-    let renders = status_renders(
-        &[normal("old.sh", body)],
-        |dir| {
-            std::fs::remove_file(dir.join("old.sh")).unwrap();
-            write_entry(dir, &exec("new.sh", body));
-        },
-    );
+    let renders = status_renders(&[normal("old.sh", body)], |dir| {
+        std::fs::remove_file(dir.join("old.sh")).unwrap();
+        write_entry(dir, &exec("new.sh", body));
+    });
     assert!(
         renders.stat.contains("renamed") && renders.stat.contains("old.sh -> new.sh"),
         "--stat must show the regular→exec move as a rename:\n{}",
@@ -1791,7 +1831,10 @@ fn status_regular_to_exec_move_still_collapses_to_rename() {
     apply_oracle(
         &[normal("old.sh", body)],
         &patch,
-        &[Expect::Absent("old.sh"), Expect::Present(exec("new.sh", body))],
+        &[
+            Expect::Absent("old.sh"),
+            Expect::Present(exec("new.sh", body)),
+        ],
     );
 }
 
@@ -1804,7 +1847,10 @@ fn status_regular_to_exec_move_still_collapses_to_rename() {
 #[test]
 fn status_same_path_regular_to_symlink_splits_not_modified() {
     let renders = status_renders(
-        &[normal("swap", "shared payload\n"), normal("anchor.txt", "shared payload\n")],
+        &[
+            normal("swap", "shared payload\n"),
+            normal("anchor.txt", "shared payload\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("swap")).unwrap();
             write_entry(dir, &symlink("swap", "anchor.txt"));
@@ -1820,7 +1866,11 @@ fn status_same_path_regular_to_symlink_splits_not_modified() {
     );
     // `--name-only` lists the path on both the delete and add halves.
     assert_eq!(
-        renders.name_only.lines().filter(|line| *line == "swap").count(),
+        renders
+            .name_only
+            .lines()
+            .filter(|line| *line == "swap")
+            .count(),
         2,
         "--name-only must list the split path twice (delete + add):\n{}",
         renders.name_only
@@ -1880,7 +1930,10 @@ fn git_overlay_status_renders(pre: &[Entry], mutate: impl Fn(&Path)) -> (StatusR
 #[test]
 fn git_overlay_status_symlink_to_regular_rename_candidate_stays_split() {
     let (renders, patch) = git_overlay_status_renders(
-        &[symlink("mover_link", "dest/dir/file"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("mover_link", "dest/dir/file"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("mover_link")).unwrap();
             write_entry(dir, &normal("newreg.txt", "dest/dir/file"));
@@ -1924,7 +1977,10 @@ fn dir_to_file_type_change_round_trips() {
     // replaced by a regular file `data`. git deletes `data/item.txt` and
     // adds the `data` file.
     native_cell(
-        &[normal("data/item.txt", "x\ny\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("data/item.txt", "x\ny\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("data/item.txt")).unwrap();
             std::fs::remove_dir(dir.join("data")).unwrap();
@@ -1950,7 +2006,10 @@ fn regular_to_symlink_type_change_round_trips() {
     // `node` is a tracked regular file; it becomes a symlink. git represents
     // that as delete(100644 node) + add(120000 node -> target).
     native_cell(
-        &[normal("node", "real contents\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("node", "real contents\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
             write_entry(dir, &symlink("node", "some/target/path"));
@@ -1967,7 +2026,10 @@ fn regular_to_symlink_type_change_round_trips() {
 fn symlink_to_regular_type_change_round_trips() {
     // The mirror: a tracked symlink becomes a regular file.
     native_cell(
-        &[symlink("node", "some/target/path"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("node", "some/target/path"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
             write_entry(dir, &normal("node", "now real contents\n"));
@@ -2032,7 +2094,10 @@ fn state_file_to_dir_type_change_round_trips() {
 #[test]
 fn state_dir_to_file_type_change_round_trips() {
     state_cell(
-        &[normal("data/item.txt", "x\ny\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("data/item.txt", "x\ny\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("data/item.txt")).unwrap();
             std::fs::remove_dir(dir.join("data")).unwrap();
@@ -2049,7 +2114,10 @@ fn state_dir_to_file_type_change_round_trips() {
 #[test]
 fn state_regular_to_symlink_type_change_round_trips() {
     state_cell(
-        &[normal("node", "real contents\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("node", "real contents\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
             write_entry(dir, &symlink("node", "some/target/path"));
@@ -2065,7 +2133,10 @@ fn state_regular_to_symlink_type_change_round_trips() {
 #[test]
 fn state_symlink_to_regular_type_change_round_trips() {
     state_cell(
-        &[symlink("node", "some/target/path"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("node", "some/target/path"),
+            normal("keep.txt", "keep\n"),
+        ],
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
             write_entry(dir, &normal("node", "now real contents\n"));
@@ -2315,7 +2386,10 @@ fn plain_git_regular_to_symlink_type_change_round_trips() {
     // regular → symlink in a plain-Git repo must split into delete(100644)
     // + add(120000), matching the heddle path's `expand_type_changes`.
     plain_git_cell(
-        &[normal("node", "real contents\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("node", "real contents\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         false,
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
@@ -2332,7 +2406,10 @@ fn plain_git_regular_to_symlink_type_change_round_trips() {
 #[test]
 fn plain_git_symlink_to_regular_type_change_round_trips() {
     plain_git_cell(
-        &[symlink("node", "some/target/path"), normal("keep.txt", "keep\n")],
+        &[
+            symlink("node", "some/target/path"),
+            normal("keep.txt", "keep\n"),
+        ],
         false,
         |dir| {
             std::fs::remove_file(dir.join("node")).unwrap();
@@ -2395,7 +2472,10 @@ fn plain_git_dir_to_file_type_change_round_trips() {
     // is added (untracked). Neither lands in the modified set, so this guards
     // that the plain-Git add/delete ordering still round-trips.
     plain_git_cell(
-        &[normal("data/item.txt", "x\ny\n"), normal("keep.txt", "keep\n")],
+        &[
+            normal("data/item.txt", "x\ny\n"),
+            normal("keep.txt", "keep\n"),
+        ],
         false,
         |dir| {
             std::fs::remove_file(dir.join("data/item.txt")).unwrap();
@@ -2649,9 +2729,9 @@ fn merge_with_diff_json_carries_patch() {
         String::from_utf8_lossy(&out.stderr)
     );
     let parsed: Value = serde_json::from_slice(&out.stdout).expect("merge output should be JSON");
-    let patch = parsed["diff"]["patch"]
-        .as_str()
-        .unwrap_or_else(|| panic!("merge preview `.diff.patch` must be populated, not null: {parsed}"));
+    let patch = parsed["diff"]["patch"].as_str().unwrap_or_else(|| {
+        panic!("merge preview `.diff.patch` must be populated, not null: {parsed}")
+    });
     assert!(
         patch.contains("+feature") && patch.contains("new.txt"),
         "embedded patch must carry the incoming hunks:\n{patch}"
@@ -2693,17 +2773,13 @@ const NAME_POOL: &[&str] = &[
 /// line w/ or w/o trailing newline. ASCII-only so heddle never treats it
 /// as binary.
 fn content_strategy() -> impl Strategy<Value = String> {
-    (
-        proptest::collection::vec("[a-z]{1,6}", 0..5),
-        any::<bool>(),
-    )
-        .prop_map(|(lines, trailing)| {
-            let mut joined = lines.join("\n");
-            if !joined.is_empty() && trailing {
-                joined.push('\n');
-            }
-            joined
-        })
+    (proptest::collection::vec("[a-z]{1,6}", 0..5), any::<bool>()).prop_map(|(lines, trailing)| {
+        let mut joined = lines.join("\n");
+        if !joined.is_empty() && trailing {
+            joined.push('\n');
+        }
+        joined
+    })
 }
 
 fn tree_strategy() -> impl Strategy<Value = BTreeMap<String, String>> {

--- a/crates/cli/tests/cli_integration/error_envelope_lint.rs
+++ b/crates/cli/tests/cli_integration/error_envelope_lint.rs
@@ -186,8 +186,9 @@ fn parse_json_envelope(stderr: &str, label: &str) -> Value {
         .map(str::trim)
         .find(|line| !line.is_empty())
         .unwrap_or_else(|| panic!("[{label}] empty stderr; expected a JSON envelope"));
-    serde_json::from_str(line)
-        .unwrap_or_else(|err| panic!("[{label}] stderr is not a JSON envelope: {err}\n  line: {line}"))
+    serde_json::from_str(line).unwrap_or_else(|err| {
+        panic!("[{label}] stderr is not a JSON envelope: {err}\n  line: {line}")
+    })
 }
 
 #[test]
@@ -348,8 +349,7 @@ fn status_success_payload_omits_argv_siblings() {
         "status should exit 0 on a clean committed repo"
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let payload: Value =
-        serde_json::from_str(stdout.trim()).expect("status payload is JSON");
+    let payload: Value = serde_json::from_str(stdout.trim()).expect("status payload is JSON");
 
     let mut offending = Vec::new();
     collect_keys(&payload, &mut |key| {
@@ -383,8 +383,10 @@ fn collect_keys(value: &Value, visit: &mut impl FnMut(&str)) {
 
 #[test]
 fn swept_commands_have_envelope_coverage() {
-    let covered: std::collections::BTreeSet<&str> =
-        cases().iter().flat_map(|case| case.covers.iter().copied()).collect();
+    let covered: std::collections::BTreeSet<&str> = cases()
+        .iter()
+        .flat_map(|case| case.covers.iter().copied())
+        .collect();
     let missing: Vec<&str> = SWEPT_COVERAGE
         .iter()
         .copied()

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -145,14 +145,22 @@ fn merge_preview_exits_zero() {
 fn bridge_git_import_exits_zero() {
     // Documented: `0 ok`.
     let repo = adopted_git_overlay();
-    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
 }
 
 #[test]
 fn bridge_git_sync_exits_zero() {
     // Documented: `0 ok`.
     let repo = adopted_git_overlay();
-    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
     assert_exit(&["bridge", "git", "sync"], repo.path(), 0);
 }
 
@@ -162,7 +170,11 @@ fn bridge_git_reconcile_without_side_is_data_err() {
     // `reconcile_direction_required` refusal (no `--prefer` side) was the
     // `74 IoErr` catch-all before HeddleCo/heddle#252.
     let repo = adopted_git_overlay();
-    assert_exit(&["bridge", "git", "import", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
     assert_exit(
         &["bridge", "git", "reconcile", "--ref", "main"],
         repo.path(),

--- a/crates/cli/tests/cli_integration/git_overlay_interop_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_interop_matrix.rs
@@ -48,13 +48,7 @@ fn git_overlay_interop_bridge_shorthand_imports_current_branch() {
 
     let import = heddle(
         &[
-            "--output",
-            "json",
-            "bridge",
-            "git",
-            "import",
-            "--ref",
-            "main",
+            "--output", "json", "bridge", "git", "import", "--ref", "main",
         ],
         Some(temp.path()),
     )

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -200,10 +200,7 @@ fn inject_post_verification(cwd: &std::path::Path, args: &[&str], mut value: Val
     } else {
         // Clean verify flattens the proof; reconstruct as a nested
         // object by dropping verify's own wrapper keys.
-        let mut obj_map = parsed
-            .as_object()
-            .cloned()
-            .unwrap_or_default();
+        let mut obj_map = parsed.as_object().cloned().unwrap_or_default();
         obj_map.remove("output_kind");
         obj_map.remove("repository_label");
         obj_map.remove("repository_context");
@@ -845,8 +842,7 @@ fn git_overlay_matrix_commit_no_all_nothing_staged_refuses_before_identity_prefl
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
-    let envelope: Value =
-        serde_json::from_str(stderr).expect("refusal should emit JSON envelope");
+    let envelope: Value = serde_json::from_str(stderr).expect("refusal should emit JSON envelope");
     assert_eq!(
         envelope["kind"], "nothing_to_commit",
         "--no-all with nothing staged must surface nothing-to-commit before the identity preflight, not an identity refusal: {stderr}"
@@ -3446,7 +3442,10 @@ fn git_overlay_matrix_top_level_push_closes_remote_verification_loop() {
     let commit = json(temp.path(), &["--output", "json", "commit", "-m", "change"]);
     assert_eq!(commit["output_kind"], "commit");
     assert_eq!(commit["next_action"], "heddle push");
-    assert_eq!(commit["next_action_template"]["argv_template"], heddle_argv_json(["push"]));
+    assert_eq!(
+        commit["next_action_template"]["argv_template"],
+        heddle_argv_json(["push"])
+    );
     assert_eq!(commit["recommended_action"], "heddle push");
     assert_eq!(
         commit["recommended_action_template"]["argv_template"],
@@ -4066,7 +4065,10 @@ fn git_overlay_matrix_remote_remove_clears_both_sources() {
     git_commit_all(temp.path(), "seed");
     heddle_adopt(temp.path());
 
-    let staging_arg = staging.path().to_str().expect("staging path should be utf8");
+    let staging_arg = staging
+        .path()
+        .to_str()
+        .expect("staging path should be utf8");
     let added = json(
         temp.path(),
         &["--output", "json", "remote", "add", "staging", staging_arg],
@@ -4188,7 +4190,10 @@ fn git_overlay_matrix_remote_set_default_works_for_dual_location_remote() {
     heddle_adopt(temp.path());
 
     let origin_arg = origin.path().to_str().expect("origin path should be utf8");
-    let staging_arg = staging.path().to_str().expect("staging path should be utf8");
+    let staging_arg = staging
+        .path()
+        .to_str()
+        .expect("staging path should be utf8");
     json(
         temp.path(),
         &["--output", "json", "remote", "add", "origin", origin_arg],
@@ -4487,9 +4492,9 @@ fn git_overlay_matrix_manual_git_commit_after_bootstrap_commands() {
         "diagnose should show the same current Git dirty set as status under needs_import: {dirty_diagnose}"
     );
     let dirty_diff = json(temp.path(), &["diff", "--output", "json", "--stat"]);
-    let dirty_changes = dirty_diff["changes"]
-        .as_object()
-        .unwrap_or_else(|| panic!("worktree diff changes should be a category object: {dirty_diff}"));
+    let dirty_changes = dirty_diff["changes"].as_object().unwrap_or_else(|| {
+        panic!("worktree diff changes should be a category object: {dirty_diff}")
+    });
     let dirty_total: usize = ["modified", "added", "deleted"]
         .iter()
         .filter_map(|key| dirty_changes[*key].as_array())
@@ -5605,7 +5610,10 @@ fn git_overlay_matrix_diff_status_keeps_cross_type_move_split() {
     // 3321103601 flagged), instead of the heddle-native builder.
     std::fs::write(temp.path().join("filler.txt"), "filler edit\n").unwrap();
     git(&["add", "filler.txt"], temp.path());
-    git(&["commit", "-m", "advance branch outside heddle"], temp.path());
+    git(
+        &["commit", "-m", "advance branch outside heddle"],
+        temp.path(),
+    );
 
     // The cross-type move stays UNCOMMITTED in the worktree: `linked` follows
     // to `anchor.txt`, so the worktree blob read for the added side equals the
@@ -5659,7 +5667,9 @@ fn git_overlay_matrix_diff_added_symlink_renders_link_target() {
         .unwrap()
         .iter()
         .find(|change| change["path"] == "link-to-readme")
-        .unwrap_or_else(|| panic!("diff should include added symlink under the added category: {diff}"));
+        .unwrap_or_else(|| {
+            panic!("diff should include added symlink under the added category: {diff}")
+        });
     assert_eq!(link_change["kind"], "added");
     let added_line = link_change["lines"]
         .as_array()

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -899,17 +899,18 @@ fn git_replacement_matrix_undo_preserves_recovery_marker_for_absorbed_edit() {
 
     // An edit that lived only in the worktree, then absorbed by `commit`.
     std::fs::write(work.join("story.txt"), "FRICTION ONE\nFRICTION TWO\n").unwrap();
-    let commit = assert_clean_json_without_git(
-        &["--output", "json", "commit", "-m", "friction"],
-        &work,
-    );
+    let commit =
+        assert_clean_json_without_git(&["--output", "json", "commit", "-m", "friction"], &work);
     assert_eq!(commit["output_kind"], "commit");
     let friction_state = commit["change_id"]
         .as_str()
         .expect("commit emits the absorbed heddle change-id")
         .to_string();
     let friction_commit = git_head_oid(&work);
-    assert_ne!(friction_commit, base, "commit advances the checkout Git ref");
+    assert_ne!(
+        friction_commit, base,
+        "commit advances the checkout Git ref"
+    );
 
     let undo = assert_clean_json_without_git(&["--output", "json", "undo"], &work);
     assert_eq!(undo["action"], "undo");

--- a/crates/cli/tests/cli_integration/hydrate.rs
+++ b/crates/cli/tests/cli_integration/hydrate.rs
@@ -193,10 +193,8 @@ fn hydrate_does_not_dirty_a_tracked_heddleignore() {
     );
 
     // The dep-ignore rule landed in the worktree-local, never-captured exclude.
-    let exclude = std::fs::read_to_string(
-        thread_path.join(".heddle").join("info").join("exclude"),
-    )
-    .expect("hydrate should write the worktree-local exclude");
+    let exclude = std::fs::read_to_string(thread_path.join(".heddle").join("info").join("exclude"))
+        .expect("hydrate should write the worktree-local exclude");
     assert!(
         exclude.contains("node_modules"),
         "the dep-ignore rule must live in the worktree-local exclude; got:\n{exclude}"
@@ -605,7 +603,10 @@ fn start_partial_materialize_preserves_preexisting_empty_dir() {
             thread_path.display()
         )
     });
-    assert!(meta.is_dir(), "the pre-existing target must remain a directory");
+    assert!(
+        meta.is_dir(),
+        "the pre-existing target must remain a directory"
+    );
     let remaining: Vec<_> = std::fs::read_dir(&thread_path)
         .unwrap()
         .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -1490,8 +1490,7 @@ fn verify_cold_flow_scripts_assert_required_proof_steps() {
                 script.display()
             );
             assert!(
-                source.contains("recommended_action_template")
-                    && source.contains("argv_template"),
+                source.contains("recommended_action_template") && source.contains("argv_template"),
                 "{} should execute structured verify actions and fill display-only templates",
                 script.display()
             );
@@ -2456,7 +2455,10 @@ fn git_overlay_commit_empty_index_sweeps_whole_worktree() {
     std::fs::write(temp.path().join("file.txt"), "base\nswept\n").unwrap();
     std::fs::write(temp.path().join("scratch.txt"), "untracked\n").unwrap();
 
-    let commit = json_value(temp.path(), &["commit", "-m", "sweep all", "--output", "json"]);
+    let commit = json_value(
+        temp.path(),
+        &["commit", "-m", "sweep all", "--output", "json"],
+    );
     assert_eq!(
         commit["git_index"]["commit_mode"], "worktree_all",
         "an empty index should commit all worktree paths: {commit}"
@@ -3942,7 +3944,8 @@ fn core_mutations_emit_post_verification_in_json() {
         "capture's post-verify checkpoint template must be display-only: {capture}"
     );
     assert_eq!(
-        capture["recommended_action_template"]["argv_template"], capture["verification"]["recommended_action_template"]["argv_template"],
+        capture["recommended_action_template"]["argv_template"],
+        capture["verification"]["recommended_action_template"]["argv_template"],
         "capture top-level argv should match the promoted verify action: {capture}"
     );
     assert_eq!(
@@ -3951,7 +3954,8 @@ fn core_mutations_emit_post_verification_in_json() {
         "display-only capture recommendation should carry matching top-level template metadata: {capture}"
     );
     assert_eq!(
-        capture["next_action_template"]["argv_template"], capture["recommended_action_template"]["argv_template"],
+        capture["next_action_template"]["argv_template"],
+        capture["recommended_action_template"]["argv_template"],
         "capture next_action should carry matching argv metadata: {capture}"
     );
     assert_eq!(
@@ -4100,7 +4104,8 @@ fn dirty_git_repo_after_init_requires_import_before_commit() {
             check["name"] == "Mapping"
                 && check["status"] == "needs_import"
                 && check["recommended_action"] == "heddle adopt --ref main"
-                && check["recommended_action_template"]["argv_template"] == heddle_argv_json(["adopt", "--ref", "main"])
+                && check["recommended_action_template"]["argv_template"]
+                    == heddle_argv_json(["adopt", "--ref", "main"])
         }),
         "dirty first-run verify should block on import before worktree advice: {verify}"
     );
@@ -4265,11 +4270,7 @@ fn json_value(cwd: &std::path::Path, args: &[&str]) -> Value {
 /// the returned value for test ergonomics by invoking
 /// `heddle verify --output json` after the original call. Real
 /// consumers see the field omitted.
-fn inject_post_verification_at(
-    cwd: &std::path::Path,
-    args: &[&str],
-    mut value: Value,
-) -> Value {
+fn inject_post_verification_at(cwd: &std::path::Path, args: &[&str], mut value: Value) -> Value {
     let obj = match value.as_object_mut() {
         Some(obj) => obj,
         None => return value,
@@ -4897,8 +4898,7 @@ fn branch_delete_current_refuses_with_typed_advice() {
     let create = templates
         .iter()
         .find(|template| {
-            template["argv_template"]
-                == heddle_argv_json(["thread", "create", "<other>"])
+            template["argv_template"] == heddle_argv_json(["thread", "create", "<other>"])
         })
         .unwrap_or_else(|| panic!("create recovery template should be present: {envelope}"));
     assert_eq!(create["agent_may_fill"], Value::Bool(true));
@@ -5687,11 +5687,8 @@ fn revert_refuses_dirty_worktree_with_shared_advice() {
         .to_string();
 
     std::fs::write(temp.path().join("tracked.txt"), "dirty\n").unwrap();
-    let output = heddle_output(
-        &["--output", "json", "revert", &target],
-        Some(temp.path()),
-    )
-    .expect("invoke revert");
+    let output = heddle_output(&["--output", "json", "revert", &target], Some(temp.path()))
+        .expect("invoke revert");
     assert!(!output.status.success(), "dirty revert should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     let envelope: Value =
@@ -6122,8 +6119,7 @@ fn thread_drop_current_recovery_points_to_create_when_no_sibling() {
     let create = templates
         .iter()
         .find(|template| {
-            template["argv_template"]
-                == heddle_argv_json(["thread", "create", "<other>"])
+            template["argv_template"] == heddle_argv_json(["thread", "create", "<other>"])
         })
         .unwrap_or_else(|| panic!("create recovery template should be present: {stderr}"));
     assert_eq!(create["agent_may_fill"], Value::Bool(true));
@@ -6147,7 +6143,14 @@ fn thread_drop_delete_thread_current_recovery_preserves_delete_flag() {
     heddle(&["init"], Some(temp.path())).unwrap();
 
     let output = heddle_output(
-        &["--output", "json", "thread", "drop", "main", "--delete-thread"],
+        &[
+            "--output",
+            "json",
+            "thread",
+            "drop",
+            "main",
+            "--delete-thread",
+        ],
         Some(temp.path()),
     )
     .expect("invoke destructive current thread drop");
@@ -6184,7 +6187,10 @@ fn branch_delete_current_recovery_preserves_delete_mode() {
         Some(temp.path()),
     )
     .expect("invoke current branch delete");
-    assert!(!output.status.success(), "current branch delete should refuse");
+    assert!(
+        !output.status.success(),
+        "current branch delete should refuse"
+    );
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).expect("branch delete should emit JSON envelope");
@@ -6207,15 +6213,21 @@ fn thread_drop_delete_thread_recovery_retry_actually_deletes_ref() {
 
     // Refused while `main` is the current checkout.
     let refused = heddle_output(
-        &["--output", "json", "thread", "drop", "main", "--delete-thread"],
+        &[
+            "--output",
+            "json",
+            "thread",
+            "drop",
+            "main",
+            "--delete-thread",
+        ],
         Some(temp.path()),
     )
     .expect("invoke destructive current thread drop");
     assert!(!refused.status.success());
 
     // Follow the advice: create a sibling and switch to it.
-    heddle(&["thread", "create", "feature"], Some(temp.path()))
-        .expect("create a sibling thread");
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("create a sibling thread");
     heddle(&["thread", "switch", "feature"], Some(temp.path()))
         .expect("switch to the sibling thread");
 
@@ -6239,8 +6251,7 @@ fn thread_drop_delete_thread_recovery_retry_actually_deletes_ref() {
 fn thread_drop_current_recovery_points_to_switch_when_sibling_exists() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["thread", "create", "feature"], Some(temp.path()))
-        .expect("create a sibling thread");
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("create a sibling thread");
 
     let output = heddle_output(
         &["--output", "json", "thread", "drop", "main"],
@@ -6272,16 +6283,14 @@ fn thread_drop_current_recovery_points_to_switch_when_sibling_exists() {
     let switch = templates
         .iter()
         .find(|template| {
-            template["argv_template"]
-                == heddle_argv_json(["thread", "switch", "<other>"])
+            template["argv_template"] == heddle_argv_json(["thread", "switch", "<other>"])
         })
         .unwrap_or_else(|| panic!("switch recovery template should be present: {stderr}"));
     assert_eq!(switch["agent_may_fill"], Value::Bool(true));
     // Both recovery paths are exposed so machine callers can choose.
     assert!(
         templates.iter().any(|template| {
-            template["argv_template"]
-                == heddle_argv_json(["thread", "create", "<other>"])
+            template["argv_template"] == heddle_argv_json(["thread", "create", "<other>"])
         }),
         "create recovery template should also be present: {stderr}"
     );
@@ -10329,8 +10338,7 @@ fn actor_explain_detached_head_recommends_minting_spawn_not_no_thread() {
     // Detached HEAD: recommend the minting form (mints a dedicated thread),
     // NOT `--no-thread`, which cannot succeed without a current thread.
     assert_eq!(
-        parsed["recommended_action"],
-        "heddle actor spawn --provider openai --model gpt-5.3-codex",
+        parsed["recommended_action"], "heddle actor spawn --provider openai --model gpt-5.3-codex",
         "detached HEAD should recommend the thread-minting spawn form: {parsed}"
     );
     assert!(
@@ -11016,7 +11024,10 @@ fn doctor_schemas_reports_runtime_and_documented_coverage() {
         "doctor schemas should summarize the machine-contract result at the top level: {output}"
     );
     assert_eq!(parsed["recommended_action"], serde_json::Value::Null);
-    assert_eq!(parsed["recommended_action_template"], serde_json::Value::Null);
+    assert_eq!(
+        parsed["recommended_action_template"],
+        serde_json::Value::Null
+    );
     assert_eq!(parsed["recovery_commands"], serde_json::json!([]));
     assert_eq!(
         parsed["unmatched_verbs"].as_array().map(Vec::len),
@@ -12217,8 +12228,8 @@ fn read_commands_gate_repository_preamble_on_verbose() {
             Some(temp.path()),
         )
         .unwrap_or_else(|e| panic!("{label} json should render: {e}"));
-        let parsed: Value =
-            serde_json::from_str(&json).unwrap_or_else(|e| panic!("{label} json should parse: {e}"));
+        let parsed: Value = serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("{label} json should parse: {e}"));
         assert!(
             parsed["repository_capability"].is_string(),
             "{label} json must keep repository_capability: {json}"

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -27,13 +27,12 @@
 
 use std::collections::BTreeSet;
 
-use serde_json::Value;
-use tempfile::TempDir;
-
 use cli::cli::commands::{
     CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog,
     documented_samples_with_bound_verbs, schema_for_verb,
 };
+use serde_json::Value;
+use tempfile::TempDir;
 
 use super::{heddle, heddle_output};
 
@@ -389,11 +388,10 @@ fn kind_field_exceptions_use_kind_intentionally() {
             .commands
             .iter()
             .find(|c| c.display == display)
-            .unwrap_or_else(|| panic!("`{display}` listed in KIND_FIELD_EXCEPTIONS is not in the catalog"));
-        let has_kind = entry
-            .json_discriminators
-            .iter()
-            .any(|d| d.field == "kind");
+            .unwrap_or_else(|| {
+                panic!("`{display}` listed in KIND_FIELD_EXCEPTIONS is not in the catalog")
+            });
+        let has_kind = entry.json_discriminators.iter().any(|d| d.field == "kind");
         assert!(
             has_kind,
             "`{display}` is documented as a `kind`-rather-than-output_kind exception but the catalog declares no `kind` discriminator. Update the catalog or drop the exception."
@@ -625,7 +623,9 @@ fn init_fixture() -> TempDir {
 /// whether the verb is expected to exit zero. Some named verbs need a
 /// non-trivial fixture (e.g. `revert` requires a state to revert); we
 /// skip those here and rely on dedicated tests elsewhere.
-fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bool /* expect_ok */)> {
+fn runtime_invocation_args(
+    display: &str,
+) -> Option<(&'static [&'static str], bool /* expect_ok */)> {
     match display {
         "stack" => Some((&["stack"], true)),
         "stack ready" => Some((&["stack", "ready"], true)),
@@ -678,8 +678,7 @@ fn runtime_init_emits_output_kind() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let first_line = stdout.lines().next().unwrap_or("").trim();
-    let parsed: Value =
-        serde_json::from_str(first_line).expect("init stdout is parseable JSON");
+    let parsed: Value = serde_json::from_str(first_line).expect("init stdout is parseable JSON");
     assert_eq!(
         parsed.get("output_kind").and_then(|v| v.as_str()),
         Some("init"),
@@ -691,8 +690,8 @@ fn runtime_init_emits_output_kind() {
 /// `dir`. Panics with the captured output on failure so doc-vs-runtime
 /// mismatches surface a readable diff.
 fn runtime_top_level_keys(argv: &[&str], dir: &std::path::Path) -> BTreeSet<String> {
-    let output = heddle_output(argv, Some(dir))
-        .unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
+    let output =
+        heddle_output(argv, Some(dir)).unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
     assert!(
         output.status.success(),
         "{argv:?} exited non-zero: stdout={} stderr={}",
@@ -793,8 +792,11 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         "stack_ready" => (init_fixture(), sv(&["stack", "ready"])),
         "stack_snapshot" => {
             let t = init_fixture();
-            heddle(&["start", "feature-x", "--workspace", "solid"], Some(t.path()))
-                .expect("start feature-x");
+            heddle(
+                &["start", "feature-x", "--workspace", "solid"],
+                Some(t.path()),
+            )
+            .expect("start feature-x");
             (t, sv(&["stack", "snapshot", "--thread", "feature-x"]))
         }
         "stash_list" => (init_fixture(), sv(&["stash", "list"])),
@@ -824,7 +826,15 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             (
                 t,
-                sv(&["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"]),
+                sv(&[
+                    "redact",
+                    "apply",
+                    "HEAD",
+                    "--path",
+                    "secrets.env",
+                    "--reason",
+                    "credential",
+                ]),
             )
         }
         "purge_apply" => {
@@ -832,7 +842,15 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             std::fs::write(t.path().join("secrets.env"), "TOKEN=abc").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             heddle(
-                &["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"],
+                &[
+                    "redact",
+                    "apply",
+                    "HEAD",
+                    "--path",
+                    "secrets.env",
+                    "--reason",
+                    "credential",
+                ],
                 Some(t.path()),
             )
             .expect("redact apply");
@@ -844,15 +862,25 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         "redact_trust_add" => (
             init_fixture(),
             sv(&[
-                "redact", "trust", "add", "--public-key", "abc123def456", "--algorithm", "ed25519",
-                "--label", "security",
+                "redact",
+                "trust",
+                "add",
+                "--public-key",
+                "abc123def456",
+                "--algorithm",
+                "ed25519",
+                "--label",
+                "security",
             ]),
         ),
         "discuss_open" => {
             let t = init_fixture();
             std::fs::write(t.path().join("a.txt"), "fn verify(){}").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
-            (t, sv(&["discuss", "open", "a.txt", "verify", "check edge case"]))
+            (
+                t,
+                sv(&["discuss", "open", "a.txt", "verify", "check edge case"]),
+            )
         }
         "discuss_list" => (init_fixture(), sv(&["discuss", "list"])),
         "context_set" => {
@@ -861,7 +889,16 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             (
                 t,
-                sv(&["context", "set", "--path", "a.txt", "--scope", "file", "-m", "owner note"]),
+                sv(&[
+                    "context",
+                    "set",
+                    "--path",
+                    "a.txt",
+                    "--scope",
+                    "file",
+                    "-m",
+                    "owner note",
+                ]),
             )
         }
         "context_list" => (init_fixture(), sv(&["context", "list"])),

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -30,8 +30,11 @@ fn init_and_capture() -> TempDir {
 
 /// Capture a second state on top of the seeded one so `HEAD~1` resolves.
 fn capture_second(temp: &TempDir) {
-    fs::write(temp.path().join("main.rs"), "fn main() { println!(\"hi\"); }\n")
-        .expect("modify main.rs");
+    fs::write(
+        temp.path().join("main.rs"),
+        "fn main() { println!(\"hi\"); }\n",
+    )
+    .expect("modify main.rs");
     heddle(&["capture", "-m", "second"], Some(temp.path())).expect("second capture");
 }
 
@@ -169,9 +172,9 @@ fn clean_dry_run_emits_output_kind() {
         value
             .get("removed")
             .and_then(|v| v.as_array())
-            .is_some_and(|arr| arr.iter().any(|entry| entry
-                .as_str()
-                .is_some_and(|s| s.contains("stray.txt")))),
+            .is_some_and(|arr| arr
+                .iter()
+                .any(|entry| entry.as_str().is_some_and(|s| s.contains("stray.txt")))),
         "clean --dry-run must list the would-remove paths: {value}"
     );
 }
@@ -373,9 +376,7 @@ fn purge_apply_emits_output_kind() {
     .expect("redact apply");
 
     let value = heddle_json(
-        &[
-            "purge", "apply", &state, "--path", "main.rs", "--force",
-        ],
+        &["purge", "apply", &state, "--path", "main.rs", "--force"],
         &temp,
     );
     assert_output_kind(&value, "purge_apply");
@@ -474,10 +475,7 @@ fn context_set_get_history_audit_check_emit_output_kind() {
         "context suggest envelope must carry an `items` array: {suggest}"
     );
 
-    let rm = heddle_json(
-        &["context", "rm", "--path", "main.rs", "--all"],
-        &temp,
-    );
+    let rm = heddle_json(&["context", "rm", "--path", "main.rs", "--all"], &temp);
     assert_output_kind(&rm, "context_rm");
     assert_eq!(rm["removed"].as_bool(), Some(true));
 }
@@ -500,8 +498,16 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
     let populated_temp = init_and_capture();
     heddle(
         &[
-            "context", "set", "--path", "main.rs", "--scope", "file", "--kind",
-            "rationale", "-m", "entry point",
+            "context",
+            "set",
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "rationale",
+            "-m",
+            "entry point",
         ],
         Some(populated_temp.path()),
     )
@@ -530,7 +536,10 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
         "context list row must keep its `target`: {populated}"
     );
     assert!(
-        items[0].get("annotations").and_then(|v| v.as_array()).is_some(),
+        items[0]
+            .get("annotations")
+            .and_then(|v| v.as_array())
+            .is_some(),
         "context list row must keep its `annotations` array: {populated}"
     );
 }
@@ -539,16 +548,7 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
 fn discuss_open_show_append_emit_output_kind() {
     let temp = init_and_capture();
 
-    let open = heddle_json(
-        &[
-            "discuss",
-            "open",
-            "main.rs",
-            "main",
-            "first turn",
-        ],
-        &temp,
-    );
+    let open = heddle_json(&["discuss", "open", "main.rs", "main", "first turn"], &temp);
     assert_output_kind(&open, "discuss_open");
     let discussion_id = open["id"]
         .as_str()
@@ -568,10 +568,7 @@ fn discuss_open_show_append_emit_output_kind() {
     // Flattened `turns` field must surface both turns at the top
     // level — the envelope must not nest the discussion payload.
     assert_eq!(
-        show["turns"]
-            .as_array()
-            .map(|arr| arr.len())
-            .unwrap_or(0),
+        show["turns"].as_array().map(|arr| arr.len()).unwrap_or(0),
         2,
         "discuss show must flatten `turns` at the top level: {show}"
     );
@@ -635,9 +632,7 @@ fn purge_list_envelope_includes_recent_apply() {
     )
     .expect("redact apply");
     heddle(
-        &[
-            "purge", "apply", &state, "--path", "main.rs", "--force",
-        ],
+        &["purge", "apply", &state, "--path", "main.rs", "--force"],
         Some(temp.path()),
     )
     .expect("purge apply");
@@ -658,8 +653,11 @@ fn stack_snapshot_text_mode_still_emits_envelope_with_output_kind() {
     // sessions can still route on it.
     let temp = init_and_capture();
     detach_head(&temp);
-    let output = heddle_output(&["--output", "text", "stack", "snapshot"], Some(temp.path()))
-        .expect("invoke stack snapshot text");
+    let output = heddle_output(
+        &["--output", "text", "stack", "snapshot"],
+        Some(temp.path()),
+    )
+    .expect("invoke stack snapshot text");
     assert!(
         output.status.success(),
         "stack snapshot text must succeed: stderr={}",

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -61,8 +61,8 @@ fn piped_status_with_explicit_json_flag_emits_json() {
 
     let stdout = heddle(&["status", "--output", "json"], Some(temp.path()))
         .expect("status --output json should succeed under a pipe");
-    let parsed: Value =
-        serde_json::from_str(&stdout).unwrap_or_else(|err| panic!("JSON parse failed: {err}: {stdout}"));
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("JSON parse failed: {err}: {stdout}"));
     assert!(
         parsed.is_object(),
         "status --output json should emit a JSON object: {stdout}"
@@ -152,9 +152,8 @@ fn repo_config_with_output_format_auto_errors_with_typed_envelope() {
         .lines()
         .rfind(|line| line.trim_start().starts_with('{'))
         .unwrap_or_else(|| panic!("expected a JSON envelope on stderr; got: {stderr_json_text}"));
-    let envelope: Value = serde_json::from_str(last_line.trim()).unwrap_or_else(|err| {
-        panic!("stderr JSON envelope should parse: {err}: {last_line}")
-    });
+    let envelope: Value = serde_json::from_str(last_line.trim())
+        .unwrap_or_else(|err| panic!("stderr JSON envelope should parse: {err}: {last_line}"));
     assert_eq!(
         envelope["kind"], "invalid_repo_config_output_format",
         "JSON envelope kind should classify the field-specific failure: {envelope}"
@@ -281,8 +280,7 @@ fn user_config_with_output_format_auto_via_home_path_errors_with_typed_envelope(
     let fake_home = temp.path();
     let config_path = fake_home.join(".config").join("heddle").join("config.toml");
     std::fs::create_dir_all(config_path.parent().unwrap()).expect("mkdir config parent");
-    std::fs::write(&config_path, "[output]\nformat = \"auto\"\n")
-        .expect("write bad home config");
+    std::fs::write(&config_path, "[output]\nformat = \"auto\"\n").expect("write bad home config");
 
     let text_out = run_with_home_user_config(fake_home, None, &["status"]);
     assert!(

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -942,7 +942,11 @@ fn quickstart_resolves_principal_from_shared_dir_in_materialized_checkout() {
     )
     .unwrap();
     assert!(
-        checkout.path().join(".heddle").join("objectstore").is_file(),
+        checkout
+            .path()
+            .join(".heddle")
+            .join("objectstore")
+            .is_file(),
         "checkout must be a materialized (objectstore-pointer) checkout"
     );
 
@@ -1311,7 +1315,10 @@ fn quickstart_native_repo_nested_in_git_checkout_is_not_overlay_refused() {
         Some("native-heddle"),
         "the nested repo stays native, not a Git overlay: {init}"
     );
-    assert!(inner.join(".heddle").is_dir(), "native .heddle/ was created");
+    assert!(
+        inner.join(".heddle").is_dir(),
+        "native .heddle/ was created"
+    );
 }
 
 /// Codex r7 (cid 3329270259): in a materialized checkout whose `.heddle/`
@@ -1349,7 +1356,11 @@ fn quickstart_resolves_shared_checkout_parent_git_identity() {
     )
     .unwrap();
     assert!(
-        checkout.path().join(".heddle").join("objectstore").is_file(),
+        checkout
+            .path()
+            .join(".heddle")
+            .join("objectstore")
+            .is_file(),
         "checkout must be a materialized (objectstore-pointer) checkout"
     );
 
@@ -1482,7 +1493,10 @@ fn quickstart_from_subdir_targets_discovered_native_repo() {
     let temp = TempDir::new().unwrap();
     let root = temp.path();
     heddle(&["init", "--no-harness-install"], Some(root)).unwrap();
-    assert!(root.join(".heddle").is_dir(), "native repo created at the root");
+    assert!(
+        root.join(".heddle").is_dir(),
+        "native repo created at the root"
+    );
 
     let sub = root.join("nested").join("deeper");
     std::fs::create_dir_all(&sub).unwrap();

--- a/crates/cli/tests/cli_integration/refs_and_history.rs
+++ b/crates/cli/tests/cli_integration/refs_and_history.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::*;
 use objects::object::ThreadName;
+
+use super::*;
 
 #[test]
 fn test_cli_track_operations() {

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::*;
 use objects::object::{MarkerName, ThreadName};
+
+use super::*;
 
 fn heddle_without_git_for_remote_tests(args: &[&str], cwd: &std::path::Path) -> String {
     let output = heddle_output_with_env(args, Some(cwd), &[("PATH", ""), ("NO_COLOR", "1")])
@@ -908,9 +909,13 @@ fn git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated() 
         "removing a remote defined in an uneditable include must refuse, not partially apply"
     );
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
-    let envelope: Value = serde_json::from_str(stderr)
-        .unwrap_or_else(|err| panic!("uneditable-include refusal should emit JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "git_remote_in_included_config", "{stderr}");
+    let envelope: Value = serde_json::from_str(stderr).unwrap_or_else(|err| {
+        panic!("uneditable-include refusal should emit JSON: {err}: {stderr}")
+    });
+    assert_eq!(
+        envelope["kind"], "git_remote_in_included_config",
+        "{stderr}"
+    );
 
     // No partial state: every config the command could have touched is unchanged.
     assert_eq!(
@@ -2984,16 +2989,18 @@ fn test_cli_fetch_local_creates_remote_thread_and_marker() {
     assert!(heddle(&["fetch", "origin"], Some(local.path())).is_ok());
 
     let repo = Repository::open(local.path()).unwrap();
-    assert!(repo
-        .refs()
-        .get_remote_thread("origin", &ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_remote_thread("origin", &ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/thread_cleanup.rs
+++ b/crates/cli/tests/cli_integration/thread_cleanup.rs
@@ -18,11 +18,10 @@
 //! storage and visibility halves are what `thread list` and
 //! `thread cleanup` actually read.
 
-use objects::store::ObjectStore;
 use std::fs;
 
 use chrono::{Duration, Utc};
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 use repo::{
     Repository, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadIntegrationPolicy,
     ThreadManager, ThreadMode, ThreadState, ThreadVerificationSummary,
@@ -317,7 +316,10 @@ fn thread_cleanup_merged_drops_matching_threads() {
         dropped.state
     );
     assert!(
-        repo.refs().get_thread(&ThreadName::new("feat/done")).unwrap().is_none(),
+        repo.refs()
+            .get_thread(&ThreadName::new("feat/done"))
+            .unwrap()
+            .is_none(),
         "merged cleanup should remove the live thread ref so default surfaces stop treating it as active"
     );
     let default_view = list_thread_names(temp.path(), &[]);

--- a/crates/cli/tests/comprehensive/performance.rs
+++ b/crates/cli/tests/comprehensive/performance.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{path::Path, process::Command};
 
+use objects::store::ObjectStore;
 use repo::Repository;
 
 use super::*;

--- a/crates/cli/tests/conflict_resolution.rs
+++ b/crates/cli/tests/conflict_resolution.rs
@@ -5,8 +5,10 @@
 //! the lifecycle a stack-aware rebase produces — start → resolve →
 //! finish / abort / carry_forward.
 
-use objects::store::ObjectStore;
-use objects::object::{ChangeId, ThreadName};
+use objects::{
+    object::{ChangeId, ThreadName},
+    store::ObjectStore,
+};
 use repo::{MergeState, MergeStateManager, Repository};
 use tempfile::TempDir;
 
@@ -136,16 +138,18 @@ fn test_non_conflicting_changes() {
 
     // These changes don't conflict - different files
     // A merge would succeed
-    assert!(repo
-        .store()
-        .get_state(&branch1.change_id)
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .store()
-        .get_state(&branch2.change_id)
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.store()
+            .get_state(&branch1.change_id)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.store()
+            .get_state(&branch2.change_id)
+            .unwrap()
+            .is_some()
+    );
 }
 
 /// Test fast-forward merge detection.

--- a/crates/cli/tests/core_functionality/diff_and_status.rs
+++ b/crates/cli/tests/core_functionality/diff_and_status.rs
@@ -87,7 +87,11 @@ fn test_diff_worktree_json_groups_changes_by_category() {
             .map(|entry| entry["path"].as_str().unwrap_or_default().to_string())
             .collect()
     };
-    assert_eq!(paths("modified"), vec!["modified.txt".to_string()], "{json}");
+    assert_eq!(
+        paths("modified"),
+        vec!["modified.txt".to_string()],
+        "{json}"
+    );
     assert_eq!(paths("added"), vec!["added.txt".to_string()], "{json}");
     assert_eq!(paths("deleted"), vec!["delete.txt".to_string()], "{json}");
 }

--- a/crates/cli/tests/core_functionality/history_navigation.rs
+++ b/crates/cli/tests/core_functionality/history_navigation.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use objects::store::ObjectStore;
+
 use super::*;
 
 #[test]

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::*;
 use objects::object::ThreadName;
+
+use super::*;
 
 /// Convenience: read the current state's short change-id by opening the repo
 /// directly. Used by undo tests that assert HEAD has moved to a specific state.
@@ -111,10 +112,11 @@ fn test_undo_preserves_ignored_siblings_in_tracked_dirs() {
     assert!(!temp.path().join("main.rs").exists());
     assert!(!temp.path().join("web/index.html").exists());
     // Ignored siblings preserved across the apply.
-    assert!(temp
-        .path()
-        .join("web/node_modules/lodash/index.js")
-        .exists());
+    assert!(
+        temp.path()
+            .join("web/node_modules/lodash/index.js")
+            .exists()
+    );
     assert!(temp.path().join("target/foo.bin").exists());
 
     // HEAD advanced and disk matches state — no divergence.
@@ -140,11 +142,8 @@ fn test_undo_refuses_when_untracked_file_present() {
     let untracked = temp.path().join("my-notes.md");
     std::fs::write(&untracked, "user-written content").unwrap();
 
-    let err = heddle(
-        &["undo", "-n", "1", "--output", "json"],
-        Some(temp.path()),
-    )
-    .expect_err("undo must refuse on dirty worktree");
+    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
+        .expect_err("undo must refuse on dirty worktree");
     assert!(
         err.contains("untracked"),
         "error should mention untracked: {err}"
@@ -168,11 +167,8 @@ fn test_undo_refuses_when_tracked_file_modified() {
 
     std::fs::write(temp.path().join("a.txt"), "uncommitted edit").unwrap();
 
-    let err = heddle(
-        &["undo", "-n", "1", "--output", "json"],
-        Some(temp.path()),
-    )
-    .expect_err("undo must refuse with modified file");
+    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
+        .expect_err("undo must refuse with modified file");
     assert!(
         err.contains("modified"),
         "error should mention modified: {err}"
@@ -659,7 +655,10 @@ fn test_undo_recovery_lives_outside_user_marker_namespace() {
     heddle_must_succeed(&["marker", "delete", "undo-recovery"], temp.path());
     let repo = Repository::open(temp.path()).unwrap();
     assert_eq!(
-        repo.refs().get_undo_recovery().unwrap().map(|id| id.short()),
+        repo.refs()
+            .get_undo_recovery()
+            .unwrap()
+            .map(|id| id.short()),
         Some(friction_state),
         "user marker create/delete must not touch the internal recovery ref"
     );

--- a/crates/cli/tests/lazy_blob_hydration_kernel.rs
+++ b/crates/cli/tests/lazy_blob_hydration_kernel.rs
@@ -21,7 +21,6 @@
 //!   on-read hydration completes against a real promisor remote. Run
 //!   it with `cargo test -p heddle-cli --test lazy_blob_hydration_kernel -- --include-ignored`.
 
-use objects::store::ObjectStore;
 use std::{
     path::Path,
     sync::Arc,
@@ -29,7 +28,7 @@ use std::{
 };
 
 use cli::{bridge::git_core::clone_url_to_bare, cli::commands::GitOverlayBlobHydrator};
-use objects::object::Blob;
+use objects::{object::Blob, store::ObjectStore};
 use repo::Repository;
 use tempfile::TempDir;
 

--- a/crates/cli/tests/multi_agent_worktrees.rs
+++ b/crates/cli/tests/multi_agent_worktrees.rs
@@ -184,10 +184,7 @@ fn head_track(path: &std::path::Path) -> String {
 /// is omitted from the wire). This helper grafts the proof back onto
 /// the returned value for test ergonomics by invoking
 /// `heddle verify --output json` after the original call.
-pub(crate) fn inject_post_verification_at(
-    cwd: &std::path::Path,
-    mut value: Value,
-) -> Value {
+pub(crate) fn inject_post_verification_at(cwd: &std::path::Path, mut value: Value) -> Value {
     let obj = match value.as_object_mut() {
         Some(obj) => obj,
         None => return value,

--- a/crates/cli/tests/multi_agent_worktrees/materialized_threads_e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/materialized_threads_e2e.rs
@@ -252,9 +252,7 @@ fn short_status_surfaces_stale_materialized_thread_advisory() {
         .as_array()
         .and_then(|arr| arr.iter().find(|m| m["name"] == "feature/short-stale"))
         .unwrap_or_else(|| {
-            panic!(
-                "json status must list feature/short-stale after manifest rewrite:\n{json_out}"
-            )
+            panic!("json status must list feature/short-stale after manifest rewrite:\n{json_out}")
         });
     assert_eq!(
         entry["stale"], true,

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests for verifying system behavior with large repositories and files.
 
-use objects::store::ObjectStore;
 use std::{
     path::Path,
     process::Command,
@@ -11,7 +10,10 @@ use std::{
 
 use objects::{
     object::{Blob, ChangeId, ContentHash},
-    store::{CompressionConfig, PackBuilder, PackObjectId, pack::ObjectType as PackObjectType},
+    store::{
+        CompressionConfig, ObjectStore, PackBuilder, PackObjectId,
+        pack::ObjectType as PackObjectType,
+    },
 };
 use proto::{ObjectData, ObjectId, ObjectType};
 use repo::Repository;

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -3,10 +3,10 @@
 //!
 //! Tests for resolve, fetch, fsck, clone, cherry-pick, rebase, bisect, blame, gc.
 
-use objects::store::ObjectStore;
 use std::{fs, process::Command, str};
 
 use ntest::timeout;
+use objects::store::ObjectStore;
 use serde_json::Value;
 use serial_test::serial;
 use tempfile::TempDir;

--- a/crates/cli/tests/stack_rebase.rs
+++ b/crates/cli/tests/stack_rebase.rs
@@ -158,8 +158,12 @@ fn plan_rebase_emits_bfs_steps_against_real_thread_records() {
 
     std::fs::write(temp.path().join("file.txt"), "base").unwrap();
     let base = repo.snapshot(Some("base".to_string()), None).unwrap();
-    repo.refs().set_thread(&ThreadName::new("main"), &base.change_id).unwrap();
-    repo.refs().set_thread(&ThreadName::new("feat-a"), &base.change_id).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &base.change_id)
+        .unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("feat-a"), &base.change_id)
+        .unwrap();
 
     std::fs::write(temp.path().join("file.txt"), "feat-a content").unwrap();
     let feat_a_tip = repo.snapshot(Some("feat-a".to_string()), None).unwrap();
@@ -196,7 +200,9 @@ fn plan_rebase_emits_bfs_steps_against_real_thread_records() {
     // Move main forward so the planner has somewhere to rebase onto.
     std::fs::write(temp.path().join("main-only.txt"), "main work").unwrap();
     let new_main = repo.snapshot(Some("main moved".to_string()), None).unwrap();
-    repo.refs().set_thread(&ThreadName::new("main"), &new_main.change_id).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &new_main.change_id)
+        .unwrap();
 
     let plan = repo
         .plan_thread_stack_rebase("feat-a", "main")

--- a/crates/cli/tests/state_management/merge_store_integrity.rs
+++ b/crates/cli/tests/state_management/merge_store_integrity.rs
@@ -11,10 +11,9 @@
 //! than committing data loss. The second one exercises a legitimate
 //! "tree doesn't exist at this path" case (a directory rename) and
 //! asserts the new error path doesn't false-positive.
-use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
-use objects::object::ThreadName;
+use objects::{object::ThreadName, store::ObjectStore};
 use repo::Repository;
 use tempfile::TempDir;
 

--- a/crates/cli/tests/state_management/missing_tree_integrity.rs
+++ b/crates/cli/tests/state_management/missing_tree_integrity.rs
@@ -13,11 +13,12 @@
 //! `heddle fsck` — pre-fix the same scenario produced silent, plausible-
 //! looking output that masked store corruption.
 
-use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
-use objects::object::ContentHash;
-use objects::object::ThreadName;
+use objects::{
+    object::{ContentHash, ThreadName},
+    store::ObjectStore,
+};
 use repo::Repository;
 use tempfile::TempDir;
 

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -6,7 +6,6 @@ mod hydration;
 mod sync;
 mod user;
 
-use objects::store::ObjectStore;
 use cli_shared::ClientConfig;
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::v1::{
@@ -15,7 +14,7 @@ use grpc::heddle::v1::{
     hosted_user_service_client::HostedUserServiceClient, mint_biscuit_request::Proof,
     repo_sync_service_client::RepoSyncServiceClient,
 };
-use objects::object::MarkerName;
+use objects::{object::MarkerName, store::ObjectStore};
 use proto::ProtocolError;
 use repo::Repository;
 use tonic::{

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -1,4 +1,3 @@
-use objects::store::ObjectStore;
 use std::{
     collections::HashMap,
     time::{Duration, Instant},
@@ -13,7 +12,7 @@ use grpc::heddle::v1::{
 };
 use objects::{
     object::{ChangeId, ContentHash, MarkerName, ThreadName},
-    store::PackObjectId,
+    store::{ObjectStore, PackObjectId},
 };
 use proto::{ObjectType, ProtocolError, PullComplete, PushComplete, RefEntry, RefUpdated};
 use repo::{Repository, SyncedThreadMetadata, ThreadManager};
@@ -771,7 +770,8 @@ impl HostedGrpcClient {
                         if let Some(local_thread) = options.local_thread
                             && let Some(state) = final_state
                         {
-                            repo.refs().set_thread(&ThreadName::from(local_thread), &state)?;
+                            repo.refs()
+                                .set_thread(&ThreadName::from(local_thread), &state)?;
                         }
                         if let Some(state) = final_state
                             && allow_partial_fetch

--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -23,7 +23,7 @@ impl Ed25519Signer {
     }
 
     pub fn from_pem(pem: &str) -> Result<Self, SignerError> {
-        use crate::pem_loader::{classify_pem, PemKind};
+        use crate::pem_loader::{PemKind, classify_pem};
 
         match classify_pem(pem) {
             PemKind::Pkcs8 => Self::from_pkcs8_pem(pem),

--- a/crates/crypto/src/p256.rs
+++ b/crates/crypto/src/p256.rs
@@ -2,11 +2,11 @@
 //! P-256 (ECDSA) signature implementation.
 
 use p256::{
-    ecdsa::{
-        signature::{Signer as SignatureSigner, Verifier as SignatureVerifier},
-        Signature, SigningKey, VerifyingKey,
-    },
     SecretKey,
+    ecdsa::{
+        Signature, SigningKey, VerifyingKey,
+        signature::{Signer as SignatureSigner, Verifier as SignatureVerifier},
+    },
 };
 use pkcs8::DecodePrivateKey;
 use rsa::{pkcs1::DecodeRsaPrivateKey, rand_core::OsRng};

--- a/crates/crypto/src/rsa.rs
+++ b/crates/crypto/src/rsa.rs
@@ -3,7 +3,7 @@
 
 use pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePublicKey};
 use rsa::{
-    pkcs1::DecodeRsaPrivateKey, rand_core::OsRng, Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey,
+    Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey, pkcs1::DecodeRsaPrivateKey, rand_core::OsRng,
 };
 use sha2::{Digest, Sha256};
 
@@ -40,7 +40,7 @@ impl RsaSigner {
     }
 
     pub fn from_pem(pem: &str) -> Result<Self, SignerError> {
-        use crate::pem_loader::{classify_pem, PemKind};
+        use crate::pem_loader::{PemKind, classify_pem};
 
         let private_key =
             match classify_pem(pem) {

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -11,7 +11,6 @@
 //! state's blob only. A cross-state index is W2 follow-up work and is
 //! flagged with `// TODO(W2-followup):` comments.
 
-use objects::store::ObjectStore;
 use grpc::heddle::v1::{
     AppendTurnRequest, Discussion as ProtoDiscussion,
     DiscussionResolution as ProtoDiscussionResolution, DiscussionTurn as ProtoDiscussionTurn,
@@ -19,9 +18,12 @@ use grpc::heddle::v1::{
     ListDiscussionsResponse, OpenDiscussionRequest, PathSymbolRef, ResolveDiscussionRequest,
     discussion_service_server::DiscussionService,
 };
-use objects::object::{
-    AnnotationVisibility, Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn,
-    DiscussionsBlob, Principal, State, SymbolAnchor,
+use objects::{
+    object::{
+        AnnotationVisibility, Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn,
+        DiscussionsBlob, Principal, State, SymbolAnchor,
+    },
+    store::ObjectStore,
 };
 use prost::Message;
 use repo::Repository;

--- a/crates/daemon/src/grpc_local_impl/operation_log_query.rs
+++ b/crates/daemon/src/grpc_local_impl/operation_log_query.rs
@@ -64,7 +64,12 @@ fn build_query(req: &QueryOperationsRequest) -> OperationLogQuery {
         // a hand-maintained list — so a new `OpRecord` variant is surfaced by
         // default the moment it joins the catalog, instead of being silently
         // dropped from the default query (heddle#354 r9, cid 3330304663).
-        q.verbs = Some(OpRecord::verbs(false).iter().map(|s| s.to_string()).collect());
+        q.verbs = Some(
+            OpRecord::verbs(false)
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
     }
     q
 }
@@ -230,8 +235,9 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::GitCheckpoint { state, .. } => Some(*state),
         OpRecord::EphemeralThreadCollapse { final_state, .. } => Some(*final_state),
         OpRecord::Redact { state, .. } => Some(*state),
-        OpRecord::RemoteThreadUpdate { state, .. }
-        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. } | OpRecord::RemoteThreadDelete { state, .. } => {
+            Some(*state)
+        }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
@@ -404,7 +410,11 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert_eq!(resp.hits.len(), 1, "newer non-checkpoint verb must not be dropped");
+        assert_eq!(
+            resp.hits.len(),
+            1,
+            "newer non-checkpoint verb must not be dropped"
+        );
         assert_eq!(resp.hits[0].verb, "transaction_commit");
     }
 

--- a/crates/daemon/src/grpc_local_impl/signal.rs
+++ b/crates/daemon/src/grpc_local_impl/signal.rs
@@ -4,7 +4,6 @@
 //! window. The actual signal *computation* lands in R3 (`crates/state_review`);
 //! this service exposes whatever's already on disk.
 
-use objects::store::ObjectStore;
 use std::{collections::HashMap, pin::Pin};
 
 use futures::Stream;
@@ -14,7 +13,10 @@ use grpc::heddle::v1::{
     SignalAnchor as ProtoSignalAnchor, SignalHealthEntry, SignalUpdate,
     SubscribeSignalUpdatesRequest, signal_service_server::SignalService,
 };
-use objects::object::{ChangeId, RiskSignal, RiskSignalBlob, State};
+use objects::{
+    object::{ChangeId, RiskSignal, RiskSignalBlob, State},
+    store::ObjectStore,
+};
 use repo::Repository;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};

--- a/crates/daemon/src/grpc_local_impl/state_review.rs
+++ b/crates/daemon/src/grpc_local_impl/state_review.rs
@@ -8,7 +8,6 @@
 // `::state_review` disambiguates from this module's own name
 // (`grpc_local_impl::state_review`), the same way the hosted impl
 // disambiguates by being in a sibling module.
-use objects::store::ObjectStore;
 use ::state_review::{
     PathSymbol, ReadingOrderPartition, SymbolKind, build_review_payload_partition,
 };
@@ -29,6 +28,7 @@ use objects::{
         ReviewScope, ReviewSignature, ReviewSignaturesBlob, RiskSignalBlob, State, SymbolAnchor,
         signing_payload,
     },
+    store::ObjectStore,
     worktree::diff_blobs,
 };
 use prost::Message;

--- a/crates/devtools/src/check_atomic_ledger_encapsulation.rs
+++ b/crates/devtools/src/check_atomic_ledger_encapsulation.rs
@@ -234,9 +234,7 @@ fn pred_can_be_true_without_test(meta: &Meta) -> bool {
         // The `test` atom is false in a non-test build; any other atom is free.
         Meta::Path(path) => !path.is_ident("test"),
         Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
-            Some(children) if children.len() == 1 => {
-                pred_can_be_false_without_test(&children[0])
-            }
+            Some(children) if children.len() == 1 => pred_can_be_false_without_test(&children[0]),
             _ => true,
         },
         Meta::List(list) if list.path.is_ident("all") => match cfg_children(list) {
@@ -261,9 +259,7 @@ fn pred_can_be_false_without_test(meta: &Meta) -> bool {
         // atom is free and can be left unset.
         Meta::Path(_) => true,
         Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
-            Some(children) if children.len() == 1 => {
-                pred_can_be_true_without_test(&children[0])
-            }
+            Some(children) if children.len() == 1 => pred_can_be_true_without_test(&children[0]),
             _ => true,
         },
         // `all` is false if any child can be false; `any` is false only if every
@@ -382,7 +378,11 @@ mod tests {
                 do_forward()?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "an out-of-module on_rewind call must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "an out-of-module on_rewind call must be flagged"
+        );
     }
 
     #[test]
@@ -405,23 +405,33 @@ mod tests {
                 fn drives_primitive(tx: &mut Tx) { tx.on_rewind(|| Ok(())); } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     #[test]
     fn ignores_string_literal() {
         let hits = scan_source("fn f() { let s = \"tx.on_rewind(x)\"; let _ = s; }");
-        assert!(hits.is_empty(), "a string mentioning on_rewind is not a call");
+        assert!(
+            hits.is_empty(),
+            "a string mentioning on_rewind is not a call"
+        );
     }
 
     #[test]
     fn atomic_module_path_is_recognized() {
-        assert!(is_atomic_module_path(Path::new("crates/repo/src/atomic/tx.rs")));
+        assert!(is_atomic_module_path(Path::new(
+            "crates/repo/src/atomic/tx.rs"
+        )));
         assert!(is_atomic_module_path(Path::new(
             "/work/crates/repo/src/atomic/tests.rs"
         )));
         // A sibling `atomic` dir under a different crate is NOT exempt.
-        assert!(!is_atomic_module_path(Path::new("crates/cli/src/atomic/x.rs")));
+        assert!(!is_atomic_module_path(Path::new(
+            "crates/cli/src/atomic/x.rs"
+        )));
         assert!(!is_atomic_module_path(Path::new(
             "crates/cli/src/cli/commands/undo_apply.rs"
         )));
@@ -504,7 +514,11 @@ mod tests {
             "#[cfg(any(test, feature = \"x\"))] \
              fn prod(tx: &mut Tx) { tx.on_rewind(|| Ok(())); }",
         );
-        assert_eq!(hits.len(), 1, "any(test, feature) is prod-reachable and must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "any(test, feature) is prod-reachable and must be flagged"
+        );
     }
 
     #[test]
@@ -562,7 +576,10 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "out-of-module on_rewind call site(s) found: {:?}",

--- a/crates/devtools/src/check_oprecord_exhaustiveness.rs
+++ b/crates/devtools/src/check_oprecord_exhaustiveness.rs
@@ -268,9 +268,7 @@ impl<'ast> Visit<'ast> for Finder<'_> {
 /// enum — return its name. Catches `OpRecord::Snapshot { .. }`,
 /// `OpRecord::Fork(..)`, and or-patterns / refs / parens thereof.
 fn matched_target_enum(node: &ExprMatch) -> Option<String> {
-    node.arms
-        .iter()
-        .find_map(|arm| pat_target_enum(&arm.pat))
+    node.arms.iter().find_map(|arm| pat_target_enum(&arm.pat))
 }
 
 fn pat_target_enum(pat: &Pat) -> Option<String> {
@@ -382,14 +380,16 @@ mod tests {
                 OpRecord::Snapshot { .. } | _ => {} \
             } }",
         );
-        assert_eq!(hits.len(), 1, "wildcard inside an or-pattern must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "wildcard inside an or-pattern must be flagged"
+        );
     }
 
     #[test]
     fn flags_o_p_kind_match_too() {
-        let hits = scan_source(
-            "fn f(k: OpKind) { match k { OpKind::Snapshot => a(), _ => {} } }",
-        );
+        let hits = scan_source("fn f(k: OpKind) { match k { OpKind::Snapshot => a(), _ => {} } }");
         assert_eq!(hits.len(), 1, "OpKind is also a target enum");
         assert_eq!(hits[0].enum_name, "OpKind");
     }
@@ -416,15 +416,17 @@ mod tests {
                 OpRecord::Goto { .. } => c(), \
             } }",
         );
-        assert!(hits.is_empty(), "a guarded catch-all is not a silent swallow");
+        assert!(
+            hits.is_empty(),
+            "a guarded catch-all is not a silent swallow"
+        );
     }
 
     #[test]
     fn ignores_wildcard_over_non_target_enum() {
         // A `match` over a string/other enum legitimately uses `_`.
-        let hits = scan_source(
-            "fn f(kind: &str) -> u8 { match kind { \"snapshot\" => 1, _ => 0 } }",
-        );
+        let hits =
+            scan_source("fn f(kind: &str) -> u8 { match kind { \"snapshot\" => 1, _ => 0 } }");
         assert!(hits.is_empty(), "non-target matches keep their wildcard");
     }
 
@@ -433,9 +435,8 @@ mod tests {
         // `matches!` expands to a macro, not an `ExprMatch`, so its internal
         // `_ => false` is invisible to the source AST — the idiomatic predicate
         // stays allowed.
-        let hits = scan_source(
-            "fn f(op: &OpRecord) -> bool { matches!(op, OpRecord::Snapshot { .. }) }",
-        );
+        let hits =
+            scan_source("fn f(op: &OpRecord) -> bool { matches!(op, OpRecord::Snapshot { .. }) }");
         assert!(hits.is_empty(), "matches! predicate must not be flagged");
     }
 
@@ -447,7 +448,10 @@ mod tests {
                 fn t(op: &OpRecord) { match op { OpRecord::Snapshot { .. } => a(), _ => {} } } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     const PLANTED: &str = "fn f(op: &OpRecord) { match op { \
@@ -502,12 +506,21 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "non-exhaustive OpRecord/OpKind match(es) found: {:?}",
             hits.iter()
-                .map(|h| format!("{}:{} ({} arm `{}`)", h.path.display(), h.line, h.enum_name, h.arm))
+                .map(|h| format!(
+                    "{}:{} ({} arm `{}`)",
+                    h.path.display(),
+                    h.line,
+                    h.enum_name,
+                    h.arm
+                ))
                 .collect::<Vec<_>>()
         );
     }

--- a/crates/devtools/src/check_snapshot_atomicity.rs
+++ b/crates/devtools/src/check_snapshot_atomicity.rs
@@ -221,16 +221,18 @@ fn is_cfg_test(attrs: &[Attribute]) -> bool {
     fn meta_mentions_test(meta: &Meta) -> bool {
         match meta {
             Meta::Path(path) => path.is_ident("test"),
-            Meta::List(list) if list.path.is_ident("cfg") => list.tokens.to_string().contains("test"),
+            Meta::List(list) if list.path.is_ident("cfg") => {
+                list.tokens.to_string().contains("test")
+            }
             Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
                 list.tokens.to_string().contains("test")
             }
             _ => false,
         }
     }
-    attrs.iter().any(|attr| {
-        attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta)
-    })
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta))
 }
 
 struct Finder<'a> {
@@ -445,7 +447,11 @@ mod tests {
                 self.oplog.record_snapshot(&id, p, th, s)?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "publish via aliased refs handle must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "publish via aliased refs handle must be flagged"
+        );
         assert_eq!(hits[0].method, "set_thread");
     }
 
@@ -460,7 +466,11 @@ mod tests {
                 self.oplog.record_snapshot(&id, p, th, s)?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "publish via aliased accessor handle must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "publish via aliased accessor handle must be flagged"
+        );
         assert_eq!(hits[0].method, "write_head");
     }
 
@@ -562,7 +572,10 @@ mod tests {
                 } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     #[test]
@@ -621,7 +634,10 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "cross-crate publish-first snapshot site(s) found: {:?}",

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -26,9 +26,7 @@ fn main() -> Result<()> {
         Some("check-atomic-ledger-encapsulation") => {
             check_atomic_ledger_encapsulation::run(args.collect())
         }
-        Some("check-oprecord-exhaustiveness") => {
-            check_oprecord_exhaustiveness::run(args.collect())
-        }
+        Some("check-oprecord-exhaustiveness") => check_oprecord_exhaustiveness::run(args.collect()),
         Some("fuse-dispatch-bench") => fuse_dispatch_bench::run(args.collect()),
         Some(command) => bail!("unknown command '{command}'"),
         None => bail!("expected a command (for example: web-proto)"),

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -20,8 +20,8 @@ use std::path::{Path, PathBuf};
 use objects::{
     object::{Blob, ChangeId, ContentHash, Tree, TreeEntry},
     store::{
-        pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
         CompressionConfig, ObjectStore,
+        pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
     },
 };
 use oplog::oplog::{OpLog, OpLogBackend};
@@ -29,12 +29,12 @@ use refs::refs::RefBackend;
 use tracing::info;
 
 use crate::{
+    IngestError,
     git_walk::{CommitEntry, GitSource, RefDiscoveryStats, TreeChild, TreeChildKind},
     oplog_emit::{OplogEmitStats, OplogEmitter},
     ref_emit::{RefEmitStats, RefEmitter},
     sha_map::ShaMap,
     state_writer::state_from_commit,
-    IngestError,
 };
 
 /// Counters reported back from [`Importer::run`] — the post-import
@@ -89,12 +89,7 @@ pub struct Importer<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend = OpLog> 
 }
 
 impl<'a, R: RefBackend, S: ObjectStore> Importer<'a, R, S, OpLog> {
-    pub fn new(
-        git: &'a GitSource,
-        store: &'a S,
-        refs: &'a R,
-        map: &'a mut ShaMap,
-    ) -> Self {
+    pub fn new(git: &'a GitSource, store: &'a S, refs: &'a R, map: &'a mut ShaMap) -> Self {
         Self {
             git,
             store,
@@ -610,10 +605,11 @@ mod tests {
         assert_eq!(stats.refs.markers_written, 1); // v0.1
         assert_eq!(stats.refs.skipped_unmapped, 0);
         assert!(refs.get_thread(&ThreadName::new("main")).unwrap().is_some());
-        assert!(refs
-            .get_thread(&ThreadName::new("feature/x"))
-            .unwrap()
-            .is_some());
+        assert!(
+            refs.get_thread(&ThreadName::new("feature/x"))
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
@@ -632,7 +628,8 @@ mod tests {
 
         let first = pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
         let states_after_first = store.list_states().unwrap().len();
-        let second = pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
+        let second =
+            pollster::block_on(Importer::new(&git, &store, &refs, &mut map).run()).unwrap();
         let states_after_second = store.list_states().unwrap().len();
 
         assert_eq!(first.commits_imported, second.commits_imported);

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -51,7 +51,7 @@ use objects::object::{MarkerName, ThreadName};
 use oplog::oplog::OpLogBackend;
 use tracing::warn;
 
-use crate::{git_walk::ReflogEntry, sha_map::ShaMap, IngestError};
+use crate::{IngestError, git_walk::ReflogEntry, sha_map::ShaMap};
 
 /// Rolling tally returned by [`OplogEmitter::emit`].
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/crates/ingest/src/reasoning_emit.rs
+++ b/crates/ingest/src/reasoning_emit.rs
@@ -44,11 +44,13 @@
 //! (`session:{session_id}`), so operators can traverse from an
 //! annotation back to the transcript on disk.
 
-use objects::store::ObjectStore;
 use std::collections::HashMap;
 
 use chrono::Utc;
-use objects::object::{Annotation, AnnotationScope, AnnotationStatus, ContextBlob, ContextTarget};
+use objects::{
+    object::{Annotation, AnnotationScope, AnnotationStatus, ContextBlob, ContextTarget},
+    store::ObjectStore,
+};
 use repo::Repository;
 use tracing::debug;
 

--- a/crates/ingest/src/ref_emit.rs
+++ b/crates/ingest/src/ref_emit.rs
@@ -32,9 +32,9 @@ use refs::refs::{RefBackend, RefExpectation};
 use tracing::warn;
 
 use crate::{
+    IngestError,
     git_walk::{RefHead, RefNamespace},
     sha_map::ShaMap,
-    IngestError,
 };
 
 /// Rolling tally returned by [`RefEmitter::emit`].

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -2989,9 +2989,7 @@ impl<S: ObjectStore> MountInner<S> {
 /// weak handle and drains any hot buffer that's been idle longer
 /// than `idle_after`. A `None` `sweep_interval` returns `None`,
 /// meaning event-driven promotion only.
-fn spawn_sweep_worker<S: ObjectStore + 'static>(
-    inner: &Arc<MountInner<S>>,
-) -> Option<SweepHandle> {
+fn spawn_sweep_worker<S: ObjectStore + 'static>(inner: &Arc<MountInner<S>>) -> Option<SweepHandle> {
     let interval = inner
         .promotion
         .read()

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -11,8 +11,8 @@ use std::{
     ffi::OsStr,
     fs,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -47,15 +47,15 @@ pub(crate) mod mocks {
     use std::{
         ffi::OsStr,
         sync::{
-            atomic::{AtomicUsize, Ordering},
             Arc,
+            atomic::{AtomicUsize, Ordering},
         },
         time::UNIX_EPOCH,
     };
 
     use crate::{
         error::{MountError, Result},
-        shell::{Attrs, Entry, NodeId, NodeKind, PlatformShell, DIR_UNIX_MODE},
+        shell::{Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell},
     };
 
     /// Trivial in-memory shell that lets adapter unit tests validate
@@ -1631,10 +1631,12 @@ mod write_ops {
         mount
             .rmdir_entry(NodeId::ROOT, OsStr::new("scratch"))
             .expect("rmdir");
-        assert!(mount
-            .lookup(NodeId::ROOT, OsStr::new("scratch"))
-            .unwrap()
-            .is_none());
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("scratch"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// `rmdir_entry` on a directory that has any visible child (pending

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -49,9 +49,7 @@ pub use state_context::{
     Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus,
     AnnotationVisibility, ContextBlob, ContextError, ContextTarget,
 };
-pub use state_core::{
-    SignatureStatus, State, StateSignature, Status, Verification,
-};
+pub use state_core::{SignatureStatus, State, StateSignature, Status, Verification};
 pub use state_provenance::{FileProvenance, LineSpan, Origin, OriginSet, ProvenanceError};
 pub use state_review::{
     ReviewKind, ReviewScope, ReviewSignature, ReviewSignatureError, ReviewSignaturesBlob,
@@ -60,5 +58,7 @@ pub use state_review::{
 pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
 };
-pub use tree::{EntryType, FileMode, Tree, TreeEntry, TreeError, validate_name as validate_tree_entry_name};
+pub use tree::{
+    EntryType, FileMode, Tree, TreeEntry, TreeError, validate_name as validate_tree_entry_name,
+};
 pub use tree_diff::diff_trees;

--- a/crates/objects/src/object/tree.rs
+++ b/crates/objects/src/object/tree.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree types: entries, structure, and supporting enums.
 
-use std::fmt;
-use std::path::Path;
+use std::{fmt, path::Path};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -691,13 +691,19 @@ mod any_store_tests {
         // ── Blobs ──
         let blob = Blob::from("any-store dispatch blob");
         let blob_hash = store.put_blob(&blob).unwrap();
-        assert_eq!(store.get_blob(&blob_hash).unwrap().unwrap().content(), blob.content());
+        assert_eq!(
+            store.get_blob(&blob_hash).unwrap().unwrap().content(),
+            blob.content()
+        );
         assert!(store.has_blob(&blob_hash).unwrap());
         assert_eq!(
             store.get_blob_bytes(&blob_hash).unwrap().unwrap().as_ref(),
             blob.content()
         );
-        assert_eq!(store.blob_size(&blob_hash).unwrap().unwrap(), blob.content().len() as u64);
+        assert_eq!(
+            store.blob_size(&blob_hash).unwrap().unwrap(),
+            blob.content().len() as u64
+        );
         assert!(store.loose_blob_path(&blob_hash).is_some());
         store.promote_to_loose_uncompressed(&blob_hash).unwrap();
         assert!(store.list_blobs().unwrap().contains(&blob_hash));
@@ -726,7 +732,9 @@ mod any_store_tests {
         let tree2 = Tree::new();
         let tree2_bytes = rmp_serde::to_vec_named(&tree2).unwrap();
         assert_eq!(
-            store.put_tree_serialized(&tree2_bytes, tree2.hash()).unwrap(),
+            store
+                .put_tree_serialized(&tree2_bytes, tree2.hash())
+                .unwrap(),
             tree2.hash()
         );
 
@@ -797,10 +805,18 @@ mod any_store_tests {
             .unwrap();
         assert!(store.has_redactions_for_blob(&blob_hash).unwrap());
         assert_eq!(
-            store.get_redactions_bytes_for_blob(&blob_hash).unwrap().as_deref(),
+            store
+                .get_redactions_bytes_for_blob(&blob_hash)
+                .unwrap()
+                .as_deref(),
             Some(redaction.as_slice())
         );
-        assert!(store.list_blobs_with_redactions().unwrap().contains(&blob_hash));
+        assert!(
+            store
+                .list_blobs_with_redactions()
+                .unwrap()
+                .contains(&blob_hash)
+        );
 
         // ── Caches ──
         store.clear_recent_caches();

--- a/crates/objects/src/store/pack/pack_reader.rs
+++ b/crates/objects/src/store/pack/pack_reader.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use bytes::Bytes;
 
 use super::{
-    decompress_pack_payload, has_zstd_magic, pack_container_spec, pack_index::PackIndex, varint,
-    verify_container, ObjectType, PackObjectId, PackObjectRecord,
+    ObjectType, PackObjectId, PackObjectRecord, decompress_pack_payload, has_zstd_magic,
+    pack_container_spec, pack_index::PackIndex, varint, verify_container,
 };
 use crate::{
     object::ContentHash,
@@ -68,10 +68,7 @@ impl PackReader<'static> {
         })
     }
 
-    pub fn from_bytes(
-        pack_data: impl Into<Bytes>,
-        index_data: impl AsRef<[u8]>,
-    ) -> Result<Self> {
+    pub fn from_bytes(pack_data: impl Into<Bytes>, index_data: impl AsRef<[u8]>) -> Result<Self> {
         let pack_data = pack_data.into();
         let (_, _, content_end) = verify_container(&pack_data, pack_container_spec())?;
         let index = PackIndex::from_bytes(index_data.as_ref())?;
@@ -427,7 +424,7 @@ fn verify_record_id_matches(requested: &PackObjectId, found: &PackObjectId) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::{verify_record_id_matches, PackObjectId, PackReader};
+    use super::{PackObjectId, PackReader, verify_record_id_matches};
     use crate::{object::ContentHash, store::StoreError};
 
     #[test]

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -3,11 +3,11 @@
 
 use tempfile::TempDir;
 
-use super::{pack_index::PackIndex, ObjectType, PackBuilder, PackObjectId, PackReader};
+use super::{ObjectType, PackBuilder, PackObjectId, PackReader, pack_index::PackIndex};
 use crate::{
     delta::MAX_DELTA_OUTPUT_SIZE,
     object::{ChangeId, ContentHash},
-    store::{compression::CompressionConfig, pack::pack_container_spec, StoreError},
+    store::{StoreError, compression::CompressionConfig, pack::pack_container_spec},
 };
 
 fn create_test_hash(n: u8) -> ContentHash {
@@ -503,7 +503,7 @@ fn test_pack_reader_missing_object_returns_none() {
 /// with the expected diagnostic phrase.
 #[test]
 fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
-    use crate::store::{pack::pack_index::PackIndex, StoreError};
+    use crate::store::{StoreError, pack::pack_index::PackIndex};
 
     let blob_a = b"alpha-payload alpha-payload alpha-payload alpha".to_vec();
     let blob_b = b"bravo-payload bravo-payload bravo-payload bravo".to_vec();

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -8,8 +8,7 @@ use std::{
 use objects::object::{ChangeId, ContentHash};
 use tempfile::TempDir;
 
-use super::oplog_backend::OpLogBackend;
-use super::{OpLog, OpRecord};
+use super::{OpLog, OpRecord, oplog_backend::OpLogBackend};
 
 fn create_oplog() -> (TempDir, OpLog) {
     let temp_dir = TempDir::new().unwrap();
@@ -870,11 +869,12 @@ mod default_backend {
     use std::sync::{Arc, Mutex};
 
     use chrono::Utc;
-    use objects::error::Result;
-    use objects::object::Principal;
+    use objects::{error::Result, object::Principal};
 
-    use super::super::oplog_types::{OpBatch, OpEntry, OpRecord};
-    use super::OpLogBackend;
+    use super::{
+        super::oplog_types::{OpBatch, OpEntry, OpRecord},
+        OpLogBackend,
+    };
 
     #[derive(Default)]
     struct MemOpLog {

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -684,8 +684,9 @@ impl OpBatch {
 
 #[cfg(test)]
 mod verb_catalog_tests {
-    use super::*;
     use objects::object::{ChangeId, ContentHash};
+
+    use super::*;
 
     fn cid() -> ChangeId {
         ChangeId::from_bytes([7; 16])

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -5,11 +5,13 @@
 //! that model: v2 is accepted only as a migration source, and v3 is the latest
 //! single-file container with an EOF index footer.
 
-use std::cmp::Reverse;
-use std::collections::{BTreeMap, HashMap};
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, HashMap},
+    fs::{File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
 
 use chrono::{TimeZone, Utc};
 use objects::{

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -462,8 +462,10 @@ pub fn is_ancestor(
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use objects::object::{Principal, Redaction};
-    use objects::store::ObjectStore;
+    use objects::{
+        object::{Principal, Redaction},
+        store::ObjectStore,
+    };
     use repo::Repository;
     use tempfile::TempDir;
 

--- a/crates/refs/src/refs/backend.rs
+++ b/crates/refs/src/refs/backend.rs
@@ -105,11 +105,12 @@ pub trait CoreRefBackend: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::{collections::HashMap, sync::Mutex};
 
-    use objects::error::HeddleError;
-    use objects::object::{ChangeId, MarkerName, ThreadName};
+    use objects::{
+        error::HeddleError,
+        object::{ChangeId, MarkerName, ThreadName},
+    };
 
     use super::CoreRefBackend;
     use crate::refs::{Head, RefBackend, RefExpectation, RefUpdate};
@@ -352,9 +353,7 @@ mod tests {
 
         // write_head_cas writes through to the head slot.
         let head = Head::Detached { state: head_id };
-        backend
-            .write_head_cas(RefExpectation::Any, &head)
-            .unwrap();
+        backend.write_head_cas(RefExpectation::Any, &head).unwrap();
         assert_eq!(backend.read_head().unwrap(), head);
 
         // set_thread_cas inserts; list_threads + get_thread observe it.

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -7,8 +7,8 @@ mod name;
 pub mod operation_index;
 mod packed_model;
 mod packed_refs;
-mod ref_backend;
 mod reconcile;
+mod ref_backend;
 mod ref_summary_index;
 mod refs_head;
 mod refs_manager;
@@ -39,10 +39,8 @@ pub use operation_index::{IndexedOperation, OperationLogIndex, OperationLogQuery
 pub use packed_model::PackedRefsModel;
 #[cfg(feature = "postgres")]
 pub use pg_refs::PgRefBackend;
+pub use reconcile::{LoadRequest, Loaded, ReconcileOutcome, RefClass, RefCommitter, RefReconciler};
 pub use ref_backend::RefBackend;
-pub use reconcile::{
-    Loaded, LoadRequest, RefClass, RefCommitter, RefReconciler, ReconcileOutcome,
-};
 pub use ref_summary_index::RefSummaryIndexInspection;
 pub use refs_manager::{RefManager, UNDO_RECOVERY_HANDLE};
 pub use reftable_model::{ReftableError, ReftableModel};

--- a/crates/refs/src/refs/pg_refs.rs
+++ b/crates/refs/src/refs/pg_refs.rs
@@ -244,7 +244,11 @@ impl CoreRefBackend for PgRefBackend {
         let name = name.to_string();
         self.block(async move { let row = sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = true RETURNING change_id").bind(repo_id).bind(&name).fetch_optional(pool.as_ref()).await.map_err(sqlx_err)?; row.map(|r| { let bytes: Vec<u8> = r.try_get("change_id").map_err(sqlx_err)?; Self::bytes_to_id(bytes) }).transpose() })
     }
-    fn delete_thread_cas(&self, name: &ThreadName, expected: RefExpectation<ChangeId>) -> Result<()> {
+    fn delete_thread_cas(
+        &self,
+        name: &ThreadName,
+        expected: RefExpectation<ChangeId>,
+    ) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -278,7 +282,9 @@ impl CoreRefBackend for PgRefBackend {
             .map_err(sqlx_err)?
             .rows_affected();
         if n == 0 {
-            Err(HeddleError::Conflict(format!("marker '{name}' already exists")))
+            Err(HeddleError::Conflict(format!(
+                "marker '{name}' already exists"
+            )))
         } else {
             Ok(())
         }
@@ -301,7 +307,11 @@ impl CoreRefBackend for PgRefBackend {
         let name = name.to_string();
         self.block(async move { let row = sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = false RETURNING change_id").bind(repo_id).bind(&name).fetch_optional(pool.as_ref()).await.map_err(sqlx_err)?; row.map(|r| { let bytes: Vec<u8> = r.try_get("change_id").map_err(sqlx_err)?; Self::bytes_to_id(bytes) }).transpose() })
     }
-    fn delete_marker_cas(&self, name: &MarkerName, expected: RefExpectation<ChangeId>) -> Result<()> {
+    fn delete_marker_cas(
+        &self,
+        name: &MarkerName,
+        expected: RefExpectation<ChangeId>,
+    ) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -363,7 +373,11 @@ impl RefBackend for PgRefBackend {
             "remote threading refs are not supported on the server backend".into(),
         ))
     }
-    fn delete_remote_thread(&self, _remote: &str, _thread: &ThreadName) -> Result<Option<ChangeId>> {
+    fn delete_remote_thread(
+        &self,
+        _remote: &str,
+        _thread: &ThreadName,
+    ) -> Result<Option<ChangeId>> {
         Err(HeddleError::Conflict(
             "remote threading refs are not supported on the server backend".into(),
         ))

--- a/crates/refs/src/refs/ref_backend.rs
+++ b/crates/refs/src/refs/ref_backend.rs
@@ -9,7 +9,7 @@ use objects::{
     object::{ChangeId, ThreadName},
 };
 
-use super::{backend::CoreRefBackend, RefSummaryIndexInspection, RefUpdate};
+use super::{RefSummaryIndexInspection, RefUpdate, backend::CoreRefBackend};
 
 /// Backend-agnostic interface for reading and writing repository references.
 pub trait RefBackend: CoreRefBackend<Error = HeddleError> {

--- a/crates/refs/src/refs/refs_head.rs
+++ b/crates/refs/src/refs/refs_head.rs
@@ -6,7 +6,7 @@ use objects::{
     object::{ChangeId, ThreadName},
 };
 
-use super::{parse_change_id_text, Head, RefManager};
+use super::{Head, RefManager, parse_change_id_text};
 
 pub(super) struct HeadState {
     pub head: Head,

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Reference manager: threads, markers, HEAD, and packed refs.
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use objects::{
     error::{HeddleError, Result},

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -152,11 +152,7 @@ fn test_corerefbackend_trait_methods_dispatch() {
 
     CoreRefBackend::set_thread(&refs, &ThreadName::new("main"), &thread_id).unwrap();
     assert_eq!(
-        pollster::block_on(CoreRefBackend::get_thread(
-            &refs,
-            &ThreadName::new("main")
-        ))
-        .unwrap(),
+        pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main"))).unwrap(),
         Some(thread_id)
     );
 
@@ -538,16 +534,20 @@ fn undo_recovery_is_scoped_per_checkout_on_shared_ref_root() {
 // record-before-publish ordering — without the `repo`/`oplog` layer.
 
 mod chokepoint {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    };
 
-    use objects::error::Result;
-    use objects::object::{ChangeId, MarkerName, ThreadName};
+    use objects::{
+        error::Result,
+        object::{ChangeId, MarkerName, ThreadName},
+    };
     use tempfile::TempDir;
 
     use super::super::{
-        Loaded, LoadRequest, RefCommitter, RefManager, RefReconciler, ReconcileOutcome,
-        RefExpectation, RefUpdate,
+        LoadRequest, Loaded, ReconcileOutcome, RefCommitter, RefExpectation, RefManager,
+        RefReconciler, RefUpdate,
     };
 
     fn manager() -> (TempDir, std::path::PathBuf) {
@@ -574,7 +574,12 @@ mod chokepoint {
         fn generation(&self) -> Result<u64> {
             Ok(self.generation.load(Ordering::Acquire))
         }
-        fn reconcile(&self, req: &LoadRequest, raw: Loaded, _since: u64) -> Result<ReconcileOutcome> {
+        fn reconcile(
+            &self,
+            req: &LoadRequest,
+            raw: Loaded,
+            _since: u64,
+        ) -> Result<ReconcileOutcome> {
             self.calls.fetch_add(1, Ordering::AcqRel);
             // Project the request's authoritative value out of the configured
             // materialization set (mirrors the real reconciler's per-request fold).
@@ -583,7 +588,9 @@ mod chokepoint {
                     .republish
                     .iter()
                     .find_map(|u| match u {
-                        RefUpdate::Thread { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        RefUpdate::Thread { name: n, new, .. } if n == name => {
+                            Some(Loaded::Point(*new))
+                        }
                         _ => None,
                     })
                     .unwrap_or(raw),
@@ -591,7 +598,9 @@ mod chokepoint {
                     .republish
                     .iter()
                     .find_map(|u| match u {
-                        RefUpdate::Marker { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        RefUpdate::Marker { name: n, new, .. } if n == name => {
+                            Some(Loaded::Point(*new))
+                        }
                         _ => None,
                     })
                     .unwrap_or(raw),
@@ -648,7 +657,11 @@ mod chokepoint {
         // Generation still 7 ⇒ tip == cached ⇒ reconcile is never invoked.
         let got = refs.get_thread(&ThreadName::new("absent")).unwrap();
         assert_eq!(got, None);
-        assert_eq!(calls.load(Ordering::Acquire), 0, "hot path must not reconcile");
+        assert_eq!(
+            calls.load(Ordering::Acquire),
+            0,
+            "hot path must not reconcile"
+        );
     }
 
     /// The lag path drives `materialize`'s authoritative-apply branches: an
@@ -711,24 +724,37 @@ mod chokepoint {
                 },
             ],
             remote_updates: vec![
-                ("origin".to_string(), ThreadName::new("rt"), Some(remote_state)),
+                (
+                    "origin".to_string(),
+                    ThreadName::new("rt"),
+                    Some(remote_state),
+                ),
                 // `None` value, canonical absent — skipped.
                 ("origin".to_string(), ThreadName::new("gone"), None),
                 // Present-but-stale remote thread ⇒ overwritten with committed value.
-                ("origin".to_string(), ThreadName::new("rt_stale"), Some(remote_stale_new)),
+                (
+                    "origin".to_string(),
+                    ThreadName::new("rt_stale"),
+                    Some(remote_stale_new),
+                ),
                 // Present remote thread the fold deleted ⇒ removed.
                 ("origin".to_string(), ThreadName::new("rt_doomed"), None),
             ],
             undo_recovery: Some(undo_state),
             calls: Arc::clone(&calls),
         });
-        let refs = RefManager::new(&dir).with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
+        let refs = RefManager::new(&dir)
+            .with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
         refs.init().unwrap();
         // Publish present + stale AFTER injection (raw writes, bypass chokepoint).
-        refs.set_thread(&ThreadName::new("present"), &present_state).unwrap();
-        refs.set_thread(&ThreadName::new("stale"), &stale_old).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt_stale"), &remote_stale_old).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt_doomed"), &remote_doomed).unwrap();
+        refs.set_thread(&ThreadName::new("present"), &present_state)
+            .unwrap();
+        refs.set_thread(&ThreadName::new("stale"), &stale_old)
+            .unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_stale"), &remote_stale_old)
+            .unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_doomed"), &remote_doomed)
+            .unwrap();
         refs.set_undo_recovery(&undo_old).unwrap();
 
         // Bump generation so the next read lags ⇒ reconcile + materialize run.
@@ -749,19 +775,25 @@ mod chokepoint {
             Some(stale_new),
             "a stale present ref must be overwritten with the committed value"
         );
-        assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
+            refs.get_marker(&MarkerName::new("mk")).unwrap(),
+            Some(marker_state)
+        );
+        assert_eq!(
+            refs.get_remote_thread("origin", &ThreadName::new("rt"))
+                .unwrap(),
             Some(remote_state)
         );
         // The stale remote thread is overwritten; the doomed one is removed.
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt_stale")).unwrap(),
+            refs.get_remote_thread("origin", &ThreadName::new("rt_stale"))
+                .unwrap(),
             Some(remote_stale_new),
             "a stale present remote thread must be overwritten with the committed value"
         );
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt_doomed")).unwrap(),
+            refs.get_remote_thread("origin", &ThreadName::new("rt_doomed"))
+                .unwrap(),
             None,
             "a committed delete must remove a present remote thread"
         );
@@ -771,7 +803,11 @@ mod chokepoint {
         // Second read: watermark now == generation (2) ⇒ hot path, no new reconcile.
         let before = calls.load(Ordering::Acquire);
         let _ = refs.get_thread(&ThreadName::new("absent")).unwrap();
-        assert_eq!(calls.load(Ordering::Acquire), before, "watermark caught up ⇒ hot path");
+        assert_eq!(
+            calls.load(Ordering::Acquire),
+            before,
+            "watermark caught up ⇒ hot path"
+        );
     }
 
     /// `commit_and_publish` appends the ref-carrying records (phase 4) before
@@ -783,7 +819,8 @@ mod chokepoint {
         let committer = Arc::new(FakeCommitter {
             seen: Mutex::new(Vec::new()),
         });
-        let refs = RefManager::new(&dir).with_committer(Arc::clone(&committer) as Arc<dyn RefCommitter>);
+        let refs =
+            RefManager::new(&dir).with_committer(Arc::clone(&committer) as Arc<dyn RefCommitter>);
         refs.init().unwrap();
 
         let state = ChangeId::generate();
@@ -793,7 +830,8 @@ mod chokepoint {
             expected: RefExpectation::Missing,
             new: Some(state),
         }];
-        refs.commit_and_publish(&records, &updates, Some("lane")).unwrap();
+        refs.commit_and_publish(&records, &updates, Some("lane"))
+            .unwrap();
 
         // The committer saw the records (phase 4) and the ref published (phase 5).
         let seen = committer.seen.lock().unwrap();
@@ -824,7 +862,10 @@ mod chokepoint {
                 None,
             )
             .unwrap();
-        assert_eq!(plain.get_marker(&MarkerName::new("v2")).unwrap(), Some(other));
+        assert_eq!(
+            plain.get_marker(&MarkerName::new("v2")).unwrap(),
+            Some(other)
+        );
     }
 
     /// Fail closed (heddle#354 r9, cid 3330304656): a `commit_and_publish` with
@@ -874,7 +915,10 @@ mod chokepoint {
         // phase-3 read of the still-missing ref (which needs no write perm)
         // succeeds — isolating a publish-after-commit failure.
         let threads_dir = refs.threads_dir();
-        let original = std::fs::metadata(&threads_dir).unwrap().permissions().mode();
+        let original = std::fs::metadata(&threads_dir)
+            .unwrap()
+            .permissions()
+            .mode();
         std::fs::set_permissions(&threads_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let lock = refs.lock_refs().unwrap();
@@ -913,20 +957,27 @@ mod chokepoint {
         let s2 = ChangeId::generate();
         // RefBackend trait surface for remotes.
         RefBackend::set_remote_thread(&refs, "origin", &ThreadName::new("rt1"), &s1).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt2"), &s2).unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt2"), &s2)
+            .unwrap();
         assert_eq!(
             RefBackend::get_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap(),
             Some(s1)
         );
-        assert!(RefBackend::list_remotes(&refs).unwrap().contains(&"origin".to_string()));
+        assert!(
+            RefBackend::list_remotes(&refs)
+                .unwrap()
+                .contains(&"origin".to_string())
+        );
         let mut rts = RefBackend::list_remote_threads(&refs, "origin").unwrap();
         rts.sort();
         assert_eq!(rts.len(), 2);
-        let removed = RefBackend::delete_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap();
+        let removed =
+            RefBackend::delete_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap();
         assert_eq!(removed, Some(s1));
         // Deleting an absent remote thread returns None.
         assert_eq!(
-            refs.delete_remote_thread("origin", &ThreadName::new("nope")).unwrap(),
+            refs.delete_remote_thread("origin", &ThreadName::new("nope"))
+                .unwrap(),
             None
         );
 
@@ -944,12 +995,22 @@ mod chokepoint {
         assert_eq!(refs.resolve("rel").unwrap(), Some(m));
 
         // CoreRefBackend async + sync delegations.
-        let got = pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main2"))).unwrap();
+        let got = pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main2")))
+            .unwrap();
         assert_eq!(got, Some(t));
-        let gm = pollster::block_on(CoreRefBackend::get_marker(&refs, &MarkerName::new("rel"))).unwrap();
+        let gm =
+            pollster::block_on(CoreRefBackend::get_marker(&refs, &MarkerName::new("rel"))).unwrap();
         assert_eq!(gm, Some(m));
-        assert!(CoreRefBackend::list_threads(&refs).unwrap().contains(&ThreadName::new("main2")));
-        assert!(CoreRefBackend::list_markers(&refs).unwrap().contains(&MarkerName::new("rel")));
+        assert!(
+            CoreRefBackend::list_threads(&refs)
+                .unwrap()
+                .contains(&ThreadName::new("main2"))
+        );
+        assert!(
+            CoreRefBackend::list_markers(&refs)
+                .unwrap()
+                .contains(&MarkerName::new("rel"))
+        );
         let r = pollster::block_on(CoreRefBackend::resolve(&refs, "main2")).unwrap();
         assert_eq!(r, Some(t));
 
@@ -1231,8 +1292,7 @@ mod write_read_conformance {
     #[test]
     fn read_chokepoint_refreshes_watermark_fresh() {
         assert!(
-            first_body(&[MANAGER_SRC], "reconciled_load")
-                .contains("refresh_persisted_watermark("),
+            first_body(&[MANAGER_SRC], "reconciled_load").contains("refresh_persisted_watermark("),
             "the read chokepoint must re-read the persisted watermark each reconcile"
         );
     }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -255,11 +255,11 @@ impl RefManager {
                 }
                 RefUpdate::Head { expected, new } => {
                     let raw_state = self.read_head_state()?;
-                    let reconciled_head = match self.reconciled_value_under_lock(&LoadRequest::Head)?
-                    {
-                        Loaded::Head(head) => head,
-                        _ => unreachable!("Head request yields Head"),
-                    };
+                    let reconciled_head =
+                        match self.reconciled_value_under_lock(&LoadRequest::Head)? {
+                            Loaded::Head(head) => head,
+                            _ => unreachable!("Head request yields Head"),
+                        };
                     // HEAD "exists" if its file is present OR a committed record
                     // reconstructs a value the stale on-disk HEAD does not reflect.
                     let exists = raw_state.exists || reconciled_head != raw_state.head;
@@ -496,14 +496,18 @@ impl RefManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
 
     use objects::object::MarkerName;
     use tempfile::TempDir;
 
-    use super::super::reconcile::{LoadRequest, Loaded, ReconcileOutcome, RefReconciler};
-    use super::*;
+    use super::{
+        super::reconcile::{LoadRequest, Loaded, ReconcileOutcome, RefReconciler},
+        *,
+    };
 
     fn create_ref_manager() -> (TempDir, RefManager) {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/repo/src/atomic/committer.rs
+++ b/crates/repo/src/atomic/committer.rs
@@ -9,8 +9,10 @@
 
 use std::path::{Path, PathBuf};
 
-use objects::error::{HeddleError, Result};
-use objects::object::Principal;
+use objects::{
+    error::{HeddleError, Result},
+    object::Principal,
+};
 use oplog::{OpLog, OpRecord};
 use refs::RefCommitter;
 

--- a/crates/repo/src/atomic/execute.rs
+++ b/crates/repo/src/atomic/execute.rs
@@ -15,8 +15,10 @@ use std::{
 use objects::error::{HeddleError, Result};
 use oplog::IsolationPrecondition;
 
-use super::traits::{AtomicMutation, StagedCommit};
-use super::tx::{CommitOutcome, Tx};
+use super::{
+    traits::{AtomicMutation, StagedCommit},
+    tx::{CommitOutcome, Tx},
+};
 use crate::Repository;
 
 /// Run a mutation as one all-or-nothing transaction.

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -7,11 +7,15 @@
 //! class) to re-derive the authoritative ref value when the canonical cache
 //! lags a committed-but-unpublished write.
 
-use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
-use objects::error::Result;
-use objects::object::{ChangeId, MarkerName, ThreadName};
+use objects::{
+    error::Result,
+    object::{ChangeId, MarkerName, ThreadName},
+};
 use oplog::{OpLog, OpRecord};
 use refs::{
     Head, LoadRequest, Loaded, ReconcileOutcome, RefClass, RefExpectation, RefManager,

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Unit tests for the atomic-mutation primitive (heddle#330 §7 item 1).
 
-use std::cell::RefCell;
-use std::collections::BTreeSet;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::BTreeSet,
+    panic::{AssertUnwindSafe, catch_unwind},
+    rc::Rc,
+};
 
-use objects::error::{HeddleError, Result};
-use objects::object::{ChangeId, MarkerName, ThreadName};
+use objects::{
+    error::{HeddleError, Result},
+    object::{ChangeId, MarkerName, ThreadName},
+};
 use oplog::{
     ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord,
     isolation_keys_for_record,

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -8,8 +8,7 @@
 //! [`execute`](super::execute) reaches `commit`. The ledger is a LIFO stack of
 //! inverse closures, popped in reverse on any unwind.
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 use objects::error::{HeddleError, Result};
 use oplog::{ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpRecord};

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //! In-memory commit graph index with persistence and Bloom filter support.
 
-use objects::store::ObjectStore;
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
 };
 
 use anyhow::Result;
-use objects::object::{diff_trees, ChangeId, ContentHash, Tree};
+use objects::{
+    object::{ChangeId, ContentHash, Tree, diff_trees},
+    store::ObjectStore,
+};
 use tracing::warn;
 
 use super::{
+    Repository,
     bloom_filter::bloom_insert,
     commit_graph_persistence::{
-        commit_graph_path, load_commit_graph, save_commit_graph, PersistedCommitGraphNode,
+        PersistedCommitGraphNode, commit_graph_path, load_commit_graph, save_commit_graph,
     },
-    Repository,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/repo/src/context_suggestions.rs
+++ b/crates/repo/src/context_suggestions.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Context rewrite scoring and low-noise suggestion heuristics.
 
-use objects::store::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
-use objects::object::{ContextTarget, State};
+use objects::{
+    object::{ContextTarget, State},
+    store::ObjectStore,
+};
 
 use crate::{HistoryQuery, Repository, staleness};
 

--- a/crates/repo/src/git_worktree_status.rs
+++ b/crates/repo/src/git_worktree_status.rs
@@ -128,9 +128,7 @@ pub fn git_worktree_entry_state(
 
 fn hash_and_compare(expected_oid: gix::ObjectId, bytes: &[u8]) -> Result<GitWorktreeEntryState> {
     let actual_oid = gix::objs::compute_hash(expected_oid.kind(), gix::objs::Kind::Blob, bytes)
-        .map_err(|error| {
-            HeddleError::Config(format!("failed to hash worktree path: {error}"))
-        })?;
+        .map_err(|error| HeddleError::Config(format!("failed to hash worktree path: {error}")))?;
     Ok(if actual_oid == expected_oid {
         GitWorktreeEntryState::Clean
     } else {
@@ -153,8 +151,8 @@ mod tests {
     fn missing_path_is_deleted() {
         let temp = tempfile::TempDir::new().unwrap();
         let oid = write_blob_hash(b"anything");
-        let state = git_worktree_entry_state(temp.path(), "nope.txt", oid, GIT_MODE_REGULAR)
-            .expect("call");
+        let state =
+            git_worktree_entry_state(temp.path(), "nope.txt", oid, GIT_MODE_REGULAR).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Deleted);
     }
 
@@ -258,15 +256,18 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn symlink_with_non_utf8_target_compares_via_raw_bytes() {
-        use std::{ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::fs::symlink};
+        use std::{
+            ffi::OsStr,
+            os::unix::{ffi::OsStrExt, fs::symlink},
+        };
         let temp = tempfile::TempDir::new().unwrap();
         let raw_target = b"target-\xff-bytes";
         let target_os = OsStr::from_bytes(raw_target);
         let link = temp.path().join("link");
         symlink(target_os, &link).unwrap();
         let oid = write_blob_hash(raw_target);
-        let state = git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK)
-            .expect("call");
+        let state =
+            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Clean);
     }
 }

--- a/crates/repo/src/lazy_hydrator.rs
+++ b/crates/repo/src/lazy_hydrator.rs
@@ -247,8 +247,10 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use objects::object::{Blob, ContentHash};
-    use objects::store::ObjectStore;
+    use objects::{
+        object::{Blob, ContentHash},
+        store::ObjectStore,
+    };
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -78,20 +78,16 @@ pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,
-    compute_heavy_impact_paths, format_confidence,
-    refresh_active_thread_metadata, refresh_thread_freshness, summarize_confidence,
-    summarize_verification, update_thread_state_from_state,
+    compute_heavy_impact_paths, format_confidence, refresh_active_thread_metadata,
+    refresh_thread_freshness, summarize_confidence, summarize_verification,
+    update_thread_state_from_state,
 };
-pub use stash::{StashEntry, StashManager};
 pub use stack_snapshot::{
     REPOSITORY_SNAPSHOT_SCHEMA_VERSION, RepositorySnapshot, StackNextAction, ThreadSnapshot,
 };
+pub use stash::{StashEntry, StashManager};
 pub use thread_advice::{
     RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
-};
-pub use thread_stack::{
-    PlanRebaseError, StackNode, StackRebasePlan, StackRebaseStep, ThreadStack, compute_stacks,
-    plan_stack_rebase, stack_for,
 };
 pub use thread_model::{
     ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
@@ -99,6 +95,10 @@ pub use thread_model::{
     ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView,
 };
 pub use thread_record_store::{FilesystemThreadRecordStore, ThreadRecordStore};
+pub use thread_stack::{
+    PlanRebaseError, StackNode, StackRebasePlan, StackRebaseStep, ThreadStack, compute_stacks,
+    plan_stack_rebase, stack_for,
+};
 pub use thread_storage::{SyncedThreadMetadata, SyncedThreadMetadataStore, Thread, ThreadManager};
 pub use worktree_index::{DirectoryCacheEntry, IndexEntry, WorktreeIndex};
 pub use worktree_state::WorktreeState;

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -35,8 +35,10 @@ use objects::{
 use oplog::IsolationKey;
 use serde::{Deserialize, Serialize};
 
-use crate::Repository;
-use crate::atomic::{AtomicMutation, Compensator, EagerMutation, StagedCommit, Tx, execute};
+use crate::{
+    Repository,
+    atomic::{AtomicMutation, Compensator, EagerMutation, StagedCommit, Tx, execute},
+};
 
 const DEDUP_FORMAT_VERSION: u8 = 1;
 const DEDUP_FILE_NAME: &str = "operation_dedup.bin";
@@ -551,13 +553,15 @@ pub fn hash_request_body(bytes: &[u8]) -> [u8; 32] {
 mod tests {
     use std::sync::Arc;
 
-    use crate::Repository;
-    use crate::atomic::{AtomicMutation, StagedCommit, Tx, execute};
-    use crate::operation_dedup::{ReserveOpId, reserve_operation_id_eager};
     use objects::error::{HeddleError, Result};
     use tempfile::TempDir;
 
     use super::*;
+    use crate::{
+        Repository,
+        atomic::{AtomicMutation, StagedCommit, Tx, execute},
+        operation_dedup::{ReserveOpId, reserve_operation_id_eager},
+    };
 
     fn make_store() -> (TempDir, OperationDedupStore) {
         let temp = TempDir::new().unwrap();

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -522,8 +522,8 @@ version = 1
 [output]
 format = "auto"
 "#;
-        let err = toml::from_str::<RepoConfig>(toml_auto)
-            .expect_err("output.format='auto' must reject");
+        let err =
+            toml::from_str::<RepoConfig>(toml_auto).expect_err("output.format='auto' must reject");
         let message = err.to_string();
         assert!(
             message.contains("output.format"),

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -79,8 +79,6 @@ use objects::{
 use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
-
-use crate::git_worktree_status::GitWorktreeEntryState;
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
 // Review-epic config types — re-exported here so the new
 // `repository_signals.rs` (and external crates wanting to construct a
@@ -103,6 +101,8 @@ pub use repository_thread_materialize::ThreadCaptureOutcome;
 pub use repository_tree::{TreeBuildProfile, WorktreeCompareProfile};
 pub use repository_worktree_status::{UntrackedSet, UntrackedSubtree, WorktreeStatusDetailed};
 use serde::{Deserialize, Serialize};
+
+use crate::git_worktree_status::GitWorktreeEntryState;
 
 const GIT_CHECKPOINTS_FILE: &str = "git-checkpoints.json";
 const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[".heddle/"];
@@ -1354,10 +1354,7 @@ impl Repository {
                 continue;
             }
             match crate::git_worktree_status::git_worktree_entry_state(
-                &self.root,
-                path,
-                *oid,
-                *mode,
+                &self.root, path, *oid, *mode,
             )? {
                 GitWorktreeEntryState::Clean => {}
                 GitWorktreeEntryState::Deleted => {
@@ -1712,7 +1709,9 @@ impl Repository {
             })
             .collect::<Result<Vec<_>>>()?;
         let scope = self.op_scope();
-        let result = self.refs.commit_and_publish(&encoded, ref_updates, Some(&scope));
+        let result = self
+            .refs
+            .commit_and_publish(&encoded, ref_updates, Some(&scope));
         // The committer appended through a fresh `OpLog` handle (the `refs`→`repo`
         // seam), so this repository's own cached oplog handle is now stale.
         // Refresh it so a same-process read via `self.oplog()` observes the
@@ -1896,7 +1895,9 @@ impl Repository {
                 .git_overlay_mapped_change_for_branch(&branch)?
                 .is_some()
         {
-            return Ok(Head::Attached { thread: branch_thread });
+            return Ok(Head::Attached {
+                thread: branch_thread,
+            });
         }
         Ok(raw)
     }
@@ -2525,7 +2526,9 @@ fn detect_git_head_state(path: &Path) -> Result<Option<GitHeadState>> {
 /// than guess).
 fn detect_git_head(path: &Path) -> Result<Option<Head>> {
     if let Some(GitHeadState::Attached(thread)) = detect_git_head_state(path)? {
-        return Ok(Some(Head::Attached { thread: ThreadName::from(thread) }));
+        return Ok(Some(Head::Attached {
+            thread: ThreadName::from(thread),
+        }));
     }
     Ok(None)
 }

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Context annotation helpers for attaching metadata to file and state targets.
 
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
-use objects::object::{
-    Annotation, AnnotationScope, Blob, ContentHash, ContextBlob, ContextTarget, EntryType, State,
-    Tree, TreeEntry,
+use objects::{
+    object::{
+        Annotation, AnnotationScope, Blob, ContentHash, ContextBlob, ContextTarget, EntryType,
+        State, Tree, TreeEntry,
+    },
+    store::ObjectStore,
 };
 
 use super::{HeddleError, Repository, Result};

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Worktree movement operations.
 
-use objects::store::ObjectStore;
 use std::time::Instant;
 
-use objects::{lock::RepositoryLockExt, object::ChangeId};
+use objects::{lock::RepositoryLockExt, object::ChangeId, store::ObjectStore};
 use refs::Head;
 use tracing::debug;
 

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared history traversal and filtering primitives.
 
-use objects::store::ObjectStore;
 use std::path::{Component, Path};
 
-use objects::object::{ChangeId, State, Tree};
+use objects::{
+    object::{ChangeId, State, Tree},
+    store::ObjectStore,
+};
 use tracing::{instrument, trace};
 
 use crate::{HeddleError, Repository, Result};

--- a/crates/repo/src/repository_maintenance.rs
+++ b/crates/repo/src/repository_maintenance.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{
     collections::HashSet,
     fs, io,
@@ -7,7 +6,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use objects::{fs_atomic::write_file_atomic, object::ChangeId};
+use objects::{fs_atomic::write_file_atomic, object::ChangeId, store::ObjectStore};
 use proto::{PlannedObject, StateClosureOptions, enumerate_state_closure_plan_with_options};
 use refs::{Head, RefSummaryIndexInspection};
 use serde::{Deserialize, Serialize};
@@ -734,13 +733,15 @@ fn load_ref_snapshots(repo: &Repository, threads: bool) -> Result<Vec<RefSnapsho
         let names = repo.refs().list_threads()?;
         let mut out = Vec::with_capacity(names.len());
         for name in names {
-            let state = repo.refs().get_thread(&name)?
-                .ok_or_else(|| {
-                    HeddleError::Io(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("thread '{}' disappeared while rebuilding pull planner manifest", name),
-                    ))
-                })?;
+            let state = repo.refs().get_thread(&name)?.ok_or_else(|| {
+                HeddleError::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "thread '{}' disappeared while rebuilding pull planner manifest",
+                        name
+                    ),
+                ))
+            })?;
             out.push(RefSnapshotMirror {
                 name: name.to_string(),
                 state_id: state.to_string_full(),
@@ -751,13 +752,15 @@ fn load_ref_snapshots(repo: &Repository, threads: bool) -> Result<Vec<RefSnapsho
         let names = repo.refs().list_markers()?;
         let mut out = Vec::with_capacity(names.len());
         for name in names {
-            let state = repo.refs().get_marker(&name)?
-                .ok_or_else(|| {
-                    HeddleError::Io(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("marker '{}' disappeared while rebuilding pull planner manifest", name),
-                    ))
-                })?;
+            let state = repo.refs().get_marker(&name)?.ok_or_else(|| {
+                HeddleError::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "marker '{}' disappeared while rebuilding pull planner manifest",
+                        name
+                    ),
+                ))
+            })?;
             out.push(RefSnapshotMirror {
                 name: name.to_string(),
                 state_id: state.to_string_full(),

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree materialization helpers.
 
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,
@@ -15,6 +14,7 @@ use std::{
 use objects::{
     fs_atomic::enrich_fs_error,
     object::{ChangeId, ContentHash, EntryType, Tree},
+    store::ObjectStore,
 };
 use tracing::{debug, instrument};
 
@@ -820,8 +820,7 @@ fn requested_materialization_threads() -> Option<NonZeroUsize> {
 mod tests {
     use std::{num::NonZeroUsize, path::PathBuf};
 
-    use objects::store::ObjectStore;
-    use objects::{fs_clone::filesystem_supports_reflink, object::Blob};
+    use objects::{fs_clone::filesystem_supports_reflink, object::Blob, store::ObjectStore};
     use tempfile::TempDir;
 
     use super::{

--- a/crates/repo/src/repository_provenance/blame_file.rs
+++ b/crates/repo/src/repository_provenance/blame_file.rs
@@ -56,10 +56,12 @@
 //! path, so every caller — `heddle blame`, the gRPC `GetBlame` RPC,
 //! the web app — benefits without any client-side change.
 
-use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
-use objects::object::{ChangeId, ContentHash, FileProvenance, Origin, State};
+use objects::{
+    object::{ChangeId, ContentHash, FileProvenance, Origin, State},
+    store::ObjectStore,
+};
 
 use super::{
     Repository, Result,

--- a/crates/repo/src/repository_provenance/helpers.rs
+++ b/crates/repo/src/repository_provenance/helpers.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
-use objects::object::{
-    Blob, ContentHash, FileProvenance, LineSpan, Origin, ProvenanceError, State, Tree, TreeEntry,
+use objects::{
+    object::{
+        Blob, ContentHash, FileProvenance, LineSpan, Origin, ProvenanceError, State, Tree,
+        TreeEntry,
+    },
+    store::ObjectStore,
 };
 
 use super::{HeddleError, Repository, Result, builder::ProvenanceBuilder};

--- a/crates/repo/src/repository_provenance/merge.rs
+++ b/crates/repo/src/repository_provenance/merge.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::path::Path;
 
-use objects::object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry};
+use objects::{
+    object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry},
+    store::ObjectStore,
+};
 
 use super::{
     Repository, Result,

--- a/crates/repo/src/repository_provenance/mod.rs
+++ b/crates/repo/src/repository_provenance/mod.rs
@@ -10,10 +10,12 @@ mod storage;
 #[cfg(test)]
 mod tests;
 
-use objects::store::ObjectStore;
 use std::{collections::HashMap, path::Path};
 
-use objects::object::{ChangeId, ContentHash, FileProvenance, State};
+use objects::{
+    object::{ChangeId, ContentHash, FileProvenance, State},
+    store::ObjectStore,
+};
 
 use super::{HeddleError, Repository, Result};
 

--- a/crates/repo/src/repository_provenance/snapshot.rs
+++ b/crates/repo/src/repository_provenance/snapshot.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{collections::BTreeSet, path::Path};
 
-use objects::object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry};
+use objects::{
+    object::{ContentHash, EntryType, FileProvenance, State, Tree, TreeEntry},
+    store::ObjectStore,
+};
 
 use super::{
     Repository, Result,

--- a/crates/repo/src/repository_provenance/storage.rs
+++ b/crates/repo/src/repository_provenance/storage.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::path::Path;
 
-use objects::object::{Blob, ContentHash, FileProvenance};
+use objects::{
+    object::{Blob, ContentHash, FileProvenance},
+    store::ObjectStore,
+};
 
 use super::{HeddleError, Repository, Result, helpers::split_path};
 

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -22,7 +22,6 @@
 //! identical ids, which preserves the "redact is idempotent" property
 //! from the build brief.
 
-use objects::store::ObjectStore;
 use std::{collections::HashSet, fs, path::PathBuf};
 
 use anyhow::{Context, Result};
@@ -31,6 +30,7 @@ use crypto::verify_payload_signature;
 use objects::{
     fs_atomic::write_file_atomic,
     object::{ChangeId, ContentHash, Principal, Redaction, RedactionsBlob, Tree},
+    store::ObjectStore,
 };
 
 use crate::repository::Repository;

--- a/crates/repo/src/repository_resolve.rs
+++ b/crates/repo/src/repository_resolve.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! State resolution helpers for the Repository.
 
-use objects::object::{Agent, ChangeId};
-use objects::store::ObjectStore;
+use objects::{
+    object::{Agent, ChangeId},
+    store::ObjectStore,
+};
 
 use super::{HeddleError, Repository, Result};
 
@@ -134,8 +136,10 @@ fn resolve_short_change_id(repo: &Repository, spec: &str) -> Result<Option<Chang
 mod tests {
     use std::fs;
 
-    use objects::object::{ChangeId, MarkerName};
-    use objects::store::ObjectStore;
+    use objects::{
+        object::{ChangeId, MarkerName},
+        store::ObjectStore,
+    };
     use tempfile::TempDir;
 
     use crate::{HeddleError, Repository};

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -13,8 +13,10 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use objects::store::ObjectStore;
-use objects::object::{Blob, ContentHash, RiskSignalBlob, State};
+use objects::{
+    object::{Blob, ContentHash, RiskSignalBlob, State},
+    store::ObjectStore,
+};
 use state_review::{
     ReviewSignalsConfig, SemanticContext,
     config::{

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -2,8 +2,10 @@
 //! State signing operations for Repository.
 
 use crypto::{Signer, StateSigningExt, load_signer, verify_state_signature_bytes};
-use objects::object::{ChangeId, SignatureStatus, StateSignature};
-use objects::store::ObjectStore;
+use objects::{
+    object::{ChangeId, SignatureStatus, StateSignature},
+    store::ObjectStore,
+};
 use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result};

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -3,21 +3,23 @@
 
 use std::collections::BTreeSet;
 
-use objects::store::ObjectStore;
 use objects::{
     lock::RepositoryLockExt,
     object::{Attribution, Blob, ChangeId, ContentHash, State, Tree, TreeEntry},
+    store::ObjectStore,
 };
 use oplog::{IsolationKey, OpRecord};
 use refs::Head;
 use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result, repository_tree::TreeBuildProfile};
-use crate::atomic::{AtomicMutation, RewindLedger, StagedCommit, Tx, execute};
-use crate::worktree_ignore::WorktreeIgnoreMatcher;
-use crate::worktree_walk::{
-    WalkDirectory, WalkEntry, WorktreeWalkPolicy, read_file_hash, validate_symlink_target,
-    walk_worktree,
+use crate::{
+    atomic::{AtomicMutation, RewindLedger, StagedCommit, Tx, execute},
+    worktree_ignore::WorktreeIgnoreMatcher,
+    worktree_walk::{
+        WalkDirectory, WalkEntry, WorktreeWalkPolicy, read_file_hash, validate_symlink_target,
+        walk_worktree,
+    },
 };
 
 #[derive(Debug, Clone, Default)]

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::fs;
 
 use objects::{
     object::{Blob, ChangeId, ThreadName, Tree, TreeEntry},
+    store::ObjectStore,
     util::symlink_target_bytes,
 };
 use oplog::OpRecord;
@@ -11,7 +11,7 @@ use refs::Head;
 use serde_json::json;
 use tempfile::TempDir;
 
-use super::repository_snapshot::{with_snapshot_fault, SnapshotFault};
+use super::repository_snapshot::{SnapshotFault, with_snapshot_fault};
 use crate::{
     ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
     ThreadFreshness, ThreadManager, WorktreeIndex,
@@ -41,7 +41,10 @@ fn test_init_creates_structure() {
     assert!(temp_dir.path().join(".heddle/objects/trees").exists());
     assert!(temp_dir.path().join(".heddle/objects/states").exists());
     let root_state = repo.head().unwrap().expect("init should seed main state");
-    assert_eq!(repo.refs().get_thread(&ThreadName::new("main")).unwrap(), Some(root_state));
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
+        Some(root_state)
+    );
     let state = repo.store().get_state(&root_state).unwrap().unwrap();
     assert!(state.parents.is_empty());
     let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
@@ -62,8 +65,7 @@ fn test_open_with_store_threads_a_custom_object_store() {
     drop(repo);
 
     let store = FsStore::new(&heddle_dir);
-    let repo: Repository<_, _, FsStore> =
-        Repository::open_with_store(&heddle_dir, store).unwrap();
+    let repo: Repository<_, _, FsStore> = Repository::open_with_store(&heddle_dir, store).unwrap();
 
     let blob = objects::object::Blob::from("open_with_store round-trip");
     let hash = repo.store().put_blob(&blob).unwrap();
@@ -254,7 +256,10 @@ fn snapshot_atomic_mutation_fault_and_exactly_once_contract() {
         .iter()
         .filter(|entry| matches!(entry.operation, OpRecord::TransactionCommit { .. }))
         .count();
-    assert_eq!(snapshot_count, 1, "capture batch must contain one snapshot record");
+    assert_eq!(
+        snapshot_count, 1,
+        "capture batch must contain one snapshot record"
+    );
     assert_eq!(
         transaction_count, 1,
         "capture batch must contain one transaction marker"
@@ -1147,7 +1152,9 @@ fn test_fast_forward_attached_preserves_head_and_advances_thread() {
     // Repo::init_default attaches HEAD to "main"; explicitly rewind the
     // thread ref to state1 so a fast-forward to state2 is meaningful.
     let state1 = repo.head().unwrap().expect("base state should exist");
-    repo.refs().set_thread(&ThreadName::new("main"), &state1).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &state1)
+        .unwrap();
     repo.refs()
         .write_head(&Head::Attached {
             thread: ThreadName::new("main"),
@@ -1362,9 +1369,8 @@ mod blob_hydrator_callback {
     use objects::{
         error::Result,
         object::{Blob, ContentHash},
+        store::ObjectStore,
     };
-
-    use objects::store::ObjectStore;
 
     use super::create_test_repo;
     use crate::{BlobHydrator, HeddleError, Repository};
@@ -1656,8 +1662,10 @@ mod require_tree_callback {
     //! `crates/cli/tests/state_management/missing_tree_integrity.rs`
     //! cover the on-disk wiring.
 
-    use objects::object::{ContentHash, Tree};
-    use objects::store::ObjectStore;
+    use objects::{
+        object::{ContentHash, Tree},
+        store::ObjectStore,
+    };
 
     use super::create_test_repo;
     use crate::{HeddleError, Repository};
@@ -1853,12 +1861,18 @@ fn dir_only_ignore_covers_node_modules_symlink_native() {
     let status = repo.compare_worktree_cached(&tree).unwrap();
 
     assert!(
-        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        !status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules")),
         "node_modules symlink must be ignored by `node_modules/`, not reported as added: {:?}",
         status.added,
     );
     assert!(
-        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "a non-ignored sibling must still be reported (proves the scan ran): {:?}",
         status.added,
     );
@@ -1887,7 +1901,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_native() {
     // First status: no ignore yet, so the dep file is seen as untracked.
     let before = repo.compare_worktree_cached(&tree).unwrap();
     assert!(
-        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        before
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules/dep.js")),
         "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
         before.added,
     );
@@ -1902,7 +1919,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_native() {
         after.added,
     );
     assert!(
-        after.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        after
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "non-ignored sibling must still be reported after the refresh: {:?}",
         after.added,
     );
@@ -1932,12 +1952,18 @@ fn dir_only_ignore_covers_node_modules_symlink_git_overlay() {
 
     let status = repo.git_overlay_worktree_status().unwrap().unwrap();
     assert!(
-        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        !status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules")),
         "node_modules symlink must be ignored in git-overlay status: {:?}",
         status.added,
     );
     assert!(
-        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "a non-ignored sibling must still be reported in git-overlay status: {:?}",
         status.added,
     );
@@ -1962,7 +1988,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
 
     let before = repo.git_overlay_worktree_status().unwrap().unwrap();
     assert!(
-        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        before
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules/dep.js")),
         "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
         before.added,
     );

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -12,7 +12,6 @@
 //! userspace FS callbacks in the hot path. Disk usage is the
 //! ~zero-cost clonefile share until the agent diverges blocks.
 
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeMap,
     fs,
@@ -22,6 +21,7 @@ use std::{
 use objects::{
     lock::RepositoryLockExt,
     object::{ChangeId, State, ThreadName, Tree},
+    store::ObjectStore,
 };
 use tracing::{debug, instrument};
 
@@ -811,7 +811,11 @@ mod tests {
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         fs::write(repo_dir.path().join("hello.txt"), b"hello\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let before = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let before = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
@@ -829,7 +833,11 @@ mod tests {
         };
 
         // Thread head advanced.
-        let after = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let after = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_ne!(before, after);
         assert_eq!(after, new_state);
 
@@ -850,7 +858,11 @@ mod tests {
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         fs::write(repo_dir.path().join("steady.txt"), b"unchanged\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let before = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let before = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
@@ -860,7 +872,11 @@ mod tests {
         assert_eq!(outcome, ThreadCaptureOutcome::NoOp);
 
         // Thread head unchanged.
-        let after = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let after = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_eq!(before, after);
     }
 
@@ -1077,7 +1093,11 @@ mod tests {
         // And `heddle status`'s staleness check should now correctly
         // report the materialized worktree as stale (head moved,
         // manifest didn't).
-        let head_now = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let head_now = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_ne!(
             head_now, after.state_id,
             "post-fix invariant: main head advanced past manifest's recorded state → stale"
@@ -1304,7 +1324,11 @@ mod tests {
         let repo = Arc::new(Repository::init_default(repo_dir.path()).unwrap());
         fs::write(repo_dir.path().join("shared.txt"), b"seed\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let initial_head = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("seeded");
+        let initial_head = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("seeded");
 
         // Two sibling materialized worktrees of the same thread.
         let dest_a_holder = TempDir::new().unwrap();
@@ -1352,7 +1376,11 @@ mod tests {
         // the loser's parent would be `initial_head`. With the
         // lock, the loser's parent is the winner's id and the
         // winner's parent is `initial_head`.
-        let final_head = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let final_head = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         let winner_id = final_head;
         let loser_id = if final_head == id_a { id_b } else { id_a };
 

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree building and materialization helpers.
 
-use objects::store::ObjectStore;
 use std::{collections::HashSet, fs, path::Path, time::Instant};
 
 use objects::{
     object::{Blob, ContentHash, Tree, TreeEntry},
+    store::ObjectStore,
     worktree::WorktreeStatus,
 };
 use tracing::{debug, instrument, trace, warn};

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared worktree apply planning and execution.
 
-use objects::store::ObjectStore;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
@@ -12,6 +11,7 @@ use std::{
 use objects::{
     fs_atomic::{enrich_fs_error, is_directory_not_empty as fs_is_directory_not_empty},
     object::{EntryType, Tree, TreeEntry},
+    store::ObjectStore,
     worktree::should_ignore as should_ignore_path,
 };
 use tracing::{debug, warn};

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -13,18 +13,18 @@
 //! logic in one place and lets `crates/mount` avoid pulling in
 //! `crates/cli` deps.
 
-use objects::store::ObjectStore;
 use std::path::Path;
 
 use chrono::Utc;
 use objects::{
     error::HeddleError,
     object::{ChangeId, State, ThreadName, Tree, Verification},
+    store::ObjectStore,
 };
 
 use crate::{
-    repository::Repository, ConfidenceBand, Thread, ThreadConfidenceSummary, ThreadFreshness,
-    ThreadImpactCategory, ThreadManager, ThreadState, ThreadVerificationSummary,
+    ConfidenceBand, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadImpactCategory,
+    ThreadManager, ThreadState, ThreadVerificationSummary, repository::Repository,
 };
 
 /// Result of a metadata refresh: derived signal the caller may want

--- a/crates/repo/src/stack_snapshot.rs
+++ b/crates/repo/src/stack_snapshot.rs
@@ -159,9 +159,7 @@ impl RepositorySnapshot {
     /// Look up the stack containing `thread_name`. Returns `None` if the
     /// thread is unknown to this snapshot.
     pub fn stack_containing(&self, thread_name: &str) -> Option<&ThreadStack> {
-        self.stacks
-            .iter()
-            .find(|stack| stack.contains(thread_name))
+        self.stacks.iter().find(|stack| stack.contains(thread_name))
     }
 
     /// Decide the next stack-level action for the stack containing
@@ -397,7 +395,10 @@ mod tests {
             snap("b", Some("a"), ThreadState::Ready),
             snap("c", Some("b"), ThreadState::Merged),
         ]);
-        assert_eq!(snapshot.next_action_for("a").unwrap(), StackNextAction::Ready);
+        assert_eq!(
+            snapshot.next_action_for("a").unwrap(),
+            StackNextAction::Ready
+        );
     }
 
     #[test]

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,
@@ -7,7 +6,10 @@ use std::{
     time::Instant,
 };
 
-use objects::object::{ContentHash, EntryType, Tree, TreeEntry};
+use objects::{
+    object::{ContentHash, EntryType, Tree, TreeEntry},
+    store::ObjectStore,
+};
 
 use crate::{
     Repository, Result, WorktreeIndex,

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use std::{
     collections::BTreeSet,
     fs,
@@ -7,7 +6,10 @@ use std::{
     time::Instant,
 };
 
-use objects::object::{EntryType, Tree};
+use objects::{
+    object::{EntryType, Tree},
+    store::ObjectStore,
+};
 
 use crate::{
     Repository, Result, WorktreeIndex,

--- a/crates/repo/src/thread_stack.rs
+++ b/crates/repo/src/thread_stack.rs
@@ -395,9 +395,7 @@ impl Repository {
             }
         }
         let plan = plan_stack_rebase(&records, root_thread, onto, |name| {
-            tips.get(name)
-                .cloned()
-                .unwrap_or_else(|| name.to_string())
+            tips.get(name).cloned().unwrap_or_else(|| name.to_string())
         });
         Ok(plan)
     }
@@ -445,9 +443,7 @@ mod tests {
         r
     }
 
-    fn current_states<'a>(
-        map: &'a HashMap<&'a str, &'a str>,
-    ) -> impl FnMut(&str) -> String + 'a {
+    fn current_states<'a>(map: &'a HashMap<&'a str, &'a str>) -> impl FnMut(&str) -> String + 'a {
         move |name: &str| map.get(name).copied().unwrap_or(name).to_string()
     }
 
@@ -528,8 +524,8 @@ mod tests {
     #[test]
     fn plan_rejects_unknown_root() {
         let records: Vec<ThreadRecord> = Vec::new();
-        let err = plan_stack_rebase(&records, "missing", "new-base", |_| String::new())
-            .unwrap_err();
+        let err =
+            plan_stack_rebase(&records, "missing", "new-base", |_| String::new()).unwrap_err();
         assert_eq!(err, PlanRebaseError::ThreadNotFound("missing".into()));
     }
 
@@ -539,8 +535,8 @@ mod tests {
             record_at("feature-a", None, "main-1"),
             record_at("feature-b", Some("feature-a"), "feature-a-tip"),
         ];
-        let err = plan_stack_rebase(&records, "feature-b", "main-2", |n| n.to_string())
-            .unwrap_err();
+        let err =
+            plan_stack_rebase(&records, "feature-b", "main-2", |n| n.to_string()).unwrap_err();
         assert_eq!(
             err,
             PlanRebaseError::NotARoot("feature-b".into(), "feature-a".into())
@@ -552,8 +548,8 @@ mod tests {
         let records = vec![record_at("feature-a", None, "main-1")];
         let mut current = HashMap::new();
         current.insert("feature-a", "feature-a-tip");
-        let plan = plan_stack_rebase(&records, "feature-a", "main-2", current_states(&current))
-            .unwrap();
+        let plan =
+            plan_stack_rebase(&records, "feature-a", "main-2", current_states(&current)).unwrap();
         assert_eq!(plan.step_count(), 1);
         let step = &plan.steps[0];
         assert_eq!(step.thread, "feature-a");
@@ -579,8 +575,7 @@ mod tests {
         current.insert("b", "b-tip");
         current.insert("c", "c-tip");
         current.insert("d", "d-tip");
-        let plan =
-            plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
+        let plan = plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
         let order: Vec<&str> = plan.steps.iter().map(|s| s.thread.as_str()).collect();
         assert_eq!(order, vec!["a", "b", "d", "c"]);
 
@@ -626,8 +621,7 @@ mod tests {
         let records = vec![record_at("a", None, "main-2")];
         let mut current = HashMap::new();
         current.insert("a", "main-2");
-        let plan =
-            plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
+        let plan = plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
         assert!(plan.is_no_op());
     }
 }

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread storage and lifecycle management.
 
-use objects::store::ObjectStore;
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 use objects::{
     lock::RepoLock,
     object::ChangeId,
-    store::{HeddleError, Result},
+    store::{HeddleError, ObjectStore, Result},
 };
 
 use crate::{
@@ -685,7 +686,9 @@ mod tests {
             "precondition: newer leaked record shadows prev"
         );
 
-        manager.converge_records(name, std::slice::from_ref(&prev)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&prev))
+            .unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -741,7 +744,9 @@ mod tests {
             "precondition: the newer same-name record shadows the target"
         );
 
-        manager.converge_records(name, std::slice::from_ref(&target)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&target))
+            .unwrap();
 
         let under_name: Vec<_> = manager
             .list()
@@ -749,7 +754,11 @@ mod tests {
             .into_iter()
             .filter(|t| t.thread == name)
             .collect();
-        assert_eq!(under_name.len(), 1, "exactly the target remains under the name");
+        assert_eq!(
+            under_name.len(),
+            1,
+            "exactly the target remains under the name"
+        );
         assert_eq!(under_name[0].id, "rec-target");
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -800,7 +809,12 @@ mod tests {
         drop_c.updated_at = keep_a.updated_at + chrono::Duration::seconds(10);
         manager.save(&drop_c).unwrap();
         assert_eq!(
-            manager.list().unwrap().iter().filter(|t| t.thread == name).count(),
+            manager
+                .list()
+                .unwrap()
+                .iter()
+                .filter(|t| t.thread == name)
+                .count(),
             3,
             "precondition: three records under the name"
         );
@@ -878,7 +892,9 @@ mod tests {
         rec.thread = name.to_string();
         manager.save(&rec).unwrap();
 
-        manager.converge_records(name, std::slice::from_ref(&rec)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&rec))
+            .unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared worktree walking infrastructure.
 
-use objects::store::ObjectStore;
 use std::{
     fs::{self, File},
     io::Read,
@@ -12,6 +11,7 @@ use std::{
 use objects::{
     error::{HeddleError, Result},
     object::{ContentHash, Tree, TreeEntry},
+    store::ObjectStore,
 };
 
 use crate::{
@@ -539,8 +539,9 @@ fn path_stays_within_base_lexically(base: &Path, path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_symlink_target;
     use std::path::Path;
+
+    use super::validate_symlink_target;
 
     #[test]
     #[cfg(unix)]

--- a/crates/review/src/github/rest.rs
+++ b/crates/review/src/github/rest.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, de::DeserializeOwned};
 
 use crate::{
     Result,
@@ -508,13 +507,15 @@ fn parse_name_email(raw: &str) -> (String, String) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serde_json::json;
     use std::collections::VecDeque;
+
+    use serde_json::json;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
     };
+
+    use super::*;
 
     struct MockResponse {
         status: u16,

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -26,7 +26,7 @@ use std::rc::Rc;
 use tree_sitter::Node;
 
 pub(super) use super::language_rules::ItemKind;
-use super::language_rules::{rules_for, Classified, MetadataBinding};
+use super::language_rules::{Classified, MetadataBinding, rules_for};
 use crate::parser::{Language, ParsedFile};
 
 /// Stable identifier for an item across the three sides. Two items match iff

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use merge::{text_hunk_merge_with_markers, ConflictMarkers, MergeOutcome};
+use merge::{ConflictMarkers, MergeOutcome, text_hunk_merge_with_markers};
 
 use super::items::{FileSegments, Item, ItemKey};
 

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
 use semantic::{
-    analysis::{compute_similarity, SimilarityMethod},
+    analysis::{SimilarityMethod, compute_similarity},
     parser::FunctionDef,
 };
 

--- a/crates/state_review/src/modules/pattern_deviation.rs
+++ b/crates/state_review/src/modules/pattern_deviation.rs
@@ -8,7 +8,7 @@
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
 use semantic::{
-    analysis::{compute_similarity, SimilarityMethod},
+    analysis::{SimilarityMethod, compute_similarity},
     parser::FunctionDef,
 };
 

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -18,14 +18,13 @@ use std::{
 };
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
-use semantic::{parser::FunctionDef, Language};
+use semantic::{Language, parser::FunctionDef};
 
 use crate::{config::ReviewSignalsConfig, registry::SemanticContext};
 
 const VERSION: u32 = 1;
 const MODULE_ID: &str = "test_reachability.tree_sitter";
-const REASON_TEXT: &str =
-    "no test reaches this symbol via static reachability via tree-sitter call graph; \
+const REASON_TEXT: &str = "no test reaches this symbol via static reachability via tree-sitter call graph; \
      this is not runtime coverage";
 
 pub fn run(


### PR DESCRIPTION
## Summary
- Ran `cargo +nightly fmt --all` across the workspace. The repo's committed formatting had drifted from its own `rustfmt.toml` (nightly-only `imports_granularity = "Crate"`, `group_imports = "StdExternalCrate"`) — 186 files, pure mechanical reformat, **no logic changes**.
- CI does not enforce `cargo fmt --check`, which is why the drift accumulated. This normalizes the baseline so feature PRs stop carrying incidental reformat churn.

## Why now
While reviewing two in-flight PRs, codex agents' own `cargo fmt` runs cascaded 100+ file reformats on top of small changes. Normalizing main to the intended nightly format keeps that noise out of feature diffs.

## Test plan
- [ ] CI green (build + test + clippy) — formatting is semantically identical, so behavior is unchanged.
- [ ] Reviewer can confirm purity with `git show --stat` / spot-checking that hunks are whitespace/import-ordering only.

## Merge note
This touches files that open PRs #452 (#449) and #453 (#438) also touch. To avoid conflict-thrash, recommend landing **after** those two merge (or merge this first and re-run `cargo +nightly fmt` on their rebased branches — fmt conflicts are mechanical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783035365&installation_id=132405951&pr_number=454&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F454&signature=2fedfb3a51774c219f425495f78a786f5ec6d31e4a25623662af17879a37b4fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->