### PR TITLE
fix(agent): honor explicit env attribution

### DIFF
--- a/crates/cli/src/attribution.rs
+++ b/crates/cli/src/attribution.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// Treat the `"unknown"` harness placeholder and empty/whitespace
+/// strings as absent so they don't beat real attribution values in
+/// precedence chains.
+pub(crate) fn clean_attribution_value(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        None
+    } else {
+        Some(value)
+    }
+}

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -643,9 +643,9 @@ pub async fn cmd_actor_explain(cli: &Cli, session_id: Option<String>) -> Result<
 fn explain_detected_actor_identity(cli: &Cli, repo: &Repository) -> Result<()> {
     let probe = crate::harness::probe_current_process_harness(
         repo,
-        std::env::var("HEDDLE_AGENT_PROVIDER").ok(),
-        std::env::var("HEDDLE_AGENT_MODEL").ok(),
-        std::env::var("HEDDLE_AGENT_POLICY").ok(),
+        std::env::var("HEDDLE_AGENT_PROVIDER").ok().and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_MODEL").ok().and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_POLICY").ok().and_then(crate::attribution::clean_attribution_value),
     )?;
     let env_signals = actor_identity_env_signals();
     // Route through the same "is there a current lane?" predicate that

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -216,9 +216,9 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
     let reservation_path = existing_thread_execution_path(&repo, &thread_name)?;
     let probe = crate::harness::probe_current_process_harness(
         &repo,
-        std::env::var("HEDDLE_AGENT_PROVIDER").ok(),
-        std::env::var("HEDDLE_AGENT_MODEL").ok(),
-        std::env::var("HEDDLE_AGENT_POLICY").ok(),
+        std::env::var("HEDDLE_AGENT_PROVIDER").ok().and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_MODEL").ok().and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_POLICY").ok().and_then(crate::attribution::clean_attribution_value),
     )?;
     // `--hold-for-pid PID` binds the reservation to an external
     // process (typically the orchestrator that wraps the heddle

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -32,6 +32,7 @@ use super::{
     thread_cmd::current_thread,
 };
 use crate::{
+    attribution::clean_attribution_value,
     bridge::GitBridge,
     cli::{Cli, should_output_json, style},
     config::UserConfig,
@@ -908,18 +909,6 @@ fn build_attribution_with_env(
             Ok(Attribution::with_agent(principal, agent))
         }
         _ => Ok(Attribution::human(principal)),
-    }
-}
-
-/// Treat the `"unknown"` harness placeholder and empty/whitespace
-/// strings as absent so they don't beat real env-var or config
-/// values in the attribution precedence chain.
-fn clean_attribution_value(value: String) -> Option<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
-        None
-    } else {
-        Some(value)
     }
 }
 

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -119,6 +119,15 @@ pub struct SnapshotAgentOverrides {
     pub no_agent: bool,
 }
 
+#[derive(Clone, Debug, Default)]
+struct AgentEnv {
+    provider: Option<String>,
+    model: Option<String>,
+    policy: Option<String>,
+    session: Option<String>,
+    segment: Option<String>,
+}
+
 /// Stable exit code emitted when capture aborts because the filesystem
 /// is out of space. Mirrors the POSIX ENOSPC value (28) so shell users
 /// and supervisors that already classify "disk full" by OS code see a
