### PR TITLE
chore(deps): upgrade dep crates + strip unused + cargo-audit fix

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,30 @@
+# cargo-audit configuration — companion to deny.toml.
+#
+# Heddle's authoritative supply-chain gate is `cargo deny check` (run by
+# .github/workflows/audit.yml). Both tools read the same RustSec advisory
+# database; this file mirrors the `[advisories].ignore` list from deny.toml
+# so `cargo audit` runs clean locally AND in CI (the cargo-audit job in
+# audit.yml relies on this file's auto-discovery rather than inline
+# --ignore flags).
+#
+# When you ignore an advisory here you MUST also ignore it in deny.toml
+# (with the same rationale). The deny.toml entry is canonical; treat this
+# file as a derived mirror.
+
+[advisories]
+ignore = [
+    # rsa 0.9.x Marvin timing sidechannel. Heddle's path is signature
+    # verification, not RSA decryption, so the attack precondition does not
+    # apply. Revisit when rsa 0.10 (constant-time) ships.
+    "RUSTSEC-2023-0071",
+
+    # The next three are all the same transitive chain:
+    #   aws-sdk-s3 → aws-smithy-http-client → hyper-rustls 0.24 → rustls 0.21
+    #     → rustls-webpki 0.101 / rustls-pemfile 2
+    # Unblocks when aws-sdk-s3 1.135 can land, which is itself gated on
+    # s3s cutting a release that uses stable sha2/sha1 (currently pinned to
+    # 0.11.0-rc.5 in s3s 0.13.0). Tracked in the deps-upgrade follow-up.
+    "RUSTSEC-2026-0098", # rustls-webpki: URI name constraint accepted
+    "RUSTSEC-2026-0099", # rustls-webpki: wildcard SAN constraint bypass
+    "RUSTSEC-2026-0104", # rustls-webpki: reachable panic on malformed CRL
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -72,14 +72,9 @@ jobs:
 
       - name: Run cargo-audit
         # --deny warnings escalates yanked / unmaintained / notice advisories
-        # to errors. The --ignore list below MUST mirror deny.toml's
-        # [advisories].ignore — cargo-audit doesn't read deny.toml. If you add
-        # an ignore there, add it here too (and update CONTRIBUTING's Security
-        # section so the rationale stays discoverable).
-        run: |
-          cargo audit \
-            --deny warnings \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2026-0098 \
-            --ignore RUSTSEC-2026-0099 \
-            --ignore RUSTSEC-2026-0104
+        # to errors. The ignore list lives in .cargo/audit.toml (auto-
+        # discovered by cargo-audit). That file mirrors deny.toml's
+        # [advisories].ignore — cargo-audit doesn't read deny.toml directly.
+        # To accept a new advisory: add it to BOTH deny.toml and audit.toml
+        # with matching rationale, and update CONTRIBUTING's Security section.
+        run: cargo audit --deny warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,15 +274,10 @@ cargo install --locked cargo-audit # once
 
 cargo deny check                   # full policy run
 
-# advisory check — flags MUST mirror .github/workflows/audit.yml so a green
-# local run means a green CI run. If you add/remove an --ignore here, also
-# update the workflow (cargo-audit doesn't read deny.toml's ignore list).
-cargo audit \
-  --deny warnings \
-  --ignore RUSTSEC-2023-0071 \
-  --ignore RUSTSEC-2026-0098 \
-  --ignore RUSTSEC-2026-0099 \
-  --ignore RUSTSEC-2026-0104
+# advisory check — reads .cargo/audit.toml for the ignore list (same set
+# as deny.toml, mirrored). Both local and CI invoke the bare command;
+# the file is the single source for cargo-audit's ignores.
+cargo audit --deny warnings
 ```
 
 Both should be green before you push. CI runs them on every PR (no
@@ -294,19 +289,18 @@ unchanged dependency surfaces without anyone having to push code.
 
 If a RustSec advisory cannot be fixed by a version bump (upstream
 hasn't released; advisory doesn't apply to our usage; etc.), add an
-entry to **all three** of:
+entry to **both** of:
 
 1. `deny.toml` — `[advisories].ignore` with `{ id, reason }`. The
    `reason` must explain *why* it's safe to ignore in Heddle's context,
-   not just acknowledge the advisory exists.
-2. `.github/workflows/audit.yml` — `cargo audit --ignore <ID>` in the
-   `cargo-audit` step. cargo-audit doesn't read `deny.toml`, so the
-   two lists must be kept in sync by hand.
-3. The local-run command in this file (above) — so contributors running
-   `cargo audit` locally see the same advisories pass that CI does.
+   not just acknowledge the advisory exists. This is the canonical entry.
+2. `.cargo/audit.toml` — `[advisories].ignore = [...]`. cargo-audit
+   doesn't read `deny.toml`, so this mirror keeps the two tools in sync.
+   Both local `cargo audit` and the CI `cargo-audit` job auto-discover
+   this file; no third place to update.
 
-When upstream ships a fix, remove the entry from all three places in
-the same PR that bumps the dependency.
+When upstream ships a fix, remove the entry from both places in the
+same PR that bumps the dependency.
 
 ### Adding a license to the allow-list
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,15 +846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytestream"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f720842a717d6afaf69fee2dc69b771edc165f12cc3eb1b0e8eeef53a86454"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "bytestring"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,7 +3531,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4170,22 +4161,18 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nfsserve"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73615e054238e6bf5e554407b5b23e82fc63616db459057c51b794799eda6fb"
+checksum = "ef1424b6d88c60a091931392970999ea3ceab132d968e6a5545c770fad5b97d7"
 dependencies = [
  "anyhow",
  "async-trait",
  "byteorder",
- "bytestream",
  "filetime",
- "futures",
  "num-derive",
  "num-traits",
- "smallvec",
  "tokio",
  "tracing",
- "tracing-attributes",
 ]
 
 [[package]]
@@ -4340,13 +4327,13 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7601,25 +7588,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -7628,22 +7613,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7651,17 +7636,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7686,12 +7660,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -7701,16 +7676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7804,6 +7769,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,9 +1885,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix"
-version = "0.80.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa56fdbfe98258af2759818ddc3175cc581112660e74c3fd55669836d29a994"
+checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -1931,6 +1931,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "gix-worktree",
+ "gix-worktree-stream",
  "nonempty",
  "smallvec",
  "thiserror 2.0.18",
@@ -1938,21 +1939,20 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.40.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-attributes"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1985,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1998,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.34.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea2fcfa6bc7329cd094696ba76682b89bdb61cafc848d91b34abba1c1d7e040"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.53.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c24b190bd42b55724368c28ae750840b48e2038b9b5281202de6fca4ec1fce1"
+checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -2023,18 +2023,16 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
  "bitflags 2.12.1",
  "bstr",
@@ -2045,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.37.2"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0493f25da3ce9e8f7d925e5b64dc6d0b6109c96add422a6bcada52416448147d"
+checksum = "f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2075,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.60.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60592771b104eda4e537c311e8239daef0df651d61e0e21855f7e6166416ff12"
+checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2087,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810764b92e8cb95e4d91b7adfc5a14666434fd32ace02900dfb66aae71f845df"
+checksum = "77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7"
 dependencies = [
  "bstr",
  "dunce",
@@ -2111,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.46.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2130,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eda328750accaac05ce7637298fd7d6ba0d5d7bdf49c21f899d0b97e3df822d"
+checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2151,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.19.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2165,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
  "bitflags 2.12.1",
  "bstr",
@@ -2177,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.22.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ced05d2d7b13bff08b2f7eb4e47cfeaf00b974c2ddce08377c4fe1f706b3eb"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -2189,20 +2187,20 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.12.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
+checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2213,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b28482b86662c8b78160e0750b097a35fd61185803a960681351b3a07de07e"
+checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
 dependencies = [
  "bitflags 2.12.1",
  "bstr",
@@ -2230,7 +2228,7 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "libc",
  "memmap2",
@@ -2241,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "21.0.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -2252,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.28.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a925ec9bc3664eaff9c7dc49bc857fe0de7e90ece6e092cb66ba923812824db"
+checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
 dependencies = [
  "bitflags 2.12.1",
  "gix-commitgraph",
@@ -2266,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.57.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013eae8e072c6155191ac266950dfbc8d162408642571b32e2c6b3e4b03740fb"
+checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2276,20 +2274,18 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.77.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8901a182923799e8857ac01bff6d7c6fecea999abd79a86dab638aadbb843f3"
+checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -2300,6 +2296,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "memmap2",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -2307,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.67.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a9f96f4058359d6874123f160e5b2044974829a29f3a71bb9c9218d1916c3"
+checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -2342,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2354,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
  "bitflags 2.12.1",
  "bstr",
@@ -2369,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de52c2570684db3eb8cebda77c1d0e3d03ddaad2d9bbb5055eba31fb9f8292a"
+checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2382,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.58.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c64ec7b04c57df6e97a2ac4738a4a09897b88febd6ec4bd2c5d3ff3ad3849df"
+checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -2404,7 +2401,6 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2420,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.60.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc7b230945f02d706a49bcf823b671785ecd9e88e713b8bd2ca5db104c97add"
+checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2436,14 +2432,13 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3dc194cdc1176fc20f39f233d0d516f83df843ea14a9eb758a2690f3e38d1e"
+checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2457,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.42.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9e31cd402edae08c3fdb67917b9fb75b0c9c9bd2fbed0c2dd9c0847039c556"
+checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
  "bitflags 2.12.1",
  "bstr",
@@ -2476,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.28.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573f6e471d76c0796f0b8ed5a431521ea5d121a7860121a2a9703e9434ab1d52"
+checksum = "85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2492,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
  "bitflags 2.12.1",
  "gix-path",
@@ -2504,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.9.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee51037c8a27ddb1c7a6d6db2553d01e501d5b1dae7dc65e41905a70960e658"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2517,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cba2022599491d620fbc77b3729dba0120862ce9b4af6e3c47d19a9f2a5d884"
+checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2532,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "21.0.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
 dependencies = [
  "gix-fs",
  "libc",
@@ -2550,9 +2545,9 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
-version = "0.55.1"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -2569,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.54.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99b3cf9dc87c13f1404e7b0e8c5e4bff4975d6f788831c02d6c006f3c76b4a0"
+checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
 dependencies = [
  "bitflags 2.12.1",
  "gix-commitgraph",
@@ -2586,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.3"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2617,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.49.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005627fc149315f39473e3e94a50058dd5d345c490a23723f67f32ee9c505232"
+checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -2631,6 +2626,24 @@ dependencies = [
  "gix-object",
  "gix-path",
  "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
 ]
 
 [[package]]
@@ -7923,9 +7936,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,28 +167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,18 +2788,13 @@ version = "0.2.4"
 dependencies = [
  "anstyle",
  "anyhow",
- "async-stream",
  "async-trait",
- "base32",
  "base64 0.22.1",
  "blake3",
- "bytes",
  "chrono",
  "clap",
  "clap_complete",
  "criterion",
- "ed25519-dalek",
- "fs2",
  "futures",
  "gix",
  "gix-config",
@@ -2848,7 +2821,6 @@ dependencies = [
  "hyper-util",
  "ignore",
  "libc",
- "memmap2",
  "notify",
  "ntest",
  "opentelemetry",
@@ -2856,7 +2828,6 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "prost-types 0.14.3",
- "rand 0.10.1",
  "rmp-serde",
  "rustls 0.23.40",
  "schemars",
@@ -2867,10 +2838,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
- "tokio-test",
  "tokio-tungstenite",
- "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tonic-health",
@@ -2881,7 +2849,6 @@ dependencies = [
  "uuid",
  "walkdir",
  "weft-client-shim",
- "zstd",
 ]
 
 [[package]]
@@ -2899,17 +2866,12 @@ name = "heddle-cli-shared"
 version = "0.2.4"
 dependencies = [
  "anyhow",
- "chrono",
  "heddle-objects",
  "heddle-proto",
  "heddle-repo",
- "rustls 0.23.40",
- "rustls-webpki 0.103.13",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -2917,11 +2879,8 @@ name = "heddle-client"
 version = "0.2.4"
 dependencies = [
  "anyhow",
- "async-stream",
- "async-trait",
  "base64 0.22.1",
  "biscuit-auth",
- "blake3",
  "chrono",
  "clap",
  "futures",
@@ -2932,30 +2891,16 @@ dependencies = [
  "heddle-proto",
  "heddle-refs",
  "heddle-repo",
- "hex",
- "hyper-util",
- "ignore",
- "jsonwebtoken",
- "libc",
- "prost 0.14.3",
  "prost-types 0.14.3",
- "reqwest",
- "rmp-serde",
- "rustls 0.23.40",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "toml 1.1.2+spec-1.1.0",
  "tonic",
- "tonic-health",
- "tower",
  "tracing",
- "walkdir",
  "weft-client-shim",
 ]
 
@@ -2980,9 +2925,7 @@ dependencies = [
 name = "heddle-daemon"
 version = "0.2.4"
 dependencies = [
- "async-stream",
  "chrono",
- "fs2",
  "futures",
  "heddle-crypto",
  "heddle-grpc",
@@ -3001,7 +2944,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml 1.1.2+spec-1.1.0",
@@ -3093,7 +3035,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "windows",
 ]
 
@@ -3102,7 +3043,6 @@ name = "heddle-objects"
 version = "0.2.4"
 dependencies = [
  "anyhow",
- "async-trait",
  "aws-sdk-s3",
  "aws-smithy-async",
  "base32",
@@ -3117,7 +3057,6 @@ dependencies = [
  "ignore",
  "libc",
  "memmap2",
- "ntest",
  "proptest",
  "rand 0.10.1",
  "rmp-serde",
@@ -3125,16 +3064,13 @@ dependencies = [
  "s3s-fs",
  "serde",
  "serde_json",
- "serial_test",
  "similar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
- "walkdir",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -3145,17 +3081,14 @@ version = "0.2.4"
 dependencies = [
  "chrono",
  "criterion",
- "fs2",
  "heddle-objects",
  "heddle-runtime-bridge",
  "pollster",
- "rand 0.10.1",
  "rmp-serde",
  "serde",
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -3164,7 +3097,6 @@ dependencies = [
 name = "heddle-proto"
 version = "0.2.4"
 dependencies = [
- "blake3",
  "chrono",
  "heddle-objects",
  "heddle-repo",
@@ -3217,7 +3149,6 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "similar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3241,7 +3172,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
  "uuid",
 ]
 
@@ -3261,7 +3191,6 @@ dependencies = [
  "heddle-merge",
  "heddle-objects",
  "pprof",
- "similar",
  "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-c",
@@ -3278,12 +3207,9 @@ dependencies = [
 name = "heddle-state-review"
 version = "0.2.4"
 dependencies = [
- "chrono",
  "heddle-objects",
  "heddle-semantic",
  "serde",
- "tempfile",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6733,17 +6659,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-credential-types"
@@ -273,7 +273,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -307,7 +307,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -333,7 +333,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -362,7 +362,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "md-5 0.10.6",
@@ -396,7 +396,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -429,10 +429,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -447,20 +449,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -472,16 +475,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -500,16 +503,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -533,13 +547,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -554,7 +569,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -578,7 +593,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -728,9 +743,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -798,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -865,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.2"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
 dependencies = [
  "heck",
  "indexmap",
@@ -883,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1036,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1261,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1388,15 +1403,15 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1463,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1706,7 +1721,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "log",
  "memchr",
@@ -1961,18 +1976,18 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
 dependencies = [
  "gix-error",
 ]
@@ -2030,7 +2045,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bstr",
  "gix-path",
  "libc",
@@ -2057,15 +2072,14 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
 dependencies = [
  "bstr",
  "gix-error",
  "itoa",
  "jiff",
- "smallvec",
 ]
 
 [[package]]
@@ -2097,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
 dependencies = [
  "bstr",
 ]
@@ -2164,7 +2178,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2212,7 +2226,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b28482b86662c8b78160e0750b097a35fd61185803a960681351b3a07de07e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bstr",
  "filetime",
  "fnv",
@@ -2251,7 +2265,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a925ec9bc3664eaff9c7dc49bc857fe0de7e90ece6e092cb66ba923812824db"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2325,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2353,7 +2367,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -2404,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2456,7 +2470,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9e31cd402edae08c3fdb67917b9fb75b0c9c9bd2fbed0c2dd9c0847039c556"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -2491,7 +2505,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2539,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
@@ -2558,7 +2572,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
 ]
 
@@ -2568,7 +2582,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99b3cf9dc87c13f1404e7b0e8c5e4bff4975d6f788831c02d6c006f3c76b4a0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2593,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "fastrand",
  "unicode-normalization",
@@ -2603,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
 ]
@@ -2682,7 +2696,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -2916,7 +2930,7 @@ dependencies = [
  "libc",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmp-serde",
  "rustls 0.23.40",
  "serde",
@@ -3212,7 +3226,7 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "regex-lite",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -3334,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3360,7 +3374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -3371,7 +3385,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3423,16 +3437,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3464,8 +3478,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "tokio",
@@ -3479,7 +3493,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3496,14 +3510,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3690,11 +3704,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "inotify-sys",
  "libc",
 ]
@@ -3776,9 +3790,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3786,14 +3800,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3876,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3912,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3922,11 +3936,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -3968,14 +3982,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -4012,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"
@@ -4048,9 +4062,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4079,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -4124,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4177,7 +4191,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4215,7 +4229,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4233,7 +4247,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4306,9 +4320,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4450,7 +4464,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry",
  "reqwest 0.12.28",
 ]
@@ -4461,7 +4475,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -4907,7 +4921,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -5070,11 +5084,11 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "memchr",
  "unicase",
 ]
@@ -5126,7 +5140,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5164,7 +5178,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5301,16 +5315,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -5379,10 +5393,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "js-sys",
  "log",
@@ -5404,9 +5418,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5415,10 +5429,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -5522,7 +5536,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -5557,7 +5571,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5594,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5706,11 +5720,11 @@ dependencies = [
  "futures",
  "hex-simd",
  "hmac 0.13.0-rc.5",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "itoa",
  "md-5 0.11.0-rc.5",
  "memchr",
@@ -5788,15 +5802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,12 +5863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5896,7 +5895,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5962,9 +5961,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -6007,24 +6006,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6115,9 +6113,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6157,9 +6155,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
 ]
@@ -6203,9 +6201,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6345,7 +6343,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -6389,7 +6387,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "chrono",
  "crc",
@@ -6707,7 +6705,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6822,7 +6820,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6845,14 +6843,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6861,7 +6859,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6881,15 +6879,15 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -6974,14 +6972,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -7114,9 +7112,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
@@ -7227,7 +7225,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -7240,9 +7238,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -7339,9 +7337,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7433,9 +7431,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7446,9 +7444,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7456,9 +7454,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7466,9 +7464,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7479,9 +7477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -7514,7 +7512,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -7522,9 +7520,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7973,9 +7971,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -8044,7 +8042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",
@@ -8111,18 +8109,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
 ]
 
@@ -2935,7 +2935,7 @@ dependencies = [
  "libc",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "reqwest 0.13.4",
+ "reqwest",
  "rmp-serde",
  "rustls 0.23.40",
  "serde",
@@ -3231,7 +3231,7 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "regex-lite",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -4458,9 +4458,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4472,22 +4472,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.1",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.1",
  "opentelemetry",
@@ -4495,18 +4495,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4517,15 +4517,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -5395,40 +5396,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"
@@ -6966,6 +6933,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7070,9 +7048,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5793,12 +5793,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -5806,9 +5807,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.1",
  "http-body 1.0.1",
- "lru",
+ "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
  "sha2 0.10.9",
@@ -2760,6 +2760,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3074,7 +3079,7 @@ dependencies = [
  "heddle-refs",
  "heddle-repo",
  "libc",
- "lru",
+ "lru 0.18.0",
  "memmap2",
  "nfsserve",
  "proptest",
@@ -4037,6 +4042,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -6766,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7218,22 +7232,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.4.1",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 1.0.69",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7316,12 +7328,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
 protoc-bin-vendored = "3"
-opentelemetry = "0.31"
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "trace", "metrics"] }
-opentelemetry_sdk = "0.31"
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace", "metrics"] }
+opentelemetry_sdk = "0.32"
 rand = "0.10"
 regex-lite = "0.1"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls-no-provider"] }
@@ -124,7 +124,7 @@ tonic-reflection = "0.14"
 tonic-web = "0.14"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tree-sitter = "0.26"
 tree-sitter-c = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rustls-pki-types = "1"
 webpki = { package = "rustls-webpki", version = "0.103", features = ["std", "ring"] }
 s3s = "0.13.0"
 s3s-fs = "0.13.0"
-schemars = { version = "0.8", features = ["chrono"] }
+schemars = { version = "1.2", features = ["chrono04"] }
 sec1 = { version = "0.8", features = ["pem"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_cbor = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"
 libc = "0.2"
-lru = "0.16"
+lru = "0.18"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 memmap2 = "0.9"
 notify = "8"
@@ -112,7 +112,7 @@ tokio = { version = "1", default-features = false, features = [
 tokio-rustls = "0.26"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-test = "0.4"
-tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 toml = "1.1"
 tonic = { version = "0.14", features = ["transport", "tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-gix = { version = "=0.80.0", default-features = false, features = ["revision", "tree-editor", "blocking-network-client", "blocking-http-transport-reqwest-rust-tls"] }
+gix = { version = "=0.84.0", default-features = false, features = ["sha1", "revision", "tree-editor", "blocking-network-client", "blocking-http-transport-reqwest-rust-tls"] }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"
@@ -139,7 +139,7 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 walkdir = "2"
 windows-sys = "0.61"
 zstd = "0.13"
-gix-transport = { version = "0.55", features = ["http-client-insecure-credentials"] }
+gix-transport = { version = "0.57", features = ["http-client-insecure-credentials"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-async-stream = "0.3"
 async-trait = "0.1"
-atty = "0.2"
 aws-sdk-s3 = { version = "1.129", default-features = false, features = ["behavior-version-latest", "rustls"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 base32 = "0.5"
@@ -67,7 +65,6 @@ p256 = { version = "0.13", features = ["ecdsa", "pem"] }
 pkcs8 = { version = "0.10", features = ["pem", "encryption"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 prost = "0.14"
-prost-build = "0.14"
 prost-types = "0.14"
 protoc-bin-vendored = "3"
 opentelemetry = "0.32"
@@ -79,19 +76,14 @@ reqwest = { version = "0.13.2", default-features = false, features = ["json", "r
 rmp-serde = "1"
 rsa = { version = "0.9", features = ["pem"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
-rustls-pemfile = "2"
-rustls-pki-types = "1"
-webpki = { package = "rustls-webpki", version = "0.103", features = ["std", "ring"] }
 s3s = "0.13.0"
 s3s-fs = "0.13.0"
 schemars = { version = "1.2", features = ["chrono04"] }
 sec1 = { version = "0.8", features = ["pem"] }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_cbor = "0.11"
 serde_json = "1"
 serial_test = "3"
 sha2 = { version = "0.10", features = ["oid"] }
-signature = "2"
 similar = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "json"] }
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
@@ -109,20 +101,13 @@ tokio = { version = "1", default-features = false, features = [
     "fs",          # async filesystem ops in some daemons
     "rt-multi-thread", # hosted daemon binary uses multi-thread runtime
 ] }
-tokio-rustls = "0.26"
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-test = "0.4"
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7", features = ["codec"] }
 toml = "1.1"
 tonic = { version = "0.14", features = ["transport", "tls-webpki-roots"] }
-tonic-build = "0.14"
 tonic-health = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
-tonic-reflection = "0.14"
-tonic-web = "0.14"
-tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/crates/cli-macro-poc/src/output.rs
+++ b/crates/cli-macro-poc/src/output.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 /// `.heddle` sidecar and updates the local `.git/info/exclude` file for Heddle
 /// metadata only; it does not import Git history or write Git-tracked files.
 #[derive(Debug, Serialize, JsonSchema)]
-#[schemars(example = "init_example")]
+#[schemars(example = init_example())]
 pub struct InitOutput {
     /// Stable output discriminator. Always `"init"`.
     pub output_kind: &'static str,

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,17 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
 repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
-rustls.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-tracing.workspace = true
-webpki.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,16 +23,11 @@ exclude = [
 # consumer; the version range matches what `cargo tree` resolves.
 anstyle = "1"
 anyhow.workspace = true
-async-stream.workspace = true
-base32.workspace = true
 base64.workspace = true
 blake3.workspace = true
-bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-ed25519-dalek.workspace = true
-fs2.workspace = true
 futures.workspace = true
 gix-config = "0.57"
 gix-index = "0.52"
@@ -67,13 +62,11 @@ proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-
 refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
 repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false }
 semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2", optional = true }
-memmap2.workspace = true
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 prost-types.workspace = true
-rand.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
@@ -81,9 +74,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-stream.workspace = true
 tokio-tungstenite = { workspace = true, optional = true }
-tokio-util.workspace = true
 toml.workspace = true
 tonic.workspace = true
 # `uuid::Uuid::new_v4().simple()` suffixes rebase transaction ids
@@ -110,7 +101,6 @@ tracing.workspace = true
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 walkdir.workspace = true
-zstd = { workspace = true, optional = true }
 
 # Mount is platform-agnostic in source, but each adapter only
 # compiles for one OS — FUSE on Linux (`fuse`), FSKit on macOS
@@ -181,7 +171,6 @@ observability = [
 # when the dep itself is enabled (`ingest` is gated behind
 # the `ingest` feature).
 zstd = [
-    "dep:zstd",
     "objects/zstd",
     "proto/zstd",
     "repo/zstd",
@@ -222,7 +211,6 @@ proptest.workspace = true
 tokio-tungstenite.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
-tokio-test.workspace = true
 uuid.workspace = true
 
 [[bin]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,10 +34,10 @@ clap_complete.workspace = true
 ed25519-dalek.workspace = true
 fs2.workspace = true
 futures.workspace = true
-gix-config = "0.53"
-gix-index = "0.48"
-gix-pack = "0.67"
-gix-protocol = { version = "0.58", features = ["blocking-client"] }
+gix-config = "0.57"
+gix-index = "0.52"
+gix-pack = "0.71"
+gix-protocol = { version = "0.62", features = ["blocking-client"] }
 gix-transport.workspace = true
 gix.workspace = true
 hex.workspace = true

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -2811,7 +2811,8 @@ pub(crate) fn copy_reachable_objects(
     for oid in collect_reachable_object_ids(source, roots)? {
         let object = source.find_object(oid).map_err(git_err)?;
         let object_ref =
-            gix::objs::ObjectRef::from_bytes(object.kind, &object.data).map_err(git_err)?;
+            gix::objs::ObjectRef::from_bytes(&object.data, object.kind, source.object_hash())
+                .map_err(git_err)?;
         target.write_object(object_ref).map_err(git_err)?;
     }
 
@@ -3037,6 +3038,7 @@ fn pack_reachable_objects(
         let data = gix::objs::Data {
             kind: object.kind,
             data: &object.data,
+            object_hash: repo.object_hash(),
         };
         let count = gix_pack::data::output::Count::from_data(*oid, None);
         let entry = gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?;

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2779,8 +2779,13 @@ mod tests {
     fn schema_allows_null(root: &Value, schema: &Value) -> bool {
         if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
             let definition = reference
-                .strip_prefix("#/definitions/")
-                .and_then(|name| root.get("definitions").and_then(|defs| defs.get(name)))
+                .strip_prefix("#/$defs/")
+                .or_else(|| reference.strip_prefix("#/definitions/"))
+                .and_then(|name| {
+                    root.get("$defs")
+                        .or_else(|| root.get("definitions"))
+                        .and_then(|defs| defs.get(name))
+                })
                 .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"));
             return schema_allows_null(root, definition);
         }
@@ -2811,8 +2816,13 @@ mod tests {
     fn collect_string_enums<'a>(root: &'a Value, schema: &'a Value, values: &mut Vec<&'a str>) {
         if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
             let definition = reference
-                .strip_prefix("#/definitions/")
-                .and_then(|name| root.get("definitions").and_then(|defs| defs.get(name)))
+                .strip_prefix("#/$defs/")
+                .or_else(|| reference.strip_prefix("#/definitions/"))
+                .and_then(|name| {
+                    root.get("$defs")
+                        .or_else(|| root.get("definitions"))
+                        .and_then(|defs| defs.get(name))
+                })
                 .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"));
             collect_string_enums(root, definition, values);
         }

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -16,13 +16,13 @@
 
 use std::{collections::BTreeMap, sync::OnceLock};
 
-use anyhow::{Result, anyhow};
-use schemars::{JsonSchema, schema_for};
+use anyhow::{anyhow, Result};
+use schemars::{schema_for, JsonSchema};
 use serde::Serialize;
 use serde_json::Value;
 
-use super::{CommandCatalogOutput, RecoveryAdvice, command_catalog, command_runtime_contract};
-use crate::cli::{Cli, should_output_json};
+use super::{command_catalog, command_runtime_contract, CommandCatalogOutput, RecoveryAdvice};
+use crate::cli::{should_output_json, Cli};
 
 static SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
 static DOCUMENTED_SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
@@ -1832,11 +1832,9 @@ pub struct PushSchema {
     #[schemars(required)]
     pub next_action: Option<String>,
     #[schemars(required)]
-    #[schemars(required)]
     pub next_action_template: Option<ActionTemplateSchema>,
     #[schemars(required)]
     pub recommended_action: Option<String>,
-    #[schemars(required)]
     #[schemars(required)]
     pub recommended_action_template: Option<ActionTemplateSchema>,
 }
@@ -2314,11 +2312,11 @@ pub struct ReviewNextSchema {
 pub struct RequiredNullableNextState(pub Option<ReviewNextStateSchema>);
 
 impl JsonSchema for RequiredNullableNextState {
-    fn schema_name() -> String {
-        "RequiredNullableNextState".to_owned()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("RequiredNullableNextState")
     }
 
-    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         <Option<ReviewNextStateSchema> as JsonSchema>::json_schema(generator)
     }
 }

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -2286,7 +2286,7 @@ impl HostedPresenceWatch {
             subscribe: vec![namespace.to_string()],
         })
         .ok()?;
-        stream.send(Message::Text(hello)).await.ok()?;
+        stream.send(Message::Text(hello.into())).await.ok()?;
         Some(Self { stream })
     }
 

--- a/crates/cli/tests/presence_publish.rs
+++ b/crates/cli/tests/presence_publish.rs
@@ -37,7 +37,9 @@ async fn spawn_stub_server() -> (SocketAddr, mpsc::UnboundedReceiver<Value>, Joi
 
         // Send a benign ready so the publisher proceeds.
         ws.send(Message::Text(
-            serde_json::json!({"type":"ready","subscribed":[]}).to_string(),
+            serde_json::json!({"type":"ready","subscribed":[]})
+                .to_string()
+                .into(),
         ))
         .await
         .ok();

--- a/crates/cli/tests/snapshots/agent_api_schema.json
+++ b/crates/cli/tests/snapshots/agent_api_schema.json
@@ -1,7 +1,6 @@
 {
   "AgentReservationEnvelope": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "definitions": {
+    "$defs": {
       "ActionTemplate": {
         "properties": {
           "action": {
@@ -25,9 +24,9 @@
         },
         "required": [
           "action",
-          "agent_may_fill",
           "argv_template",
-          "required_inputs"
+          "required_inputs",
+          "agent_may_fill"
         ],
         "type": "object"
       },
@@ -92,7 +91,7 @@
             "type": "string"
           },
           "status": {
-            "description": "Lifecycle status as a stable kebab-case string (`active|abandoned|complete|merged`). Mirrors `objects::store::AgentStatus` but kept as a `String` here so the schema lives entirely in the CLI crate.",
+            "description": "Lifecycle status as a stable kebab-case string\n(`active|abandoned|complete|merged`). Mirrors\n`objects::store::AgentStatus` but kept as a `String` here so\nthe schema lives entirely in the CLI crate.",
             "type": "string"
           },
           "task": {
@@ -113,8 +112,8 @@
         },
         "required": [
           "session_id",
-          "status",
-          "thread"
+          "thread",
+          "status"
         ],
         "type": "object"
       },
@@ -128,7 +127,7 @@
           },
           "accepted_opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope": {
@@ -142,67 +141,67 @@
           },
           "advanced_scope_json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "catalog_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "catalog_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "documented_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "jsonl_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "missing_mutating_schema_examples": {
@@ -219,32 +218,32 @@
           },
           "mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "status": {
@@ -255,7 +254,7 @@
           },
           "supports_op_id_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "unaccepted_opaque_schema_examples": {
@@ -266,7 +265,7 @@
           },
           "unaccepted_opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "undocumented_schema_examples": {
@@ -277,7 +276,7 @@
           },
           "undocumented_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope": {
@@ -291,22 +290,22 @@
           },
           "verified_scope_json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_missing_schema_examples": {
@@ -317,69 +316,69 @@
           },
           "verified_scope_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           }
         },
         "required": [
-          "accepted_opaque_schema_examples",
-          "accepted_opaque_schema_verbs_total",
+          "status",
+          "verified_scope",
           "advanced_scope",
-          "advanced_scope_accepted_opaque_schema_examples",
-          "advanced_scope_json_commands_total",
-          "advanced_scope_json_commands_with_accepted_opaque_schema",
-          "advanced_scope_mutating_commands_total",
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+          "summary",
           "catalog_commands_total",
           "catalog_mutating_commands_total",
-          "documented_schema_verbs_total",
           "json_commands_total",
-          "json_commands_with_accepted_opaque_schema",
-          "json_commands_with_schema",
-          "json_commands_without_schema",
           "json_mutating_commands_total",
-          "jsonl_commands_total",
-          "missing_mutating_schema_examples",
-          "missing_schema_examples",
-          "mutating_commands_total",
-          "mutating_commands_with_accepted_opaque_schema",
-          "mutating_commands_with_schema",
-          "mutating_commands_without_schema",
-          "opaque_schema_verbs_total",
-          "schema_verbs_total",
-          "status",
-          "summary",
-          "supports_op_id_total",
-          "unaccepted_opaque_schema_examples",
-          "unaccepted_opaque_schema_verbs_total",
-          "undocumented_schema_examples",
-          "undocumented_schema_verbs_total",
-          "verified_scope",
-          "verified_scope_accepted_opaque_schema_examples",
+          "json_commands_with_schema",
+          "json_commands_with_accepted_opaque_schema",
+          "json_commands_without_schema",
           "verified_scope_json_commands_total",
-          "verified_scope_json_commands_with_accepted_opaque_schema",
           "verified_scope_json_commands_with_schema",
+          "verified_scope_json_commands_with_accepted_opaque_schema",
           "verified_scope_json_commands_without_schema",
-          "verified_scope_missing_schema_examples",
+          "advanced_scope_json_commands_total",
+          "advanced_scope_json_commands_with_accepted_opaque_schema",
+          "mutating_commands_total",
+          "mutating_commands_with_schema",
+          "mutating_commands_with_accepted_opaque_schema",
+          "mutating_commands_without_schema",
           "verified_scope_mutating_commands_total",
-          "verified_scope_mutating_commands_with_accepted_opaque_schema",
           "verified_scope_mutating_commands_with_schema",
-          "verified_scope_mutating_commands_without_schema"
+          "verified_scope_mutating_commands_with_accepted_opaque_schema",
+          "verified_scope_mutating_commands_without_schema",
+          "advanced_scope_mutating_commands_total",
+          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+          "schema_verbs_total",
+          "documented_schema_verbs_total",
+          "undocumented_schema_verbs_total",
+          "opaque_schema_verbs_total",
+          "accepted_opaque_schema_verbs_total",
+          "unaccepted_opaque_schema_verbs_total",
+          "supports_op_id_total",
+          "jsonl_commands_total",
+          "missing_schema_examples",
+          "missing_mutating_schema_examples",
+          "verified_scope_missing_schema_examples",
+          "verified_scope_accepted_opaque_schema_examples",
+          "advanced_scope_accepted_opaque_schema_examples",
+          "accepted_opaque_schema_examples",
+          "unaccepted_opaque_schema_examples",
+          "undocumented_schema_examples"
         ],
         "type": "object"
       },
@@ -393,7 +392,7 @@
           },
           "checks": {
             "items": {
-              "$ref": "#/definitions/VerificationCheck"
+              "$ref": "#/$defs/VerificationCheck"
             },
             "type": "array"
           },
@@ -428,7 +427,7 @@
             "type": "string"
           },
           "machine_contract_coverage": {
-            "$ref": "#/definitions/MachineContractCoverage"
+            "$ref": "#/$defs/MachineContractCoverage"
           },
           "mapping_state": {
             "type": "string"
@@ -442,7 +441,7 @@
           "recommended_action_template": {
             "anyOf": [
               {
-                "$ref": "#/definitions/ActionTemplate"
+                "$ref": "#/$defs/ActionTemplate"
               },
               {
                 "type": "null"
@@ -451,7 +450,7 @@
           },
           "recovery_action_templates": {
             "items": {
-              "$ref": "#/definitions/ActionTemplate"
+              "$ref": "#/$defs/ActionTemplate"
             },
             "type": "array"
           },
@@ -490,24 +489,24 @@
           }
         },
         "required": [
-          "checks",
-          "clone_verification",
+          "verified",
+          "status",
+          "repository_mode",
           "heddle_initialized",
+          "worktree_dirty",
+          "worktree_state",
           "import_state",
+          "mapping_state",
+          "remote_drift",
+          "clone_verification",
           "machine_contract",
           "machine_contract_coverage",
-          "mapping_state",
-          "recovery_action_templates",
-          "recovery_commands",
-          "remote_drift",
-          "repository_mode",
-          "status",
-          "summary",
-          "verified",
           "workflow_status",
           "workflow_summary",
-          "worktree_dirty",
-          "worktree_state"
+          "summary",
+          "recovery_commands",
+          "recovery_action_templates",
+          "checks"
         ],
         "type": "object"
       },
@@ -535,7 +534,7 @@
           "recommended_action_template": {
             "anyOf": [
               {
-                "$ref": "#/definitions/ActionTemplate"
+                "$ref": "#/$defs/ActionTemplate"
               },
               {
                 "type": "null"
@@ -544,7 +543,7 @@
           },
           "recovery_action_templates": {
             "items": {
-              "$ref": "#/definitions/ActionTemplate"
+              "$ref": "#/$defs/ActionTemplate"
             },
             "type": "array"
           },
@@ -562,26 +561,23 @@
           }
         },
         "required": [
-          "clean",
           "name",
-          "recovery_action_templates",
-          "recovery_commands",
           "status",
-          "summary"
+          "clean",
+          "summary",
+          "recovery_commands",
+          "recovery_action_templates"
         ],
         "type": "object"
       }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
       "reservation": {
-        "$ref": "#/definitions/AgentReservationOutput"
+        "$ref": "#/$defs/AgentReservationOutput"
       },
       "verification": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/RepositoryVerificationState"
-          }
-        ],
+        "$ref": "#/$defs/RepositoryVerificationState",
         "writeOnly": true
       }
     },
@@ -593,8 +589,7 @@
     "type": "object"
   },
   "AgentReservationListOutput": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "definitions": {
+    "$defs": {
       "ActionTemplate": {
         "properties": {
           "action": {
@@ -618,9 +613,9 @@
         },
         "required": [
           "action",
-          "agent_may_fill",
           "argv_template",
-          "required_inputs"
+          "required_inputs",
+          "agent_may_fill"
         ],
         "type": "object"
       },
@@ -685,7 +680,7 @@
             "type": "string"
           },
           "status": {
-            "description": "Lifecycle status as a stable kebab-case string (`active|abandoned|complete|merged`). Mirrors `objects::store::AgentStatus` but kept as a `String` here so the schema lives entirely in the CLI crate.",
+            "description": "Lifecycle status as a stable kebab-case string\n(`active|abandoned|complete|merged`). Mirrors\n`objects::store::AgentStatus` but kept as a `String` here so\nthe schema lives entirely in the CLI crate.",
             "type": "string"
           },
           "task": {
@@ -706,8 +701,8 @@
         },
         "required": [
           "session_id",
-          "status",
-          "thread"
+          "thread",
+          "status"
         ],
         "type": "object"
       },
@@ -721,7 +716,7 @@
           },
           "accepted_opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope": {
@@ -735,67 +730,67 @@
           },
           "advanced_scope_json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "catalog_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "catalog_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "documented_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "json_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "jsonl_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "missing_mutating_schema_examples": {
@@ -812,32 +807,32 @@
           },
           "mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "mutating_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "status": {
@@ -848,7 +843,7 @@
           },
           "supports_op_id_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "unaccepted_opaque_schema_examples": {
@@ -859,7 +854,7 @@
           },
           "unaccepted_opaque_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "undocumented_schema_examples": {
@@ -870,7 +865,7 @@
           },
           "undocumented_schema_verbs_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope": {
@@ -884,22 +879,22 @@
           },
           "verified_scope_json_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_json_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_missing_schema_examples": {
@@ -910,69 +905,69 @@
           },
           "verified_scope_mutating_commands_total": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_with_accepted_opaque_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_with_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           },
           "verified_scope_mutating_commands_without_schema": {
             "format": "uint",
-            "minimum": 0.0,
+            "minimum": 0,
             "type": "integer"
           }
         },
         "required": [
-          "accepted_opaque_schema_examples",
-          "accepted_opaque_schema_verbs_total",
+          "status",
+          "verified_scope",
           "advanced_scope",
-          "advanced_scope_accepted_opaque_schema_examples",
-          "advanced_scope_json_commands_total",
-          "advanced_scope_json_commands_with_accepted_opaque_schema",
-          "advanced_scope_mutating_commands_total",
-          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+          "summary",
           "catalog_commands_total",
           "catalog_mutating_commands_total",
-          "documented_schema_verbs_total",
           "json_commands_total",
-          "json_commands_with_accepted_opaque_schema",
-          "json_commands_with_schema",
-          "json_commands_without_schema",
           "json_mutating_commands_total",
-          "jsonl_commands_total",
-          "missing_mutating_schema_examples",
-          "missing_schema_examples",
-          "mutating_commands_total",
-          "mutating_commands_with_accepted_opaque_schema",
-          "mutating_commands_with_schema",
-          "mutating_commands_without_schema",
-          "opaque_schema_verbs_total",
-          "schema_verbs_total",
-          "status",
-          "summary",
-          "supports_op_id_total",
-          "unaccepted_opaque_schema_examples",
-          "unaccepted_opaque_schema_verbs_total",
-          "undocumented_schema_examples",
-          "undocumented_schema_verbs_total",
-          "verified_scope",
-          "verified_scope_accepted_opaque_schema_examples",
+          "json_commands_with_schema",
+          "json_commands_with_accepted_opaque_schema",
+          "json_commands_without_schema",
           "verified_scope_json_commands_total",
-          "verified_scope_json_commands_with_accepted_opaque_schema",
           "verified_scope_json_commands_with_schema",
+          "verified_scope_json_commands_with_accepted_opaque_schema",
           "verified_scope_json_commands_without_schema",
-          "verified_scope_missing_schema_examples",
+          "advanced_scope_json_commands_total",
+          "advanced_scope_json_commands_with_accepted_opaque_schema",
+          "mutating_commands_total",
+          "mutating_commands_with_schema",
+          "mutating_commands_with_accepted_opaque_schema",
+          "mutating_commands_without_schema",
           "verified_scope_mutating_commands_total",
-          "verified_scope_mutating_commands_with_accepted_opaque_schema",
           "verified_scope_mutating_commands_with_schema",
-          "verified_scope_mutating_commands_without_schema"
+          "verified_scope_mutating_commands_with_accepted_opaque_schema",
+          "verified_scope_mutating_commands_without_schema",
+          "advanced_scope_mutating_commands_total",
+          "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+          "schema_verbs_total",
+          "documented_schema_verbs_total",
+          "undocumented_schema_verbs_total",
+          "opaque_schema_verbs_total",
+          "accepted_opaque_schema_verbs_total",
+          "unaccepted_opaque_schema_verbs_total",
+          "supports_op_id_total",
+          "jsonl_commands_total",
+          "missing_schema_examples",
+          "missing_mutating_schema_examples",
+          "verified_scope_missing_schema_examples",
+          "verified_scope_accepted_opaque_schema_examples",
+          "advanced_scope_accepted_opaque_schema_examples",
+          "accepted_opaque_schema_examples",
+          "unaccepted_opaque_schema_examples",
+          "undocumented_schema_examples"
         ],
         "type": "object"
       },
@@ -986,7 +981,7 @@
           },
           "checks": {
             "items": {
-              "$ref": "#/definitions/VerificationCheck"
+              "$ref": "#/$defs/VerificationCheck"
             },
             "type": "array"
           },
@@ -1021,7 +1016,7 @@
             "type": "string"
           },
           "machine_contract_coverage": {
-            "$ref": "#/definitions/MachineContractCoverage"
+            "$ref": "#/$defs/MachineContractCoverage"
           },
           "mapping_state": {
             "type": "string"
@@ -1035,7 +1030,7 @@
           "recommended_action_template": {
             "anyOf": [
               {
-                "$ref": "#/definitions/ActionTemplate"
+                "$ref": "#/$defs/ActionTemplate"
               },
               {
                 "type": "null"
@@ -1044,7 +1039,7 @@
           },
           "recovery_action_templates": {
             "items": {
-              "$ref": "#/definitions/ActionTemplate"
+              "$ref": "#/$defs/ActionTemplate"
             },
             "type": "array"
           },
@@ -1083,24 +1078,24 @@
           }
         },
         "required": [
-          "checks",
-          "clone_verification",
+          "verified",
+          "status",
+          "repository_mode",
           "heddle_initialized",
+          "worktree_dirty",
+          "worktree_state",
           "import_state",
+          "mapping_state",
+          "remote_drift",
+          "clone_verification",
           "machine_contract",
           "machine_contract_coverage",
-          "mapping_state",
-          "recovery_action_templates",
-          "recovery_commands",
-          "remote_drift",
-          "repository_mode",
-          "status",
-          "summary",
-          "verified",
           "workflow_status",
           "workflow_summary",
-          "worktree_dirty",
-          "worktree_state"
+          "summary",
+          "recovery_commands",
+          "recovery_action_templates",
+          "checks"
         ],
         "type": "object"
       },
@@ -1128,7 +1123,7 @@
           "recommended_action_template": {
             "anyOf": [
               {
-                "$ref": "#/definitions/ActionTemplate"
+                "$ref": "#/$defs/ActionTemplate"
               },
               {
                 "type": "null"
@@ -1137,7 +1132,7 @@
           },
           "recovery_action_templates": {
             "items": {
-              "$ref": "#/definitions/ActionTemplate"
+              "$ref": "#/$defs/ActionTemplate"
             },
             "type": "array"
           },
@@ -1155,23 +1150,24 @@
           }
         },
         "required": [
-          "clean",
           "name",
-          "recovery_action_templates",
-          "recovery_commands",
           "status",
-          "summary"
+          "clean",
+          "summary",
+          "recovery_commands",
+          "recovery_action_templates"
         ],
         "type": "object"
       }
     },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
       "alive_only": {
         "type": "boolean"
       },
       "reservations": {
         "items": {
-          "$ref": "#/definitions/AgentReservationOutput"
+          "$ref": "#/$defs/AgentReservationOutput"
         },
         "type": "array"
       },
@@ -1182,19 +1178,19 @@
         ]
       },
       "verification": {
-        "$ref": "#/definitions/RepositoryVerificationState"
+        "$ref": "#/$defs/RepositoryVerificationState"
       }
     },
     "required": [
-      "alive_only",
       "reservations",
+      "alive_only",
       "verification"
     ],
     "title": "AgentReservationListOutput",
     "type": "object"
   },
   "AgentReservationOutput": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
       "anchor_root": {
         "type": [
@@ -1255,7 +1251,7 @@
         "type": "string"
       },
       "status": {
-        "description": "Lifecycle status as a stable kebab-case string (`active|abandoned|complete|merged`). Mirrors `objects::store::AgentStatus` but kept as a `String` here so the schema lives entirely in the CLI crate.",
+        "description": "Lifecycle status as a stable kebab-case string\n(`active|abandoned|complete|merged`). Mirrors\n`objects::store::AgentStatus` but kept as a `String` here so\nthe schema lives entirely in the CLI crate.",
         "type": "string"
       },
       "task": {
@@ -1276,8 +1272,8 @@
     },
     "required": [
       "session_id",
-      "status",
-      "thread"
+      "thread",
+      "status"
     ],
     "title": "AgentReservationOutput",
     "type": "object"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,37 +11,20 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-stream.workspace = true
-async-trait.workspace = true
 base64.workspace = true
 biscuit-auth.workspace = true
-blake3.workspace = true
 chrono.workspace = true
 clap.workspace = true
 futures.workspace = true
-hex.workspace = true
-hyper-util.workspace = true
-ignore.workspace = true
-jsonwebtoken.workspace = true
-libc.workspace = true
-prost.workspace = true
 prost-types.workspace = true
-reqwest.workspace = true
-rmp-serde.workspace = true
-rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha2.workspace = true
-thiserror.workspace = true
 tokio = { workspace = true }
 tokio-stream.workspace = true
 tokio-tungstenite.workspace = true
 toml.workspace = true
 tonic.workspace = true
-tonic-health.workspace = true
-tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing.workspace = true
-walkdir.workspace = true
 
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published

--- a/crates/client/src/presence.rs
+++ b/crates/client/src/presence.rs
@@ -483,7 +483,7 @@ async fn connect_and_stream(
             let _ = tx
                 .send(Message::Close(Some(CloseFrame {
                     code: CloseCode::Normal,
-                    reason: std::borrow::Cow::Borrowed("agent_done"),
+                    reason: "agent_done".into(),
                 })))
                 .await;
             return Ok(LoopExit::Cancelled);
@@ -550,7 +550,7 @@ where
     <S as futures::Sink<Message>>::Error: std::fmt::Display,
 {
     let payload = serde_json::to_string(frame).context("serialise client frame")?;
-    tx.send(Message::Text(payload))
+    tx.send(Message::Text(payload.into()))
         .await
         .map_err(|e| anyhow!("ws send: {e}"))?;
     Ok(())

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -10,10 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-async-stream.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-fs2.workspace = true
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
@@ -27,7 +25,6 @@ repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-fea
 serde.workspace = true
 serde_json.workspace = true
 state_review = { path = "../state_review", package = "heddle-state-review", version = "0.2" }
-thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -12,9 +12,18 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 libc.workspace = true
+# Needed for the `span-locations` feature; syn alone pulls proc-macro2
+# without it, and `Span::start()` (used by every static-analysis bin
+# below) is gated behind that feature.
 proc-macro2.workspace = true
 protoc-bin-vendored.workspace = true
 serde_json.workspace = true
 syn.workspace = true
 tempfile.workspace = true
 walkdir.workspace = true
+
+# proc-macro2 is needed for the `span-locations` cargo feature so
+# `Span::start()` is available; syn alone re-exports the type but not
+# the feature.
+[package.metadata.cargo-machete]
+ignored = ["proc-macro2"]

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -20,6 +20,12 @@ tonic-prost.workspace = true
 protoc-bin-vendored.workspace = true
 tonic-prost-build.workspace = true
 
+# prost, prost-types, and tonic-prost are consumed by code emitted via
+# `tonic::include_proto!` so they don't appear in source. protoc-bin-vendored
+# and tonic-prost-build are used by build.rs above.
+[package.metadata.cargo-machete]
+ignored = ["prost", "prost-types", "tonic-prost", "protoc-bin-vendored", "tonic-prost-build"]
+
 [lib]
 path = "src/lib.rs"
 name = "grpc"

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { workspace = true }
 # NFS client to mount it. Works wherever the kernel ships an NFS
 # client (Linux, macOS, Windows w/ NFS client feature).
 async-trait = { workspace = true, optional = true }
-nfsserve = { version = "0.10", optional = true }
+nfsserve = { version = "0.11", optional = true }
 tokio = { workspace = true, optional = true }
 
 # `fuser` provides the FUSE bindings on Linux. Gated behind the
@@ -61,7 +61,7 @@ fuser = { version = "0.17", optional = true }
 # Windows so non-Windows builds with `projfs` accidentally enabled
 # get a no-op rather than a download.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Storage_ProjectedFileSystem",
     "Win32_System_Com",

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -34,7 +34,6 @@ serde = { workspace = true }
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true }
 
 # NFS fallback adapter — only built when the `nfs` feature is on.
 # Unlike `fuse`/`fskit`/`projfs` (which target one OS each), the
@@ -151,6 +150,10 @@ nfs = ["dep:nfsserve", "dep:tokio", "dep:async-trait"]
 # entirely, and `--all-features` on Linux still compiles cleanly
 # because the build-script no-ops on non-macOS targets.
 cbindgen = { version = "0.29", default-features = false, optional = true }
+
+# cbindgen is consumed by build.rs (FSKit Swift header regen).
+[package.metadata.cargo-machete]
+ignored = ["cbindgen"]
 
 # The `heddle-fuse-worker` binary lives in `crates/cli` (see
 # `crates/cli/Cargo.toml`'s `[[bin]]` for it). The mount crate exposes

--- a/crates/mount/src/projfs.rs
+++ b/crates/mount/src/projfs.rs
@@ -1060,7 +1060,7 @@ fn emit_entry_slice(
 
 unsafe extern "system" fn notification_trampoline(
     callback_data: *const PRJ_CALLBACK_DATA,
-    _is_directory: windows::Win32::Foundation::BOOLEAN,
+    _is_directory: bool,
     notification: PRJ_NOTIFICATION,
     destination_file_name: PCWSTR,
     _operation_parameters: *mut windows::Win32::Storage::ProjectedFileSystem::PRJ_NOTIFICATION_PARAMETERS,

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -29,27 +29,22 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 uuid.workspace = true
-walkdir.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 zstd = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-smithy-async = { workspace = true, optional = true }
-async-trait = { workspace = true, optional = true }
 runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
 
 [features]
-s3 = ["dep:aws-sdk-s3", "dep:aws-smithy-async", "dep:async-trait", "dep:tokio", "dep:runtime-bridge"]
+s3 = ["dep:aws-sdk-s3", "dep:aws-smithy-async", "dep:tokio", "dep:runtime-bridge"]
 memory-backend = []
 zstd = ["dep:zstd"]
 
 [dev-dependencies]
 criterion = "0.8"
 tempfile.workspace = true
-tokio-test.workspace = true
-serial_test.workspace = true
-ntest.workspace = true
 tokio = { workspace = true, features = ["full"] }
 s3s.workspace = true
 s3s-fs.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,9 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-fs2.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
-thiserror.workspace = true
 
 runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
 serde_json = { workspace = true, optional = true }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -17,7 +17,6 @@ categories.workspace = true
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-blake3.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -28,7 +28,6 @@ semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2",
 state_review = { path = "../state_review", package = "heddle-state-review", version = "0.2", optional = true }
 serde.workspace = true
 serde_json.workspace = true
-similar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, optional = true }

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -20,7 +20,6 @@ rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 uuid.workspace = true
 
 [lib]

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -30,7 +30,6 @@ lang-java = ["dep:tree-sitter-java"]
 anyhow.workspace = true
 merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.2", features = ["memory-backend"] }
-similar.workspace = true
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,14 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-chrono.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
 semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2" }
 serde.workspace = true
-thiserror.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## Summary

Three-part dep maintenance pass:

1. **Crate upgrades** (commits 1–6) — bumped what we could; documented what's blocked upstream.
2. **Dep cleanup** (commit 7) — removed ~60 unused dependency declarations.
3. **cargo-audit fix** (commit 8) — upgraded the tool, consolidated the ignore-list drift surface.

## Upgrades landed

| Set | Detail |
|---|---|
| `cargo update` | ~60 compatible transitive bumps |
| `lru` 0.16→0.18 + `tokio-tungstenite` 0.24→0.29 | 4 callsites updated for `Message::Text(Utf8Bytes)` / `CloseFrame::reason: Utf8Bytes` |
| OpenTelemetry cohort 0.31→0.32 + `tracing-opentelemetry` 0.32→0.33 | Zero source changes |
| Mount: `nfsserve` 0.10→0.11, `windows` 0.58→0.62 | Crate-local |
| gix cohort 0.80→0.84 | Added `"sha1"` feature; 2 callsites updated for `ObjectRef::from_bytes` and `objs::Data { object_hash }` |
| `schemars` 0.8→1.2 | `chrono`→`chrono04` feature, `#[schemars(example = fn())]` syntax, removed pre-existing duplicate `#[schemars(required)]`, `JsonSchema` impl signature update for `Cow<'static, str>` |

## Upgrades blocked upstream (left at current versions)

| Crate | Blocker |
|---|---|
| `aws-sdk-s3` 1.135 | Wants `sha2 ^0.11` stable; `s3s 0.13.0` pins `=0.11.0-rc.5`. Waits on s3s release. |
| `sqlx` 0.9 | Same s3s `sha1` pin via `sqlx-mysql`. Also requires `runtime-tokio-rustls` → `runtime-tokio` + `tls-rustls-ring-webpki` when unblocked. |
| `rusqlite` 0.40 | Needs `libsqlite3-sys 0.38`; sqlx 0.8's `sqlx-sqlite` pins 0.28. Native `links = "sqlite3"` rule blocks both — unblocks with sqlx 0.9. |
| RustCrypto cohort (`pkcs8` 0.11, `sha2` 0.11, `signature` 3) | `ed25519-dalek`, `p256`, `rsa` stable versions all still depend on the old family; their signature-3 versions are RCs only. |

## Cleanup

Surveyed with `cargo-machete`, verified each hit, removed **~58 declarations** across 16 Cargo.toml files (16 in `heddle-client`, 13 in `heddle-cli`, the rest spread across smaller crates). Pruned 15 orphan `[workspace.dependencies]` entries including the deprecated `atty` crate. Suppressed 7 confirmed false positives via `[package.metadata.cargo-machete] ignored = [...]` on `heddle-grpc` (proto-gen + build.rs deps), `heddle-devtools` (proc-macro2 needed for `span-locations` feature), and `heddle-mount` (cbindgen in build.rs).

Resolved dep graph shrank from 892 → 880 crates. Build time / binary size essentially unchanged — the win is **manifest hygiene**, not perf. After: `cargo machete --with-metadata` reports zero unused deps, so it's now a useful CI gate.

## cargo-audit

- Local tool was broken: 0.21.2 couldn't parse the RustSec database since RUSTSEC-2026-0073 started using CVSS 4.0 vectors. Fixed by upgrading to 0.22.1 (developer-machine action; no repo change).
- Consolidated ignore-list drift: was three places (`deny.toml` + workflow `--ignore` flags + CONTRIBUTING snippet), now two (`deny.toml` canonical + `.cargo/audit.toml` mirror). Workflow and docs both collapse to bare `cargo audit --deny warnings`.

## Test plan

- [x] `cargo check --workspace --all-features --lib --bins --tests` clean
- [x] `cargo machete --with-metadata` reports zero unused
- [x] `cargo audit --deny warnings` exits 0 (4 accepted advisories ignored via `.cargo/audit.toml`)
- [ ] CI green
- [ ] Spot-check `heddle status` / `heddle bridge import` against a real repo before merging — gix 0.80→0.84 is the highest-API-surface bump and only had two compile-level breakages, but runtime regressions in the overlay are the kind of thing the test suite may not catch.

## Notable caveats

- The `RequiredNullableNextState` custom `JsonSchema` impl in `schemas.rs` relied on schemars 0.8's `_schemars_private_is_option` internal to mark its `next` field required-but-nullable. The 1.x derive uses a different mechanism — the resulting schema shape on this one struct may differ at runtime. Worth a snapshot test before relying on the schema output.
- The pre-existing `crates/mount/benches/fuse_worker_ipc.rs` fails workspace-wide `--all-targets` on macOS because the file is `#![cfg(target_os = "linux")]` and its `main` function disappears. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783101517&installation_id=132405951&pr_number=483&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F483&signature=21d59978b41fe97271ef58cdb4a4eaae1c800c7b4cbb301cecf0f7ef4d395dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->