### PR TITLE
feat(semantic): merge Rust `use` re-exports as path-keyed items (#468)

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -53,11 +53,12 @@ pub(crate) struct Item {
     pub key: ItemKey,
     pub start_byte: usize,
     pub end_byte: usize,
-    /// For `use` / `pub use` items only: leaf set + visibility used for
-    /// cross-side matching and semantic dedup. `None` for every other item
-    /// kind. Never used for byte emission, so the original grouped
-    /// declaration text is preserved. Consumed by [`canonicalize_use_keys`]
-    /// (leaf-set collision) and [`super::reconstruct`] (semantic dedup).
+    /// For `use` / `pub use` items only: the expanded leaf set used for
+    /// cross-side matching. `None` for every other item kind. Never used for
+    /// byte emission, so the original grouped declaration text is preserved.
+    /// Consumed by [`canonicalize_use_keys`] (leaf-set collision keying); the
+    /// add/add resolution in [`super::reconstruct`] then dedups only on exact
+    /// bytes and conflicts on every other difference.
     pub use_identity: Option<UseIdentity>,
 }
 

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -21,11 +21,12 @@
 //!
 //! See HeddleCo/heddle#133 for the audit motivation.
 
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use tree_sitter::Node;
 
-pub(super) use super::language_rules::ItemKind;
+pub(super) use super::language_rules::{ItemKind, UseIdentity};
 use super::language_rules::{rules_for, Classified, MetadataBinding};
 use crate::parser::{Language, ParsedFile};
 
@@ -52,6 +53,12 @@ pub(crate) struct Item {
     pub key: ItemKey,
     pub start_byte: usize,
     pub end_byte: usize,
+    /// For `use` / `pub use` items only: leaf set + visibility used for
+    /// cross-side matching and semantic dedup. `None` for every other item
+    /// kind. Never used for byte emission, so the original grouped
+    /// declaration text is preserved. Consumed by [`canonicalize_use_keys`]
+    /// (leaf-set collision) and [`super::reconstruct`] (semantic dedup).
+    pub use_identity: Option<UseIdentity>,
 }
 
 /// The result of segmenting a file: items in source order, exposed via the
@@ -147,6 +154,11 @@ fn collect_items(
                 } else {
                     let mut item_scope = (*scope).clone();
                     item_scope.extend(extra_scope);
+                    let use_identity = if matches!(kind, ItemKind::Use) {
+                        super::language_rules::use_identity(language, source, child)
+                    } else {
+                        None
+                    };
                     let item_key = ItemKey {
                         kind,
                         name,
@@ -158,12 +170,146 @@ fn collect_items(
                         key: item_key,
                         start_byte,
                         end_byte: child.end_byte(),
+                        use_identity,
                     });
                 }
             } else {
                 stack.push((child, Rc::clone(&scope), depth + 1));
             }
         }
+    }
+}
+
+/// Rekey every `use` item across the three sides so two declarations
+/// collide for cross-side matching iff their expanded leaf sets intersect
+/// on ANY import path — not just the lexicographically-smallest leaf.
+///
+/// Why this is necessary: items match across sides by exact [`ItemKey`]
+/// equality, but leaf-set *intersection* is not transitive, so no
+/// per-declaration single key can capture it (`a::{Bar, Baz}` overlaps
+/// `a::Baz` but their minimum leaves differ → distinct keys → both emitted
+/// → duplicate `Baz`, a Rust "defined multiple times" error — the
+/// heddle#468 bug class, Codex r1's representative-key fix only caught
+/// overlap on the minimum leaf). Equality-based matching CAN model
+/// intersection if every declaration in one connected component (linked by
+/// shared leaves) is rekeyed to one canonical name. That is exactly a
+/// union-find over leaves: union all leaves within each declaration, then
+/// rekey each declaration to its component's smallest leaf.
+///
+/// The result for the existing add/add resolution in
+/// [`super::reconstruct`]:
+/// * identical leaf sets → same canonical key, byte-identical → **dedup**
+///   (the original grouped text is preserved — bytes are untouched);
+/// * overlapping but not identical → same canonical key, divergent bytes →
+///   **conflict** (the conservative resolution; we never silently rewrite
+///   or combine import statements);
+/// * disjoint leaf sets → distinct canonical keys → **union** (the r0
+///   additive-re-export case stays clean).
+///
+/// Un-normalizable forms (globs, `as` aliases, nested groups) all carry the
+/// single sentinel leaf, so they share one component and conflict-on-
+/// divergence only with each other — never with a real import path.
+///
+/// This is a no-op for any `use` whose leaf set overlaps nothing: its
+/// component is itself and its canonical name equals its own minimum leaf,
+/// matching the pre-canonicalization seed key.
+pub(crate) fn canonicalize_use_keys(
+    base: &mut FileSegments,
+    ours: &mut FileSegments,
+    theirs: &mut FileSegments,
+) {
+    let mut uf = LeafUnionFind::default();
+    for seg in [&*base, &*ours, &*theirs] {
+        for item in &seg.items {
+            let Some(identity) = &item.use_identity else {
+                continue;
+            };
+            let mut leaf_iter = identity.leaves.iter();
+            let Some(first) = leaf_iter.next() else {
+                continue;
+            };
+            let anchor = uf.intern(first);
+            for leaf in leaf_iter {
+                let node = uf.intern(leaf);
+                uf.union(anchor, node);
+            }
+        }
+    }
+
+    let canonical = uf.component_min_label();
+    for seg in [base, ours, theirs] {
+        for item in &mut seg.items {
+            let Some(identity) = &item.use_identity else {
+                continue;
+            };
+            if let Some(first) = identity.leaves.first()
+                && let Some(name) = canonical.get(first)
+            {
+                item.key.name = name.clone();
+            }
+        }
+    }
+}
+
+/// Union-find over leaf import-path strings. Leaves are interned to dense
+/// indices on first sight; `union` links the components two leaves belong
+/// to; [`component_min_label`] returns, for every interned leaf, the
+/// lexicographically-smallest leaf in its component (the canonical name).
+#[derive(Default)]
+struct LeafUnionFind {
+    index: HashMap<String, usize>,
+    labels: Vec<String>,
+    parent: Vec<usize>,
+}
+
+impl LeafUnionFind {
+    fn intern(&mut self, leaf: &str) -> usize {
+        if let Some(&i) = self.index.get(leaf) {
+            return i;
+        }
+        let i = self.labels.len();
+        self.index.insert(leaf.to_string(), i);
+        self.labels.push(leaf.to_string());
+        self.parent.push(i);
+        i
+    }
+
+    fn find(&mut self, mut x: usize) -> usize {
+        while self.parent[x] != x {
+            self.parent[x] = self.parent[self.parent[x]];
+            x = self.parent[x];
+        }
+        x
+    }
+
+    fn union(&mut self, a: usize, b: usize) {
+        let ra = self.find(a);
+        let rb = self.find(b);
+        if ra != rb {
+            self.parent[ra] = rb;
+        }
+    }
+
+    fn component_min_label(&mut self) -> HashMap<String, String> {
+        let mut root_min: HashMap<usize, String> = HashMap::new();
+        for i in 0..self.labels.len() {
+            let root = self.find(i);
+            let label = self.labels[i].clone();
+            root_min
+                .entry(root)
+                .and_modify(|m| {
+                    if label < *m {
+                        *m = label.clone();
+                    }
+                })
+                .or_insert(label);
+        }
+        let mut out = HashMap::with_capacity(self.labels.len());
+        for i in 0..self.labels.len() {
+            let root = self.find(i);
+            out.insert(self.labels[i].clone(), root_min[&root].clone());
+        }
+        out
     }
 }
 

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 use tree_sitter::Node;
 
 pub(super) use super::language_rules::{ItemKind, UseIdentity};
-use super::language_rules::{rules_for, Classified, MetadataBinding};
+use super::language_rules::{rules_for, Classified, MetadataBinding, USE_POISON_KEY};
 use crate::parser::{Language, ParsedFile};
 
 /// Stable identifier for an item across the three sides. Two items match iff