@@ -711,6 +720,31 @@ fn build_attribution(
     user_config: &UserConfig,
     agent: &SnapshotAgentOverrides,
 ) -> Result<Attribution> {
+    build_attribution_with_env(repo, user_config, agent, current_agent_env())
+}
+
+fn current_agent_env() -> AgentEnv {
+    AgentEnv {
+        provider: std::env::var("HEDDLE_AGENT_PROVIDER")
+            .ok()
+            .and_then(clean_attribution_value),
+        model: std::env::var("HEDDLE_AGENT_MODEL")
+            .ok()
+            .and_then(clean_attribution_value),
+        policy: std::env::var("HEDDLE_AGENT_POLICY")
+            .ok()
+            .and_then(clean_attribution_value),
+        session: std::env::var("HEDDLE_SESSION_ID").ok(),
+        segment: std::env::var("HEDDLE_SESSION_SEGMENT").ok(),
+    }
+}
+
+fn build_attribution_with_env(
+    repo: &Repository,
+    user_config: &UserConfig,
+    agent: &SnapshotAgentOverrides,
+    env: AgentEnv,
+) -> Result<Attribution> {
     let principal = resolve_principal(repo, user_config)?;
     if is_default_unknown_principal(&principal) {
         return Err(anyhow!(missing_capture_identity_advice()));
@@ -732,11 +766,11 @@ fn build_attribution(
     // thread would show `Principal: Unknown`, which broke the
     // provenance demo and the `heddle blame --context` story.
     //
-    // Precedence: this slots in *after* explicit CLI overrides but
-    // *before* the ambient HEDDLE_AGENT_* env (those reflect whoever
-    // happens to be running heddle right now; the thread's actor is
-    // the user's stated intent for *this* thread, which is more
-    // specific). Falls back to the rest of the cascade unchanged.
+    // Precedence: explicit CLI overrides and `HEDDLE_AGENT_*` env are
+    // user-supplied attribution for this capture, so they must not be
+    // silently masked by a detected harness actor. The active thread
+    // actor remains the zero-config fallback for agent threads when no
+    // explicit attribution is present.
     let thread_actor = current_thread(repo)
         .ok()
         .flatten()
@@ -796,12 +830,8 @@ fn build_attribution(
     let provider = agent
         .provider
         .clone()
+        .or(env.provider)
         .or(thread_provider)
-        .or_else(|| {
-            std::env::var("HEDDLE_AGENT_PROVIDER")
-                .ok()
-                .and_then(clean_attribution_value)
-        })
         .or(harness_provider)
         .or(session_provider)
         .or_else(|| {
@@ -821,12 +851,8 @@ fn build_attribution(
     let model = agent
         .model
         .clone()
+        .or(env.model)
         .or(thread_model)
-        .or_else(|| {
-            std::env::var("HEDDLE_AGENT_MODEL")
-                .ok()
-                .and_then(clean_attribution_value)
-        })
         .or(harness_model)
         .or(session_model)
         .or_else(|| {
@@ -846,12 +872,12 @@ fn build_attribution(
     let session_id = agent
         .session
         .clone()
-        .or_else(|| std::env::var("HEDDLE_SESSION_ID").ok())
+        .or(env.session)
         .or_else(|| current_session.as_ref().map(|session| session.id.clone()));
     let segment_id = agent
         .segment
         .clone()
-        .or_else(|| std::env::var("HEDDLE_SESSION_SEGMENT").ok())
+        .or(env.segment)
         .or_else(|| {
             current_session
                 .as_ref()
@@ -863,11 +889,7 @@ fn build_attribution(
         agent
             .policy
             .clone()
-            .or_else(|| {
-                std::env::var("HEDDLE_AGENT_POLICY")
-                    .ok()
-                    .and_then(clean_attribution_value)
-            })
+            .or(env.policy)
             .or(harness_policy)
             .or(session_policy)
             .or_else(|| user_config.agent.default_policy.clone())
@@ -1023,6 +1045,118 @@ fn is_disk_full_anyhow(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn user_config_with_principal() -> UserConfig {
+        UserConfig {
+            principal: Some(crate::config::UserPrincipalConfig {
+                name: "Ada Lovelace".to_string(),
+                email: "ada@example.com".to_string(),
+            }),
+            ..UserConfig::default()
+        }
+    }
+
+    fn save_active_harness_entry(
+        repo: &Repository,
+        provider: &str,
+        model: &str,
+    ) -> objects::store::AgentEntry {
+        let thread = current_thread(repo)
+            .unwrap()
+            .expect("initialized repository has a current thread");
+        let registry = objects::store::AgentRegistry::new(repo.heddle_dir());
+        let entry = objects::store::AgentEntry {
+            session_id: objects::store::generate_agent_id(),
+            client_instance_id: None,
+            native_actor_key: Some("claude-code:session:session-457".to_string()),
+            native_parent_actor_key: None,
+            native_instance_key: Some("claude-code:transcript:/tmp/claude/457.jsonl".to_string()),
+            heddle_session_id: None,
+            thread_id: Some(thread.id.clone()),
+            thread: thread.id,
+            pid: Some(std::process::id()),
+            boot_id: None,
+            liveness_path: None,
+            heartbeat_at: Some(chrono::Utc::now()),
+            anchor_state: None,
+            anchor_root: None,
+            reservation_token: Some(objects::store::generate_agent_id()),
+            path: Some(repo.root().to_path_buf()),
+            base_state: String::new(),
+            started_at: chrono::Utc::now(),
+            provider: Some(provider.to_string()),
+            model: Some(model.to_string()),
+            harness: Some("claude-code".to_string()),
+            thinking_level: None,
+            usage_summary: objects::store::AgentUsageSummary::default(),
+            last_progress_at: None,
+            report_flush_state: Some("pending-local".to_string()),
+            attach_reason: Some("test detected harness actor".to_string()),
+            attach_precedence: Vec::new(),
+            winning_attach_rule: Some("test".to_string()),
+            probe_source: Some("hook_payload".to_string()),
+            probe_confidence: Some(0.99),
+            status: objects::store::AgentStatus::Active,
+            completed_at: None,
+            context_queries: Vec::new(),
+        };
+        registry.save(&entry).unwrap();
+        entry
+    }
+
+    fn empty_agent_overrides() -> SnapshotAgentOverrides {
+        SnapshotAgentOverrides {
+            provider: None,
+            model: None,
+            session: None,
+            segment: None,
+            policy: None,
+            no_policy: false,
+            no_agent: false,
+        }
+    }
+
+    #[test]
+    fn build_attribution_explicit_env_wins_over_active_harness_actor() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        save_active_harness_entry(&repo, "anthropic", "claude-opus-4-8[1m]");
+
+        let attribution = build_attribution_with_env(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+            AgentEnv {
+                provider: Some("openai".to_string()),
+                model: Some("gpt-5-codex".to_string()),
+                ..AgentEnv::default()
+            },
+        )
+        .unwrap();
+
+        let agent = attribution.agent.expect("explicit env should set agent");
+        assert_eq!(agent.provider, "openai");
+        assert_eq!(agent.model, "gpt-5-codex");
+    }
+
+    #[test]
+    fn build_attribution_uses_detected_harness_actor_when_env_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        save_active_harness_entry(&repo, "anthropic", "claude-opus-4-8[1m]");
+
+        let attribution = build_attribution_with_env(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+            AgentEnv::default(),
+        )
+        .unwrap();
+
+        let agent = attribution.agent.expect("detected harness actor should set agent");
+        assert_eq!(agent.provider, "anthropic");
+        assert_eq!(agent.model, "claude-opus-4-8[1m]");
+    }
 
     #[test]
     fn is_disk_full_anyhow_detects_direct_io_error() {

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2963,6 +2963,51 @@ mod tests {
     }
 
     #[test]
+    fn blank_agent_model_hint_falls_through_to_detected_model_without_segment_rotation() {
+        let (_temp, repo) = init_repo();
+        let user_config = UserConfig::default();
+        let mut runtime = HarnessBridgeRuntime::new(repo, user_config);
+        let blank_model_env = BTreeMap::from([
+            ("HEDDLE_AGENT_PROVIDER".to_string(), "anthropic".to_string()),
+            ("HEDDLE_AGENT_MODEL".to_string(), String::new()),
+        ]);
+
+        let opened = runtime
+            .open_session(OpenSessionParams {
+                harness: Some("claude-code".to_string()),
+                env_hints: blank_model_env.clone(),
+                probe_metadata: BTreeMap::from([
+                    ("session_id".to_string(), "claude-sess-blank".to_string()),
+                    ("model".to_string(), "claude-opus-4-8[1m]".to_string()),
+                ]),
+                ..OpenSessionParams::default()
+            })
+            .unwrap();
+        assert_eq!(opened.model.as_deref(), Some("claude-opus-4-8[1m]"));
+
+        let original_segment = opened.heddle_segment_id.clone();
+        runtime
+            .update_progress(UpdateProgressParams {
+                heddle_session_id: opened.heddle_session_id.clone(),
+                env_hints: blank_model_env,
+                probe_metadata: BTreeMap::from([
+                    ("session_id".to_string(), "claude-sess-blank".to_string()),
+                    ("model".to_string(), "claude-opus-4-8[1m]".to_string()),
+                ]),
+                ..UpdateProgressParams::default()
+            })
+            .unwrap();
+
+        let report = runtime
+            .reports
+            .load(&opened.heddle_session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.harness.model.as_deref(), Some("claude-opus-4-8[1m]"));
+        assert_eq!(report.heddle_segment_id, original_segment);
+    }
+
+    #[test]
     fn close_session_captures_changed_paths_from_status_and_hints() {
         let (temp, repo) = init_repo();
         let config = UserConfig::default();

--- a/crates/cli/src/harness/probe/claude_code.rs
+++ b/crates/cli/src/harness/probe/claude_code.rs
@@ -54,11 +54,12 @@ impl HarnessActorProbe for ClaudeCodeProbe {
                 .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
                 .or_else(|| input.current_provider.clone())
                 .or(Some("anthropic".to_string())),
-            model: metadata
-                .get("model")
-                .cloned()
-                .or_else(|| argv_value(argv, "--model"))
+            model: input
+                .explicit_model
+                .clone()
                 .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+                .or_else(|| metadata.get("model").cloned())
+                .or_else(|| argv_value(argv, "--model"))
                 .or_else(|| input.env_hints.get("CLAUDE_MODEL").cloned())
                 .or_else(|| input.env_hints.get("ANTHROPIC_MODEL").cloned())
                 .or_else(|| input.env_hints.get("MODEL").cloned())
@@ -92,6 +93,11 @@ impl HarnessActorProbe for ClaudeCodeProbe {
                 tool_calls: metadata.get("tool_calls").and_then(|v| v.parse().ok()),
                 cost_micros_usd: parse_u64(metadata.get("cost_micros_usd")),
             },
+            policy: input
+                .explicit_policy
+                .clone()
+                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
+                .or_else(|| input.current_policy.clone()),
             touched_paths: csv_paths(metadata.get("touched_paths")),
             transcript_refs: transcript_path
                 .map(|path| {

--- a/crates/cli/src/harness/probe/claude_code.rs
+++ b/crates/cli/src/harness/probe/claude_code.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, csv_paths, parse_u64,
+    attribution_env_hint, argv_value, csv_paths, parse_u64,
 };
 
 pub(crate) struct ClaudeCodeProbe;
@@ -51,13 +51,13 @@ impl HarnessActorProbe for ClaudeCodeProbe {
             provider: input
                 .explicit_provider
                 .clone()
-                .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
+                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_PROVIDER"))
                 .or_else(|| input.current_provider.clone())
                 .or(Some("anthropic".to_string())),
             model: input
                 .explicit_model
                 .clone()
-                .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
                 .or_else(|| metadata.get("model").cloned())
                 .or_else(|| argv_value(argv, "--model"))
                 .or_else(|| input.env_hints.get("CLAUDE_MODEL").cloned())
@@ -96,7 +96,7 @@ impl HarnessActorProbe for ClaudeCodeProbe {
             policy: input
                 .explicit_policy
                 .clone()
-                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
+                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_POLICY"))
                 .or_else(|| input.current_policy.clone()),
             touched_paths: csv_paths(metadata.get("touched_paths")),
             transcript_refs: transcript_path

--- a/crates/cli/src/harness/probe/codex.rs
+++ b/crates/cli/src/harness/probe/codex.rs
@@ -44,18 +44,20 @@ impl HarnessActorProbe for CodexProbe {
                     .get("CODEX_INTERNAL_ORIGINATOR_OVERRIDE")
                     .cloned()
             });
-        let model = metadata
-            .get("model")
-            .cloned()
+        let model = input
+            .explicit_model
+            .clone()
+            .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+            .or_else(|| metadata.get("model").cloned())
             .or_else(|| argv_value(argv, "--model"))
             .or_else(|| input.env_hints.get("CODEX_MODEL").cloned())
             .or_else(|| input.env_hints.get("OPENAI_MODEL").cloned())
             .or_else(|| input.current_model.clone());
-        let provider = metadata
-            .get("model_provider")
-            .cloned()
-            .or_else(|| input.explicit_provider.clone())
+        let provider = input
+            .explicit_provider
+            .clone()
             .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
+            .or_else(|| metadata.get("model_provider").cloned())
             .or_else(|| input.current_provider.clone())
             .or(Some("openai".to_string()));
         let thinking_level = metadata
@@ -79,6 +81,7 @@ impl HarnessActorProbe for CodexProbe {
             policy: input
                 .explicit_policy
                 .clone()
+                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
                 .or_else(|| input.current_policy.clone()),
             native_actor_key: thread_id.map(|id| format!("codex:thread:{id}")),
             native_parent_actor_key: None,

--- a/crates/cli/src/harness/probe/codex.rs
+++ b/crates/cli/src/harness/probe/codex.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, csv_paths, parse_u64,
+    attribution_env_hint, argv_value, csv_paths, parse_u64,
 };
 
 pub(crate) struct CodexProbe;
@@ -47,7 +47,7 @@ impl HarnessActorProbe for CodexProbe {
         let model = input
             .explicit_model
             .clone()
-            .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
             .or_else(|| metadata.get("model").cloned())
             .or_else(|| argv_value(argv, "--model"))
             .or_else(|| input.env_hints.get("CODEX_MODEL").cloned())
@@ -56,7 +56,7 @@ impl HarnessActorProbe for CodexProbe {
         let provider = input
             .explicit_provider
             .clone()
-            .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
+            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_PROVIDER"))
             .or_else(|| metadata.get("model_provider").cloned())
             .or_else(|| input.current_provider.clone())
             .or(Some("openai".to_string()));
@@ -81,7 +81,7 @@ impl HarnessActorProbe for CodexProbe {
             policy: input
                 .explicit_policy
                 .clone()
-                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
+                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_POLICY"))
                 .or_else(|| input.current_policy.clone()),
             native_actor_key: thread_id.map(|id| format!("codex:thread:{id}")),
             native_parent_actor_key: None,

--- a/crates/cli/src/harness/probe/mod.rs
+++ b/crates/cli/src/harness/probe/mod.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use proto::{TranscriptAttachmentRef, UsageTotals};
 
+use crate::attribution::clean_attribution_value;
+
 mod claude_code;
 mod codex;
 mod opencode;
@@ -177,10 +179,16 @@ fn fingerprint_from_hints(
         fingerprint.harness = Some("aider".to_string());
     }
 
-    fingerprint.provider = env_hints.get("HEDDLE_AGENT_PROVIDER").cloned();
+    fingerprint.provider = fingerprint.provider.or_else(|| {
+        env_hints
+            .get("HEDDLE_AGENT_PROVIDER")
+            .cloned()
+            .and_then(clean_attribution_value)
+    });
     fingerprint.model = env_hints
         .get("HEDDLE_AGENT_MODEL")
         .cloned()
+        .and_then(clean_attribution_value)
         .or_else(|| env_hints.get("CODEX_MODEL").cloned())
         .or_else(|| env_hints.get("CLAUDE_MODEL").cloned())
         .or_else(|| env_hints.get("ANTHROPIC_MODEL").cloned())
@@ -197,8 +205,19 @@ fn fingerprint_from_hints(
     fingerprint.policy = env_hints
         .get("HEDDLE_AGENT_POLICY")
         .cloned()
+        .and_then(clean_attribution_value)
         .or_else(|| env_hints.get("PROMPT_POLICY").cloned());
     fingerprint
+}
+
+pub(crate) fn attribution_env_hint(
+    env_hints: &BTreeMap<String, String>,
+    key: &str,
+) -> Option<String> {
+    env_hints
+        .get(key)
+        .cloned()
+        .and_then(clean_attribution_value)
 }
 
 pub(crate) fn argv_value(argv: &[String], flag: &str) -> Option<String> {
@@ -315,6 +334,33 @@ mod tests {
         assert_eq!(result.harness.as_deref(), Some("claude-code"));
         assert_eq!(result.provider.as_deref(), Some("openai"));
         assert_eq!(result.model.as_deref(), Some("gpt-5-codex"));
+    }
+
+    #[test]
+    fn blank_heddle_agent_env_falls_through_to_detected_claude_identity() {
+        let mut env_hints = BTreeMap::new();
+        env_hints.insert("CLAUDECODE".to_string(), "1".to_string());
+        env_hints.insert("HEDDLE_AGENT_PROVIDER".to_string(), "anthropic".to_string());
+        env_hints.insert("HEDDLE_AGENT_MODEL".to_string(), String::new());
+        env_hints.insert("HEDDLE_AGENT_POLICY".to_string(), "unknown".to_string());
+
+        let result = probe_harness_actor(&HarnessProbeInput {
+            env_hints,
+            explicit_harness: Some("claude-code".to_string()),
+            probe_metadata: BTreeMap::from([
+                ("model".to_string(), "claude-opus-4-8[1m]".to_string()),
+                ("session_id".to_string(), "claude-sess-1".to_string()),
+            ]),
+            current_policy: Some("detected-policy".to_string()),
+            repo_root: "/tmp/repo".to_string(),
+            ..HarnessProbeInput::default()
+        })
+        .expect("probe should succeed");
+
+        assert_eq!(result.harness.as_deref(), Some("claude-code"));
+        assert_eq!(result.provider.as_deref(), Some("anthropic"));
+        assert_eq!(result.model.as_deref(), Some("claude-opus-4-8[1m]"));
+        assert_eq!(result.policy.as_deref(), Some("detected-policy"));
     }
 
     #[test]

--- a/crates/cli/src/harness/probe/mod.rs
+++ b/crates/cli/src/harness/probe/mod.rs
@@ -295,6 +295,29 @@ mod tests {
     }
 
     #[test]
+    fn explicit_heddle_agent_env_wins_over_detected_claude_identity() {
+        let mut env_hints = BTreeMap::new();
+        env_hints.insert("CLAUDECODE".to_string(), "1".to_string());
+        env_hints.insert("HEDDLE_AGENT_PROVIDER".to_string(), "openai".to_string());
+        env_hints.insert("HEDDLE_AGENT_MODEL".to_string(), "gpt-5-codex".to_string());
+
+        let result = probe_harness_actor(&HarnessProbeInput {
+            env_hints,
+            probe_metadata: BTreeMap::from([(
+                "model".to_string(),
+                "claude-opus-4-8[1m]".to_string(),
+            )]),
+            repo_root: "/tmp/repo".to_string(),
+            ..HarnessProbeInput::default()
+        })
+        .expect("probe should succeed");
+
+        assert_eq!(result.harness.as_deref(), Some("claude-code"));
+        assert_eq!(result.provider.as_deref(), Some("openai"));
+        assert_eq!(result.model.as_deref(), Some("gpt-5-codex"));
+    }
+
+    #[test]
     fn argv_parent_hint_identifies_claude_code_actor() {
         let result = probe_harness_actor(&HarnessProbeInput {
             argv: Some(vec![

--- a/crates/cli/src/harness/probe/opencode.rs
+++ b/crates/cli/src/harness/probe/opencode.rs
@@ -42,20 +42,20 @@ impl HarnessActorProbe for OpenCodeProbe {
             Some(origin) => format!("opencode:client:{client_name}@{origin}"),
             None => format!("opencode:client:{client_name}"),
         });
-        let provider = metadata
-            .get("provider")
-            .cloned()
-            .or_else(|| input.explicit_provider.clone())
+        let provider = input
+            .explicit_provider
+            .clone()
             .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
+            .or_else(|| metadata.get("provider").cloned())
             .or_else(|| input.env_hints.get("OPENCODE_PROVIDER").cloned())
             .or_else(|| input.current_provider.clone());
-        let model = metadata
-            .get("model")
-            .cloned()
+        let model = input
+            .explicit_model
+            .clone()
+            .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+            .or_else(|| metadata.get("model").cloned())
             .or_else(|| metadata.get("agent_model").cloned())
             .or_else(|| argv_value(argv, "--model"))
-            .or_else(|| input.explicit_model.clone())
-            .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
             .or_else(|| input.env_hints.get("OPENCODE_MODEL").cloned())
             .or_else(|| input.env_hints.get("MODEL").cloned())
             .or_else(|| input.current_model.clone());
@@ -70,6 +70,11 @@ impl HarnessActorProbe for OpenCodeProbe {
             harness: Some("opencode".to_string()),
             provider,
             model,
+            policy: input
+                .explicit_policy
+                .clone()
+                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
+                .or_else(|| input.current_policy.clone()),
             native_actor_key: session_id
                 .clone()
                 .map(|id| format!("opencode:session:{id}")),

--- a/crates/cli/src/harness/probe/opencode.rs
+++ b/crates/cli/src/harness/probe/opencode.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, csv_paths, parse_u64,
+    attribution_env_hint, argv_value, csv_paths, parse_u64,
 };
 
 pub(crate) struct OpenCodeProbe;
@@ -45,14 +45,14 @@ impl HarnessActorProbe for OpenCodeProbe {
         let provider = input
             .explicit_provider
             .clone()
-            .or_else(|| input.env_hints.get("HEDDLE_AGENT_PROVIDER").cloned())
+            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_PROVIDER"))
             .or_else(|| metadata.get("provider").cloned())
             .or_else(|| input.env_hints.get("OPENCODE_PROVIDER").cloned())
             .or_else(|| input.current_provider.clone());
         let model = input
             .explicit_model
             .clone()
-            .or_else(|| input.env_hints.get("HEDDLE_AGENT_MODEL").cloned())
+            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
             .or_else(|| metadata.get("model").cloned())
             .or_else(|| metadata.get("agent_model").cloned())
             .or_else(|| argv_value(argv, "--model"))
@@ -73,7 +73,7 @@ impl HarnessActorProbe for OpenCodeProbe {
             policy: input
                 .explicit_policy
                 .clone()
-                .or_else(|| input.env_hints.get("HEDDLE_AGENT_POLICY").cloned())
+                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_POLICY"))
                 .or_else(|| input.current_policy.clone()),
             native_actor_key: session_id
                 .clone()

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,6 +11,7 @@ compile_error!(
 );
 
 pub mod bench;
+pub(crate) mod attribution;
 // The bridge module stays always-compiled so light consumers (fsck,
 // clone, fetch, remote, checkpoint, operator_loop, gc) keep working in
 // native-only builds without fanning #[cfg] through their use blocks.


### PR DESCRIPTION
## Summary
- Honor explicit `HEDDLE_AGENT_*` attribution before active harness/thread/session identity during capture attribution resolution.
- Prefer explicit provider/model/policy in harness probes before detected metadata or harness defaults.
- Add regression coverage for explicit env winning over a detected Claude harness identity, plus the no-env zero-config fallback.

Closes #457.

## Approach
This takes the honor-explicit-over-fingerprint path. `HEDDLE_AGENT_*` is user-supplied attribution for the current capture, so silently masking it with an auto-detected harness actor is the trust failure. Harness detection remains a fallback when explicit env is absent.

## Validation
- `cargo test -p heddle-cli build_attribution_` passed
- `cargo test -p heddle-cli explicit_heddle_agent_env_wins_over_detected_claude_identity` passed
- `cargo test -p heddle-cli` currently fails in unrelated `multi_agent_worktrees` next-action tests: the built mainline binary emits/validates `heddle land --thread ...`, while `land` is not a registered subcommand and the tests expect older `merge --preview` / `thread resolve` actions. This reproduces with a single exact test and with harness env cleared.
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd 2>&1 | tail -20` passed before the final test-only env-injection refactor; the package test blocker above prevents a clean rerun.
- `bash scripts/check-no-silent-default-tree-load.sh` passed
- `cargo clippy --locked --workspace --all-targets -- -D warnings` passed

Did not run `cargo fmt`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783049278&installation_id=132405951&pr_number=465&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F465&signature=e52a6171081fde975c6489a48994180f0add7e69a583e81ffef9b6d249e25004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->