### PR TITLE
feat(cli): consolidate save verbs onto commit/ready/land/sync (#464)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ cd ../feature-auth
 heddle commit -m "add auth validation"
 heddle ready
 
-# Preview a merge, then merge and push
-heddle merge feature/auth --preview
-heddle ship --thread feature/auth --push
+# Land and push
+heddle land --thread feature/auth --push
 
 # Inspect history and provenance
 heddle log

--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -1381,6 +1381,46 @@ fn import_handles_merge_history_without_missing_parent_mappings() {
     assert!(bridge.mapping.get_heddle(merge).is_some());
 }
 
+// heddle#464 close-the-class (import boundary): a git branch name becomes a
+// Heddle thread id on import. Git permits ref names containing shell
+// metacharacters (e.g. `;`) that are NOT safe thread ids — interpolating one
+// into a recommended-command breadcrumb would be unrunnable. Reject such an
+// import with an actionable rename hint rather than silently slugifying it.
+#[test]
+fn import_rejects_branch_name_that_is_not_a_valid_thread_id() {
+    use crate::bridge::git_core::GitBridgeError;
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_git_temp, git_repo) = init_git_repo();
+
+    let tree_oid = empty_tree_oid(&git_repo);
+    let base = commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "base", &[]);
+    // Git accepts `;` in a branch name; a Heddle thread id must not.
+    commit_with_tree(
+        &git_repo,
+        Some("refs/heads/evil;rm"),
+        tree_oid,
+        "evil",
+        &[base],
+    );
+
+    let mut bridge = GitBridge::new(&repo);
+    let err = import_all(&mut bridge, Some(git_repo.workdir().expect("workdir")))
+        .expect_err("import must reject a branch whose name is not a valid thread id");
+
+    match err {
+        GitBridgeError::InvalidThreadName { branch, message } => {
+            assert_eq!(branch, "evil;rm");
+            assert!(
+                message.contains("evil;rm") && message.contains("try 'evil-rm'"),
+                "the rejection must name the branch and suggest a valid rename, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidThreadName, got: {other:?}"),
+    }
+}
+
 #[test]
 fn push_exports_local_branches_and_tags_to_path_remote() {
     let heddle_temp = TempDir::new().expect("heddle temp");

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -78,6 +78,9 @@ pub enum GitBridgeError {
     #[error("conflict during sync: {0}")]
     Conflict(String),
 
+    #[error("Git branch '{branch}' cannot be imported as a Heddle thread: {message}")]
+    InvalidThreadName { branch: String, message: String },
+
     #[error(
         "Git branch {branch} and Heddle thread {thread} diverged: thread {thread_change}, branch {branch_change}"
     )]

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -9,7 +9,7 @@ use objects::object::{
     Agent, Attribution, ChangeId, MarkerName, Principal, State, Status, ThreadName,
 };
 use refs::{Head, RefExpectation};
-use repo::Repository as HeddleRepository;
+use repo::{Repository as HeddleRepository, ThreadId};
 use tracing::warn;
 
 pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
@@ -578,6 +578,18 @@ fn import_with_ref_filter(
             continue;
         }
         if let Some(change_id) = bridge.mapping.get_heddle(plan.peeled_commit_oid) {
+            // A git branch name becomes a Heddle thread id here. Reject one that
+            // isn't a valid thread id (e.g. contains a shell metacharacter git
+            // permits in a ref) rather than silently slugifying it — a silent
+            // rewrite would violate the no-silent-default stance, and an unsafe
+            // id breaks recommended-command breadcrumbs. Pre-1.0: the operator
+            // renames the branch and re-imports. (heddle#464 close-the-class.)
+            if let Err(err) = ThreadId::new(name.as_str()) {
+                return Err(GitBridgeError::InvalidThreadName {
+                    branch: name.to_string(),
+                    message: err.to_string(),
+                });
+            }
             let existing = bridge
                 .heddle_repo
                 .refs()

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -867,14 +867,14 @@ pub struct SyncArgs {
     pub thread: Option<String>,
 }
 
-/// Arguments for the `ship` command.
+/// Arguments for the `land` command.
 #[derive(Clone, Debug, clap::Args)]
-pub struct ShipArgs {
+pub struct LandArgs {
     /// Thread to capture, integrate, and optionally push (default: current thread).
     #[arg(long = "thread")]
     pub thread: Option<String>,
 
-    /// Intent/message to use if ship needs to capture outstanding work first.
+    /// Intent/message to use if land needs to capture outstanding work first.
     #[arg(short = 'm', long)]
     pub message: Option<String>,
 

--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -17,7 +17,7 @@ use super::{
         AttemptArgs, BranchArgs, CloneArgs, CollapseArgs, CommandCatalogArgs, CommitArgs,
         DelegateArgs, DiagnoseArgs, DiffArgs, DoctorArgs, InitArgs, LogArgs, MergeArgs, PullArgs,
         PushArgs, ReadyArgs, ResolveArgs, RetroArgs, RevertArgs, RunArgs, SessionEndArgs,
-        SessionListArgs, SessionSegmentArgs, SessionShowArgs, SessionStartArgs, ShipArgs,
+        SessionListArgs, SessionSegmentArgs, SessionShowArgs, SessionStartArgs, LandArgs,
         SnapshotArgs, SwitchArgs, SyncArgs, ThreadStartArgs, TryArgs, UndoArgs, WatchArgs,
     },
 };
@@ -196,12 +196,12 @@ Examples:
 
     /// Land a ready thread and optionally publish it.
     ///
-    /// `ship` is the do-it verb: capture outstanding work if needed,
+    /// `land` is the local integration verb: capture outstanding work if needed,
     /// refresh against the target when safe, land the thread, write the
     /// Git checkpoint, and optionally push. It fails closed when
     /// conflicts or other blockers exist. Pair it with `ready` when you
     /// want the verdict and next action before landing anything.
-    Ship(ShipArgs),
+    Land(LandArgs),
 
     /// Automation/workflow command: fan a parent thread into one or
     /// more delegated child threads.

--- a/crates/cli/src/cli/cli_args/commands_stack.rs
+++ b/crates/cli/src/cli/cli_args/commands_stack.rs
@@ -36,7 +36,7 @@ pub enum StackCommands {
     /// thread, by default) and emits one of three verdicts:
     ///
     /// * `ready` — every member of the stack is Ready / Merged /
-    ///   Promoted; you can ship the bottom.
+    ///   Promoted; you can land the bottom.
     /// * `blocked` — at least one member is Blocked; that thread is
     ///   named in the output so you know where to look.
     /// * `waiting-on-review` — the stack is otherwise clean but the

--- a/crates/cli/src/cli/cli_args/mod.rs
+++ b/crates/cli/src/cli/cli_args/mod.rs
@@ -40,7 +40,7 @@ pub use commands_args::{
     DiagnoseArgs, DiffArgs, DoctorArgs, DoctorCommands, DoctorDocsArgs, InitArgs, LogArgs,
     MergeArgs, PullArgs, PushArgs, ReadyArgs, ResolveArgs, RetroArgs, RevertArgs, RunArgs,
     SessionEndArgs, SessionListArgs, SessionSegmentArgs, SessionShowArgs, SessionStartArgs,
-    ShipArgs, SnapshotArgs, SwitchArgs, SyncArgs, ThreadAbsorbArgs, ThreadApprovalsArgs,
+    LandArgs, SnapshotArgs, SwitchArgs, SyncArgs, ThreadAbsorbArgs, ThreadApprovalsArgs,
     ThreadApproveArgs, ThreadCapturesArgs, ThreadCheckMergeArgs, ThreadDropArgs, ThreadMoveArgs,
     ThreadNameArgs, ThreadPromoteArgs, ThreadRenameArgs, ThreadResolveArgs,
     ThreadRevokeApprovalArgs, ThreadShowArgs, ThreadStartArgs, TryArgs, UndoArgs, WatchArgs,

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -566,7 +566,7 @@ pub async fn cmd_actor_done(cli: &Cli, session_id: Option<String>) -> Result<()>
 
 fn actor_done_recommended_action(thread: &str, coordination_status: &str) -> Option<String> {
     (coordination_status == "merge-ready")
-        .then(|| super::thread_landing::merge_preview_command(thread))
+        .then(|| super::thread_landing::land_local_command(thread))
 }
 
 pub async fn cmd_actor_explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
@@ -850,7 +850,7 @@ fn no_active_actor_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "no_active_actor",
         "No active actor for this checkout",
-        "After a thread is shipped or an actor is marked done, it is no longer selected implicitly. Run `heddle actor list` to inspect completed actors, or pass a session id to `heddle actor show <session>`.",
+        "After a thread is landed or an actor is marked done, it is no longer selected implicitly. Run `heddle actor list` to inspect completed actors, or pass a session id to `heddle actor show <session>`.",
         "no active actor registry entry matches the current thread or checkout path",
         "choosing a completed actor implicitly could show the wrong session",
         "no actor registry entries, refs, repository objects, or worktree files were changed",

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, anyhow};
 use chrono::Utc;
 use objects::object::ThreadName;
 use objects::store::{ActorChainNode, AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary};
-use repo::Repository;
+use repo::{Repository, ThreadId};
 use serde::Serialize;
 
 use super::{
@@ -19,7 +19,7 @@ use super::{
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
     },
-    thread::find_thread_summary,
+    thread::{find_thread_summary, thread_name_invalid_advice},
 };
 use crate::cli::{Cli, should_output_json};
 
@@ -265,6 +265,13 @@ pub async fn cmd_actor_spawn(
     provider: Option<String>,
     model: Option<String>,
 ) -> Result<()> {
+    // A user-supplied `--thread` name is a creation boundary (spawn mints or
+    // attaches the named thread), so reject an unsafe name before any ref is
+    // written. The generated `actor/<session>` fallback is safe by construction.
+    // (heddle#464 close-the-class.)
+    if let Some(name) = thread.as_deref() {
+        ThreadId::new(name).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
+    }
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
 
     let base_state = repo.head()?.ok_or_else(|| {

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -743,32 +743,32 @@ impl RecoveryAdvice {
         )
     }
 
-    pub(crate) fn ship_push_remote_missing(thread: &str) -> Self {
-        let local_command = super::thread_landing::ship_local_command(thread);
+    pub(crate) fn land_push_remote_missing(thread: &str) -> Self {
+        let local_command = super::thread_landing::land_local_command(thread);
         Self::safety_refusal(
-            "ship_push_remote_missing",
-            format!("Refusing to ship thread `{thread}` with --push: no push remote is configured"),
+            "land_push_remote_missing",
+            format!("Refusing to land thread `{thread}` with --push: no push remote is configured"),
             format!(
                 "Run `{local_command}` to land locally, or configure a remote and retry with `--push`."
             ),
             "no default Git or Heddle remote is configured for push",
-            "shipping with --push would merge and checkpoint before discovering there is nowhere to push",
+            "landing with --push would merge and checkpoint before discovering there is nowhere to push",
             "repository state, refs, metadata, and worktree files were left unchanged",
             local_command.clone(),
             vec![local_command, "heddle remote add <name> <url>".to_string()],
         )
     }
 
-    pub(crate) fn ship_remote_requires_push(thread: &str, remote: &str) -> Self {
-        let push_command = super::thread_landing::ship_push_remote_command(thread, remote);
-        let local_command = super::thread_landing::ship_local_command(thread);
+    pub(crate) fn land_remote_requires_push(thread: &str, remote: &str) -> Self {
+        let push_command = super::thread_landing::land_push_remote_command(thread, remote);
+        let local_command = super::thread_landing::land_local_command(thread);
         Self::safety_refusal(
-            "ship_remote_requires_push",
-            format!("Ship remote `{remote}` was provided without --push"),
+            "land_remote_requires_push",
+            format!("Land remote `{remote}` was provided without --push"),
             format!(
                 "Run `{push_command}` to land and publish, or `{local_command}` to land locally."
             ),
-            "`--remote` names a push destination, but this ship invocation did not request a push",
+            "`--remote` names a push destination, but this land invocation did not request a push",
             "continuing would merge/checkpoint locally while leaving the named remote unchanged",
             "repository state, refs, metadata, remote refs, and worktree files were left unchanged",
             push_command.clone(),
@@ -776,12 +776,12 @@ impl RecoveryAdvice {
         )
     }
 
-    pub(crate) fn ship_push_option_conflict(thread: &str) -> Self {
-        let push_command = super::thread_landing::ship_push_command(thread);
-        let local_command = super::thread_landing::ship_local_command(thread);
+    pub(crate) fn land_push_option_conflict(thread: &str) -> Self {
+        let push_command = super::thread_landing::land_push_command(thread);
+        let local_command = super::thread_landing::land_local_command(thread);
         Self::safety_refusal(
-            "ship_push_option_conflict",
-            "Ship was asked to both push and not push",
+            "land_push_option_conflict",
+            "Land was asked to both push and not push",
             format!("Choose `{push_command}` or `{local_command}`."),
             "`--push` and `--no-push` are mutually exclusive publish choices",
             "continuing would make the publish side effect ambiguous",
@@ -791,7 +791,7 @@ impl RecoveryAdvice {
         )
     }
 
-    pub(crate) fn ship_push_partial_failure(
+    pub(crate) fn land_push_partial_failure(
         thread: &str,
         push_error: impl fmt::Display,
         performed_steps: Vec<String>,
@@ -811,12 +811,12 @@ impl RecoveryAdvice {
             .map(|remote| format!("heddle push {remote}"))
             .unwrap_or_else(|| "heddle push".to_string());
         Self::safety_refusal(
-            "ship_push_partial_failure",
-            format!("Ship partially completed for `{thread}`, but push failed: {push_error}"),
+            "land_push_partial_failure",
+            format!("Land partially completed for `{thread}`, but push failed: {push_error}"),
             format!(
-                "The thread was preserved locally. Run `heddle undo` to roll back the local ship, or fix the remote and run `{push_command}`."
+                "The thread was preserved locally. Run `heddle undo` to roll back the local land, or fix the remote and run `{push_command}`."
             ),
-            "push failed after Heddle had already completed local ship steps",
+            "push failed after Heddle had already completed local land steps",
             "retrying blindly could duplicate or obscure the already-landed local merge/checkpoint",
             format!("completed steps: {completed}.{checkpoint}"),
             "heddle undo",
@@ -824,7 +824,7 @@ impl RecoveryAdvice {
         )
     }
 
-    pub(crate) fn ship_checkpoint_partial_failure(
+    pub(crate) fn land_checkpoint_partial_failure(
         thread: &str,
         checkpoint_error: impl fmt::Display,
         performed_steps: Vec<String>,
@@ -835,18 +835,18 @@ impl RecoveryAdvice {
             performed_steps.join(", ")
         };
         Self::safety_refusal(
-            "ship_checkpoint_partial_failure",
+            "land_checkpoint_partial_failure",
             format!(
-                "Ship partially completed for `{thread}`, but Git checkpoint failed: {checkpoint_error}"
+                "Land partially completed for `{thread}`, but Git checkpoint failed: {checkpoint_error}"
             ),
-            "Run `heddle undo` to roll back the local ship, or resolve the checkpoint issue and run `heddle checkpoint -m \"...\"`.",
-            "Git checkpoint failed after Heddle had already completed local ship steps",
+            "Run `heddle undo` to roll back the local land, or resolve the checkpoint issue and run `heddle commit -m \"...\"`.",
+            "Git checkpoint failed after Heddle had already completed local land steps",
             "retrying blindly could obscure the already-landed local merge state",
             format!("completed steps: {completed}. No Git checkpoint was written."),
             "heddle undo",
             vec![
                 "heddle undo".to_string(),
-                "heddle checkpoint -m \"...\"".to_string(),
+                "heddle commit -m \"...\"".to_string(),
             ],
         )
     }

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -10,8 +10,8 @@ use objects::store::{
 };
 use refs::{Head, RefExpectation};
 use repo::{
-    Repository, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadIntegrationPolicy,
-    ThreadManager, ThreadMode, ThreadState, ThreadVerificationSummary,
+    Repository, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
+    ThreadIntegrationPolicy, ThreadManager, ThreadMode, ThreadState, ThreadVerificationSummary,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -19,6 +19,7 @@ use serde::Serialize;
 use super::{
     advice::RecoveryAdvice,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
+    thread::thread_name_invalid_advice,
 };
 use crate::cli::{
     Cli,
@@ -160,6 +161,10 @@ fn anchor_drift_no_owner_advice(
 }
 
 pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
+    // User/external creation boundary: `agent reserve` persists a thread
+    // record, so reject an unsafe thread name here too (same early-reject
+    // rule as `start_thread` / `thread create`). (heddle#464 close-the-class.)
+    ThreadId::new(args.thread.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
     let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
     let anchor = match &args.anchor {
         Some(spec) => repo

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -42,7 +42,7 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use objects::worktree::{WorktreeIgnoreMatcher, build_worktree_ignore};
-use repo::Repository;
+use repo::{Repository, shell_quote};
 use serde::Serialize;
 
 use super::{
@@ -500,7 +500,10 @@ pub fn cmd_attempt(cli: &Cli, args: AttemptArgs) -> Result<()> {
 
     let next_action = recommended
         .as_deref()
-        .map(|name| format!("heddle ready --thread {name}"));
+        // Quote defensively at construction (heddle#464 defense-in-depth): the
+        // thread id flows into the validated next_action / recommended_action
+        // fields, so an unsafe one renders as a single shell token, never bare.
+        .map(|name| format!("heddle ready --thread {}", shell_quote(name)));
     let next_action = ActionFields::from_optional_action(next_action);
     let recommended_action = next_action.clone();
 

--- a/crates/cli/src/cli/commands/attempt.rs
+++ b/crates/cli/src/cli/commands/attempt.rs
@@ -500,7 +500,7 @@ pub fn cmd_attempt(cli: &Cli, args: AttemptArgs) -> Result<()> {
 
     let next_action = recommended
         .as_deref()
-        .map(|name| format!("heddle merge {name} --preview --with-diff"));
+        .map(|name| format!("heddle ready --thread {name}"));
     let next_action = ActionFields::from_optional_action(next_action);
     let recommended_action = next_action.clone();
 

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -205,6 +205,20 @@ where
     checked_action_from_argv(argv)
 }
 
+/// Build the `--thread <id>` argv fragment for splicing into a [`heddle_action`]
+/// argv. A historical / `new_unchecked` thread id that starts with `-` is
+/// rendered as the combined `--thread=<id>` token, which clap binds as the
+/// flag's value; the plain `--thread`, `<id>` pair would otherwise be re-parsed
+/// (after `split_recommended_action`) with `-foo` as another option, and
+/// `checked_action_from_argv` would panic. (heddle#464 close-the-class.)
+pub(crate) fn thread_flag_args(thread_id: &str) -> Vec<String> {
+    if thread_id.starts_with('-') {
+        vec![format!("--thread={thread_id}")]
+    } else {
+        vec!["--thread".to_string(), thread_id.to_string()]
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct CommandJsonDiscriminator {
     pub path: Vec<String>,

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -364,6 +364,7 @@ const RECOMMENDED_ACTION_PLACEHOLDERS: &[&str] = &[
     "heddle capture -m \"...\" --confidence <confidence>",
     "heddle checkpoint -m \"...\"",
     "heddle commit -m \"...\"",
+    "heddle commit -m \"...\" --confidence <confidence>",
     "heddle init --principal-name <name> --principal-email <email>",
     "heddle ready -m \"...\"",
     "heddle context get --path <path>",
@@ -429,6 +430,19 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
         "heddle commit -m \"...\"",
         &["heddle", "commit", "-m", "<message>"],
         &["message"],
+        true,
+    ),
+    (
+        "heddle commit -m \"...\" --confidence <confidence>",
+        &[
+            "heddle",
+            "commit",
+            "-m",
+            "<message>",
+            "--confidence",
+            "<confidence>",
+        ],
+        &["message", "confidence"],
         true,
     ),
     (
@@ -523,8 +537,8 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
         true,
     ),
     (
-        "heddle ship --thread <name>",
-        &["heddle", "ship", "--thread", "<thread>"],
+        "heddle land --thread <name>",
+        &["heddle", "land", "--thread", "<thread>"],
         &["thread"],
         true,
     ),
@@ -1881,7 +1895,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["merge"],
         exits(
-            front_door(
+            surface(
                 advertised_action(
                     documented_schemas(WORKTREE_MUTATION, &["merge --preview"]),
                     "heddle merge <thread> --preview",
@@ -1890,7 +1904,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     true,
                     false,
                 ),
-                60,
+                "native",
             ),
             &[
                 (0, "ok"),
@@ -2232,7 +2246,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["shell"], READ_TEXT),
     entry(&["shell", "init"], READ_TEXT),
     entry(
-        &["ship"],
+        &["land"],
         front_door(
             documented_schemas(
                 CommandContract {
@@ -2240,7 +2254,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     network_io: true,
                     ..MUTATING
                 },
-                &["ship"],
+                &["land"],
             ),
             70,
         ),
@@ -3771,7 +3785,7 @@ fn is_display_only_template(action: &str) -> bool {
     action.contains("...") || action.contains('…') || (action.contains('<') && action.contains('>'))
 }
 
-fn split_recommended_action(action: &str) -> std::result::Result<Vec<String>, String> {
+pub(crate) fn split_recommended_action(action: &str) -> std::result::Result<Vec<String>, String> {
     let mut args = Vec::new();
     let mut current = String::new();
     let mut chars = action.chars().peekable();
@@ -3865,7 +3879,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         Commands::Sync(_) => vec!["sync"],
         Commands::Continue => vec!["continue"],
         Commands::Abort => vec!["abort"],
-        Commands::Ship(_) => vec!["ship"],
+        Commands::Land(_) => vec!["land"],
         Commands::Delegate(_) => vec!["delegate"],
         Commands::Ready(_) => vec!["ready"],
         Commands::Capture(_) => vec!["capture"],
@@ -4411,7 +4425,7 @@ mod tests {
         sample(&["session", "show"], &["session", "show"]),
         sample(&["session", "list"], &["session", "list"]),
         sample(&["shell", "init"], &["shell", "init", "bash"]),
-        sample(&["ship"], &["ship"]),
+        sample(&["land"], &["land"]),
         sample(&["show"], &["show", "HEAD"]),
         sample(&["start"], &["start", "feature"]),
         sample(&["stash", "push"], &["stash", "push"]),
@@ -5436,7 +5450,7 @@ mod tests {
             (
                 "commit", "everyday", "native", "everyday", None, None, false,
             ),
-            ("ship", "everyday", "native", "everyday", None, None, false),
+            ("land", "everyday", "native", "everyday", None, None, false),
             ("push", "everyday", "native", "everyday", None, None, false),
             (
                 "capture", "advanced", "native", "advanced", None, None, false,

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -4737,6 +4737,26 @@ mod tests {
     }
 
     #[test]
+    fn leading_dash_thread_breadcrumbs_pass_validation() {
+        // A historical / `new_unchecked` thread id literally named `-foo` renders
+        // breadcrumbs via the `=` (flag) and `--` (positional) forms; the
+        // validator splits to argv and runs clap, which would reject the bare
+        // `--thread -foo` form as an unknown flag. (heddle#464 round 8.)
+        for action in [
+            repo::RecommendedAction::Sync,
+            repo::RecommendedAction::Ready,
+            repo::RecommendedAction::Land,
+            repo::RecommendedAction::Promote,
+        ] {
+            if let Some(cmd) = action.command("-foo") {
+                validate_recommended_action(&cmd).unwrap_or_else(|err| {
+                    panic!("breadcrumb `{cmd}` must validate for a leading-dash id: {err}")
+                });
+            }
+        }
+    }
+
+    #[test]
     fn action_fields_fail_loudly_for_invalid_recommendations() {
         let panic = std::panic::catch_unwind(|| ActionFields::from_action("git status"));
         assert!(

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -3689,6 +3689,43 @@ fn dynamic_message_recommended_action_template(
                 true,
             ))
         }
+        // The confidence/verification policy-blocker recovery scopes itself to
+        // the thread's checkout via the global `--repo <path>` flag (heddle#464).
+        // `<path>` is a concrete worktree path, not a placeholder, so the only
+        // fillable inputs remain the message and confidence.
+        [
+            heddle,
+            repo_flag,
+            repo_path,
+            command,
+            message_flag,
+            message,
+            confidence_flag,
+            confidence,
+        ] if heddle == "heddle"
+            && repo_flag == "--repo"
+            && matches!(command.as_str(), "capture" | "commit")
+            && is_message_flag(message_flag)
+            && is_message_placeholder_arg(message)
+            && confidence_flag == "--confidence"
+            && is_placeholder_arg(confidence) =>
+        {
+            Some(action_template_from_owned(
+                action.to_string(),
+                vec![
+                    "heddle".to_string(),
+                    "--repo".to_string(),
+                    repo_path.clone(),
+                    command.clone(),
+                    "-m".to_string(),
+                    "<message>".to_string(),
+                    "--confidence".to_string(),
+                    confidence.clone(),
+                ],
+                vec!["message".to_string(), placeholder_input_name(confidence)],
+                true,
+            ))
+        }
         [heddle, stash, push, message_flag, message]
             if heddle == "heddle"
                 && stash == "stash"

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -2,7 +2,7 @@
 //! Shared helper for fast-forward call sites that need to record an
 //! `OpRecord::FastForwardV2` instead of the implicit `OpRecord::Goto`.
 //!
-//! See heddle#99 (merge FF) and heddle#110 (rebase / ship /
+//! See heddle#99 (merge FF) and heddle#110 (rebase / land /
 //! merge-abort): recording a thread-advancing fast-forward as a plain
 //! `OpRecord::Goto` strands the target thread ref on undo, because the
 //! `Goto` inverse only rewinds HEAD. The fix is to perform the FF
@@ -31,7 +31,7 @@ use super::advice::RecoveryAdvice;
 /// Reads the pre-FF tip from the attached thread's ref (or from HEAD
 /// for detached). Use this overload at call sites where the thread
 /// ref has *not* been mutated since whatever you want undo to restore
-/// — e.g. merge / rebase / ship. Callers that also materialize a
+/// — e.g. merge / rebase / land. Callers that also materialize a
 /// worktree must not publish the ref first: a dirty refusal must never
 /// leave a ref advanced without the matching worktree materialization.
 ///

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -30,8 +30,10 @@ use super::{
     git_overlay_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState,
         build_repository_verification_state, git_overlay_mutation_preflight_advice,
-        plain_git_mutation_preflight_advice, repository_verification_blocked_advice,
+        override_trust_recommended_action, plain_git_mutation_preflight_advice,
+        repository_verification_blocked_advice,
     },
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
         preflight_large_capture_for_compat_commit, resolve_principal,
@@ -165,7 +167,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
                     Some(message.as_str()),
                     worktree_status_options(Some(repo.config())),
                 )?;
-                let trust = build_repository_verification_state(&repo);
+                let trust = commit_safe_trust(build_repository_verification_state(&repo));
                 let output = CommitCompatOutput {
                     output_kind: "commit",
                     status: "committed",
@@ -186,7 +188,11 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
                     trust,
                 };
                 let output = with_commit_action_metadata(output);
-                render_commit_compat(&output, should_output_json(cli, Some(repo.config())))?;
+                render_commit_compat(
+                    &output,
+                    should_output_json(cli, Some(repo.config())),
+                    repo.capability(),
+                )?;
                 return Ok(());
             }
             if !trust.verified {
@@ -214,7 +220,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         let captured_state = repo
             .current_state()?
             .ok_or_else(|| anyhow!("capture succeeded but no current state was recorded"))?;
-        let trust = build_repository_verification_state(&repo);
+        let trust = commit_safe_trust(build_repository_verification_state(&repo));
         let output = CommitCompatOutput {
             output_kind: "commit",
             status: "committed",
@@ -239,7 +245,11 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         };
         let output = with_commit_action_metadata(output);
 
-        render_commit_compat(&output, should_output_json(cli, Some(repo.config())))?;
+        render_commit_compat(
+            &output,
+            should_output_json(cli, Some(repo.config())),
+            repo.capability(),
+        )?;
         return Ok(());
     }
 
@@ -315,7 +325,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             "commit completed but failed to record capture and Git checkpoint as one undo batch",
         )?;
 
-    let trust = build_repository_verification_state(&repo);
+    let trust = commit_safe_trust(build_repository_verification_state(&repo));
     let output = CommitCompatOutput {
         output_kind: "commit",
         status: "committed",
@@ -340,7 +350,11 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     };
     let output = with_commit_action_metadata(output);
 
-    render_commit_compat(&output, should_output_json(cli, Some(repo.config())))?;
+    render_commit_compat(
+        &output,
+        should_output_json(cli, Some(repo.config())),
+        repo.capability(),
+    )?;
 
     Ok(())
 }
@@ -395,7 +409,7 @@ fn commit_staged_index(
             "commit completed but failed to record capture and Git checkpoint as one undo batch",
         )?;
 
-    let trust = build_repository_verification_state(repo);
+    let trust = commit_safe_trust(build_repository_verification_state(repo));
     let output = CommitCompatOutput {
         output_kind: "commit",
         status: "committed",
@@ -419,7 +433,11 @@ fn commit_staged_index(
         trust,
     };
     let output = with_commit_action_metadata(output);
-    render_commit_compat(&output, should_output_json(cli, Some(repo.config())))?;
+    render_commit_compat(
+        &output,
+        should_output_json(cli, Some(repo.config())),
+        repo.capability(),
+    )?;
     Ok(())
 }
 
@@ -970,6 +988,32 @@ fn bstr_path(path: &BStr) -> String {
     path.to_str_lossy().into_owned()
 }
 
+fn commit_safe_trust(mut trust: RepositoryVerificationState) -> RepositoryVerificationState {
+    if is_commit_action(&trust.recommended_action) {
+        override_trust_recommended_action(&mut trust, "heddle status");
+    }
+    let status_action = "heddle status".to_string();
+    let status_template = ActionFields::from_action(&status_action).template;
+    for check in &mut trust.checks {
+        if check
+            .recommended_action
+            .as_deref()
+            .is_some_and(is_commit_action)
+        {
+            check.recommended_action = Some(status_action.clone());
+            check.recommended_action_template = status_template.clone();
+        }
+    }
+    trust
+}
+
+fn is_commit_action(action: &str) -> bool {
+    matches!(
+        action.trim(),
+        "heddle commit" | "heddle commit -m \"...\"" | "heddle commit -m \"...\" --confidence <confidence>"
+    ) || action.trim().starts_with("heddle commit ")
+}
+
 fn commit_next_action(trust: &RepositoryVerificationState) -> Option<String> {
     if !trust.recommended_action.trim().is_empty() {
         return Some(trust.recommended_action.clone());
@@ -1064,7 +1108,7 @@ fn commit_checkpoint_failed_advice(
         format!("capture {change_id} was preserved, but checkpoint failed: {err}"),
         format!("Resolve the checkpoint issue, then run `{recovery}`."),
         "the Heddle capture succeeded but the Git checkpoint step failed",
-        "retrying `heddle commit` could create a duplicate capture instead of checkpointing the preserved state",
+        "retrying through the canonical save path keeps the Git checkpoint repair on the supported surface",
         format!("captured Heddle state {change_id} was preserved"),
         recovery.clone(),
         vec![recovery],
@@ -1073,8 +1117,8 @@ fn commit_checkpoint_failed_advice(
 
 fn checkpoint_recovery_command(message: Option<&str>) -> String {
     format!(
-        "heddle checkpoint -m {}",
-        shell_double_quoted(message.unwrap_or("checkpoint"))
+        "heddle commit -m {}",
+        shell_double_quoted(message.unwrap_or("commit"))
     )
 }
 
@@ -1129,9 +1173,16 @@ fn git_head_oid(root: &Path) -> Option<String> {
     git.head_id().ok().map(|id| id.to_string())
 }
 
-fn render_commit_compat(output: &CommitCompatOutput, json: bool) -> Result<()> {
+fn render_commit_compat(
+    output: &CommitCompatOutput,
+    json: bool,
+    repository_capability: RepositoryCapability,
+) -> Result<()> {
     if json {
-        println!("{}", serde_json::to_string(&output)?);
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::new(&["commit"], repository_capability),
+        )?;
     } else {
         println!(
             "{}",
@@ -1255,7 +1306,7 @@ pub async fn cmd_switch_compat(cli: &Cli, args: SwitchArgs) -> Result<()> {
             "git_checkout_create_branch",
             "`heddle switch -c` / `heddle checkout -b` are guided to Heddle's isolated thread flow",
             format!(
-                "Create a Heddle thread with `{primary}` so the new work has its own checkout, provenance, and ready/ship path."
+                "Create a Heddle thread with `{primary}` so the new work has its own checkout, provenance, and ready/land path."
             ),
             "Git-style branch creation would hide whether the user wants an in-place thread or an isolated checkout",
             "Heddle did not create a branch, move HEAD, or write the worktree",
@@ -1308,11 +1359,11 @@ mod tests {
         assert!(advice.error.contains("git write failed"));
         assert_eq!(
             advice.primary_command,
-            "heddle checkpoint -m \"say \\\"hello\\\"\""
+            "heddle commit -m \"say \\\"hello\\\"\""
         );
         assert_eq!(
             advice.recovery_commands,
-            vec!["heddle checkpoint -m \"say \\\"hello\\\"\""]
+            vec!["heddle commit -m \"say \\\"hello\\\"\""]
         );
         assert!(advice.preserved.contains("change-123"));
     }

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -315,7 +315,8 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         anyhow!(commit_checkpoint_failed_advice(
             &snapshot.change_id,
             Some(message.as_str()),
-            &err
+            &err,
+            false,
         ))
     })?;
     let checkpoint_batch = find_recent_git_checkpoint_batch(&repo, &record.git_commit)?;
@@ -399,7 +400,8 @@ fn commit_staged_index(
         anyhow!(commit_checkpoint_failed_advice(
             &snapshot.change_id,
             Some(message),
-            &err
+            &err,
+            true,
         ))
     })?;
     let checkpoint_batch = find_recent_git_checkpoint_batch(repo, &record.git_commit)?;
@@ -1101,8 +1103,9 @@ fn commit_checkpoint_failed_advice(
     change_id: &str,
     message: Option<&str>,
     err: &anyhow::Error,
+    index_only: bool,
 ) -> RecoveryAdvice {
-    let recovery = checkpoint_recovery_command(message);
+    let recovery = checkpoint_recovery_command(message, index_only);
     RecoveryAdvice::safety_refusal(
         "commit_checkpoint_failed",
         format!("capture {change_id} was preserved, but checkpoint failed: {err}"),
@@ -1115,9 +1118,13 @@ fn commit_checkpoint_failed_advice(
     )
 }
 
-fn checkpoint_recovery_command(message: Option<&str>) -> String {
+fn checkpoint_recovery_command(message: Option<&str>, index_only: bool) -> String {
+    // Preserve the index-only (`--no-all`) intent on the staged-index path: a
+    // plain `heddle commit` retry would sweep unstaged worktree changes into a
+    // new capture and lose the staged-only state the user committed.
+    let scope = if index_only { " --no-all" } else { "" };
     format!(
-        "heddle commit -m {}",
+        "heddle commit{scope} -m {}",
         shell_double_quoted(message.unwrap_or("commit"))
     )
 }
@@ -1352,7 +1359,8 @@ mod tests {
     #[test]
     fn commit_checkpoint_failure_advice_preserves_capture_and_exact_recovery() {
         let error = anyhow!("git write failed");
-        let advice = commit_checkpoint_failed_advice("change-123", Some("say \"hello\""), &error);
+        let advice =
+            commit_checkpoint_failed_advice("change-123", Some("say \"hello\""), &error, false);
 
         assert_eq!(advice.kind, "commit_checkpoint_failed");
         assert!(advice.error.contains("capture change-123 was preserved"));
@@ -1366,6 +1374,23 @@ mod tests {
             vec!["heddle commit -m \"say \\\"hello\\\"\""]
         );
         assert!(advice.preserved.contains("change-123"));
+    }
+
+    // heddle#464: the staged-index (`--no-all`) checkpoint-failure recovery must
+    // keep the index-only intent, otherwise a plain `heddle commit` retry would
+    // sweep unstaged worktree changes into a new capture and lose the staged-only
+    // state the user committed.
+    #[test]
+    fn commit_checkpoint_failure_advice_preserves_index_only_intent() {
+        let error = anyhow!("git write failed");
+        let advice =
+            commit_checkpoint_failed_advice("change-456", Some("index only"), &error, true);
+
+        assert_eq!(advice.primary_command, "heddle commit --no-all -m \"index only\"");
+        assert_eq!(
+            advice.recovery_commands,
+            vec!["heddle commit --no-all -m \"index only\""]
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -488,7 +488,7 @@ fn ready_thread_actions(repo: &Repository) -> Vec<WorkflowThreadAction> {
                 .map(|mut thread| {
                     // Ready manifests can go stale when their target advances.
                     let _ = refresh_thread_freshness(repo, &mut thread);
-                    let fallback = super::thread_landing::merge_preview_command(&thread.id);
+                    let fallback = super::thread_landing::land_local_command(&thread.id);
                     let advice = describe_thread_advice(&thread, false, 0, false);
                     // A dedicated checkout can safely print a parent-repo
                     // merge command; the main checkout must be on the
@@ -2450,20 +2450,20 @@ pub(crate) fn remote_drift_decision(
                 };
             }
             let import = canonical_bridge_import_ref_command(upstream);
-            let merge_preview = super::thread_landing::merge_preview_command(upstream);
+            let reconcile = canonical_bridge_reconcile_ref_preview_command(None, upstream);
             let imported = repo.refs().get_thread(&ThreadName::new(upstream)).ok().flatten().is_some();
             RemoteDriftDecision {
                 status,
                 verified_as_clean: false,
                 primary_action: Some(if imported {
-                    merge_preview.clone()
+                    reconcile.clone()
                 } else {
                     import.clone()
                 }),
                 recovery_commands: if imported {
-                    vec![merge_preview]
+                    vec![reconcile]
                 } else {
-                    vec![import, merge_preview]
+                    vec![import, reconcile]
                 },
                 requires_clean_worktree: false,
             }
@@ -2732,7 +2732,7 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
                     summary: format!(
                         "{changed} Git worktree path(s) are captured in Heddle but not checkpointed to Git"
                     ),
-                    recovery_commands: vec!["heddle checkpoint -m \"...\"".to_string()],
+                    recovery_commands: vec!["heddle commit -m \"...\"".to_string()],
                     checks,
                 };
             }
@@ -2748,7 +2748,6 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
                 summary: format!("{changed} Git worktree path(s) have uncommitted changes"),
                 recovery_commands: vec![
                     "heddle commit -m \"...\"".to_string(),
-                    "heddle capture -m \"...\"".to_string(),
                     "heddle stash push -m \"...\"".to_string(),
                 ],
                 checks,
@@ -2788,7 +2787,7 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
                 .cloned()
                 .unwrap_or_else(|| "<branch>".to_string());
             let recovery = if status == "needs_checkpoint" {
-                "heddle checkpoint -m \"...\"".to_string()
+                "heddle commit -m \"...\"".to_string()
             } else {
                 canonical_bridge_reconcile_ref_preview_command(None, &ref_name)
             };
@@ -2834,7 +2833,6 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
             summary: format!("{changed} Heddle worktree path(s) differ from the current state"),
             recovery_commands: vec![
                 "heddle commit -m \"...\"".to_string(),
-                "heddle capture -m \"...\"".to_string(),
                 "heddle stash push -m \"...\"".to_string(),
             ],
             checks,
@@ -3154,7 +3152,6 @@ fn build_native_heddle_health(repo: &Repository) -> GitOverlayHealth {
                 ),
                 recovery_commands: vec![
                     "heddle commit -m \"...\"".to_string(),
-                    "heddle capture -m \"...\"".to_string(),
                     "heddle stash push -m \"...\"".to_string(),
                 ],
                 checks,
@@ -3612,7 +3609,7 @@ mod tests {
         let machine_gap = VerificationActionPlan::from_parts(
             &clean_health,
             Some("heddle push".to_string()),
-            Some("heddle merge feature --preview".to_string()),
+            Some("heddle land --thread feature --no-push".to_string()),
             Some("heddle doctor schemas --output json".to_string()),
         );
         assert_eq!(
@@ -3626,18 +3623,18 @@ mod tests {
         assert_eq!(machine_gap.remote_action.as_deref(), Some("heddle push"));
         assert_eq!(
             machine_gap.workflow_action.as_deref(),
-            Some("heddle merge feature --preview")
+            Some("heddle land --thread feature --no-push")
         );
 
         let workflow_waiting = VerificationActionPlan::from_parts(
             &clean_health,
             Some("heddle push".to_string()),
-            Some("heddle merge feature --preview".to_string()),
+            Some("heddle land --thread feature --no-push".to_string()),
             None,
         );
         assert_eq!(
             workflow_waiting.primary_action,
-            "heddle merge feature --preview"
+            "heddle land --thread feature --no-push"
         );
 
         let publish_guidance = VerificationActionPlan::from_parts(
@@ -3687,7 +3684,7 @@ mod tests {
             unimported.recovery_commands,
             vec![
                 "heddle bridge git import --ref origin/main",
-                "heddle merge origin/main --preview"
+                "heddle bridge git reconcile --ref origin/main --preview"
             ]
         );
 
@@ -3696,11 +3693,11 @@ mod tests {
         let imported = remote_drift_decision(&repo, &diverged);
         assert_eq!(
             imported.primary_action.as_deref(),
-            Some("heddle merge origin/main --preview")
+            Some("heddle bridge git reconcile --ref origin/main --preview")
         );
         assert_eq!(
             imported.recovery_commands,
-            vec!["heddle merge origin/main --preview"]
+            vec!["heddle bridge git reconcile --ref origin/main --preview"]
         );
     }
 

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -1556,7 +1556,14 @@ pub(crate) fn detached_git_head_mutation_advice(repo: &Repository, action: &str)
 fn detached_head_primary_recovery(repo: &Repository) -> String {
     match repo.refs().read_head() {
         Ok(Head::Attached { thread }) if !thread.trim().is_empty() => {
-            return heddle_action(["switch", thread.as_str()]);
+            // `switch` takes the thread as a positional; a leading-dash id needs
+            // the `--` separator so clap binds it as a value, not a flag.
+            // (heddle#464 close-the-class.)
+            return if thread.starts_with('-') {
+                heddle_action(["switch", "--", thread.as_str()])
+            } else {
+                heddle_action(["switch", thread.as_str()])
+            };
         }
         _ => {}
     }

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -8,8 +8,8 @@ use std::{
 
 use anyhow::{Result, bail};
 use objects::object::{Principal, ThreadName, Tree};
-use refs::{Head, validate_ref_name};
-use repo::{Repository, RepositoryCapability};
+use refs::Head;
+use repo::{Repository, RepositoryCapability, ThreadId};
 use serde::Serialize;
 use tracing::{debug, info};
 
@@ -631,17 +631,19 @@ fn quickstart_preflight(
         bail!(quickstart_shallow_clone_advice());
     }
 
-    // Validate the requested thread name BEFORE any write, using the same
-    // ref-name rules the thread machinery enforces when the ref is actually
-    // created. A bad name (`.bad`, `a..b`, …) must fail here rather than
-    // after init/bootstrap/import have already written `.heddle/` data,
+    // Validate the requested thread name BEFORE any write, using the SAME
+    // centralized rule every thread-creation boundary enforces ([`ThreadId::new`]
+    // / `validate_thread_id`) — one rule, not an ad-hoc copy. A bad name
+    // (`a..b`, `my feature`, a shell metacharacter, …) must fail here rather
+    // than after init/bootstrap/import have already written `.heddle/` data,
     // leaving a half-initialized repo for a pure argument error.
     let thread = args.quickstart_thread.as_deref().unwrap_or("quickstart");
-    if validate_ref_name(thread).is_err() {
+    if let Err(err) = ThreadId::new(thread) {
         bail!(RecoveryAdvice::invalid_usage(
             "quickstart_thread_name_invalid",
-            format!("'{thread}' is not a valid thread name"),
-            "Choose a thread name without '..', a leading '.', a trailing '/' or '.lock', backslashes, or control characters.",
+            err.to_string(),
+            "Choose a thread name using only letters, digits, and _ - . / @ : + = \
+             (no spaces or shell metacharacters).",
             "heddle init --quickstart --quickstart-thread <name>",
         ));
     }

--- a/crates/cli/src/cli/commands/merge/git_commit.rs
+++ b/crates/cli/src/cli/commands/merge/git_commit.rs
@@ -334,12 +334,12 @@ fn merge_git_commit_empty_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "merge_git_commit_empty",
         "Merge produced no changed paths; refusing to write an empty Git commit",
-        "Inspect the merge with `heddle merge --preview`; rerun without `--git-commit` if no Git commit is needed.",
+        "Inspect repository state with `heddle status`; rerun without `--git-commit` if no Git commit is needed.",
         "the merge result has no paths to stage for Git",
         "--git-commit would create an empty Git commit that does not correspond to landed Heddle paths",
         "Heddle and Git state were left unchanged by the Git commit writer",
-        "heddle merge --preview",
-        vec!["heddle merge --preview".to_string()],
+        "heddle status",
+        vec!["heddle status".to_string()],
     )
 }
 
@@ -352,13 +352,13 @@ fn merge_git_commit_failed_advice(stage: &'static str, detail: String) -> Recove
     RecoveryAdvice::safety_refusal(
         "merge_git_commit_failed",
         format!("{stage} failed while finalizing merge --git-commit: {detail}"),
-        "Resolve the Git checkout issue, then run `heddle checkpoint -m \"...\"`; do not rerun `heddle merge`.",
+        "Resolve the Git checkout issue, then run `heddle commit -m \"...\"`; do not rerun `heddle merge`.",
         format!("{stage} failed after Heddle merge commit coordination started"),
         "retrying the Heddle merge could duplicate or obscure the already-landed Heddle merge state",
         "the Heddle merge state is preserved; the Git commit writer did not report a completed commit",
-        "heddle checkpoint -m \"...\"",
+        "heddle commit -m \"...\"",
         vec![
-            "heddle checkpoint -m \"...\"".to_string(),
+            "heddle commit -m \"...\"".to_string(),
             "heddle verify".to_string(),
         ],
     )
@@ -398,7 +398,7 @@ mod tests {
         let advice = merge_git_commit_empty_advice();
 
         assert_eq!(advice.kind, "merge_git_commit_empty");
-        assert_eq!(advice.primary_command, "heddle merge --preview");
+        assert_eq!(advice.primary_command, "heddle status");
         assert!(advice.error.contains("no changed paths"));
         assert!(advice.would_change.contains("empty Git commit"));
     }
@@ -411,7 +411,7 @@ mod tests {
         assert_eq!(advice.kind, "merge_git_commit_failed");
         assert!(advice.error.contains("writing Git index failed"));
         assert!(advice.error.contains("index locked"));
-        assert!(advice.primary_command.contains("heddle checkpoint"));
+        assert!(advice.primary_command.contains("heddle commit"));
         assert!(advice.preserved.contains("Heddle merge state is preserved"));
     }
 }

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -27,11 +27,12 @@ use super::{
         override_trust_recommended_action,
         repository_verification_blocked_advice,
     },
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
     ready_cmd::{worktree_dirty, worktree_dirty_paths},
     snapshot::ensure_current_state,
     thread_cmd::{refresh_thread_freshness, thread_not_found_advice},
-    thread_landing::{ship_command_for_thread, ship_local_command},
+    thread_landing::{land_command_for_thread, land_local_command},
     worktree_safety::ensure_worktree_clean,
 };
 use crate::{
@@ -253,7 +254,7 @@ pub fn cmd_merge(
     }
 
     let exit_code = merge_output_exit_code(&output);
-    render_merge_output(cli, output)?;
+    render_merge_output(cli, &repo, output)?;
     if let Some(code) = exit_code {
         std::process::exit(code);
     }
@@ -720,8 +721,13 @@ pub(crate) fn merge_thread_into_current(
                         .any(|blocker| is_real_merge_blocker(blocker))
                 {
                     Some(report.recommended_action.clone())
+                } else if preview_report
+                    .as_ref()
+                    .is_some_and(preview_needs_readiness_review)
+                {
+                    None
                 } else {
-                    Some(ship_local_command(&thread.id))
+                    Some(land_local_command(&thread.id))
                 }
             } else {
                 None
@@ -1180,7 +1186,7 @@ pub(crate) fn merge_thread_into_current(
                 ));
                 post_snapshot_git_blockers.push(format!(
                     "recovery: heddle merge state {} is intact; resolve the Git checkout issue \
-                     (identity, locks, or filesystem errors) and run `heddle checkpoint -m \"{}\"` — do NOT re-run `heddle merge`",
+                     (identity, locks, or filesystem errors) and run `heddle commit -m \"{}\"` — do NOT re-run `heddle merge`",
                     new_state.change_id.short(),
                     merge_message
                 ));
@@ -1243,7 +1249,7 @@ fn mark_merge_previewed(repo: &Repository, thread_id: &str) -> Result<()> {
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "mark merge previewed")))?;
     thread.integration_policy_result = ThreadIntegrationPolicy {
         status: Some("previewed".to_string()),
-        reason: Some("clean merge preview established ship path".to_string()),
+        reason: Some("clean merge preview established land path".to_string()),
         manual_resolution_state: thread.integration_policy_result.manual_resolution_state,
     };
     manager.save(&thread)?;
@@ -1766,7 +1772,7 @@ pub(crate) fn build_thread_preview_report(
     prefer_apply_recommendation: bool,
 ) -> Result<ThreadPreviewReport> {
     let mut graph = CommitGraphIndex::new(repo);
-    // External callers (`heddle sync`, `heddle ship`, `heddle ready`)
+    // External callers (`heddle sync`, `heddle land`, `heddle ready`)
     // don't have a `--semantic` flag today; preserve the historic
     // hunk-only preview behaviour. The merge command path threads its
     // own strategy by calling `_with_graph` directly.
@@ -1806,7 +1812,7 @@ fn build_thread_preview_report_with_graph(
     // Resolve the destination side. Prefer the caller's override (the
     // merge command supplies the actual current HEAD); otherwise fall
     // back to `thread.target_thread` for callers like `ready` / `sync` /
-    // `ship` that don't carry an explicit merge destination.
+    // `land` that don't carry an explicit merge destination.
     let resolved_target: Option<(String, ChangeId)> = if let Some(ovr) = target_override {
         Some((ovr.label.to_string(), ovr.change_id))
     } else if let Some(name) = thread.target_thread.as_deref() {
@@ -1877,7 +1883,7 @@ fn build_thread_preview_report_with_graph(
     };
     if manual_resolution_current {
         advice.blockers.clear();
-        advice.recommended_action = ship_command_for_thread(repo, &thread.id);
+        advice.recommended_action = land_command_for_thread(repo, &thread.id);
         advice.thread_health = "ready".to_string();
     }
 
@@ -1967,7 +1973,7 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
     let stale_refresh_action = input.preview_report.and_then(|report| {
         (report.freshness == ThreadFreshness::Stale.to_string()).then(|| {
             if report.recommended_action.trim().is_empty() {
-                format!("heddle thread refresh {}", report.thread)
+                format!("heddle sync --thread {}", recommended_action_quote(&report.thread))
             } else {
                 report.recommended_action.clone()
             }
@@ -1985,16 +1991,14 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
     } else if !input.extra_blockers.is_empty() {
         // Coordination blocker. Two shapes:
         //   1. Pre-snapshot (`merge_state` is None): typical
-        //      `--git-commit` precondition failure. Nothing landed, so
-        //      the safe retry is the same Heddle merge after the Git
-        //      checkout issue is fixed.
+        //      `--git-commit` precondition failure. Nothing landed; surface
+        //      status rather than a self-loop back into this merge command.
         //   2. Post-snapshot (`merge_state` is Some): `git commit`
         //      itself failed AFTER heddle advanced. Re-running
         //      `heddle merge` would noop; the safe recovery is the
         //      shared checkpoint template, which records the landed
         //      Heddle state in Git after the checkout issue is fixed.
         Some(coordination_blocker_recommended_action(
-            input.thread.as_ref(),
             input.merge_state.as_ref(),
         ))
     } else if input.preview_only
@@ -2004,10 +2008,17 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
         stale_refresh_action
     } else if input.preview_only && input.message != "Already up to date" {
         // Clean preview: the actionable next step is the human landing
-        // command. `ship` keeps capture, merge, checkpoint, push, and
+        // command. `land` keeps capture, merge, checkpoint, push, and
         // verification in one loop, so the preview does not bounce users back
         // to the lower-level merge apply command.
-        input.thread.as_ref().map(|t| ship_local_command(&t.id))
+        if input
+            .preview_report
+            .is_some_and(preview_needs_readiness_review)
+        {
+            None
+        } else {
+            input.thread.as_ref().map(|t| land_local_command(&t.id))
+        }
     } else {
         // Clean apply: nothing to do.
         None
@@ -2134,19 +2145,11 @@ fn merge_output_thread_health(
     }
 }
 
-fn coordination_blocker_recommended_action(
-    thread: Option<&Thread>,
-    merge_state: Option<&String>,
-) -> String {
+fn coordination_blocker_recommended_action(merge_state: Option<&String>) -> String {
     if merge_state.is_some() {
-        "heddle checkpoint -m \"...\"".to_string()
-    } else if let Some(thread) = thread {
-        format!(
-            "heddle merge {} --git-commit",
-            recommended_action_quote(&thread.id)
-        )
+        "heddle commit -m \"...\"".to_string()
     } else {
-        "heddle merge <thread> --git-commit".to_string()
+        "heddle status".to_string()
     }
 }
 
@@ -2323,7 +2326,7 @@ fn stale_thread_merge_blocked_output(
     preview_only: bool,
 ) -> MergeOutput {
     let recommended_action = if preview_report.recommended_action.trim().is_empty() {
-        format!("heddle thread refresh {}", preview_report.thread)
+        format!("heddle sync --thread {}", recommended_action_quote(&preview_report.thread))
     } else {
         preview_report.recommended_action.clone()
     };
@@ -2478,9 +2481,12 @@ fn merge_preview_blocked_advice(output: &MergeOutput) -> RecoveryAdvice {
     advice
 }
 
-fn render_merge_output(cli: &Cli, output: MergeOutput) -> Result<()> {
+fn render_merge_output(cli: &Cli, repo: &Repository, output: MergeOutput) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        write_validated_json_stdout(
+            &output,
+            NextActionValidationContext::new(&["merge"], repo.capability()),
+        )?;
     } else {
         // Fast-forward is the happy-path success message; colour the
         // verb (`Fast-forwarded`) accent-green and dim the change-id
@@ -2556,6 +2562,10 @@ fn render_merge_output(cli: &Cli, output: MergeOutput) -> Result<()> {
 /// every "needs attention" string as a blocker causes the "merge
 /// succeeded but status:blocked" contradiction that this helper exists
 /// to prevent.
+fn preview_needs_readiness_review(report: &ThreadPreviewReport) -> bool {
+    report.thread_state != ThreadState::Ready.to_string() && !report.heavy_impact_paths.is_empty()
+}
+
 fn is_real_merge_blocker(advisory: &str) -> bool {
     let lower = advisory.to_lowercase();
     lower.contains("path conflict") || lower.contains("heavy-impact change")
@@ -2871,18 +2881,18 @@ mod tests {
     #[test]
     fn coordination_blocker_recommendations_are_machine_actions() {
         let merge_state = "hd-landed123".to_string();
-        let post_snapshot = coordination_blocker_recommended_action(None, Some(&merge_state));
-        assert_eq!(post_snapshot, "heddle checkpoint -m \"...\"");
+        let post_snapshot = coordination_blocker_recommended_action(Some(&merge_state));
+        assert_eq!(post_snapshot, "heddle commit -m \"...\"");
         assert!(
             action_template(&post_snapshot).is_some(),
-            "checkpoint placeholder should carry a fillable template"
+            "commit placeholder should carry a fillable template"
         );
 
-        let pre_snapshot = coordination_blocker_recommended_action(None, None);
-        assert_eq!(pre_snapshot, "heddle merge <thread> --git-commit");
+        let pre_snapshot = coordination_blocker_recommended_action(None);
+        assert_eq!(pre_snapshot, "heddle status");
         assert!(
             action_template(&pre_snapshot).is_some(),
-            "thread placeholder should carry a fillable template"
+            "status action should carry a template"
         );
         for action in [post_snapshot, pre_snapshot] {
             assert!(

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -216,5 +216,5 @@ pub use try_cmd::cmd_try;
 pub use undo::{cmd_redo, cmd_undo};
 pub use verify::cmd_verify;
 pub use watch::cmd_watch;
-pub use workflow::{cmd_delegate, cmd_ship, cmd_sync};
+pub use workflow::{cmd_delegate, cmd_land, cmd_sync};
 pub use workspace::{cmd_workspace, cmd_workspace_show};

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -110,6 +110,24 @@ fn validate_next_actions_at_path(
     Ok(())
 }
 
+// heddle#464 close-the-class note. This validator rejects *non-canonical*
+// breadcrumbs (demoted verbs, wrong repo type, self-loops) but deliberately
+// does NOT generically reject state-gated verbs (`resolve`/`continue`/`abort`)
+// when the emitting repo lacks merge/operation state. A sound generic check is
+// impractical here for two reasons:
+//   1. Thread-scoped breadcrumbs carry their state in a *different* repository
+//      than the one being validated — e.g. `sync` emits
+//      `heddle --repo <thread-worktree> resolve --list` after materializing the
+//      conflict in that worktree, while validation runs against the repo `sync`
+//      ran from (where no merge is in progress). The validator cannot see the
+//      worktree's state, so a state-gate would false-positive exactly the
+//      correct scoped breadcrumbs.
+//   2. The validator operates on the serialized JSON with only repository
+//      *capability* in context; plumbing live merge/operation state through
+//      every emit site is a broad change beyond this fix-round's blast radius.
+// The class is instead closed at the *source* (see the audit: `cmd_sync`,
+// `cmd_land`, and `describe_thread_advice` no longer emit a `resolve` breadcrumb
+// from an unmaterialized state) and guarded by the regression tests.
 pub(crate) fn validate_next_action(
     action: &str,
     context: NextActionValidationContext<'_>,

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Shared next-action selection for command surfaces.
+//! Shared next-action selection and validation for command surfaces.
 
+use anyhow::{Context, Result};
 use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, RepositoryOperationStatus};
+use serde::Serialize;
+use serde_json::Value;
 
+use crate::cli::render::write_stdout;
+
+use super::command_catalog::{split_recommended_action, validate_recommended_action};
 use super::git_overlay_health::{
     RepositoryVerificationState, import_hint_includes_active_branch, remote_tracking_next_action,
 };
@@ -22,6 +28,195 @@ pub(crate) struct NextActionInput<'a> {
     pub thread_health: Option<&'a str>,
     pub trust: Option<&'a RepositoryVerificationState>,
     pub scope: NextActionScope,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NextActionValidationContext<'a> {
+    pub(crate) emitting_command: &'a [&'a str],
+    pub(crate) repository_capability: Option<repo::RepositoryCapability>,
+}
+
+impl<'a> NextActionValidationContext<'a> {
+    pub(crate) fn new(
+        emitting_command: &'a [&'a str],
+        repository_capability: repo::RepositoryCapability,
+    ) -> Self {
+        Self {
+            emitting_command,
+            repository_capability: Some(repository_capability),
+        }
+    }
+
+    pub(crate) fn without_repo(emitting_command: &'a [&'a str]) -> Self {
+        Self {
+            emitting_command,
+            repository_capability: None,
+        }
+    }
+}
+
+pub(crate) fn validated_json_string<T: Serialize>(
+    output: &T,
+    context: NextActionValidationContext<'_>,
+) -> Result<String> {
+    let encoded = serde_json::to_string(output)?;
+    let value: Value = serde_json::from_str(&encoded)
+        .context("failed to re-read command JSON for next_action validation")?;
+    validate_next_actions_in_value(&value, context)?;
+    Ok(encoded)
+}
+
+pub(crate) fn write_validated_json_stdout<T: Serialize>(
+    output: &T,
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    let mut encoded = validated_json_string(output, context)?;
+    encoded.push('\n');
+    write_stdout(&encoded)
+}
+
+pub(crate) fn validate_next_actions_in_value(
+    value: &Value,
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    validate_next_actions_at_path(value, context, "$")
+}
+
+fn validate_next_actions_at_path(
+    value: &Value,
+    context: NextActionValidationContext<'_>,
+    path: &str,
+) -> Result<()> {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let child_path = format!("{path}.{key}");
+                if matches!(key.as_str(), "next_action" | "recommended_action")
+                    && let Some(action) = child.as_str()
+                {
+                    validate_next_action(action, context)
+                        .with_context(|| format!("invalid {key} at {child_path}"))?;
+                }
+                validate_next_actions_at_path(child, context, &child_path)?;
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                validate_next_actions_at_path(child, context, &format!("{path}[{index}]"))?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_next_action(
+    action: &str,
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    let action = action.trim();
+    if action.is_empty() {
+        return Ok(());
+    }
+    validate_recommended_action(action)
+        .map_err(|err| next_action_validation_error(format!("action is not a valid heddle command: {err}")))?;
+    let argv = split_recommended_action(action)
+        .map_err(|err| next_action_validation_error(format!("action cannot be tokenized: {err}")))?;
+    let Some(command_path) = next_action_command_path(&argv) else {
+        return Ok(());
+    };
+
+    reject_wrong_repo_type(action, &command_path, context)?;
+    reject_demoted_breadcrumbs(action, &command_path)?;
+    reject_self_loop(action, &command_path, context)?;
+    Ok(())
+}
+
+fn next_action_command_path(argv: &[String]) -> Option<Vec<&str>> {
+    if argv.first().map(String::as_str) != Some("heddle") {
+        return None;
+    }
+    let command_index = first_command_index(argv)?;
+    let command = argv.get(command_index)?.as_str();
+    if command == "thread" || command == "bridge" || command == "doctor" {
+        return argv
+            .get(command_index + 1)
+            .map(|subcommand| vec![command, subcommand.as_str()])
+            .or_else(|| Some(vec![command]));
+    }
+    Some(vec![command])
+}
+
+fn first_command_index(argv: &[String]) -> Option<usize> {
+    let mut index = 1;
+    while index < argv.len() {
+        match argv[index].as_str() {
+            "--repo" | "-C" | "--output" | "--color" | "--config" | "--config-file"
+            | "--config-env" => index += 2,
+            "--quiet" | "-q" | "--verbose" | "-v" | "--no-color" | "--profile" => index += 1,
+            token if token.starts_with("-C") && token.len() > 2 => index += 1,
+            token if token.starts_with('-') => index += 1,
+            _ => return Some(index),
+        }
+    }
+    None
+}
+
+fn reject_demoted_breadcrumbs(action: &str, command_path: &[&str]) -> Result<()> {
+    match command_path {
+        ["ship"] => Err(next_action_validation_error(format!(
+            "`ship` was renamed to `land`; next_action `{action}` is non-canonical"
+        ))),
+        ["checkpoint"] => Err(next_action_validation_error(format!(
+            "`checkpoint` is an advanced Git primitive; next_action `{action}` must use `commit`"
+        ))),
+        ["capture"] => Err(next_action_validation_error(format!(
+            "`capture` is an advanced savepoint primitive; next_action `{action}` must use `commit`"
+        ))),
+        ["merge"] => Err(next_action_validation_error(format!(
+            "`merge` is an advanced merge primitive; managed-thread next_action `{action}` must use `ready`, `sync`, or `land`"
+        ))),
+        ["thread", "refresh"] => Err(next_action_validation_error(format!(
+            "`thread refresh` is an implementation-shaped freshness primitive; next_action `{action}` must use `sync`"
+        ))),
+        ["thread", "resolve"] => Err(next_action_validation_error(format!(
+            "`thread resolve` is not a breadcrumb; next_action `{action}` must use `resolve`, `continue`, `sync`, or `land`"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+fn reject_wrong_repo_type(
+    action: &str,
+    command_path: &[&str],
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    if command_path == ["checkpoint"]
+        && context.repository_capability != Some(repo::RepositoryCapability::GitOverlay)
+    {
+        return Err(next_action_validation_error(format!(
+            "next_action `{action}` is not executable from this repository type"
+        )));
+    }
+    Ok(())
+}
+
+fn reject_self_loop(
+    action: &str,
+    command_path: &[&str],
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    if context.emitting_command == command_path {
+        return Err(next_action_validation_error(format!(
+            "next_action `{action}` is a self-loop for `{}`",
+            context.emitting_command.join(" ")
+        )));
+    }
+    Ok(())
+}
+
+fn next_action_validation_error(message: String) -> anyhow::Error {
+    anyhow::Error::msg(message)
 }
 
 impl<'a> NextActionInput<'a> {
@@ -156,12 +351,90 @@ pub(crate) fn thread_recovery_action_is_primary(
     matches!(
         thread_health.unwrap_or_default(),
         "blocked" | "dirty_worktree" | "uncaptured"
-    ) || thread_action == "heddle capture"
-        || thread_action.starts_with("heddle thread refresh ")
-        || thread_action.starts_with("heddle thread resolve ")
+    ) || thread_action == "heddle commit"
+        || thread_action.starts_with("heddle commit ")
+        || thread_action.starts_with("heddle sync ")
+        || thread_action.starts_with("heddle resolve ")
         || thread_action.starts_with("heddle thread promote ")
 }
 
 fn non_empty_action(action: Option<&str>) -> Option<&str> {
     action.filter(|action| !action.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx(command: &'static [&'static str]) -> NextActionValidationContext<'static> {
+        NextActionValidationContext::new(command, repo::RepositoryCapability::NativeHeddle)
+    }
+
+    #[test]
+    fn validator_accepts_canonical_everyday_actions() {
+        for action in [
+            "heddle commit -m \"...\"",
+            "heddle ready --thread feature",
+            "heddle land --thread feature --no-push",
+            "heddle sync --thread feature",
+            "heddle resolve --list",
+            "heddle continue",
+            "heddle abort",
+            "heddle push",
+        ] {
+            validate_next_action(action, ctx(&["status"]))
+                .unwrap_or_else(|err| panic!("expected `{action}` to validate: {err:#}"));
+        }
+    }
+
+    #[test]
+    fn validator_rejects_demoted_breadcrumbs() {
+        for action in [
+            "heddle ship --thread feature",
+            "heddle checkpoint -m \"...\"",
+            "heddle capture -m \"...\"",
+            "heddle merge feature --preview",
+            "heddle thread refresh feature",
+            "heddle thread resolve feature",
+        ] {
+            assert!(
+                validate_next_action(action, ctx(&["status"])).is_err(),
+                "`{action}` should be rejected as a next_action"
+            );
+        }
+    }
+
+    #[test]
+    fn validator_rejects_wrong_repo_type_checkpoint_before_demoted_class() {
+        let err = validate_next_action("heddle checkpoint -m \"...\"", ctx(&["status"]))
+            .expect_err("native repositories must not receive checkpoint breadcrumbs");
+        assert!(err.to_string().contains("not executable"));
+    }
+
+    #[test]
+    fn validator_rejects_self_loops() {
+        let err = validate_next_action(
+            "heddle ready --thread feature",
+            NextActionValidationContext::new(&["ready"], repo::RepositoryCapability::NativeHeddle),
+        )
+        .expect_err("ready must not point back to ready");
+        assert!(err.to_string().contains("self-loop"));
+    }
+
+    #[test]
+    fn recursive_validator_covers_nested_recommended_actions() {
+        let payload = json!({
+            "output_kind": "status",
+            "recommended_action": "heddle commit -m \"...\"",
+            "verification": {
+                "checks": [
+                    {"name": "Workflow", "recommended_action": "heddle thread resolve feature"}
+                ]
+            }
+        });
+        let err = validate_next_actions_in_value(&payload, ctx(&["status"]))
+            .expect_err("nested demoted breadcrumbs must fail validation");
+        assert!(err.to_string().contains("$.verification.checks[0].recommended_action"));
+    }
 }

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -88,7 +88,7 @@ impl OperatorCommandOutput {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct VerificationClaimPolicy {
-    allow_ship_publish_followup: bool,
+    allow_land_publish_followup: bool,
     allow_matching_workflow_action: bool,
 }
 
@@ -97,8 +97,8 @@ impl VerificationClaimPolicy {
         Self::default()
     }
 
-    pub(crate) fn allow_ship_publish_followup(mut self) -> Self {
-        self.allow_ship_publish_followup = true;
+    pub(crate) fn allow_land_publish_followup(mut self) -> Self {
+        self.allow_land_publish_followup = true;
         self
     }
 
@@ -116,9 +116,9 @@ fn repository_verification_allows_success_claim(
     if trust.verified || matches!(output.status.as_str(), "blocked" | "failed") {
         return true;
     }
-    if policy.allow_ship_publish_followup
-        && output.action == "ship"
-        && output.status == "shipped"
+    if policy.allow_land_publish_followup
+        && output.action == "land"
+        && output.status == "landed"
         && trust.recommended_action == "heddle push"
         && matches!(
             trust.remote_drift.as_str(),
@@ -343,7 +343,7 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
     let target = thread.target_thread.clone();
     manager.save(&thread)?;
 
-    let action = super::thread_landing::ship_command_for_thread(repo, &thread_id);
+    let action = super::thread_landing::land_command_for_thread(repo, &thread_id);
     Ok(Some(super::thread::contextual_thread_action(
         repo,
         &thread_id,
@@ -367,8 +367,8 @@ fn continue_from_operation(
                             .to_string(),
                     blockers: Vec::new(),
                     warnings: Vec::new(),
-                    next_action: Some("heddle capture -m \"Manual resolution\"".to_string()),
-                    recommended_action: Some("heddle capture -m \"Manual resolution\"".to_string()),
+                    next_action: Some("heddle commit -m \"Manual resolution\"".to_string()),
+                    recommended_action: Some("heddle commit -m \"Manual resolution\"".to_string()),
                 },
                 OperatorContinueStatus::Continued => OperatorCommandOutput {
                     status: "continued".to_string(),
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn verification_claim_gate_blocks_local_success_claims() {
-        let trust = verification_state(false, "needs_checkpoint", "heddle checkpoint -m \"...\"");
+        let trust = verification_state(false, "needs_checkpoint", "heddle commit -m \"...\"");
         let mut output = OperatorCommandOutput {
             status: "synced".to_string(),
             action: "sync".to_string(),
@@ -598,7 +598,7 @@ mod tests {
         assert_eq!(output.status, "blocked");
         assert_eq!(
             output.recommended_action.as_deref(),
-            Some("heddle checkpoint -m \"...\"")
+            Some("heddle commit -m \"...\"")
         );
         assert!(output
             .message
@@ -606,33 +606,33 @@ mod tests {
     }
 
     #[test]
-    fn verification_claim_gate_allows_ship_publish_followup_only_by_policy() {
+    fn verification_claim_gate_allows_land_publish_followup_only_by_policy() {
         let trust = verification_state(false, "remote_ahead", "heddle push");
-        let shipped = || OperatorCommandOutput {
-            status: "shipped".to_string(),
-            action: "ship".to_string(),
-            message: "Shipped thread 'feature'".to_string(),
+        let landed = || OperatorCommandOutput {
+            status: "landed".to_string(),
+            action: "land".to_string(),
+            message: "Landed thread 'feature'".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
             next_action: Some("heddle push".to_string()),
             recommended_action: Some("heddle push".to_string()),
         };
 
-        let mut strict = shipped();
+        let mut strict = landed();
         strict.block_success_claim_if_verification_blocked(
             &trust,
-            "ship",
+            "land",
             VerificationClaimPolicy::strict(),
         );
         assert_eq!(strict.status, "blocked");
 
-        let mut allowed = shipped();
+        let mut allowed = landed();
         allowed.block_success_claim_if_verification_blocked(
             &trust,
-            "ship",
-            VerificationClaimPolicy::strict().allow_ship_publish_followup(),
+            "land",
+            VerificationClaimPolicy::strict().allow_land_publish_followup(),
         );
-        assert_eq!(allowed.status, "shipped");
+        assert_eq!(allowed.status, "landed");
         assert_eq!(allowed.recommended_action.as_deref(), Some("heddle push"));
     }
 

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -594,6 +594,60 @@ mod tests {
         );
     }
 
+    // heddle#464 defense-in-depth — the exact P1 scenario. A blocked `land`
+    // emits its `OperatorCommandOutput` (flattened into `LandOutput`) with both
+    // `next_action` and `recommended_action` carrying a `heddle sync --thread
+    // <id>` breadcrumb. The `<id>` is NOT guaranteed to be a freshly-validated
+    // `ThreadId`: `new_unchecked` (Deserialize / `ThreadRecord::thread_id`),
+    // historical records, and `heddle agent reserve --thread` all bypass
+    // `validate_thread_id`. An unsafe id here (`bad;echo pwn`) would tokenize
+    // into extra positionals and fail the next_action validator — the render
+    // failure Codex flagged. Quoting at construction makes it a single token, so
+    // the JSON validates regardless of where the id came from. This asserts the
+    // P1 cannot recur.
+    #[test]
+    fn blocked_land_with_unvalidated_thread_id_passes_only_when_quoted() {
+        use crate::cli::commands::next_action::{
+            validated_json_string, NextActionValidationContext,
+        };
+        use repo::shell_quote;
+
+        // Simulates a `new_unchecked` / historical / `agent reserve` id that
+        // never went through `ThreadId::new`.
+        let unsafe_id = "bad;echo pwn";
+        let context = NextActionValidationContext::without_repo(&["land"]);
+
+        let quoted = OperatorCommandOutput {
+            status: "blocked".to_string(),
+            action: "land".to_string(),
+            message: format!("Thread '{unsafe_id}' must be synced manually"),
+            blockers: vec!["thread is stale".to_string()],
+            warnings: Vec::new(),
+            next_action: Some(format!("heddle sync --thread {}", shell_quote(unsafe_id))),
+            recommended_action: Some(format!("heddle sync --thread {}", shell_quote(unsafe_id))),
+        };
+        let json = validated_json_string(&quoted, context).expect(
+            "a shell-quoted unvalidated thread id must pass next_action validation (the P1 fix)",
+        );
+        assert!(
+            json.contains("heddle sync --thread 'bad;echo pwn'"),
+            "both action fields must carry the quoted, single-token thread id: {json}"
+        );
+
+        // Guard: the BARE interpolation is exactly the P1 bug — the id tokenizes
+        // into extra positionals (`echo`, `pwn`) and fails the validator, so the
+        // JSON output would never render.
+        let bare = OperatorCommandOutput {
+            next_action: Some(format!("heddle sync --thread {unsafe_id}")),
+            recommended_action: Some(format!("heddle sync --thread {unsafe_id}")),
+            ..quoted.clone()
+        };
+        assert!(
+            validated_json_string(&bare, context).is_err(),
+            "a bare unvalidated thread id must fail validation — proving quoting is what closes the hole"
+        );
+    }
+
     #[test]
     fn raw_git_operation_handoff_recommends_heddle_preservation_not_git_cli() {
         let operation = RepositoryOperationStatus {

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 use gix::bstr::ByteSlice;
 use objects::object::ThreadName;
 use repo::{
-    update_thread_state_from_state, GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind,
-    OperationScope, Repository, RepositoryOperationStatus, ThreadFreshness,
+    shell_quote, update_thread_state_from_state, GitOverlayImportHint, GitRemoteTrackingStatus,
+    OperationKind, OperationScope, Repository, RepositoryOperationStatus, ThreadFreshness,
     ThreadIntegrationPolicy, ThreadManager, ThreadState,
 };
 use serde::{ser::SerializeStruct, Serialize, Serializer};
@@ -204,7 +204,11 @@ pub(crate) fn continue_operator(repo: &Repository) -> Result<OperatorCommandOutp
     if repo.merge_state_manager().is_merge_in_progress() {
         let unresolved = repo.merge_state_manager().unresolved()?;
         if !unresolved.is_empty() {
-            let recommended_action = format!("heddle resolve {}", unresolved[0]);
+            // A conflict path can legitimately contain spaces, so shell-quote
+            // it: this is a *validated* recommended_action (write_validated_json_stdout
+            // tokenizes it), and an unquoted space would split into extra args
+            // and fail the next_action validator. (heddle#464 close-the-class.)
+            let recommended_action = format!("heddle resolve {}", shell_quote(&unresolved[0]));
             return Ok(OperatorCommandOutput {
                 status: "blocked".to_string(),
                 action: "continue".to_string(),
@@ -546,6 +550,49 @@ mod tests {
 
     use super::*;
     use crate::cli::commands::git_overlay_health::{machine_contract_coverage, VerificationCheck};
+
+    // heddle#464 close-the-class (paths): a conflict path can contain spaces.
+    // `continue` builds `recommended_action = heddle resolve <path>`, a VALIDATED
+    // action. Shell-quoting the path keeps it a single token, so it survives the
+    // next_action validator; leaving it bare would split into extra positionals
+    // and fail validation (the render failure Codex flagged for thread ids).
+    #[test]
+    fn validated_resolve_action_with_spaced_path_passes_only_when_quoted() {
+        use crate::cli::commands::next_action::{
+            validated_json_string, NextActionValidationContext,
+        };
+        use repo::shell_quote;
+
+        let path = "my conflicted file.txt";
+        let context = NextActionValidationContext::without_repo(&["continue"]);
+
+        let quoted = OperatorCommandOutput {
+            status: "blocked".to_string(),
+            action: "continue".to_string(),
+            message: "conflicts remain".to_string(),
+            blockers: vec![path.to_string()],
+            warnings: Vec::new(),
+            next_action: Some("heddle resolve --list".to_string()),
+            recommended_action: Some(format!("heddle resolve {}", shell_quote(path))),
+        };
+        let json = validated_json_string(&quoted, context)
+            .expect("a shell-quoted conflict path must pass next_action validation");
+        assert!(
+            json.contains("heddle resolve 'my conflicted file.txt'"),
+            "the serialized recommended_action must carry the quoted path: {json}"
+        );
+
+        // Guard: the UNQUOTED interpolation is exactly the bug — it tokenizes
+        // into extra positionals and fails the validator.
+        let bare = OperatorCommandOutput {
+            recommended_action: Some(format!("heddle resolve {path}")),
+            ..quoted.clone()
+        };
+        assert!(
+            validated_json_string(&bare, context).is_err(),
+            "an unquoted spaced path must fail validation"
+        );
+    }
 
     #[test]
     fn raw_git_operation_handoff_recommends_heddle_preservation_not_git_cli() {

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -5,7 +5,10 @@ use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, RepositoryOperationSta
 use super::{
     action_line::print_next_step,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
-    next_action::{NextActionInput, effective_next_action},
+    next_action::{
+        NextActionInput, NextActionValidationContext, effective_next_action,
+        write_validated_json_stdout,
+    },
     operator_core::{
         OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
         open_operator_repo_from_path, recommend_next_action,
@@ -25,7 +28,7 @@ pub async fn cmd_continue(cli: &Cli) -> Result<()> {
     let repo = open_operator_repo_from_path(cwd)?;
     let output = super::operator_core::continue_operator(&repo)?;
     let status = output.status.clone();
-    emit(cli, output)?;
+    emit(cli, &repo, output, &["continue"])?;
     exit_if_blocked_operator_status(&status);
     Ok(())
 }
@@ -35,7 +38,7 @@ pub fn cmd_abort(cli: &Cli) -> Result<()> {
     let cwd = cli.repo.as_ref().unwrap_or(&current_dir);
     let repo = open_operator_repo_from_path(cwd)?;
     let output = abort_operator(&repo)?;
-    emit(cli, output)
+    emit(cli, &repo, output, &["abort"])
 }
 
 pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
@@ -45,6 +48,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
     if repo.operation_status()?.is_some() || repo.merge_state_manager().is_merge_in_progress() {
         return emit(
             cli,
+            &repo,
             OperatorCommandOutput {
                 status: "blocked".to_string(),
                 action: "sync".to_string(),
@@ -54,6 +58,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 next_action: Some("heddle continue".to_string()),
                 recommended_action: Some("heddle continue".to_string()),
             },
+            &["sync"],
         );
     }
 
@@ -66,6 +71,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 .unwrap_or_else(|| "heddle verify".to_string());
             return emit(
                 cli,
+                &repo,
                 OperatorCommandOutput {
                     status: "blocked".to_string(),
                     action: "sync".to_string(),
@@ -78,6 +84,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: Some(recommended_action.clone()),
                     recommended_action: Some(recommended_action),
                 },
+                &["sync"],
             );
         }
         if remote_decision.status == "remote_behind" {
@@ -87,10 +94,11 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
             let outcome = bridge.pull(&remote_name)?;
             let verification = build_repository_verification_state(&repo);
             if !verification.verified {
-                return emit(cli, sync_blocked_by_trust(verification));
+                return emit(cli, &repo, sync_blocked_by_trust(verification), &["sync"]);
             }
             return emit(
                 cli,
+                &repo,
                 OperatorCommandOutput {
                     status: "synced".to_string(),
                     action: "sync".to_string(),
@@ -103,11 +111,13 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: None,
                     recommended_action: None,
                 },
+                &["sync"],
             );
         }
         if remote_decision.status == "remote_ahead" {
             return emit(
                 cli,
+                &repo,
                 OperatorCommandOutput {
                     status: "ahead".to_string(),
                     action: "sync".to_string(),
@@ -117,6 +127,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: Some("heddle push".to_string()),
                     recommended_action: Some("heddle push".to_string()),
                 },
+                &["sync"],
             );
         }
     }
@@ -135,9 +146,17 @@ fn sync_blocked_by_trust(trust: RepositoryVerificationState) -> OperatorCommandO
     )
 }
 
-fn emit(cli: &Cli, output: OperatorCommandOutput) -> Result<()> {
+fn emit(
+    cli: &Cli,
+    repo: &repo::Repository,
+    output: OperatorCommandOutput,
+    emitting_command: &[&str],
+) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        write_validated_json_stdout(
+            &output,
+            NextActionValidationContext::new(emitting_command, repo.capability()),
+        )?;
     } else {
         let message = match output.status.as_str() {
             "blocked" => style::warn(&output.message),

--- a/crates/cli/src/cli/commands/oss.rs
+++ b/crates/cli/src/cli/commands/oss.rs
@@ -24,7 +24,7 @@ pub fn cmd_git_overlay_guide(cli: &Cli) -> Result<()> {
             "{}",
             serde_json::json!({
                 "topic": "git-overlay",
-                "summary": "Use Heddle as the daily loop with Git compatibility through the bridge: status, diff, commit, start --path, ready, merge --preview, ship, undo, verify.",
+                "summary": "Use Heddle as the daily loop with Git compatibility through the bridge: status, diff, commit, start --path, ready, land, push, undo, verify.",
                 "steps": [
                     "heddle status",
                     "heddle adopt --ref <branch>",
@@ -32,8 +32,7 @@ pub fn cmd_git_overlay_guide(cli: &Cli) -> Result<()> {
                     "heddle commit -m <message>",
                     "heddle start <name> --path ../<name>",
                     "heddle ready",
-                    "heddle merge <name> --preview",
-                    "heddle ship --thread <name> --no-push",
+                    "heddle land --thread <name> --no-push",
                     "heddle push",
                     "heddle undo",
                     "heddle verify"
@@ -68,10 +67,9 @@ pub fn cmd_git_overlay_guide(cli: &Cli) -> Result<()> {
     println!("   {}", style::bold("heddle start <name> --path ../<name>"));
     println!("5. Integrate");
     println!("   {}", style::bold("heddle ready"));
-    println!("   {}", style::bold("heddle merge <name> --preview"));
     println!(
         "   {}",
-        style::bold("heddle ship --thread <name> --no-push")
+        style::bold("heddle land --thread <name> --no-push")
     );
     println!("6. Sync with remotes");
     println!("   {}", style::bold("heddle pull"));
@@ -87,7 +85,7 @@ pub fn cmd_git_overlay_guide(cli: &Cli) -> Result<()> {
     );
     println!(
         "  Captured in Heddle but not Git: {}",
-        style::bold("heddle checkpoint -m '<message>'")
+        style::bold("heddle commit -m '<message>'")
     );
     println!(
         "  Git refs changed externally: {}",

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -18,14 +18,17 @@ use super::{
         build_repository_verification_state, override_trust_recommended_action,
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},
-    next_action::{NextActionInput, effective_next_action},
+    next_action::{
+        NextActionInput, NextActionValidationContext, effective_next_action,
+        write_validated_json_stdout,
+    },
     operator_core::{
         OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
     },
     snapshot::{SnapshotAgentOverrides, create_snapshot, ensure_current_state},
     thread::contextual_thread_action,
     thread_cmd::{current_thread, load_thread, thread_manager, thread_not_found_advice},
-    thread_landing::{merge_preview_command, ship_local_command},
+    thread_landing::land_local_command,
 };
 use crate::{
     cli::{Cli, ReadyArgs, should_output_json, style, worktree_status_options},
@@ -191,7 +194,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
     let mut report = build_thread_preview_report(&repo, &mut thread, true)?;
     let has_integration_target = report.semantic_result != "no_target";
     if has_integration_target {
-        let policy_blockers = super::workflow::auto_ship_policy_blockers(&repo, &thread);
+        let policy_blockers = super::workflow::auto_land_policy_blockers(&repo, &thread);
         if !policy_blockers.is_empty() {
             for blocker in policy_blockers {
                 if !report.blockers.contains(&blocker) {
@@ -237,12 +240,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         && report.blockers.is_empty()
     {
         report.thread_health = "ready".to_string();
-        report.recommended_action =
-            if thread.integration_policy_result.status.as_deref() == Some("previewed") {
-                ship_local_command(&thread.id)
-            } else {
-                merge_preview_command(&thread.id)
-            };
+        report.recommended_action = land_local_command(&thread.id);
         report.refresh_recommended_action_metadata();
     }
 
@@ -349,16 +347,28 @@ fn ready_verification_preflight_blocks(trust: &RepositoryVerificationState) -> b
 }
 
 fn write_ready_output(cli: &Cli, repo: &Repository, output: &ReadyOutput) -> Result<()> {
-    write_ready_output_inner(output, should_output_json(cli, Some(repo.config())))
+    write_ready_output_inner(
+        output,
+        should_output_json(cli, Some(repo.config())),
+        NextActionValidationContext::new(&["ready"], repo.capability()),
+    )
 }
 
 fn write_ready_output_without_repo(cli: &Cli, output: &ReadyOutput) -> Result<()> {
-    write_ready_output_inner(output, should_output_json(cli, None))
+    write_ready_output_inner(
+        output,
+        should_output_json(cli, None),
+        NextActionValidationContext::without_repo(&["ready"]),
+    )
 }
 
-fn write_ready_output_inner(output: &ReadyOutput, json: bool) -> Result<()> {
+fn write_ready_output_inner(
+    output: &ReadyOutput,
+    json: bool,
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
     if json {
-        println!("{}", serde_json::to_string(output)?);
+        write_validated_json_stdout(output, context)?;
     } else {
         let missing_intent = ready_blocked_by_missing_intent(output);
         if !missing_intent {
@@ -402,7 +412,7 @@ fn ready_blocked_by_missing_intent(output: &ReadyOutput) -> bool {
             .operator
             .recommended_action
             .as_deref()
-            .is_some_and(|action| action == "heddle ready -m \"...\"")
+            .is_some_and(|action| action == "heddle commit -m \"...\"")
 }
 
 fn write_trust_blocked_setup(recommended_action: Option<&str>) {
@@ -521,7 +531,7 @@ fn missing_ready_capture_intent_output(
             format!("uncaptured path(s): {shown}, and {overflow} more")
         }
     };
-    let recommended_action = "heddle ready -m \"...\"".to_string();
+    let recommended_action = "heddle commit -m \"...\"".to_string();
     Ok(ReadyOutput {
         operator: OperatorCommandOutput {
             status: "blocked".to_string(),
@@ -530,7 +540,7 @@ fn missing_ready_capture_intent_output(
                 "Thread '{thread}' has uncaptured work; provide an intent before readiness checks"
             ),
             blockers: vec![format!(
-                "{path_summary}; readiness capture needs -m/--message/--intent"
+                "{path_summary}; commit the work with -m/--message/--intent before readiness checks"
             )],
             warnings: Vec::new(),
             next_action: Some(recommended_action.clone()),
@@ -563,7 +573,7 @@ fn missing_ready_capture_intent_report_for(
         semantic_result: "not_checked".to_string(),
         conflicts: Vec::new(),
         conflict_count: 0,
-        blockers: vec!["provide -m/--message/--intent before ready captures work".to_string()],
+        blockers: vec!["commit the work with -m/--message/--intent before readiness checks".to_string()],
         recommended_action: recommended_action.to_string(),
         recommended_action_template: super::git_overlay_health::action_template(recommended_action),
         thread_health: "blocked".to_string(),
@@ -708,13 +718,13 @@ mod tests {
     }
 
     #[test]
-    fn ready_keeps_merge_action_for_targeted_threads() {
+    fn ready_keeps_land_action_for_targeted_threads() {
         assert_eq!(
             ready_report_recommended_action(&report(
                 "fast_forward",
-                "heddle merge feature --preview"
+                "heddle land --thread feature --no-push"
             )),
-            Some("heddle merge feature --preview".to_string())
+            Some("heddle land --thread feature --no-push".to_string())
         );
     }
 }

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -201,9 +201,12 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
                     report.blockers.push(blocker);
                 }
             }
-            if let Some(action) =
-                super::workflow::integration_blocker_recommended_action(&report.blockers)
-            {
+            let recovery_scope =
+                super::workflow::recovery_scope_checkout(&thread, repo.root());
+            if let Some(action) = super::workflow::integration_blocker_recommended_action(
+                &report.blockers,
+                recovery_scope.as_deref(),
+            ) {
                 report.recommended_action = action;
                 report.refresh_recommended_action_metadata();
             }

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -73,7 +73,7 @@ schema_registry! {
     (&["switch", "checkout"], SwitchCheckoutSchema),
     (&["merge --preview"], MergePreviewSchema),
     (&["ready"], ReadySchema),
-    (&["ship"], ShipSchema),
+    (&["land"], LandSchema),
     (&["sync"], SyncSchema),
     (&["continue", "abort"], OperatorCommandSchema),
     (&["delegate"], DelegateSchema),
@@ -1172,7 +1172,7 @@ pub struct SyncSchema {
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct ShipSchema {
+pub struct LandSchema {
     pub status: String,
     pub action: String,
     pub message: String,

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -28,6 +28,7 @@ use super::{
         build_repository_verification_state, git_overlay_mutation_preflight_advice,
         plain_git_mutation_preflight_advice, unimported_git_history_advice,
     },
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
     thread::find_active_thread_entry,
     thread_cmd::current_thread,
 };
@@ -193,7 +194,10 @@ pub async fn cmd_snapshot(
     }
 
     if as_json {
-        println!("{}", serde_json::to_string(&output)?);
+        write_validated_json_stdout(
+            &output,
+            NextActionValidationContext::new(&["capture"], repo.capability()),
+        )?;
     } else {
         // The bare `{message}` was `"Created state <id> (<hash>)"` —
         // we restyle the parts here rather than inside the message

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -37,6 +37,7 @@ use super::{
         remote_tracking_with_verification_action, repository_setup_guidance,
         serialize_empty_action_as_null,
     },
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
     operator_loop::primary_next_action_with_verification,
     snapshot::resolve_principal,
     thread::{
@@ -63,6 +64,8 @@ pub(crate) struct StatusOutput {
     hosted_enabled: bool,
     #[serde(skip)]
     render_json: bool,
+    #[serde(skip)]
+    validation_capability: RepositoryCapability,
     operation: Option<RepositoryOperationStatus>,
     remote_tracking: Option<GitRemoteTrackingStatus>,
     #[serde(rename = "verification")]
@@ -379,7 +382,10 @@ fn build_plain_git_status_probe(cli: &Cli) -> Result<Option<PlainGitStatusOutput
 
 fn render_plain_git_status(cli: &Cli, output: &PlainGitStatusOutput, short: bool) -> Result<()> {
     if should_output_json(cli, None) {
-        crate::cli::render::write_json_stdout(output)?;
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::without_repo(&["status"]),
+        )?;
         return Ok(());
     }
     if short {
@@ -545,6 +551,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             storage_model: repo.storage_model_label().to_string(),
             hosted_enabled: repo.hosted_enabled(),
             render_json: as_json,
+            validation_capability: repo.capability(),
             git_overlay_import_hint: import_hint.clone().map(|hint| GitOverlayImportHintOutput {
                 current_branch: hint.current_branch,
                 missing_branch_count: hint.missing_branch_count,
@@ -722,6 +729,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         storage_model: repo.storage_model_label().to_string(),
         hosted_enabled: repo.hosted_enabled(),
         render_json: as_json,
+        validation_capability: repo.capability(),
         git_overlay_import_hint: import_hint.clone().map(|hint| GitOverlayImportHintOutput {
             current_branch: hint.current_branch,
             missing_branch_count: hint.missing_branch_count,
@@ -1073,7 +1081,10 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
 pub(crate) fn render_status(cli: &Cli, output: &StatusOutput, short: bool) -> Result<()> {
     let render_start = Instant::now();
     if output.render_json {
-        crate::cli::render::write_json_stdout(output)?;
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::new(&["status"], output.validation_capability),
+        )?;
     } else if short {
         render_short_status(output);
     } else {
@@ -1754,9 +1765,6 @@ fn status_next_reason(output: &StatusOutput) -> &'static str {
     if output.operation.is_some() {
         return "an operation is in progress; finish or abort it before starting another workflow";
     }
-    if output.recommended_action.contains("checkpoint") {
-        return "the work is saved in Heddle; checkpoint writes the Git commit for this saved state";
-    }
     if output.recommended_action.contains("adopt --ref")
         || output.git_overlay_import_hint.as_ref().is_some_and(|hint| {
             hint.missing_branches
@@ -1770,10 +1778,10 @@ fn status_next_reason(output: &StatusOutput) -> &'static str {
         if output.repository_capability != "git-overlay" {
             return "there are uncommitted worktree changes; commit captures them as a Heddle state";
         }
-        return "there are uncommitted worktree changes; commit captures them and writes the Git checkpoint";
+        return "there are uncommitted worktree changes; commit captures them and writes the matching Git commit";
     }
-    if output.changed_path_count > 0 && output.recommended_action.contains("capture") {
-        return "there are uncaptured worktree changes; capture records a recoverable state";
+    if output.repository_capability == "git-overlay" && output.recommended_action.contains("commit") {
+        return "the work is saved in Heddle; commit writes the matching Git commit";
     }
     if !output.blockers.is_empty() {
         return "the current thread has blockers that must be cleared before integration";
@@ -1787,8 +1795,8 @@ fn status_next_reason(output: &StatusOutput) -> &'static str {
     if output.recommended_action.contains("ready") {
         return "the work is captured; readiness checks merge blockers without landing changes";
     }
-    if output.recommended_action.contains("merge") {
-        return "the thread is ready to integrate into its target";
+    if output.recommended_action.contains("land") {
+        return "the thread is ready to land into its target";
     }
     "this is the safest command for the current repository and thread state"
 }
@@ -1796,17 +1804,11 @@ fn status_next_reason(output: &StatusOutput) -> &'static str {
 fn status_next_follow_up(output: &StatusOutput) -> Option<&'static str> {
     let action = output.recommended_action.as_str();
     if action.contains("commit") && status_has_publish_target(output) {
-        Some("run `heddle push` when the checkpoint is ready to publish")
-    } else if action.contains("checkpoint") && status_has_publish_target(output) {
-        Some("run `heddle push` when the Git checkpoint is ready to publish")
-    } else if action.contains("capture") {
-        Some("run `heddle ready` when the captured work should be checked for merge")
+        Some("run `heddle push` when the Git commit is ready to publish")
     } else if action.contains("ready") {
-        Some("preview integration with `heddle merge <thread> --preview` before landing it")
-    } else if action.contains("merge") && action.contains("--preview") {
-        Some(
-            "land the previewed thread with `heddle ship --thread <thread> --no-push`; add `--push` only when a remote is configured",
-        )
+        Some("run `heddle land --thread <thread> --no-push` after readiness passes")
+    } else if action.contains("land") {
+        Some("add `--push` only when a remote is configured and the thread should be published")
     } else if action.contains("resolve") || action.contains("continue") || action.contains("abort")
     {
         Some("check `heddle status` again after the operation state changes")

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1649,7 +1649,7 @@ pub(crate) fn resolve_start_epoch(repo: &Repository, name: &str) -> Result<DateT
 /// Centralized "invalid thread name" advice (text + JSON error envelope) built
 /// from a [`ThreadIdError`]. The error's `Display` already names the offending
 /// input and suggests a valid rename; this wraps it as a usage refusal.
-fn thread_name_invalid_advice(err: &ThreadIdError) -> RecoveryAdvice {
+pub(crate) fn thread_name_invalid_advice(err: &ThreadIdError) -> RecoveryAdvice {
     RecoveryAdvice::invalid_usage(
         "thread_name_invalid",
         err.to_string(),
@@ -2324,6 +2324,12 @@ pub(crate) fn cmd_thread_create(
     ephemeral: bool,
     ttl_secs: Option<u32>,
 ) -> Result<()> {
+    // Same user/external creation boundary guard as `start_thread`: reject a
+    // name that isn't a safe single shell token before any ref/record is
+    // persisted, so `heddle thread create` can't slip an unsafe id past the
+    // early-reject layer. (heddle#464 close-the-class.)
+    ThreadId::new(name.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
+
     // `ephemeral` / `ttl_secs` are part of main's evolved
     // ephemeral-threads API; not yet plumbed into the Thread record
     // here. TODO: thread these through to a ThreadLifecycle field

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -36,8 +36,9 @@ use super::{
     },
     mount_lifecycle,
     next_action::{
-        NextActionInput, effective_next_action,
+        NextActionInput, NextActionValidationContext, effective_next_action,
         thread_recovery_action_is_primary as shared_thread_recovery_action_is_primary,
+        write_validated_json_stdout,
     },
     operator_loop::{primary_next_action, primary_next_action_with_verification},
     snapshot::{ensure_current_state, summarize_confidence, summarize_verification},
@@ -629,7 +630,7 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadSummary>>
             summary.coordination_status = CoordinationStatus::Clean;
             summary.blockers.clear();
             summary.recommended_action =
-                super::thread_landing::merge_preview_command(&summary.name);
+                canonical_bridge_reconcile_ref_preview_command(None, &summary.name);
         }
         if summary.is_current {
             enrich_current_summary_with_dirty_paths(repo, &mut summary)?;
@@ -1304,7 +1305,10 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
     };
 
     if as_json {
-        println!("{}", serde_json::to_string(&output)?);
+        write_validated_json_stdout(
+            &output,
+            NextActionValidationContext::new(&["thread", "list"], repo.capability()),
+        )?;
     } else if output.threads.is_empty() && output.available_git_refs.is_empty() {
         println!("No threads");
     } else {
@@ -2321,7 +2325,7 @@ pub(crate) fn cmd_thread_create(
         .set_thread_cas(&ThreadName::new(&name), RefExpectation::Missing, &current)?;
 
     // Persist a Thread record so subsequent commands that go through
-    // `ThreadManager::load` (delegate, ship, integration policy,
+    // `ThreadManager::load` (delegate, land, integration policy,
     // `thread show`'s record path) can find it. Without this the ref
     // exists but the record file is missing and any `manager.load(name)`
     // returns `None`, surfacing as `Thread '<name>' not found` even
@@ -2615,7 +2619,7 @@ pub(crate) fn cmd_thread_switch(
     // private|virtualized` recorded under `.run-heddle-threads/<name>/`)
     // is a metadata-only operation. The on-disk worktree at the
     // recorded path is already X's worktree — it was set up by `start`
-    // and is kept in sync by the metadata-driven merge/rebase/goto/ship
+    // and is kept in sync by the metadata-driven merge/rebase/goto/land
     // dispatcher (see `Repository::active_worktree_path`). The operator's
     // CWD must stay untouched so `thread switch X` from `$ROOT` does NOT
     // overwrite `$ROOT`'s files with X's tree.
@@ -2865,22 +2869,21 @@ pub(crate) fn show_thread_summary(
         summary.parent_thread.as_deref(),
     );
     if should_output_json(cli, Some(repo.config())) {
-        println!(
-            "{}",
-            serde_json::to_string(&ThreadShowOutput {
-                output_kind: "thread_show",
-                repository_label: presentation.label,
-                repository_context: presentation.context,
-                next_action: summary.recommended_action.clone(),
-                next_action_template: recommended_action_template(&summary.recommended_action),
-                recommended_action_template: recommended_action_template(
-                    &summary.recommended_action
-                ),
-                summary,
-                recovery_commands: trust.recovery_commands.clone(),
-                trust,
-            })?
-        );
+        let output = ThreadShowOutput {
+            output_kind: "thread_show",
+            repository_label: presentation.label,
+            repository_context: presentation.context,
+            next_action: summary.recommended_action.clone(),
+            next_action_template: recommended_action_template(&summary.recommended_action),
+            recommended_action_template: recommended_action_template(&summary.recommended_action),
+            summary,
+            recovery_commands: trust.recovery_commands.clone(),
+            trust,
+        };
+        write_validated_json_stdout(
+            &output,
+            NextActionValidationContext::new(&["thread", "show"], repo.capability()),
+        )?;
     } else {
         println!("Repository: {}", presentation.label);
         render_repository_context_lines(presentation.context.as_ref());

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -19,9 +19,9 @@ use refs::{Head, RefExpectation, RefUpdate};
 use repo::{
     AgentUsageSummary, GitOverlayBranchTip, GitOverlayImportHint, GitRemoteTrackingStatus,
     Repository, RepositoryOperationStatus, Thread, ThreadCaptureOutcome, ThreadConfidenceSummary,
-    ThreadFreshness, ThreadImpactCategory, ThreadIntegrationPolicy, ThreadManager, ThreadMode,
-    ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView,
-    describe_thread_advice,
+    ThreadFreshness, ThreadId, ThreadIdError, ThreadImpactCategory, ThreadIntegrationPolicy,
+    ThreadManager, ThreadMode, ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary,
+    ThreadView, describe_thread_advice,
 };
 use serde::Serialize;
 
@@ -1646,7 +1646,27 @@ pub(crate) fn resolve_start_epoch(repo: &Repository, name: &str) -> Result<DateT
     Ok(prior_active.map_or_else(Utc::now, |thread| thread.created_at))
 }
 
+/// Centralized "invalid thread name" advice (text + JSON error envelope) built
+/// from a [`ThreadIdError`]. The error's `Display` already names the offending
+/// input and suggests a valid rename; this wraps it as a usage refusal.
+fn thread_name_invalid_advice(err: &ThreadIdError) -> RecoveryAdvice {
+    RecoveryAdvice::invalid_usage(
+        "thread_name_invalid",
+        err.to_string(),
+        "Choose a thread name using only letters, digits, and _ - . / @ : + = \
+         (no spaces or shell metacharacters).",
+        "heddle start <name>",
+    )
+}
+
 pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<ThreadOpOutput> {
+    // The single user/external creation boundary for every thread start
+    // (`heddle start`, `heddle thread start`, `try`, `attempt`, workflow). Reject
+    // a name that isn't a safe single shell token here so a thread id with a
+    // space or shell metacharacter can never be persisted — and so every
+    // downstream breadcrumb can interpolate it bare. (heddle#464 close-the-class.)
+    ThreadId::new(args.name.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
+
     let existing = find_active_thread_entry(repo, &args.name)?;
     if let Some(entry) = existing {
         if let Some(ref requested_path) = args.path {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -3250,6 +3250,10 @@ pub(crate) fn cmd_thread_rename(
     old: String,
     new: String,
 ) -> Result<()> {
+    // Renaming persists a new thread id, so the destination name is a
+    // user/external creation boundary too — reject an unsafe name here.
+    // (heddle#464 close-the-class.)
+    ThreadId::new(new.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
     let old_tn = ThreadName::new(&old);
     let new_tn = ThreadName::new(&new);
     let state = repo

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -795,18 +795,19 @@ pub(crate) fn thread_not_found_advice(thread_id: &str, action: &str) -> Recovery
 }
 
 fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice {
-    let merge_preview = super::thread_landing::merge_preview_command(thread_id);
+    let reconcile_preview =
+        super::git_overlay_health::canonical_bridge_reconcile_ref_preview_command(None, thread_id);
     RecoveryAdvice::safety_refusal(
         "imported_git_ref_not_managed_thread",
         format!("'{thread_id}' is an imported Git ref, not a managed Heddle thread"),
         format!(
-            "Preview it as an integration source with `{merge_preview}`. Use managed threads for `ready` and `ship`."
+            "Preview Git/Heddle reconciliation with `{reconcile_preview}`. Use managed threads for `ready` and `land`."
         ),
         format!("thread ref '{thread_id}' exists, but no managed thread metadata exists for it"),
-        "ready/ship require managed thread metadata and explicit integration authority; treating an imported Git ref as shippable would be ambiguous",
+        "ready/land require managed thread metadata and explicit integration authority; treating an imported Git ref as landable would be ambiguous",
         "thread refs, Git refs, checkout files, and thread metadata were left unchanged",
-        merge_preview.clone(),
-        vec![merge_preview, "heddle thread list".to_string()],
+        reconcile_preview.clone(),
+        vec![reconcile_preview, "heddle thread list".to_string()],
     )
 }
 

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -3,10 +3,22 @@
 
 use repo::Repository;
 
-use super::command_catalog::heddle_action;
+use super::command_catalog::{heddle_action, thread_flag_args};
 
 pub(crate) fn merge_preview_command(thread_id: &str) -> String {
-    heddle_action(["merge", thread_id, "--preview"])
+    // `merge` takes the thread as a POSITIONAL. A leading-dash id needs the `--`
+    // end-of-options separator (positionals can't use the `=` form), so the
+    // flags move ahead of it. (heddle#464 close-the-class.)
+    if thread_id.starts_with('-') {
+        heddle_action(vec![
+            "merge".to_string(),
+            "--preview".to_string(),
+            "--".to_string(),
+            thread_id.to_string(),
+        ])
+    } else {
+        heddle_action(["merge", thread_id, "--preview"])
+    }
 }
 
 pub(crate) fn land_command_for_thread(repo: &Repository, thread_id: &str) -> String {
@@ -26,15 +38,24 @@ pub(crate) fn land_command_with_push_target(thread_id: &str, has_push_target: bo
 }
 
 pub(crate) fn land_push_command(thread_id: &str) -> String {
-    heddle_action(["land", "--thread", thread_id, "--push"])
+    let mut argv = vec!["land".to_string()];
+    argv.extend(thread_flag_args(thread_id));
+    argv.push("--push".to_string());
+    heddle_action(argv)
 }
 
 pub(crate) fn land_push_remote_command(thread_id: &str, remote: &str) -> String {
-    heddle_action(["land", "--thread", thread_id, "--push", "--remote", remote])
+    let mut argv = vec!["land".to_string()];
+    argv.extend(thread_flag_args(thread_id));
+    argv.extend(["--push".to_string(), "--remote".to_string(), remote.to_string()]);
+    heddle_action(argv)
 }
 
 pub(crate) fn land_local_command(thread_id: &str) -> String {
-    heddle_action(["land", "--thread", thread_id, "--no-push"])
+    let mut argv = vec!["land".to_string()];
+    argv.extend(thread_flag_args(thread_id));
+    argv.push("--no-push".to_string());
+    heddle_action(argv)
 }
 
 pub(crate) fn contextual_thread_action(
@@ -50,33 +71,42 @@ pub(crate) fn contextual_thread_action(
         return action.to_string();
     }
     if action == merge_preview_command(thread_id) {
-        return heddle_action(vec![
-            "--repo".to_string(),
-            main_root.display().to_string(),
-            "merge".to_string(),
-            thread_id.to_string(),
-            "--preview".to_string(),
-        ]);
+        let mut argv = vec!["--repo".to_string(), main_root.display().to_string()];
+        if thread_id.starts_with('-') {
+            argv.extend([
+                "merge".to_string(),
+                "--preview".to_string(),
+                "--".to_string(),
+                thread_id.to_string(),
+            ]);
+        } else {
+            argv.extend([
+                "merge".to_string(),
+                thread_id.to_string(),
+                "--preview".to_string(),
+            ]);
+        }
+        return heddle_action(argv);
     }
     if action == land_local_command(thread_id) {
-        return heddle_action(vec![
+        let mut argv = vec![
             "--repo".to_string(),
             main_root.display().to_string(),
             "land".to_string(),
-            "--thread".to_string(),
-            thread_id.to_string(),
-            "--no-push".to_string(),
-        ]);
+        ];
+        argv.extend(thread_flag_args(thread_id));
+        argv.push("--no-push".to_string());
+        return heddle_action(argv);
     }
     if action == land_push_command(thread_id) {
-        return heddle_action(vec![
+        let mut argv = vec![
             "--repo".to_string(),
             main_root.display().to_string(),
             "land".to_string(),
-            "--thread".to_string(),
-            thread_id.to_string(),
-            "--push".to_string(),
-        ]);
+        ];
+        argv.extend(thread_flag_args(thread_id));
+        argv.push("--push".to_string());
+        return heddle_action(argv);
     }
     action.to_string()
 }
@@ -107,5 +137,39 @@ mod tests {
             merge_preview_command("feature with spaces"),
             "heddle merge 'feature with spaces' --preview"
         );
+    }
+
+    // heddle#464 close-the-class (r9): a historical `-foo` thread id (un-creatable
+    // now, but reachable via `new_unchecked` deserialization) must yield a
+    // clap-valid command from EVERY land/merge breadcrumb builder. `heddle_action`
+    // validates through clap and panics on an invalid action, so a builder still
+    // emitting the bare `--thread -foo` (or positional `-foo`) form would panic
+    // here — this test is the conformance gate against the next sibling.
+    #[test]
+    fn land_breadcrumbs_handle_leading_dash_thread_ids() {
+        use super::super::command_catalog::validate_recommended_action;
+        let id = "-foo";
+        let cmds = [
+            land_local_command(id),
+            land_push_command(id),
+            land_push_remote_command(id, "origin"),
+            merge_preview_command(id),
+        ];
+        for cmd in &cmds {
+            validate_recommended_action(cmd).unwrap_or_else(|e| {
+                panic!("breadcrumb `{cmd}` must validate for a leading-dash id: {e}")
+            });
+        }
+        // `cli::render::shell_quote` (used by checked_action_from_argv) treats
+        // `=` as unsafe, so `--thread=-foo` renders single-quoted — still
+        // runnable (the shell strips the quotes, clap binds the value) and, as
+        // the loop above asserts, accepted by the validator.
+        assert_eq!(land_local_command(id), "heddle land '--thread=-foo' --no-push");
+        assert_eq!(land_push_command(id), "heddle land '--thread=-foo' --push");
+        assert_eq!(
+            land_push_remote_command(id, "origin"),
+            "heddle land '--thread=-foo' --push --remote origin"
+        );
+        assert_eq!(merge_preview_command(id), "heddle merge --preview -- -foo");
     }
 }

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Shared commands for the ready -> preview -> ship thread landing loop.
+//! Shared commands for the ready -> land thread landing loop.
 
 use repo::Repository;
 
@@ -9,32 +9,32 @@ pub(crate) fn merge_preview_command(thread_id: &str) -> String {
     heddle_action(["merge", thread_id, "--preview"])
 }
 
-pub(crate) fn ship_command_for_thread(repo: &Repository, thread_id: &str) -> String {
+pub(crate) fn land_command_for_thread(repo: &Repository, thread_id: &str) -> String {
     let has_push_target = super::remote::resolved_default_remote_name(repo)
         .ok()
         .flatten()
         .is_some();
-    ship_command_with_push_target(thread_id, has_push_target)
+    land_command_with_push_target(thread_id, has_push_target)
 }
 
-pub(crate) fn ship_command_with_push_target(thread_id: &str, has_push_target: bool) -> String {
+pub(crate) fn land_command_with_push_target(thread_id: &str, has_push_target: bool) -> String {
     if has_push_target {
-        ship_push_command(thread_id)
+        land_push_command(thread_id)
     } else {
-        ship_local_command(thread_id)
+        land_local_command(thread_id)
     }
 }
 
-pub(crate) fn ship_push_command(thread_id: &str) -> String {
-    heddle_action(["ship", "--thread", thread_id, "--push"])
+pub(crate) fn land_push_command(thread_id: &str) -> String {
+    heddle_action(["land", "--thread", thread_id, "--push"])
 }
 
-pub(crate) fn ship_push_remote_command(thread_id: &str, remote: &str) -> String {
-    heddle_action(["ship", "--thread", thread_id, "--push", "--remote", remote])
+pub(crate) fn land_push_remote_command(thread_id: &str, remote: &str) -> String {
+    heddle_action(["land", "--thread", thread_id, "--push", "--remote", remote])
 }
 
-pub(crate) fn ship_local_command(thread_id: &str) -> String {
-    heddle_action(["ship", "--thread", thread_id, "--no-push"])
+pub(crate) fn land_local_command(thread_id: &str) -> String {
+    heddle_action(["land", "--thread", thread_id, "--no-push"])
 }
 
 pub(crate) fn contextual_thread_action(
@@ -58,21 +58,21 @@ pub(crate) fn contextual_thread_action(
             "--preview".to_string(),
         ]);
     }
-    if action == ship_local_command(thread_id) {
+    if action == land_local_command(thread_id) {
         return heddle_action(vec![
             "--repo".to_string(),
             main_root.display().to_string(),
-            "ship".to_string(),
+            "land".to_string(),
             "--thread".to_string(),
             thread_id.to_string(),
             "--no-push".to_string(),
         ]);
     }
-    if action == ship_push_command(thread_id) {
+    if action == land_push_command(thread_id) {
         return heddle_action(vec![
             "--repo".to_string(),
             main_root.display().to_string(),
-            "ship".to_string(),
+            "land".to_string(),
             "--thread".to_string(),
             thread_id.to_string(),
             "--push".to_string(),
@@ -92,16 +92,16 @@ mod tests {
             "heddle merge feature/demo --preview"
         );
         assert_eq!(
-            ship_local_command("feature/demo"),
-            "heddle ship --thread feature/demo --no-push"
+            land_local_command("feature/demo"),
+            "heddle land --thread feature/demo --no-push"
         );
         assert_eq!(
-            ship_command_with_push_target("feature/demo", true),
-            "heddle ship --thread feature/demo --push"
+            land_command_with_push_target("feature/demo", true),
+            "heddle land --thread feature/demo --push"
         );
         assert_eq!(
-            ship_push_remote_command("feature/demo", "origin"),
-            "heddle ship --thread feature/demo --push --remote origin"
+            land_push_remote_command("feature/demo", "origin"),
+            "heddle land --thread feature/demo --push --remote origin"
         );
         assert_eq!(
             merge_preview_command("feature with spaces"),

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -21,6 +21,21 @@ pub(crate) fn merge_preview_command(thread_id: &str) -> String {
     }
 }
 
+pub(crate) fn switch_thread_command(thread_id: &str) -> String {
+    // `switch` takes the thread as a POSITIONAL, so a leading-dash id needs the
+    // `--` end-of-options separator (the `=` form is flag-only). (heddle#464
+    // close-the-class.)
+    if thread_id.starts_with('-') {
+        heddle_action(vec![
+            "switch".to_string(),
+            "--".to_string(),
+            thread_id.to_string(),
+        ])
+    } else {
+        heddle_action(["switch", thread_id])
+    }
+}
+
 pub(crate) fn land_command_for_thread(repo: &Repository, thread_id: &str) -> String {
     let has_push_target = super::remote::resolved_default_remote_name(repo)
         .ok()
@@ -154,6 +169,7 @@ mod tests {
             land_push_command(id),
             land_push_remote_command(id, "origin"),
             merge_preview_command(id),
+            switch_thread_command(id),
         ];
         for cmd in &cmds {
             validate_recommended_action(cmd).unwrap_or_else(|e| {
@@ -171,5 +187,15 @@ mod tests {
             "heddle land '--thread=-foo' --push --remote origin"
         );
         assert_eq!(merge_preview_command(id), "heddle merge --preview -- -foo");
+        assert_eq!(switch_thread_command(id), "heddle switch -- -foo");
+    }
+
+    #[test]
+    fn switch_thread_command_is_stable_and_copy_pasteable() {
+        assert_eq!(switch_thread_command("feature/demo"), "heddle switch feature/demo");
+        assert_eq!(
+            switch_thread_command("feature with spaces"),
+            "heddle switch 'feature with spaces'"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -16,12 +16,11 @@ use super::{
     merge::merge_thread_into_current,
     operator_core::OperatorCommandOutput,
     operator_loop::primary_next_action,
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
     ready_cmd::worktree_dirty,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread_cmd::{load_thread, refresh_thread, refresh_thread_freshness, thread_not_found_advice},
-    thread_landing::{
-        merge_preview_command, ship_command_for_thread, ship_command_with_push_target,
-    },
+    thread_landing::{land_command_for_thread, land_command_with_push_target},
 };
 use crate::{
     cli::{Cli, render::shell_quote, should_output_json, style, worktree_status_options},
@@ -297,6 +296,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 };
                 return emit_thread_resolve(
                     cli,
+                    &repo,
                     &ThreadResolveOutput {
                         operator,
                         thread: thread_id,
@@ -312,6 +312,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                     )?;
                     return emit_thread_resolve(
                         cli,
+                        &repo,
                         &ThreadResolveOutput {
                             operator,
                             thread: thread_id,
@@ -323,6 +324,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 {
                     return emit_thread_resolve(
                         cli,
+                        &repo,
                         &ThreadResolveOutput {
                             operator,
                             thread: thread_id,
@@ -382,7 +384,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 thread.id,
                 preview.conflicts.join(", ")
             ));
-            recommended_action = merge_preview_command(&thread.id);
+            recommended_action = "heddle resolve --list".to_string();
         }
     }
     if blockers.is_empty() {
@@ -398,7 +400,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
         if rebase_state_path.exists() {
             recommended_action
         } else {
-            ship_command_for_thread(&repo, &summary.name)
+            land_command_for_thread(&repo, &summary.name)
         }
     } else {
         recommended_action
@@ -415,6 +417,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
     );
     emit_thread_resolve(
         cli,
+        &repo,
         &ThreadResolveOutput {
             operator: OperatorCommandOutput {
                 status: if blockers.is_empty() {
@@ -540,7 +543,7 @@ fn thread_resolve_refresh_operator(
     thread_id: &str,
     trust: &RepositoryVerificationState,
 ) -> OperatorCommandOutput {
-    let ship_command = ship_command_with_push_target(thread_id, trust.default_remote.is_some());
+    let land_command = land_command_with_push_target(thread_id, trust.default_remote.is_some());
     if trust.verified {
         return OperatorCommandOutput {
             status: "synced".to_string(),
@@ -548,8 +551,8 @@ fn thread_resolve_refresh_operator(
             message: "Thread refreshed cleanly".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
-            next_action: Some(ship_command.clone()),
-            recommended_action: Some(ship_command),
+            next_action: Some(land_command.clone()),
+            recommended_action: Some(land_command),
         };
     }
 
@@ -753,9 +756,16 @@ fn emit<T: Serialize>(cli: &Cli, output: &T) -> Result<()> {
     Ok(())
 }
 
-fn emit_thread_resolve(cli: &Cli, output: &ThreadResolveOutput) -> Result<()> {
+fn emit_thread_resolve(
+    cli: &Cli,
+    repo: &Repository,
+    output: &ThreadResolveOutput,
+) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(output)?);
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::new(&["thread", "resolve"], repo.capability()),
+        )?;
     } else {
         println!("{}", output.operator.message);
         println!("Thread: {}", style::bold(&output.thread));
@@ -848,7 +858,7 @@ mod tests {
         assert_eq!(clean.status, "synced");
         assert_eq!(
             clean.recommended_action.as_deref(),
-            Some("heddle ship --thread feature/clean --no-push")
+            Some("heddle land --thread feature/clean --no-push")
         );
 
         let blocked = thread_resolve_refresh_operator("feature/blocked", &trust_state(false));
@@ -894,13 +904,10 @@ mod tests {
             None,
             Some(&remote),
             None,
-            "heddle merge feature/conflict --preview",
+            "heddle resolve --list",
         );
 
-        assert_eq!(
-            action.as_deref(),
-            Some("heddle merge feature/conflict --preview")
-        );
+        assert_eq!(action.as_deref(), Some("heddle resolve --list"));
     }
 
     #[test]
@@ -918,7 +925,7 @@ mod tests {
         };
 
         let action =
-            thread_resolve_next_action(&[], None, Some(&remote), None, "heddle ship --thread x");
+            thread_resolve_next_action(&[], None, Some(&remote), None, "heddle land --thread x");
 
         assert_eq!(action.as_deref(), Some("heddle push"));
     }

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -37,7 +37,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use repo::{Repository, ThreadManager};
+use repo::{Repository, ThreadManager, shell_quote};
 use serde::Serialize;
 
 use super::{
@@ -357,7 +357,11 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
     }
 
     let next_action = if !args.auto_merge {
-        Some(format!("heddle ready --thread {thread_name}"))
+        // Quote defensively at construction (heddle#464 defense-in-depth): a
+        // thread id flows into the validated next_action / recommended_action
+        // fields, so an unsafe one must render as a single shell token, never
+        // bare. A clean slug passes through unchanged.
+        Some(format!("heddle ready --thread {}", shell_quote(&thread_name)))
     } else {
         None
     };

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -357,7 +357,7 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
     }
 
     let next_action = if !args.auto_merge {
-        Some(super::thread_landing::merge_preview_command(&thread_name))
+        Some(format!("heddle ready --thread {thread_name}"))
     } else {
         None
     };
@@ -392,11 +392,11 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
     } else {
         match &captured_state {
             Some(state) => format!(
-                "`{}` succeeded; thread '{}' ready (state {}). Preview with `{}` before landing.",
+                "`{}` succeeded; thread '{}' ready (state {}). Check readiness with `heddle ready --thread {}` before landing.",
                 display_cmd(&args.command),
                 thread_name,
                 state,
-                super::thread_landing::merge_preview_command(&thread_name)
+                thread_name
             ),
             None => format!(
                 "`{}` succeeded; thread '{}' ready (no capture).",

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -345,8 +345,8 @@ fn human_clean_summary(output: &VerifyOutput) -> &str {
             "Nothing to do. Workspace verified."
         } else if output.trust.recommended_action.contains("push") {
             "Local work is ready to publish."
-        } else if output.trust.recommended_action.contains("ship") {
-            "Thread is ready to ship."
+        } else if output.trust.recommended_action.contains("land") {
+            "Thread is ready to land."
         } else {
             "Workspace verified."
         }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -337,8 +337,11 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         ),
                         blockers: land_blockers_for_preview(&preview, &stale_blockers),
                         warnings: Vec::new(),
-                        next_action: Some("heddle sync".to_string()),
-                        recommended_action: Some("heddle sync".to_string()),
+                        next_action: Some(format!("heddle sync --thread {}", refreshed_thread.id)),
+                        recommended_action: Some(format!(
+                            "heddle sync --thread {}",
+                            refreshed_thread.id
+                        )),
                     },
                     thread: refreshed_thread.id.clone(),
                     captured,
@@ -766,7 +769,7 @@ fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push("heddle sync".to_string());
+            commands.push(format!("heddle sync --thread {}", thread_id));
             commands.push(land_local_command(thread_id));
             commands
         } else {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3,7 +3,7 @@ use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::{OpBatch, OpRecord};
-use repo::{Repository, Thread, ThreadIntegrationPolicy, shell_quote};
+use repo::{Repository, Thread, ThreadIntegrationPolicy, thread_flag};
 use serde::Serialize;
 
 use super::{
@@ -389,12 +389,12 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         blockers: land_blockers_for_preview(&preview, &stale_blockers),
                         warnings: Vec::new(),
                         next_action: Some(format!(
-                            "heddle sync --thread {}",
-                            shell_quote(&refreshed_thread.id)
+                            "heddle sync {}",
+                            thread_flag(&refreshed_thread.id)
                         )),
                         recommended_action: Some(format!(
-                            "heddle sync --thread {}",
-                            shell_quote(&refreshed_thread.id)
+                            "heddle sync {}",
+                            thread_flag(&refreshed_thread.id)
                         )),
                     },
                     thread: refreshed_thread.id.clone(),
@@ -546,7 +546,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| format!("heddle sync --thread {}", shell_quote(&merge_thread.id)));
+            .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -829,7 +829,7 @@ fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push(format!("heddle sync --thread {}", shell_quote(thread_id)));
+            commands.push(format!("heddle sync {}", thread_flag(thread_id)));
             commands.push(land_local_command(thread_id));
             commands
         } else {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -119,10 +119,12 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             current_state: thread.current_state.clone(),
             chosen_path: "no_op".to_string(),
         }
-    } else if stale_report.conflict_count > 0 || !stale_blockers.is_empty() {
-        let recommended_action = if stale_report.conflict_count > 0 {
-            "heddle resolve --list".to_string()
-        } else if stale_report.recommended_action.trim().is_empty()
+    } else if stale_report.conflict_count == 0 && !stale_blockers.is_empty() {
+        // Genuine non-conflict blockers (e.g. failing verification) cannot be
+        // auto-refreshed away. Surface the blocker without a refresh. (The
+        // conflict case carries a "path conflict(s)" blocker too, but it is
+        // routed to the refresh attempt below so the breadcrumb materializes.)
+        let recommended_action = if stale_report.recommended_action.trim().is_empty()
             || stale_report.recommended_action.starts_with("heddle sync")
         {
             String::new()
@@ -160,29 +162,78 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             chosen_path: "blocked".to_string(),
         }
     } else {
-        let refreshed = refresh_thread(&repo, &thread.id, cli)?;
-        update_integration_policy(&repo, &refreshed.id, "current", "thread refreshed cleanly")?;
-        let recommended_action = primary_next_action(
-            operation.as_ref(),
-            remote_tracking.as_ref(),
-            import_hint.as_ref(),
-            Some(&land_local_command(&refreshed.id)),
-        );
-        let trust = build_repository_verification_state(&repo);
-        SyncOutput {
-            operator: OperatorCommandOutput {
-                status: "refreshed".to_string(),
-                action: "sync".to_string(),
-                message: format!("Refreshed thread '{}'", refreshed.id),
-                blockers: vec![],
-                warnings: Vec::new(),
-                next_action: Some(recommended_action.clone()),
-                recommended_action: Some(recommended_action),
-            },
-            trust,
-            thread: refreshed.id.clone(),
-            current_state: refreshed.current_state.clone(),
-            chosen_path: "refresh".to_string(),
+        // Either a clean stale thread or one whose replay genuinely conflicts
+        // (conflict_count > 0). Attempt the refresh in both cases.
+        // `refresh_thread` persists the merge state + worktree conflict
+        // markers in the thread's checkout *before* returning the conflict
+        // advice, so the `resolve` breadcrumb below points at real state.
+        // heddle#464 r2: the old conflict branch returned here early and
+        // emitted `heddle resolve --list` with no merge in progress — a dead
+        // breadcrumb that failed with `no_merge_in_progress`. A previewed
+        // conflict that the 3-way merge resolves cleanly also completes here
+        // and recommends `land`.
+        match refresh_thread(&repo, &thread.id, cli) {
+            Ok(refreshed) => {
+                update_integration_policy(
+                    &repo,
+                    &refreshed.id,
+                    "current",
+                    "thread refreshed cleanly",
+                )?;
+                let recommended_action = primary_next_action(
+                    operation.as_ref(),
+                    remote_tracking.as_ref(),
+                    import_hint.as_ref(),
+                    Some(&land_local_command(&refreshed.id)),
+                );
+                let trust = build_repository_verification_state(&repo);
+                SyncOutput {
+                    operator: OperatorCommandOutput {
+                        status: "refreshed".to_string(),
+                        action: "sync".to_string(),
+                        message: format!("Refreshed thread '{}'", refreshed.id),
+                        blockers: vec![],
+                        warnings: Vec::new(),
+                        next_action: Some(recommended_action.clone()),
+                        recommended_action: Some(recommended_action),
+                    },
+                    trust,
+                    thread: refreshed.id.clone(),
+                    current_state: refreshed.current_state.clone(),
+                    chosen_path: "refresh".to_string(),
+                }
+            }
+            Err(error) => {
+                // refresh_thread materializes the conflict before returning;
+                // only then is `resolve` a live breadcrumb. If no merge was
+                // materialized the failure is genuine — propagate it.
+                if !sync_conflict_merge_in_progress(&repo, &thread) {
+                    return Err(error);
+                }
+                update_integration_policy(
+                    &repo,
+                    &thread.id,
+                    "blocked",
+                    "refresh produced conflicts requiring manual resolution",
+                )?;
+                let recommended_action = scoped_resolve_list_command(&thread);
+                let trust = build_repository_verification_state(&repo);
+                SyncOutput {
+                    operator: OperatorCommandOutput {
+                        status: "blocked".to_string(),
+                        action: "sync".to_string(),
+                        message: format!("Thread '{}' has merge conflicts to resolve", thread.id),
+                        blockers: stale_report.blockers.clone(),
+                        warnings: Vec::new(),
+                        next_action: Some(recommended_action.clone()),
+                        recommended_action: Some(recommended_action),
+                    },
+                    trust,
+                    thread: thread.id.clone(),
+                    current_state: thread.current_state.clone(),
+                    chosen_path: "blocked".to_string(),
+                }
+            }
         }
     };
     output.operator.block_success_claim_if_verification_blocked(
@@ -485,8 +536,14 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             .first()
             .cloned()
             .unwrap_or_else(|| "integration requires manual review".to_string());
+        // Never fall back to `preview.recommended_action` here: this is the
+        // pre-merge bail, so no merge state is materialized (a `resolve`
+        // breadcrumb would die with `no_merge_in_progress`) and the preview's
+        // own land recommendation would self-loop this very command. Drive the
+        // operator through `sync`, which materializes and resolves a genuine
+        // conflict before a land retry. (heddle#464 close-the-class.)
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| preview.recommended_action.clone());
+            .unwrap_or_else(|| format!("heddle sync --thread {}", merge_thread.id));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -1346,6 +1403,38 @@ fn emit_with_next_action_validation<T: Serialize>(
 
 fn non_empty_next_action(action: &str) -> Option<String> {
     (!action.trim().is_empty()).then(|| action.to_string())
+}
+
+/// True when `refresh_thread` materialized a conflicted merge for `thread`
+/// (so `heddle resolve` has state to read). The merge state lives in the
+/// thread's own checkout, which may differ from the repo `sync` ran against.
+fn sync_conflict_merge_in_progress(repo: &Repository, thread: &Thread) -> bool {
+    if thread.execution_path.as_os_str().is_empty() {
+        repo.merge_state_manager().is_merge_in_progress()
+    } else if thread.execution_path.exists() {
+        Repository::open(&thread.execution_path)
+            .map(|worktree| worktree.merge_state_manager().is_merge_in_progress())
+            .unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+/// `heddle resolve --list` scoped to wherever the conflict was materialized.
+/// When the thread has its own checkout the breadcrumb must carry `--repo` so
+/// it reads the merge state in that checkout rather than the repo `sync` ran
+/// against (where no merge is in progress).
+fn scoped_resolve_list_command(thread: &Thread) -> String {
+    if thread.execution_path.as_os_str().is_empty() {
+        super::command_catalog::heddle_action(["resolve", "--list"])
+    } else {
+        super::command_catalog::heddle_action(vec![
+            "--repo".to_string(),
+            thread.execution_path.display().to_string(),
+            "resolve".to_string(),
+            "--list".to_string(),
+        ])
+    }
 }
 
 fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Result<()> {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -23,7 +23,7 @@ use super::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
     next_action::{NextActionValidationContext, write_validated_json_stdout},
-    thread_landing::land_local_command,
+    thread_landing::{land_local_command, switch_thread_command},
 };
 use crate::{
     cli::{
@@ -278,12 +278,18 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         })?)
     } else {
         let land_command = land_local_command(&thread.id);
+        // `heddle start` would refuse here — the thread still holds an active
+        // reservation, so it returns `active_reservation_advice` and the
+        // operator is stuck. `heddle switch` rebuilds the dedicated worktree at
+        // the recorded `execution_path` from the thread's current state (see
+        // `cmd_thread_switch`), which is exactly the path this `land` reads, so
+        // the rebuild clears the blocker and the follow-up `land` succeeds.
+        let switch_command = switch_thread_command(&thread.id);
         return Err(anyhow!(RecoveryAdvice::safety_refusal(
             "thread_worktree_missing",
             format!("Thread '{}' worktree is missing", thread.id),
             format!(
-                "Materialize the thread again with `heddle start {} --path <path>`, then retry `{land_command}`.",
-                thread.id
+                "Rebuild the thread's checkout with `{switch_command}` (it re-materializes the recorded worktree from the thread's current state), then retry `{land_command}`.",
             ),
             format!(
                 "recorded execution path does not exist: {}",
@@ -291,8 +297,8 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             ),
             "land would need to inspect that checkout for unsaved work before merging",
             "repository state, refs, metadata, and worktree files were left unchanged",
-            land_command.clone(),
-            vec![land_command],
+            switch_command.clone(),
+            vec![switch_command, land_command],
         )));
     };
     if args.push && args.no_push {
@@ -545,8 +551,10 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // own land recommendation would self-loop this very command. Drive the
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
-        let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
+        let recovery_scope = recovery_scope_checkout(&merge_thread, repo.root());
+        let recommended_action =
+            integration_blocker_recommended_action(&integration_blockers, recovery_scope.as_deref())
+                .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -1304,14 +1312,55 @@ pub(crate) fn auto_land_policy_blockers(repo: &Repository, thread: &Thread) -> V
     blockers
 }
 
-pub(crate) fn integration_blocker_recommended_action(blockers: &[String]) -> Option<String> {
+pub(crate) fn integration_blocker_recommended_action(
+    blockers: &[String],
+    scope_to_checkout: Option<&std::path::Path>,
+) -> Option<String> {
     blockers
         .iter()
         .any(|blocker| {
             blocker.starts_with("confidence ")
                 || blocker == "verification summary reports failing tests"
         })
-        .then(|| AUTO_LAND_CONFIDENCE_RECOVERY_ACTION.to_string())
+        .then(|| auto_land_confidence_recovery_action(scope_to_checkout))
+}
+
+/// The `confidence`/`verification` policy blocker is cleared by re-capturing the
+/// thread's state with a fresh confidence. That capture must land in the
+/// *thread's* checkout, not whatever checkout `ready`/`land` was invoked from —
+/// running an unscoped `heddle commit` from the parent of an isolated
+/// agent-authored thread commits the parent and never updates the blocked
+/// thread. When the thread's checkout differs from the current one, scope the
+/// recovery with the global `--repo` flag so the capture targets the thread.
+/// (heddle#464.)
+fn auto_land_confidence_recovery_action(scope_to_checkout: Option<&std::path::Path>) -> String {
+    match scope_to_checkout {
+        Some(path) => format!(
+            "heddle --repo {} {}",
+            crate::cli::render::shell_quote(&path.display().to_string()),
+            AUTO_LAND_CONFIDENCE_RECOVERY_ACTION
+                .strip_prefix("heddle ")
+                .expect("recovery action is a heddle command"),
+        ),
+        None => AUTO_LAND_CONFIDENCE_RECOVERY_ACTION.to_string(),
+    }
+}
+
+/// Returns the thread's recorded checkout iff it is a real, distinct path from
+/// `current_checkout` — i.e. when a recovery breadcrumb that mutates thread
+/// state must be re-scoped away from the current checkout. Canonicalizes both
+/// sides (falling back to the raw path) so a symlinked worktree doesn't read as
+/// "different" and over-scope the in-thread case.
+pub(crate) fn recovery_scope_checkout(
+    thread: &Thread,
+    current_checkout: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let execution_path = &thread.execution_path;
+    if execution_path.as_os_str().is_empty() {
+        return None;
+    }
+    let canonical = |path: &std::path::Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    (canonical(execution_path) != canonical(current_checkout)).then(|| execution_path.clone())
 }
 
 fn land_blockers_for_preview(
@@ -1544,5 +1593,123 @@ fn land_text_step(step: &str) -> String {
         "push(not requested)" => "push not requested".to_string(),
         "push(not reached)" => "push not reached".to_string(),
         other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::commands::command_catalog::validate_recommended_action;
+    use std::path::{Path, PathBuf};
+
+    fn thread_with_execution_path(execution_path: PathBuf) -> Thread {
+        Thread {
+            id: "agent-thread".to_string(),
+            thread: "agent-thread".to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode: repo::ThreadMode::Solid,
+            state: repo::ThreadState::Active,
+            base_state: "base".to_string(),
+            base_root: "root".to_string(),
+            current_state: Some("base".to_string()),
+            merged_state: None,
+            task: None,
+            execution_path,
+            materialized_path: None,
+            changed_paths: vec![],
+            impact_categories: vec![],
+            heavy_impact_paths: vec![],
+            promotion_suggested: false,
+            freshness: repo::ThreadFreshness::Current,
+            verification_summary: repo::ThreadVerificationSummary::default(),
+            confidence_summary: repo::ThreadConfidenceSummary::default(),
+            integration_policy_result: ThreadIntegrationPolicy::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        }
+    }
+
+    // heddle#464 bug 2: the confidence/verification policy-blocker recovery used
+    // to be a bare `heddle commit ... --confidence`, which commits the CURRENT
+    // checkout. Run from the parent of an isolated thread, that never updates the
+    // blocked thread's state. Scope it to the thread's checkout via `--repo`.
+    #[test]
+    fn confidence_blocker_recovery_scopes_to_thread_checkout() {
+        let blockers = vec!["confidence 0.40 is below the auto-land threshold of 0.75".to_string()];
+        let action = integration_blocker_recommended_action(
+            &blockers,
+            Some(Path::new("/work/threads/agent-thread")),
+        )
+        .expect("a confidence blocker must yield a recovery action");
+        assert_eq!(
+            action,
+            "heddle --repo /work/threads/agent-thread commit -m \"...\" --confidence <confidence>"
+        );
+        validate_recommended_action(&action)
+            .unwrap_or_else(|e| panic!("scoped recovery must validate: {e}"));
+    }
+
+    #[test]
+    fn verification_blocker_recovery_scopes_to_thread_checkout() {
+        let blockers = vec!["verification summary reports failing tests".to_string()];
+        let action = integration_blocker_recommended_action(
+            &blockers,
+            Some(Path::new("/work/threads/agent-thread")),
+        )
+        .expect("a verification blocker must yield a recovery action");
+        assert_eq!(
+            action,
+            "heddle --repo /work/threads/agent-thread commit -m \"...\" --confidence <confidence>"
+        );
+        validate_recommended_action(&action)
+            .unwrap_or_else(|e| panic!("scoped recovery must validate: {e}"));
+    }
+
+    // The in-thread case (recovery run from inside the thread's own checkout)
+    // must stay unscoped — a `--repo` pointing back at the current checkout is
+    // noise, and the bare command already targets the right state.
+    #[test]
+    fn confidence_blocker_recovery_stays_unscoped_in_thread() {
+        let blockers = vec!["confidence 0.40 is below the auto-land threshold of 0.75".to_string()];
+        let action = integration_blocker_recommended_action(&blockers, None)
+            .expect("a confidence blocker must yield a recovery action");
+        assert_eq!(action, AUTO_LAND_CONFIDENCE_RECOVERY_ACTION);
+        validate_recommended_action(&action)
+            .unwrap_or_else(|e| panic!("unscoped recovery must validate: {e}"));
+    }
+
+    #[test]
+    fn non_policy_blockers_yield_no_recovery_action() {
+        let blockers = vec!["3 path conflict(s) need manual resolution".to_string()];
+        assert!(integration_blocker_recommended_action(&blockers, None).is_none());
+    }
+
+    // `recovery_scope_checkout` is the gate that decides whether to scope: an
+    // isolated thread (execution_path differs from the current checkout) scopes;
+    // the in-thread case (paths equal) and a worktree-less thread (empty path)
+    // do not.
+    #[test]
+    fn recovery_scope_checkout_distinguishes_isolated_from_in_thread() {
+        let isolated = thread_with_execution_path(PathBuf::from("/work/threads/agent-thread"));
+        assert_eq!(
+            recovery_scope_checkout(&isolated, Path::new("/work/parent")),
+            Some(PathBuf::from("/work/threads/agent-thread")),
+        );
+
+        let in_thread = thread_with_execution_path(PathBuf::from("/work/threads/agent-thread"));
+        assert_eq!(
+            recovery_scope_checkout(&in_thread, Path::new("/work/threads/agent-thread")),
+            None,
+        );
+
+        let no_worktree = thread_with_execution_path(PathBuf::new());
+        assert_eq!(
+            recovery_scope_checkout(&no_worktree, Path::new("/work/parent")),
+            None,
+        );
     }
 }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -22,12 +22,13 @@ use super::{
     thread_cmd::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
-    thread_landing::{merge_preview_command, ship_local_command},
+    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    thread_landing::land_local_command,
 };
 use crate::{
     cli::{
         Cli, ThreadStartArgs, WorkspaceModeArg,
-        cli_args::{DelegateArgs, ShipArgs, SyncArgs},
+        cli_args::{DelegateArgs, LandArgs, SyncArgs},
         should_output_json, style, worktree_status_options,
     },
     config::UserConfig,
@@ -46,7 +47,7 @@ struct SyncOutput {
 }
 
 #[derive(Serialize)]
-struct ShipOutput {
+struct LandOutput {
     #[serde(flatten)]
     operator: OperatorCommandOutput,
     thread: String,
@@ -100,7 +101,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             operation.as_ref(),
             remote_tracking.as_ref(),
             import_hint.as_ref(),
-            Some("heddle ship"),
+            Some(&land_local_command(&thread.id)),
         );
         let trust = build_repository_verification_state(&repo);
         SyncOutput {
@@ -119,12 +120,20 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             chosen_path: "no_op".to_string(),
         }
     } else if stale_report.conflict_count > 0 || !stale_blockers.is_empty() {
-        let recommended_action = primary_next_action(
-            operation.as_ref(),
-            remote_tracking.as_ref(),
-            import_hint.as_ref(),
-            Some(&stale_report.recommended_action),
-        );
+        let recommended_action = if stale_report.conflict_count > 0 {
+            "heddle resolve --list".to_string()
+        } else if stale_report.recommended_action.trim().is_empty()
+            || stale_report.recommended_action.starts_with("heddle sync")
+        {
+            String::new()
+        } else {
+            primary_next_action(
+                operation.as_ref(),
+                remote_tracking.as_ref(),
+                import_hint.as_ref(),
+                Some(&stale_report.recommended_action),
+            )
+        };
         update_integration_policy(
             &repo,
             &thread.id,
@@ -139,11 +148,11 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             operator: OperatorCommandOutput {
                 status: "blocked".to_string(),
                 action: "sync".to_string(),
-                message: format!("Thread '{}' needs manual refresh", thread.id),
+                message: format!("Thread '{}' needs manual sync", thread.id),
                 blockers: stale_report.blockers.clone(),
                 warnings: Vec::new(),
-                next_action: Some(recommended_action.clone()),
-                recommended_action: Some(recommended_action),
+                next_action: non_empty_next_action(&recommended_action),
+                recommended_action: non_empty_next_action(&recommended_action),
             },
             trust,
             thread: thread.id.clone(),
@@ -157,7 +166,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             operation.as_ref(),
             remote_tracking.as_ref(),
             import_hint.as_ref(),
-            Some("heddle ship"),
+            Some(&land_local_command(&refreshed.id)),
         );
         let trust = build_repository_verification_state(&repo);
         SyncOutput {
@@ -182,14 +191,14 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
         VerificationClaimPolicy::strict(),
     );
 
-    emit(cli, &output)
+    emit_with_next_action_validation(cli, &repo, &output, &["sync"])
 }
 
-pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
+pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     // Open at CWD only to discover the active thread, then re-open at
-    // its metadata-recorded worktree. This makes `heddle ship` work
+    // its metadata-recorded worktree. This makes `heddle land` work
     // from anywhere — operators don't need to `cd` into a lightweight
-    // thread directory before shipping. The capture/merge below run
+    // thread directory before landing. The capture/merge below run
     // against `repo`, so they all see the same checkout. See
     // `Repository::active_worktree_path`.
     let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
@@ -203,8 +212,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     let thread = resolve_thread(
         &repo,
         args.thread.as_deref(),
-        "ship",
-        "heddle ship --thread <name>",
+        "land",
+        "heddle land --thread <name>",
     )?;
     let thread_repo = if thread.execution_path.as_os_str().is_empty() {
         None
@@ -217,33 +226,33 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
             )
         })?)
     } else {
-        let merge_preview = merge_preview_command(&thread.id);
+        let land_command = land_local_command(&thread.id);
         return Err(anyhow!(RecoveryAdvice::safety_refusal(
             "thread_worktree_missing",
             format!("Thread '{}' worktree is missing", thread.id),
             format!(
-                "Materialize the thread again with `heddle start {} --path <path>` or merge it by ref with `{merge_preview}`.",
+                "Materialize the thread again with `heddle start {} --path <path>`, then retry `{land_command}`.",
                 thread.id
             ),
             format!(
                 "recorded execution path does not exist: {}",
                 thread.execution_path.display()
             ),
-            "ship would need to inspect that checkout for unsaved work before merging",
+            "land would need to inspect that checkout for unsaved work before merging",
             "repository state, refs, metadata, and worktree files were left unchanged",
-            merge_preview.clone(),
-            vec![merge_preview],
+            land_command.clone(),
+            vec![land_command],
         )));
     };
     if args.push && args.no_push {
-        return Err(anyhow!(RecoveryAdvice::ship_push_option_conflict(
+        return Err(anyhow!(RecoveryAdvice::land_push_option_conflict(
             &thread.id
         )));
     }
     if let Some(remote) = args.remote.as_deref()
         && !args.push
     {
-        return Err(anyhow!(RecoveryAdvice::ship_remote_requires_push(
+        return Err(anyhow!(RecoveryAdvice::land_remote_requires_push(
             &thread.id, remote,
         )));
     }
@@ -256,7 +265,7 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
         {
             Some(remote) => Some(remote),
             None => {
-                return Err(anyhow!(RecoveryAdvice::ship_push_remote_missing(
+                return Err(anyhow!(RecoveryAdvice::land_push_remote_missing(
                     &thread.id
                 )));
             }
@@ -264,7 +273,7 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     } else {
         None
     };
-    if let Some(advice) = ship_checkpoint_preflight_advice(&repo, &thread.id) {
+    if let Some(advice) = land_checkpoint_preflight_advice(&repo, &thread.id) {
         return Err(anyhow!(advice));
     }
 
@@ -275,7 +284,7 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
             let capture_message = args
                 .message
                 .clone()
-                .or_else(|| Some(format!("Ship {}", thread.id)));
+                .or_else(|| Some(format!("Land {}", thread.id)));
             create_snapshot(
                 thread_repo,
                 &user_config,
@@ -299,8 +308,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     let mut refreshed_thread = resolve_thread(
         &repo,
         Some(&thread.id),
-        "ship",
-        "heddle ship --thread <name>",
+        "land",
+        "heddle land --thread <name>",
     )?;
     if refreshed_thread.freshness == repo::ThreadFreshness::Stale {
         let preview = build_thread_preview_report(&repo, &mut refreshed_thread, true)?;
@@ -313,22 +322,23 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
                 stale_blockers
                     .first()
                     .cloned()
-                    .unwrap_or_else(|| "refresh requires manual resolution".to_string()),
+                    .unwrap_or_else(|| "sync requires manual resolution".to_string()),
             )?;
-            return write_ship_output(
+            return write_land_output(
                 cli,
-                &ShipOutput {
+                &repo,
+                &LandOutput {
                     operator: OperatorCommandOutput {
                         status: "blocked".to_string(),
-                        action: "ship".to_string(),
+                        action: "land".to_string(),
                         message: format!(
-                            "Thread '{}' must be refreshed manually",
+                            "Thread '{}' must be synced manually",
                             refreshed_thread.id
                         ),
-                        blockers: ship_blockers_for_preview(&preview, &stale_blockers),
+                        blockers: land_blockers_for_preview(&preview, &stale_blockers),
                         warnings: Vec::new(),
-                        next_action: Some(preview.recommended_action.clone()),
-                        recommended_action: Some(preview.recommended_action),
+                        next_action: Some("heddle sync".to_string()),
+                        recommended_action: Some("heddle sync".to_string()),
                     },
                     thread: refreshed_thread.id.clone(),
                     captured,
@@ -341,8 +351,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
                     merge_state: None,
                     trust: build_repository_verification_state(&repo),
                     chosen_path: "blocked".to_string(),
-                    performed_steps: ship_performed_steps(captured, false, false, false, false),
-                    skipped_steps: ship_skipped_steps(captured, false, false, false, false),
+                    performed_steps: land_performed_steps(captured, false, false, false, false),
+                    skipped_steps: land_skipped_steps(captured, false, false, false, false),
                 },
             );
         }
@@ -354,8 +364,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     let mut merge_thread = resolve_thread(
         &repo,
         Some(&refreshed_thread.id),
-        "ship",
-        "heddle ship --thread <name>",
+        "land",
+        "heddle land --thread <name>",
     )?;
     let preview = build_thread_preview_report(&repo, &mut merge_thread, true)?;
     let integration_blockers = integration_blockers(&repo, &merge_thread, &preview);
@@ -372,34 +382,34 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
         )?;
         if repo.capability() == repo::RepositoryCapability::GitOverlay {
             let checkpoint_message =
-                ship_checkpoint_message(&repo, &merge_thread, args.message.as_deref());
+                land_checkpoint_message(&repo, &merge_thread, args.message.as_deref());
             let record = create_git_checkpoint(
                 &repo,
                 Some(&checkpoint_message),
                 worktree_status_options(Some(repo.config())),
             )
             .map_err(|error| {
-                anyhow!(RecoveryAdvice::ship_checkpoint_partial_failure(
+                anyhow!(RecoveryAdvice::land_checkpoint_partial_failure(
                     &merge_thread.id,
                     error,
-                    ship_performed_steps(captured, synced, true, false, false),
+                    land_performed_steps(captured, synced, true, false, false),
                 ))
             })?;
             checkpointed = true;
             git_commit = Some(record.git_commit);
         }
-        coalesce_ship_integration_and_checkpoint(
+        coalesce_land_integration_and_checkpoint(
             &repo,
             Some(&merge_state),
             git_commit.as_deref(),
         )
         .context(
-            "ship completed but failed to record manual integration and Git checkpoint as one undo batch",
+            "land completed but failed to record manual integration and Git checkpoint as one undo batch",
         )?;
         let mut pushed = false;
         let mut pushed_remote = None;
         if should_push {
-            let remote_name = push_after_ship(
+            let remote_name = push_after_land(
                 cli,
                 &repo,
                 planned_push_remote.clone(),
@@ -407,10 +417,10 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
             )
             .await
             .map_err(|error| {
-                anyhow!(RecoveryAdvice::ship_push_partial_failure(
+                anyhow!(RecoveryAdvice::land_push_partial_failure(
                     &merge_thread.id,
                     error,
-                    ship_performed_steps(captured, synced, true, checkpointed, false),
+                    land_performed_steps(captured, synced, true, checkpointed, false),
                     git_commit.as_deref(),
                     planned_push_remote.as_deref(),
                 ))
@@ -420,27 +430,28 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
         }
         clear_manual_resolution_state(&repo, &merge_thread.id)?;
         let trust = build_repository_verification_state(&repo);
-        let post_ship_action = integrated_ship_next_action(true, pushed, &trust);
+        let post_land_action = integrated_land_next_action(true, pushed, &trust);
         let mut operator = OperatorCommandOutput {
-            status: "shipped".to_string(),
-            action: "ship".to_string(),
+            status: "landed".to_string(),
+            action: "land".to_string(),
             message: format!(
-                "Shipped thread '{}' from a manually resolved integration state",
+                "Landed thread '{}' from a manually resolved integration state",
                 merge_thread.id
             ),
             blockers: Vec::new(),
             warnings: Vec::new(),
-            next_action: post_ship_action.clone(),
-            recommended_action: post_ship_action,
+            next_action: post_land_action.clone(),
+            recommended_action: post_land_action,
         };
         operator.block_success_claim_if_verification_blocked(
             &trust,
-            "ship",
-            VerificationClaimPolicy::strict().allow_ship_publish_followup(),
+            "land",
+            VerificationClaimPolicy::strict().allow_land_publish_followup(),
         );
-        return write_ship_output(
+        return write_land_output(
             cli,
-            &ShipOutput {
+            &repo,
+            &LandOutput {
                 operator,
                 thread: merge_thread.id.clone(),
                 captured,
@@ -452,8 +463,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
                 pushed_remote,
                 merge_state: Some(merge_state),
                 trust,
-                performed_steps: ship_performed_steps(captured, synced, true, checkpointed, pushed),
-                skipped_steps: ship_skipped_steps(captured, synced, true, checkpointed, pushed),
+                performed_steps: land_performed_steps(captured, synced, true, checkpointed, pushed),
+                skipped_steps: land_skipped_steps(captured, synced, true, checkpointed, pushed),
                 chosen_path: if checkpointed {
                     if pushed {
                         "capture_sync_manual_resolution_checkpoint_push".to_string()
@@ -474,14 +485,15 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
             .unwrap_or_else(|| preview.recommended_action.clone());
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
-        return write_ship_output(
+        return write_land_output(
             cli,
-            &ShipOutput {
+            &repo,
+            &LandOutput {
                 operator: OperatorCommandOutput {
                     status: "blocked".to_string(),
-                    action: "ship".to_string(),
-                    message: format!("Thread '{}' is not eligible for auto-ship", merge_thread.id),
-                    blockers: ship_blockers_for_preview(&preview, &integration_blockers),
+                    action: "land".to_string(),
+                    message: format!("Thread '{}' is not eligible for auto-land", merge_thread.id),
+                    blockers: land_blockers_for_preview(&preview, &integration_blockers),
                     warnings: Vec::new(),
                     next_action: Some(recommended_action.clone()),
                     recommended_action: Some(recommended_action),
@@ -497,8 +509,8 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
                 merge_state: None,
                 trust: build_repository_verification_state(&repo),
                 chosen_path: "blocked".to_string(),
-                performed_steps: ship_performed_steps(captured, synced, false, false, false),
-                skipped_steps: ship_skipped_steps(captured, synced, false, false, false),
+                performed_steps: land_performed_steps(captured, synced, false, false, false),
+                skipped_steps: land_skipped_steps(captured, synced, false, false, false),
             },
         );
     }
@@ -533,33 +545,33 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
 
     if integrated && repo.capability() == repo::RepositoryCapability::GitOverlay {
         let checkpoint_message =
-            ship_checkpoint_message(&repo, &merge_thread, args.message.as_deref());
+            land_checkpoint_message(&repo, &merge_thread, args.message.as_deref());
         let record = create_git_checkpoint(
             &repo,
             Some(&checkpoint_message),
             worktree_status_options(Some(repo.config())),
         )
         .map_err(|error| {
-            anyhow!(RecoveryAdvice::ship_checkpoint_partial_failure(
+            anyhow!(RecoveryAdvice::land_checkpoint_partial_failure(
                 &merge_thread.id,
                 error,
-                ship_performed_steps(captured, synced, integrated, false, false),
+                land_performed_steps(captured, synced, integrated, false, false),
             ))
         })?;
         checkpointed = true;
         git_commit = Some(record.git_commit);
     }
-    coalesce_ship_integration_and_checkpoint(
+    coalesce_land_integration_and_checkpoint(
         &repo,
         merge_output.merge_state.as_deref(),
         git_commit.as_deref(),
     )
-    .context("ship completed but failed to record merge and Git checkpoint as one undo batch")?;
+    .context("land completed but failed to record merge and Git checkpoint as one undo batch")?;
 
     let mut pushed = false;
     let mut pushed_remote = None;
     if integrated && should_push {
-        let remote_name = push_after_ship(
+        let remote_name = push_after_land(
             cli,
             &repo,
             planned_push_remote.clone(),
@@ -567,10 +579,10 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
         )
         .await
         .map_err(|error| {
-            anyhow!(RecoveryAdvice::ship_push_partial_failure(
+            anyhow!(RecoveryAdvice::land_push_partial_failure(
                 &merge_thread.id,
                 error,
-                ship_performed_steps(captured, synced, integrated, checkpointed, false),
+                land_performed_steps(captured, synced, integrated, checkpointed, false),
                 git_commit.as_deref(),
                 planned_push_remote.as_deref(),
             ))
@@ -584,14 +596,14 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     }
 
     let trust = build_repository_verification_state(&repo);
-    let integrated_next_action = integrated_ship_next_action(integrated, pushed, &trust);
+    let integrated_next_action = integrated_land_next_action(integrated, pushed, &trust);
     let mut operator = OperatorCommandOutput {
-        status: if integrated { "shipped" } else { "blocked" }.to_string(),
-        action: "ship".to_string(),
+        status: if integrated { "landed" } else { "blocked" }.to_string(),
+        action: "land".to_string(),
         message: if integrated {
-            format!("Shipped thread '{}'", merge_thread.id)
+            format!("Landed thread '{}'", merge_thread.id)
         } else {
-            format!("Thread '{}' could not be shipped cleanly", merge_thread.id)
+            format!("Thread '{}' could not be landed cleanly", merge_thread.id)
         },
         blockers: merge_output.operator.blockers.clone(),
         warnings: Vec::new(),
@@ -608,13 +620,14 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     };
     operator.block_success_claim_if_verification_blocked(
         &trust,
-        "ship",
-        VerificationClaimPolicy::strict().allow_ship_publish_followup(),
+        "land",
+        VerificationClaimPolicy::strict().allow_land_publish_followup(),
     );
 
-    write_ship_output(
+    write_land_output(
         cli,
-        &ShipOutput {
+        &repo,
+        &LandOutput {
             operator,
             thread: merge_thread.id.clone(),
             captured,
@@ -626,14 +639,14 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
             pushed_remote,
             merge_state: merge_output.merge_state.clone(),
             trust,
-            performed_steps: ship_performed_steps(
+            performed_steps: land_performed_steps(
                 captured,
                 synced,
                 integrated,
                 checkpointed,
                 pushed,
             ),
-            skipped_steps: ship_skipped_steps(captured, synced, integrated, checkpointed, pushed),
+            skipped_steps: land_skipped_steps(captured, synced, integrated, checkpointed, pushed),
             chosen_path: if integrated {
                 if pushed {
                     "capture_sync_merge_checkpoint_push"
@@ -650,7 +663,7 @@ pub async fn cmd_ship(cli: &Cli, args: ShipArgs) -> Result<()> {
     )
 }
 
-async fn push_after_ship(
+async fn push_after_land(
     cli: &Cli,
     repo: &Repository,
     remote: Option<String>,
@@ -670,7 +683,7 @@ async fn push_after_ship(
     }
 }
 
-fn ship_performed_steps(
+fn land_performed_steps(
     captured: bool,
     synced: bool,
     integrated: bool,
@@ -689,7 +702,7 @@ fn ship_performed_steps(
     .collect()
 }
 
-fn ship_skipped_steps(
+fn land_skipped_steps(
     captured: bool,
     synced: bool,
     integrated: bool,
@@ -710,7 +723,7 @@ fn ship_skipped_steps(
     .collect()
 }
 
-fn integrated_ship_next_action(
+fn integrated_land_next_action(
     integrated: bool,
     pushed: bool,
     trust: &RepositoryVerificationState,
@@ -725,7 +738,7 @@ fn integrated_ship_next_action(
     }
 }
 
-fn ship_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Option<RecoveryAdvice> {
+fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Option<RecoveryAdvice> {
     if repo.capability() != repo::RepositoryCapability::GitOverlay {
         return None;
     }
@@ -753,21 +766,21 @@ fn ship_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push(merge_preview_command(thread_id));
-            commands.push(ship_local_command(thread_id));
+            commands.push("heddle sync".to_string());
+            commands.push(land_local_command(thread_id));
             commands
         } else {
             trust.recovery_commands.clone()
         };
         return Some(RecoveryAdvice::safety_refusal(
-            "ship_requires_current_upstream",
-            format!("Refusing to ship '{thread_id}': upstream work must be integrated first"),
-            format!("Run `{primary_command}`, then preview and retry the ship."),
+            "land_requires_current_upstream",
+            format!("Refusing to land '{thread_id}': upstream work must be integrated first"),
+            format!("Run `{primary_command}`, then retry the land."),
             format!(
                 "repository verification reports {}: {}",
                 trust.remote_drift, trust.summary
             ),
-            "ship would first land Heddle state locally, then fail while writing the Git checkpoint because the checkout branch is behind its upstream",
+            "land would first integrate Heddle state locally, then fail while writing the Git checkpoint because the checkout branch is behind its upstream",
             "thread refs, Heddle refs, Git refs, index, and worktree files were left unchanged",
             primary_command,
             recovery_commands,
@@ -775,11 +788,11 @@ fn ship_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
     }
     if repo.root().join(".git/index.lock").exists() {
         return Some(RecoveryAdvice::safety_refusal(
-            "ship_checkpoint_preflight_blocked",
-            format!("Refusing to ship '{thread_id}': Git index is locked"),
-            "Remove the stale Git index lock or wait for the active Git operation to finish, then retry the ship.",
+            "land_checkpoint_preflight_blocked",
+            format!("Refusing to land '{thread_id}': Git index is locked"),
+            "Remove the stale Git index lock or wait for the active Git operation to finish, then retry the land.",
             ".git/index.lock exists in the parent checkout",
-            "ship would first land Heddle state locally, then fail while writing the Git checkpoint because the Git index is locked",
+            "land would first integrate Heddle state locally, then fail while writing the Git checkpoint because the Git index is locked",
             "thread refs, Heddle refs, Git refs, index, and worktree files were left unchanged",
             "heddle status",
             vec!["heddle status".to_string()],
@@ -788,7 +801,7 @@ fn ship_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
     None
 }
 
-fn ship_checkpoint_message(repo: &Repository, thread: &Thread, explicit: Option<&str>) -> String {
+fn land_checkpoint_message(repo: &Repository, thread: &Thread, explicit: Option<&str>) -> String {
     if let Some(message) = explicit.filter(|message| !message.trim().is_empty()) {
         return message.to_string();
     }
@@ -809,7 +822,7 @@ fn ship_checkpoint_message(repo: &Repository, thread: &Thread, explicit: Option<
     {
         return task.to_string();
     }
-    format!("Ship {}", thread.id)
+    format!("Land {}", thread.id)
 }
 
 pub fn cmd_delegate(cli: &Cli, args: DelegateArgs) -> Result<()> {
@@ -953,13 +966,15 @@ pub fn cmd_delegate(cli: &Cli, args: DelegateArgs) -> Result<()> {
         })
         .collect::<Result<Vec<_>>>()?;
 
-    emit(
+    emit_with_next_action_validation(
         cli,
+        &repo,
         &DelegateOutput {
             parent_thread: parent.id,
             delegated,
             message: "Delegated child threads created".to_string(),
         },
+        &["delegate"],
     )
 }
 
@@ -1054,7 +1069,7 @@ fn update_integration_policy(
     let keep_previewed = status == "blocked" && prior_status.as_deref() == Some("previewed");
     let next_status = if keep_previewed { "previewed" } else { status };
     let next_reason = if keep_previewed {
-        format!("auto-ship blocked: {reason}")
+        format!("auto-land blocked: {reason}")
     } else {
         reason
     };
@@ -1079,7 +1094,7 @@ fn clear_manual_resolution_state(repo: &Repository, thread_id: &str) -> Result<(
     Ok(manager.save(&thread)?)
 }
 
-fn coalesce_ship_integration_and_checkpoint(
+fn coalesce_land_integration_and_checkpoint(
     repo: &Repository,
     merge_state: Option<&str>,
     git_commit: Option<&str>,
@@ -1091,14 +1106,14 @@ fn coalesce_ship_integration_and_checkpoint(
         return Ok(());
     };
 
-    let integration_batch = find_recent_ship_integration_batch(repo, merge_state)?;
-    let checkpoint_batch = find_recent_ship_git_checkpoint_batch(repo, git_commit)?;
+    let integration_batch = find_recent_land_integration_batch(repo, merge_state)?;
+    let checkpoint_batch = find_recent_land_git_checkpoint_batch(repo, git_commit)?;
     repo.oplog()
         .coalesce_batches(integration_batch.id, checkpoint_batch.id)?;
     Ok(())
 }
 
-fn find_recent_ship_integration_batch(repo: &Repository, merge_state: &str) -> Result<OpBatch> {
+fn find_recent_land_integration_batch(repo: &Repository, merge_state: &str) -> Result<OpBatch> {
     repo.oplog()
         .recent_batches_scoped(12, Some(&repo.op_scope()))?
         .into_iter()
@@ -1108,10 +1123,10 @@ fn find_recent_ship_integration_batch(repo: &Repository, merge_state: &str) -> R
                 .iter()
                 .any(|entry| op_targets_merge_state(&entry.operation, merge_state))
         })
-        .ok_or_else(|| anyhow!("ship merge succeeded but its oplog batch was not found"))
+        .ok_or_else(|| anyhow!("land merge succeeded but its oplog batch was not found"))
 }
 
-fn find_recent_ship_git_checkpoint_batch(repo: &Repository, git_commit: &str) -> Result<OpBatch> {
+fn find_recent_land_git_checkpoint_batch(repo: &Repository, git_commit: &str) -> Result<OpBatch> {
     repo.oplog()
         .recent_batches_scoped(12, Some(&repo.op_scope()))?
         .into_iter()
@@ -1123,7 +1138,7 @@ fn find_recent_ship_git_checkpoint_batch(repo: &Repository, git_commit: &str) ->
                 )
             })
         })
-        .ok_or_else(|| anyhow!("ship Git checkpoint succeeded but its oplog batch was not found"))
+        .ok_or_else(|| anyhow!("land Git checkpoint succeeded but its oplog batch was not found"))
 }
 
 fn op_targets_merge_state(op: &OpRecord, merge_state: &str) -> bool {
@@ -1134,7 +1149,7 @@ fn op_targets_merge_state(op: &OpRecord, merge_state: &str) -> bool {
         OpRecord::FastForwardV2 { post_target_id, .. } => {
             change_id_matches_display(post_target_id, merge_state)
         }
-        // These records don't advance HEAD/thread to a merge target the ship
+        // These records don't advance HEAD/thread to a merge target the land
         // flow tracks (legacy V1 `FastForward` re-resolves at apply time and
         // carries no post-target id). Enumerated explicitly (no wildcard) so a
         // new state-advancing variant must be considered as a possible merge
@@ -1189,9 +1204,9 @@ fn adopt_manual_resolution(repo: &Repository, thread_id: &str) -> Result<String>
     Ok(target.short())
 }
 
-const AUTO_SHIP_CONFIDENCE_THRESHOLD: f32 = 0.75;
-const AUTO_SHIP_CONFIDENCE_RECOVERY_ACTION: &str =
-    "heddle capture -m \"...\" --confidence <confidence>";
+const AUTO_LAND_CONFIDENCE_THRESHOLD: f32 = 0.75;
+const AUTO_LAND_CONFIDENCE_RECOVERY_ACTION: &str =
+    "heddle commit -m \"...\" --confidence <confidence>";
 
 pub(crate) fn integration_blockers(
     repo: &Repository,
@@ -1204,19 +1219,19 @@ pub(crate) fn integration_blockers(
     } else {
         non_staleness_blockers(&preview.blockers)
     };
-    blockers.extend(auto_ship_policy_blockers(repo, thread));
+    blockers.extend(auto_land_policy_blockers(repo, thread));
     blockers
 }
 
-pub(crate) fn auto_ship_policy_blockers(repo: &Repository, thread: &Thread) -> Vec<String> {
+pub(crate) fn auto_land_policy_blockers(repo: &Repository, thread: &Thread) -> Vec<String> {
     let mut blockers = Vec::new();
     let agent_authored = thread_is_agent_authored(repo, thread);
     if agent_authored
         && let Some(confidence) = thread.confidence_summary.value
-            && confidence < AUTO_SHIP_CONFIDENCE_THRESHOLD
+            && confidence < AUTO_LAND_CONFIDENCE_THRESHOLD
         {
             blockers.push(format!(
-                "confidence {:.2} is below the auto-ship threshold of 0.75",
+                "confidence {:.2} is below the auto-land threshold of 0.75",
                 confidence
             ));
         }
@@ -1233,10 +1248,10 @@ pub(crate) fn integration_blocker_recommended_action(blockers: &[String]) -> Opt
             blocker.starts_with("confidence ")
                 || blocker == "verification summary reports failing tests"
         })
-        .then(|| AUTO_SHIP_CONFIDENCE_RECOVERY_ACTION.to_string())
+        .then(|| AUTO_LAND_CONFIDENCE_RECOVERY_ACTION.to_string())
 }
 
-fn ship_blockers_for_preview(
+fn land_blockers_for_preview(
     preview: &super::merge::ThreadPreviewReport,
     blockers: &[String],
 ) -> Vec<String> {
@@ -1309,21 +1324,36 @@ fn slugify(input: &str) -> String {
     out.trim_matches('-').to_string()
 }
 
-fn emit<T: Serialize>(cli: &Cli, output: &T) -> Result<()> {
+fn emit_with_next_action_validation<T: Serialize>(
+    cli: &Cli,
+    repo: &Repository,
+    output: &T,
+    emitting_command: &[&str],
+) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(output)?);
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::new(emitting_command, repo.capability()),
+        )
     } else {
         println!("{}", serde_json::to_string_pretty(output)?);
+        Ok(())
     }
-    Ok(())
 }
 
-fn write_ship_output(cli: &Cli, output: &ShipOutput) -> Result<()> {
+fn non_empty_next_action(action: &str) -> Option<String> {
+    (!action.trim().is_empty()).then(|| action.to_string())
+}
+
+fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(output)?);
+        write_validated_json_stdout(
+            output,
+            NextActionValidationContext::new(&["land"], repo.capability()),
+        )?;
     } else {
         let marker = match output.operator.status.as_str() {
-            "shipped" => style::ok_marker(),
+            "landed" => style::ok_marker(),
             "blocked" => style::warn_marker(),
             _ => style::working_marker(),
         };
@@ -1350,7 +1380,7 @@ fn write_ship_output(cli: &Cli, output: &ShipOutput) -> Result<()> {
                         &output
                             .performed_steps
                             .iter()
-                            .map(|step| ship_text_step(step))
+                            .map(|step| land_text_step(step))
                             .collect::<Vec<_>>()
                             .join(", ")
                     )
@@ -1364,7 +1394,7 @@ fn write_ship_output(cli: &Cli, output: &ShipOutput) -> Result<()> {
                         &output
                             .skipped_steps
                             .iter()
-                            .map(|step| ship_text_step(step))
+                            .map(|step| land_text_step(step))
                             .collect::<Vec<_>>()
                             .join(", ")
                     )
@@ -1404,7 +1434,7 @@ fn write_ship_output(cli: &Cli, output: &ShipOutput) -> Result<()> {
     Ok(())
 }
 
-fn ship_text_step(step: &str) -> String {
+fn land_text_step(step: &str) -> String {
     match step {
         "capture" => "saved".to_string(),
         "sync" => "refreshed".to_string(),

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3,7 +3,7 @@ use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::{OpBatch, OpRecord};
-use repo::{Repository, Thread, ThreadIntegrationPolicy, shell_quote};
+use repo::{Repository, Thread, ThreadIntegrationPolicy};
 use serde::Serialize;
 
 use super::{
@@ -390,7 +390,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         warnings: Vec::new(),
                         next_action: Some(format!(
                             "heddle sync --thread {}",
-                            shell_quote(&refreshed_thread.id)
+                            refreshed_thread.id
                         )),
                         recommended_action: Some(format!(
                             "heddle sync --thread {}",
@@ -546,7 +546,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| format!("heddle sync --thread {}", shell_quote(&merge_thread.id)));
+            .unwrap_or_else(|| format!("heddle sync --thread {}", merge_thread.id));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -829,7 +829,7 @@ fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push(format!("heddle sync --thread {}", shell_quote(thread_id)));
+            commands.push(format!("heddle sync --thread {}", thread_id));
             commands.push(land_local_command(thread_id));
             commands
         } else {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3,7 +3,7 @@ use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::{OpBatch, OpRecord};
-use repo::{Repository, Thread, ThreadIntegrationPolicy};
+use repo::{Repository, Thread, ThreadIntegrationPolicy, shell_quote};
 use serde::Serialize;
 
 use super::{
@@ -390,11 +390,11 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         warnings: Vec::new(),
                         next_action: Some(format!(
                             "heddle sync --thread {}",
-                            refreshed_thread.id
+                            shell_quote(&refreshed_thread.id)
                         )),
                         recommended_action: Some(format!(
                             "heddle sync --thread {}",
-                            refreshed_thread.id
+                            shell_quote(&refreshed_thread.id)
                         )),
                     },
                     thread: refreshed_thread.id.clone(),
@@ -546,7 +546,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| format!("heddle sync --thread {}", merge_thread.id));
+            .unwrap_or_else(|| format!("heddle sync --thread {}", shell_quote(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -829,7 +829,7 @@ fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push(format!("heddle sync --thread {}", thread_id));
+            commands.push(format!("heddle sync --thread {}", shell_quote(thread_id)));
             commands.push(land_local_command(thread_id));
             commands
         } else {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3,7 +3,7 @@ use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
 use oplog::{OpBatch, OpRecord};
-use repo::{Repository, Thread, ThreadIntegrationPolicy};
+use repo::{Repository, Thread, ThreadIntegrationPolicy, shell_quote};
 use serde::Serialize;
 
 use super::{
@@ -388,7 +388,10 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         ),
                         blockers: land_blockers_for_preview(&preview, &stale_blockers),
                         warnings: Vec::new(),
-                        next_action: Some(format!("heddle sync --thread {}", refreshed_thread.id)),
+                        next_action: Some(format!(
+                            "heddle sync --thread {}",
+                            shell_quote(&refreshed_thread.id)
+                        )),
                         recommended_action: Some(format!(
                             "heddle sync --thread {}",
                             refreshed_thread.id
@@ -543,7 +546,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recommended_action = integration_blocker_recommended_action(&integration_blockers)
-            .unwrap_or_else(|| format!("heddle sync --thread {}", merge_thread.id));
+            .unwrap_or_else(|| format!("heddle sync --thread {}", shell_quote(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -826,7 +829,7 @@ fn land_checkpoint_preflight_advice(repo: &Repository, thread_id: &str) -> Optio
             let mut commands = remote_decision
                 .map(|decision| decision.recovery_commands)
                 .unwrap_or_else(|| vec![primary_command.clone()]);
-            commands.push(format!("heddle sync --thread {}", thread_id));
+            commands.push(format!("heddle sync --thread {}", shell_quote(thread_id)));
             commands.push(land_local_command(thread_id));
             commands
         } else {

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -108,7 +108,7 @@ pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> 
             )?;
             writeln!(
                 out,
-                "Isolated work: heddle start <name> --path ../<name> -> heddle ready -> heddle merge --preview -> heddle ship"
+                "Isolated work: heddle start <name> --path ../<name> -> heddle commit -m \"...\" -> heddle ready -> heddle land"
             )?;
             writeln!(out)?;
             writeln!(
@@ -370,7 +370,7 @@ pub fn topic_text(topic: &str) -> Option<&'static str> {
 const ADVANCED_HELP: &str = "Advanced commands for power users, agents, automation, Git interop, and recovery.\n\
 \n\
 The default `heddle help` curates the native loop: init/adopt/clone,\n\
-status/diff/commit/start, ready/merge/ship/push/pull, undo, log/show,\n\
+status/diff/commit/start, ready/land/push/pull, resolve/continue/abort,\n\
 doctor/verify. Power nouns such as thread/workspace/remote/bridge/agent and\n\
 Git adapter commands live behind this topic. Use `heddle help\n\
 <verb>` for curated topics or `heddle <verb> --help` for the full clap-derived\n\
@@ -451,8 +451,7 @@ Everyday loop:
     heddle commit -m "..."
     heddle start <name> --path ../<name>
     heddle ready
-    heddle merge <name> --preview
-    heddle ship --thread <name>
+    heddle land --thread <name>
     heddle undo
     heddle verify
 
@@ -473,7 +472,7 @@ history, and a target it eventually merges into. It is *not* a git branch:\n\
 the git-overlay branch is downstream plumbing (created at checkpoint),\n\
 not the primary object. You start work with `heddle start <name>`, switch\n\
 between threads with `heddle thread switch <name>`, and integrate with\n\
-`heddle ship` (or check readiness without merging via `heddle ready`).\n\
+`heddle land` (or check readiness without merging via `heddle ready`).\n\
 \n\
 # Threads vs. git branches\n\
 \n\
@@ -507,7 +506,7 @@ workflow states:\n\
   `virtualized` when a mount is available, otherwise `solid`.\n\
 \n\
 A `solid` thread and a `materialized` thread are interchangeable from\n\
-the workflow's point of view — `capture`, `ship`, `goto`, etc. behave\n\
+the workflow's point of view — `capture`, `land`, `goto`, etc. behave\n\
 identically. The mode only controls bytes-on-disk semantics.\n\
 \n\
 # Materialize vs. promote\n\
@@ -532,12 +531,10 @@ Resolution paths:\n\
 - `heddle sync` — refresh the current thread onto its target when\n\
   the replay is clean. The fast path for a stale thread with no\n\
   conflicts.\n\
-- `heddle thread refresh <name>` — the same refresh, addressed by\n\
-  thread name rather than the current checkout.\n\
 - If `sync` reports conflicts or other blockers, use\n\
-  `heddle thread resolve <name>` to walk through the next steps, or\n\
-  `heddle conflict` to handle the conflicts as structured data.\n\
-- `heddle ship` will refresh-then-merge for you when the replay is\n\
+  `heddle resolve`, `heddle continue`, or `heddle conflict` to handle\n\
+  the conflicts as structured data.\n\
+- `heddle land` will refresh-then-merge for you when the replay is\n\
   clean; it fails closed when manual resolution is required.\n\
 \n\
 # `goto` vs. `git checkout` vs. `thread switch`\n\
@@ -692,10 +689,10 @@ Isolate risky work:\n\
 \n\
     heddle start <name> --path ../<name>\n\
     cd ../<name>\n\
+    heddle commit -m \"...\"\n\
     heddle ready\n\
     cd -\n\
-    heddle merge <name> --preview\n\
-    heddle ship --thread <name> --no-push     # add --push when ready to publish\n\
+    heddle land --thread <name> --no-push     # add --push when ready to publish\n\
 \n\
 Recover or prove state:\n\
 \n\
@@ -705,7 +702,7 @@ Recover or prove state:\n\
 State-specific recovery:\n\
 \n\
     Worktree has unsaved edits: heddle commit -m \"...\"\n\
-    Captured in Heddle but not Git: heddle checkpoint -m \"...\"\n\
+    Captured in Heddle but not Git: heddle commit -m \"...\"\n\
     Git refs changed externally: heddle adopt --ref <branch>\n";
 
 const BRIDGE_TOPIC: &str = "Git bridge — adopt existing Git repos through an adapter.\n\
@@ -732,8 +729,7 @@ Daily loop:\n\
     heddle push                               # Git-overlay remotes use the top-level verb\n\
     heddle start <name> --path ../<name>\n\
     heddle ready --thread <name>              # or cd into ../<name> and run heddle ready\n\
-    heddle merge <name> --preview\n\
-    heddle ship --thread <name> --no-push     # add --push to land and push together\n\
+    heddle land --thread <name> --no-push     # add --push to land and push together\n\
 \n\
 Recovery and inspection:\n\
 \n\
@@ -869,7 +865,7 @@ mod tests {
     fn everyday_verbs_surface_the_core_loop() {
         let everyday: std::collections::HashSet<&str> = everyday_verbs().into_iter().collect();
         for verb in [
-            "init", "clone", "status", "start", "commit", "ready", "diff", "merge", "ship",
+            "init", "clone", "status", "start", "commit", "ready", "diff", "land",
             "resolve", "undo", "log", "show", "pull", "push", "doctor", "verify",
         ] {
             assert!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,7 +18,7 @@ use cli::{
         DaemonCommands, DiagnoseArgs, DiffArgs, LogArgs, MergeArgs, ResolveArgs, RetroArgs,
         RevertArgs, RunArgs, SessionCommands, SessionEndArgs, SessionListArgs, SessionSegmentArgs,
         SessionShowArgs, SessionStartArgs, UndoArgs,
-        cli_args::{DelegateArgs, ShipArgs, SyncArgs},
+        cli_args::{DelegateArgs, LandArgs, SyncArgs},
         commands::{
             LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
             cmd_abort, cmd_actor_done, cmd_actor_explain, cmd_actor_list, cmd_actor_show,
@@ -34,7 +34,7 @@ use cli::{
             cmd_maintenance, cmd_marker, cmd_merge, cmd_monitor, cmd_pull, cmd_push, cmd_query,
             cmd_ready, cmd_rebase, cmd_redo, cmd_remote, cmd_resolve, cmd_retro, cmd_revert,
             cmd_review, cmd_run, cmd_schemas, cmd_session_end, cmd_session_list,
-            cmd_session_segment, cmd_session_show, cmd_session_start, cmd_shell, cmd_ship,
+            cmd_session_segment, cmd_session_show, cmd_session_start, cmd_shell, cmd_land,
             cmd_show, cmd_snapshot, cmd_stack, cmd_start, cmd_stash, cmd_status, cmd_store,
             cmd_switch_compat, cmd_sync_smart, cmd_thread, cmd_thread_show, cmd_transaction,
             cmd_try, cmd_undo, cmd_verify, cmd_version, cmd_watch, cmd_workspace,
@@ -340,16 +340,16 @@ async fn async_main() -> Result<()> {
 
         Commands::Abort => cmd_abort(&cli),
 
-        Commands::Ship(ShipArgs {
+        Commands::Land(LandArgs {
             thread,
             message,
             push,
             no_push,
             remote,
         }) => {
-            cmd_ship(
+            cmd_land(
                 &cli,
-                ShipArgs {
+                LandArgs {
                     thread: thread.clone(),
                     message: message.clone(),
                     push: *push,

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -66,6 +66,8 @@ mod output_kind_invariant;
 mod output_kind_runtime;
 #[path = "cli_integration/output_mode_no_auto.rs"]
 mod output_mode_no_auto;
+#[path = "cli_integration/next_action_contract.rs"]
+mod next_action_contract;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
 #[path = "cli_integration/quickstart.rs"]

--- a/crates/cli/tests/cli_integration/attempt.rs
+++ b/crates/cli/tests/cli_integration/attempt.rs
@@ -89,8 +89,8 @@ fn attempt_n_one_is_degenerate_try() {
         .expect("attempt should recommend a winning thread");
     assert_eq!(
         value["next_action"],
-        format!("heddle merge {recommended} --preview --with-diff"),
-        "attempt should preview the winning thread before landing it: {raw}"
+        format!("heddle ready --thread {recommended}"),
+        "attempt should check readiness for the winning thread before landing it: {raw}"
     );
     assert_eq!(
         value["recommended_action"], value["next_action"],
@@ -98,14 +98,14 @@ fn attempt_n_one_is_degenerate_try() {
     );
     assert_eq!(
         value["next_action_template"]["argv_template"],
-        heddle_argv_json(["merge", recommended, "--preview", "--with-diff"]),
-        "attempt should expose replayable argv_template for the preview action: {raw}"
+        heddle_argv_json(["ready", "--thread", recommended]),
+        "attempt should expose replayable argv_template for the readiness action: {raw}"
     );
     assert!(
         value["next_action_template"]["required_inputs"]
             .as_array()
             .is_some_and(|inputs| inputs.is_empty()),
-        "attempt's concrete preview action template should need no inputs to run: {raw}"
+        "attempt's concrete readiness action template should need no inputs to run: {raw}"
     );
     assert_eq!(
         value["recommended_action_template"]["argv_template"], value["next_action_template"]["argv_template"],

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -4318,3 +4318,58 @@ fn start_rejects_thread_name_with_space_in_text_and_json() {
         "the rejected name must never have been persisted: {list}"
     );
 }
+
+/// heddle#464 close-the-class (round 6): the SAME early-reject rule must guard
+/// every user/external thread-creation boundary, not just `start`. `heddle
+/// thread create` with a shell-metacharacter name is rejected before any ref or
+/// record is persisted.
+#[test]
+fn thread_create_rejects_thread_name_with_metachar() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let out = heddle_output(&["thread", "create", "bad;id"], Some(temp.path())).unwrap();
+    assert!(
+        !out.status.success(),
+        "thread create must reject an unsafe name: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("is invalid"),
+        "thread create must explain the name is invalid: {stderr}"
+    );
+
+    let list = heddle(&["thread", "list", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !list.contains("bad;id"),
+        "the rejected name must never have been persisted: {list}"
+    );
+}
+
+/// heddle#464 close-the-class (round 6): `heddle agent reserve` also persists a
+/// thread record, so it must reject an unsafe thread name at the same boundary.
+#[test]
+fn agent_reserve_rejects_thread_name_with_metachar() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let out =
+        heddle_output(&["agent", "reserve", "--thread", "bad;id"], Some(temp.path())).unwrap();
+    assert!(
+        !out.status.success(),
+        "agent reserve must reject an unsafe name: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("is invalid"),
+        "agent reserve must explain the name is invalid: {stderr}"
+    );
+
+    let list = heddle(&["thread", "list", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !list.contains("bad;id"),
+        "the rejected name must never have been persisted: {list}"
+    );
+}

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -4347,6 +4347,70 @@ fn thread_create_rejects_thread_name_with_metachar() {
     );
 }
 
+/// heddle#464 close-the-class: `thread rename` writes a NEW thread id, so the
+/// destination name is a creation boundary too — an unsafe new name is rejected
+/// and the original thread is left untouched.
+#[test]
+fn thread_rename_rejects_unsafe_new_name() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["thread", "create", "safe-thread"], Some(temp.path())).unwrap();
+
+    let out = heddle_output(
+        &["thread", "rename", "safe-thread", "bad;id"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    assert!(
+        !out.status.success(),
+        "rename to an unsafe name must be rejected: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("is invalid"),
+        "rename must explain the name is invalid: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let list = heddle(&["thread", "list", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !list.contains("bad;id"),
+        "the rejected name must never have been persisted: {list}"
+    );
+    assert!(
+        list.contains("safe-thread"),
+        "a rejected rename must leave the original thread intact: {list}"
+    );
+}
+
+/// heddle#464 close-the-class: `actor spawn --thread <name>` mints/attaches the
+/// named thread, so a user-supplied unsafe name is rejected before any ref is
+/// written. (The generated `actor/<session>` fallback is safe by construction.)
+#[test]
+fn actor_spawn_rejects_unsafe_thread_name() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    let out =
+        heddle_output(&["actor", "spawn", "--thread", "bad;id"], Some(temp.path())).unwrap();
+    assert!(
+        !out.status.success(),
+        "actor spawn with an unsafe thread name must be rejected: stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("is invalid"),
+        "actor spawn must explain the name is invalid: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let list = heddle(&["thread", "list", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !list.contains("bad;id"),
+        "the rejected name must never have been persisted: {list}"
+    );
+}
+
 /// heddle#464 close-the-class (round 6): `heddle agent reserve` also persists a
 /// thread record, so it must reject an unsafe thread name at the same boundary.
 #[test]

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -4270,3 +4270,51 @@ fn test_cli_diff_patch_plain_git_delete_executable_and_symlink_modes() {
         "applying the delete patch must unlink both special files:\n{patch}"
     );
 }
+
+/// heddle#464 close-the-class: `heddle start` validates the thread name at the
+/// creation boundary. A name with a space (or any shell metacharacter) is
+/// rejected with the centralized `thread_name_invalid` advice — in BOTH text
+/// and JSON-error modes — and never persisted, so no downstream breadcrumb can
+/// interpolate an unsafe thread id. The CLI exits non-zero; it does not panic.
+#[test]
+fn start_rejects_thread_name_with_space_in_text_and_json() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+
+    // Text mode: non-zero exit, actionable rename hint on stderr.
+    let text = heddle_output(&["start", "my feature"], Some(temp.path())).unwrap();
+    assert!(
+        !text.status.success(),
+        "an invalid thread name must be rejected: stdout={}",
+        String::from_utf8_lossy(&text.stdout)
+    );
+    let text_stderr = String::from_utf8_lossy(&text.stderr);
+    assert!(
+        text_stderr.contains("is invalid"),
+        "text mode must explain the name is invalid: {text_stderr}"
+    );
+    assert!(
+        text_stderr.contains("try 'my-feature'"),
+        "the rename hint must suggest a valid name: {text_stderr}"
+    );
+
+    // JSON mode: still rejected with the same kind, no panic.
+    let json_out =
+        heddle_output(&["start", "my feature", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !json_out.status.success(),
+        "an invalid thread name must be rejected in JSON mode too"
+    );
+    let json_stderr = String::from_utf8_lossy(&json_out.stderr);
+    assert!(
+        json_stderr.contains("thread_name_invalid"),
+        "JSON-error mode must carry the thread_name_invalid kind: {json_stderr}"
+    );
+
+    // The invalid name was rejected before any thread was created.
+    let list = heddle(&["thread", "list", "--output", "json"], Some(temp.path())).unwrap();
+    assert!(
+        !list.contains("my feature"),
+        "the rejected name must never have been persisted: {list}"
+    );
+}

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -918,14 +918,14 @@ fn test_cli_ready_in_plain_git_repo_captures_mixed_git_state() {
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], true);
     assert_eq!(ready["verification"]["status"], "needs_checkpoint");
-    assert_eq!(ready["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(ready["recommended_action"], "heddle commit -m \"...\"");
 
     let status: Value =
         serde_json::from_str(&heddle(&["status", "--output", "json"], Some(temp.path())).unwrap())
             .unwrap();
     assert!(status["state"]["change_id"].as_str().is_some());
     assert_eq!(status["verification"]["status"], "needs_checkpoint");
-    assert_eq!(status["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
 }
 
 #[test]
@@ -1673,7 +1673,7 @@ fn test_cli_ready_captures_current_git_branch_after_switch() {
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], true);
     assert_eq!(ready["verification"]["status"], "needs_checkpoint");
-    assert_eq!(ready["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(ready["recommended_action"], "heddle commit -m \"...\"");
 
     let status: Value =
         serde_json::from_str(&heddle(&["status", "--output", "json"], Some(temp.path())).unwrap())
@@ -1681,7 +1681,7 @@ fn test_cli_ready_captures_current_git_branch_after_switch() {
     assert_eq!(status["thread"], "support/ready-switch");
     assert!(status["state"]["change_id"].as_str().is_some());
     assert_eq!(status["verification"]["status"], "needs_checkpoint");
-    assert_eq!(status["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
 }
 
 #[test]
@@ -1981,7 +1981,7 @@ fn test_cli_ready_in_git_overlay_auto_captures_initial_state() {
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], true);
     assert_eq!(ready["verification"]["status"], "needs_checkpoint");
-    assert_eq!(ready["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(ready["recommended_action"], "heddle commit -m \"...\"");
 
     let status: Value =
         serde_json::from_str(&heddle(&["status", "--output", "json"], Some(temp.path())).unwrap())
@@ -1989,7 +1989,7 @@ fn test_cli_ready_in_git_overlay_auto_captures_initial_state() {
     assert!(status["state"]["change_id"].as_str().is_some());
     assert!(status["git_checkpoint"].is_null());
     assert_eq!(status["verification"]["status"], "needs_checkpoint");
-    assert_eq!(status["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
 }
 
 #[test]
@@ -2100,7 +2100,7 @@ fn test_cli_ship_in_git_overlay_auto_checkpoints() {
                 "--output",
                 "json",
                 "start",
-                "feature/ship-it",
+                "feature/land-it",
                 "--workspace",
                 "auto",
             ],
@@ -2110,20 +2110,20 @@ fn test_cli_ship_in_git_overlay_auto_checkpoints() {
     )
     .unwrap();
     let thread = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
-    std::fs::write(thread.join("ship.txt"), "ship me").unwrap();
+    std::fs::write(thread.join("land.txt"), "land me").unwrap();
 
-    let shipped: Value = serde_json::from_str(
+    let landed: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/ship-it"],
+            &["--output", "json", "land", "--thread", "feature/land-it"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(shipped["status"], "shipped");
-    assert_eq!(shipped["checkpointed"], true);
-    assert!(shipped["git_commit"].as_str().is_some());
-    assert!(temp.path().join("ship.txt").exists());
+    assert_eq!(landed["status"], "landed");
+    assert_eq!(landed["checkpointed"], true);
+    assert!(landed["git_commit"].as_str().is_some());
+    assert!(temp.path().join("land.txt").exists());
 
     let status: Value =
         serde_json::from_str(&heddle(&["status", "--output", "json"], Some(temp.path())).unwrap())
@@ -2243,13 +2243,13 @@ fn test_parallel_heddle_threads_capture_independently_and_checkpoint_via_git_ove
 
     let auth_ship: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/auth"],
+            &["--output", "json", "land", "--thread", "feature/auth"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(auth_ship["status"], "shipped");
+    assert_eq!(auth_ship["status"], "landed");
     assert_eq!(auth_ship["checkpointed"], true);
     assert!(auth_ship["git_commit"].as_str().is_some());
 
@@ -2265,13 +2265,13 @@ fn test_parallel_heddle_threads_capture_independently_and_checkpoint_via_git_ove
 
     let search_ship: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/search"],
+            &["--output", "json", "land", "--thread", "feature/search"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(search_ship["status"], "shipped");
+    assert_eq!(search_ship["status"], "landed");
     assert_eq!(search_ship["checkpointed"], true);
     assert!(search_ship["git_commit"].as_str().is_some());
 
@@ -2298,10 +2298,10 @@ fn test_parallel_heddle_threads_capture_independently_and_checkpoint_via_git_ove
     );
     assert_ne!(
         auth_ship["git_commit"], search_ship["git_commit"],
-        "separate shipped threads should produce distinct git commits"
+        "separate landed threads should produce distinct git commits"
     );
 
-    // Each shipped thread should record a Heddle change id on the
+    // Each landed thread should record a Heddle change id on the
     // bridge mirror's `refs/notes/heddle` ref without publishing the
     // metadata notes ref into the user's ordinary `.git/refs`.
     for git_commit in [
@@ -2319,7 +2319,7 @@ fn test_parallel_heddle_threads_capture_independently_and_checkpoint_via_git_ove
             .expect("git notes show should run");
         assert!(
             notes.status.success(),
-            "shipped commit {git_commit} should have a heddle note in the bridge mirror; stderr: {}",
+            "landed commit {git_commit} should have a heddle note in the bridge mirror; stderr: {}",
             String::from_utf8_lossy(&notes.stderr)
         );
         let note_body = String::from_utf8(notes.stdout).unwrap();
@@ -2400,13 +2400,13 @@ fn test_parallel_heddle_threads_ship_with_one_stale_refresh_path_and_checkpoint_
 
     let auth_ship: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/auth"],
+            &["--output", "json", "land", "--thread", "feature/auth"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(auth_ship["status"], "shipped");
+    assert_eq!(auth_ship["status"], "landed");
     assert_eq!(auth_ship["checkpointed"], true);
     assert!(auth_ship["git_commit"].as_str().is_some());
 
@@ -2422,13 +2422,13 @@ fn test_parallel_heddle_threads_ship_with_one_stale_refresh_path_and_checkpoint_
 
     let search_ship: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/search"],
+            &["--output", "json", "land", "--thread", "feature/search"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(search_ship["status"], "shipped");
+    assert_eq!(search_ship["status"], "landed");
     assert_eq!(search_ship["synced"], false);
     assert_eq!(search_ship["checkpointed"], true);
     assert!(search_ship["git_commit"].as_str().is_some());
@@ -2469,13 +2469,13 @@ fn test_parallel_heddle_threads_ship_with_one_stale_refresh_path_and_checkpoint_
         records
             .iter()
             .any(|record| record["summary"] == "auth work"),
-        "stale auth ship should record a git checkpoint: {checkpoint_records}"
+        "stale auth land should record a git checkpoint: {checkpoint_records}"
     );
     assert!(
         records
             .iter()
             .any(|record| record["summary"] == "search work"),
-        "clean search ship should record a git checkpoint: {checkpoint_records}"
+        "clean search land should record a git checkpoint: {checkpoint_records}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/cli_premium_output.rs
+++ b/crates/cli/tests/cli_integration/cli_premium_output.rs
@@ -57,15 +57,15 @@ fn merged_thread_list_reads_integrated_not_actionable() {
     let thread_path = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
     std::fs::write(thread_path.join("polish.txt"), "premium").unwrap();
 
-    let shipped: Value = serde_json::from_str(
+    let landed: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "ship", "--thread", "feature/polish"],
+            &["--output", "json", "land", "--thread", "feature/polish"],
             Some(temp.path()),
         )
         .unwrap(),
     )
     .unwrap();
-    assert_eq!(shipped["status"], "shipped");
+    assert_eq!(landed["status"], "landed");
 
     heddle(&["thread", "refresh", "feature/polish"], Some(temp.path())).unwrap();
     let listed: Value = serde_json::from_str(
@@ -163,7 +163,7 @@ fn status_does_not_advertise_ready_thread_for_another_target() {
             .unwrap();
 
     assert_ne!(
-        status["recommended_action"], "heddle merge feature/ready-main --preview",
+        status["recommended_action"], "heddle land --thread feature/ready-main --no-push",
         "status on a non-target thread must not suggest merging target-main work into the active thread: {status}"
     );
     assert_eq!(

--- a/crates/cli/tests/cli_integration/current_context_advice.rs
+++ b/crates/cli/tests/cli_integration/current_context_advice.rs
@@ -74,14 +74,14 @@ fn ready_without_current_thread_uses_typed_advice() {
 fn ship_without_current_thread_uses_typed_advice() {
     let temp = setup_detached_repo_without_current_thread();
 
-    let envelope = json_failure(&["--output", "json", "ship"], temp.path());
+    let envelope = json_failure(&["--output", "json", "land"], temp.path());
     assert_eq!(envelope["kind"], "no_current_thread");
-    assert_eq!(envelope["primary_command"], "heddle ship --thread <name>");
+    assert_eq!(envelope["primary_command"], "heddle land --thread <name>");
     assert_eq!(envelope["primary_command_argv"], Value::Null);
     assert_action_template(
         &envelope["primary_command_template"],
-        "heddle ship --thread <name>",
-        heddle_argv_json(["ship", "--thread", "<thread>"]),
+        "heddle land --thread <name>",
+        heddle_argv_json(["land", "--thread", "<thread>"]),
         &["thread"],
         true,
     );
@@ -89,7 +89,7 @@ fn ship_without_current_thread_uses_typed_advice() {
         envelope["hint"]
             .as_str()
             .is_some_and(|hint| hint.contains("--thread")),
-        "ship advice should name the explicit selector: {envelope}"
+        "land advice should name the explicit selector: {envelope}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -2,7 +2,7 @@
 //! Crash-mid-write integration tests (R7 + R9 from the OSS-launch
 //! plan).
 //!
-//! W2b shipped the rollback machinery — atomic mapping persistence,
+//! W2b landed the rollback machinery — atomic mapping persistence,
 //! mirror Drop guard, HEAD/index restore on failure, snapshot
 //! state-then-ref ordering. These tests crash the heddle process at
 //! the load-bearing transition points (via `HEDDLE_FAULT_INJECT`)

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -401,7 +401,7 @@ fn git_overlay_imported_ref_ready_and_ship_fail_closed() {
         vec![
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature",
             "--no-push",
@@ -424,7 +424,7 @@ fn git_overlay_imported_ref_ready_and_ship_fail_closed() {
             "{envelope}"
         );
         assert_eq!(
-            envelope["primary_command"], "heddle merge feature --preview",
+            envelope["primary_command"], "heddle bridge git reconcile --ref feature --preview",
             "{envelope}"
         );
     }
@@ -1482,12 +1482,12 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
         &["--output", "json", "ready", "-m", "ready thread work"],
     );
     assert_eq!(ready["status"], "completed");
-    let parent_preview_action = format!(
-        "heddle --repo {} merge feature/ready-verify --preview",
+    let parent_land_action = format!(
+        "heddle --repo {} land --thread feature/ready-verify --no-push",
         temp.path().display()
     );
     assert_eq!(
-        ready["recommended_action"], parent_preview_action,
+        ready["recommended_action"], parent_land_action,
         "ready from an isolated checkout should print a command that works from that checkout: {ready}"
     );
     assert_eq!(ready["verification"]["verified"], true);
@@ -1509,7 +1509,7 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
     // proof (grafted from a separate verify call) carries a plain
     // recommendation without the original `--repo` prefix, which is
     // expected: the separate verify call has no caller context.
-    let _ = parent_preview_action;
+    let _ = parent_land_action;
     assert_eq!(
         ready["verification"]["recovery_commands"],
         serde_json::json!([])
@@ -1519,29 +1519,29 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
     let parent_status_before_preview = json(temp.path(), &["--output", "json", "status"]);
     assert_eq!(
         parent_status_before_preview["recommended_action"],
-        "heddle merge feature/ready-verify --preview",
+        "heddle land --thread feature/ready-verify --no-push",
         "parent status should keep ready workflow actionable: {parent_status_before_preview}"
     );
     let thread_list_before_preview = json(temp.path(), &["--output", "json", "thread", "list"]);
     assert_eq!(
         thread_list_before_preview["recommended_action"],
-        "heddle merge feature/ready-verify --preview",
+        "heddle land --thread feature/ready-verify --no-push",
         "thread list top-level action should match verify after ready: {thread_list_before_preview}"
     );
     assert_eq!(
         thread_list_before_preview["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["merge", "feature/ready-verify", "--preview"]),
+        heddle_argv_json(["land", "--thread", "feature/ready-verify", "--no-push"]),
         "thread list top-level action should be directly executable: {thread_list_before_preview}"
     );
     let workspace_before_preview = json(temp.path(), &["--output", "json", "workspace", "show"]);
     assert_eq!(
         workspace_before_preview["recommended_action"],
-        "heddle merge feature/ready-verify --preview",
+        "heddle land --thread feature/ready-verify --no-push",
         "workspace top-level action should match verify after ready: {workspace_before_preview}"
     );
     assert_eq!(
         workspace_before_preview["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["merge", "feature/ready-verify", "--preview"]),
+        heddle_argv_json(["land", "--thread", "feature/ready-verify", "--no-push"]),
         "workspace top-level action should be directly executable: {workspace_before_preview}"
     );
 
@@ -1571,8 +1571,8 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
     );
     assert_eq!(
         thread_show_before_preview["recommended_action"],
-        "heddle merge feature/ready-verify --preview",
-        "thread show should not skip preview and jump straight to ship: {thread_show_before_preview}"
+        "heddle land --thread feature/ready-verify --no-push",
+        "thread show should follow the canonical land path after ready: {thread_show_before_preview}"
     );
     let preview = json(
         temp.path(),
@@ -1586,7 +1586,7 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
     );
     assert_eq!(
         preview["recommended_action"],
-        "heddle ship --thread feature/ready-verify --no-push"
+        "heddle land --thread feature/ready-verify --no-push"
     );
     let thread_show_after_preview = json(
         temp.path(),
@@ -1594,12 +1594,12 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
     );
     assert_eq!(
         thread_show_after_preview["recommended_action"],
-        "heddle ship --thread feature/ready-verify --no-push",
-        "thread show should keep the established ship path after merge preview: {thread_show_after_preview}"
+        "heddle land --thread feature/ready-verify --no-push",
+        "thread show should keep the established land path after merge preview: {thread_show_after_preview}"
     );
     assert_eq!(
         thread_show_after_preview["verification"]["recommended_action"],
-        "heddle ship --thread feature/ready-verify --no-push",
+        "heddle land --thread feature/ready-verify --no-push",
         "nested verify should not send agents back to preview after preview already succeeded: {thread_show_after_preview}"
     );
     assert!(
@@ -1609,32 +1609,32 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
             .iter()
             .any(|check| check["name"] == "Workflow"
                 && check["recommended_action"]
-                    == "heddle ship --thread feature/ready-verify --no-push"),
-        "Workflow check should match the established ship path: {thread_show_after_preview}"
+                    == "heddle land --thread feature/ready-verify --no-push"),
+        "Workflow check should match the established land path: {thread_show_after_preview}"
     );
     let ready_after_preview = json(&thread_path, &["--output", "json", "ready"]);
-    let parent_ship_action = format!(
-        "heddle --repo {} ship --thread feature/ready-verify --no-push",
+    let parent_land_action = format!(
+        "heddle --repo {} land --thread feature/ready-verify --no-push",
         temp.path().display()
     );
     assert_eq!(
-        ready_after_preview["recommended_action"], parent_ship_action,
-        "ready rerun after preview should preserve the ship path: {ready_after_preview}"
+        ready_after_preview["recommended_action"], parent_land_action,
+        "ready rerun after preview should preserve the land path: {ready_after_preview}"
     );
     // Mutation reply no longer carries verification on the wire; the
     // injected verify is rooted in `thread_path` without --repo, so
     // its recommendation lacks the parent --repo prefix the original
     // ready built. The top-level assertion above already proves the
-    // ship path is preserved end-to-end.
+    // land path is preserved end-to-end.
     let parent_status_after_preview = json(temp.path(), &["--output", "json", "status"]);
     assert_eq!(
         parent_status_after_preview["recommended_action"],
-        "heddle ship --thread feature/ready-verify --no-push",
+        "heddle land --thread feature/ready-verify --no-push",
         "parent status should keep previewed workflow actionable: {parent_status_after_preview}"
     );
     let thread_list = json(temp.path(), &["--output", "json", "thread", "list"]);
     assert_eq!(
-        thread_list["recommended_action"], "heddle ship --thread feature/ready-verify --no-push",
+        thread_list["recommended_action"], "heddle land --thread feature/ready-verify --no-push",
         "thread list top-level action should match verify after preview: {thread_list}"
     );
     let listed = thread_list["threads"]
@@ -1644,17 +1644,17 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
         .find(|thread| thread["name"] == "feature/ready-verify")
         .expect("ready thread should be listed");
     assert_eq!(
-        listed["recommended_action"], "heddle ship --thread feature/ready-verify --no-push",
+        listed["recommended_action"], "heddle land --thread feature/ready-verify --no-push",
         "thread list should match ready/verify next action: {thread_list}"
     );
     assert_eq!(
         listed["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ship", "--thread", "feature/ready-verify", "--no-push"]),
+        heddle_argv_json(["land", "--thread", "feature/ready-verify", "--no-push"]),
         "thread list item actions should be directly executable: {thread_list}"
     );
     let workspace = json(temp.path(), &["--output", "json", "workspace", "show"]);
     assert_eq!(
-        workspace["recommended_action"], "heddle ship --thread feature/ready-verify --no-push",
+        workspace["recommended_action"], "heddle land --thread feature/ready-verify --no-push",
         "workspace top-level action should match verify after preview: {workspace}"
     );
     let workspace_thread = workspace["groups"]
@@ -1666,12 +1666,12 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
         .expect("ready thread should appear in workspace");
     assert_eq!(
         workspace_thread["recommended_action"],
-        "heddle ship --thread feature/ready-verify --no-push",
+        "heddle land --thread feature/ready-verify --no-push",
         "workspace should match ready/verify next action: {workspace}"
     );
     assert_eq!(
         workspace_thread["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ship", "--thread", "feature/ready-verify", "--no-push"]),
+        heddle_argv_json(["land", "--thread", "feature/ready-verify", "--no-push"]),
         "workspace item actions should be directly executable: {workspace}"
     );
 }
@@ -1690,7 +1690,7 @@ fn git_overlay_matrix_agent_ship_allows_absent_confidence() {
             "--output",
             "json",
             "start",
-            "feature/ship-absent-confidence",
+            "feature/land-absent-confidence",
             "--workspace",
             "materialized",
         ],
@@ -1715,7 +1715,7 @@ fn git_overlay_matrix_agent_ship_allows_absent_confidence() {
     let ready = json(&thread_path, &["--output", "json", "ready"]);
     assert_eq!(
         ready["status"], "completed",
-        "absent confidence should not make ready and ship disagree: {ready}"
+        "absent confidence should not make ready and land disagree: {ready}"
     );
     let preview = json(
         temp.path(),
@@ -1723,36 +1723,36 @@ fn git_overlay_matrix_agent_ship_allows_absent_confidence() {
             "--output",
             "json",
             "merge",
-            "feature/ship-absent-confidence",
+            "feature/land-absent-confidence",
             "--preview",
         ],
     );
     assert_eq!(
         preview["recommended_action"],
-        "heddle ship --thread feature/ship-absent-confidence --no-push"
+        "heddle land --thread feature/land-absent-confidence --no-push"
     );
 
-    let ship = json(
+    let land = json(
         temp.path(),
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
-            "feature/ship-absent-confidence",
+            "feature/land-absent-confidence",
             "--no-push",
         ],
     );
     assert_eq!(
-        ship["status"], "shipped",
-        "ship should not block on absent confidence after ready completed: {ship}"
+        land["status"], "landed",
+        "land should not block on absent confidence after ready completed: {land}"
     );
-    assert_eq!(ship["integrated"], true);
+    assert_eq!(land["integrated"], true);
     assert!(
-        ship["blockers"]
+        land["blockers"]
             .as_array()
             .is_none_or(|blockers| blockers.is_empty()),
-        "successful ship should have no blockers: {ship}"
+        "successful land should have no blockers: {land}"
     );
 }
 
@@ -1770,7 +1770,7 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
             "--output",
             "json",
             "start",
-            "feature/ship-low-confidence",
+            "feature/land-low-confidence",
             "--workspace",
             "materialized",
         ],
@@ -1803,7 +1803,7 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
     let ready = json(&thread_path, &["--output", "json", "ready"]);
     assert_eq!(ready["status"], "blocked", "{ready}");
     assert_eq!(
-        ready["recommended_action"], "heddle capture -m \"...\" --confidence <confidence>",
+        ready["recommended_action"], "heddle commit -m \"...\" --confidence <confidence>",
         "ready should give the corrective action before marking the thread ready: {ready}"
     );
     assert!(
@@ -1823,65 +1823,65 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
             "--output",
             "json",
             "merge",
-            "feature/ship-low-confidence",
+            "feature/land-low-confidence",
             "--preview",
         ],
     );
     assert_eq!(
         preview["recommended_action"],
-        "heddle ship --thread feature/ship-low-confidence --no-push"
+        "heddle land --thread feature/land-low-confidence --no-push"
     );
 
     let ship_output = heddle_output(
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
-            "feature/ship-low-confidence",
+            "feature/land-low-confidence",
             "--no-push",
         ],
         Some(temp.path()),
     )
-    .expect("invoke blocked low-confidence ship");
+    .expect("invoke blocked low-confidence land");
     assert!(
         !ship_output.status.success(),
-        "blocked policy ship should exit nonzero"
+        "blocked policy land should exit nonzero"
     );
-    let ship: Value = serde_json::from_slice(&ship_output.stdout)
-        .unwrap_or_else(|err| panic!("blocked ship should emit JSON on stdout: {err}"));
-    assert_eq!(ship["status"], "blocked");
-    assert_eq!(ship["integrated"], false);
-    assert_eq!(ship["checkpointed"], false);
+    let land: Value = serde_json::from_slice(&ship_output.stdout)
+        .unwrap_or_else(|err| panic!("blocked land should emit JSON on stdout: {err}"));
+    assert_eq!(land["status"], "blocked");
+    assert_eq!(land["integrated"], false);
+    assert_eq!(land["checkpointed"], false);
     assert_eq!(
-        ship["recommended_action"], "heddle capture -m \"...\" --confidence <confidence>",
-        "blocked policy ship should recommend recovery, not ship again: {ship}"
+        land["recommended_action"], "heddle commit -m \"...\" --confidence <confidence>",
+        "blocked policy land should recommend recovery, not land again: {land}"
     );
     assert!(
-        ship["blockers"]
+        land["blockers"]
             .as_array()
             .unwrap()
             .iter()
             .any(|blocker| blocker
                 .as_str()
                 .is_some_and(|text| text.contains("confidence 0.60 is below"))),
-        "ship should explain the policy blocker: {ship}"
+        "land should explain the policy blocker: {land}"
     );
     assert!(
-        ship["skipped_steps"]
+        land["skipped_steps"]
             .as_array()
             .unwrap()
             .iter()
             .any(|step| step == "checkpoint(not reached)"),
-        "blocked ship should not claim checkpoint was unnecessary: {ship}"
+        "blocked land should not claim checkpoint was unnecessary: {land}"
     );
     assert!(
-        !ship["skipped_steps"]
+        !land["skipped_steps"]
             .as_array()
             .unwrap()
             .iter()
             .any(|step| step == "checkpoint(not needed)"),
-        "blocked ship should reserve checkpoint(not needed) for paths that reached merge: {ship}"
+        "blocked land should reserve checkpoint(not needed) for paths that reached merge: {land}"
     );
 }
 
@@ -1939,11 +1939,11 @@ fn git_overlay_matrix_ready_thread_action_not_overridden_by_remote_push() {
     );
     assert_eq!(ready["status"], "blocked", "{ready}");
     assert_eq!(
-        ready["recommended_action"], "heddle thread refresh feature/stale-ready",
+        ready["recommended_action"], "heddle sync --thread feature/stale-ready",
         "thread-scoped ready should keep the stale-thread recovery primary, not global push: {ready}"
     );
     assert_eq!(
-        ready["report"]["recommended_action"], "heddle thread refresh feature/stale-ready",
+        ready["report"]["recommended_action"], "heddle sync --thread feature/stale-ready",
         "nested report should match the top-level ready action: {ready}"
     );
     assert!(
@@ -2024,7 +2024,7 @@ fn git_overlay_matrix_current_thread_recovery_not_overridden_by_remote_push() {
     ] {
         let output = json(&thread_path, &args);
         assert_eq!(
-            output["recommended_action"], "heddle thread refresh feature/stale-current",
+            output["recommended_action"], "heddle sync --thread feature/stale-current",
             "{label} should keep current-thread recovery primary, not global push: {output}"
         );
         assert_eq!(
@@ -3687,7 +3687,7 @@ fn git_overlay_matrix_checkpoint_closes_imported_remote_divergence_after_merge()
         "{needs_checkpoint}"
     );
     assert_eq!(
-        needs_checkpoint["recommended_action"], "heddle checkpoint -m \"...\"",
+        needs_checkpoint["recommended_action"], "heddle commit -m \"...\"",
         "after integrating upstream into Heddle, checkpoint must remain the primary way out: {needs_checkpoint}"
     );
 
@@ -3753,8 +3753,15 @@ fn git_overlay_matrix_imported_remote_divergence_surfaces_agree_on_next_action()
         ],
     );
 
-    let merge_action = "heddle merge origin/main --preview";
-    let merge_argv = Some(heddle_argv_json(["merge", "origin/main", "--preview"]));
+    let merge_action = "heddle bridge git reconcile --ref origin/main --preview";
+    let merge_argv = Some(heddle_argv_json([
+        "bridge",
+        "git",
+        "reconcile",
+        "--ref",
+        "origin/main",
+        "--preview",
+    ]));
     for (label, output) in [
         ("status", json(temp.path(), &["--output", "json", "status"])),
         ("verify", json(temp.path(), &["--output", "json", "verify"])),
@@ -3776,8 +3783,8 @@ fn git_overlay_matrix_imported_remote_divergence_surfaces_agree_on_next_action()
             merge_argv.clone(),
         );
         assert_ne!(
-            output["recommended_action"], "heddle ship",
-            "{label} must not recommend ship for imported remote divergence: {output}"
+            output["recommended_action"], "heddle land",
+            "{label} must not recommend land for imported remote divergence: {output}"
         );
     }
 
@@ -3798,7 +3805,7 @@ fn git_overlay_matrix_imported_remote_divergence_surfaces_agree_on_next_action()
     );
     json(temp.path(), &["--output", "json", "merge", "origin/main"]);
 
-    let checkpoint_action = "heddle checkpoint -m \"...\"";
+    let checkpoint_action = "heddle commit -m \"...\"";
     for (label, output) in [
         ("status", json(temp.path(), &["--output", "json", "status"])),
         ("verify", json(temp.path(), &["--output", "json", "verify"])),
@@ -5232,29 +5239,25 @@ fn git_overlay_matrix_stale_conflict_ship_blocks_with_guidance() {
     assert_eq!(before_ship["freshness"], "stale");
 
     let ship_output = heddle_output(
-        &["--output", "json", "ship", "--thread", "feature/conflict"],
+        &["--output", "json", "land", "--thread", "feature/conflict"],
         Some(temp.path()),
     )
-    .expect("invoke blocked conflict ship");
+    .expect("invoke blocked conflict land");
     assert!(
         !ship_output.status.success(),
-        "blocked conflict ship should exit nonzero"
+        "blocked conflict land should exit nonzero"
     );
-    let ship: Value = serde_json::from_slice(&ship_output.stdout)
-        .unwrap_or_else(|err| panic!("blocked conflict ship should emit JSON on stdout: {err}"));
-    assert_eq!(ship["status"], "blocked");
-    assert_eq!(ship["checkpointed"], false);
-    assert_eq!(ship["integrated"], false);
+    let land: Value = serde_json::from_slice(&ship_output.stdout)
+        .unwrap_or_else(|err| panic!("blocked conflict land should emit JSON on stdout: {err}"));
+    assert_eq!(land["status"], "blocked");
+    assert_eq!(land["checkpointed"], false);
+    assert_eq!(land["integrated"], false);
     assert!(
-        ship["next_action"]
+        land["next_action"]
             .as_str()
             .unwrap_or("")
-            .contains("refresh")
-            || ship["next_action"]
-                .as_str()
-                .unwrap_or("")
-                .contains("resolve"),
-        "blocked ship should surface the next operator step: {ship}"
+            .contains("sync --thread feature/conflict"),
+        "blocked land should surface the next operator step: {land}"
     );
 
     let thread_show = json(
@@ -5266,11 +5269,7 @@ fn git_overlay_matrix_stale_conflict_ship_blocks_with_guidance() {
         thread_show["recommended_action"]
             .as_str()
             .unwrap_or("")
-            .contains("refresh")
-            || thread_show["recommended_action"]
-                .as_str()
-                .unwrap_or("")
-                .contains("resolve")
+            .contains("sync --thread feature/conflict")
     );
 }
 
@@ -5315,7 +5314,7 @@ fn git_overlay_matrix_conflicted_merge_exits_nonzero_after_writing_markers() {
     assert!(
         parsed["recommended_action"]
             .as_str()
-            .is_some_and(|action| action == "heddle thread refresh feature/conflict-merge"),
+            .is_some_and(|action| action == "heddle sync --thread feature/conflict-merge"),
         "stale conflicted merge should refresh before materializing conflict markers: {parsed}"
     );
     let conflict_file = std::fs::read_to_string(temp.path().join("conflict.txt")).unwrap();
@@ -5380,7 +5379,7 @@ fn git_overlay_matrix_stale_conflict_thread_resolve_enters_conflict_recovery() {
     assert_eq!(preview["kind"], "merge_preview_blocked", "{preview}");
     assert_eq!(
         preview["primary_command"],
-        "heddle thread refresh feature/resolve-conflict"
+        "heddle sync --thread feature/resolve-conflict"
     );
     assert_eq!(preview["conflict_count"], 1, "{preview}");
     assert_eq!(preview["conflicts"], serde_json::json!(["conflict.txt"]));
@@ -5798,19 +5797,19 @@ fn git_overlay_matrix_stale_thread_can_recover_via_sync_then_ship() {
     );
     assert_eq!(after_sync["freshness"], "current");
 
-    let ship = json(
+    let land = json(
         temp.path(),
-        &["--output", "json", "ship", "--thread", "feature/recover"],
+        &["--output", "json", "land", "--thread", "feature/recover"],
     );
-    assert_eq!(ship["status"], "shipped");
-    assert_eq!(ship["checkpointed"], true);
-    assert!(ship["git_commit"].as_str().is_some());
+    assert_eq!(land["status"], "landed");
+    assert_eq!(land["checkpointed"], true);
+    assert!(land["git_commit"].as_str().is_some());
     assert_eq!(
-        ship["performed_steps"],
+        land["performed_steps"],
         serde_json::json!(["merge", "checkpoint"])
     );
     assert_eq!(
-        ship["skipped_steps"],
+        land["skipped_steps"],
         serde_json::json!([
             "capture(no changes)",
             "sync(current)",
@@ -5869,11 +5868,12 @@ fn git_overlay_matrix_stale_merge_preview_blocks_ship_recommendation_and_diff() 
 
     let parent_status = json(temp.path(), &["--output", "json", "status"]);
     assert_eq!(
-        parent_status["recommended_action"], "heddle thread refresh feature/stale-preview",
+        parent_status["recommended_action"], "heddle sync --thread feature/stale-preview",
         "parent status must refresh a stale ready thread before merge preview is actionable: {parent_status}"
     );
     assert_ne!(
-        parent_status["recommended_action"], "heddle merge feature/stale-preview --preview",
+        parent_status["recommended_action"],
+        "heddle merge feature/stale-preview --preview",
         "parent status must not recommend merge preview for a stale ready thread: {parent_status}"
     );
 
@@ -5902,7 +5902,7 @@ fn git_overlay_matrix_stale_merge_preview_blocks_ship_recommendation_and_diff() 
     assert_eq!(no_diff_preview["kind"], "merge_preview_blocked");
     assert_eq!(
         no_diff_preview["primary_command"],
-        "heddle thread refresh feature/stale-preview"
+        "heddle sync --thread feature/stale-preview"
     );
 
     let preview_output = heddle_output(
@@ -5932,11 +5932,11 @@ fn git_overlay_matrix_stale_merge_preview_blocks_ship_recommendation_and_diff() 
     assert_eq!(preview["kind"], "merge_preview_blocked");
     assert_eq!(
         preview["primary_command"],
-        "heddle thread refresh feature/stale-preview"
+        "heddle sync --thread feature/stale-preview"
     );
     assert_eq!(
         preview["recovery_commands"],
-        serde_json::json!(["heddle thread refresh feature/stale-preview"])
+        serde_json::json!(["heddle sync --thread feature/stale-preview"])
     );
     assert!(
         preview["unsafe_condition"]
@@ -5949,8 +5949,8 @@ fn git_overlay_matrix_stale_merge_preview_blocks_ship_recommendation_and_diff() 
         !preview["primary_command"]
             .as_str()
             .unwrap_or("")
-            .contains("ship"),
-        "stale preview must not recommend ship: {preview}"
+            .contains("land"),
+        "stale preview must not recommend land: {preview}"
     );
 }
 
@@ -6020,14 +6020,14 @@ fn git_overlay_matrix_ship_uses_thread_intent_for_git_checkpoint_subject() {
     git_commit_all(temp.path(), "base");
     heddle_adopt(temp.path());
 
-    let feature_path = temp.path().with_extension("feature-ship-message");
+    let feature_path = temp.path().with_extension("feature-land-message");
     json(
         temp.path(),
         &[
             "--output",
             "json",
             "start",
-            "feature/ship-message",
+            "feature/land-message",
             "--path",
             feature_path.to_str().unwrap(),
         ],
@@ -6039,20 +6039,20 @@ fn git_overlay_matrix_ship_uses_thread_intent_for_git_checkpoint_subject() {
     );
     assert_eq!(ready["status"], "completed");
 
-    let ship = json(
+    let land = json(
         temp.path(),
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
-            "feature/ship-message",
+            "feature/land-message",
             "--no-push",
         ],
     );
-    assert_eq!(ship["status"], "shipped");
-    assert_eq!(ship["checkpointed"], true);
-    assert!(ship["git_commit"].as_str().is_some());
+    assert_eq!(land["status"], "landed");
+    assert_eq!(land["checkpointed"], true);
+    assert!(land["git_commit"].as_str().is_some());
     assert_eq!(
         git_stdout(temp.path(), &["log", "-1", "--pretty=%s"]),
         "Add evaluation tags"
@@ -6067,7 +6067,7 @@ fn git_overlay_matrix_ship_uses_thread_intent_for_git_checkpoint_subject() {
             .unwrap()
             .iter()
             .any(|record| record["summary"] == "Add evaluation tags"),
-        "ship should record the meaningful thread intent as the Git checkpoint summary: {checkpoint_records}"
+        "land should record the meaningful thread intent as the Git checkpoint summary: {checkpoint_records}"
     );
 }
 
@@ -6084,19 +6084,19 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     git(&["push", "-u", "origin", "main"], temp.path());
     heddle_adopt(temp.path());
 
-    let feature_path = temp.path().with_extension("feature-ship-undo");
+    let feature_path = temp.path().with_extension("feature-land-undo");
     let started = json(
         temp.path(),
         &[
             "--output",
             "json",
             "start",
-            "feature/ship-undo",
+            "feature/land-undo",
             "--path",
             feature_path.to_str().unwrap(),
         ],
     );
-    assert_eq!(started["thread"]["name"], "feature/ship-undo");
+    assert_eq!(started["thread"]["name"], "feature/land-undo");
 
     std::fs::write(feature_path.join("README.md"), "base\nfeature\n").unwrap();
     std::fs::write(feature_path.join("feature.txt"), "feature\n").unwrap();
@@ -6107,7 +6107,7 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
             "json",
             "ready",
             "-m",
-            "feature ready for ship undo",
+            "feature ready for land undo",
         ],
     );
     assert_eq!(ready["status"], "completed");
@@ -6117,28 +6117,28 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     assert_eq!(base_verify["status"], "clean");
     assert_eq!(
         base_verify["recommended_action"],
-        "heddle merge feature/ship-undo --preview"
+        "heddle land --thread feature/land-undo --no-push"
     );
 
-    let ship = json(
+    let land = json(
         temp.path(),
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
-            "feature/ship-undo",
+            "feature/land-undo",
             "--no-push",
         ],
     );
-    assert_eq!(ship["status"], "shipped");
-    assert_eq!(ship["checkpointed"], true);
-    assert_eq!(ship["verification"]["verified"], true);
-    assert_eq!(ship["verification"]["status"], "clean");
-    assert_eq!(ship["verification"]["recommended_action"], "heddle push");
-    assert_eq!(ship["recommended_action"], "heddle push");
-    assert_eq!(ship["next_action"], "heddle push");
-    assert!(ship["git_commit"].as_str().is_some());
+    assert_eq!(land["status"], "landed");
+    assert_eq!(land["checkpointed"], true);
+    assert_eq!(land["verification"]["verified"], true);
+    assert_eq!(land["verification"]["status"], "clean");
+    assert_eq!(land["verification"]["recommended_action"], "heddle push");
+    assert_eq!(land["recommended_action"], "heddle push");
+    assert_eq!(land["next_action"], "heddle push");
+    assert!(land["git_commit"].as_str().is_some());
 
     let after_ship = json(temp.path(), &["--output", "json", "verify"]);
     assert_eq!(after_ship["verified"], true);
@@ -6146,7 +6146,7 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     assert_eq!(after_ship["recommended_action"], "heddle push");
     let thread_after_ship = json(
         temp.path(),
-        &["--output", "json", "thread", "show", "feature/ship-undo"],
+        &["--output", "json", "thread", "show", "feature/land-undo"],
     );
     assert_eq!(thread_after_ship["thread_state"], "merged");
     assert_eq!(
@@ -6160,27 +6160,27 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     let after_undo = json(temp.path(), &["--output", "json", "verify"]);
     assert_eq!(
         after_undo["verified"], true,
-        "ship undo should not leave Git/Heddle mapping blocked: {after_undo}"
+        "land undo should not leave Git/Heddle mapping blocked: {after_undo}"
     );
     assert_eq!(after_undo["status"], "clean");
     assert_eq!(
         after_undo["recommended_action"],
-        "heddle merge feature/ship-undo --preview"
+        "heddle land --thread feature/land-undo --no-push"
     );
     let status_after_undo = json(temp.path(), &["--output", "json", "status"]);
     assert_eq!(
-        status_after_undo["recommended_action"], "heddle merge feature/ship-undo --preview",
-        "status should restore the ready workflow action after ship undo: {status_after_undo}"
+        status_after_undo["recommended_action"], "heddle land --thread feature/land-undo --no-push",
+        "status should restore the ready workflow action after land undo: {status_after_undo}"
     );
     let thread_list_after_undo = json(temp.path(), &["--output", "json", "thread", "list"]);
     assert_eq!(
-        thread_list_after_undo["recommended_action"], "heddle merge feature/ship-undo --preview",
-        "thread list should restore the ready workflow action after ship undo: {thread_list_after_undo}"
+        thread_list_after_undo["recommended_action"], "heddle land --thread feature/land-undo --no-push",
+        "thread list should restore the ready workflow action after land undo: {thread_list_after_undo}"
     );
     let workspace_after_undo = json(temp.path(), &["--output", "json", "workspace", "show"]);
     assert_eq!(
-        workspace_after_undo["recommended_action"], "heddle merge feature/ship-undo --preview",
-        "workspace should restore the ready workflow action after ship undo: {workspace_after_undo}"
+        workspace_after_undo["recommended_action"], "heddle land --thread feature/land-undo --no-push",
+        "workspace should restore the ready workflow action after land undo: {workspace_after_undo}"
     );
     assert_eq!(git_status_short(temp.path()), "");
     assert!(
@@ -6190,16 +6190,16 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
 
     let thread_after_undo = json(
         temp.path(),
-        &["--output", "json", "thread", "show", "feature/ship-undo"],
+        &["--output", "json", "thread", "show", "feature/land-undo"],
     );
     assert_eq!(
         thread_after_undo["thread_state"], "ready",
-        "undoing the ship should unmark the source thread as merged: {thread_after_undo}"
+        "undoing the land should unmark the source thread as merged: {thread_after_undo}"
     );
     assert_eq!(
         thread_after_undo["integration_policy_result"]["status"],
         Value::Null,
-        "undoing the ship should clear stale auto-integrated metadata: {thread_after_undo}"
+        "undoing the land should clear stale auto-integrated metadata: {thread_after_undo}"
     );
 
     let thread_record_path = std::fs::read_dir(temp.path().join(".heddle/thread_records"))
@@ -6208,7 +6208,7 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
         .map(|entry| entry.path())
         .find(|path| {
             std::fs::read_to_string(path)
-                .map(|content| content.contains(r#"thread = "feature/ship-undo""#))
+                .map(|content| content.contains(r#"thread = "feature/land-undo""#))
                 .unwrap_or(false)
         })
         .expect("feature thread record should exist");
@@ -6252,12 +6252,12 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     assert_eq!(git_status_short(temp.path()), "");
     assert!(
         temp.path().join("feature.txt").exists(),
-        "redo should restore the shipped feature file once preflights pass"
+        "redo should restore the landed feature file once preflights pass"
     );
 
     let thread_after_redo = json(
         temp.path(),
-        &["--output", "json", "thread", "show", "feature/ship-undo"],
+        &["--output", "json", "thread", "show", "feature/land-undo"],
     );
     assert_eq!(thread_after_redo["thread_state"], "merged");
     assert_eq!(
@@ -6311,15 +6311,15 @@ fn git_overlay_matrix_ship_push_without_remote_refuses_before_mutation() {
     );
     assert_eq!(
         preview["recommended_action"],
-        "heddle ship --thread feature/no-remote-push --no-push"
+        "heddle land --thread feature/no-remote-push --no-push"
     );
     assert_eq!(
         preview["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ship", "--thread", "feature/no-remote-push", "--no-push"])
+        heddle_argv_json(["land", "--thread", "feature/no-remote-push", "--no-push"])
     );
     assert_eq!(
         preview["verification"]["recommended_action"],
-        "heddle ship --thread feature/no-remote-push --no-push"
+        "heddle land --thread feature/no-remote-push --no-push"
     );
 
     let before_state = json(temp.path(), &["--output", "json", "status"])["current_state"].clone();
@@ -6329,17 +6329,17 @@ fn git_overlay_matrix_ship_push_without_remote_refuses_before_mutation() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/no-remote-push",
             "--push",
         ],
         Some(temp.path()),
     )
-    .expect("invoke ship --push");
+    .expect("invoke land --push");
     assert!(
         !push.status.success(),
-        "ship --push should refuse without a remote"
+        "land --push should refuse without a remote"
     );
     assert!(
         push.stdout.is_empty(),
@@ -6349,15 +6349,15 @@ fn git_overlay_matrix_ship_push_without_remote_refuses_before_mutation() {
     let stderr = std::str::from_utf8(&push.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "ship_push_remote_missing");
+    assert_eq!(envelope["kind"], "land_push_remote_missing");
     assert_json_recovery_advice_fields(&envelope, &envelope.to_string());
     assert!(
         envelope["preserved"]
             .as_str()
             .is_some_and(|preserved| preserved.contains("repository state"))
             && envelope["primary_command"]
-                == "heddle ship --thread feature/no-remote-push --no-push",
-        "refusal should explain preservation and local ship recovery: {envelope}"
+                == "heddle land --thread feature/no-remote-push --no-push",
+        "refusal should explain preservation and local land recovery: {envelope}"
     );
     assert_eq!(
         json(temp.path(), &["--output", "json", "status"])["current_state"],
@@ -6408,11 +6408,11 @@ fn git_overlay_matrix_ship_remote_without_push_refuses_before_mutation() {
     let before_state = json(temp.path(), &["--output", "json", "status"])["current_state"].clone();
     let before_git = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
     let before_refs = git_ref_snapshot(temp.path());
-    let ship = heddle_output(
+    let land = heddle_output(
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/remote-without-push",
             "--remote",
@@ -6420,23 +6420,23 @@ fn git_overlay_matrix_ship_remote_without_push_refuses_before_mutation() {
         ],
         Some(temp.path()),
     )
-    .expect("invoke ship --remote");
+    .expect("invoke land --remote");
     assert!(
-        !ship.status.success(),
-        "ship --remote without --push should refuse"
+        !land.status.success(),
+        "land --remote without --push should refuse"
     );
     assert!(
-        ship.stdout.is_empty(),
+        land.stdout.is_empty(),
         "JSON refusal should not emit partial stdout: {}",
-        String::from_utf8_lossy(&ship.stdout)
+        String::from_utf8_lossy(&land.stdout)
     );
-    let stderr = std::str::from_utf8(&ship.stderr).unwrap();
+    let stderr = std::str::from_utf8(&land.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "ship_remote_requires_push");
+    assert_eq!(envelope["kind"], "land_remote_requires_push");
     assert_eq!(
         envelope["primary_command"],
-        "heddle ship --thread feature/remote-without-push --push --remote origin"
+        "heddle land --thread feature/remote-without-push --push --remote origin"
     );
     assert_json_recovery_advice_fields(&envelope, &envelope.to_string());
     assert_eq!(
@@ -6491,15 +6491,15 @@ fn git_overlay_matrix_ship_push_failure_reports_partial_local_ship() {
     );
     assert_eq!(
         preview["recommended_action"],
-        "heddle ship --thread feature/partial-push --no-push"
+        "heddle land --thread feature/partial-push --no-push"
     );
     assert_eq!(
         preview["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ship", "--thread", "feature/partial-push", "--no-push"])
+        heddle_argv_json(["land", "--thread", "feature/partial-push", "--no-push"])
     );
     assert_eq!(
         preview["verification"]["recommended_action"],
-        "heddle ship --thread feature/partial-push --no-push"
+        "heddle land --thread feature/partial-push --no-push"
     );
 
     let text_preview = heddle(
@@ -6515,8 +6515,8 @@ fn git_overlay_matrix_ship_push_failure_reports_partial_local_ship() {
     )
     .expect("text merge preview with diff should succeed");
     assert!(
-        text_preview.contains("Next: heddle ship --thread feature/partial-push --no-push"),
-        "text merge preview should recommend local ship first: {text_preview}"
+        text_preview.contains("Next: heddle land --thread feature/partial-push --no-push"),
+        "text merge preview should recommend local land first: {text_preview}"
     );
     assert!(
         !text_preview.contains("--push"),
@@ -6529,7 +6529,7 @@ fn git_overlay_matrix_ship_push_failure_reports_partial_local_ship() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/partial-push",
             "--push",
@@ -6538,7 +6538,7 @@ fn git_overlay_matrix_ship_push_failure_reports_partial_local_ship() {
         ],
         Some(temp.path()),
     )
-    .expect("invoke ship --push");
+    .expect("invoke land --push");
     assert!(!push.status.success(), "push to missing remote should fail");
     assert!(
         push.stdout.is_empty(),
@@ -6548,7 +6548,7 @@ fn git_overlay_matrix_ship_push_failure_reports_partial_local_ship() {
     let stderr = std::str::from_utf8(&push.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "ship_push_partial_failure");
+    assert_eq!(envelope["kind"], "land_push_partial_failure");
     assert_json_recovery_advice_fields(&envelope, &envelope.to_string());
     assert!(
         envelope["preserved"]
@@ -6646,56 +6646,56 @@ fn git_overlay_matrix_ship_no_push_refuses_known_upstream_drift_before_mutation(
     let before_git = git_stdout(&local, &["rev-parse", "HEAD"]);
     let before_refs = git_ref_snapshot(&local);
 
-    let ship = heddle_output(
+    let land = heddle_output(
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "isolated",
             "--no-push",
         ],
         Some(&local),
     )
-    .expect("invoke ship --no-push with known upstream drift");
+    .expect("invoke land --no-push with known upstream drift");
     assert!(
-        !ship.status.success(),
-        "ship should fail before landing when checkpoint cannot move Git safely"
+        !land.status.success(),
+        "land should fail before landing when checkpoint cannot move Git safely"
     );
     assert!(
-        ship.stdout.is_empty(),
+        land.stdout.is_empty(),
         "JSON refusal should not emit partial stdout: {}",
-        String::from_utf8_lossy(&ship.stdout)
+        String::from_utf8_lossy(&land.stdout)
     );
-    let stderr = std::str::from_utf8(&ship.stderr).unwrap();
+    let stderr = std::str::from_utf8(&land.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "ship_requires_current_upstream");
+    assert_eq!(envelope["kind"], "land_requires_current_upstream");
     assert_eq!(envelope["primary_command"], "heddle pull");
     assert!(
         envelope["preserved"]
             .as_str()
             .is_some_and(|preserved| preserved.contains("left unchanged")),
-        "refusal should clearly promise no local ship occurred: {envelope}"
+        "refusal should clearly promise no local land occurred: {envelope}"
     );
 
     let after_status = json(&local, &["--output", "json", "status"]);
     assert_eq!(
         after_status["current_state"], before_state,
-        "failed ship must not fast-forward the parent Heddle thread"
+        "failed land must not fast-forward the parent Heddle thread"
     );
     assert_eq!(git_stdout(&local, &["rev-parse", "HEAD"]), before_git);
     assert_eq!(
         git_ref_snapshot(&local),
         before_refs,
-        "failed ship must not move visible Git refs"
+        "failed land must not move visible Git refs"
     );
     let undo_list = json(&local, &["--output", "json", "undo", "--list"]);
     assert!(
         !undo_list
             .to_string()
             .contains("fast-forward isolated into main"),
-        "failed ship must not leave an undo batch for a merge that should not have happened: {undo_list}"
+        "failed land must not leave an undo batch for a merge that should not have happened: {undo_list}"
     );
 }
 
@@ -6730,32 +6730,32 @@ fn git_overlay_matrix_ship_refuses_index_lock_before_mutation() {
     let before_refs = git_ref_snapshot(temp.path());
     std::fs::write(temp.path().join(".git/index.lock"), "stale lock").unwrap();
 
-    let ship = heddle_output(
+    let land = heddle_output(
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/index-lock",
             "--no-push",
         ],
         Some(temp.path()),
     )
-    .expect("invoke ship with index lock");
+    .expect("invoke land with index lock");
     assert!(
-        !ship.status.success(),
-        "ship should fail before landing when checkpoint preflight sees index lock"
+        !land.status.success(),
+        "land should fail before landing when checkpoint preflight sees index lock"
     );
-    assert!(ship.stdout.is_empty());
-    let stderr = std::str::from_utf8(&ship.stderr).unwrap();
+    assert!(land.stdout.is_empty());
+    let stderr = std::str::from_utf8(&land.stderr).unwrap();
     let envelope: Value =
         serde_json::from_str(stderr).unwrap_or_else(|err| panic!("stderr JSON: {err}: {stderr}"));
-    assert_eq!(envelope["kind"], "ship_checkpoint_preflight_blocked");
+    assert_eq!(envelope["kind"], "land_checkpoint_preflight_blocked");
     assert_eq!(envelope["primary_command"], "heddle status");
     assert_eq!(
         json(temp.path(), &["--output", "json", "status"])["current_state"],
         before_state,
-        "failed ship must not fast-forward Heddle state"
+        "failed land must not fast-forward Heddle state"
     );
     assert_eq!(git_stdout(temp.path(), &["rev-parse", "HEAD"]), before_git);
     assert_eq!(git_ref_snapshot(temp.path()), before_refs);
@@ -7314,13 +7314,13 @@ fn git_overlay_matrix_stale_ship_manual_resolution_then_retry_ships() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/manual-recover",
         ],
     );
     assert_eq!(blocked["status"], "blocked");
-    assert_operator_json_contract(&blocked, "ship");
+    assert_operator_json_contract(&blocked, "land");
 
     let refresh_error = heddle(
         &[
@@ -7350,8 +7350,8 @@ fn git_overlay_matrix_stale_ship_manual_resolution_then_retry_ships() {
     assert!(
         continued["recommended_action"]
             .as_str()
-            .is_some_and(|action| action.contains("ship")),
-        "continue should hand the operator back to the parent ship flow: {continued}"
+            .is_some_and(|action| action.contains("land")),
+        "continue should hand the operator back to the parent land flow: {continued}"
     );
 
     let after_continue = json(
@@ -7401,13 +7401,13 @@ fn git_overlay_matrix_stale_ship_manual_resolution_then_retry_ships() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/manual-recover",
         ],
     );
-    assert_eq!(retry_ship["status"], "shipped");
-    assert_operator_json_contract(&retry_ship, "ship");
+    assert_eq!(retry_ship["status"], "landed");
+    assert_operator_json_contract(&retry_ship, "land");
     assert_eq!(retry_ship["checkpointed"], true);
     assert!(retry_ship["git_commit"].as_str().is_some());
     let expected_next_action = if retry_ship["verification"]["recommended_action"] == "heddle push"
@@ -7460,13 +7460,13 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/manual-push",
         ],
     );
     assert_eq!(blocked["status"], "blocked");
-    assert_operator_json_contract(&blocked, "ship");
+    assert_operator_json_contract(&blocked, "land");
 
     let refresh_error = heddle(
         &[
@@ -7504,7 +7504,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
         &[
             "--output",
             "json",
-            "ship",
+            "land",
             "--thread",
             "feature/manual-push",
             "--push",
@@ -7512,8 +7512,8 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
             "origin",
         ],
     );
-    assert_eq!(retry_ship["status"], "shipped");
-    assert_operator_json_contract(&retry_ship, "ship");
+    assert_eq!(retry_ship["status"], "landed");
+    assert_operator_json_contract(&retry_ship, "land");
     assert_eq!(retry_ship["checkpointed"], true);
     assert_eq!(retry_ship["pushed"], true);
     assert_eq!(retry_ship["pushed_remote"], "origin");
@@ -7527,7 +7527,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
             .expect("performed_steps array")
             .iter()
             .any(|step| step == "push"),
-        "manual-resolution ship --push should record the push step: {retry_ship}"
+        "manual-resolution land --push should record the push step: {retry_ship}"
     );
     assert!(
         !retry_ship["skipped_steps"]
@@ -7535,7 +7535,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
             .expect("skipped_steps array")
             .iter()
             .any(|step| step == "push(not requested)"),
-        "manual-resolution ship --push must not claim the push was not requested: {retry_ship}"
+        "manual-resolution land --push must not claim the push was not requested: {retry_ship}"
     );
     assert_eq!(
         retry_ship["recommended_action"],
@@ -7544,7 +7544,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
     assert_eq!(
         git_stdout(origin.path(), &["rev-parse", "refs/heads/feature/drop-in"]),
         git_stdout(temp.path(), &["rev-parse", "HEAD"]),
-        "explicit ship --push --remote origin should update the remote branch"
+        "explicit land --push --remote origin should update the remote branch"
     );
     let verify = json(temp.path(), &["--output", "json", "verify"]);
     assert_eq!(verify["verified"], true);

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1853,9 +1853,19 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
     assert_eq!(land["status"], "blocked");
     assert_eq!(land["integrated"], false);
     assert_eq!(land["checkpointed"], false);
+    // heddle#464 bug 2: this land runs from the PARENT checkout (`temp.path()`)
+    // against an isolated thread whose checkout is `thread_path`. An unscoped
+    // `heddle commit` would commit the parent and never update the blocked
+    // thread's confidence, so the recovery must scope the recapture to the
+    // thread via the global `--repo` flag. (Contrast the in-thread `ready`
+    // recovery above, which stays unscoped.)
+    let expected_scoped_recapture = format!(
+        "heddle --repo {} commit -m \"...\" --confidence <confidence>",
+        thread_path.display()
+    );
     assert_eq!(
-        land["recommended_action"], "heddle commit -m \"...\" --confidence <confidence>",
-        "blocked policy land should recommend recovery, not land again: {land}"
+        land["recommended_action"], expected_scoped_recapture,
+        "blocked policy land from the parent must scope the recapture to the thread's checkout, not land again or commit the parent: {land}"
     );
     assert!(
         land["blockers"]

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -1256,7 +1256,7 @@ fn git_replacement_matrix_branch_like_thread_refresh_without_git_on_path() {
     let verify = assert_verify_failed_json_without_git(&["--output", "json", "verify"], &work);
     assert_eq!(verify["status"], "needs_checkpoint", "{verify}");
     assert_eq!(
-        verify["recommended_action"], "heddle checkpoint -m \"...\"",
+        verify["recommended_action"], "heddle commit -m \"...\"",
         "{verify}"
     );
 }

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{heddle, heddle_output};
+
+const BANNED_NEXT_ACTION_FRAGMENTS: &[&str] = &[
+    "heddle checkpoint",
+    "heddle capture",
+    "heddle ship",
+    "heddle merge",
+    "heddle thread refresh",
+    "heddle thread resolve",
+];
+
+fn json(args: &[&str], cwd: &std::path::Path) -> Value {
+    let output = heddle_output(args, Some(cwd)).unwrap_or_else(|err| {
+        panic!("`heddle {}` should run: {err}", args.join(" "))
+    });
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|err| {
+        panic!(
+            "`heddle {}` should emit JSON: {err}\nstdout: {stdout}\nstderr: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn setup_native_repo() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+    heddle(&["commit", "-m", "base"], Some(temp.path())).unwrap();
+    temp
+}
+
+fn setup_managed_thread(name: &str) -> (TempDir, TempDir, String) {
+    let main = setup_native_repo();
+    let checkout = TempDir::new().unwrap();
+    let checkout_arg = checkout.path().join("work");
+    let started = json(
+        &[
+            "--output",
+            "json",
+            "start",
+            name,
+            "--path",
+            checkout_arg.to_str().unwrap(),
+        ],
+        main.path(),
+    );
+    let execution_path = started["execution_path"]
+        .as_str()
+        .expect("start should report execution_path")
+        .to_string();
+    (main, checkout, execution_path)
+}
+
+fn assert_no_banned_next_actions(value: &Value) {
+    fn walk(value: &Value, path: &str) {
+        match value {
+            Value::Object(map) => {
+                for (key, child) in map {
+                    let child_path = format!("{path}.{key}");
+                    if matches!(key.as_str(), "next_action" | "recommended_action")
+                        && let Some(action) = child.as_str()
+                    {
+                        for banned in BANNED_NEXT_ACTION_FRAGMENTS {
+                            assert!(
+                                !action.starts_with(banned),
+                                "{child_path} used banned next-action `{action}`"
+                            );
+                        }
+                    }
+                    walk(child, &child_path);
+                }
+            }
+            Value::Array(items) => {
+                for (index, child) in items.iter().enumerate() {
+                    walk(child, &format!("{path}[{index}]"));
+                }
+            }
+            _ => {}
+        }
+    }
+    walk(value, "$");
+}
+
+#[test]
+fn native_dirty_status_and_thread_list_suggest_commit_not_capture_or_checkpoint() {
+    let repo = setup_native_repo();
+    std::fs::write(repo.path().join("dirty.txt"), "dirty\n").unwrap();
+
+    let status = json(&["--output", "json", "status"], repo.path());
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
+    assert_no_banned_next_actions(&status);
+
+    let threads = json(&["--output", "json", "thread", "list"], repo.path());
+    assert_no_banned_next_actions(&threads);
+}
+
+#[test]
+fn dirty_isolated_checkout_suggests_commit_and_never_checkpoint() {
+    let (_main, checkout_owner, execution_path) = setup_managed_thread("feature/dirty");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("dirty.txt"), "dirty\n").unwrap();
+
+    let status = json(&["--output", "json", "status"], checkout);
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
+    assert_no_banned_next_actions(&status);
+
+    drop(checkout_owner);
+}
+
+#[test]
+fn ready_thread_surfaces_land_across_ready_show_and_list() {
+    let (main, checkout_owner, execution_path) = setup_managed_thread("feature/ready-land");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["commit", "-m", "feature"], Some(checkout)).unwrap();
+
+    let ready = json(
+        &["--output", "json", "ready", "--thread", "feature/ready-land"],
+        main.path(),
+    );
+    assert_eq!(ready["recommended_action"], "heddle land --thread feature/ready-land --no-push");
+    assert_eq!(
+        ready["report"]["recommended_action"],
+        "heddle land --thread feature/ready-land --no-push"
+    );
+    assert_no_banned_next_actions(&ready);
+
+    let shown = json(
+        &["--output", "json", "thread", "show", "feature/ready-land"],
+        main.path(),
+    );
+    assert_eq!(
+        shown["next_action"],
+        "heddle land --thread feature/ready-land --no-push"
+    );
+    assert_no_banned_next_actions(&shown);
+
+    let listed = json(&["--output", "json", "thread", "list"], main.path());
+    let thread = listed["threads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|thread| thread["name"] == "feature/ready-land")
+        .expect("thread list should include ready thread");
+    assert_eq!(
+        thread["recommended_action"],
+        "heddle land --thread feature/ready-land --no-push"
+    );
+    assert_no_banned_next_actions(&listed);
+
+    drop(checkout_owner);
+}
+
+#[test]
+fn stale_managed_thread_suggests_sync_not_refresh_or_merge_preview() {
+    let (main, checkout_owner, execution_path) = setup_managed_thread("feature/stale-sync");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["commit", "-m", "feature"], Some(checkout)).unwrap();
+
+    std::fs::write(main.path().join("base.txt"), "base changed\n").unwrap();
+    heddle(&["commit", "-m", "advance main"], Some(main.path())).unwrap();
+
+    let ready = json(
+        &["--output", "json", "ready", "--thread", "feature/stale-sync"],
+        main.path(),
+    );
+    assert_eq!(
+        ready["recommended_action"],
+        "heddle sync --thread feature/stale-sync"
+    );
+    assert_eq!(
+        ready["report"]["recommended_action"],
+        "heddle sync --thread feature/stale-sync"
+    );
+    assert_no_banned_next_actions(&ready);
+
+    let shown = json(
+        &["--output", "json", "thread", "show", "feature/stale-sync"],
+        main.path(),
+    );
+    assert_eq!(
+        shown["next_action"],
+        "heddle sync --thread feature/stale-sync"
+    );
+    assert_no_banned_next_actions(&shown);
+
+    drop(checkout_owner);
+}

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -194,3 +194,51 @@ fn stale_managed_thread_suggests_sync_not_refresh_or_merge_preview() {
 
     drop(checkout_owner);
 }
+
+// heddle#464 r2: `sync --thread` on a stale thread whose replay genuinely
+// conflicts used to emit `heddle resolve --list` *before* refreshing — a dead
+// breadcrumb, because no merge state existed yet and the top-level `resolve`
+// failed with `no_merge_in_progress`. sync must now materialize the conflict
+// (merge state + worktree markers) so the emitted breadcrumb actually runs.
+#[test]
+fn sync_conflicting_stale_thread_emits_runnable_resolve_breadcrumb() {
+    let (main, checkout_owner, execution_path) = setup_managed_thread("feature/conflict-sync");
+    let checkout = std::path::Path::new(&execution_path);
+
+    // Both sides edit the SAME file divergently so the refresh genuinely
+    // conflicts. (Disjoint-file edits 3-way merge cleanly — that path is
+    // covered by `stale_managed_thread_suggests_sync_not_refresh_or_merge_preview`.)
+    std::fs::write(checkout.join("base.txt"), "thread change\n").unwrap();
+    heddle(&["commit", "-m", "thread edit"], Some(checkout)).unwrap();
+
+    std::fs::write(main.path().join("base.txt"), "main change\n").unwrap();
+    heddle(&["commit", "-m", "advance main"], Some(main.path())).unwrap();
+
+    let sync = json(
+        &["--output", "json", "sync", "--thread", "feature/conflict-sync"],
+        main.path(),
+    );
+    assert_eq!(sync["status"], "blocked", "conflicting sync must block: {sync}");
+    let next_action = sync["next_action"]
+        .as_str()
+        .unwrap_or_else(|| panic!("sync conflict must carry a next_action: {sync}"));
+    assert!(
+        next_action.contains("resolve --list"),
+        "sync conflict breadcrumb should drive the resolve flow: {sync}"
+    );
+    assert_no_banned_next_actions(&sync);
+
+    // The breadcrumb must actually run: the conflict was materialized in the
+    // thread's checkout, so `resolve --list` there reads real merge state
+    // instead of failing with `no_merge_in_progress`.
+    let resolve = heddle_output(&["--output", "json", "resolve", "--list"], Some(checkout))
+        .expect("resolve --list should spawn");
+    assert!(
+        resolve.status.success(),
+        "materialized resolve --list must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&resolve.stdout),
+        String::from_utf8_lossy(&resolve.stderr),
+    );
+
+    drop(checkout_owner);
+}

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -12,7 +12,7 @@ fn git_overlay_guide_is_concise_and_actionable() {
         help.contains("Git-overlay quick start")
             && help.contains("heddle adopt")
             && help.contains("heddle commit -m")
-            && help.contains("heddle merge <name> --preview"),
+            && help.contains("heddle land --thread <name> --no-push"),
         "help git-overlay should render the actual guide, not only clap usage: {help}"
     );
 
@@ -37,8 +37,8 @@ fn git_overlay_guide_is_concise_and_actionable() {
         "guide should teach isolated threads with the real start argument name: {output}"
     );
     assert!(
-        output.contains("heddle merge <name> --preview"),
-        "guide should teach preview before landing: {output}"
+        output.contains("heddle land --thread <name> --no-push"),
+        "guide should teach landing after readiness: {output}"
     );
     assert!(
         output.contains("heddle undo"),
@@ -60,7 +60,7 @@ fn model_help_topic_gives_short_first_time_mental_model() {
             && help.contains("Capture:")
             && help.contains("Commit:")
             && help.contains("Verify:")
-            && help.contains("heddle merge <name> --preview")
+            && help.contains("heddle land --thread <name>")
             && help.contains("heddle adopt"),
         "model topic should explain the everyday concepts without the long thread manual: {help}"
     );
@@ -85,8 +85,7 @@ fn bridge_help_topic_teaches_adoption_before_export_notes() {
         "heddle verify",
         "heddle commit -m",
         "heddle push",
-        "heddle merge <name> --preview",
-        "heddle ship --thread <name> --no-push",
+        "heddle land --thread <name> --no-push",
         "heddle bridge git reconcile --ref <branch> --preview",
         "Export metadata for Git readers",
     ] {
@@ -100,8 +99,8 @@ fn bridge_help_topic_teaches_adoption_before_export_notes() {
         "bridge topic should put adoption before notes/export details: {help}"
     );
     assert!(
-        !help.contains("\n    heddle ship --push\n"),
-        "bridge topic should not teach a threadless ship from the main checkout: {help}"
+        !help.contains("\n    heddle land --push\n"),
+        "bridge topic should not teach a threadless land from the main checkout: {help}"
     );
 }
 
@@ -1077,7 +1076,7 @@ fn command_catalog_exposes_agent_metadata_for_options() {
     );
     for placeholder in [
         "heddle capture -m \"...\"",
-        "heddle checkpoint -m \"...\"",
+        "heddle commit -m \"...\"",
         "heddle commit -m \"...\"",
         "heddle stash push -m \"...\"",
         "heddle switch <branch>",
@@ -1508,7 +1507,7 @@ fn verify_cold_flow_scripts_assert_required_proof_steps() {
             );
             assert!(
                 source.contains("assert_merge_preview_points_to_ship_json"),
-                "{} should prove merge preview points to the ship landing loop",
+                "{} should prove merge preview points to the land landing loop",
                 script.display()
             );
             assert!(
@@ -3117,7 +3116,7 @@ fn core_loop_schemas_are_discoverable() {
         "stash clear",
         "stash show",
         "revert",
-        "ship",
+        "land",
         "start",
         "thread create",
         "thread current",
@@ -3392,7 +3391,7 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
     )
     .unwrap();
     assert!(
-        capture_text.contains("Next:") && capture_text.contains("heddle checkpoint -m \"...\""),
+        capture_text.contains("Next:") && capture_text.contains("heddle commit -m \"...\""),
         "Git-overlay capture should point to the concrete checkpoint step: {capture_text}"
     );
     assert!(
@@ -3415,7 +3414,7 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
         status["thread_state"], "blocked",
         "captured work that only needs a Git checkpoint should not rewrite lifecycle as blocked: {status}"
     );
-    assert_eq!(status["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(status["recommended_action"], "heddle commit -m \"...\"");
     assert!(
         status["verification"]["recommended_action_template"]["required_inputs"]
             .as_array()
@@ -3424,7 +3423,7 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
     );
     assert_eq!(
         status["recovery_commands"],
-        serde_json::json!(["heddle checkpoint -m \"...\""])
+        serde_json::json!(["heddle commit -m \"...\""])
     );
     assert_eq!(
         status["recovery_action_templates"], status["verification"]["recovery_action_templates"],
@@ -3432,17 +3431,17 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
     );
     assert_eq!(
         status["recovery_action_templates"][0]["argv_template"],
-        heddle_argv_json(["checkpoint", "-m", "<message>"]),
-        "templated checkpoint recovery should be machine-fillable at top level: {status}"
+        heddle_argv_json(["commit", "-m", "<message>"]),
+        "templated commit recovery should be machine-fillable at top level: {status}"
     );
     let thread_list = json_value(temp.path(), &["thread", "list", "--output", "json"]);
     assert_eq!(
-        thread_list["recommended_action"], "heddle checkpoint -m \"...\"",
+        thread_list["recommended_action"], "heddle commit -m \"...\"",
         "thread list should use the same verification blocker as status: {thread_list}"
     );
     assert_eq!(
         thread_list["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["checkpoint", "-m", "<message>"]),
+        heddle_argv_json(["commit", "-m", "<message>"]),
         "thread list top-level placeholder action should be machine-fillable: {thread_list}"
     );
     assert_eq!(
@@ -3451,12 +3450,12 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
     );
     let workspace = json_value(temp.path(), &["workspace", "show", "--output", "json"]);
     assert_eq!(
-        workspace["recommended_action"], "heddle checkpoint -m \"...\"",
+        workspace["recommended_action"], "heddle commit -m \"...\"",
         "workspace should use the same verification blocker as status: {workspace}"
     );
     assert_eq!(
         workspace["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["checkpoint", "-m", "<message>"]),
+        heddle_argv_json(["commit", "-m", "<message>"]),
         "workspace top-level placeholder action should be machine-fillable: {workspace}"
     );
     assert_eq!(status["verification"]["worktree_dirty"], true);
@@ -3487,7 +3486,7 @@ fn captured_git_overlay_work_recommends_checkpoint_not_recapture() {
 
     let verify = json_value(temp.path(), &["verify", "--output", "json"]);
     assert_eq!(verify["status"], "needs_checkpoint");
-    assert_eq!(verify["recommended_action"], "heddle checkpoint -m \"...\"");
+    assert_eq!(verify["recommended_action"], "heddle commit -m \"...\"");
     assert!(
         verify["recommended_action_template"]["required_inputs"]
             .as_array()
@@ -3925,7 +3924,7 @@ fn core_mutations_emit_post_verification_in_json() {
     );
     assert_eq!(
         capture["verification"]["recommended_action"],
-        "heddle checkpoint -m \"...\""
+        "heddle commit -m \"...\""
     );
     assert_eq!(
         capture["next_action"], capture["verification"]["recommended_action"],
@@ -6542,7 +6541,7 @@ feature
     assert_eq!(preview["would_merge"], true);
     assert_eq!(
         preview["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ship", "--thread", "feature/a", "--no-push"])
+        heddle_argv_json(["land", "--thread", "feature/a", "--no-push"])
     );
     assert_schema_declares_runtime_top_level(&["merge", "--preview"], &preview);
     assert_eq!(
@@ -6814,10 +6813,10 @@ fn ready_refuses_dirty_capture_without_intent() {
     assert_eq!(ready["output_kind"], "ready");
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], false);
-    assert_eq!(ready["recommended_action"], "heddle ready -m \"...\"");
+    assert_eq!(ready["recommended_action"], "heddle commit -m \"...\"");
     assert_eq!(
         ready["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["ready", "-m", "<message>"])
+        heddle_argv_json(["commit", "-m", "<message>"])
     );
     assert_eq!(
         ready["verification"]["status"], "uncaptured",
@@ -7851,7 +7850,7 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
         "default help should not frame Git adapter commands as compatibility: {stdout}"
     );
     for verb in [
-        "status", "diff", "commit", "start", "ready", "merge", "ship",
+        "status", "diff", "commit", "start", "ready", "land",
     ] {
         assert!(
             stdout.contains(&format!("\n  {verb}")),
@@ -7875,7 +7874,7 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
     assert!(
         stdout.contains("Existing Git: heddle status -> heddle adopt -> heddle verify -> heddle commit -m \"...\" -> heddle push")
             && stdout
-                .contains("Isolated work: heddle start <name> --path ../<name> -> heddle ready -> heddle merge --preview -> heddle ship"),
+                .contains("Isolated work: heddle start <name> --path ../<name> -> heddle commit -m \"...\" -> heddle ready -> heddle land"),
         "default help should connect first-run adoption and isolated work to the same product loop: {stdout}"
     );
     assert!(
@@ -7938,7 +7937,7 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         !advanced.contains("see `heddle help advanced`"),
         "advanced help should not be self-referential: {advanced}"
     );
-    for verb in ["commit", "ship", "push"] {
+    for verb in ["commit", "land", "push"] {
         assert!(
             !advanced.contains(&format!("\n  {verb}")),
             "`{verb}` is an everyday path and should not be duplicated in advanced help: {advanced}"
@@ -8301,7 +8300,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     assert!(
         ready.contains("Next:")
             && ready.contains("heddle --repo")
-            && ready.contains("merge feature/capture-next --preview"),
+            && ready.contains("land --thread feature/capture-next --no-push"),
         "ready should use a shared next-action label that runs from the isolated checkout: {ready}"
     );
     assert!(
@@ -8313,7 +8312,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     assert_eq!(
         checkout_status["recommended_action"],
         format!(
-            "heddle --repo {} merge feature/capture-next --preview",
+            "heddle --repo {} land --thread feature/capture-next --no-push",
             temp.path().display()
         )
     );
@@ -8322,16 +8321,17 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         heddle_argv_json([
             "--repo",
             temp.path().to_str().expect("repo path utf8"),
-            "merge",
+            "land",
+            "--thread",
             "feature/capture-next",
-            "--preview",
+            "--no-push",
         ]),
-        "status inside an isolated checkout should emit a runnable parent-repo merge action: {checkout_status}"
+        "status inside an isolated checkout should emit a runnable parent-repo land action: {checkout_status}"
     );
     assert_eq!(
         checkout_status["verification"]["recommended_action"],
         checkout_status["recommended_action"],
-        "status verification should not keep the parent-repo merge action in raw, non-contextual form: {checkout_status}"
+        "status verification should not keep the parent-repo land action in raw, non-contextual form: {checkout_status}"
     );
     assert_eq!(
         checkout_status["verification"]["recommended_action_template"]["argv_template"],
@@ -8344,27 +8344,27 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     );
     assert_eq!(
         checkout_thread_show["recommended_action"], checkout_status["recommended_action"],
-        "thread show inside an isolated checkout should emit the same runnable parent-repo merge action: {checkout_thread_show}"
+        "thread show inside an isolated checkout should emit the same runnable parent-repo land action: {checkout_thread_show}"
     );
     assert_eq!(
         checkout_thread_show["verification"]["recommended_action"],
         checkout_thread_show["recommended_action"],
-        "thread show verification should match its contextual top-level merge action: {checkout_thread_show}"
+        "thread show verification should match its contextual top-level land action: {checkout_thread_show}"
     );
     let checkout_workspace = json_value(&checkout, &["workspace", "show", "--output", "json"]);
     assert_eq!(
         checkout_workspace["recommended_action"], checkout_status["recommended_action"],
-        "workspace show inside an isolated checkout should emit the same runnable parent-repo merge action: {checkout_workspace}"
+        "workspace show inside an isolated checkout should emit the same runnable parent-repo land action: {checkout_workspace}"
     );
     assert_eq!(
         checkout_workspace["verification"]["recommended_action"],
         checkout_workspace["recommended_action"],
-        "workspace verification should match its contextual top-level merge action: {checkout_workspace}"
+        "workspace verification should match its contextual top-level land action: {checkout_workspace}"
     );
     let checkout_status_text = heddle(&["status", "--output", "text"], Some(&checkout)).unwrap();
     assert!(
         checkout_status_text.contains("heddle --repo")
-            && checkout_status_text.contains("merge feature/capture-next --preview"),
+            && checkout_status_text.contains("land --thread feature/capture-next --no-push"),
         "status text inside an isolated checkout should point to the parent repo: {checkout_status_text}"
     );
 
@@ -8381,7 +8381,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     .unwrap();
     assert!(
         preview.contains("Next:")
-            && preview.contains("heddle ship --thread feature/capture-next --no-push"),
+            && preview.contains("heddle land --thread feature/capture-next --no-push"),
         "merge preview should use the shared next-action label: {preview}"
     );
     assert!(
@@ -8404,7 +8404,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     assert_eq!(
         contextual_preview["recommended_action"],
         format!(
-            "heddle --repo {} ship --thread feature/capture-next --no-push",
+            "heddle --repo {} land --thread feature/capture-next --no-push",
             temp.path().display()
         ),
         "merge preview invoked from an isolated checkout must preserve parent repo context: {contextual_preview}"
@@ -8414,7 +8414,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         heddle_argv_json([
             "--repo",
             temp.path().to_str().expect("repo path utf8"),
-            "ship",
+            "land",
             "--thread",
             "feature/capture-next",
             "--no-push",
@@ -8426,7 +8426,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     assert_eq!(
         checkout_after_preview["recommended_action"],
         format!(
-            "heddle --repo {} ship --thread feature/capture-next --no-push",
+            "heddle --repo {} land --thread feature/capture-next --no-push",
             temp.path().display()
         )
     );
@@ -8435,27 +8435,27 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         heddle_argv_json([
             "--repo",
             temp.path().to_str().expect("repo path utf8"),
-            "ship",
+            "land",
             "--thread",
             "feature/capture-next",
             "--no-push",
         ]),
-        "status inside an isolated checkout should emit a runnable parent-repo ship action after preview: {checkout_after_preview}"
+        "status inside an isolated checkout should emit a runnable parent-repo land action after preview: {checkout_after_preview}"
     );
     assert_eq!(
         checkout_after_preview["verification"]["recommended_action"],
         checkout_after_preview["recommended_action"],
-        "status verification should match the contextual parent-repo ship action after preview: {checkout_after_preview}"
+        "status verification should match the contextual parent-repo land action after preview: {checkout_after_preview}"
     );
     assert_eq!(
         checkout_after_preview["verification"]["recommended_action_template"]["argv_template"],
         checkout_after_preview["recommended_action_template"]["argv_template"],
-        "status verification argv should match the contextual parent-repo ship action after preview: {checkout_after_preview}"
+        "status verification argv should match the contextual parent-repo land action after preview: {checkout_after_preview}"
     );
 
-    let ship = heddle(
+    let land = heddle(
         &[
-            "ship",
+            "land",
             "--thread",
             "feature/capture-next",
             "--no-push",
@@ -8466,18 +8466,18 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     )
     .unwrap();
     assert!(
-        ship.contains("landed: on parent") && ship.contains("push: not pushed"),
-        "ship should report the landed value state and push state: {ship}"
+        land.contains("landed: on parent") && land.contains("push: not pushed"),
+        "land should report the landed value state and push state: {land}"
     );
     assert!(
-        !ship.contains("completed:")
-            && !ship.contains("up to date:")
-            && !ship.contains("integrated: yes"),
-        "ship should not render step accounting as the primary human output: {ship}"
+        !land.contains("completed:")
+            && !land.contains("up to date:")
+            && !land.contains("integrated: yes"),
+        "land should not render step accounting as the primary human output: {land}"
     );
     assert!(
-        ship.contains("Next:") && ship.contains("heddle thread cleanup --merged --dry-run"),
-        "ship should surface the safe cleanup path for merged isolated checkouts: {ship}"
+        land.contains("Next:") && land.contains("heddle thread cleanup --merged --dry-run"),
+        "land should surface the safe cleanup path for merged isolated checkouts: {land}"
     );
 
     let list = heddle(&["thread", "list", "--output", "text"], Some(temp.path())).unwrap();
@@ -9424,7 +9424,7 @@ fn everyday_commands_have_all_required_help_entrypoints() {
         .collect::<std::collections::BTreeSet<_>>();
 
     for verb in [
-        "status", "diff", "commit", "start", "ready", "merge", "ship", "undo", "verify", "doctor",
+        "status", "diff", "commit", "start", "ready", "land", "undo", "verify", "doctor",
     ] {
         assert!(
             everyday_set.contains(verb),

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -204,7 +204,7 @@ const UNSWEPT_TODO: &[&str] = &[
     "session segment",
     "session show",
     "session start",
-    "ship",
+    "land",
     "show",
     "stash apply",
     "stash clear",

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -759,7 +759,7 @@ fn git_overlay_push_all_threads_skips_threads_pruned_by_cleanup() {
     )
     .unwrap();
     heddle(
-        &["ship", "--thread", "feature/cleaned", "--no-push"],
+        &["land", "--thread", "feature/cleaned", "--no-push"],
         Some(work.path()),
     )
     .unwrap();
@@ -2677,7 +2677,7 @@ fn test_cli_git_overlay_sync_refuses_diverged_branch_before_rebase() {
     assert_eq!(import_remote["branches_synced"], 1, "{import_remote}");
     let after_import = verify_json(&local);
     assert_eq!(
-        after_import["recommended_action"], "heddle merge origin/main --preview",
+        after_import["recommended_action"], "heddle bridge git reconcile --ref origin/main --preview",
         "after importing the upstream tip, verify should recommend upstream integration, not local Git/Heddle reconcile: {after_import}"
     );
     let thread_list_json = heddle(&["thread", "list", "--output", "json"], Some(&local))
@@ -2697,14 +2697,15 @@ fn test_cli_git_overlay_sync_refuses_diverged_branch_before_rebase() {
         "{thread_list}"
     );
     assert_eq!(
-        origin_main["recommended_action"], "heddle merge origin/main --preview",
+        origin_main["recommended_action"], "heddle bridge git reconcile --ref origin/main --preview",
         "remote-tracking refs should be presented as upstream integration previews: {thread_list}"
     );
     assert!(
         origin_main["recommended_action"]
             .as_str()
-            .is_some_and(|action| !action.contains("ship") && action.contains("merge origin/main")),
-        "remote-tracking refs must avoid dead-end ship/reconcile advice: {thread_list}"
+            .is_some_and(|action| !action.contains("land")
+                && action.contains("bridge git reconcile --ref origin/main --preview")),
+        "remote-tracking refs must avoid dead-end land advice: {thread_list}"
     );
     let merge_preview = heddle(
         &["merge", "origin/main", "--preview", "--output", "text"],

--- a/crates/cli/tests/cli_integration/try_cmd.rs
+++ b/crates/cli/tests/cli_integration/try_cmd.rs
@@ -90,7 +90,7 @@ fn try_succeeds_creates_thread_and_preserves_parent_head() {
     );
     assert_eq!(
         value["next_action"],
-        format!("heddle merge {thread_name} --preview"),
+        format!("heddle ready --thread {thread_name}"),
         "try should emit one parseable primary action, not a combined choice: {raw}"
     );
     assert_eq!(
@@ -99,12 +99,12 @@ fn try_succeeds_creates_thread_and_preserves_parent_head() {
     );
     assert_eq!(
         value["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["merge", thread_name, "--preview"]),
+        heddle_argv_json(["ready", "--thread", thread_name]),
         "try should provide argv for the primary action: {raw}"
     );
     assert_eq!(
         value["next_action_template"]["argv_template"],
-        heddle_argv_json(["merge", thread_name, "--preview"]),
+        heddle_argv_json(["ready", "--thread", thread_name]),
         "try should provide argv for the next action too: {raw}"
     );
     assert_eq!(

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1112,7 +1112,7 @@ fn test_stale_non_ff_merge_refuses_without_moving_threads() {
     let err = heddle(&["merge", "feature"], Some(temp.path()))
         .expect_err("stale divergent merge must refuse before mutation");
     assert!(
-        err.contains("Thread 'feature' is stale") && err.contains("heddle thread refresh feature"),
+        err.contains("Thread 'feature' is stale") && err.contains("heddle sync --thread feature"),
         "stale merge should explain the refresh path: {err}"
     );
     assert_eq!(
@@ -2143,7 +2143,7 @@ fn test_undo_preview_surfaces_worktree_refusal() {
 
 // ---------------------------------------------------------------------------
 // heddle#110 — Rule-7 sweep for the remaining `fast_forward_attached`
-// callers (rebase / pull / ship / merge-abort). Each daily-use command
+// callers (rebase / pull / land / merge-abort). Each daily-use command
 // recorded an implicit `OpRecord::Goto` for its FF, and the `Goto`
 // inverse only rewinds HEAD — silently stranding the attached thread
 // ref at the post-FF target. heddle#99 closed the bug for `merge` by
@@ -2404,22 +2404,22 @@ fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
     }
 }
 
-/// Ship (manual-resolution adopt path): `heddle ship` calls
+/// Land (manual-resolution adopt path): `heddle land` calls
 /// `adopt_manual_resolution`, which fast-forwards the current
 /// attached thread to a manually-resolved tip. Undo must restore
-/// the attached thread's ref to its pre-ship tip — pre-fix the
+/// the attached thread's ref to its pre-land tip — pre-fix the
 /// implicit `OpRecord::Goto` left the ref stranded at the adopted
 /// state.
 ///
-/// The ship-via-manual-resolution path requires a materialized
+/// The land-via-manual-resolution path requires a materialized
 /// thread workspace and `integration_policy.manual_resolution_state`
 /// set. We bootstrap that here by `heddle start --workspace
 /// materialized`, capturing work in the side worktree, then running
 /// `thread resolve` from main to flip the resolution flag. `heddle
-/// ship --thread <feature>` then enters `adopt_manual_resolution`,
+/// land --thread <feature>` then enters `adopt_manual_resolution`,
 /// whose `fast_forward_attached` call we're pinning.
 ///
-/// In environments where ship can't reach the adopt branch (no
+/// In environments where land can't reach the adopt branch (no
 /// git-overlay, no hosted config), we fall back to asserting that
 /// the migration didn't break the `thread resolve` flow itself.
 #[test]
@@ -2430,7 +2430,7 @@ fn test_undo_ship_manual_resolution_restores_thread_ref() {
     std::fs::write(temp.path().join("a.txt"), "base").unwrap();
     heddle_must_succeed(&["capture", "-m", "base"], temp.path());
 
-    // Create a materialized side worktree for feature so ship can
+    // Create a materialized side worktree for feature so land can
     // open the thread's checkout.
     let feature_wt = temp.path().join("feature-wt");
     heddle_must_succeed(
@@ -2452,27 +2452,27 @@ fn test_undo_ship_manual_resolution_restores_thread_ref() {
 
     // `thread resolve` flips manual_resolution_state on feature
     // when the thread merges cleanly. This is the trigger
-    // `adopt_manual_resolution` looks for during ship.
+    // `adopt_manual_resolution` looks for during land.
     let _ = heddle(&["thread", "resolve", "feature"], Some(temp.path()));
 
-    let ship = heddle(
-        &["--output", "json", "ship", "--thread", "feature"],
+    let land = heddle(
+        &["--output", "json", "land", "--thread", "feature"],
         Some(temp.path()),
     );
-    let ship_out = match ship {
+    let ship_out = match land {
         Ok(out) => out,
         Err(err) => {
-            panic!("ship failed: {err}");
+            panic!("land failed: {err}");
         }
     };
     assert!(
-        ship_out.contains("\"status\":\"shipped\"") || ship_out.contains("\"status\": \"shipped\""),
-        "ship must reach the manual-resolution adopt path: {ship_out}"
+        ship_out.contains("\"status\":\"landed\"") || ship_out.contains("\"status\": \"landed\""),
+        "land must reach the manual-resolution adopt path: {ship_out}"
     );
     let after_ship = head_short(temp.path());
     assert_ne!(
         after_ship, main_tip_before,
-        "ship must advance main; otherwise the FF is a no-op and there's nothing to undo: {ship_out}"
+        "land must advance main; otherwise the FF is a no-op and there's nothing to undo: {ship_out}"
     );
 
     heddle_must_succeed(&["undo"], temp.path());
@@ -2485,7 +2485,7 @@ fn test_undo_ship_manual_resolution_restores_thread_ref() {
         .short();
     assert_eq!(
         main_tip, main_tip_before,
-        "undo of ship must restore main thread ref to pre-ship tip \
+        "undo of land must restore main thread ref to pre-land tip \
          (heddle#110 — was stranded at the adopted state before the fix)"
     );
 }

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -970,7 +970,7 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
     assert_eq!(ready["report"]["semantic_result"], "fast_forward");
     assert_eq!(
         ready["report"]["recommended_action"],
-        "heddle merge feature/native-cli --preview"
+        "heddle land --thread feature/native-cli --no-push"
     );
 
     let thread_show_json = heddle(
@@ -982,7 +982,7 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
     assert_eq!(thread_show["thread_state"], "ready");
     assert_eq!(
         thread_show["recommended_action"].as_str(),
-        Some("heddle merge feature/native-cli --preview")
+        Some("heddle land --thread feature/native-cli --no-push")
     );
 
     let actor_list_json = heddle(&["--output", "json", "actor", "list"], Some(main.path()))
@@ -1010,12 +1010,12 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
     let actor_done: Value = serde_json::from_str(&actor_done_json).unwrap();
     assert_eq!(actor_done["coordination_status"], "merge-ready");
     assert_eq!(
-        actor_done["recommended_action"], "heddle merge feature/native-cli --preview",
-        "actor completion should keep agents on the preview-first merge path: {actor_done}"
+        actor_done["recommended_action"], "heddle land --thread feature/native-cli --no-push",
+        "actor completion should keep agents on the canonical land path: {actor_done}"
     );
     assert_eq!(
         actor_done["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["merge", "feature/native-cli", "--preview"]),
+        heddle_argv_json(["land", "--thread", "feature/native-cli", "--no-push"]),
         "{actor_done}"
     );
 }
@@ -1060,12 +1060,9 @@ fn ready_blocks_stale_or_heavy_impact_threads_and_status_reports_next_step() {
     assert_eq!(ready["thread_state"], "blocked");
     assert_eq!(
         ready["report"]["recommended_action"].as_str(),
-        Some("heddle thread resolve feature/dep")
+        Some("")
     );
-    assert_eq!(
-        ready["recommended_action"].as_str(),
-        Some("heddle thread resolve feature/dep")
-    );
+    assert!(ready["recommended_action"].is_null());
 
     let reviewed: Value = serde_json::from_str(
         &heddle(
@@ -1098,7 +1095,7 @@ fn ready_blocks_stale_or_heavy_impact_threads_and_status_reports_next_step() {
     assert_eq!(status["thread_health"], "blocked");
     assert_eq!(
         status["recommended_action"].as_str(),
-        Some("heddle thread refresh feature/dep")
+        Some("heddle sync --thread feature/dep")
     );
 
     let thread_refresh_status = heddle(
@@ -1239,7 +1236,7 @@ fn sync_refreshes_stale_thread_when_replay_is_clean() {
 }
 
 #[test]
-fn ship_auto_captures_and_merges_clean_thread() {
+fn land_auto_captures_and_merges_clean_thread() {
     let main = setup_repo("base.txt", "base");
     let started: Value = serde_json::from_str(
         &heddle(
@@ -1247,7 +1244,7 @@ fn ship_auto_captures_and_merges_clean_thread() {
                 "--output",
                 "json",
                 "start",
-                "feature/ship-it",
+                "feature/land-it",
                 "--workspace",
                 "auto",
             ],
@@ -1258,22 +1255,22 @@ fn ship_auto_captures_and_merges_clean_thread() {
     .unwrap();
     let thread = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
 
-    std::fs::write(thread.join("ship.txt"), "ship me").unwrap();
+    std::fs::write(thread.join("land.txt"), "land me").unwrap();
 
     let ship_json = heddle(
-        &["--output", "json", "ship", "--thread", "feature/ship-it"],
+        &["--output", "json", "land", "--thread", "feature/land-it"],
         Some(main.path()),
     )
     .unwrap();
-    let shipped: Value = serde_json::from_str(&ship_json).unwrap();
-    assert_eq!(shipped["status"], "shipped");
-    assert_eq!(shipped["captured"], true);
-    assert_eq!(shipped["integrated"], true);
-    assert!(main.path().join("ship.txt").exists());
+    let landed: Value = serde_json::from_str(&ship_json).unwrap();
+    assert_eq!(landed["status"], "landed");
+    assert_eq!(landed["captured"], true);
+    assert_eq!(landed["integrated"], true);
+    assert!(main.path().join("land.txt").exists());
 
     let thread_show: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "thread", "show", "feature/ship-it"],
+            &["--output", "json", "thread", "show", "feature/land-it"],
             Some(main.path()),
         )
         .unwrap(),
@@ -1286,10 +1283,10 @@ fn ship_auto_captures_and_merges_clean_thread() {
     );
 
     let actor_show = heddle_output(&["--output", "json", "actor", "show"], Some(main.path()))
-        .expect("invoke actor show after ship");
+        .expect("invoke actor show after land");
     assert!(
         !actor_show.status.success(),
-        "actor show should not select the merged actor implicitly after ship"
+        "actor show should not select the merged actor implicitly after land"
     );
     let stderr = str::from_utf8(&actor_show.stderr).unwrap_or("");
     let envelope: Value = serde_json::from_str(stderr.trim())
@@ -1299,8 +1296,8 @@ fn ship_auto_captures_and_merges_clean_thread() {
     assert!(
         envelope["hint"]
             .as_str()
-            .is_some_and(|hint| hint.contains("shipped") && hint.contains("session id")),
-        "actor show no-active advice should explain the post-ship transition: {envelope}"
+            .is_some_and(|hint| hint.contains("landed") && hint.contains("session id")),
+        "actor show no-active advice should explain the post-land transition: {envelope}"
     );
 }
 
@@ -1692,8 +1689,8 @@ fn lightweight_thread_capture_marks_heavy_impact_and_merge_preview_reports_it() 
     assert_eq!(preview["heavy_impact_paths"][0], "Cargo.toml");
     assert_eq!(
         preview["recommended_action"].as_str(),
-        Some("heddle thread resolve feature/deps"),
-        "merge preview should not recommend ship while heavy-impact review is still blocked: {preview}"
+        None,
+        "merge preview should not recommend a breadcrumb while heavy-impact review is still blocked: {preview}"
     );
 }
 

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -2201,3 +2201,90 @@ fn log_never_surfaces_unknown_principal_after_init() {
         }
     }
 }
+
+// heddle#464 bug 1: when a materialized thread's recorded worktree dir is
+// deleted out of band, `land --thread` refuses with `thread_worktree_missing`.
+// The recovery used to point at `heddle start <thread> --path <path>`, which
+// can never succeed (the thread still holds an active reservation, so `start`
+// returns `active_thread_reservation`), and the JSON `recovery_commands` list
+// was only the same `land` that just failed — a dead loop. The fix points the
+// recovery at `heddle switch <thread>`, which rebuilds the dedicated worktree at
+// the recorded path so the follow-up `land` succeeds.
+#[test]
+fn land_worktree_missing_recovery_points_at_switch_not_failing_loop() {
+    let main = setup_repo("hello.txt", "hello world");
+
+    let thread_dir = TempDir::new().unwrap();
+    let thread_path = thread_dir.path();
+
+    heddle(
+        &[
+            "start",
+            "feature/gone",
+            "--workspace",
+            "materialized",
+            "--path",
+            thread_path.to_str().unwrap(),
+        ],
+        Some(main.path()),
+    )
+    .expect("start materialized thread");
+
+    // Capture some work inside the thread so it has a landable state.
+    fs::write(thread_path.join("hello.txt"), "agent edits").unwrap();
+    heddle(&["capture", "-m", "agent work"], Some(thread_path)).expect("capture in thread");
+
+    // Delete the worktree out of band — the ref + record survive, only the
+    // checkout dir is gone.
+    fs::remove_dir_all(thread_path).expect("remove thread worktree dir");
+
+    let output = heddle_output(
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/gone",
+            "--no-push",
+        ],
+        Some(main.path()),
+    )
+    .expect("land invocation runs");
+    assert!(
+        !output.status.success(),
+        "land must refuse when the thread worktree is missing"
+    );
+    let stderr = str::from_utf8(&output.stderr).unwrap_or("");
+    let envelope: Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|e| panic!("worktree-missing refusal must emit a JSON envelope: {e}\n{stderr}"));
+
+    assert_eq!(envelope["kind"], "thread_worktree_missing");
+    let primary = envelope["primary_command"].as_str().unwrap_or_default();
+    assert_eq!(
+        primary, "heddle switch feature/gone",
+        "primary recovery must rematerialize the existing thread via switch"
+    );
+
+    let recovery: Vec<String> = envelope["recovery_commands"]
+        .as_array()
+        .expect("recovery_commands array present")
+        .iter()
+        .map(|v| v.as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        recovery.contains(&"heddle switch feature/gone".to_string()),
+        "recovery_commands must include the rematerialize command: {recovery:?}"
+    );
+    let land_command = "heddle land --thread feature/gone --no-push".to_string();
+    assert!(
+        recovery != vec![land_command.clone()],
+        "recovery_commands must not be just the failing land command (the old dead loop): {recovery:?}"
+    );
+    // The switch must come before the land retry so the operator rebuilds the
+    // checkout first.
+    let switch_idx = recovery.iter().position(|c| c == "heddle switch feature/gone");
+    let land_idx = recovery.iter().position(|c| c == &land_command);
+    if let (Some(s), Some(l)) = (switch_idx, land_idx) {
+        assert!(s < l, "switch must precede the land retry: {recovery:?}");
+    }
+}

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -117,7 +117,7 @@ fn assert_stale_merge_refuses(path: &std::path::Path, thread: &str) {
     let err = result.expect_err("stale direct merge should refuse before mutation");
     assert!(
         err.contains(&format!("Thread '{thread}' is stale"))
-            && err.contains(&format!("heddle thread refresh {thread}")),
+            && err.contains(&format!("heddle sync --thread {thread}")),
         "stale merge should explain the refresh path: {err}"
     );
     assert!(

--- a/crates/cli/tests/production_features/merge_rename_output.rs
+++ b/crates/cli/tests/production_features/merge_rename_output.rs
@@ -22,7 +22,7 @@ fn test_merge_json_output_includes_renames() {
     let err = result.expect_err("stale JSON merge should refuse before producing rename output");
     assert!(
         err.contains("\"status\":\"blocked\"")
-            && err.contains("\"recommended_action\":\"heddle thread refresh feature\""),
+            && err.contains("\"recommended_action\":\"heddle sync --thread feature\""),
         "stale JSON merge should recommend thread refresh: {err}"
     );
 
@@ -51,7 +51,7 @@ fn test_merge_text_output_shows_rename_lines() {
     let result = heddle(&["merge", "feature", "--output", "text"], Some(temp.path()));
     let err = result.expect_err("stale text merge should refuse before producing rename lines");
     assert!(
-        err.contains("Thread 'feature' is stale") && err.contains("heddle thread refresh feature"),
+        err.contains("Thread 'feature' is stale") && err.contains("heddle sync --thread feature"),
         "stale text merge should recommend thread refresh: {err}"
     );
 
@@ -101,7 +101,7 @@ fn test_merge_json_output_includes_directory_renames() {
     let err = result.expect_err("stale directory rename merge should refuse before metadata");
     assert!(
         err.contains("\"status\":\"blocked\"")
-            && err.contains("\"recommended_action\":\"heddle thread refresh feature\""),
+            && err.contains("\"recommended_action\":\"heddle sync --thread feature\""),
         "stale JSON merge should recommend thread refresh: {err}"
     );
 

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -361,7 +361,7 @@ fn test_merge_no_commit() {
     assert_eq!(parsed["status"], "blocked");
     assert_eq!(
         parsed["recommended_action"],
-        "heddle thread refresh feature"
+        "heddle sync --thread feature"
     );
 }
 #[test]
@@ -1366,7 +1366,7 @@ fn test_merge_with_real_conflict_reports_blocked_with_null_merge_state() {
     );
     assert_eq!(
         parsed["recommended_action"],
-        "heddle thread refresh feature"
+        "heddle sync --thread feature"
     );
     refresh_thread_expect_conflict(&temp, "feature");
 }
@@ -2137,7 +2137,7 @@ fn test_merge_stale_thread_preview_and_git_commit_apply_refuse_consistently() {
     assert_eq!(preview_json["kind"], "merge_preview_blocked");
     assert_eq!(
         preview_json["primary_command"],
-        "heddle thread refresh feature"
+        "heddle sync --thread feature"
     );
 
     let apply = heddle_output(
@@ -2157,7 +2157,7 @@ fn test_merge_stale_thread_preview_and_git_commit_apply_refuse_consistently() {
         "stale apply must refuse just like preview: {apply_json}"
     );
     assert_eq!(
-        apply_json["recommended_action"], "heddle thread refresh feature",
+        apply_json["recommended_action"], "heddle sync --thread feature",
         "apply must use the same freshness recovery path as preview: {apply_json}"
     );
     assert_eq!(apply_json["merge_state"], Value::Null);
@@ -2228,8 +2228,8 @@ fn test_merge_git_commit_blocks_on_unrelated_uncommitted_git_changes() {
         "git_commit must be absent when blocked: {parsed}"
     );
     assert_eq!(
-        parsed["recommended_action"], "heddle merge feature --git-commit",
-        "blocked pre-snapshot git coordination should recommend a concrete Heddle retry, not prose: {parsed}"
+        parsed["recommended_action"], "heddle status",
+        "blocked pre-snapshot git coordination should recommend a concrete Heddle state reader, not a self-loop: {parsed}"
     );
     let action_tail = parsed["recommended_action_template"]["argv_template"]
         .as_array()
@@ -2240,11 +2240,7 @@ fn test_merge_git_commit_blocks_on_unrelated_uncommitted_git_changes() {
         .collect::<Vec<_>>();
     assert_eq!(
         action_tail,
-        vec![
-            Value::String("merge".to_string()),
-            Value::String("feature".to_string()),
-            Value::String("--git-commit".to_string()),
-        ]
+        vec![Value::String("status".to_string())]
     );
 }
 
@@ -2550,7 +2546,7 @@ fn test_merge_semantic_preview_summary_matches_semantic_plan_on_structural_resha
         "stale semantic preview must refuse before claiming merge semantics: {envelope}"
     );
     assert_eq!(
-        envelope["primary_command"], "heddle thread refresh feature",
+        envelope["primary_command"], "heddle sync --thread feature",
         "stale semantic preview should route through refresh: {envelope}"
     );
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -88,7 +88,7 @@ pub use stack_snapshot::{
 };
 pub use thread_advice::{
     RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
-    shell_quote,
+    shell_quote, thread_flag,
 };
 pub use thread_stack::{
     PlanRebaseError, StackNode, StackRebasePlan, StackRebaseStep, ThreadStack, compute_stacks,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -88,6 +88,7 @@ pub use stack_snapshot::{
 };
 pub use thread_advice::{
     RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
+    shell_quote,
 };
 pub use thread_stack::{
     PlanRebaseError, StackNode, StackRebasePlan, StackRebaseStep, ThreadStack, compute_stacks,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -96,8 +96,9 @@ pub use thread_stack::{
 };
 pub use thread_model::{
     ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
-    ThreadImpactCategory, ThreadIntegrationPolicy, ThreadLifecycleState, ThreadMode, ThreadRecord,
-    ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView,
+    ThreadIdError, ThreadImpactCategory, ThreadIntegrationPolicy, ThreadLifecycleState, ThreadMode,
+    ThreadRecord, ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView,
+    validate_thread_id,
 };
 pub use thread_record_store::{FilesystemThreadRecordStore, ThreadRecordStore};
 pub use thread_storage::{SyncedThreadMetadata, SyncedThreadMetadataStore, Thread, ThreadManager};

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -9,11 +9,15 @@ use crate::{Thread, ThreadFreshness, ThreadState};
 /// value containing whitespace or shell metacharacters yields a runnable
 /// command (and tokenizes correctly through the CLI's next_action validator).
 ///
-/// Thread ids no longer need this — they are validated to the safe slug set at
-/// creation ([`crate::validate_thread_id`]) and so are single tokens by
-/// construction. It is kept for the values that legitimately CAN contain
-/// spaces and cannot be disallowed: file PATHS interpolated into breadcrumbs
-/// (e.g. `heddle resolve <conflict path>`).
+/// Applied defensively at EVERY breadcrumb construction site — to thread ids
+/// as well as file paths — because not every id reaching a breadcrumb is a
+/// freshly-validated [`crate::ThreadId`]. [`ThreadId::new_unchecked`] (used for
+/// `Deserialize` and `ThreadRecord::thread_id`), historical/persisted records,
+/// and `heddle agent reserve --thread` all bypass [`crate::validate_thread_id`].
+/// Creation-time validation stays as a UX / early-reject layer, but the SAFETY
+/// guarantee is the emit-quoting here: a clean slug (`feature/x`) passes through
+/// bare and renders unchanged, while an unsafe id is single-quoted into one
+/// token so it can never split into extra args and break the breadcrumb.
 pub fn shell_quote(arg: &str) -> String {
     let safe = !arg.is_empty()
         && arg.bytes().all(|b| {
@@ -41,18 +45,25 @@ pub enum RecommendedAction {
 
 impl RecommendedAction {
     pub fn command(&self, thread_id: &str) -> Option<String> {
-        // `thread_id` is validated to the safe slug set at creation, so it is a
-        // single shell token by construction — interpolate it bare. (heddle#464
-        // close-the-class: the invariant lives at the ThreadId boundary, not at
-        // each breadcrumb site.)
+        // Quote `thread_id` defensively: not every id reaching this function is
+        // a freshly-validated `ThreadId`. `new_unchecked` (Deserialize /
+        // `ThreadRecord::thread_id`), historical/persisted records, and
+        // `heddle agent reserve --thread` all bypass `validate_thread_id`, so an
+        // unsafe id (whitespace / shell metacharacter) can reach here. A clean
+        // slug passes through bare (unchanged); an unsafe one becomes a single
+        // quoted token so the breadcrumb stays runnable and survives the CLI's
+        // next_action validator. (heddle#464 — defense-in-depth: quote at the
+        // emit boundary; creation-time validation stays as a UX/early-reject
+        // layer, but safety does not depend on it being covered everywhere.)
+        let tid = shell_quote(thread_id);
         match self {
             Self::Commit => Some("heddle commit -m \"...\"".to_string()),
-            Self::Ready => Some(format!("heddle ready --thread {thread_id}")),
-            Self::Sync => Some(format!("heddle sync --thread {thread_id}")),
-            Self::Land => Some(format!("heddle land --thread {thread_id} --no-push")),
+            Self::Ready => Some(format!("heddle ready --thread {tid}")),
+            Self::Sync => Some(format!("heddle sync --thread {tid}")),
+            Self::Land => Some(format!("heddle land --thread {tid} --no-push")),
             Self::Resolve => Some("heddle resolve --list".to_string()),
             Self::Review => None,
-            Self::Promote => Some(format!("heddle thread promote {thread_id}")),
+            Self::Promote => Some(format!("heddle thread promote {tid}")),
         }
     }
 }
@@ -173,7 +184,10 @@ pub fn describe_thread_advice_with_initial(
         return ThreadAdvice {
             thread_health: "ready".to_string(),
             blockers,
-            recommended_action: format!("heddle land --thread {} --no-push", thread.id),
+            recommended_action: format!(
+                "heddle land --thread {} --no-push",
+                shell_quote(&thread.id)
+            ),
         };
     } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
         RecommendedAction::Land
@@ -269,26 +283,62 @@ mod tests {
         );
     }
 
-    // Thread ids are validated to the safe slug set at creation, so breadcrumbs
-    // interpolate them bare — no quoting in `command()`.
+    // A clean slug renders bare in every breadcrumb (no regression): quoting is
+    // a no-op for the safe set, so existing copy-pasteable commands are
+    // unchanged.
     #[test]
-    fn command_interpolates_validated_thread_id_bare() {
+    fn command_interpolates_safe_slug_bare() {
         assert_eq!(
             RecommendedAction::Sync.command("feature/x").as_deref(),
             Some("heddle sync --thread feature/x")
         );
+        assert_eq!(
+            RecommendedAction::Land.command("feature/x").as_deref(),
+            Some("heddle land --thread feature/x --no-push")
+        );
+        assert_eq!(
+            RecommendedAction::Promote.command("team@scope").as_deref(),
+            Some("heddle thread promote team@scope")
+        );
     }
 
-    // `shell_quote` survives for the values that legitimately CAN contain
-    // spaces and cannot be disallowed: file PATHS interpolated into breadcrumbs.
+    // heddle#464 defense-in-depth: an UNVALIDATED id that bypassed
+    // `ThreadId::new` — exactly what `ThreadId::new_unchecked` models for a
+    // deserialized / historical record or a `heddle agent reserve --thread`
+    // value — must still render as a single quoted shell token through
+    // `command()`, never bare. This is the close-the-class proof: safety does
+    // not depend on the creation boundary being covered.
     #[test]
-    fn shell_quote_quotes_paths_with_whitespace_and_metacharacters() {
+    fn command_quotes_unsafe_unvalidated_thread_id() {
+        for unsafe_id in ["bad;echo pwn", "my feature", "a$(x)"] {
+            // Construct the id the way a persisted/historical record does —
+            // straight through `new_unchecked`, skipping validation.
+            let historical = crate::ThreadId::new_unchecked(unsafe_id);
+            let rendered = RecommendedAction::Sync
+                .command(historical.as_str())
+                .expect("sync breadcrumb");
+            assert_eq!(rendered, format!("heddle sync --thread '{unsafe_id}'"));
+            // Guard: the offending id must not appear bare (the P1 bug).
+            assert!(
+                !rendered.contains(&format!("--thread {unsafe_id}")),
+                "the unsafe id must be quoted, not interpolated bare: {rendered}"
+            );
+        }
+    }
+
+    // `shell_quote` leaves the safe slug set bare and single-quotes anything
+    // else — thread ids AND the file PATHS that legitimately CAN contain spaces.
+    #[test]
+    fn shell_quote_quotes_whitespace_and_metacharacters() {
         // Safe slugs / ordinary paths pass through bare...
         assert_eq!(shell_quote("src/lib.rs"), "src/lib.rs");
-        // ...but a path with a space is single-quoted so the recommended
-        // command is runnable and tokenizes correctly in the next_action
-        // validator (e.g. `heddle resolve 'my file.txt'`).
+        assert_eq!(shell_quote("feature/x"), "feature/x");
+        assert_eq!(shell_quote("team@scope"), "team@scope");
+        // ...but whitespace / shell metacharacters are single-quoted so the
+        // recommended command is runnable and tokenizes correctly in the
+        // next_action validator (e.g. `heddle resolve 'my file.txt'`).
         assert_eq!(shell_quote("my file.txt"), "'my file.txt'");
+        assert_eq!(shell_quote("bad;echo pwn"), "'bad;echo pwn'");
         assert_eq!(shell_quote("a'b"), r"'a'\''b'");
     }
 }

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -5,9 +5,15 @@ use serde::Serialize;
 
 use crate::{Thread, ThreadFreshness, ThreadState};
 
-/// Shell-quote an argument for inclusion in a recommended-command string, so a
-/// thread id containing whitespace or shell metacharacters yields a runnable
+/// Shell-quote an argument for inclusion in a recommended-command string so a
+/// value containing whitespace or shell metacharacters yields a runnable
 /// command (and tokenizes correctly through the CLI's next_action validator).
+///
+/// Thread ids no longer need this — they are validated to the safe slug set at
+/// creation ([`crate::validate_thread_id`]) and so are single tokens by
+/// construction. It is kept for the values that legitimately CAN contain
+/// spaces and cannot be disallowed: file PATHS interpolated into breadcrumbs
+/// (e.g. `heddle resolve <conflict path>`).
 pub fn shell_quote(arg: &str) -> String {
     let safe = !arg.is_empty()
         && arg.bytes().all(|b| {
@@ -35,15 +41,18 @@ pub enum RecommendedAction {
 
 impl RecommendedAction {
     pub fn command(&self, thread_id: &str) -> Option<String> {
-        let tid = shell_quote(thread_id);
+        // `thread_id` is validated to the safe slug set at creation, so it is a
+        // single shell token by construction — interpolate it bare. (heddle#464
+        // close-the-class: the invariant lives at the ThreadId boundary, not at
+        // each breadcrumb site.)
         match self {
             Self::Commit => Some("heddle commit -m \"...\"".to_string()),
-            Self::Ready => Some(format!("heddle ready --thread {tid}")),
-            Self::Sync => Some(format!("heddle sync --thread {tid}")),
-            Self::Land => Some(format!("heddle land --thread {tid} --no-push")),
+            Self::Ready => Some(format!("heddle ready --thread {thread_id}")),
+            Self::Sync => Some(format!("heddle sync --thread {thread_id}")),
+            Self::Land => Some(format!("heddle land --thread {thread_id} --no-push")),
             Self::Resolve => Some("heddle resolve --list".to_string()),
             Self::Review => None,
-            Self::Promote => Some(format!("heddle thread promote {tid}")),
+            Self::Promote => Some(format!("heddle thread promote {thread_id}")),
         }
     }
 }
@@ -164,10 +173,7 @@ pub fn describe_thread_advice_with_initial(
         return ThreadAdvice {
             thread_health: "ready".to_string(),
             blockers,
-            recommended_action: format!(
-                "heddle land --thread {} --no-push",
-                shell_quote(&thread.id)
-            ),
+            recommended_action: format!("heddle land --thread {} --no-push", thread.id),
         };
     } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
         RecommendedAction::Land
@@ -263,17 +269,26 @@ mod tests {
         );
     }
 
+    // Thread ids are validated to the safe slug set at creation, so breadcrumbs
+    // interpolate them bare — no quoting in `command()`.
     #[test]
-    fn breadcrumbs_shell_quote_thread_ids_with_whitespace() {
-        // Safe slugs pass through bare (so existing breadcrumbs are unchanged)...
-        assert_eq!(shell_quote("feature/x"), "feature/x");
-        // ...but whitespace / shell metacharacters are single-quoted so the
-        // command is runnable and tokenizes correctly in the next_action validator.
-        assert_eq!(shell_quote("my feature"), "'my feature'");
-        assert_eq!(shell_quote("a'b"), r"'a'\''b'");
+    fn command_interpolates_validated_thread_id_bare() {
         assert_eq!(
-            RecommendedAction::Sync.command("my feature").as_deref(),
-            Some("heddle sync --thread 'my feature'")
+            RecommendedAction::Sync.command("feature/x").as_deref(),
+            Some("heddle sync --thread feature/x")
         );
+    }
+
+    // `shell_quote` survives for the values that legitimately CAN contain
+    // spaces and cannot be disallowed: file PATHS interpolated into breadcrumbs.
+    #[test]
+    fn shell_quote_quotes_paths_with_whitespace_and_metacharacters() {
+        // Safe slugs / ordinary paths pass through bare...
+        assert_eq!(shell_quote("src/lib.rs"), "src/lib.rs");
+        // ...but a path with a space is single-quoted so the recommended
+        // command is runnable and tokenizes correctly in the next_action
+        // validator (e.g. `heddle resolve 'my file.txt'`).
+        assert_eq!(shell_quote("my file.txt"), "'my file.txt'");
+        assert_eq!(shell_quote("a'b"), r"'a'\''b'");
     }
 }

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -55,16 +55,44 @@ impl RecommendedAction {
         // next_action validator. (heddle#464 — defense-in-depth: quote at the
         // emit boundary; creation-time validation stays as a UX/early-reject
         // layer, but safety does not depend on it being covered everywhere.)
-        let tid = shell_quote(thread_id);
         match self {
             Self::Commit => Some("heddle commit -m \"...\"".to_string()),
-            Self::Ready => Some(format!("heddle ready --thread {tid}")),
-            Self::Sync => Some(format!("heddle sync --thread {tid}")),
-            Self::Land => Some(format!("heddle land --thread {tid} --no-push")),
+            Self::Ready => Some(format!("heddle ready {}", thread_flag(thread_id))),
+            Self::Sync => Some(format!("heddle sync {}", thread_flag(thread_id))),
+            Self::Land => Some(format!("heddle land {} --no-push", thread_flag(thread_id))),
             Self::Resolve => Some("heddle resolve --list".to_string()),
             Self::Review => None,
-            Self::Promote => Some(format!("heddle thread promote {tid}")),
+            Self::Promote => Some(format!(
+                "heddle thread promote {}",
+                positional_value(thread_id)
+            )),
         }
+    }
+}
+
+/// Render `--thread <id>` so a leading-dash id (e.g. a historical/`new_unchecked`
+/// thread literally named `-foo`) is bound via the `=` form. clap parses
+/// `--thread=-foo` as the flag's value, whereas `--thread -foo` parses `-foo` as
+/// another option and breaks the breadcrumb (clap has no `allow_hyphen_values`
+/// here). Shell-quoting still applies for whitespace/metacharacters.
+pub fn thread_flag(thread_id: &str) -> String {
+    let q = shell_quote(thread_id);
+    if thread_id.starts_with('-') {
+        format!("--thread={q}")
+    } else {
+        format!("--thread {q}")
+    }
+}
+
+/// Render a trailing POSITIONAL value. A leading-dash value needs the `--`
+/// end-of-options separator (positionals can't use the `=` form), so
+/// `heddle thread promote -foo` becomes `heddle thread promote -- -foo`.
+fn positional_value(value: &str) -> String {
+    let q = shell_quote(value);
+    if value.starts_with('-') {
+        format!("-- {q}")
+    } else {
+        q
     }
 }
 
@@ -185,8 +213,8 @@ pub fn describe_thread_advice_with_initial(
             thread_health: "ready".to_string(),
             blockers,
             recommended_action: format!(
-                "heddle land --thread {} --no-push",
-                shell_quote(&thread.id)
+                "heddle land {} --no-push",
+                thread_flag(&thread.id)
             ),
         };
     } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
@@ -340,5 +368,36 @@ mod tests {
         assert_eq!(shell_quote("my file.txt"), "'my file.txt'");
         assert_eq!(shell_quote("bad;echo pwn"), "'bad;echo pwn'");
         assert_eq!(shell_quote("a'b"), r"'a'\''b'");
+    }
+
+    // heddle#464 round 8: a leading-dash id (e.g. a historical `-foo` that
+    // `validate_thread_id` now rejects, but that can still arrive via
+    // `new_unchecked`) is in `shell_quote`'s safe set, so quoting alone leaves it
+    // bare and clap parses `-foo` as a flag. The flag form must use `=` (clap
+    // binds the value); the positional form needs the `--` end-of-options marker.
+    #[test]
+    fn leading_dash_thread_ids_use_equals_and_separator_forms() {
+        let id = crate::ThreadId::new_unchecked("-foo");
+        assert_eq!(
+            RecommendedAction::Sync.command(id.as_str()).as_deref(),
+            Some("heddle sync --thread=-foo")
+        );
+        assert_eq!(
+            RecommendedAction::Ready.command(id.as_str()).as_deref(),
+            Some("heddle ready --thread=-foo")
+        );
+        assert_eq!(
+            RecommendedAction::Land.command(id.as_str()).as_deref(),
+            Some("heddle land --thread=-foo --no-push")
+        );
+        assert_eq!(
+            RecommendedAction::Promote.command(id.as_str()).as_deref(),
+            Some("heddle thread promote -- -foo")
+        );
+        // Clean slugs are unchanged (space form, bare).
+        assert_eq!(
+            RecommendedAction::Sync.command("feature/x").as_deref(),
+            Some("heddle sync --thread feature/x")
+        );
     }
 }

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -8,11 +8,10 @@ use crate::{Thread, ThreadFreshness, ThreadState};
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RecommendedAction {
-    Capture,
+    Commit,
     Ready,
-    Refresh,
-    MergePreview,
-    MergeApply,
+    Sync,
+    Land,
     Resolve,
     Review,
     Promote,
@@ -21,13 +20,12 @@ pub enum RecommendedAction {
 impl RecommendedAction {
     pub fn command(&self, thread_id: &str) -> Option<String> {
         match self {
-            Self::Capture => Some("heddle capture".to_string()),
+            Self::Commit => Some("heddle commit -m \"...\"".to_string()),
             Self::Ready => Some(format!("heddle ready --thread {thread_id}")),
-            Self::Refresh => Some(format!("heddle thread refresh {thread_id}")),
-            Self::MergePreview => Some(format!("heddle merge {thread_id} --preview")),
-            Self::MergeApply => Some(format!("heddle merge {thread_id}")),
-            Self::Resolve => Some(format!("heddle thread resolve {thread_id}")),
-            Self::Review => Some(format!("heddle thread resolve {thread_id}")),
+            Self::Sync => Some(format!("heddle sync --thread {thread_id}")),
+            Self::Land => Some(format!("heddle land --thread {thread_id} --no-push")),
+            Self::Resolve => Some("heddle resolve --list".to_string()),
+            Self::Review => None,
             Self::Promote => Some(format!("heddle thread promote {thread_id}")),
         }
     }
@@ -61,7 +59,7 @@ pub fn describe_thread_advice(
 ///
 /// When `initial_state` is true and the worktree is dirty, the thread
 /// is labeled `"uncaptured"` instead of `"dirty_worktree"`. The
-/// recommended action stays `heddle capture` — only the label
+/// recommended action stays `heddle commit` — only the label
 /// changes, so the user-facing first impression matches the actual
 /// situation (nothing has been captured yet) rather than implying
 /// that something has drifted. See heddle#160.
@@ -102,7 +100,7 @@ pub fn describe_thread_advice_with_initial(
 
     let mut blockers = Vec::new();
     let action = if worktree_dirty {
-        RecommendedAction::Capture
+        RecommendedAction::Commit
     } else if thread.freshness == ThreadFreshness::Stale {
         blockers.push(format!(
             "Thread '{}' is stale against '{}'",
@@ -118,7 +116,7 @@ pub fn describe_thread_advice_with_initial(
                 conflicts
             ));
         }
-        RecommendedAction::Refresh
+        RecommendedAction::Sync
     } else if thread.promotion_suggested && !thread.heavy_impact_paths.is_empty() {
         blockers.push(format!(
             "Heavy-impact change: {} — review broader impact before merging",
@@ -138,16 +136,13 @@ pub fn describe_thread_advice_with_initial(
     } else if thread.state == ThreadState::Ready
         && thread.integration_policy_result.status.as_deref() == Some("previewed")
     {
-        let thread_health = "ready".to_string();
         return ThreadAdvice {
-            thread_health,
+            thread_health: "ready".to_string(),
             blockers,
-            recommended_action: format!("heddle ship --thread {} --no-push", thread.id),
+            recommended_action: format!("heddle land --thread {} --no-push", thread.id),
         };
-    } else if clean_ready_merges_to_apply {
-        RecommendedAction::MergeApply
-    } else if thread.state == ThreadState::Ready {
-        RecommendedAction::MergePreview
+    } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
+        RecommendedAction::Land
     } else {
         RecommendedAction::Ready
     };

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -132,7 +132,15 @@ pub fn describe_thread_advice_with_initial(
         } else if blockers.is_empty() {
             blockers.push("Thread needs attention before integration".to_string());
         }
-        RecommendedAction::Resolve
+        // `land` — not `resolve --list`. This is a metadata-only function; it
+        // is always called from non-materialized contexts (status passes
+        // conflicts=0, the only conflicts>0 caller is the merge dry-run
+        // preview), so no merge state exists for `resolve` to read here and a
+        // `resolve --list` breadcrumb dies with `no_merge_in_progress`. `land`
+        // re-drives the thread: it materializes a real conflict (then surfaces
+        // `continue`) or re-reports the specific blocker with its own
+        // recommendation. (heddle#464 close-the-class.)
+        RecommendedAction::Land
     } else if thread.state == ThreadState::Ready
         && thread.integration_policy_result.status.as_deref() == Some("previewed")
     {
@@ -184,4 +192,54 @@ fn preview_paths(paths: &[String]) -> String {
         String::new()
     };
     format!("{}{suffix}", visible.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thread_json(state: &str) -> Thread {
+        serde_json::from_value(serde_json::json!({
+            "id": "feature/x",
+            "thread": "feature/x",
+            "target_thread": "main",
+            "mode": "materialized",
+            "state": state,
+            "base_state": "aaaa",
+            "base_root": "bbbb",
+            "freshness": "current",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }))
+        .expect("thread fixture should deserialize")
+    }
+
+    // heddle#464 close-the-class: `describe_thread_advice` is metadata-only —
+    // it is never called from a context that has materialized a merge (status
+    // passes conflicts=0; the lone conflicts>0 caller is the dry-run merge
+    // preview). So it must never emit `heddle resolve --list`, which would die
+    // with `no_merge_in_progress`. A blocked thread re-drives through `land`.
+    #[test]
+    fn blocked_thread_recommends_land_not_dead_resolve_breadcrumb() {
+        let advice = describe_thread_advice(&thread_json("blocked"), false, 0, false);
+        assert_eq!(advice.thread_health, "blocked");
+        assert_ne!(advice.recommended_action, "heddle resolve --list");
+        assert_eq!(
+            advice.recommended_action,
+            "heddle land --thread feature/x --no-push"
+        );
+    }
+
+    // Even when a preview reports conflicts, the merge is a dry run with no
+    // materialized state, so the breadcrumb must drive materialization (land),
+    // never a dead `resolve --list`.
+    #[test]
+    fn previewed_conflicts_recommend_land_not_dead_resolve_breadcrumb() {
+        let advice = describe_thread_advice(&thread_json("active"), false, 2, false);
+        assert_ne!(advice.recommended_action, "heddle resolve --list");
+        assert_eq!(
+            advice.recommended_action,
+            "heddle land --thread feature/x --no-push"
+        );
+    }
 }

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -5,6 +5,22 @@ use serde::Serialize;
 
 use crate::{Thread, ThreadFreshness, ThreadState};
 
+/// Shell-quote an argument for inclusion in a recommended-command string, so a
+/// thread id containing whitespace or shell metacharacters yields a runnable
+/// command (and tokenizes correctly through the CLI's next_action validator).
+pub fn shell_quote(arg: &str) -> String {
+    let safe = !arg.is_empty()
+        && arg.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(b, b'_' | b'-' | b'.' | b'/' | b'@' | b':' | b'+' | b'=')
+        });
+    if safe {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', r"'\''"))
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RecommendedAction {
@@ -19,14 +35,15 @@ pub enum RecommendedAction {
 
 impl RecommendedAction {
     pub fn command(&self, thread_id: &str) -> Option<String> {
+        let tid = shell_quote(thread_id);
         match self {
             Self::Commit => Some("heddle commit -m \"...\"".to_string()),
-            Self::Ready => Some(format!("heddle ready --thread {thread_id}")),
-            Self::Sync => Some(format!("heddle sync --thread {thread_id}")),
-            Self::Land => Some(format!("heddle land --thread {thread_id} --no-push")),
+            Self::Ready => Some(format!("heddle ready --thread {tid}")),
+            Self::Sync => Some(format!("heddle sync --thread {tid}")),
+            Self::Land => Some(format!("heddle land --thread {tid} --no-push")),
             Self::Resolve => Some("heddle resolve --list".to_string()),
             Self::Review => None,
-            Self::Promote => Some(format!("heddle thread promote {thread_id}")),
+            Self::Promote => Some(format!("heddle thread promote {tid}")),
         }
     }
 }
@@ -147,7 +164,10 @@ pub fn describe_thread_advice_with_initial(
         return ThreadAdvice {
             thread_health: "ready".to_string(),
             blockers,
-            recommended_action: format!("heddle land --thread {} --no-push", thread.id),
+            recommended_action: format!(
+                "heddle land --thread {} --no-push",
+                shell_quote(&thread.id)
+            ),
         };
     } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
         RecommendedAction::Land
@@ -240,6 +260,20 @@ mod tests {
         assert_eq!(
             advice.recommended_action,
             "heddle land --thread feature/x --no-push"
+        );
+    }
+
+    #[test]
+    fn breadcrumbs_shell_quote_thread_ids_with_whitespace() {
+        // Safe slugs pass through bare (so existing breadcrumbs are unchanged)...
+        assert_eq!(shell_quote("feature/x"), "feature/x");
+        // ...but whitespace / shell metacharacters are single-quoted so the
+        // command is runnable and tokenizes correctly in the next_action validator.
+        assert_eq!(shell_quote("my feature"), "'my feature'");
+        assert_eq!(shell_quote("a'b"), r"'a'\''b'");
+        assert_eq!(
+            RecommendedAction::Sync.command("my feature").as_deref(),
+            Some("heddle sync --thread 'my feature'")
         );
     }
 }

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -5,11 +5,30 @@ use chrono::{DateTime, Utc};
 use objects::store::AgentUsageSummary;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+/// A validated thread id. Construction from user- or externally-supplied
+/// input goes through [`ThreadId::new`], which rejects anything that is not a
+/// safe single shell token (see [`validate_thread_id`]). That invariant is what
+/// lets recommended-command breadcrumbs interpolate a thread id *bare* — there
+/// is no whitespace or shell metacharacter to quote, by construction.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct ThreadId(String);
 
 impl ThreadId {
-    pub fn new(value: impl Into<String>) -> Self {
+    /// Construct a thread id from user/external input, validating it against
+    /// the safe slug rule. Returns a [`ThreadIdError`] carrying an actionable
+    /// rename hint when the input is empty or contains a space, a shell
+    /// metacharacter, a `..` path segment, or a leading `/`.
+    pub fn new(value: impl Into<String>) -> Result<Self, ThreadIdError> {
+        let value = value.into();
+        validate_thread_id(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Wrap a value WITHOUT validation. Reserved for inputs that are
+    /// safe-by-construction: deserialization of thread records already on disk
+    /// (validate at creation, trust thereafter) and internally-generated slug
+    /// ids. Never call this on user/external input — use [`ThreadId::new`].
+    pub(crate) fn new_unchecked(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
@@ -24,15 +43,95 @@ impl std::fmt::Display for ThreadId {
     }
 }
 
-impl From<String> for ThreadId {
-    fn from(value: String) -> Self {
-        Self(value)
+impl<'de> Deserialize<'de> for ThreadId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Persisted thread ids were validated when the thread was created; a
+        // record on disk is trusted, so deserialize through `new_unchecked`
+        // rather than re-running validation (and rejecting historical data).
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::new_unchecked(value))
     }
 }
 
-impl From<&str> for ThreadId {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
+/// Rejection from [`ThreadId::new`] / [`validate_thread_id`]. Its `Display` is
+/// a clear, actionable CLI message naming the offending input and suggesting a
+/// valid rename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadIdError {
+    input: String,
+    suggestion: String,
+}
+
+impl std::fmt::Display for ThreadIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.input.is_empty() {
+            write!(f, "thread name must not be empty")
+        } else {
+            write!(
+                f,
+                "thread name '{}' is invalid: use only letters, digits, and _ - . / @ : + = \
+                 (no spaces, shell metacharacters, '..' path segments, or a leading '/') — try '{}'",
+                self.input, self.suggestion
+            )
+        }
+    }
+}
+
+impl std::error::Error for ThreadIdError {}
+
+/// The single rule for thread-id validity. A valid id is non-empty, made up
+/// only of the safe slug set (ASCII alphanumerics plus `_ - . / @ : + =`), has
+/// no `..` segment, and does not begin with `/`. This is deliberately the same
+/// safe set [`crate::shell_quote`] treats as needing no quoting, so a valid
+/// thread id is always a single shell token: `feature/x`, `v1.2`, `my-thread`,
+/// and `team@scope` are accepted; spaces, quotes, `;`, `|`, `$`, `&`, `*`,
+/// backticks, and newlines are rejected. Thread ids flow into worktree paths,
+/// so `..` and a leading `/` are rejected to keep them in-tree.
+pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
+    let safe_charset = value.bytes().all(|b| {
+        b.is_ascii_alphanumeric()
+            || matches!(b, b'_' | b'-' | b'.' | b'/' | b'@' | b':' | b'+' | b'=')
+    });
+    let ok = !value.is_empty()
+        && safe_charset
+        && !value.contains("..")
+        && !value.starts_with('/');
+    if ok {
+        Ok(())
+    } else {
+        Err(ThreadIdError {
+            input: value.to_string(),
+            suggestion: suggest_thread_id(value),
+        })
+    }
+}
+
+/// Best-effort slugify for the rename hint: map every disallowed character to
+/// `-`, collapse runs, drop `..`, and trim. Always returns a non-empty,
+/// [`validate_thread_id`]-valid string.
+fn suggest_thread_id(value: &str) -> String {
+    let mut slug = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
+            slug.push(ch);
+        } else {
+            slug.push('-');
+        }
+    }
+    while slug.contains("--") {
+        slug = slug.replace("--", "-");
+    }
+    while slug.contains("..") {
+        slug = slug.replace("..", "-");
+    }
+    let trimmed = slug.trim_matches(|c| c == '-' || c == '.');
+    if trimmed.is_empty() {
+        "thread".to_string()
+    } else {
+        trimmed.to_string()
     }
 }
 
@@ -313,7 +412,8 @@ impl EphemeralMarker {
 
 impl ThreadRecord {
     pub fn thread_id(&self) -> ThreadId {
-        ThreadId::new(self.id.clone())
+        // A persisted record's id was validated at creation — trust it.
+        ThreadId::new_unchecked(self.id.clone())
     }
 
     pub fn ref_name(&self) -> &str {
@@ -399,4 +499,59 @@ fn path_present(path: Option<&PathBuf>) -> bool {
 
 fn default_freshness() -> ThreadFreshness {
     ThreadFreshness::Unknown
+}
+
+#[cfg(test)]
+mod thread_id_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_safe_slugs() {
+        for ok in ["feature/x", "v1.2", "a_b-c.d", "team@scope", "main", "wip+1=2"] {
+            assert!(
+                ThreadId::new(ok).is_ok(),
+                "expected '{ok}' to be a valid thread id"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_whitespace_metachars_traversal_and_empty() {
+        for bad in [
+            "my feature", // space
+            "a;b",        // shell separator
+            "a|b",        // pipe
+            "a$(x)",      // command substitution
+            "a\nb",       // newline
+            "a&b",        // background
+            "`x`",        // backtick
+            "..",         // bare traversal
+            "a/../b",     // traversal segment
+            "/abs",       // leading slash
+            "",           // empty
+        ] {
+            assert!(
+                ThreadId::new(bad).is_err(),
+                "expected '{bad}' to be rejected as an invalid thread id"
+            );
+        }
+    }
+
+    #[test]
+    fn error_message_carries_a_valid_rename_hint() {
+        let err = ThreadId::new("my feature").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("my feature"), "names the offending input: {msg}");
+        assert!(msg.contains("try 'my-feature'"), "suggests a rename: {msg}");
+        // The suggestion itself must be a valid thread id.
+        assert!(ThreadId::new(err.suggestion.as_str()).is_ok());
+    }
+
+    #[test]
+    fn deserialize_trusts_persisted_ids_without_revalidating() {
+        // A record written before this rule existed (or by a future version)
+        // must still deserialize — validation is at creation, not on read.
+        let id: ThreadId = serde_json::from_str("\"legacy id\"").unwrap();
+        assert_eq!(id.as_str(), "legacy id");
+    }
 }

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -73,7 +73,7 @@ impl std::fmt::Display for ThreadIdError {
             write!(
                 f,
                 "thread name '{}' is invalid: use only letters, digits, and _ - . / @ : + = \
-                 (no spaces, shell metacharacters, '..' path segments, or a leading '/') — try '{}'",
+                 (no spaces, shell metacharacters, '..' path segments, or a leading '/' or '-') — try '{}'",
                 self.input, self.suggestion
             )
         }
@@ -89,7 +89,9 @@ impl std::error::Error for ThreadIdError {}
 /// thread id is always a single shell token: `feature/x`, `v1.2`, `my-thread`,
 /// and `team@scope` are accepted; spaces, quotes, `;`, `|`, `$`, `&`, `*`,
 /// backticks, and newlines are rejected. Thread ids flow into worktree paths,
-/// so `..` and a leading `/` are rejected to keep them in-tree.
+/// so `..` and a leading `/` are rejected to keep them in-tree. A leading `-`
+/// is also rejected: it is in the safe set (for `my-thread`) but a breadcrumb
+/// like `heddle land --thread -foo` parses `-foo` as a flag, not the value.
 pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
     let safe_charset = value.bytes().all(|b| {
         b.is_ascii_alphanumeric()
@@ -98,7 +100,11 @@ pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
     let ok = !value.is_empty()
         && safe_charset
         && !value.contains("..")
-        && !value.starts_with('/');
+        && !value.starts_with('/')
+        // A leading '-' is in the safe set (for `my-thread`) but makes the id
+        // look like a CLI flag: `heddle land --thread -foo` parses `-foo` as an
+        // option, and argv-template construction panics. Reject it at the source.
+        && !value.starts_with('-');
     if ok {
         Ok(())
     } else {
@@ -528,6 +534,8 @@ mod thread_id_tests {
             "..",         // bare traversal
             "a/../b",     // traversal segment
             "/abs",       // leading slash
+            "-foo",       // leading dash — parses as a CLI flag in breadcrumbs
+            "--bar",      // leading double-dash
             "",           // empty
         ] {
             assert!(

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -63,7 +63,7 @@ enough to deserve a name.
 
 Less to remember. The everyday `heddle help` follows the core loop:
 inspect, adopt or clone, save work, isolate a thread, prove readiness,
-preview integration, ship or push, undo, inspect history, and recover.
+preview advanced integration, land or push, undo, inspect history, and recover.
 The exact verb list comes from the command contract table so human help
 and `heddle commands --output json` do not drift. Collaboration and
 annotation surfaces such as `review`, `discuss`, and `context` stay

--- a/docs/VERIFICATION_STATE_LOGIC_MAP.md
+++ b/docs/VERIFICATION_STATE_LOGIC_MAP.md
@@ -44,7 +44,7 @@ A clean verification report means all applicable dimensions agree:
 | Worktree | Git index/worktree and Heddle worktree compare cleanly. Native Heddle worktrees compare cleanly against the current state. | `dirty_worktree`, `needs_checkpoint`, native `uncaptured`, or worktree inspection `degraded`. |
 | Remote tracking | No upstream work must be integrated before local mutation. `remote_ahead` and `remote_untracked` are verified-clean publish guidance. | `remote_behind`, `remote_diverged`, `remote_contains_undone_checkpoint`, or remote check `degraded`. |
 | Operation | No Git or Heddle operation is in progress. | Rebase, cherry-pick, merge, bisect, or bridge operation needs continue, abort, resolve, or raw-Git handoff. |
-| Workflow | Ready work is reported as workflow guidance after repository safety is known, and merged-thread metadata agrees with target history. | `workflow_status: blocked` when ready work exists but a repository blocker prevents preview or ship; `stale_integration_metadata` when merged-thread records no longer match target history. |
+| Workflow | Ready work is reported as workflow guidance after repository safety is known, and merged-thread metadata agrees with target history. | `workflow_status: blocked` when ready work exists but a repository blocker prevents landing; `stale_integration_metadata` when merged-thread records no longer match target history. |
 | Machine contract | Command catalog, JSON error envelopes, op-id metadata, schema introspection, docs drift, and schema coverage agree. `available_with_doc_gaps` is currently non-blocking. | `machine_contract_gaps` / `schema_gaps`, command contract drift, schema validation failures. |
 | Generated and ignored artifacts | Heddle auto-ignores only its own `.heddle/` metadata. Everything else is ignored only when the repo explicitly says so. In Git-overlay mode, `.gitignore` is the preferred source of ignored-worktree truth; `.heddleignore` is reserved for Heddle-specific or native-Heddle excludes. | Unignored generated output is ordinary worktree dirt; large captures/deletions require explicit force; redaction/purge flows must name the ignore file that Heddle will actually consult. |
 | Persona/output contract | TTY text is human-facing, piped/explicit JSON is machine-facing, and both carry the same next action semantics. | Prose on JSON stdout, missing error envelopes, stale help/schema metadata, narrow/no-color output that hides the action. |
@@ -87,7 +87,7 @@ flowchart TD
     U -- no --> Y["machine_contract_gaps / schema_gaps"]
     U -- yes --> Z["repository verified clean"]
     Z --> AA{"Actionable ready threads waiting?"}
-    AA -- yes --> AB["workflow_status: ready; merge --preview or ship next"]
+    AA -- yes --> AB["workflow_status: ready; land next"]
     AA -- no --> AC{"Local commits ahead or branch untracked?"}
     AC -- yes --> AD["verified clean; recommended_action: heddle push"]
     AC -- no --> AE["workflow_status: clean; no action"]
@@ -104,7 +104,7 @@ flowchart TD
 | Tag import and marker agreement | Git tags visible to the checkout must map to Heddle markers. Missing markers report `tags_need_import`; disagreeing or unmapped markers report `tag_marker_mismatch`. Both are current hard blockers because tag names are user-facing refs, not optional side-branch hints. |
 | Dirty materialization | `switch`, `checkout`, `goto`, `pull`, `thread drop`, `branch -d/-D`, `thread promote`, `start --path`, `merge`, `rebase`, `cherry-pick`, and `undo` must refuse dirty work unless a command has an explicit safe preview or force path. |
 | Commit/checkpoint | Git-compatible `commit` is one logical operation: capture Heddle state, checkpoint Git, return one verification proof, and make one safe `undo` restore both when possible. A commit may not create a Heddle-only state if Git checkpoint preflight is blocked by remote divergence or import repair. |
-| Ready/preview/ship | `ready` preflights active-branch import before auto-capture and then points to `merge --preview`. `merge --preview` is non-mutating and proves the integration decision from verified state. A previewed ready thread can advance the next action to `ship --thread ... --no-push` or `--push`. Ready workflow guidance takes priority over local-ahead or untracked-branch push guidance. |
+| Ready/land | `ready` preflights active-branch import before auto-capture and then points to `land`. `merge --preview` remains an advanced non-mutating proof surface, but it is not the everyday breadcrumb. Ready workflow guidance takes priority over local-ahead or untracked-branch push guidance. |
 | Resolve | `resolve` and `thread resolve` must distinguish no operation, no conflicts, conflict resolution, and thread-review resolution. No-op resolve failures use typed errors and should point back to `status` rather than leaking object lookup internals. |
 | Undo | `undo --preview` and real `undo` share safety refusals. Both refuse dirty worktree and active-operation states before moving refs or worktree bytes. Post-undo text must report the current verification state and next action instead of claiming clean by default. |
 | Remote push/pull | Transfer commands refresh tracking and return post-transfer verification. `remote_ahead` and `remote_untracked` are verified clean publish guidance and recommend `push`; behind and diverged states are blockers. If upstream still points at the exact Git checkpoint just undone locally, verification reports `remote_contains_undone_checkpoint` and recommends `heddle push --force` with `heddle redo` as the restore-work option, never `heddle pull` as the primary action. A command may not claim synced while blocking remote drift remains. |
@@ -143,7 +143,7 @@ the new behavior.
 | No command claims up to date while verification is blocked | `git_overlay_matrix_local_ahead_noop_merge_preserves_semantic_result`; `git_overlay_matrix_rebase_noop_defers_up_to_date_claim_to_verification` |
 | Operation continue/abort advice is consistent | `git_overlay_matrix_in_progress_operations_surface_consistently`; `git_overlay_matrix_continue_and_abort_unify_operator_flow`; `git_overlay_matrix_operator_states_survive_reopen_and_keep_guidance_consistent`; `git_overlay_matrix_continue_retry_loops_block_then_succeed_after_resolution` |
 | Stale integration metadata blocks workflow verification | `git_overlay_matrix_ship_undo_restores_git_and_heddle_together` |
-| Ready/preview/ship/resolve/undo workflow is explicit | `start_merge_undo_json_workflow_keeps_machine_streams_clean`; `ready_text_names_ready_and_already_ready_noop_states`; `resolve_without_merge_emits_actionable_json_error`; `git_overlay_matrix_undo_preview_refuses_active_operation_like_real_undo` |
+| Ready/land/resolve/undo workflow is explicit | `start_merge_undo_json_workflow_keeps_machine_streams_clean`; `ready_text_names_ready_and_already_ready_noop_states`; `resolve_without_merge_emits_actionable_json_error`; `git_overlay_matrix_undo_preview_refuses_active_operation_like_real_undo` |
 | Generated and ignored artifacts are safe | `git_overlay_matrix_commit_ignores_gitignored_noise_and_refuses_noop`; `git_overlay_matrix_commit_requires_explicit_ignore_for_python_generated_noise`; `git_overlay_matrix_init_excludes_only_heddle_metadata`; `test_cli_capture_blocks_large_git_overlay_deletion_without_force`; `.heddleignore` file-operation tests |
 | Persona/output contracts stay coherent | `piped_status_with_no_output_flag_renders_text`; `output_auto_flag_errors_at_parse_with_helpful_message`; `tty_auto_mode_renders_text_and_explicit_json_stays_json`; `quiet_no_color_and_narrow_text_outputs_preserve_global_contract`; `narrow_no_color_text_outputs_cover_everyday_read_surfaces` |
 | Machine contracts stay single-sourced | `op_id_coverage`; `doctor_schemas_reports_runtime_and_documented_coverage`; `public_command_paths_have_command_contract_metadata`; `target/debug/heddle doctor schemas --output json`; `target/debug/heddle doctor docs --all --output json` |
@@ -158,7 +158,7 @@ the new behavior.
 - Machine-contract repair and ready workflow guidance outrank publish guidance.
 - Ready threads are workflow guidance, not repository disverification. They keep
   `verified: true` and `status: clean`, while `workflow_status: ready` and the
-  recommended action points to preview or ship the waiting work.
+  recommended action points to land the waiting work.
 - `import.status: available` is an informational side-branch hint. It must not
   block verification for the active checkout.
 - Every concrete `recommended_action` emitted by verification must parse through

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -328,7 +328,7 @@ Today's call sites that emit `FastForwardV2` (via the shared
 | `commands/rebase/mod.rs` (empty-replay) | `heddle rebase` (no commits to replay) | rebase target thread | heddle#110; same `flush_rebase_batch` envelope as the is_ancestor arm |
 | `commands/rebase/rebase_ops.rs:apply_commit` | `heddle rebase` (replay step) | `"<rebase>"` synthetic | heddle#110; one op per replayed commit, **buffered in `RebaseState.pending_advances` and flushed as one batch on completion** (heddle#198) so `heddle undo` rewinds the whole rebase atomically |
 | `commands/rebase/rebase_ops.rs:apply_tree_to_worktree` | `heddle rebase` (parentless replay) | `"<rebase>"` synthetic | heddle#110; rare parentless-commit replay; same buffering as `apply_commit` |
-| `commands/workflow.rs:adopt_manual_resolution` | `heddle ship` (manual-resolution adopt) | shipped thread name | heddle#110 |
+| `commands/workflow.rs:adopt_manual_resolution` | `heddle land` (manual-resolution adopt) | landed thread name | heddle#110 |
 | `commands/remote/remote_ops.rs:pull_local` | `heddle pull` (local sync, repeat pull) | remote thread name | heddle#110; first-time pull falls back to `Goto` because there's no pre-target tip to restore |
 | `commands/resolve.rs:abort_merge_state` | `heddle resolve --abort` | `"<abort>"` synthetic | heddle#110; today this is a pre-target = post-target no-op record (HEAD doesn't move during a 3-way conflict merge), kept on the same code path so a future merge variant that does move HEAD before abort gets correct undo semantics for free |
 

--- a/docs/design/fuse-worker-ipc-decision.md
+++ b/docs/design/fuse-worker-ipc-decision.md
@@ -228,7 +228,7 @@ action) and the gRPC latency is invisible.
 
 **Why `Ship` is not here.** The worker is the state-owner (it captures
 pending overlay → CAS object). The daemon is the network-talker (it takes
-a CAS hash and pushes to the remote). `heddle ship` is therefore a
+a CAS hash and pushes to the remote). `heddle land` is therefore a
 two-step CLI flow: (1) CLI → `FuseWorkerService.Capture` returning a CAS
 hash; (2) CLI → daemon's ship RPC with that hash. The daemon side does
 not currently expose a `Ship` RPC — `grep -r "Ship" crates/daemon/` is
@@ -325,7 +325,7 @@ time the worker is running.
 |---|---|
 | `heddle start` / mount registration | daemon (then daemon spawns the worker) |
 | `heddle capture` (mount-bound) | fuse-worker (per-mount socket; CLI looks up via daemon's registry) |
-| `heddle ship` | two-step: (1) `FuseWorkerService.Capture` on fuse-worker → CAS hash; (2) daemon's `Ship` RPC with that hash for the network push |
+| `heddle land` | two-step: (1) `FuseWorkerService.Capture` on fuse-worker → CAS hash; (2) daemon's `Ship` RPC with that hash for the network push |
 | Mount status (`heddle status` mount fields) | fuse-worker (per-mount socket); daemon aggregates if multi-mount |
 | `heddle agent serve` and any agent-loop RPC | daemon |
 | `heddle log` / `heddle review` / state-review RPCs | daemon |

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -189,7 +189,7 @@ in-progress operation.
       "status": "available",
       "verified_scope": "everyday_and_agent",
       "advanced_scope": "advanced_internal_admin",
-      "summary": "211 command(s), 181 JSON command(s), 108 mutating command(s), 107 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 59 accepted opaque schema(s) outside clean verification",
+      "summary": "211 command(s), 181 JSON command(s), 108 mutating command(s), 107 mutating JSON command(s); verified everyday/agent machine surface has 38 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 59 accepted opaque schema(s) outside clean verification",
       "catalog_commands_total": 211,
       "catalog_mutating_commands_total": 108,
       "json_commands_total": 181,
@@ -197,21 +197,21 @@ in-progress operation.
       "json_commands_with_schema": 122,
       "json_commands_with_accepted_opaque_schema": 59,
       "json_commands_without_schema": 0,
-      "verified_scope_json_commands_total": 39,
-      "verified_scope_json_commands_with_schema": 39,
+      "verified_scope_json_commands_total": 38,
+      "verified_scope_json_commands_with_schema": 38,
       "verified_scope_json_commands_with_accepted_opaque_schema": 0,
       "verified_scope_json_commands_without_schema": 0,
-      "advanced_scope_json_commands_total": 142,
+      "advanced_scope_json_commands_total": 143,
       "advanced_scope_json_commands_with_accepted_opaque_schema": 59,
       "mutating_commands_total": 107,
       "mutating_commands_with_schema": 75,
       "mutating_commands_with_accepted_opaque_schema": 32,
       "mutating_commands_without_schema": 0,
-      "verified_scope_mutating_commands_total": 24,
-      "verified_scope_mutating_commands_with_schema": 24,
+      "verified_scope_mutating_commands_total": 23,
+      "verified_scope_mutating_commands_with_schema": 23,
       "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
       "verified_scope_mutating_commands_without_schema": 0,
-      "advanced_scope_mutating_commands_total": 83,
+      "advanced_scope_mutating_commands_total": 84,
       "advanced_scope_mutating_commands_with_accepted_opaque_schema": 32,
       "schema_verbs_total": 183,
       "documented_schema_verbs_total": 183,
@@ -525,8 +525,8 @@ saves a Heddle state without recommending a Git checkpoint.
   "message": "Thread 'feature/parser' is ready to integrate",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle merge feature/parser --preview",
-  "recommended_action": "heddle merge feature/parser --preview",
+  "next_action": "heddle land --thread feature/parser --no-push",
+  "recommended_action": "heddle land --thread feature/parser --no-push",
   "captured": true,
   "captured_state": "hd-sqr398dvx9ay",
   "thread_state": "ready",
@@ -534,13 +534,13 @@ saves a Heddle state without recommending a Git checkpoint.
 }
 ```
 
-`heddle ship --output json` emits:
+`heddle land --output json` emits:
 
 ```json
 {
-  "status": "shipped",
-  "action": "ship",
-  "message": "Shipped thread 'feature/parser'",
+  "status": "landed",
+  "action": "land",
+  "message": "Landed thread 'feature/parser'",
   "thread": "feature/parser",
   "captured": false,
   "checkpointed": true,
@@ -551,7 +551,7 @@ saves a Heddle state without recommending a Git checkpoint.
   "pushed_remote": null,
   "performed_steps": ["merge", "checkpoint"],
   "skipped_steps": ["capture(no changes)", "sync(current)", "push(not requested)"],
-  "merge_state": "hd-ship123",
+  "merge_state": "hd-land123",
   "chosen_path": "capture_sync_merge_checkpoint"
 }
 ```
@@ -572,12 +572,12 @@ saves a Heddle state without recommending a Git checkpoint.
 | `next_action_template`, `recommended_action_template` | object \| null | required | Fillable template metadata (`argv_template`, `required_inputs`, `agent_may_fill`) for the next/recommended command; present for every valid action, `null` when none. |
 | `git_commit` | string \| null | required for `checkpoint`/`commit` | Git commit OID produced by the checkpoint path; `null` for native Heddle commits. |
 | `capability`, `storage_model`, `committed_at` | string | required for `checkpoint` | Repository mode, storage model, and checkpoint timestamp. |
-| `status` | string | required for `capture`/`checkpoint`/`commit`/`ready`/`ship` | Machine-stable success status for the operation. |
-| `action` | string | required for `capture`/`checkpoint`/`commit`/`undo`/`redo`/`ship` | Logical operation name. |
+| `status` | string | required for `capture`/`checkpoint`/`commit`/`ready`/`land` | Machine-stable success status for the operation. |
+| `action` | string | required for `capture`/`checkpoint`/`commit`/`undo`/`redo`/`land` | Logical operation name. |
 | `batches` | array<object> | required for `undo`/`redo` | Oplog batches affected by the operation. Empty if none are reported. |
 | `thread_state`, `report` | string \| null / object | required for `ready` | Readiness result and structured readiness report. |
-| `thread`, `captured`, `checkpointed`, `synced`, `integrated`, `pushed`, `pushed_remote` | string / bool / string \| null | required for `ship` | Thread shipped, which local/publish steps completed, and the remote name pushed when publish ran. |
-| `performed_steps`, `skipped_steps`, `merge_state`, `chosen_path` | array<string> / string \| null / string | required for `ship` | Machine-readable path through the ship loop and the merge state landed, when one exists. |
+| `thread`, `captured`, `checkpointed`, `synced`, `integrated`, `pushed`, `pushed_remote` | string / bool / string \| null | required for `land` | Thread landed, which local/publish steps completed, and the remote name pushed when publish ran. |
+| `performed_steps`, `skipped_steps`, `merge_state`, `chosen_path` | array<string> / string \| null / string | required for `land` | Machine-readable path through the land loop and the merge state landed, when one exists. |
 | `verification` | object \| null | required | Post-operation verification proof. `null` only for undo/redo paths that cannot compute it. |
 
 ---
@@ -658,8 +658,8 @@ Preview a merge without changing the worktree.
   "thread_health": "ready",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle ship --thread feature/parser --push",
-  "recommended_action": "heddle ship --thread feature/parser --push",
+  "next_action": "heddle land --thread feature/parser --push",
+  "recommended_action": "heddle land --thread feature/parser --push",
   "diff": {}
 }
 ```
@@ -832,8 +832,8 @@ Report manual follow-up after a blocked or refreshed thread.
   "message": "Thread requires a manual follow-up",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle ship --thread feature/parser --no-push",
-  "recommended_action": "heddle ship --thread feature/parser --no-push",
+  "next_action": "heddle land --thread feature/parser --no-push",
+  "recommended_action": "heddle land --thread feature/parser --no-push",
   "thread": "feature/parser"
 }
 ```
@@ -1926,7 +1926,7 @@ Control-tower view across every active thread.
     "recovery_commands": [],
     "checks": []
   },
-  "recommended_action": "heddle capture",
+  "recommended_action": "heddle commit -m \"...\"",
   "current_thread": "feature/parser-fast",
   "groups": [
     {
@@ -2122,8 +2122,8 @@ instead of treating it as a global catalog option.
     }
   ],
   "recommended_action_placeholders": [
-    "heddle capture -m \"...\"",
-    "heddle checkpoint -m \"...\"",
+    "heddle commit -m \"...\"",
+    "heddle commit -m \"...\"",
     "heddle commit -m \"...\"",
     "heddle ready -m \"...\"",
     "heddle stash push -m \"...\"",
@@ -2464,7 +2464,7 @@ catalog-wide schema coverage.
   "output_kind": "doctor_schemas",
   "status": "available",
   "verified": true,
-  "summary": "211 command(s), 181 JSON command(s), 108 mutating command(s), 107 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 59 accepted opaque schema(s) outside clean verification",
+  "summary": "211 command(s), 181 JSON command(s), 108 mutating command(s), 107 mutating JSON command(s); verified everyday/agent machine surface has 38 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 59 accepted opaque schema(s) outside clean verification",
   "recommended_action": null,
   "recovery_commands": [],
   "registered_verbs": ["status", "verify", "try"],
@@ -2477,7 +2477,6 @@ catalog-wide schema coverage.
     "status": "available",
     "verified_scope": "everyday_and_agent",
     "advanced_scope": "advanced_internal_admin",
-    "summary": "211 command(s), 181 JSON command(s), 108 mutating command(s), 107 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 59 accepted opaque schema(s) outside clean verification",
     "catalog_commands_total": 211,
     "catalog_mutating_commands_total": 108,
     "json_commands_total": 181,
@@ -2485,21 +2484,19 @@ catalog-wide schema coverage.
     "json_commands_with_schema": 122,
     "json_commands_with_accepted_opaque_schema": 59,
     "json_commands_without_schema": 0,
-    "verified_scope_json_commands_total": 39,
-    "verified_scope_json_commands_with_schema": 39,
+    "verified_scope_json_commands_total": 38,
+    "verified_scope_json_commands_with_schema": 38,
     "verified_scope_json_commands_with_accepted_opaque_schema": 0,
     "verified_scope_json_commands_without_schema": 0,
-    "advanced_scope_json_commands_total": 142,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 59,
     "mutating_commands_total": 107,
     "mutating_commands_with_schema": 75,
     "mutating_commands_with_accepted_opaque_schema": 32,
     "mutating_commands_without_schema": 0,
-    "verified_scope_mutating_commands_total": 24,
-    "verified_scope_mutating_commands_with_schema": 24,
+    "verified_scope_mutating_commands_total": 23,
+    "verified_scope_mutating_commands_with_schema": 23,
     "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
     "verified_scope_mutating_commands_without_schema": 0,
-    "advanced_scope_mutating_commands_total": 83,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 32,
     "undocumented_schema_verbs_total": 0,
     "opaque_schema_verbs_total": 59,
@@ -2528,7 +2525,7 @@ surface, not repository state.
 ```json
 {
   "topic": "git-overlay",
-  "summary": "Use Heddle as the daily Git-overlay loop: status, diff, commit, start --path, ready, merge --preview, ship, undo, verification.",
+  "summary": "Use Heddle as the daily Git-overlay loop: status, diff, commit, start --path, ready, land, push, undo, verification.",
   "steps": [
     "heddle status",
     "heddle adopt --ref <branch>",
@@ -2536,8 +2533,7 @@ surface, not repository state.
     "heddle commit -m <message>",
     "heddle start <name> --path ../<name>",
     "heddle ready",
-    "heddle merge <name> --preview",
-    "heddle ship --thread <name> --no-push",
+    "heddle land --thread <name> --no-push",
     "heddle push",
     "heddle undo",
     "heddle verify"
@@ -2594,15 +2590,15 @@ lives in `recovery_commands`.
 {
   "status": "completed",
   "action": "try",
-  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hd-sqr398dvx9ay). Run `heddle merge try-1234abcd` to land.",
+  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hd-sqr398dvx9ay). Run `heddle ready --thread try-1234abcd` to land.",
   "thread": "try-1234abcd",
   "thread_dropped": false,
   "exit_code": 0,
   "duration_ms": 1420,
   "captured_state": "hd-sqr398dvx9ay",
   "merge_state": null,
-  "next_action": "heddle merge try-1234abcd",
-  "recommended_action": "heddle merge try-1234abcd",
+  "next_action": "heddle ready --thread try-1234abcd",
+  "recommended_action": "heddle ready --thread try-1234abcd",
   "recovery_commands": ["heddle thread drop try-1234abcd"]
 }
 ```
@@ -2639,7 +2635,7 @@ Run N isolated candidates and recommend the best thread to inspect or merge.
     }
   ],
   "recommended": "attempt-1",
-  "next_action": "heddle merge attempt-1 --with-diff"
+  "next_action": "heddle ready --thread attempt-1"
 }
 ```
 
@@ -2674,8 +2670,8 @@ Refresh the active or named thread, or report the verification/action blocker.
   "message": "Refreshed thread 'feature/parser'",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle ship",
-  "recommended_action": "heddle ship",
+  "next_action": "heddle land",
+  "recommended_action": "heddle land",
   "thread": "feature/parser",
   "current_state": "hd-sqr398dvx9ay",
   "chosen_path": "refresh"


### PR DESCRIPTION
## Summary

Implements the accepted #461 spike decision (`docs/spikes/save-verb-consolidation.md`, merged in #463). The everyday workflow is now a single canonical chain:

```
commit -> ready -> land -> push
```

with `sync` for freshness/remote-drift and `resolve`/`continue`/`abort` for conflict recovery. `ship` is renamed to `land`; `checkpoint`, `capture`, `merge`, `thread refresh`, and `thread resolve` are demoted to advanced primitives and removed from every `next_action` / `recommended_action` breadcrumb.

**Closes #456, #458, #459, #460** — the coordinated guidance fix subsumes all four.

## Canonical surface
- `ship` → `land` (no compat shim — pre-1.0, command strings + JSON templates migrated together).
- Git-overlay `needs_checkpoint` advice → `commit` (#458).
- Dirty-work / manual-resolution breadcrumbs → repo-type-aware `commit` (not `capture`).
- `ready -> merge --preview -> ship` → `ready -> land` (managed preview/readiness folded into `ready`).
- Stale-thread `thread refresh` → top-level `sync` (#460).
- `thread resolve` removed as a breadcrumb; its legitimate cases map to `resolve`/`continue` (active conflicts), `sync` (stale), `land` (clean ready), or a concrete blocker with no self-loop (#456, #459).

## How the invariant is enforced (close-the-class)
A **centralized next_action validator** (`crates/cli/src/cli/commands/next_action.rs`) re-reads every command's serialized JSON before emit and rejects:
1. non-canonical / demoted verbs (`ship`, `checkpoint`, `capture`, `merge`, `thread refresh`, `thread resolve`),
2. wrong-repo-type verbs (e.g. `checkpoint` from a native/isolated checkout),
3. no-op self-loops (an emitter pointing back at itself).

It walks the output tree recursively, so nested `recommended_action` fields are covered too. All JSON emitters route through `write_validated_json_stdout`, so the entire trap-class fails at runtime/CI rather than being patched cell-by-cell.

## Regression tests
`crates/cli/tests/cli_integration/next_action_contract.rs` plus validator unit tests assert: isolated checkouts never emit `checkpoint`; no `next_action` begins with `heddle thread resolve`; stale managed threads suggest `sync` (not `merge --preview` / `thread refresh`); dirty work suggests `commit`; ready threads surface `land` across `ready` / `thread show` / `thread list`.

Docs, command-catalog templates, and help topics are migrated in the same branch so agents and humans see one surface.

## Test plan
- [x] `cargo test -p heddle-cli` (default features)
- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` (verified per-suite: multi_agent_worktrees, git_overlay_matrix, next_action_contract, oss_cli_polish, git_replacement_matrix, heddle-repo, devtools)
- [x] `bash scripts/check-no-silent-default-tree-load.sh`
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic,zstd -- -D warnings`
- [x] `cargo build -p heddle-cli`
- [x] Did NOT run cargo fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783058549&installation_id=132405951&pr_number=478&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F478&signature=0d65630d4bfaf06b313187a460bc7cfbc126f302b77fbb2f6fc92001df2b5f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->