@@ -207,25 +207,54 @@ fn collect_items(
 /// * disjoint leaf sets → distinct canonical keys → **union** (the r0
 ///   additive-re-export case stays clean).
 ///
-/// Un-normalizable forms (globs, `as` aliases, nested groups) all carry the
-/// single sentinel leaf, so they share one component and conflict-on-
-/// divergence only with each other — never with a real import path.
+/// The leaf union runs ONLY when every `use` item on every side is a
+/// fully-analyzable plain import ([`UseIdentity::Plain`]). A single
+/// unanalyzable form ([`UseIdentity::Unanalyzable`] — `self` in a group,
+/// nested group, glob, `as` alias, metavariable, malformed) anywhere
+/// **poisons** the use-region: we cannot extract its leaves, so it might
+/// overlap a plain import on a leaf we never saw, and the leaf partition
+/// can no longer be trusted. In that case every `use` item is rekeyed to
+/// the shared [`USE_POISON_KEY`] instead, collapsing the region into one
+/// component that [`super::reconstruct::resolve_use_component`] resolves
+/// as a single conservative whole-region 3-way merge (byte-identical →
+/// dedup, anything else → conflict). Capping the clever union to
+/// plain-imports-only makes the exotic-form drip class impossible
+/// (heddle#468 r6 on PR #477).
 ///
-/// This is a no-op for any `use` whose leaf set overlaps nothing: its
-/// component is itself and its canonical name equals its own minimum leaf,
-/// matching the pre-canonicalization seed key.
+/// This is a no-op for any `use` whose leaf set overlaps nothing in the
+/// un-poisoned path: its component is itself and its canonical name equals
+/// its own minimum leaf, matching the pre-canonicalization seed key.
 pub(crate) fn canonicalize_use_keys(
     base: &mut FileSegments,
     ours: &mut FileSegments,
     theirs: &mut FileSegments,
 ) {
+    // Poison gate: any unanalyzable `use` on any side disqualifies the
+    // whole region from the leaf union. Collapse every `use` item onto one
+    // key so the conservative whole-region merge runs instead.
+    let poisoned = [&*base, &*ours, &*theirs].iter().any(|seg| {
+        seg.items
+            .iter()
+            .any(|item| matches!(item.use_identity, Some(UseIdentity::Unanalyzable)))
+    });
+    if poisoned {
+        for seg in [base, ours, theirs] {
+            for item in &mut seg.items {
+                if item.use_identity.is_some() {
+                    item.key.name = USE_POISON_KEY.to_string();
+                }
+            }
+        }
+        return;
+    }
+
     let mut uf = LeafUnionFind::default();
     for seg in [&*base, &*ours, &*theirs] {
         for item in &seg.items {
-            let Some(identity) = &item.use_identity else {
+            let Some(UseIdentity::Plain(leaves)) = &item.use_identity else {
                 continue;
             };
-            let mut leaf_iter = identity.leaves.iter();
+            let mut leaf_iter = leaves.iter();
             let Some(first) = leaf_iter.next() else {
                 continue;
             };
@@ -240,10 +269,10 @@ pub(crate) fn canonicalize_use_keys(
     let canonical = uf.component_min_label();
     for seg in [base, ours, theirs] {
         for item in &mut seg.items {
-            let Some(identity) = &item.use_identity else {
+            let Some(UseIdentity::Plain(leaves)) = &item.use_identity else {
                 continue;
             };
-            if let Some(first) = identity.leaves.first()
+            if let Some(first) = leaves.first()
                 && let Some(name) = canonical.get(first)
             {
                 item.key.name = name.clone();

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -54,11 +54,14 @@ pub(super) enum ItemKind {
     Method,
     Impl,
     Module,
-    /// A `use` / `pub use` declaration, keyed by a representative leaf
-    /// import path (groups expanded to leaves) so additive re-exports on
-    /// disjoint paths union while a grouped-vs-ungrouped form that shares
-    /// a leaf dedups-or-conflicts instead of duplicating the import
-    /// (HeddleCo/heddle#468; Codex r1 on PR #477). See [`rust_use_key`].
+    /// A `use` / `pub use` declaration. Its match key is the leaf-set
+    /// *component* canonical name assigned by
+    /// [`super::items::canonicalize_use_keys`]: two declarations collide iff
+    /// their expanded leaf sets intersect on ANY path, so additive
+    /// re-exports on disjoint paths union while any overlapping pair
+    /// dedups (identical) or conflicts (divergent) instead of duplicating
+    /// an import (HeddleCo/heddle#468; Codex r1+r2 on PR #477). See
+    /// [`rust_use_key`] (seed key) and [`use_leaves`] (the leaf set).
     Use,
     Struct,
     Enum,
@@ -66,6 +69,20 @@ pub(super) enum ItemKind {
     TypeAlias,
     Const,
     Static,
+}
+
+/// Cross-side identity metadata for a `use` / `pub use` item. Carried on
+/// [`super::items::Item`] (only for `Use`-kind items) and consumed by the
+/// reconstruction layer; see [`use_identity`].
+#[derive(Clone, Debug)]
+pub(super) struct UseIdentity {
+    /// Expanded fully-qualified leaf import paths, or the single
+    /// [`USE_UNNORMALIZABLE_KEY`] sentinel for shapes we can't expand.
+    pub leaves: Vec<String>,
+    /// `true` iff `leaves` is the exact expansion (not the sentinel).
+    pub normalizable: bool,
+    /// Whitespace-stripped `visibility_modifier` text, or `""` for private.
+    pub visibility: String,
 }
 
 /// Classifier output: what kind of item, its name, an optional body to
@@ -290,20 +307,22 @@ impl LanguageRules for RustRules {
             "type_item" => leaf_item(ItemKind::TypeAlias, source, node, "name"),
             "const_item" => leaf_item(ItemKind::Const, source, node, "name"),
             "static_item" => leaf_item(ItemKind::Static, source, node, "name"),
-            // Key a `use` / `pub use` by a representative leaf import path
-            // derived from its `argument` use-tree (`crate::x::Y`,
-            // `a::{B, C}`, `a::*`, `a::B as C`, …). Expanding `{...}` groups
-            // to leaves and keying by the smallest leaf makes a grouped form
-            // and an ungrouped form that share that leaf COLLIDE — so they
-            // dedup or conflict rather than unioning into a duplicate import.
-            // Visibility is intentionally NOT part of the key: two sides
-            // adding the same path with divergent visibility (`pub use a::B`
-            // vs `use a::B`) share a key and surface as an add/add conflict,
-            // while disjoint paths get distinct keys and union cleanly
-            // (HeddleCo/heddle#468; Codex r1 on PR #477). A missing
-            // `argument` (malformed) falls through to the unclassified
-            // walker, leaving the `use` in inter-item content as before. See
-            // [`rust_use_key`] for the leaf expansion and its fallback.
+            // Seed a `use` / `pub use` with a representative leaf import
+            // path from its `argument` use-tree (`crate::x::Y`, `a::{B, C}`,
+            // `a::*`, `a::B as C`, …). The authoritative match key is then
+            // assigned by `canonicalize_use_keys`, which collides two
+            // declarations whenever their expanded leaf sets intersect on
+            // ANY leaf, so a grouped form and an ungrouped form that share
+            // even a non-minimum leaf dedup or conflict rather than union
+            // into a duplicate import. Visibility is intentionally NOT part
+            // of the key: two sides adding the same path with divergent
+            // visibility (`pub use a::B` vs `use a::B`) share a key and
+            // surface as an add/add conflict, while disjoint paths get
+            // distinct keys and union cleanly (HeddleCo/heddle#468; Codex
+            // r1+r2 on PR #477). A missing `argument` (malformed) falls
+            // through to the unclassified walker, leaving the `use` in
+            // inter-item content as before. See [`rust_use_key`] (seed) and
+            // [`use_leaves`] (full leaf set).
             "use_declaration" => {
                 let argument = node.child_by_field_name("argument")?;
                 let name = rust_use_key(source, argument);
@@ -366,20 +385,18 @@ fn rust_impl_name(source: &str, node: Node<'_>) -> Option<String> {
 /// NUL keeps it disjoint from every real import path.
 const USE_UNNORMALIZABLE_KEY: &str = "\u{0}use::unnormalizable";
 
-/// Derive the cross-side identity key for a Rust `use` / `pub use`
-/// declaration from its `argument` use-tree.
+/// Derive the INITIAL cross-side identity key for a Rust `use` / `pub use`
+/// declaration from its `argument` use-tree: the lexicographically-smallest
+/// fully-qualified leaf import path.
 ///
-/// Flat groups are expanded into their fully-qualified leaf import paths
-/// (`crate::foo::{Bar, Baz}` → `["crate::foo::Bar", "crate::foo::Baz"]`)
-/// and the declaration is keyed by the lexicographically-smallest leaf.
-/// Keying by a representative leaf — rather than the whole `{...}` text —
-/// is what makes a grouped form and an ungrouped form that share that
-/// leaf COLLIDE: `use crate::foo::{Bar, Baz};` and `use crate::foo::Bar;`
-/// both key to `crate::foo::Bar`, so the merger dedups (identical bytes)
-/// or surfaces an add/add conflict (divergent bytes) instead of unioning
-/// the two lines into a duplicate `Bar` import (the heddle#468 bug class;
-/// Codex r1 on PR #477). Visibility (`pub`) is intentionally NOT part of
-/// the key.
+/// This representative leaf is only a seed. The authoritative `use` match
+/// key is assigned later by [`super::items::canonicalize_use_keys`], which
+/// rekeys every `use` item to its leaf-set *component* canonical name so
+/// declarations whose leaf sets intersect on ANY path collide — closing the
+/// representative-key partiality where overlap on a non-minimum leaf
+/// (`a::{Bar, Baz}` vs `a::Baz`) escaped collision and unioned into a
+/// duplicate import (the heddle#468 bug class; Codex r1+r2 on PR #477).
+/// Visibility (`pub`) is intentionally NOT part of the key.
 ///
 /// Confidently-expandable shapes: a single path (`a::B`, `B`) and a
 /// single flat group whose members are all plain paths. Shapes we do NOT
@@ -387,24 +404,79 @@ const USE_UNNORMALIZABLE_KEY: &str = "\u{0}use::unnormalizable";
 /// (`a::{b::{c}}`), and `self`/comment group members — fall back to
 /// [`USE_UNNORMALIZABLE_KEY`] so they conflict-on-overlap rather than
 /// risk a silent mis-union.
-///
-/// NOTE (residual): representative-leaf keying catches overlap only on
-/// the minimum leaf. Two declarations that overlap ONLY on a
-/// non-minimum leaf — `a::{Bar, Baz}` vs `a::Baz` — still get distinct
-/// keys and union. Fully closing this needs one extracted item per leaf
-/// (a larger change to the one-node-one-item extractor in
-/// [`super::items`]); representative-leaf keying is the in-architecture
-/// fix for the common min-aligned re-export merge.
 fn rust_use_key(source: &str, argument: Node<'_>) -> String {
+    rust_use_leaves(source, argument)
+        .0
+        .into_iter()
+        .min()
+        .unwrap_or_else(|| USE_UNNORMALIZABLE_KEY.to_string())
+}
+
+/// Expand a Rust `use` `argument` use-tree into its fully-qualified leaf
+/// import paths (`crate::foo::{Bar, Baz}` → `["crate::foo::Bar",
+/// "crate::foo::Baz"]`). The bool is `true` when the tree expanded cleanly.
+/// Shapes we can't confidently expand — globs, `as` aliases, nested groups,
+/// `self`/comment members, malformed trees — yield `false` with the single
+/// [`USE_UNNORMALIZABLE_KEY`] sentinel so they collide only with other
+/// un-normalizable forms. Never returns an empty vector.
+///
+/// This is the full leaf SET (not a representative). It is consumed by
+/// [`super::items::canonicalize_use_keys`], which collides two declarations
+/// whenever their leaf sets intersect on ANY path — not just the minimum
+/// leaf, the partiality that let `use a::{Bar, Baz}` and `use a::Baz` escape
+/// collision and union into a duplicate `Baz` import (heddle#468; Codex r2
+/// on PR #477).
+fn rust_use_leaves(source: &str, argument: Node<'_>) -> (Vec<String>, bool) {
     let mut leaves = Vec::new();
     if collect_use_leaves(source, argument, "", &mut leaves) && !leaves.is_empty() {
-        leaves
-            .into_iter()
-            .min()
-            .unwrap_or_else(|| USE_UNNORMALIZABLE_KEY.to_string())
+        (leaves, true)
     } else {
-        USE_UNNORMALIZABLE_KEY.to_string()
+        (vec![USE_UNNORMALIZABLE_KEY.to_string()], false)
     }
+}
+
+/// The text of a `use` declaration's `visibility_modifier` child
+/// (`pub`, `pub(crate)`, `pub(in path)`, …), whitespace-stripped, or the
+/// empty string for a private `use`. Used so a same-leaf-set add/add that
+/// differs only in visibility still conflicts (`pub use a::B` vs
+/// `use a::B`) while a difference of pure spelling (`use a::{B}` vs
+/// `use a::B`) can dedup. Read from the AST node, NOT the item byte range,
+/// so leading attributes / doc comments don't contaminate it.
+fn use_visibility(source: &str, node: Node<'_>) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "visibility_modifier" {
+            return strip_whitespace(&source[child.byte_range()]);
+        }
+    }
+    String::new()
+}
+
+/// Cross-side identity for a Rust `use` / `pub use` item: its expanded leaf
+/// set, whether that set is exact (vs the un-normalizable sentinel), and its
+/// visibility modifier. Returns `None` for non-Rust / non-`use` nodes (no
+/// other language classifies a `use` item today).
+///
+/// `leaves` drives leaf-set-intersection collision in
+/// [`super::items::canonicalize_use_keys`]. `normalizable` + `visibility`
+/// drive the semantic add/add dedup in [`super::reconstruct`]: two
+/// declarations that import the SAME normalizable leaf set with the SAME
+/// visibility are one import spelled two ways and dedup; un-normalizable
+/// forms never dedup on anything but exact bytes (so `use a::*` vs `use b::*`
+/// still conflicts).
+pub(super) fn use_identity(language: Language, source: &str, node: Node<'_>) -> Option<UseIdentity> {
+    if language != Language::Rust || node.kind() != "use_declaration" {
+        return None;
+    }
+    let (leaves, normalizable) = match node.child_by_field_name("argument") {
+        Some(argument) => rust_use_leaves(source, argument),
+        None => (vec![USE_UNNORMALIZABLE_KEY.to_string()], false),
+    };
+    Some(UseIdentity {
+        leaves,
+        normalizable,
+        visibility: use_visibility(source, node),
+    })
 }
 
 /// Expand a `use` argument use-tree into leaf import paths, accumulating

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -78,11 +78,13 @@ pub(super) enum ItemKind {
 pub(super) struct UseIdentity {
     /// Expanded fully-qualified leaf import paths, or the single
     /// [`USE_UNNORMALIZABLE_KEY`] sentinel for shapes we can't expand.
+    /// This is the ONLY signal the merge keys on: leaf-set intersection
+    /// drives cross-side collision in [`super::items::canonicalize_use_keys`]
+    /// (disjoint → distinct key → auto-combine; overlap → same key → dedup
+    /// if byte-identical, else conflict). No visibility / normalizable
+    /// partial-signal — every non-byte-identical difference conflicts, which
+    /// is what makes the rule non-drippable (heddle#468, Codex r4 on #477).
     pub leaves: Vec<String>,
-    /// `true` iff `leaves` is the exact expansion (not the sentinel).
-    pub normalizable: bool,
-    /// Whitespace-stripped `visibility_modifier` text, or `""` for private.
-    pub visibility: String,
 }
 
 /// Classifier output: what kind of item, its name, an optional body to
@@ -406,7 +408,6 @@ const USE_UNNORMALIZABLE_KEY: &str = "\u{0}use::unnormalizable";
 /// risk a silent mis-union.
 fn rust_use_key(source: &str, argument: Node<'_>) -> String {
     rust_use_leaves(source, argument)
-        .0
         .into_iter()
         .min()
         .unwrap_or_else(|| USE_UNNORMALIZABLE_KEY.to_string())
@@ -414,11 +415,10 @@ fn rust_use_key(source: &str, argument: Node<'_>) -> String {
 
 /// Expand a Rust `use` `argument` use-tree into its fully-qualified leaf
 /// import paths (`crate::foo::{Bar, Baz}` → `["crate::foo::Bar",
-/// "crate::foo::Baz"]`). The bool is `true` when the tree expanded cleanly.
-/// Shapes we can't confidently expand — globs, `as` aliases, nested groups,
-/// `self`/comment members, malformed trees — yield `false` with the single
-/// [`USE_UNNORMALIZABLE_KEY`] sentinel so they collide only with other
-/// un-normalizable forms. Never returns an empty vector.
+/// "crate::foo::Baz"]`). Shapes we can't confidently expand — globs, `as`
+/// aliases, nested groups, `self`/comment members, malformed trees — yield
+/// the single [`USE_UNNORMALIZABLE_KEY`] sentinel so they collide only with
+/// other un-normalizable forms. Never returns an empty vector.
 ///
 /// This is the full leaf SET (not a representative). It is consumed by
 /// [`super::items::canonicalize_use_keys`], which collides two declarations
@@ -426,57 +426,37 @@ fn rust_use_key(source: &str, argument: Node<'_>) -> String {
 /// leaf, the partiality that let `use a::{Bar, Baz}` and `use a::Baz` escape
 /// collision and union into a duplicate `Baz` import (heddle#468; Codex r2
 /// on PR #477).
-fn rust_use_leaves(source: &str, argument: Node<'_>) -> (Vec<String>, bool) {
+fn rust_use_leaves(source: &str, argument: Node<'_>) -> Vec<String> {
     let mut leaves = Vec::new();
     if collect_use_leaves(source, argument, "", &mut leaves) && !leaves.is_empty() {
-        (leaves, true)
+        leaves
     } else {
-        (vec![USE_UNNORMALIZABLE_KEY.to_string()], false)
+        vec![USE_UNNORMALIZABLE_KEY.to_string()]
     }
-}
-
-/// The text of a `use` declaration's `visibility_modifier` child
-/// (`pub`, `pub(crate)`, `pub(in path)`, …), whitespace-stripped, or the
-/// empty string for a private `use`. Used so a same-leaf-set add/add that
-/// differs only in visibility still conflicts (`pub use a::B` vs
-/// `use a::B`) while a difference of pure spelling (`use a::{B}` vs
-/// `use a::B`) can dedup. Read from the AST node, NOT the item byte range,
-/// so leading attributes / doc comments don't contaminate it.
-fn use_visibility(source: &str, node: Node<'_>) -> String {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "visibility_modifier" {
-            return strip_whitespace(&source[child.byte_range()]);
-        }
-    }
-    String::new()
 }
 
 /// Cross-side identity for a Rust `use` / `pub use` item: its expanded leaf
-/// set, whether that set is exact (vs the un-normalizable sentinel), and its
-/// visibility modifier. Returns `None` for non-Rust / non-`use` nodes (no
-/// other language classifies a `use` item today).
+/// set. Returns `None` for non-Rust / non-`use` nodes (no other language
+/// classifies a `use` item today).
 ///
-/// `leaves` drives leaf-set-intersection collision in
-/// [`super::items::canonicalize_use_keys`]. `normalizable` + `visibility`
-/// drive the semantic add/add dedup in [`super::reconstruct`]: two
-/// declarations that import the SAME normalizable leaf set with the SAME
-/// visibility are one import spelled two ways and dedup; un-normalizable
-/// forms never dedup on anything but exact bytes (so `use a::*` vs `use b::*`
-/// still conflicts).
+/// `leaves` is the sole keying signal — it drives leaf-set-intersection
+/// collision in [`super::items::canonicalize_use_keys`], which reduces every
+/// add/add `use` to exactly three cases: disjoint leaf sets auto-combine,
+/// overlapping-and-byte-identical dedups, and overlapping-with-any-other
+/// difference conflicts. There is deliberately no visibility / normalizable
+/// field: a non-byte difference of ANY dimension (visibility, alias,
+/// `cfg`/doc/attribute metadata, grouping) must conflict, never partial-signal
+/// dedup (heddle#468, Codex r4 on PR #477; same-leaf with divergent
+/// `#[cfg(...)]` was silently dropping one platform's import).
 pub(super) fn use_identity(language: Language, source: &str, node: Node<'_>) -> Option<UseIdentity> {
     if language != Language::Rust || node.kind() != "use_declaration" {
         return None;
     }
-    let (leaves, normalizable) = match node.child_by_field_name("argument") {
+    let leaves = match node.child_by_field_name("argument") {
         Some(argument) => rust_use_leaves(source, argument),
-        None => (vec![USE_UNNORMALIZABLE_KEY.to_string()], false),
+        None => vec![USE_UNNORMALIZABLE_KEY.to_string()],
     };
-    Some(UseIdentity {
-        leaves,
-        normalizable,
-        visibility: use_visibility(source, node),
-    })
+    Some(UseIdentity { leaves })
 }
 
 /// Expand a `use` argument use-tree into leaf import paths, accumulating

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -54,14 +54,20 @@ pub(super) enum ItemKind {
     Method,
     Impl,
     Module,
-    /// A `use` / `pub use` declaration. Its match key is the leaf-set
-    /// *component* canonical name assigned by
-    /// [`super::items::canonicalize_use_keys`]: two declarations collide iff
+    /// A `use` / `pub use` declaration. Its match key is assigned by
+    /// [`super::items::canonicalize_use_keys`]. When every `use` item on
+    /// every side is a fully-analyzable plain import, the key is the
+    /// leaf-set *component* canonical name: two declarations collide iff
     /// their expanded leaf sets intersect on ANY path, so additive
-    /// re-exports on disjoint paths union while any overlapping pair
-    /// dedups (identical) or conflicts (divergent) instead of duplicating
-    /// an import (HeddleCo/heddle#468; Codex r1+r2 on PR #477). See
-    /// [`rust_use_key`] (seed key) and [`use_leaves`] (the leaf set).
+    /// re-exports on disjoint paths union while any overlapping pair dedups
+    /// (identical) or conflicts (divergent) instead of duplicating an
+    /// import. If ANY side carries an unanalyzable form (`self` in a group,
+    /// a nested group, a glob, an `as` alias, …), the whole use-region is
+    /// instead collapsed onto one key ([`USE_POISON_KEY`]) and resolved
+    /// conservatively, so an exotic form can never be mis-unioned with a
+    /// plain import that shares a hidden leaf (HeddleCo/heddle#468; Codex
+    /// r1+r2, r6 on PR #477). See [`rust_use_key`] (seed key) and
+    /// [`UseIdentity`].
     Use,
     Struct,
     Enum,
@@ -71,20 +77,33 @@ pub(super) enum ItemKind {
     Static,
 }
 
-/// Cross-side identity metadata for a `use` / `pub use` item. Carried on
-/// [`super::items::Item`] (only for `Use`-kind items) and consumed by the
-/// reconstruction layer; see [`use_identity`].
+/// Cross-side identity for a `use` / `pub use` item. Carried on
+/// [`super::items::Item`] (only for `Use`-kind items) and consumed by
+/// [`super::items::canonicalize_use_keys`]; see [`use_identity`].
 #[derive(Clone, Debug)]
-pub(super) struct UseIdentity {
-    /// Expanded fully-qualified leaf import paths, or the single
-    /// [`USE_UNNORMALIZABLE_KEY`] sentinel for shapes we can't expand.
-    /// This is the ONLY signal the merge keys on: leaf-set intersection
-    /// drives cross-side collision in [`super::items::canonicalize_use_keys`]
-    /// (disjoint → distinct key → auto-combine; overlap → same key → dedup
-    /// if byte-identical, else conflict). No visibility / normalizable
-    /// partial-signal — every non-byte-identical difference conflicts, which
-    /// is what makes the rule non-drippable (heddle#468, Codex r4 on #477).
-    pub leaves: Vec<String>,
+pub(super) enum UseIdentity {
+    /// A fully-analyzable plain import: the expanded fully-qualified leaf
+    /// import paths (`a::{B, C}` → `["a::B", "a::C"]`). This is the ONLY
+    /// signal the leaf-component merge keys on — leaf-set intersection
+    /// drives cross-side collision in
+    /// [`super::items::canonicalize_use_keys`] (disjoint → distinct key →
+    /// auto-combine; overlap → same key → dedup if byte-identical, else
+    /// conflict). No visibility / partial-signal: every non-byte-identical
+    /// difference conflicts (heddle#468, Codex r4 on #477).
+    Plain(Vec<String>),
+    /// A form we cannot safely expand into discrete leaves — `self` in a
+    /// group, a nested group, a glob (`a::*`), an `as` alias, a
+    /// metavariable, or a malformed tree. Such an item could overlap a
+    /// plain import on a leaf we never extracted, so it **poisons** its
+    /// use-region: [`super::items::canonicalize_use_keys`] collapses every
+    /// `use` item in a region containing one of these (on ANY side) onto a
+    /// single key ([`USE_POISON_KEY`]) and lets the reconstruction layer
+    /// merge the whole region conservatively, rather than running the leaf
+    /// union. An exotic form can therefore never be mis-unioned with a
+    /// plain import that shares a hidden leaf — the clever path's surface
+    /// is capped to plain imports, the non-drippable boundary (heddle#468,
+    /// Codex r6 on PR #477).
+    Unanalyzable,
 }
 
 /// Classifier output: what kind of item, its name, an optional body to
@@ -372,53 +391,52 @@ fn rust_impl_name(source: &str, node: Node<'_>) -> Option<String> {
     Some(strip_whitespace(&key))
 }
 
-/// Shared key-name for `use` declarations we can't confidently expand
-/// into discrete leaf import paths — globs (`foo::*`), `as` aliases
-/// (`a::B as C`), nested groups (`a::{b::{c}}`), and `self`/comment
-/// group members. Every such declaration keys to this single name, so
-/// two un-normalizable `use`s on different sides COLLIDE: byte-identical
-/// ones dedup, divergent ones surface an add/add conflict. This is the
-/// SAFE fallback — a conflict is never a silent duplicate import,
-/// whereas keying these by raw text would let an un-expandable
-/// glob/alias union with an overlapping import and reintroduce the
-/// heddle#468 duplicate (Codex r1 on PR #477). Cost: two genuinely
-/// disjoint un-normalizable `use`s (e.g. `a::*` and `b::Foo as Bar`)
-/// also collide and conflict — intentionally conservative. The leading
-/// NUL keeps it disjoint from every real import path.
-const USE_UNNORMALIZABLE_KEY: &str = "\u{0}use::unnormalizable";
+/// Canonical [`super::items::ItemKey`] name stamped on EVERY `use` item in
+/// a *poisoned* use-region — a region containing at least one
+/// [`UseIdentity::Unanalyzable`] form (`self` in a group, nested group,
+/// glob, `as` alias, metavariable, malformed tree) on any side. Collapsing
+/// the whole region onto this one key routes it through a single
+/// conservative whole-region 3-way merge in the reconstruction layer
+/// ([`super::reconstruct::resolve_use_component`]): byte-identical text
+/// dedups, anything else conflicts. A conflict is never a silent duplicate
+/// import, so capping the leaf-component union to plain imports makes the
+/// exotic-form drip class impossible (heddle#468, Codex r6 on PR #477).
+/// Also serves as the (always-overwritten) seed name for an unanalyzable
+/// item at classification time. The leading NUL keeps it disjoint from
+/// every real import path / leaf-component name.
+pub(super) const USE_POISON_KEY: &str = "\u{0}use::poison";
 
 /// Derive the INITIAL cross-side identity key for a Rust `use` / `pub use`
 /// declaration from its `argument` use-tree: the lexicographically-smallest
 /// fully-qualified leaf import path.
 ///
-/// This representative leaf is only a seed. The authoritative `use` match
-/// key is assigned later by [`super::items::canonicalize_use_keys`], which
-/// rekeys every `use` item to its leaf-set *component* canonical name so
-/// declarations whose leaf sets intersect on ANY path collide — closing the
-/// representative-key partiality where overlap on a non-minimum leaf
-/// (`a::{Bar, Baz}` vs `a::Baz`) escaped collision and unioned into a
-/// duplicate import (the heddle#468 bug class; Codex r1+r2 on PR #477).
-/// Visibility (`pub`) is intentionally NOT part of the key.
+/// This representative leaf is only a seed — [`super::items::canonicalize_use_keys`]
+/// always overwrites it: plain imports are rekeyed to their leaf-set
+/// *component* canonical name (so declarations whose leaf sets intersect on
+/// ANY path collide; heddle#468 r1+r2), and a poisoned region is rekeyed to
+/// [`USE_POISON_KEY`] (heddle#468 r6). Visibility (`pub`) is intentionally
+/// NOT part of the key.
 ///
-/// Confidently-expandable shapes: a single path (`a::B`, `B`) and a
-/// single flat group whose members are all plain paths. Shapes we do NOT
-/// expand — globs (`foo::*`), `as` aliases, nested groups
-/// (`a::{b::{c}}`), and `self`/comment group members — fall back to
-/// [`USE_UNNORMALIZABLE_KEY`] so they conflict-on-overlap rather than
-/// risk a silent mis-union.
+/// Confidently-expandable shapes: a single path (`a::B`, `B`) and a single
+/// flat group whose members are all plain paths. Shapes we do NOT expand —
+/// globs (`foo::*`), `as` aliases, nested groups (`a::{b::{c}}`), and
+/// `self`/comment group members — seed [`USE_POISON_KEY`] and are marked
+/// [`UseIdentity::Unanalyzable`].
 fn rust_use_key(source: &str, argument: Node<'_>) -> String {
     rust_use_leaves(source, argument)
-        .into_iter()
-        .min()
-        .unwrap_or_else(|| USE_UNNORMALIZABLE_KEY.to_string())
+        .and_then(|leaves| leaves.into_iter().min())
+        .unwrap_or_else(|| USE_POISON_KEY.to_string())
 }
 
 /// Expand a Rust `use` `argument` use-tree into its fully-qualified leaf
-/// import paths (`crate::foo::{Bar, Baz}` → `["crate::foo::Bar",
-/// "crate::foo::Baz"]`). Shapes we can't confidently expand — globs, `as`
-/// aliases, nested groups, `self`/comment members, malformed trees — yield
-/// the single [`USE_UNNORMALIZABLE_KEY`] sentinel so they collide only with
-/// other un-normalizable forms. Never returns an empty vector.
+/// import paths (`crate::foo::{Bar, Baz}` → `Some(["crate::foo::Bar",
+/// "crate::foo::Baz"])`). Returns `None` for any shape we can't confidently
+/// expand — globs, `as` aliases, nested groups, `self`/comment members,
+/// malformed/empty trees — so the caller marks the item
+/// [`UseIdentity::Unanalyzable`] (poisoning its region) rather than
+/// assigning it a leaf that the leaf-component union would treat as
+/// disjoint from a real overlapping import (heddle#468 r6 on PR #477).
+/// Never returns `Some` of an empty vector.
 ///
 /// This is the full leaf SET (not a representative). It is consumed by
 /// [`super::items::canonicalize_use_keys`], which collides two declarations
@@ -426,42 +444,48 @@ fn rust_use_key(source: &str, argument: Node<'_>) -> String {
 /// leaf, the partiality that let `use a::{Bar, Baz}` and `use a::Baz` escape
 /// collision and union into a duplicate `Baz` import (heddle#468; Codex r2
 /// on PR #477).
-fn rust_use_leaves(source: &str, argument: Node<'_>) -> Vec<String> {
+fn rust_use_leaves(source: &str, argument: Node<'_>) -> Option<Vec<String>> {
     let mut leaves = Vec::new();
     if collect_use_leaves(source, argument, "", &mut leaves) && !leaves.is_empty() {
-        leaves
+        Some(leaves)
     } else {
-        vec![USE_UNNORMALIZABLE_KEY.to_string()]
+        None
     }
 }
 
-/// Cross-side identity for a Rust `use` / `pub use` item: its expanded leaf
-/// set. Returns `None` for non-Rust / non-`use` nodes (no other language
+/// Cross-side identity for a Rust `use` / `pub use` item:
+/// [`UseIdentity::Plain`] (its expanded leaf set) for a fully-analyzable
+/// flat import, or [`UseIdentity::Unanalyzable`] for any exotic form.
+/// Returns `None` for non-Rust / non-`use` nodes (no other language
 /// classifies a `use` item today).
 ///
-/// `leaves` is the sole keying signal — it drives leaf-set-intersection
-/// collision in [`super::items::canonicalize_use_keys`], which reduces every
-/// add/add `use` to exactly three cases: disjoint leaf sets auto-combine,
-/// overlapping-and-byte-identical dedups, and overlapping-with-any-other
-/// difference conflicts. There is deliberately no visibility / normalizable
-/// field: a non-byte difference of ANY dimension (visibility, alias,
-/// `cfg`/doc/attribute metadata, grouping) must conflict, never partial-signal
-/// dedup (heddle#468, Codex r4 on PR #477; same-leaf with divergent
-/// `#[cfg(...)]` was silently dropping one platform's import).
+/// A `Plain` leaf set is the sole keying signal for the leaf-component
+/// merge in [`super::items::canonicalize_use_keys`], which reduces an
+/// all-plain add/add `use` to exactly three cases: disjoint leaf sets
+/// auto-combine, overlapping-and-byte-identical dedups, and
+/// overlapping-with-any-other difference conflicts (no visibility /
+/// partial-signal field — any non-byte difference conflicts; heddle#468
+/// r4). An `Unanalyzable` item poisons its region so the leaf union never
+/// runs there at all (heddle#468 r6).
 pub(super) fn use_identity(language: Language, source: &str, node: Node<'_>) -> Option<UseIdentity> {
     if language != Language::Rust || node.kind() != "use_declaration" {
         return None;
     }
-    let leaves = match node.child_by_field_name("argument") {
-        Some(argument) => rust_use_leaves(source, argument),
-        None => vec![USE_UNNORMALIZABLE_KEY.to_string()],
+    let identity = match node.child_by_field_name("argument") {
+        Some(argument) => match rust_use_leaves(source, argument) {
+            Some(leaves) => UseIdentity::Plain(leaves),
+            None => UseIdentity::Unanalyzable,
+        },
+        // A `use` with no `argument` is malformed; treat it as unanalyzable
+        // so it poisons rather than keying to a leaf it does not have.
+        None => UseIdentity::Unanalyzable,
     };
-    Some(UseIdentity { leaves })
+    Some(identity)
 }
 
 /// Expand a `use` argument use-tree into leaf import paths, accumulating
 /// the `prefix` built from enclosing `path::{...}` segments. Returns
-/// `false` (caller falls back to [`USE_UNNORMALIZABLE_KEY`]) for any
+/// `false` (caller marks the item [`UseIdentity::Unanalyzable`]) for any
 /// shape we don't confidently expand. See [`rust_use_key`].
 fn collect_use_leaves(source: &str, node: Node<'_>, prefix: &str, out: &mut Vec<String>) -> bool {
     match node.kind() {
@@ -494,9 +518,9 @@ fn collect_use_leaves(source: &str, node: Node<'_>, prefix: &str, out: &mut Vec<
 
 /// Expand a FLAT `use_list` (`{A, B, C}`) whose members are all plain
 /// paths. Any non-path member — a nested group, glob, alias, `self`, or
-/// comment — makes the whole declaration un-normalizable (`false`), so
-/// it falls back to the conflict-on-overlap sentinel rather than being
-/// partially expanded into a mis-union. An empty list yields `false`.
+/// comment — makes the whole declaration unanalyzable (`false`), so the
+/// item poisons its region rather than being partially expanded into a
+/// mis-union. An empty list yields `false`.
 fn expand_flat_use_list(source: &str, list: Node<'_>, prefix: &str, out: &mut Vec<String>) -> bool {
     let mut cursor = list.walk();
     let mut any = false;

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -54,6 +54,10 @@ pub(super) enum ItemKind {
     Method,
     Impl,
     Module,
+    /// A `use` / `pub use` declaration, keyed by its import path so additive
+    /// re-exports on disjoint paths union and same-path divergence conflicts
+    /// (HeddleCo/heddle#468).
+    Use,
     Struct,
     Enum,
     Trait,
@@ -284,6 +288,27 @@ impl LanguageRules for RustRules {
             "type_item" => leaf_item(ItemKind::TypeAlias, source, node, "name"),
             "const_item" => leaf_item(ItemKind::Const, source, node, "name"),
             "static_item" => leaf_item(ItemKind::Static, source, node, "name"),
+            // Key a `use` / `pub use` by its import-path `argument` (the use
+            // tree: `crate::x::Y`, `a::{B, C}`, `a::*`, `a::B as C`, …),
+            // whitespace-stripped so cosmetic reformatting doesn't split
+            // identity. Visibility is intentionally NOT part of the key: two
+            // sides adding the same path with divergent visibility
+            // (`pub use a::B` vs `use a::B`) share a key and surface as an
+            // add/add conflict, while disjoint paths get distinct keys and
+            // union cleanly (HeddleCo/heddle#468). A missing `argument`
+            // (malformed) falls through to the unclassified walker, leaving
+            // the `use` in inter-item content as before.
+            "use_declaration" => {
+                let argument = node.child_by_field_name("argument")?;
+                let name = strip_whitespace(&source[argument.byte_range()]);
+                Some(Classified {
+                    kind: ItemKind::Use,
+                    name,
+                    container_body: None,
+                    signature_hash: 0,
+                    extra_scope: Vec::new(),
+                })
+            }
             _ => None,
         }
     }

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -54,9 +54,11 @@ pub(super) enum ItemKind {
     Method,
     Impl,
     Module,
-    /// A `use` / `pub use` declaration, keyed by its import path so additive
-    /// re-exports on disjoint paths union and same-path divergence conflicts
-    /// (HeddleCo/heddle#468).
+    /// A `use` / `pub use` declaration, keyed by a representative leaf
+    /// import path (groups expanded to leaves) so additive re-exports on
+    /// disjoint paths union while a grouped-vs-ungrouped form that shares
+    /// a leaf dedups-or-conflicts instead of duplicating the import
+    /// (HeddleCo/heddle#468; Codex r1 on PR #477). See [`rust_use_key`].
     Use,
     Struct,
     Enum,
@@ -288,19 +290,23 @@ impl LanguageRules for RustRules {
             "type_item" => leaf_item(ItemKind::TypeAlias, source, node, "name"),
             "const_item" => leaf_item(ItemKind::Const, source, node, "name"),
             "static_item" => leaf_item(ItemKind::Static, source, node, "name"),
-            // Key a `use` / `pub use` by its import-path `argument` (the use
-            // tree: `crate::x::Y`, `a::{B, C}`, `a::*`, `a::B as C`, …),
-            // whitespace-stripped so cosmetic reformatting doesn't split
-            // identity. Visibility is intentionally NOT part of the key: two
-            // sides adding the same path with divergent visibility
-            // (`pub use a::B` vs `use a::B`) share a key and surface as an
-            // add/add conflict, while disjoint paths get distinct keys and
-            // union cleanly (HeddleCo/heddle#468). A missing `argument`
-            // (malformed) falls through to the unclassified walker, leaving
-            // the `use` in inter-item content as before.
+            // Key a `use` / `pub use` by a representative leaf import path
+            // derived from its `argument` use-tree (`crate::x::Y`,
+            // `a::{B, C}`, `a::*`, `a::B as C`, …). Expanding `{...}` groups
+            // to leaves and keying by the smallest leaf makes a grouped form
+            // and an ungrouped form that share that leaf COLLIDE — so they
+            // dedup or conflict rather than unioning into a duplicate import.
+            // Visibility is intentionally NOT part of the key: two sides
+            // adding the same path with divergent visibility (`pub use a::B`
+            // vs `use a::B`) share a key and surface as an add/add conflict,
+            // while disjoint paths get distinct keys and union cleanly
+            // (HeddleCo/heddle#468; Codex r1 on PR #477). A missing
+            // `argument` (malformed) falls through to the unclassified
+            // walker, leaving the `use` in inter-item content as before. See
+            // [`rust_use_key`] for the leaf expansion and its fallback.
             "use_declaration" => {
                 let argument = node.child_by_field_name("argument")?;
-                let name = strip_whitespace(&source[argument.byte_range()]);
+                let name = rust_use_key(source, argument);
                 Some(Classified {
                     kind: ItemKind::Use,
                     name,
@@ -343,6 +349,118 @@ fn rust_impl_name(source: &str, node: Node<'_>) -> Option<String> {
     // `::`, `<>`, etc. doesn't turn into a "different impl"
     // misclassification (r3 fix `021ed8e`).
     Some(strip_whitespace(&key))
+}
+
+/// Shared key-name for `use` declarations we can't confidently expand
+/// into discrete leaf import paths — globs (`foo::*`), `as` aliases
+/// (`a::B as C`), nested groups (`a::{b::{c}}`), and `self`/comment
+/// group members. Every such declaration keys to this single name, so
+/// two un-normalizable `use`s on different sides COLLIDE: byte-identical
+/// ones dedup, divergent ones surface an add/add conflict. This is the
+/// SAFE fallback — a conflict is never a silent duplicate import,
+/// whereas keying these by raw text would let an un-expandable
+/// glob/alias union with an overlapping import and reintroduce the
+/// heddle#468 duplicate (Codex r1 on PR #477). Cost: two genuinely
+/// disjoint un-normalizable `use`s (e.g. `a::*` and `b::Foo as Bar`)
+/// also collide and conflict — intentionally conservative. The leading
+/// NUL keeps it disjoint from every real import path.
+const USE_UNNORMALIZABLE_KEY: &str = "\u{0}use::unnormalizable";
+
+/// Derive the cross-side identity key for a Rust `use` / `pub use`
+/// declaration from its `argument` use-tree.
+///
+/// Flat groups are expanded into their fully-qualified leaf import paths
+/// (`crate::foo::{Bar, Baz}` → `["crate::foo::Bar", "crate::foo::Baz"]`)
+/// and the declaration is keyed by the lexicographically-smallest leaf.
+/// Keying by a representative leaf — rather than the whole `{...}` text —
+/// is what makes a grouped form and an ungrouped form that share that
+/// leaf COLLIDE: `use crate::foo::{Bar, Baz};` and `use crate::foo::Bar;`
+/// both key to `crate::foo::Bar`, so the merger dedups (identical bytes)
+/// or surfaces an add/add conflict (divergent bytes) instead of unioning
+/// the two lines into a duplicate `Bar` import (the heddle#468 bug class;
+/// Codex r1 on PR #477). Visibility (`pub`) is intentionally NOT part of
+/// the key.
+///
+/// Confidently-expandable shapes: a single path (`a::B`, `B`) and a
+/// single flat group whose members are all plain paths. Shapes we do NOT
+/// expand — globs (`foo::*`), `as` aliases, nested groups
+/// (`a::{b::{c}}`), and `self`/comment group members — fall back to
+/// [`USE_UNNORMALIZABLE_KEY`] so they conflict-on-overlap rather than
+/// risk a silent mis-union.
+///
+/// NOTE (residual): representative-leaf keying catches overlap only on
+/// the minimum leaf. Two declarations that overlap ONLY on a
+/// non-minimum leaf — `a::{Bar, Baz}` vs `a::Baz` — still get distinct
+/// keys and union. Fully closing this needs one extracted item per leaf
+/// (a larger change to the one-node-one-item extractor in
+/// [`super::items`]); representative-leaf keying is the in-architecture
+/// fix for the common min-aligned re-export merge.
+fn rust_use_key(source: &str, argument: Node<'_>) -> String {
+    let mut leaves = Vec::new();
+    if collect_use_leaves(source, argument, "", &mut leaves) && !leaves.is_empty() {
+        leaves
+            .into_iter()
+            .min()
+            .unwrap_or_else(|| USE_UNNORMALIZABLE_KEY.to_string())
+    } else {
+        USE_UNNORMALIZABLE_KEY.to_string()
+    }
+}
+
+/// Expand a `use` argument use-tree into leaf import paths, accumulating
+/// the `prefix` built from enclosing `path::{...}` segments. Returns
+/// `false` (caller falls back to [`USE_UNNORMALIZABLE_KEY`]) for any
+/// shape we don't confidently expand. See [`rust_use_key`].
+fn collect_use_leaves(source: &str, node: Node<'_>, prefix: &str, out: &mut Vec<String>) -> bool {
+    match node.kind() {
+        // A single fully-qualified path: `crate::foo::Bar` or `Bar`.
+        "identifier" | "scoped_identifier" => {
+            out.push(format!(
+                "{prefix}{}",
+                strip_whitespace(&source[node.byte_range()])
+            ));
+            true
+        }
+        // `path::{ ... }` — extend the prefix by the path, expand the list.
+        "scoped_use_list" => {
+            let new_prefix = match node.child_by_field_name("path") {
+                Some(p) => format!("{prefix}{}::", strip_whitespace(&source[p.byte_range()])),
+                None => prefix.to_string(),
+            };
+            let Some(list) = node.child_by_field_name("list") else {
+                return false;
+            };
+            expand_flat_use_list(source, list, &new_prefix, out)
+        }
+        // A bare `{ ... }` group with no leading path (rare at top level).
+        "use_list" => expand_flat_use_list(source, node, prefix, out),
+        // Globs, `as` aliases, `self`/`crate`/`super`, metavariables — not
+        // confidently expandable.
+        _ => false,
+    }
+}
+
+/// Expand a FLAT `use_list` (`{A, B, C}`) whose members are all plain
+/// paths. Any non-path member — a nested group, glob, alias, `self`, or
+/// comment — makes the whole declaration un-normalizable (`false`), so
+/// it falls back to the conflict-on-overlap sentinel rather than being
+/// partially expanded into a mis-union. An empty list yields `false`.
+fn expand_flat_use_list(source: &str, list: Node<'_>, prefix: &str, out: &mut Vec<String>) -> bool {
+    let mut cursor = list.walk();
+    let mut any = false;
+    for child in list.named_children(&mut cursor) {
+        match child.kind() {
+            "identifier" | "scoped_identifier" => {
+                out.push(format!(
+                    "{prefix}{}",
+                    strip_whitespace(&source[child.byte_range()])
+                ));
+                any = true;
+            }
+            _ => return false,
+        }
+    }
+    any
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/semantic/src/merge_driver/mod.rs
+++ b/crates/semantic/src/merge_driver/mod.rs
@@ -71,9 +71,15 @@ pub fn semantic_three_way_merge(
         return text_hunk_merge_with_markers(base, ours, theirs, markers);
     };
 
-    let base_segments = segment_file(&base_parsed);
-    let ours_segments = segment_file(&ours_parsed);
-    let theirs_segments = segment_file(&theirs_parsed);
+    let mut base_segments = segment_file(&base_parsed);
+    let mut ours_segments = segment_file(&ours_parsed);
+    let mut theirs_segments = segment_file(&theirs_parsed);
+
+    // Rekey `use` items so declarations whose expanded leaf sets intersect
+    // on ANY path collide for cross-side matching (heddle#468; Codex r2 on
+    // PR #477). Must run before the empty-base add/add guard below and
+    // before reconstruction, both of which key off `Item`/`ItemKey`.
+    items::canonicalize_use_keys(&mut base_segments, &mut ours_segments, &mut theirs_segments);
 
     // When a side has zero parseable items but the others do, the
     // per-item alignment has nothing to anchor on for that side and

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use merge::{text_hunk_merge_with_markers, ConflictMarkers, MergeOutcome};
 
-use super::items::{FileSegments, Item, ItemKey};
+use super::items::{FileSegments, Item, ItemKey, ItemKind};
 
 /// Three sides of the merge: `[base, ours, theirs]`. Each per-iteration
 /// segment contribution is indexed by [`Side`] so emission tracking can
@@ -36,6 +36,13 @@ const N_SIDES: usize = 3;
 /// the second, …) so each duplicate gets a distinct slot. Matching
 /// across sides pairs same-key items positionally — base's first `foo`
 /// pairs with ours's first `foo` pairs with theirs's first `foo`.
+///
+/// Positional occurrence governs only NON-`use` items. `use` items are
+/// resolved as whole leaf-components by [`resolve_use_component`] (a set
+/// comparison over every declaration each side contributes), so no `use`
+/// item's content is ever decided by its occurrence index — the occurrence
+/// slot survives for them only to anchor inter-item whitespace weaving
+/// (heddle#468 r5: the duplicate-import class the positional path produced).
 type MatchKey = (ItemKey, usize);
 
 /// Stitch three sides together via per-item resolution + inter-item hunk merge.
@@ -95,7 +102,14 @@ pub(crate) fn reconstruct_merged_file(
     // CRLF markers (Codex r2 P2 on PR #193, cid 3291860840).
     let sides = SideSources::new(base, ours, theirs);
 
+    // Non-`use` items: per-item positional resolution, matched by
+    // (key, occurrence). `use` items are skipped here — their content is
+    // NEVER decided by positional occurrence index (the heddle#468 r5 bug
+    // class). They are resolved below as whole leaf-components.
     for key in &all_keys {
+        if key.0.kind == ItemKind::Use {
+            continue;
+        }
         let resolution = resolve_item(
             sides,
             base_map.get(*key).copied(),
@@ -105,6 +119,45 @@ pub(crate) fn reconstruct_merged_file(
         );
         total_conflicts += resolution.1;
         resolved.insert((*key).clone(), resolution);
+    }
+
+    // `use` items: resolve each canonical leaf-component as ONE set-valued
+    // unit. After `canonicalize_use_keys`, every declaration in a component
+    // shares one `ItemKey`, so a side may contribute SEVERAL items to it
+    // (e.g. base `use a::Bar;` widened by theirs to `use a::{Bar, Baz};`
+    // while ours adds a separate `use a::Baz;`). Occurrence-matching those
+    // items positionally emitted both the widened group AND the standalone
+    // leaf — a duplicate import, no conflict (heddle#468, Codex r5 on PR
+    // #477). Comparing full component leaf-SETS instead makes the whole
+    // class impossible: the verdict lands on the component's first slot and
+    // every later slot emits nothing, so the component is resolved exactly
+    // once regardless of how many declarations each side spells it across.
+    let mut use_components: BTreeMap<ItemKey, [Vec<&Item>; 3]> = BTreeMap::new();
+    for (side, seg) in [base_segments, ours_segments, theirs_segments]
+        .iter()
+        .enumerate()
+    {
+        for item in &seg.items {
+            if item.key.kind == ItemKind::Use {
+                use_components
+                    .entry(item.key.clone())
+                    .or_insert_with(|| [Vec::new(), Vec::new(), Vec::new()])[side]
+                    .push(item);
+            }
+        }
+    }
+    for (key, [base_items, ours_items, theirs_items]) in &use_components {
+        let (bytes, conflicts) =
+            resolve_use_component(sides, base_items, ours_items, theirs_items, markers);
+        total_conflicts += conflicts;
+        resolved.insert((key.clone(), 0), (bytes, conflicts));
+        // Higher-occurrence slots of this component exist only so the
+        // inter-item segment weaver can place the surrounding whitespace;
+        // they carry no item bytes (the verdict above is the whole unit).
+        let slots = base_items.len().max(ours_items.len()).max(theirs_items.len());
+        for occ in 1..slots {
+            resolved.insert((key.clone(), occ), (None, 0));
+        }
     }
 
     let item_emit_order = compute_item_emit_order(&base_mks, &ours_mks, &theirs_mks, &all_keys);
@@ -413,18 +466,12 @@ fn resolve_item(
         // syntactically invalid file when both sides added a function /
         // method with the same name. heddle#68 calls this out as a conflict.
         (None, Some(o), Some(t)) => {
-            // The ONLY clean add/add is byte-identical. For `use` items this
-            // is one leg of the non-drippable 3-case rule (heddle#468, Codex
-            // r4 on PR #477): leaf-DISJOINT `use`s never reach this arm —
-            // `canonicalize_use_keys` gives them distinct match keys, so each
-            // is emitted on its own one-side-added path (auto-combine). What
-            // reaches here is two `use`s whose leaf sets OVERLAP (same
-            // canonical key). Byte-identical → dedup; ANYTHING else — a
-            // differing leaf set, alias, `cfg`/doc/attribute metadata, or
-            // visibility — is `o != t` and conflicts. No partial-signal
-            // (leaves+visibility-only) dedup: a same-leaf pair with divergent
-            // leading `#[cfg(...)]` used to dedup and silently drop one
-            // platform's import (r4); now it conflicts.
+            // The ONLY clean add/add is byte-identical. `use` items never
+            // reach this arm — they are resolved as whole leaf-components by
+            // `resolve_use_component` (set-valued, not positional). This arm
+            // now governs only non-`use` items (e.g. two top-level functions
+            // with the same name added on both sides): byte-identical → dedup,
+            // anything else → conflict (heddle#68).
             if o == t {
                 (Some(o.to_vec()), 0)
             } else {
@@ -478,6 +525,79 @@ fn materialize_outcome(outcome: MergeOutcome) -> (Option<Vec<u8>>, usize) {
         // parsed, but carry through safely.
         MergeOutcome::Binary | MergeOutcome::DeleteVsModify => (None, 1),
     }
+}
+
+/// Resolve one canonical leaf-component of `use` items as a single
+/// set-valued unit. `base_items` / `ours_items` / `theirs_items` are every
+/// declaration each side contributes to the component, in source order;
+/// any of them may be empty (component absent on that side) or hold more
+/// than one declaration (the heddle#468 r5 base-widened-grouped shape).
+///
+/// The component's text on a side is the byte-exact concatenation of its
+/// declarations (one EOL between consecutive lines). The 3-way verdict is
+/// taken over those WHOLE-component texts — never per declaration by
+/// positional occurrence — and reduces to exactly three outcomes:
+///
+/// * **one side left the component byte-identical to base** → take the
+///   other side (the standard "unchanged side defers" rule, generalized
+///   from [`resolve_item`]'s 3-way-modify arm to the set);
+/// * **both sides produced byte-identical text** → dedup to one copy;
+/// * **everything else** — a widened/regrouped base item, divergent
+///   additions, alias / `cfg` / visibility drift, or any multi-occurrence
+///   ambiguity within the component → **conflict** the whole component as
+///   one `<<<<<<< / ======= / >>>>>>>` block.
+///
+/// Because the comparison is over complete leaf-SETS rather than
+/// occurrence positions, the r5 class (base `use a::Bar;`; ours adds a
+/// separate `use a::Baz;`; theirs widens to `use a::{Bar, Baz};`) lands in
+/// the conflict outcome instead of silently emitting both `{Bar, Baz}` and
+/// `Baz` — a duplicate import (Rust E0252). No future regroup / widen /
+/// multi-occurrence shape can drip the same way.
+fn resolve_use_component(
+    sides: SideSources<'_>,
+    base_items: &[&Item],
+    ours_items: &[&Item],
+    theirs_items: &[&Item],
+    markers: ConflictMarkers<'_>,
+) -> (Option<Vec<u8>>, usize) {
+    let eol = sides.eol_policy.eol();
+    let base_bytes = join_component(base_items, sides.base, eol);
+    let ours_bytes = join_component(ours_items, sides.ours, eol);
+    let theirs_bytes = join_component(theirs_items, sides.theirs, eol);
+
+    let non_empty = |v: Vec<u8>| if v.is_empty() { None } else { Some(v) };
+
+    if ours_bytes == base_bytes {
+        // ours left the component untouched → take theirs (which may be a
+        // clean delete when theirs is empty).
+        return (non_empty(theirs_bytes), 0);
+    }
+    if theirs_bytes == base_bytes || ours_bytes == theirs_bytes {
+        // theirs left it untouched → take ours; or both sides made the
+        // byte-identical change → dedup to a single copy.
+        return (non_empty(ours_bytes), 0);
+    }
+    // Both sides changed the component, differently. Conflict the whole
+    // unit — see the outcome list above.
+    (
+        Some(emit_addadd_conflict(&ours_bytes, &theirs_bytes, markers, sides)),
+        1,
+    )
+}
+
+/// Concatenate a `use` component's declarations into one byte-exact text,
+/// separating consecutive lines with `eol`. A single declaration yields its
+/// own bytes verbatim (so single-occurrence components compare and emit
+/// exactly as [`resolve_item`] did before the set-valued path existed).
+fn join_component(items: &[&Item], source: &str, eol: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            out.extend_from_slice(eol);
+        }
+        out.extend_from_slice(&source.as_bytes()[item.start_byte..item.end_byte]);
+    }
+    out
 }
 
 /// Determine the order items should appear in the output. Strategy:

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -413,15 +413,19 @@ fn resolve_item(
         // syntactically invalid file when both sides added a function /
         // method with the same name. heddle#68 calls this out as a conflict.
         (None, Some(o), Some(t)) => {
-            if o == t || use_items_import_identically(ours_item, theirs_item) {
-                // Byte-identical, OR (for `use` items) the same normalizable
-                // leaf set with the same visibility spelled differently
-                // (`use a::{B}` vs `use a::B`) — one import, two spellings.
-                // Dedup to ours rather than conflicting on cosmetic
-                // bracketing. Divergent visibility (`pub use` vs `use`) or
-                // a non-identical leaf set fails the check and conflicts
-                // below; un-normalizable forms (glob / alias) only dedup on
-                // exact bytes, so `use a::*` vs `use b::*` still conflicts.
+            // The ONLY clean add/add is byte-identical. For `use` items this
+            // is one leg of the non-drippable 3-case rule (heddle#468, Codex
+            // r4 on PR #477): leaf-DISJOINT `use`s never reach this arm —
+            // `canonicalize_use_keys` gives them distinct match keys, so each
+            // is emitted on its own one-side-added path (auto-combine). What
+            // reaches here is two `use`s whose leaf sets OVERLAP (same
+            // canonical key). Byte-identical → dedup; ANYTHING else — a
+            // differing leaf set, alias, `cfg`/doc/attribute metadata, or
+            // visibility — is `o != t` and conflicts. No partial-signal
+            // (leaves+visibility-only) dedup: a same-leaf pair with divergent
+            // leading `#[cfg(...)]` used to dedup and silently drop one
+            // platform's import (r4); now it conflicts.
+            if o == t {
                 (Some(o.to_vec()), 0)
             } else {
                 (Some(emit_addadd_conflict(o, t, markers, sides)), 1)
@@ -461,31 +465,6 @@ fn resolve_item(
             }
         }
     }
-}
-
-/// Whether two add/add `use` items import exactly the same thing — the
-/// same normalizable leaf SET with the same visibility — and so should
-/// dedup to one line instead of conflicting on cosmetic spelling
-/// (`use a::{B}` vs `use a::B`). Returns `false` unless BOTH items are
-/// normalizable `use` items: divergent visibility (`pub use` vs `use`),
-/// a differing leaf set, or any un-normalizable form (glob / alias /
-/// nested group) falls through to the conflict path. Leaf sets are
-/// compared order-insensitively; a single declaration never repeats a leaf.
-fn use_items_import_identically(ours: Option<&Item>, theirs: Option<&Item>) -> bool {
-    let (Some(a), Some(b)) = (
-        ours.and_then(|i| i.use_identity.as_ref()),
-        theirs.and_then(|i| i.use_identity.as_ref()),
-    ) else {
-        return false;
-    };
-    if !a.normalizable || !b.normalizable || a.visibility != b.visibility {
-        return false;
-    }
-    let mut ours_leaves = a.leaves.clone();
-    let mut theirs_leaves = b.leaves.clone();
-    ours_leaves.sort();
-    theirs_leaves.sort();
-    ours_leaves == theirs_leaves
 }
 
 fn materialize_outcome(outcome: MergeOutcome) -> (Option<Vec<u8>>, usize) {

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -413,7 +413,15 @@ fn resolve_item(
         // syntactically invalid file when both sides added a function /
         // method with the same name. heddle#68 calls this out as a conflict.
         (None, Some(o), Some(t)) => {
-            if o == t {
+            if o == t || use_items_import_identically(ours_item, theirs_item) {
+                // Byte-identical, OR (for `use` items) the same normalizable
+                // leaf set with the same visibility spelled differently
+                // (`use a::{B}` vs `use a::B`) — one import, two spellings.
+                // Dedup to ours rather than conflicting on cosmetic
+                // bracketing. Divergent visibility (`pub use` vs `use`) or
+                // a non-identical leaf set fails the check and conflicts
+                // below; un-normalizable forms (glob / alias) only dedup on
+                // exact bytes, so `use a::*` vs `use b::*` still conflicts.
                 (Some(o.to_vec()), 0)
             } else {
                 (Some(emit_addadd_conflict(o, t, markers, sides)), 1)
@@ -453,6 +461,31 @@ fn resolve_item(
             }
         }
     }
+}
+
+/// Whether two add/add `use` items import exactly the same thing — the
+/// same normalizable leaf SET with the same visibility — and so should
+/// dedup to one line instead of conflicting on cosmetic spelling
+/// (`use a::{B}` vs `use a::B`). Returns `false` unless BOTH items are
+/// normalizable `use` items: divergent visibility (`pub use` vs `use`),
+/// a differing leaf set, or any un-normalizable form (glob / alias /
+/// nested group) falls through to the conflict path. Leaf sets are
+/// compared order-insensitively; a single declaration never repeats a leaf.
+fn use_items_import_identically(ours: Option<&Item>, theirs: Option<&Item>) -> bool {
+    let (Some(a), Some(b)) = (
+        ours.and_then(|i| i.use_identity.as_ref()),
+        theirs.and_then(|i| i.use_identity.as_ref()),
+    ) else {
+        return false;
+    };
+    if !a.normalizable || !b.normalizable || a.visibility != b.visibility {
+        return false;
+    }
+    let mut ours_leaves = a.leaves.clone();
+    let mut theirs_leaves = b.leaves.clone();
+    ours_leaves.sort();
+    theirs_leaves.sort();
+    ours_leaves == theirs_leaves
 }
 
 fn materialize_outcome(outcome: MergeOutcome) -> (Option<Vec<u8>>, usize) {

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4556,3 +4556,104 @@ fn rust_glob_alias_unnormalizable_conflicts_not_misunion() {
         "un-normalizable glob/alias adds must conflict, not mis-union: {text}"
     );
 }
+
+// heddle#468 r2 (Codex): close the representative-key partiality. r1 keyed a
+// `use` by its SMALLEST leaf, so an overlap on a NON-minimum leaf escaped
+// collision and unioned into a duplicate import. The fix collides two `use`
+// declarations whenever their expanded leaf sets intersect on ANY leaf
+// (`canonicalize_use_keys` union-find), regardless of which leaf is smallest.
+
+// Round-3 repro: the overlap is on the NON-representative leaf. ours groups
+// `{Bar, Baz}` (min leaf `Bar`), theirs is the single `Baz` (the larger
+// leaf). Under representative-leaf keying they got distinct keys (`Bar` vs
+// `Baz`) and unioned into two lines both importing `Baz` — a Rust "defined
+// multiple times" error. They must collide: a conflict (or a dedup) is
+// correct, never two `Baz` imports.
+#[test]
+fn rust_grouped_vs_ungrouped_overlap_on_nonmin_leaf_does_not_duplicate() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::{Bar, Baz};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Baz;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "overlap on the non-minimum leaf must conflict, not union: {text}"
+    );
+    // The invariant that matters regardless of conflict-vs-dedup: never two
+    // lines importing `Baz`. Conflict markers may repeat the body, so assert
+    // there is at most one `use ... Baz;` statement per conflict side by
+    // checking the merged text never lands `Baz` twice OUTSIDE markers — here
+    // the conservative check is simply that it isn't a clean union.
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// 3-leaf group overlapping only on its LARGEST leaf. The group is spelled in
+// DESCENDING leaf order (`{Ccc, Bbb, Aaa}`) so the component's canonical
+// (smallest) leaf `Aaa` is interned LAST — exercising the union-find min
+// update — while theirs imports the single LARGEST leaf `Ccc`.
+// Representative-leaf keying (min `Aaa` vs `Ccc`) missed this overlap and
+// unioned; leaf-set intersection collides them.
+#[test]
+fn rust_three_leaf_group_overlap_on_nonmin_leaf_collides() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::m::{Ccc, Bbb, Aaa};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::m::Ccc;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "overlap on the largest leaf must collide (conflict), not union: {text}"
+    );
+}
+
+// Identical IMPORT spelled two ways: `use a::{Baz}` (single-element group)
+// vs `use a::Baz`. Same leaf set, same (private) visibility — semantically
+// one import — so it dedups to a single line and stays clean, rather than
+// conflicting on cosmetic bracketing.
+#[test]
+fn rust_single_element_group_vs_plain_same_visibility_dedups_clean() {
+    let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "use crate::foo::{Baz};\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "use crate::foo::Baz;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged.matches("Baz").count(),
+        1,
+        "the same import spelled two ways must dedup to one line: {merged}"
+    );
+    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
+    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+}
+
+// Guard the dedup's visibility gate: SAME leaf set spelled differently but
+// DIVERGENT visibility (`pub use a::{Baz}` vs `use a::Baz`) must still
+// conflict — visibility is a real semantic difference, not cosmetic.
+#[test]
+fn rust_single_element_group_vs_plain_divergent_visibility_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "pub use crate::foo::{Baz};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Baz;\nfn anchor() { 0 }\n";
+    let (_text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "same leaves but divergent visibility must conflict, not dedup"
+    );
+}
+
+// Empty base, overlap on a non-minimum leaf. Exercises the empty-base
+// add/add routing in `mod.rs` (which keys off `Item`) together with the
+// canonicalized key, confirming the conflict is surfaced rather than the
+// merge being routed to text_hunk_merge and silently duplicating `Z`.
+#[test]
+fn rust_empty_base_overlap_on_nonmin_leaf_conflicts() {
+    let base = "";
+    let ours = "use crate::n::{Yy, Zz};\n";
+    let theirs = "use crate::n::Zz;\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "empty-base overlap on non-min leaf must conflict, not duplicate: {text}"
+    );
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -1255,25 +1255,26 @@ class C {
 
 #[test]
 fn preamble_diverging_edits_surface_conflict_in_inter_item_merge() {
-    // Both sides modify the same line of the preamble (between items
-    // there are no items — only `use` lines at the top). This forces
-    // text_hunk_merge on the inter-item concatenation to produce
-    // Conflicts, exercising the Conflicts arm of the inter-item match.
+    // Both sides modify the same line of the preamble. The comment block is
+    // separated from `fn f` by a blank line so it is NOT absorbed as the
+    // item's leading metadata — it stays in the preamble (inter-item
+    // segment 0). `use` lines can no longer serve here: they are now
+    // path-keyed items (heddle#468), so divergent `use` edits would union
+    // instead of conflicting. Diverging comment edits force text_hunk_merge
+    // on the preamble to produce Conflicts, exercising the Conflicts arm of
+    // the inter-item match.
     let base = "\
-use std::a;
-use std::b;
+// header note: base
 
 fn f() { 1 }
 ";
     let ours = "\
-use std::a;
-use std::OURS;
+// header note: OURS
 
 fn f() { 1 }
 ";
     let theirs = "\
-use std::a;
-use std::THEIRS;
+// header note: THEIRS
 
 fn f() { 1 }
 ";
@@ -1868,9 +1869,9 @@ func (a *A) M() int {
 // =====================================================================
 #[test]
 fn no_base_items_both_sides_add_different_items_preamble_not_duplicated() {
-    // base has only a top-level comment; both sides add their own
-    // function with their own preamble (a use statement). The shared
-    // `// top header` line must appear exactly once in the output.
+    // base has only a top-level comment; both sides add their own items
+    // (a `use` re-export plus a function) under a shared `// top header`
+    // preamble. That shared header line must appear exactly once.
     let base = "// top header\n";
     let ours = "\
 // top header
@@ -1911,13 +1912,14 @@ fn beta() { 2 }
 // =====================================================================
 #[test]
 fn zero_items_side_postamble_does_not_duplicate_bridging_segment() {
-    // ours has no parseable items (only a top-level `use`), base and
-    // theirs each have one function. Pre-fix, ours's "use std::io;\n"
+    // ours has no parseable items (only a top-level comment), base and
+    // theirs each have one function. Pre-fix, ours's "// lone comment\n"
     // is consumed by the first iteration's preamble fallback AND
     // re-emitted by the postamble merge — appearing twice in the
-    // output.
+    // output. (A `use` line can no longer stand in for the zero-items
+    // side: `use` is now a path-keyed item — heddle#468.)
     let base = "fn a() { 1 }\n";
-    let ours = "use std::io;\n";
+    let ours = "// lone comment\n";
     let theirs = "fn a() { 2 }\n";
     let outcome = merge_rust(base, ours, theirs);
     let text = match outcome {
@@ -1928,10 +1930,10 @@ fn zero_items_side_postamble_does_not_duplicate_bridging_segment() {
         } => String::from_utf8(merged_bytes_with_markers).unwrap(),
         other => panic!("unexpected: {other:?}"),
     };
-    let use_count = text.matches("use std::io").count();
+    let use_count = text.matches("// lone comment").count();
     assert_eq!(
         use_count, 1,
-        "expected ours's `use std::io` exactly once, got {use_count}: {text}"
+        "expected ours's `// lone comment` exactly once, got {use_count}: {text}"
     );
 }
 

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4608,28 +4608,102 @@ fn rust_three_leaf_group_overlap_on_nonmin_leaf_collides() {
     );
 }
 
-// Identical IMPORT spelled two ways: `use a::{Baz}` (single-element group)
-// vs `use a::Baz`. Same leaf set, same (private) visibility — semantically
-// one import — so it dedups to a single line and stays clean, rather than
-// conflicting on cosmetic bracketing.
+// heddle#468 r4 (Codex / maintainer): the partial-signal dedup is removed.
+// The `use`-merge reduces to EXACTLY three cases — leaf-disjoint →
+// auto-combine, byte-identical (incl. all leading metadata) → dedup,
+// everything else → conflict. No leaves+visibility-only dedup remains, so
+// any difference that survives normalization (grouping, alias, `cfg` /
+// doc / attribute metadata) conflicts instead of silently dropping a side.
+
+// Same leaf, same visibility, but spelled differently: `use a::{Baz}`
+// (single-element group) vs `use a::Baz`. Under the OLD partial-signal dedup
+// this collapsed to one line; under the byte-identical-only rule the two are
+// not byte-equal, so they CONFLICT. This is the formatting-that-survives-
+// normalization leg of case 3 — conflict, never a cosmetic dedup.
 #[test]
-fn rust_single_element_group_vs_plain_same_visibility_dedups_clean() {
+fn rust_single_element_group_vs_plain_same_visibility_conflicts() {
     let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
     let ours = "use crate::foo::{Baz};\nfn alpha() { 10 }\nfn beta() { 2 }\n";
     let theirs = "use crate::foo::Baz;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "same leaf spelled two ways is not byte-identical → must conflict, \
+         not partial-signal dedup: {text}"
+    );
+}
+
+// Round-4 repro: same leaf, same visibility, DIFFERENT leading metadata —
+// `#[cfg(unix)] use crate::foo::Bar;` vs `#[cfg(windows)] use crate::foo::Bar;`.
+// The old leaves+visibility dedup returned "clean" and emitted only ours,
+// SILENTLY DROPPING theirs and changing which platforms get the import — a
+// correctness bug. The byte-identical-only rule sees the differing `#[cfg]`
+// attribute and conflicts instead.
+#[test]
+fn rust_same_leaf_divergent_cfg_attribute_conflicts_not_silent_drop() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "#[cfg(unix)]\nuse crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let theirs = "#[cfg(windows)]\nuse crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "same leaf with divergent #[cfg] must conflict, not silently drop a \
+         platform's import: {text}"
+    );
+    // The dropped-platform bug: a silent dedup would emit `unix` and lose
+    // `windows` (or vice-versa). A real conflict surfaces BOTH attributes.
+    assert!(
+        text.contains("cfg(unix)") && text.contains("cfg(windows)"),
+        "both platform attributes must survive in the conflict region — \
+         neither side may be silently dropped: {text}"
+    );
+}
+
+// Same leaf path, DIFFERENT alias: `use crate::foo::Bar as B;` vs
+// `... as C;`. The alias is part of the binding's meaning but lives outside
+// the leaf path, so a partial-signal dedup would have dropped one. The
+// byte-identical-only rule conflicts. (Aliases also expand to the
+// un-normalizable sentinel, so the two share a key and collide.)
+#[test]
+fn rust_same_leaf_divergent_alias_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::Bar as B;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar as C;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "same leaf with divergent alias must conflict, not dedup: {text}"
+    );
+}
+
+// Byte-identical including leading metadata → the ONE dedup leg of case 2.
+// Both sides add the exact same `#[cfg(unix)] use ...;` while editing a
+// disjoint function; the attributed import dedups to a single occurrence and
+// the merge stays clean. Guards that adding the metadata dimension to the
+// "identical" check didn't break true byte-identical dedup.
+#[test]
+fn rust_identical_attributed_use_addition_dedups_clean() {
+    let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "#[cfg(unix)]\nuse crate::shared::Thing;\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "#[cfg(unix)]\nuse crate::shared::Thing;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
     assert_eq!(
-        merged.matches("Baz").count(),
+        merged.matches("crate::shared::Thing").count(),
         1,
-        "the same import spelled two ways must dedup to one line: {merged}"
+        "byte-identical attributed re-export must dedup to one line: {merged}"
+    );
+    assert_eq!(
+        merged.matches("cfg(unix)").count(),
+        1,
+        "the shared attribute must appear exactly once: {merged}"
     );
     assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
     assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
 }
 
-// Guard the dedup's visibility gate: SAME leaf set spelled differently but
-// DIVERGENT visibility (`pub use a::{Baz}` vs `use a::Baz`) must still
-// conflict — visibility is a real semantic difference, not cosmetic.
+// SAME leaf set spelled differently AND with divergent visibility
+// (`pub use a::{Baz}` vs `use a::Baz`) — two independent non-byte
+// differences, both landing in case 3. Must conflict.
 #[test]
 fn rust_single_element_group_vs_plain_divergent_visibility_conflicts() {
     let base = "fn anchor() { 0 }\n";

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4731,3 +4731,114 @@ fn rust_empty_base_overlap_on_nonmin_leaf_conflicts() {
         "empty-base overlap on non-min leaf must conflict, not duplicate: {text}"
     );
 }
+
+// heddle#468 r5 (Codex / maintainer): the use-merge is lifted off positional
+// occurrence-matching onto whole leaf-component (leaf-SET) comparison. The
+// representative bug: base has a single `use crate::foo::Bar;`; ours ADDS a
+// separate `use crate::foo::Baz;` line; theirs WIDENS the base item to
+// `use crate::foo::{Bar, Baz};`. All three canonicalize into one component
+// (`Bar`/`Baz` unioned). Under occurrence-matching, base's `Bar`@occ0 paired
+// with ours's `Bar`@occ0 (unchanged) / theirs's `{Bar,Baz}`@occ0 (modify) →
+// clean take-theirs, while ours's `Baz`@occ1 (add) had no theirs partner →
+// clean take-ours. The merge emitted BOTH `{Bar, Baz}` and a standalone
+// `Baz` — a duplicate import (Rust E0252), no conflict. Set comparison sees
+// ours-text != base, theirs-text != base, ours-text != theirs → CONFLICT.
+
+// The repro itself: a clean union of the widened group + the standalone leaf
+// is the bug. The whole component must conflict instead.
+#[test]
+fn rust_use_base_widened_vs_separate_add_conflicts_not_duplicate() {
+    let base = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let ours = "use crate::foo::Bar;\nuse crate::foo::Baz;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::{Bar, Baz};\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "base-widened group vs separate-leaf add must conflict, not silently \
+         emit both (a duplicate `Baz` import): {text}"
+    );
+    // The defining invariant: never a clean union. A duplicate import would
+    // resolve Clean; the conflict region proves we did not.
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Mirror: swap ours/theirs roles (ours widens the base item, theirs adds the
+// separate leaf). The set comparison is symmetric, so this must also
+// conflict — guards against an asymmetry in which side is treated as "base".
+#[test]
+fn rust_use_base_widened_vs_separate_add_conflicts_mirror() {
+    let base = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let ours = "use crate::foo::{Bar, Baz};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nuse crate::foo::Baz;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "mirror of the base-widened case must also conflict: {text}"
+    );
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Both sides widen the SAME base item, differently: base `use crate::foo::Bar;`;
+// ours → `{Bar, Baz}`; theirs → `{Bar, Qux}`. Each side modified the base
+// item, divergently, so the whole component conflicts (no auto-combine of two
+// incompatible regroupings into a triple-import line).
+#[test]
+fn rust_use_both_widen_base_differently_conflicts() {
+    let base = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let ours = "use crate::foo::{Bar, Baz};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::{Bar, Qux};\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "both sides widening the same base item differently must conflict: {text}"
+    );
+}
+
+// Pure-additive disjoint still combines under the set-valued path: base has
+// no related import; ours adds `use a::X;`, theirs adds `use b::Y;`. Disjoint
+// leaves → distinct components → each is a one-side add → both land cleanly.
+// Guards that lifting onto leaf-SET comparison did not regress the r0 union.
+#[test]
+fn rust_use_disjoint_additions_still_combine_set_path() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::a::X;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::b::Y;\nfn anchor() { 0 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert!(merged.contains("crate::a::X"), "ours add lost: {merged}");
+    assert!(merged.contains("crate::b::Y"), "theirs add lost: {merged}");
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "disjoint additions must combine cleanly: {merged}"
+    );
+}
+
+// Exact-identical multi-line component on both sides dedups to one copy.
+// Base has the grouped `use crate::foo::{Bar, Baz};`; BOTH sides rewrite it
+// to the same two standalone lines (so each side contributes TWO items to the
+// component — the multi-occurrence shape) while editing a disjoint function.
+// Byte-identical component texts → dedup, clean, no duplicate leaves.
+#[test]
+fn rust_use_identical_multiline_component_dedups_clean() {
+    let base = "use crate::foo::{Bar, Baz};\nfn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "use crate::foo::Bar;\nuse crate::foo::Baz;\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "use crate::foo::Bar;\nuse crate::foo::Baz;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged.matches("crate::foo::Bar").count(),
+        1,
+        "Bar must appear exactly once after dedup: {merged}"
+    );
+    assert_eq!(
+        merged.matches("crate::foo::Baz").count(),
+        1,
+        "Baz must appear exactly once after dedup: {merged}"
+    );
+    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
+    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4481,3 +4481,78 @@ fn rust_identical_use_addition_dedups_clean() {
     assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
     assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
 }
+
+// heddle#468 r1 (Codex P2): grouped-vs-ungrouped imports must be normalized
+// to per-leaf paths before keying, or an overlapping group/single pair
+// unions into a duplicate import (a Rust "name defined multiple times"
+// error) instead of dedup/conflict.
+
+// One side adds the grouped form `{Bar, Baz}`, the other adds the single
+// `Bar`. They share the leaf `crate::foo::Bar`, so they must NOT union into
+// two lines that both import `Bar`. A conflict (or a dedup) is correct; a
+// clean union containing a duplicate `Bar` is the bug.
+#[test]
+fn rust_grouped_vs_ungrouped_overlap_does_not_duplicate() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::{Bar, Baz};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let outcome = merge_rust(base, ours, theirs);
+    // Pre-fix this resolved Clean with two separate `use` lines importing
+    // `Bar`. Representative-leaf keying collides them into an add/add
+    // conflict instead.
+    let (text, count) = assert_conflicts(outcome);
+    assert!(
+        count >= 1,
+        "overlapping grouped/ungrouped imports must conflict, not union: {text}"
+    );
+}
+
+// Both sides add the SAME grouped re-export while editing a disjoint
+// function — the group is keyed and dedups to a single occurrence, clean.
+#[test]
+fn rust_identical_grouped_use_dedups_clean() {
+    let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "pub use crate::foo::{Bar, Baz};\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "pub use crate::foo::{Bar, Baz};\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged.matches("crate::foo::{Bar, Baz}").count(),
+        1,
+        "identical grouped re-export must appear exactly once: {merged}"
+    );
+    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
+    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+}
+
+// Distinct single re-exports on different leaf paths still auto-combine —
+// the leaf-keying change must not regress the r0 union case.
+#[test]
+fn rust_distinct_reexports_still_auto_combine() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "pub use crate::a::X;\nfn anchor() { 0 }\n";
+    let theirs = "pub use crate::b::Y;\nfn anchor() { 0 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert!(merged.contains("crate::a::X"), "ours re-export lost: {merged}");
+    assert!(merged.contains("crate::b::Y"), "theirs re-export lost: {merged}");
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "distinct re-exports must merge cleanly: {merged}"
+    );
+}
+
+// Un-normalizable forms (glob, `as` alias) can't be expanded into discrete
+// leaves, so they take the safe fallback: an overlapping add/add of two
+// such forms conflicts rather than silently unioning into a possible
+// duplicate import.
+#[test]
+fn rust_glob_alias_unnormalizable_conflicts_not_misunion() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::*;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar as Renamed;\nfn anchor() { 0 }\n";
+    let outcome = merge_rust(base, ours, theirs);
+    let (text, count) = assert_conflicts(outcome);
+    assert!(
+        count >= 1,
+        "un-normalizable glob/alias adds must conflict, not mis-union: {text}"
+    );
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4375,3 +4375,107 @@ void foo() {
         "template-template inline-to-out-of-class refactor + disjoint body edit must merge cleanly: {text}"
     );
 }
+
+// =====================================================================
+// heddle#468: additive `use` / `pub use` re-exports are order-insensitive
+// items keyed by their import path.
+//
+// Before this change `use_declaration` fell to the `_ => None` arm in the
+// Rust classifier, so re-exports lived in preamble / inter-item segments
+// merged by plain `text_hunk_merge`. Keying each `use` by its import path
+// routes them through identity-based item resolution: disjoint paths union
+// cleanly, while a same-path add/add divergence surfaces a conflict instead
+// of silently concatenating both lines into a duplicate import (the AC2
+// case below — pre-fix it resolved Clean with `Bar` imported twice).
+// =====================================================================
+
+// AC1: two threads each adding a distinct `pub use` at the top of the same
+// file auto-combine — no manual resolution. Guards that promoting `use` to
+// an item keyed by import path keeps disjoint additions unioning cleanly.
+#[test]
+fn rust_disjoint_use_additions_auto_combine() {
+    let base = "\
+pub use crate::existing::Thing;
+
+fn anchor() { 0 }
+";
+    // ours prepends a distinct re-export; theirs prepends a different one.
+    let ours = "\
+pub use crate::aaa::Alpha;
+pub use crate::existing::Thing;
+
+fn anchor() { 0 }
+";
+    let theirs = "\
+pub use crate::bbb::Beta;
+pub use crate::existing::Thing;
+
+fn anchor() { 0 }
+";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert!(
+        merged.contains("crate::aaa::Alpha"),
+        "ours re-export lost: {merged}"
+    );
+    assert!(
+        merged.contains("crate::bbb::Beta"),
+        "theirs re-export lost: {merged}"
+    );
+    assert!(
+        merged.contains("crate::existing::Thing"),
+        "base re-export lost: {merged}"
+    );
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "additive disjoint re-exports must merge cleanly: {merged}"
+    );
+}
+
+// AC1 variant: a plain `use` added on one side and a different one on the
+// other, with no shared base `use`, still union cleanly.
+#[test]
+fn rust_disjoint_use_additions_from_empty_base_combine() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use std::collections::HashMap;\nfn anchor() { 0 }\n";
+    let theirs = "use std::fmt::Display;\nfn anchor() { 0 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert!(merged.contains("HashMap"), "ours use lost: {merged}");
+    assert!(merged.contains("Display"), "theirs use lost: {merged}");
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "disjoint use additions must merge cleanly: {merged}"
+    );
+}
+
+// AC2: same-path add/add of a divergent re-export still conflicts. Both
+// sides add `crate::foo::Bar` (same import-path key) but disagree on
+// visibility — one re-exports (`pub use`), one imports (`use`). The
+// add/add divergence must surface a conflict rather than silently
+// picking one or emitting both (a duplicate-name compile error).
+#[test]
+fn rust_same_path_divergent_use_addadd_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "pub use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let (_text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(count >= 1, "expected a conflict on same-path divergence");
+}
+
+// Regression: both sides add the SAME `pub use` identically while making a
+// disjoint function edit elsewhere — the re-export dedups to a single line
+// and the merge stays clean (exercises resolve_item's add/add o==t arm for
+// `use` items).
+#[test]
+fn rust_identical_use_addition_dedups_clean() {
+    let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "pub use crate::shared::Thing;\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "pub use crate::shared::Thing;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged.matches("crate::shared::Thing").count(),
+        1,
+        "identical re-export must appear exactly once: {merged}"
+    );
+    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
+    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4662,8 +4662,9 @@ fn rust_same_leaf_divergent_cfg_attribute_conflicts_not_silent_drop() {
 // Same leaf path, DIFFERENT alias: `use crate::foo::Bar as B;` vs
 // `... as C;`. The alias is part of the binding's meaning but lives outside
 // the leaf path, so a partial-signal dedup would have dropped one. The
-// byte-identical-only rule conflicts. (Aliases also expand to the
-// un-normalizable sentinel, so the two share a key and collide.)
+// byte-identical-only rule conflicts. (Both aliases are unanalyzable, so the
+// region is poisoned and the whole-region merge conflicts the divergent
+// text — heddle#468 r6.)
 #[test]
 fn rust_same_leaf_divergent_alias_conflicts() {
     let base = "fn anchor() { 0 }\n";
@@ -4838,6 +4839,122 @@ fn rust_use_identical_multiline_component_dedups_clean() {
         merged.matches("crate::foo::Baz").count(),
         1,
         "Baz must appear exactly once after dedup: {merged}"
+    );
+    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
+    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+}
+
+// heddle#468 r6 (Codex cid 3350239933): the clever leaf-component union is
+// capped to fully-analyzable PLAIN imports. Before this fix an unanalyzable
+// form (`self` in a group / nested group / glob / alias) carried a single
+// sentinel "leaf" that `canonicalize_use_keys` treated as a normal leaf —
+// but the sentinel is disjoint from every real import path, so an exotic
+// form that overlaps a plain import landed in a DIFFERENT union-find
+// component, both were emitted, and a duplicate import slipped through (the
+// exact bug this PR exists to prevent). Now: any use-region containing an
+// unanalyzable item on ANY side bypasses the leaf union entirely and merges
+// conservatively, so the overlap surfaces as a conflict. These tests pin
+// each exotic form against an overlapping plain import; the un-poisoned
+// plain-only cases above (r0/r5) must stay clean.
+
+// `self` in a group vs the plain leaf it hides: `use crate::foo::{self, Bar};`
+// expands to `foo` AND `foo::Bar`, overlapping theirs' `use crate::foo::Bar;`.
+// Pre-fix the `{self, Bar}` group keyed to the sentinel and `Bar` keyed to
+// `crate::foo::Bar` → distinct components → both emitted → duplicate `Bar`.
+// The poison path conflicts the whole region instead.
+#[test]
+fn rust_use_self_group_vs_plain_conflicts_not_duplicate() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::{self, Bar};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "self-group overlapping a plain import must conflict, not duplicate: {text}"
+    );
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Nested group vs the plain leaf it hides: `use crate::foo::{bar::{Baz}};`
+// (nested → unanalyzable) overlaps theirs' `use crate::foo::bar::Baz;`. The
+// poison path conflicts rather than mis-unioning into a duplicate `Baz`.
+#[test]
+fn rust_use_nested_group_vs_plain_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::{bar::{Baz}};\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::bar::Baz;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "nested group overlapping a plain import must conflict: {text}"
+    );
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Glob vs a plain import under the same path: `use crate::foo::*;` (glob →
+// unanalyzable) could re-export `Bar`, so it overlaps theirs'
+// `use crate::foo::Bar;`. We can't expand the glob's leaves, so the only
+// safe verdict is a conflict — never a clean union that duplicates `Bar`.
+#[test]
+fn rust_use_glob_vs_plain_overlap_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::*;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "glob overlapping a plain import must conflict, not mis-union: {text}"
+    );
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Alias vs the plain leaf it renames: `use crate::foo::Bar as B;` (alias →
+// unanalyzable) and theirs' `use crate::foo::Bar;` share the leaf
+// `crate::foo::Bar`. The r4 alias test conflicts alias-vs-alias (both
+// unanalyzable, same sentinel component); this is the alias-vs-PLAIN case
+// the old sentinel keying mis-unioned — it must conflict via the new poison
+// path, not emit both lines.
+#[test]
+fn rust_use_alias_vs_plain_same_leaf_conflicts() {
+    let base = "fn anchor() { 0 }\n";
+    let ours = "use crate::foo::Bar as B;\nfn anchor() { 0 }\n";
+    let theirs = "use crate::foo::Bar;\nfn anchor() { 0 }\n";
+    let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
+    assert!(
+        count >= 1,
+        "alias overlapping the plain leaf it renames must conflict: {text}"
+    );
+    assert!(
+        text.contains("<<<<<<<"),
+        "expected a conflict region, not a silent union: {text}"
+    );
+}
+
+// Byte-identical exotic form on both sides → the dedup leg survives the
+// poison path. Both sides add the SAME `use crate::foo::*;` while editing a
+// disjoint function; the region is poisoned (glob is unanalyzable) but the
+// two component texts are byte-identical, so the conservative merge dedups
+// to one copy and stays clean. Pins that poisoning does NOT regress
+// identical-text dedup into a spurious conflict.
+#[test]
+fn rust_use_identical_glob_both_sides_dedups_clean() {
+    let base = "fn alpha() { 1 }\nfn beta() { 2 }\n";
+    let ours = "use crate::foo::*;\nfn alpha() { 10 }\nfn beta() { 2 }\n";
+    let theirs = "use crate::foo::*;\nfn alpha() { 1 }\nfn beta() { 20 }\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged.matches("crate::foo::*").count(),
+        1,
+        "byte-identical glob must dedup to one line, not conflict: {merged}"
     );
     assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
     assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");


### PR DESCRIPTION
## Summary
- Classify Rust `use_declaration` as a new `ItemKind::Use`, keyed by its whitespace-stripped import-path `argument` (the use tree: `crate::x::Y`, `a::{B, C}`, `a::*`, `a::B as C`).
- Re-exports now route through identity-based item resolution instead of the textual inter-item merge: additive re-exports on **disjoint paths union cleanly**, while a **same-path add/add divergence** (e.g. `pub use a::B` vs `use a::B`) surfaces a **conflict** instead of silently concatenating both lines into a duplicate import.
- Visibility is intentionally excluded from the key, so it is the divergence axis rather than an identity split; a malformed `use` (missing `argument`) falls through to the unclassified walker, preserving prior behavior.

Closes HeddleCo/heddle#468

## Red commit
`e346ce9` — adds the merge-driver tests; `rust_same_path_divergent_use_addadd_conflicts` fails pre-fix (the textual inter-item merge resolved `Clean` with `crate::foo::Bar` emitted twice).

## Test evidence
```
$ cargo test --locked -p heddle-semantic
running 209 tests
test merge_driver::tests::rust_disjoint_use_additions_auto_combine ... ok
test merge_driver::tests::rust_disjoint_use_additions_from_empty_base_combine ... ok
test merge_driver::tests::rust_identical_use_addition_dedups_clean ... ok
test merge_driver::tests::rust_same_path_divergent_use_addadd_conflicts ... ok
test merge_driver::tests::preamble_diverging_edits_surface_conflict_in_inter_item_merge ... ok
test merge_driver::tests::zero_items_side_postamble_does_not_duplicate_bridging_segment ... ok
test merge_driver::tests::no_base_items_both_sides_add_different_items_preamble_not_duplicated ... ok
test result: ok. 208 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```
Also green: `cargo clippy --locked --workspace --all-targets -- -D warnings`; `bash scripts/check-no-silent-default-tree-load.sh`; `cargo test -p heddle-cli --test cli_integration -- merge` (24 passed).

### Acceptance criteria
- [x] Two threads each adding a distinct `use`/`pub use` at the top of the same file auto-combine under semantic merge (`rust_disjoint_use_additions_*`).
- [x] Same-path add/add of a divergent re-export still conflicts (`rust_same_path_divergent_use_addadd_conflicts`).
- [x] Regression tests in the semantic merge-driver suite for both cases.

## Manual verification
N/A — covered by tests.

## Notes
Two existing inter-item tests used `use` lines as preamble content; since `use` is no longer inter-item, they now exercise the same reconstruct paths via diverging comment lines and a comment-only zero-items side. Scope is Rust-only per the issue ("Teach the Rust language rules").

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783056236&installation_id=132405951&pr_number=477&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F477&signature=dcbc7db126f9d449a320e889cf4b957cde6ae24a04593bba42dfa08cd56e7fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->