### PR TITLE
feat(repo): automatic ed25519 state signing on capture/commit/merge (#482)

### DIFF
--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -103,3 +103,16 @@ jobs:
 
       - name: Assert no cross-crate publish-first snapshot regressions
         run: bash scripts/check-snapshot-atomicity.sh
+
+  authored-states-signed:
+    name: authored states sign via chokepoint (heddle#482)
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # Pure-bash grep guard: a new authored-state writer under the CLI
+      # command tree must route through Repository::put_authored_state
+      # (auto-signs), never store().put_state directly. Closes the
+      # signing coverage-leak class (heddle#482 r2).
+      - name: Assert no authored-state signing-chokepoint bypasses
+        run: bash scripts/check-authored-states-signed.sh

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Collapse command: squash multiple states into one.
 
-use objects::store::ObjectStore;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -90,8 +89,10 @@ pub fn cmd_collapse(
         new_state = new_state.with_confidence(conf);
     }
 
-    // Store the new state
-    repo.store().put_state(&new_state)?;
+    // Store the new state through the authored-state chokepoint (heddle#482):
+    // a collapse mints a new author-created state, so it is auto-signed like a
+    // capture rather than carrying any source state's signature forward.
+    repo.put_authored_state(&mut new_state)?;
     if !json {
         eprintln!("Writing collapsed state {}...", new_state.change_id.short());
     }

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -336,8 +336,14 @@ pub(crate) fn build_context_state(
 }
 
 pub(crate) fn apply_new_state(repo: &Repository, state: &State) -> Result<()> {
-    repo.store().put_state(state)?;
-    advance_head(repo, state)?;
+    // Authored-state chokepoint (heddle#482): a context annotation advances
+    // HEAD to a new author-created state, so it is auto-signed like a capture.
+    // Sign a local copy (signing only adds `.signature`; `change_id` and every
+    // other field are unchanged) so callers that reuse `state.change_id`
+    // afterward still see the right id.
+    let mut signed = state.clone();
+    repo.put_authored_state(&mut signed)?;
+    advance_head(repo, &signed)?;
     Ok(())
 }
 

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Fork command: create exploration branch.
 
-use objects::store::ObjectStore;
 use anyhow::Result;
 use objects::object::{State, ThreadName};
 use oplog::OpRecord;
@@ -66,8 +65,11 @@ pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result
         new_state = new_state.with_intent(format!("Fork from {}", source_state.change_id.short()));
     }
 
-    // Store the new state (orphan until a ref points at it).
-    repo.store().put_state(&new_state)?;
+    // Store the new state (orphan until a ref points at it). Route through the
+    // authored-state chokepoint (heddle#482) so the fork is auto-signed like
+    // every other authored capture — a fork is a new author-created state, not
+    // a replay of an existing signed one.
+    repo.put_authored_state(&mut new_state)?;
 
     // Build the atomic ref batch + its matching `Fork` record, then publish
     // record-first through the write chokepoint (heddle#330 §2.2): the oplog

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -444,10 +444,14 @@ fn apply_commit(
     )
     .with_status(commit_state.status);
 
-    let new_state = copy_state_metadata(new_state, commit_state);
+    let mut new_state = copy_state_metadata(new_state, commit_state);
 
     let new_state_id = new_state.change_id;
-    repo.store().put_state(&new_state)?;
+    // Authored-state chokepoint (heddle#482): a rebase replay re-authors the
+    // commit onto a new base (new tree + new parent) — a new author-created
+    // state — so it is auto-signed rather than carrying the pre-rebase
+    // signature forward.
+    repo.put_authored_state(&mut new_state)?;
     let advance = ff_advance_deferred(
         repo,
         REBASE_REPLAY_SOURCE,
@@ -560,10 +564,14 @@ fn apply_tree_to_worktree(
             .unwrap_or_else(|| "rebase".to_string()),
     )
     .with_status(commit_state.status);
-    let new_state = copy_state_metadata(new_state, commit_state);
+    let mut new_state = copy_state_metadata(new_state, commit_state);
 
     let new_state_id = new_state.change_id;
-    repo.store().put_state(&new_state)?;
+    // Authored-state chokepoint (heddle#482): a rebase replay re-authors the
+    // commit onto a new base (new tree + new parent) — a new author-created
+    // state — so it is auto-signed rather than carrying the pre-rebase
+    // signature forward.
+    repo.put_authored_state(&mut new_state)?;
     let advance = ff_advance_deferred(
         repo,
         REBASE_REPLAY_SOURCE,

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -878,6 +878,7 @@ pub struct CaptureSchema {
     pub agent: Option<CommitAgentSchema>,
     pub promotion_suggested: bool,
     pub heavy_impact_paths: Vec<String>,
+    pub signed: bool,
     pub message: String,
     pub next_action: Option<String>,
     pub next_action_template: Option<ActionTemplateSchema>,

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -52,6 +52,11 @@ pub(crate) struct SnapshotOutput {
     pub agent: Option<SnapshotAgentOutput>,
     pub promotion_suggested: bool,
     pub heavy_impact_paths: Vec<String>,
+    /// Whether this state carries an ed25519 author signature (heddle#482).
+    /// `false` means signing degraded (no key, or an unreadable key); the
+    /// state is still captured, just unsigned — surfaced here so a degraded
+    /// signing path is never silent.
+    pub signed: bool,
     pub message: String,
     pub next_action: Option<String>,
     pub next_action_template: Option<ActionTemplate>,
@@ -227,6 +232,15 @@ pub async fn cmd_snapshot(
                 "Agent: {}/{}",
                 style::bold(&agent.provider),
                 style::dim(&agent.model)
+            );
+        }
+        if !output.signed {
+            // Degraded signing must be visible, never silent (heddle#482).
+            println!(
+                "{}",
+                style::warn(
+                    "Unsigned: no signing identity available — captured without an ed25519 signature"
+                )
             );
         }
         if output.confidence.is_some() {
@@ -539,6 +553,7 @@ pub(crate) fn create_snapshot_profiled(
             .map(SnapshotAgentOutput::from),
         promotion_suggested,
         heavy_impact_paths: heavy_impact_paths.clone(),
+        signed: execution.state.signature.is_some(),
         message: format!(
             "Captured state {} ({})",
             execution.state.change_id.short(),
@@ -658,6 +673,7 @@ pub(crate) fn create_snapshot_from_tree_profiled(
             .map(SnapshotAgentOutput::from),
         promotion_suggested,
         heavy_impact_paths: heavy_impact_paths.clone(),
+        signed: execution.state.signature.is_some(),
         message: format!(
             "Captured state {} ({})",
             execution.state.change_id.short(),

--- a/crates/cli/tests/production_features/state_signing.rs
+++ b/crates/cli/tests/production_features/state_signing.rs
@@ -1,8 +1,178 @@
 // SPDX-License-Identifier: Apache-2.0
 use crypto::{Ed25519Signer, P256Signer, RsaSigner, Signer, SignerError};
 use objects::store::ObjectStore;
+use serial_test::serial;
 
 use super::*;
+
+/// Run `heddle` with a pinned `HEDDLE_HOME` (so no device identity leaks in
+/// from the dev's real home) and a fixed principal. Auto-signing then resolves
+/// the per-repo local identity, minted on first capture.
+fn heddle_signed(
+    args: &[&str],
+    cwd: &std::path::Path,
+    home: &std::path::Path,
+) -> Result<String, String> {
+    heddle_with_env(
+        args,
+        Some(cwd),
+        &[
+            ("HEDDLE_HOME", home.to_str().expect("home utf8")),
+            ("HEDDLE_PRINCIPAL_NAME", "Sign Test"),
+            ("HEDDLE_PRINCIPAL_EMAIL", "sign@heddle.dev"),
+        ],
+    )
+}
+
+/// Assert the repo's current HEAD state carries a valid auto-signature. This
+/// is the conformance gate: it fails for ANY authored writer that reaches the
+/// store without routing through the signing chokepoint (heddle#482).
+fn assert_head_signed(path: &std::path::Path, what: &str) {
+    let repo = repo::Repository::open(path).expect("open repo");
+    let head = repo
+        .current_state()
+        .expect("current state")
+        .expect("repo has a HEAD state");
+    assert!(
+        head.signature.is_some(),
+        "{what}: authored HEAD state {} must be auto-signed, not stored unsigned",
+        head.change_id.short(),
+    );
+    assert_eq!(
+        repo.verify_state_signature(&head.change_id)
+            .expect("verify"),
+        crypto::SignatureStatus::Valid,
+        "{what}: the auto-signature on the HEAD state must verify",
+    );
+}
+
+/// Coverage conformance (heddle#482): drive each production command that
+/// produces a new *authored* state and assert the resulting HEAD state is
+/// signed + verifies. Because signing is lifted to the repo-layer chokepoint
+/// (`Repository::put_authored_state`), a future writer that bypasses it —
+/// reaching `store().put_state` directly for an authored state — makes the
+/// matching arm below fail, so the regression can't merge.
+///
+/// `capture`, `fork`, `collapse`, `context set`, `rebase`, and `merge` are
+/// exercised here. Mount capture routes through the same chokepoint and is
+/// covered by `crates/mount` tests + the repo-level signing unit tests (it
+/// needs a FUSE mount this subprocess harness can't stand up).
+#[test]
+#[serial]
+fn authored_commands_auto_sign_their_states() {
+    // capture / commit
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("f.txt"), "x").unwrap();
+        heddle_signed(&["capture", "-m", "c"], temp.path(), home.path()).unwrap();
+        assert_head_signed(temp.path(), "capture");
+    }
+
+    // fork (creates a new authored state on a new thread)
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("f.txt"), "x").unwrap();
+        heddle_signed(&["capture", "-m", "base"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["fork", "--name", "explore"], temp.path(), home.path()).unwrap();
+        assert_head_signed(temp.path(), "fork");
+    }
+
+    // collapse (squash two states into one authored state)
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("f.txt"), "one").unwrap();
+        heddle_signed(&["capture", "-m", "first"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("f.txt"), "two").unwrap();
+        heddle_signed(&["capture", "-m", "second"], temp.path(), home.path()).unwrap();
+
+        let repo = repo::Repository::open(temp.path()).unwrap();
+        let head = repo.current_state().unwrap().unwrap();
+        let first = head.parents[0];
+        heddle_signed(
+            &[
+                "collapse",
+                &first.to_string_full(),
+                &head.change_id.to_string_full(),
+                "--into",
+                "combined",
+            ],
+            temp.path(),
+            home.path(),
+        )
+        .unwrap();
+        assert_head_signed(temp.path(), "collapse");
+    }
+
+    // context set (annotation advances HEAD to a new authored state)
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("f.txt"), "code\n").unwrap();
+        heddle_signed(&["capture", "-m", "base"], temp.path(), home.path()).unwrap();
+        heddle_signed(
+            &["context", "set", "--path", "f.txt", "-m", "why this exists"],
+            temp.path(),
+            home.path(),
+        )
+        .unwrap();
+        assert_head_signed(temp.path(), "context set");
+    }
+
+    // rebase (replay re-authors commits onto a new base)
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("base.txt"), "base").unwrap();
+        heddle_signed(&["capture", "-m", "Base"], temp.path(), home.path()).unwrap();
+
+        heddle_signed(&["thread", "create", "feature"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["thread", "switch", "feature"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("a1.txt"), "a1").unwrap();
+        heddle_signed(&["capture", "-m", "A1"], temp.path(), home.path()).unwrap();
+
+        heddle_signed(&["thread", "switch", "main"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("b1.txt"), "b1").unwrap();
+        heddle_signed(&["capture", "-m", "B1"], temp.path(), home.path()).unwrap();
+
+        heddle_signed(&["thread", "switch", "feature"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["rebase", "main"], temp.path(), home.path()).unwrap();
+        assert_head_signed(temp.path(), "rebase replay");
+    }
+
+    // merge (a two-parent merge state is itself authored)
+    {
+        let temp = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        heddle_signed(&["init"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("base.txt"), "base").unwrap();
+        heddle_signed(&["capture", "-m", "Base"], temp.path(), home.path()).unwrap();
+
+        heddle_signed(&["thread", "create", "feature"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["thread", "switch", "feature"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("feat.txt"), "feature").unwrap();
+        heddle_signed(&["capture", "-m", "Feature"], temp.path(), home.path()).unwrap();
+
+        heddle_signed(&["thread", "switch", "main"], temp.path(), home.path()).unwrap();
+        fs::write(temp.path().join("main.txt"), "main").unwrap();
+        heddle_signed(&["capture", "-m", "Main"], temp.path(), home.path()).unwrap();
+
+        // Stale threads must refresh before merge (harness invariant); refresh
+        // feature against main, then merge it back into main.
+        heddle_signed(&["thread", "switch", "feature"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["thread", "refresh", "feature"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["thread", "switch", "main"], temp.path(), home.path()).unwrap();
+        heddle_signed(&["merge", "feature"], temp.path(), home.path()).unwrap();
+        assert_head_signed(temp.path(), "merge");
+    }
+}
 
 #[test]
 fn test_sign_verify_ed25519() {

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -170,16 +170,21 @@ async fn cmd_auth_login(server: &str, no_browser: bool) -> Result<()> {
 /// Remove stored credentials.
 fn cmd_auth_logout(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     let server = resolve_server(server)?;
-    credentials::remove_server_credential(&server)?;
 
     // Remove the device signing identity `auth login` recorded for THIS server
-    // (heddle#482). Fail-closed: if a matching device key is on disk but can't
-    // be removed, surface the error rather than reporting a clean logout while
-    // the logged-out private key — which `signing_signer()` would keep
-    // preferring for every capture — still persists.
+    // BEFORE dropping the credential (heddle#482 ordering). Fail-closed: if a
+    // matching device key is on disk but can't be removed, surface the error
+    // rather than reporting a clean logout while the logged-out private key —
+    // which `signing_signer()` would keep preferring for every capture — still
+    // persists. Unlinking first keeps a failed logout retryable: were the
+    // credential removed first, `resolve_server` would no longer resolve back to
+    // this server, so a no-arg retry could never re-target the matching
+    // `device-identity.toml` still on disk. Holding the credential until the
+    // unlink succeeds preserves the same server resolution for the retry.
     let device_identity_removed = repo::identity::unlink_device_key(&server).map_err(|error| {
         anyhow::anyhow!("failed to remove device signing identity for {server}: {error}")
     })?;
+    credentials::remove_server_credential(&server)?;
 
     if ctx.should_output_json(None) {
         let output = AuthLogoutOutput {
@@ -519,7 +524,7 @@ fn open_url(url: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::infer_server_uri;
+    use super::*;
 
     #[test]
     fn infers_http_for_plain_ip_targets() {
@@ -555,5 +560,134 @@ mod tests {
             infer_server_uri("https://grpc.heddle.sh"),
             "https://grpc.heddle.sh"
         );
+    }
+
+    /// Minimal `CliContext` for the logout tests — text output, no repo.
+    struct TextCtx;
+
+    impl CliContext for TextCtx {
+        fn repo_path(&self) -> Option<&std::path::Path> {
+            None
+        }
+        fn operation_id_wire(&self) -> String {
+            String::new()
+        }
+        fn should_output_json(&self, _repo_config: Option<&repo::Config>) -> bool {
+            false
+        }
+    }
+
+    /// Run `f` with `HOME` pointed at a fresh temp dir and `HEDDLE_HOME` cleared,
+    /// so the credential store and device identity both resolve under
+    /// `<temp>/.heddle`. Serialised with the credential store's env tests.
+    fn with_isolated_home<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = credentials::lock_test_env();
+        let temp = tempfile::TempDir::new().expect("temp home");
+        let prev_home = std::env::var_os("HOME");
+        let prev_heddle_home = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("HEDDLE_HOME");
+        }
+        let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        unsafe {
+            match prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_heddle_home {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+        }
+        drop(temp);
+        match out {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    fn sample_credential() -> ServerCredential {
+        ServerCredential {
+            token: "tkn".to_string(),
+            subject: "dev".to_string(),
+            device_id: None,
+            credential_id: None,
+            private_key_pem: None,
+            expires_at: None,
+        }
+    }
+
+    /// On a successful logout, both the credential and the matching device
+    /// signing identity are removed (heddle#482).
+    #[test]
+    fn logout_removes_credential_and_device_identity_on_success() {
+        with_isolated_home(|| {
+            credentials::store_server_credential("grpc.S", sample_credential())
+                .expect("store credential");
+
+            // Record a matching device identity via the real link path.
+            let signer = Ed25519Signer::generate().expect("keypair");
+            repo::identity::link_device_key(
+                signer.public_key(),
+                &signer.to_pem().expect("pem"),
+                "grpc.S",
+            )
+            .expect("link device key");
+            assert!(repo::identity::device_identity_path().exists());
+
+            // No explicit --server: resolve_server falls back to the stored
+            // default written by `store_server_credential`.
+            cmd_auth_logout(&TextCtx, None).expect("logout succeeds");
+
+            assert!(
+                credentials::get_server_credential("grpc.S")
+                    .expect("load")
+                    .is_none(),
+                "credential must be removed on a successful logout",
+            );
+            assert!(
+                !repo::identity::device_identity_path().exists(),
+                "device identity must be removed on a successful logout",
+            );
+        });
+    }
+
+    /// Ordering (heddle#482): logout unlinks the device identity BEFORE dropping
+    /// the credential, so a fail-closed unlink leaves the credential/default
+    /// intact and `heddle auth logout` stays retryable with the SAME server
+    /// resolution. A corrupt device-identity file stands in for any unlink
+    /// failure (it fails the parse). Were the credential removed first, a no-arg
+    /// retry could no longer resolve back to this server.
+    #[test]
+    fn logout_preserves_credential_when_device_unlink_fails() {
+        with_isolated_home(|| {
+            credentials::store_server_credential("grpc.S", sample_credential())
+                .expect("store credential");
+
+            let device_path = repo::identity::device_identity_path();
+            std::fs::create_dir_all(device_path.parent().expect("home parent"))
+                .expect("home dir");
+            std::fs::write(&device_path, b"!!! definitely not valid device-identity toml !!!")
+                .expect("write corrupt device identity");
+
+            let result = cmd_auth_logout(&TextCtx, None);
+            assert!(
+                result.is_err(),
+                "a failed device unlink must fail the logout, not report a clean removal",
+            );
+
+            assert!(
+                credentials::get_server_credential("grpc.S")
+                    .expect("load")
+                    .is_some(),
+                "credential must be preserved when unlink fails, so logout is retryable",
+            );
+            assert_eq!(
+                credentials::default_server().expect("default").as_deref(),
+                Some("grpc.S"),
+                "default server must be preserved so a no-arg retry re-targets the same server",
+            );
+        });
     }
 }

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -134,7 +134,7 @@ async fn cmd_auth_login(server: &str, no_browser: bool) -> Result<()> {
         } else {
             Some(access_token.credential_id)
         },
-        private_key_pem: Some(private_key_pem),
+        private_key_pem: Some(private_key_pem.clone()),
         expires_at: access_token.expires_at.as_ref().and_then(|ts| {
             chrono::DateTime::from_timestamp(ts.seconds, ts.nanos.max(0) as u32)
                 .map(|dt| dt.to_rfc3339())
@@ -142,6 +142,18 @@ async fn cmd_auth_login(server: &str, no_browser: bool) -> Result<()> {
     };
 
     credentials::store_server_credential(server, credential)?;
+
+    // Reconcile the local signing identity with the device key (heddle#482):
+    // record the device key as the machine's active signing identity so
+    // subsequent captures sign with it (it supersedes any per-repo local key;
+    // states already signed by a local key keep verifying). Best-effort — a
+    // failure here just leaves captures signing with the local key.
+    if let Err(error) =
+        repo::identity::link_device_key(&public_key_bytes, &private_key_pem, server)
+    {
+        tracing::warn!(%error, "could not record device signing identity; captures will use the per-repo local key");
+    }
+
     println!();
     println!(
         "Authenticated as {}. Credentials saved.",

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -25,6 +25,11 @@ struct AuthLogoutOutput {
     output_kind: &'static str,
     server: String,
     removed: bool,
+    /// Whether a device signing identity recorded for this server (heddle#482)
+    /// was removed. `false` when none was linked; on a removal failure logout
+    /// errors instead of emitting this output, so a `true` here always means
+    /// the logged-out private key is no longer on disk.
+    device_identity_removed: bool,
 }
 
 #[derive(Serialize)]
@@ -166,15 +171,29 @@ async fn cmd_auth_login(server: &str, no_browser: bool) -> Result<()> {
 fn cmd_auth_logout(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     let server = resolve_server(server)?;
     credentials::remove_server_credential(&server)?;
+
+    // Remove the device signing identity `auth login` recorded for THIS server
+    // (heddle#482). Fail-closed: if a matching device key is on disk but can't
+    // be removed, surface the error rather than reporting a clean logout while
+    // the logged-out private key — which `signing_signer()` would keep
+    // preferring for every capture — still persists.
+    let device_identity_removed = repo::identity::unlink_device_key(&server).map_err(|error| {
+        anyhow::anyhow!("failed to remove device signing identity for {server}: {error}")
+    })?;
+
     if ctx.should_output_json(None) {
         let output = AuthLogoutOutput {
             output_kind: "auth_logout",
             server,
             removed: true,
+            device_identity_removed,
         };
         println!("{}", serde_json::to_string(&output)?);
     } else {
         println!("Credentials removed for {server}.");
+        if device_identity_removed {
+            println!("Device signing identity removed.");
+        }
     }
     Ok(())
 }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -56,8 +56,15 @@ pub fn load_signer(path: &Path, algorithm: Option<&str>) -> Result<Box<dyn Signe
     pem_loader::load_signer_from_pem(&pem_content)
 }
 
+/// Reject a private-key file whose permissions expose it to group/world
+/// readers. The single source of the `0600`-or-stricter rule: the key-file
+/// signer loader ([`load_signer`]) and the auto-signing identity loader
+/// (`repo::identity`) both call this so the threshold lives in one place. On
+/// unix, errors with [`SignerError::InsecureKeyPermissions`] when any of the
+/// group/world bits (`0o077`) are set; a no-op on platforms without a unix
+/// permission model. Propagates I/O errors (e.g. `NotFound`) from the stat.
 #[cfg(unix)]
-fn reject_group_or_world_readable_key(path: &Path) -> Result<(), SignerError> {
+pub fn reject_group_or_world_readable_key(path: &Path) -> Result<(), SignerError> {
     use std::os::unix::fs::PermissionsExt;
 
     let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
@@ -70,8 +77,9 @@ fn reject_group_or_world_readable_key(path: &Path) -> Result<(), SignerError> {
     Ok(())
 }
 
+/// Non-unix stub: no permission model to enforce. See the unix variant.
 #[cfg(not(unix))]
-fn reject_group_or_world_readable_key(_path: &Path) -> Result<(), SignerError> {
+pub fn reject_group_or_world_readable_key(_path: &Path) -> Result<(), SignerError> {
     Ok(())
 }
 

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -3957,11 +3957,11 @@ impl ContentAddressedMount {
         // don't see a sudden None for mount-captured states.
         state = state.with_confidence(self.inner.repo.config().defaults.confidence);
         // Auto-sign before persisting (heddle#482): route through the same
-        // capture-path chokepoint the repo capture/commit/merge paths use, so a
-        // mount-captured state is signed identically and no write bypasses it.
+        // authored-state chokepoint the repo capture/commit/merge paths use, so
+        // a mount-captured state is signed identically and no write bypasses it.
         self.inner
             .repo
-            .record_captured_state(&mut state)
+            .put_authored_state(&mut state)
             .map_err(MountError::Store)?;
 
         // Step 3 + 3a unified: advance the served thread and record the

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -3956,7 +3956,13 @@ impl ContentAddressedMount {
         // default confidence so downstream tools that key on it
         // don't see a sudden None for mount-captured states.
         state = state.with_confidence(self.inner.repo.config().defaults.confidence);
-        self.store().put_state(&state).map_err(MountError::Store)?;
+        // Auto-sign before persisting (heddle#482): route through the same
+        // capture-path chokepoint the repo capture/commit/merge paths use, so a
+        // mount-captured state is signed identically and no write bypasses it.
+        self.inner
+            .repo
+            .record_captured_state(&mut state)
+            .map_err(MountError::Store)?;
 
         // Step 3 + 3a unified: advance the served thread and record the
         // `OpRecord::Snapshot` **record-first** through the write chokepoint

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -409,6 +409,57 @@ fn write_past_end_zero_fills() {
     assert_eq!(bytes.len(), 13);
 }
 
+/// Serializes the env-mutating signing test(s) below: they pin the
+/// process-global `HEDDLE_HOME` so the device-identity lookup resolves into a
+/// per-test temp dir (absent device key -> falls to the auto-minted local key).
+static SIGNING_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// heddle#482: a state captured through the MOUNT path must be auto-signed
+/// identically to one captured via `Repository::snapshot` — the mount path
+/// routes through the same capture-path chokepoint, so no state write bypasses
+/// signing.
+#[test]
+fn mount_capture_auto_signs() {
+    use objects::object::SignatureStatus;
+
+    let _guard = SIGNING_HOME_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let home = TempDir::new().unwrap();
+    let previous = std::env::var_os("HEDDLE_HOME");
+    unsafe {
+        std::env::set_var("HEDDLE_HOME", home.path());
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let (_temp, mount) = mount_with_seed("greet.txt", b"hello world\n");
+        let node = mount.lookup_path("greet.txt").unwrap();
+        mount.write(node, 0, b"HELLO").unwrap();
+        mount.flush(node).unwrap();
+        let new_id = mount.capture(Some("signed capture".into())).unwrap();
+
+        let repo = mount.repo_handle();
+        let state = repo.store().get_state(&new_id).unwrap().unwrap();
+        assert!(
+            state.signature.is_some(),
+            "mount-captured state must be auto-signed, not stored unsigned",
+        );
+        assert_eq!(
+            repo.verify_state_signature(&new_id).unwrap(),
+            SignatureStatus::Valid,
+            "mount-captured state signature must verify",
+        );
+    }));
+
+    match previous {
+        Some(value) => unsafe { std::env::set_var("HEDDLE_HOME", value) },
+        None => unsafe { std::env::remove_var("HEDDLE_HOME") },
+    }
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 #[test]
 fn write_seeds_from_warm_tier_not_captured() {
     // Captured: "original" (8 bytes). First write replaces it with

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The machine's signing identity — the ed25519 key Heddle uses to auto-sign
+//! every captured state.
+//!
+//! Two key objects, resolved in precedence order:
+//!
+//! 1. **Device identity** (`<heddle_home>/device-identity.toml`) — the
+//!    ed25519 device-binding key minted by `heddle auth login`. Recorded here
+//!    at login so the offline capture path can sign with it without a network
+//!    round-trip or a dependency on the hosted-client crate. When present it
+//!    *supersedes* the local key for new states.
+//! 2. **Local identity** (`<heddle_dir>/identity.toml`) — a per-repo ed25519
+//!    key auto-minted on first capture in a repo that has never authenticated.
+//!    Guarantees universal signing offline, with zero user-managed keys.
+//!
+//! Both key files are written `0600` via `write_file_atomic_secret`, the same
+//! protection the credential store uses. Nothing in this module ever logs key
+//! bytes.
+//!
+//! The reconciliation model (heddle#482): the device key supersedes the local
+//! key for *new* states; both are recorded (the local key stays in the repo's
+//! `identity.toml`, the device key in the global `device-identity.toml`).
+//! States already signed by a local key keep verifying forever — their public
+//! key is embedded in the state and verification recomputes the content hash,
+//! so it needs neither the private key nor any registry.
+
+use std::path::{Path, PathBuf};
+
+use crypto::{Ed25519Signer, Signer, SignerError};
+use objects::fs_atomic::write_file_atomic_secret;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// File name for the per-repo local identity, under `<heddle_dir>`.
+pub const LOCAL_IDENTITY_FILE: &str = "identity.toml";
+/// File name for the global device identity, under `<heddle_home>`.
+pub const DEVICE_IDENTITY_FILE: &str = "device-identity.toml";
+
+/// Per-repo auto-minted signing identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalIdentity {
+    /// Hex-encoded ed25519 public key.
+    pub public_key: String,
+    /// PKCS#8 PEM private key. `0600` on disk.
+    pub private_key_pem: String,
+    /// RFC 3339 mint timestamp.
+    pub created_at: String,
+}
+
+/// Globally-recorded device identity, written at `heddle auth login`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceIdentity {
+    /// Hex-encoded ed25519 public key (the server-registered device key).
+    pub public_key: String,
+    /// PKCS#8 PEM private key, copied from the credential store at login so
+    /// the offline capture path can resolve it without re-reading credentials
+    /// (which would couple `repo` to the hosted-client crate). Same `0600`
+    /// protection and same `~/.heddle` directory as `credentials.toml`.
+    pub private_key_pem: String,
+    /// The server this device key authenticated against.
+    pub server: String,
+    /// RFC 3339 link timestamp.
+    pub linked_at: String,
+}
+
+/// `<heddle_home>` — `$HEDDLE_HOME` if set, else `$HOME/.heddle`, else
+/// `./.heddle`. Mirrors the credential store location so the device identity
+/// sits beside `credentials.toml`. `HEDDLE_HOME` exists primarily as a test
+/// and power-user override; production resolves to `$HOME/.heddle`.
+pub fn heddle_home_dir() -> PathBuf {
+    if let Some(explicit) = std::env::var_os("HEDDLE_HOME") {
+        return PathBuf::from(explicit);
+    }
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".heddle")
+}
+
+/// Path to the global device identity file.
+pub fn device_identity_path() -> PathBuf {
+    heddle_home_dir().join(DEVICE_IDENTITY_FILE)
+}
+
+/// Record the device key as the machine's active signing identity. Called by
+/// `heddle auth login` after the device keypair is minted and registered with
+/// the server. The device key supersedes any per-repo local key for *new*
+/// states; states already signed by a local key keep verifying (their public
+/// key is embedded in the state).
+pub fn link_device_key(
+    public_key: &[u8],
+    private_key_pem: &str,
+    server: &str,
+) -> std::io::Result<()> {
+    let identity = DeviceIdentity {
+        public_key: hex::encode(public_key),
+        private_key_pem: private_key_pem.to_string(),
+        server: server.to_string(),
+        linked_at: now_rfc3339(),
+    };
+    write_device(&device_identity_path(), &identity)
+}
+
+/// Resolve the active signing key: the device key if one has been linked,
+/// otherwise the per-repo local key (minted on first call). Returns `None`
+/// only when no key can be produced (e.g. an unwritable home), so the caller
+/// degrades to an unsigned-but-marked state instead of failing the capture.
+pub fn resolve_signer(local_path: &Path, device_path: &Path) -> Option<Box<dyn Signer>> {
+    match load_device(device_path) {
+        Ok(Some(device)) => match signer_from_pem(&device.private_key_pem) {
+            Ok(signer) => return Some(signer),
+            Err(error) => warn!(
+                %error,
+                "device signing key unreadable; falling back to local identity"
+            ),
+        },
+        Ok(None) => {}
+        Err(error) => warn!(
+            %error,
+            "device identity unreadable; falling back to local identity"
+        ),
+    }
+
+    match load_or_mint_local(local_path) {
+        Ok(local) => match signer_from_pem(&local.private_key_pem) {
+            Ok(signer) => Some(signer),
+            Err(error) => {
+                warn!(%error, "local signing key unreadable; capturing unsigned");
+                None
+            }
+        },
+        Err(error) => {
+            warn!(%error, "could not mint local signing identity; capturing unsigned");
+            None
+        }
+    }
+}
+
+/// Load the per-repo local identity at `path`, minting and persisting a fresh
+/// ed25519 key if the file is absent.
+pub fn load_or_mint_local(path: &Path) -> std::io::Result<LocalIdentity> {
+    if let Some(existing) = load_local(path)? {
+        return Ok(existing);
+    }
+    let signer = Ed25519Signer::generate()
+        .map_err(|error| std::io::Error::other(format!("ed25519 keygen failed: {error}")))?;
+    let pem = signer
+        .to_pem()
+        .map_err(|error| std::io::Error::other(format!("ed25519 PEM export failed: {error}")))?;
+    let identity = LocalIdentity {
+        public_key: hex::encode(signer.public_key()),
+        private_key_pem: pem,
+        created_at: now_rfc3339(),
+    };
+    persist_local(path, &identity)?;
+    Ok(identity)
+}
+
+fn load_local(path: &Path) -> std::io::Result<Option<LocalIdentity>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => toml::from_str(&contents)
+            .map(Some)
+            .map_err(|error| std::io::Error::other(format!("parsing {}: {error}", path.display()))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn persist_local(path: &Path, identity: &LocalIdentity) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let contents = toml::to_string_pretty(identity)
+        .map_err(|error| std::io::Error::other(format!("serializing local identity: {error}")))?;
+    write_file_atomic_secret(path, contents.as_bytes())
+}
+
+/// Load the global device identity at `path`, if present.
+pub fn load_device(path: &Path) -> std::io::Result<Option<DeviceIdentity>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => toml::from_str(&contents)
+            .map(Some)
+            .map_err(|error| std::io::Error::other(format!("parsing {}: {error}", path.display()))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_device(path: &Path, identity: &DeviceIdentity) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let contents = toml::to_string_pretty(identity)
+        .map_err(|error| std::io::Error::other(format!("serializing device identity: {error}")))?;
+    write_file_atomic_secret(path, contents.as_bytes())
+}
+
+fn signer_from_pem(pem: &str) -> Result<Box<dyn Signer>, SignerError> {
+    Ed25519Signer::from_pem(pem).map(|signer| Box::new(signer) as Box<dyn Signer>)
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::StateSigningExt;
+    use objects::object::{Attribution, Principal, State, Tree};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn signed_state_with(signer: &dyn Signer) -> State {
+        let attribution = Attribution::human(Principal::new("Test", "test@example.com"));
+        let mut state = State::new(Tree::new().hash(), vec![], attribution);
+        state.sign(signer).expect("sign state");
+        state
+    }
+
+    #[test]
+    fn mint_is_idempotent_and_stable() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("identity.toml");
+
+        let first = load_or_mint_local(&path).expect("mint local identity");
+        assert!(path.exists(), "identity file should be created");
+        let second = load_or_mint_local(&path).expect("reload local identity");
+        assert_eq!(
+            first.public_key, second.public_key,
+            "second load must reuse the minted key, not re-mint"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn minted_local_key_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("identity.toml");
+        load_or_mint_local(&path).expect("mint local identity");
+
+        let mode = std::fs::metadata(&path)
+            .expect("identity metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "private key file must be 0600");
+    }
+
+    #[test]
+    fn resolve_mints_local_when_no_device() {
+        let temp = TempDir::new().expect("temp dir");
+        let local = temp.path().join("identity.toml");
+        let device = temp.path().join("device-identity.toml");
+
+        let signer = resolve_signer(&local, &device).expect("resolve a local signer");
+        let state = signed_state_with(signer.as_ref());
+        state
+            .verify_signature()
+            .expect("locally-signed state must verify");
+
+        // The resolved key is the persisted local key.
+        let persisted = load_local(&local).expect("read local").expect("present");
+        assert_eq!(persisted.public_key, hex::encode(signer.public_key()));
+    }
+
+    #[test]
+    fn device_supersedes_local_and_prior_local_still_verifies() {
+        let temp = TempDir::new().expect("temp dir");
+        let local = temp.path().join("identity.toml");
+        let device = temp.path().join("device-identity.toml");
+
+        // First capture: no device key yet -> local key signs.
+        let local_signer = resolve_signer(&local, &device).expect("local signer");
+        let local_pubkey = hex::encode(local_signer.public_key());
+        let prior_state = signed_state_with(local_signer.as_ref());
+        prior_state.verify_signature().expect("local state verifies");
+
+        // Reconcile: record a device key (a distinct keypair).
+        let device_signer = Ed25519Signer::generate().expect("device keypair");
+        write_device(
+            &device,
+            &DeviceIdentity {
+                public_key: hex::encode(device_signer.public_key()),
+                private_key_pem: device_signer.to_pem().expect("device pem"),
+                server: "grpc.example".to_string(),
+                linked_at: now_rfc3339(),
+            },
+        )
+        .expect("link device key");
+
+        // Subsequent capture: device key supersedes local.
+        let resolved = resolve_signer(&local, &device).expect("device signer");
+        assert_eq!(
+            hex::encode(resolved.public_key()),
+            hex::encode(device_signer.public_key()),
+            "device key must supersede the local key for new states"
+        );
+        assert_ne!(
+            hex::encode(resolved.public_key()),
+            local_pubkey,
+            "device key is distinct from the local key"
+        );
+
+        // The prior local-signed state still verifies — its public key is
+        // embedded, so reconciliation does not invalidate it.
+        prior_state
+            .verify_signature()
+            .expect("prior local-signed state still verifies after device link");
+    }
+
+    #[test]
+    fn resolve_returns_none_when_local_mint_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        // A regular file where the local-identity *parent directory* should be,
+        // so `create_dir_all`/`read_to_string` can't produce a key.
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, b"x").expect("write blocker");
+        let local = blocker.join("identity.toml");
+        let device = temp.path().join("absent-device.toml");
+
+        assert!(
+            resolve_signer(&local, &device).is_none(),
+            "an unmintable local key must degrade to None, not panic",
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_local_when_device_key_is_corrupt() {
+        let temp = TempDir::new().expect("temp dir");
+        let local = temp.path().join("identity.toml");
+        let device = temp.path().join("device-identity.toml");
+
+        // A device record whose PEM cannot be parsed.
+        write_device(
+            &device,
+            &DeviceIdentity {
+                public_key: "deadbeef".to_string(),
+                private_key_pem: "not a valid pem".to_string(),
+                server: "grpc.example".to_string(),
+                linked_at: now_rfc3339(),
+            },
+        )
+        .expect("write device identity");
+
+        let signer = resolve_signer(&local, &device).expect("fall back to local signer");
+        let persisted = load_local(&local).expect("read local").expect("present");
+        assert_eq!(
+            persisted.public_key,
+            hex::encode(signer.public_key()),
+            "an unreadable device key falls back to the local identity",
+        );
+    }
+
+    #[test]
+    fn device_roundtrips_through_disk() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("device-identity.toml");
+        let signer = Ed25519Signer::generate().expect("keypair");
+
+        write_device(
+            &path,
+            &DeviceIdentity {
+                public_key: hex::encode(signer.public_key()),
+                private_key_pem: signer.to_pem().expect("pem"),
+                server: "grpc.example".to_string(),
+                linked_at: now_rfc3339(),
+            },
+        )
+        .expect("write device identity");
+
+        let loaded = load_device(&path).expect("load").expect("present");
+        assert_eq!(loaded.public_key, hex::encode(signer.public_key()));
+        assert_eq!(loaded.server, "grpc.example");
+    }
+}

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -101,6 +101,54 @@ pub fn link_device_key(
     write_device(&device_identity_path(), &identity)
 }
 
+/// Remove the recorded device signing identity when it belongs to `server` —
+/// the inverse of [`link_device_key`], called by `heddle auth logout`.
+///
+/// Reads the device identity's recorded `server` and deletes
+/// `<heddle_home>/device-identity.toml` only when it matches the logged-out
+/// server; a device identity bound to a *different* server is left intact.
+/// Returns `true` if a matching identity was removed, `false` if there was
+/// nothing to remove (no file, or it belongs to another server).
+///
+/// Fail-closed (heddle#482): if a matching identity file is present but cannot
+/// be deleted, the error propagates so the logout reports the device key as
+/// still on disk rather than falsely claiming a clean removal. Leaving it would
+/// let [`resolve_signer`] keep preferring the logged-out private key for every
+/// subsequent capture.
+pub fn unlink_device_key(server: &str) -> std::io::Result<bool> {
+    unlink_device_key_at(&device_identity_path(), server)
+}
+
+fn unlink_device_key_at(path: &Path, server: &str) -> std::io::Result<bool> {
+    let Some(identity) = read_device_record(path)? else {
+        return Ok(false);
+    };
+    if identity.server != server {
+        return Ok(false);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        // Lost a race with another remover — the key is gone, which is the goal.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+/// Read the device-identity record at `path` for the logout/unlink decision,
+/// WITHOUT the signing-path permission gate. [`load_device`] refuses an
+/// insecure (group/world-readable) file because it must not be *trusted* for
+/// signing; logout instead needs to *remove* it, and an exposed key is all the
+/// more reason to delete it. Returns `None` when the file is absent.
+fn read_device_record(path: &Path) -> std::io::Result<Option<DeviceIdentity>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => toml::from_str(&contents).map(Some).map_err(|error| {
+            std::io::Error::other(format!("parsing {}: {error}", path.display()))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 /// Resolve the active signing key: the device key if one has been linked,
 /// otherwise the per-repo local key (minted on first call). Returns `None`
 /// only when no key can be produced (e.g. an unwritable home), so the caller
@@ -438,6 +486,145 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
             .expect("tighten perms");
         assert!(load_local(&path).expect("re-secured identity loads").is_some());
+    }
+
+    fn write_device_for(path: &Path, server: &str) -> Ed25519Signer {
+        let signer = Ed25519Signer::generate().expect("device keypair");
+        write_device(
+            path,
+            &DeviceIdentity {
+                public_key: hex::encode(signer.public_key()),
+                private_key_pem: signer.to_pem().expect("device pem"),
+                server: server.to_string(),
+                linked_at: now_rfc3339(),
+            },
+        )
+        .expect("write device identity");
+        signer
+    }
+
+    /// `auth logout S` removes the device identity recorded for `S`, and the
+    /// resolver then falls back to the per-repo local key — the logged-out
+    /// device key no longer signs (heddle#482). Pre-fix, logout never touched
+    /// `device-identity.toml`, so the device key persisted and kept signing.
+    #[test]
+    fn unlink_removes_matching_server_device_identity_then_falls_back_to_local() {
+        let temp = TempDir::new().expect("temp dir");
+        let local = temp.path().join("identity.toml");
+        let device = temp.path().join("device-identity.toml");
+
+        let device_signer = write_device_for(&device, "grpc.S");
+        let device_pubkey = hex::encode(device_signer.public_key());
+
+        // Before logout the resolver prefers the device key.
+        let pre = resolve_signer(&local, &device).expect("device signer");
+        assert_eq!(hex::encode(pre.public_key()), device_pubkey);
+
+        // Logout for the matching server removes the device identity.
+        let removed = unlink_device_key_at(&device, "grpc.S").expect("unlink");
+        assert!(removed, "matching-server device identity must be removed");
+        assert!(!device.exists(), "device-identity file must be gone after logout");
+
+        // The resolver now mints/uses the per-repo local key (a distinct key),
+        // so the logged-out device key can no longer sign new states.
+        let post = resolve_signer(&local, &device).expect("local signer");
+        assert_ne!(
+            hex::encode(post.public_key()),
+            device_pubkey,
+            "after logout the device key must no longer sign; resolver falls back to local",
+        );
+    }
+
+    /// Logging out of a *different* server must not remove another server's
+    /// device identity (heddle#482) — the unlink is gated on the recorded
+    /// `server` field matching.
+    #[test]
+    fn unlink_leaves_non_matching_server_device_identity_intact() {
+        let temp = TempDir::new().expect("temp dir");
+        let device = temp.path().join("device-identity.toml");
+
+        let device_signer = write_device_for(&device, "grpc.S");
+        let device_pubkey = hex::encode(device_signer.public_key());
+
+        let removed = unlink_device_key_at(&device, "grpc.OTHER").expect("unlink");
+        assert!(
+            !removed,
+            "logging out of a different server must not remove this device identity",
+        );
+        assert!(device.exists(), "non-matching device identity must remain on disk");
+
+        let still = load_device(&device).expect("load").expect("present");
+        assert_eq!(still.public_key, device_pubkey);
+        assert_eq!(still.server, "grpc.S");
+    }
+
+    /// Logout is a no-op (returns `false`, no error) when there is no device
+    /// identity to remove — e.g. a device that only ever used the local key.
+    #[test]
+    fn unlink_is_noop_when_no_device_identity() {
+        let temp = TempDir::new().expect("temp dir");
+        let device = temp.path().join("device-identity.toml");
+        let removed = unlink_device_key_at(&device, "grpc.S").expect("unlink");
+        assert!(!removed, "nothing to remove when no device identity exists");
+    }
+
+    /// Probe whether the test runs as root: root bypasses unix directory
+    /// permission bits, so the read-only-dir simulation below can't actually
+    /// block a removal. Detect by checking if a `0o500` dir is still writable.
+    #[cfg(unix)]
+    fn running_as_root() -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        let probe = TempDir::new().expect("probe temp");
+        let locked = probe.path().join("locked");
+        std::fs::create_dir(&locked).expect("probe dir");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o500))
+            .expect("lock probe");
+        let writable = std::fs::write(locked.join("x"), b"x").is_ok();
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700));
+        writable
+    }
+
+    /// Fail-closed (heddle#482): when a device identity matches the logged-out
+    /// server but its file cannot be removed (here: a read-only parent dir),
+    /// `unlink_device_key` returns an error and leaves the file in place, so
+    /// logout surfaces the incompleteness instead of falsely reporting a clean
+    /// removal while the private key is still on disk.
+    #[cfg(unix)]
+    #[test]
+    fn unlink_fails_closed_when_matching_file_cannot_be_removed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if running_as_root() {
+            // Root bypasses the read-only-dir guard; this simulation only holds
+            // for an unprivileged user. The happy-path + no-op tests still
+            // cover removal semantics under root.
+            return;
+        }
+
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("home");
+        std::fs::create_dir(&dir).expect("home dir");
+        let device = dir.join("device-identity.toml");
+        write_device_for(&device, "grpc.S");
+
+        // Read-only parent dir: the file is still readable (r-x) but cannot be
+        // unlinked (removal needs write on the directory).
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o500)).expect("lock dir");
+
+        let result = unlink_device_key_at(&device, "grpc.S");
+
+        // Restore perms before asserting so the TempDir can clean up.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .expect("restore perms");
+
+        assert!(
+            result.is_err(),
+            "a matching device key that cannot be removed must surface an error, not a clean removal",
+        );
+        assert!(
+            device.exists(),
+            "the logged-out key is still on disk after the failed removal",
+        );
     }
 
     /// The device-identity load path enforces the same permission gate, so a

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -156,7 +156,24 @@ pub fn load_or_mint_local(path: &Path) -> std::io::Result<LocalIdentity> {
     Ok(identity)
 }
 
+/// Reject an identity TOML whose embedded private key is exposed by
+/// group/world-readable permissions (heddle#482). Single-sources the key-file
+/// signer loader's rule via [`crypto::reject_group_or_world_readable_key`], so
+/// auto-signing trusts an identity file only when it is as locked-down as a
+/// `heddle sign --key` key file. A no-op when the file is absent (the mint
+/// path handles that) or on platforms without a unix permission model.
+fn reject_insecure_identity(path: &Path) -> std::io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    crypto::reject_group_or_world_readable_key(path)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::PermissionDenied, error))
+}
+
 fn load_local(path: &Path) -> std::io::Result<Option<LocalIdentity>> {
+    // Refuse an exposed private key before reading its bytes — fail closed
+    // rather than sign with a key any local user could have copied.
+    reject_insecure_identity(path)?;
     match std::fs::read_to_string(path) {
         Ok(contents) => toml::from_str(&contents)
             .map(Some)
@@ -177,6 +194,9 @@ fn persist_local(path: &Path, identity: &LocalIdentity) -> std::io::Result<()> {
 
 /// Load the global device identity at `path`, if present.
 pub fn load_device(path: &Path) -> std::io::Result<Option<DeviceIdentity>> {
+    // Same fail-closed permission gate as the local identity: an exposed
+    // device key must not be trusted for auto-signing.
+    reject_insecure_identity(path)?;
     match std::fs::read_to_string(path) {
         Ok(contents) => toml::from_str(&contents)
             .map(Some)
@@ -374,5 +394,88 @@ mod tests {
         let loaded = load_device(&path).expect("load").expect("present");
         assert_eq!(loaded.public_key, hex::encode(signer.public_key()));
         assert_eq!(loaded.server, "grpc.example");
+    }
+
+    /// A `0600` identity loads; loosening it to a group/world-readable mode
+    /// (e.g. a backup restore that didn't preserve perms) makes the loader
+    /// fail closed with the same insecure-permission refusal the key-file
+    /// signer loader raises — never signing with the exposed key (heddle#482).
+    #[cfg(unix)]
+    #[test]
+    fn load_local_rejects_group_or_world_readable_identity() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("identity.toml");
+
+        // Minted 0600 — loads fine.
+        load_or_mint_local(&path).expect("mint local identity");
+        assert!(load_local(&path).expect("secure identity loads").is_some());
+
+        // Loosen to world-readable.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen perms");
+
+        let err =
+            load_local(&path).expect_err("group/world-readable identity must be rejected");
+        let signer_err = err
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<SignerError>());
+        assert!(
+            matches!(signer_err, Some(SignerError::InsecureKeyPermissions { .. })),
+            "rejection must be the insecure-permission refusal, got {err:?}",
+        );
+
+        // Fail closed: the resolver yields no signer rather than signing with
+        // the exposed key, so a capture would be unsigned-but-marked.
+        let absent_device = temp.path().join("absent-device.toml");
+        assert!(
+            resolve_signer(&path, &absent_device).is_none(),
+            "an exposed local key must degrade to no signer, never sign",
+        );
+
+        // Tightening back to 0600 restores loadability.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("tighten perms");
+        assert!(load_local(&path).expect("re-secured identity loads").is_some());
+    }
+
+    /// The device-identity load path enforces the same permission gate, so a
+    /// group/world-readable device key is refused before signing (heddle#482).
+    #[cfg(unix)]
+    #[test]
+    fn load_device_rejects_group_or_world_readable_identity() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("device-identity.toml");
+        let signer = Ed25519Signer::generate().expect("keypair");
+        write_device(
+            &path,
+            &DeviceIdentity {
+                public_key: hex::encode(signer.public_key()),
+                private_key_pem: signer.to_pem().expect("pem"),
+                server: "grpc.example".to_string(),
+                linked_at: now_rfc3339(),
+            },
+        )
+        .expect("write device identity");
+
+        // Written 0600 by `write_file_atomic_secret` — loads fine.
+        assert!(load_device(&path).expect("secure device loads").is_some());
+
+        // Loosen to group-readable -> rejected with the insecure-permission
+        // refusal, and no key bytes are trusted for signing.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640))
+            .expect("loosen perms");
+        let err =
+            load_device(&path).expect_err("group-readable device identity must be rejected");
+        let signer_err = err
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<SignerError>());
+        assert!(
+            matches!(signer_err, Some(SignerError::InsecureKeyPermissions { .. })),
+            "rejection must be the insecure-permission refusal, got {err:?}",
+        );
     }
 }

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -92,13 +92,28 @@ pub fn link_device_key(
     private_key_pem: &str,
     server: &str,
 ) -> std::io::Result<()> {
+    link_device_key_at(&device_identity_path(), public_key, private_key_pem, server)
+}
+
+/// Write the device identity at `path` while holding the device write-lock, so
+/// the link serializes with logout's [`unlink_device_key`] (heddle#482). The
+/// shared lock closes a TOCTOU window: without it, a concurrent logout that read
+/// a *matching* identity could `remove_file` the identity this link atomically
+/// renames in — deleting a *different* server's key.
+fn link_device_key_at(
+    path: &Path,
+    public_key: &[u8],
+    private_key_pem: &str,
+    server: &str,
+) -> std::io::Result<()> {
+    let _lock = acquire_device_lock(path)?;
     let identity = DeviceIdentity {
         public_key: hex::encode(public_key),
         private_key_pem: private_key_pem.to_string(),
         server: server.to_string(),
         linked_at: now_rfc3339(),
     };
-    write_device(&device_identity_path(), &identity)
+    write_device(path, &identity)
 }
 
 /// Remove the recorded device signing identity when it belongs to `server` —
@@ -115,11 +130,24 @@ pub fn link_device_key(
 /// still on disk rather than falsely claiming a clean removal. Leaving it would
 /// let [`resolve_signer`] keep preferring the logged-out private key for every
 /// subsequent capture.
+///
+/// Race-safe (heddle#482): the whole read→compare→remove runs under the device
+/// write-lock that [`link_device_key`] also takes, and the on-disk `server` is
+/// RE-READ under that lock immediately before the remove. A concurrent
+/// `auth login` that atomically swaps in a *different* server's identity can
+/// therefore never be the casualty of this unlink — the revalidation sees the
+/// new server and leaves it intact.
 pub fn unlink_device_key(server: &str) -> std::io::Result<bool> {
     unlink_device_key_at(&device_identity_path(), server)
 }
 
 fn unlink_device_key_at(path: &Path, server: &str) -> std::io::Result<bool> {
+    // Hold the device write-lock across the entire decision: a concurrent login
+    // takes the same lock in `link_device_key_at`, so the file cannot be swapped
+    // between our read and our remove (heddle#482 TOCTOU).
+    let _lock = acquire_device_lock(path)?;
+    // RE-READ under the lock and remove ONLY if the on-disk identity STILL
+    // belongs to the logged-out server — never delete one a login swapped in.
     let Some(identity) = read_device_record(path)? else {
         return Ok(false);
     };
@@ -132,6 +160,22 @@ fn unlink_device_key_at(path: &Path, server: &str) -> std::io::Result<bool> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(error),
     }
+}
+
+/// Process-wide write lock serializing device-identity mutations — login's
+/// [`link_device_key`] and logout's [`unlink_device_key`] (heddle#482). The lock
+/// file sits beside the device identity, derived from its parent, so the global
+/// path (`<heddle_home>/locks/device-identity.lock`) and any test path stay in
+/// lockstep with whichever `device-identity.toml` they guard.
+fn device_lock(device_path: &Path) -> objects::lock::RepoLock {
+    let dir = device_path.parent().unwrap_or_else(|| Path::new("."));
+    objects::lock::RepoLock::at(dir.join("locks").join("device-identity.lock"))
+}
+
+fn acquire_device_lock(device_path: &Path) -> std::io::Result<objects::lock::WriteLockGuard> {
+    device_lock(device_path)
+        .write()
+        .map_err(|error| std::io::Error::other(format!("acquiring device-identity lock: {error}")))
 }
 
 /// Read the device-identity record at `path` for the logout/unlink decision,
@@ -607,6 +651,12 @@ mod tests {
         let device = dir.join("device-identity.toml");
         write_device_for(&device, "grpc.S");
 
+        // Prime the device lock (materialises `<dir>/locks/device-identity.lock`)
+        // while `dir` is still writable, so the unlink can ACQUIRE the lock and
+        // the only thing that fails is the removal itself — this exercises the
+        // fail-closed remove path under a held lock, not lock setup.
+        drop(device_lock(&device).write().expect("prime device lock"));
+
         // Read-only parent dir: the file is still readable (r-x) but cannot be
         // unlinked (removal needs write on the directory).
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o500)).expect("lock dir");
@@ -625,6 +675,53 @@ mod tests {
             device.exists(),
             "the logged-out key is still on disk after the failed removal",
         );
+    }
+
+    /// Race-safety (heddle#482 TOCTOU): a logout for server A, racing a fresh
+    /// login for server B that atomically replaces the file, must NEVER delete
+    /// B's identity. Because link and unlink both take the device write-lock,
+    /// the logout either removes A's file before B is linked, or re-reads B
+    /// under the lock and no-ops — so in EVERY interleaving B's freshly-linked
+    /// identity is the survivor. Pre-fix, the logout's pre-lock read of A could
+    /// `remove_file` the B file that the login had just renamed in.
+    #[test]
+    fn concurrent_login_and_logout_never_delete_a_different_servers_identity() {
+        for _ in 0..64 {
+            let temp = TempDir::new().expect("temp dir");
+            let device = temp.path().join("device-identity.toml");
+
+            // The file starts as server A's identity.
+            write_device_for(&device, "grpc.A");
+
+            // Mint B's keypair up front so the login thread just writes it.
+            let b = Ed25519Signer::generate().expect("b keypair");
+            let b_pubkey = hex::encode(b.public_key());
+            let b_pub = b.public_key().to_vec();
+            let b_pem = b.to_pem().expect("b pem");
+
+            let logout_path = device.clone();
+            let logout =
+                std::thread::spawn(move || unlink_device_key_at(&logout_path, "grpc.A"));
+
+            let login_path = device.clone();
+            let login = std::thread::spawn(move || {
+                link_device_key_at(&login_path, &b_pub, &b_pem, "grpc.B")
+            });
+
+            logout.join().expect("logout thread").expect("unlink ok");
+            login.join().expect("login thread").expect("link ok");
+
+            // B's identity must survive every interleaving — it is never the
+            // unlink's casualty.
+            let surviving = load_device(&device)
+                .expect("load device")
+                .expect("the concurrent login's identity must survive");
+            assert_eq!(surviving.server, "grpc.B");
+            assert_eq!(
+                surviving.public_key, b_pubkey,
+                "the concurrent login's identity must never be deleted by the unlink",
+            );
+        }
     }
 
     /// The device-identity load path enforces the same permission gate, so a

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -13,6 +13,7 @@ mod ephemeral_thread;
 mod fsmonitor;
 pub mod git_worktree_status;
 mod hooks;
+pub mod identity;
 pub mod lazy_hydrator;
 mod merge_state;
 pub mod migration;

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -53,7 +53,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
-    sync::{Arc, RwLock},
+    sync::{Arc, OnceLock, RwLock},
 };
 
 use chrono::Utc;
@@ -285,6 +285,11 @@ where
     config: RepoConfig,
     shallow: RwLock<ShallowInfo>,
     blob_hydrator: RwLock<Option<Arc<dyn BlobHydrator>>>,
+    /// Process-lifetime cache of the resolved auto-signing key (heddle#482).
+    /// `None` (cached) means no key could be produced — captures proceed
+    /// unsigned and surface that status rather than failing. Resolved once
+    /// per handle to avoid re-reading the key file on every capture.
+    signing_signer_cache: OnceLock<Option<Arc<dyn crypto::Signer>>>,
 }
 
 impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repository<R, O, S> {
@@ -325,6 +330,7 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
             config,
             shallow: RwLock::new(shallow),
             blob_hydrator: RwLock::new(None),
+            signing_signer_cache: OnceLock::new(),
         }
     }
 
@@ -580,6 +586,7 @@ impl Repository {
             config,
             shallow: RwLock::new(ShallowInfo::load(&heddle_dir)?),
             blob_hydrator: RwLock::new(None),
+            signing_signer_cache: OnceLock::new(),
         })
     }
 

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -53,7 +53,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use chrono::Utc;
@@ -285,11 +285,6 @@ where
     config: RepoConfig,
     shallow: RwLock<ShallowInfo>,
     blob_hydrator: RwLock<Option<Arc<dyn BlobHydrator>>>,
-    /// Process-lifetime cache of the resolved auto-signing key (heddle#482).
-    /// `None` (cached) means no key could be produced — captures proceed
-    /// unsigned and surface that status rather than failing. Resolved once
-    /// per handle to avoid re-reading the key file on every capture.
-    signing_signer_cache: OnceLock<Option<Arc<dyn crypto::Signer>>>,
 }
 
 impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repository<R, O, S> {
@@ -330,7 +325,6 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
             config,
             shallow: RwLock::new(shallow),
             blob_hydrator: RwLock::new(None),
-            signing_signer_cache: OnceLock::new(),
         }
     }
 
@@ -586,7 +580,6 @@ impl Repository {
             config,
             shallow: RwLock::new(ShallowInfo::load(&heddle_dir)?),
             blob_hydrator: RwLock::new(None),
-            signing_signer_cache: OnceLock::new(),
         })
     }
 

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -16,19 +16,24 @@ impl Repository {
         self.heddle_dir().join(crate::identity::LOCAL_IDENTITY_FILE)
     }
 
-    /// Resolve — and cache for this handle's lifetime — the machine signing
-    /// key: the device key if `heddle auth login` has linked one, otherwise
-    /// the auto-minted per-repo local key. Returns `None` only when no key can
-    /// be produced (e.g. an unwritable home), in which case captures proceed
-    /// unsigned and surface that status.
+    /// Resolve the machine signing key for THIS sign attempt: the device key
+    /// if `heddle auth login` has linked one, otherwise the auto-minted
+    /// per-repo local key. Returns `None` only when no key can be produced
+    /// (e.g. an unwritable home, or — fail-closed — an identity file whose
+    /// permissions have been loosened to group/world-readable), in which case
+    /// captures proceed unsigned and surface that status.
+    ///
+    /// Deliberately NOT cached (heddle#482): the identity file's permissions
+    /// are re-validated by `resolve_signer` on every call, so a mid-session
+    /// `chmod` that exposes the private key makes the very next sign fail
+    /// closed instead of reusing a signer minted while the file was still
+    /// `0600`. A long-lived handle (e.g. the mount path) therefore can't keep
+    /// signing with a now-exposed key. Resolution is a small file read + PEM
+    /// parse — negligible against the tree/blob writes a capture already does.
     pub(crate) fn signing_signer(&self) -> Option<Arc<dyn Signer>> {
-        self.signing_signer_cache
-            .get_or_init(|| {
-                let local = self.local_identity_path();
-                let device = crate::identity::device_identity_path();
-                crate::identity::resolve_signer(&local, &device).map(Arc::from)
-            })
-            .clone()
+        let local = self.local_identity_path();
+        let device = crate::identity::device_identity_path();
+        crate::identity::resolve_signer(&local, &device).map(Arc::from)
     }
 
     /// Best-effort auto-sign on the capture/commit/merge path (heddle#482).
@@ -48,14 +53,24 @@ impl Repository {
         }
     }
 
-    /// The capture-path chokepoint (heddle#482): auto-sign (best-effort) then
-    /// persist a freshly built capture/commit/merge `State`. Every state-write
-    /// path that records a *new author capture* — in this crate AND the `mount`
-    /// crate — routes through here, so none can store a state unsigned. Signing
-    /// is the last mutation before the write, so the signature covers the final
-    /// field set. (The raw `store.put_state` remains for non-capture writes:
-    /// re-signing an existing state, seeding init, and tests.)
-    pub fn record_captured_state(&self, state: &mut State) -> Result<()> {
+    /// The authored-state write chokepoint (heddle#482): auto-sign
+    /// (best-effort) then persist a freshly authored `State`. EVERY writer that
+    /// records a *new authored state* routes through here — capture/snapshot,
+    /// merge, mount capture, thread materialize, fork, collapse, context
+    /// annotation, and both rebase replay paths, across this crate AND the
+    /// `mount`/`cli` crates — so no authored state can reach the store
+    /// unsigned. Signing is the LAST mutation before the write, so the
+    /// signature covers the final field set; any later change would invalidate
+    /// it.
+    ///
+    /// Non-authored writes deliberately do NOT use this path — they keep their
+    /// existing signature (or stay legitimately unsigned) rather than minting a
+    /// fresh one: replaying/transferring an already-signed state
+    /// (`put_state_serialized`, sync/packfile ops), the synthetic init root
+    /// (`seed_default_thread`), git-import of foreign history, and server-side
+    /// review/signal mutations. Re-signing those would either clobber an
+    /// existing signature or falsely attribute foreign content to this device.
+    pub fn put_authored_state(&self, state: &mut State) -> Result<()> {
         self.sign_state_best_effort(state);
         self.store.put_state(state)?;
         Ok(())
@@ -450,6 +465,72 @@ mod tests {
                 repo.verify_state_signature(&state.change_id)
                     .expect("verify"),
                 SignatureStatus::Unsigned,
+            );
+        });
+    }
+
+    /// The permission gate is re-checked before EVERY sign (heddle#482): a
+    /// signer minted while the identity file was `0600` must NOT survive a
+    /// mid-session `chmod` that exposes the key. The pre-fix handle cached the
+    /// signer on first capture, so a later capture on the same handle kept
+    /// signing with the now-readable key — this test fails closed instead.
+    #[cfg(unix)]
+    #[test]
+    fn perm_loosening_mid_session_fails_closed_without_cached_signer() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+            let identity = temp.path().join(".heddle").join("identity.toml");
+
+            // First capture on this handle mints the 0600 local key and signs.
+            std::fs::write(temp.path().join("a.txt"), "a").expect("write");
+            let first = repo.snapshot(Some("a".to_string()), None).expect("capture a");
+            assert!(
+                first.signature.is_some(),
+                "first capture signs with the freshly-minted 0600 key",
+            );
+            assert_eq!(
+                std::fs::metadata(&identity)
+                    .expect("identity metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600,
+            );
+
+            // Mid-session a restore/chmod exposes the private key.
+            std::fs::set_permissions(&identity, std::fs::Permissions::from_mode(0o644))
+                .expect("loosen perms");
+
+            // The SAME handle must refuse to reuse a cached signer: the gate is
+            // re-validated per sign, so this capture is unsigned-but-marked.
+            std::fs::write(temp.path().join("b.txt"), "b").expect("write");
+            let exposed = repo.snapshot(Some("b".to_string()), None).expect("capture b");
+            assert!(
+                exposed.signature.is_none(),
+                "an exposed key must make the next sign fail closed, not reuse a cached signer",
+            );
+            assert_eq!(
+                repo.verify_state_signature(&exposed.change_id)
+                    .expect("verify"),
+                SignatureStatus::Unsigned,
+            );
+
+            // Re-securing the key restores signing on the very same handle.
+            std::fs::set_permissions(&identity, std::fs::Permissions::from_mode(0o600))
+                .expect("re-secure perms");
+            std::fs::write(temp.path().join("c.txt"), "c").expect("write");
+            let resecured = repo.snapshot(Some("c".to_string()), None).expect("capture c");
+            assert!(
+                resecured.signature.is_some(),
+                "re-securing the key lets the same handle sign again",
+            );
+            assert_eq!(
+                repo.verify_state_signature(&resecured.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
             );
         });
     }

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -48,6 +48,19 @@ impl Repository {
         }
     }
 
+    /// The capture-path chokepoint (heddle#482): auto-sign (best-effort) then
+    /// persist a freshly built capture/commit/merge `State`. Every state-write
+    /// path that records a *new author capture* — in this crate AND the `mount`
+    /// crate — routes through here, so none can store a state unsigned. Signing
+    /// is the last mutation before the write, so the signature covers the final
+    /// field set. (The raw `store.put_state` remains for non-capture writes:
+    /// re-signing an existing state, seeding init, and tests.)
+    pub fn record_captured_state(&self, state: &mut State) -> Result<()> {
+        self.sign_state_best_effort(state);
+        self.store.put_state(state)?;
+        Ok(())
+    }
+
     /// Sign a state with the given signer.
     ///
     /// This loads the state, signs it, and stores the updated state.

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -1,14 +1,53 @@
 // SPDX-License-Identifier: Apache-2.0
 //! State signing operations for Repository.
 
+use std::sync::Arc;
+
 use crypto::{Signer, StateSigningExt, load_signer, verify_state_signature_bytes};
-use objects::object::{ChangeId, SignatureStatus, StateSignature};
+use objects::object::{ChangeId, SignatureStatus, State, StateSignature};
 use objects::store::ObjectStore;
 use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result};
 
 impl Repository {
+    /// Path to this repo's per-repo local signing identity (heddle#482).
+    fn local_identity_path(&self) -> std::path::PathBuf {
+        self.heddle_dir().join(crate::identity::LOCAL_IDENTITY_FILE)
+    }
+
+    /// Resolve — and cache for this handle's lifetime — the machine signing
+    /// key: the device key if `heddle auth login` has linked one, otherwise
+    /// the auto-minted per-repo local key. Returns `None` only when no key can
+    /// be produced (e.g. an unwritable home), in which case captures proceed
+    /// unsigned and surface that status.
+    pub(crate) fn signing_signer(&self) -> Option<Arc<dyn Signer>> {
+        self.signing_signer_cache
+            .get_or_init(|| {
+                let local = self.local_identity_path();
+                let device = crate::identity::device_identity_path();
+                crate::identity::resolve_signer(&local, &device).map(Arc::from)
+            })
+            .clone()
+    }
+
+    /// Best-effort auto-sign on the capture/commit/merge path (heddle#482).
+    ///
+    /// A missing or unreadable key warns and leaves the state unsigned rather
+    /// than failing the capture — the unsigned status stays observable via
+    /// `state.signature` being `None`. This MUST be the last mutation before
+    /// `put_state`: it signs `compute_hash()` over the then-current fields, so
+    /// any later field change would invalidate the signature.
+    pub(crate) fn sign_state_best_effort(&self, state: &mut State) {
+        let Some(signer) = self.signing_signer() else {
+            debug!("no signing identity available; state captured unsigned");
+            return;
+        };
+        if let Err(error) = state.sign(&*signer) {
+            tracing::warn!(%error, "auto-signing failed; state captured unsigned");
+        }
+    }
+
     /// Sign a state with the given signer.
     ///
     /// This loads the state, signs it, and stores the updated state.
@@ -207,5 +246,198 @@ mod tests {
 
         let sig = sig.expect("signature exists");
         assert_eq!(sig.algorithm(), "ed25519");
+    }
+
+    // ----- heddle#482: automatic state signing on the capture/merge path -----
+
+    use std::sync::Mutex;
+
+    /// Serializes the signing tests below — they manipulate the process-global
+    /// `HEDDLE_HOME` to point the device-identity lookup at a per-test temp dir.
+    static SIGNING_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `f` with `HEDDLE_HOME` pinned to `home` so the device-identity
+    /// resolver reads a per-test directory. Restores the prior value after.
+    fn with_signing_home<T>(home: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        let _guard = SIGNING_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", home);
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        match previous {
+            Some(value) => unsafe { std::env::set_var("HEDDLE_HOME", value) },
+            None => unsafe { std::env::remove_var("HEDDLE_HOME") },
+        }
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    fn sig_pubkey(state: &State) -> String {
+        state
+            .signature
+            .as_ref()
+            .expect("state is signed")
+            .public_key
+            .clone()
+    }
+
+    #[test]
+    fn capture_auto_signs_with_local_identity() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+            std::fs::write(temp.path().join("file.txt"), "hello").expect("write file");
+
+            let state = repo.snapshot(Some("first".to_string()), None).expect("capture");
+
+            // Every captured state is signed and verifies, with no auth login.
+            assert!(state.signature.is_some(), "capture must auto-sign");
+            assert_eq!(
+                repo.verify_state_signature(&state.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
+            );
+
+            // The signing key is the per-repo auto-minted local identity.
+            let local = crate::identity::load_or_mint_local(
+                &temp.path().join(".heddle").join("identity.toml"),
+            )
+            .expect("read local identity");
+            assert_eq!(sig_pubkey(&state), local.public_key);
+        });
+    }
+
+    #[test]
+    fn auth_login_reconciles_local_to_device_key() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+
+            // Pre-auth capture: signed by the auto-minted local key.
+            std::fs::write(temp.path().join("a.txt"), "a").expect("write");
+            let local_state = repo.snapshot(Some("local".to_string()), None).expect("capture");
+            let local_pubkey = sig_pubkey(&local_state);
+            assert_eq!(
+                repo.verify_state_signature(&local_state.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
+            );
+
+            // Simulate `heddle auth login`: mint + link a distinct device key.
+            let device = Ed25519Signer::generate().expect("device key");
+            let device_pubkey = hex::encode(device.public_key());
+            crate::identity::link_device_key(
+                device.public_key(),
+                &device.to_pem().expect("device pem"),
+                "grpc.example",
+            )
+            .expect("link device key");
+            assert_ne!(device_pubkey, local_pubkey, "device key is distinct");
+
+            // A fresh handle (fresh signer cache) now signs with the device key.
+            let repo2 = Repository::open(temp.path()).expect("reopen repo");
+            std::fs::write(temp.path().join("b.txt"), "b").expect("write");
+            let device_state = repo2.snapshot(Some("device".to_string()), None).expect("capture");
+            assert_eq!(
+                sig_pubkey(&device_state),
+                device_pubkey,
+                "post-login captures sign with the device key",
+            );
+            assert_eq!(
+                repo2
+                    .verify_state_signature(&device_state.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
+            );
+
+            // The prior local-signed state still verifies — reconciliation does
+            // not invalidate it (its public key is embedded in the state).
+            assert_eq!(
+                repo2
+                    .verify_state_signature(&local_state.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
+            );
+        });
+    }
+
+    #[test]
+    fn signature_survives_semantic_merge() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+
+            // Build a fork: A -> B on one side, A -> C on the other.
+            std::fs::write(temp.path().join("file.txt"), "a").expect("write");
+            let state_a = repo.snapshot(Some("a".to_string()), None).expect("capture a");
+            std::fs::write(temp.path().join("file.txt"), "b").expect("write");
+            let state_b = repo.snapshot(Some("b".to_string()), None).expect("capture b");
+
+            repo.goto(&state_a.change_id).expect("goto a");
+            std::fs::write(temp.path().join("side.txt"), "c").expect("write");
+            let state_c = repo.snapshot(Some("c".to_string()), None).expect("capture c");
+
+            // Merge B into head C -> a real two-parent merge state.
+            let attribution = Attribution::human(Principal::new("Merger", "merge@example.com"));
+            let merge = repo
+                .snapshot_merge_with_attribution(
+                    &state_b.change_id,
+                    Some("merge".to_string()),
+                    None,
+                    attribution,
+                    None,
+                )
+                .expect("merge");
+
+            // The merge state carries its own signature.
+            assert!(merge.signature.is_some(), "merge state must be signed");
+            assert_eq!(
+                repo.verify_state_signature(&merge.change_id).expect("verify"),
+                SignatureStatus::Valid,
+            );
+
+            // Every parent's signature still verifies after the merge — merges
+            // do not rewrite ancestors, so attribution survives.
+            for parent in [&state_a, &state_b, &state_c] {
+                assert_eq!(
+                    repo.verify_state_signature(&parent.change_id)
+                        .expect("verify parent"),
+                    SignatureStatus::Valid,
+                    "parent signature must survive the merge",
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn capture_degrades_gracefully_when_signing_unavailable() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+
+            // Force the local-identity mint to fail by occupying its path with a
+            // directory, so `read_to_string` errors and no key can be produced.
+            std::fs::create_dir(temp.path().join(".heddle").join("identity.toml"))
+                .expect("occupy identity path");
+
+            std::fs::write(temp.path().join("file.txt"), "x").expect("write");
+            // Capture must still succeed — signing is best-effort.
+            let state = repo.snapshot(Some("x".to_string()), None).expect("capture");
+
+            assert!(
+                state.signature.is_none(),
+                "degraded capture is unsigned, not silently signed",
+            );
+            assert_eq!(
+                repo.verify_state_signature(&state.change_id)
+                    .expect("verify"),
+                SignatureStatus::Unsigned,
+            );
+        });
     }
 }

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -394,6 +394,66 @@ mod tests {
         });
     }
 
+    /// login → capture (device-signed) → logout → capture (local-signed):
+    /// `auth logout` unlinks the device identity so the next capture stops
+    /// signing with the logged-out device key and falls back to the per-repo
+    /// local key (heddle#482). Pre-fix, logout left `device-identity.toml` on
+    /// disk, so this post-logout capture would still carry the device key —
+    /// the gap this test pins shut. Reuses the same handle to also confirm the
+    /// per-sign (uncached) resolution picks up the removal mid-session.
+    #[test]
+    fn logout_unlinks_device_key_so_capture_falls_back_to_local() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (temp, repo) = setup_repo();
+
+            // Simulate `auth login --server grpc.S`: link a device key.
+            let device = Ed25519Signer::generate().expect("device key");
+            let device_pubkey = hex::encode(device.public_key());
+            crate::identity::link_device_key(
+                device.public_key(),
+                &device.to_pem().expect("device pem"),
+                "grpc.S",
+            )
+            .expect("link device key");
+
+            // Post-login capture signs with the device key.
+            std::fs::write(temp.path().join("a.txt"), "a").expect("write");
+            let signed_in = repo.snapshot(Some("in".to_string()), None).expect("capture");
+            assert_eq!(
+                sig_pubkey(&signed_in),
+                device_pubkey,
+                "post-login capture uses the device key",
+            );
+
+            // Simulate `auth logout grpc.S`: unlink the device identity.
+            let removed =
+                crate::identity::unlink_device_key("grpc.S").expect("unlink device key");
+            assert!(removed, "logout removes the matching-server device identity");
+
+            // Subsequent capture on the SAME handle no longer uses the device
+            // key — it falls back to the per-repo local key (a distinct key),
+            // which still verifies.
+            std::fs::write(temp.path().join("b.txt"), "b").expect("write");
+            let signed_out = repo.snapshot(Some("out".to_string()), None).expect("capture");
+            assert_ne!(
+                sig_pubkey(&signed_out),
+                device_pubkey,
+                "post-logout capture must not sign with the logged-out device key",
+            );
+            assert_eq!(
+                repo.verify_state_signature(&signed_out.change_id)
+                    .expect("verify"),
+                SignatureStatus::Valid,
+            );
+
+            // Logout is idempotent: a second one finds nothing to remove.
+            let again =
+                crate::identity::unlink_device_key("grpc.S").expect("idempotent unlink");
+            assert!(!again, "second logout finds nothing to remove");
+        });
+    }
+
     #[test]
     fn signature_survives_semantic_merge() {
         let home = TempDir::new().expect("home temp");

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -237,15 +237,13 @@ impl SnapshotMutation<'_> {
             }
         }
 
-        // Auto-sign every captured state (heddle#482). This must be the LAST
-        // mutation before `put_state`: signing covers `compute_hash()` over the
-        // fields enriched above, so any later change would invalidate it.
-        // Best-effort — a missing key leaves the state unsigned, never fails
-        // the capture.
-        self.repo.sign_state_best_effort(&mut state);
-
+        // Auto-sign every captured state (heddle#482) via the capture-path
+        // chokepoint. Signing is the LAST mutation before the write: it covers
+        // `compute_hash()` over the fields enriched above, so any later change
+        // would invalidate it. Best-effort — a missing key leaves the state
+        // unsigned, never fails the capture.
         let state_ref_oplog_start = std::time::Instant::now();
-        self.repo.store.put_state(&state)?;
+        self.repo.record_captured_state(&mut state)?;
         self.repo.store.flush_snapshot_write_batch()?;
 
         Ok(SnapshotExecution {
@@ -697,13 +695,12 @@ impl Repository {
             state = state.with_context(merged_context);
         }
 
-        // Auto-sign the merge state (heddle#482): the merge author vouches for
-        // this merge of parents X and Y. Each parent keeps its own author
-        // signature — they are unchanged on disk, so they stay verifiable.
-        // Last mutation before `put_state`, same ordering rule as capture.
-        self.sign_state_best_effort(&mut state);
-
-        self.store.put_state(&state)?;
+        // Auto-sign the merge state (heddle#482) via the capture-path
+        // chokepoint: the merge author vouches for this merge of parents X and
+        // Y. Each parent keeps its own author signature — they are unchanged on
+        // disk, so they stay verifiable. Last mutation before the write, same
+        // ordering rule as capture.
+        self.record_captured_state(&mut state)?;
 
         let head = self.head_ref()?;
         let thread = match &head {

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -237,6 +237,13 @@ impl SnapshotMutation<'_> {
             }
         }
 
+        // Auto-sign every captured state (heddle#482). This must be the LAST
+        // mutation before `put_state`: signing covers `compute_hash()` over the
+        // fields enriched above, so any later change would invalidate it.
+        // Best-effort — a missing key leaves the state unsigned, never fails
+        // the capture.
+        self.repo.sign_state_best_effort(&mut state);
+
         let state_ref_oplog_start = std::time::Instant::now();
         self.repo.store.put_state(&state)?;
         self.repo.store.flush_snapshot_write_batch()?;
@@ -689,6 +696,12 @@ impl Repository {
         if let Some(merged_context) = self.union_parent_contexts(&[&ours_state, &theirs_state])? {
             state = state.with_context(merged_context);
         }
+
+        // Auto-sign the merge state (heddle#482): the merge author vouches for
+        // this merge of parents X and Y. Each parent keeps its own author
+        // signature — they are unchanged on disk, so they stay verifiable.
+        // Last mutation before `put_state`, same ordering rule as capture.
+        self.sign_state_best_effort(&mut state);
 
         self.store.put_state(&state)?;
 

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -243,7 +243,7 @@ impl SnapshotMutation<'_> {
         // would invalidate it. Best-effort — a missing key leaves the state
         // unsigned, never fails the capture.
         let state_ref_oplog_start = std::time::Instant::now();
-        self.repo.record_captured_state(&mut state)?;
+        self.repo.put_authored_state(&mut state)?;
         self.repo.store.flush_snapshot_write_batch()?;
 
         Ok(SnapshotExecution {
@@ -695,12 +695,12 @@ impl Repository {
             state = state.with_context(merged_context);
         }
 
-        // Auto-sign the merge state (heddle#482) via the capture-path
+        // Auto-sign the merge state (heddle#482) via the authored-state
         // chokepoint: the merge author vouches for this merge of parents X and
         // Y. Each parent keeps its own author signature — they are unchanged on
         // disk, so they stay verifiable. Last mutation before the write, same
         // ordering rule as capture.
-        self.record_captured_state(&mut state)?;
+        self.put_authored_state(&mut state)?;
 
         let head = self.head_ref()?;
         let thread = match &head {

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -248,10 +248,10 @@ impl Repository {
         };
         let mut state = State::new_snapshot(new_tree_hash, parents, attribution);
         // Auto-sign this thread-materialization capture (heddle#482) via the
-        // capture-path chokepoint, the same as the primary capture path — it is
-        // a real author capture that bypasses `stage_snapshot_objects`. Last
+        // authored-state chokepoint, the same as the primary capture path — it
+        // is a real author capture that bypasses `stage_snapshot_objects`. Last
         // mutation before the write.
-        self.record_captured_state(&mut state)?;
+        self.put_authored_state(&mut state)?;
         self.refs().set_thread(&thread_name, &state.change_id)?;
 
         // 4. Rewrite the manifest to reflect the new state. `root` is

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -247,11 +247,11 @@ impl Repository {
             None => vec![],
         };
         let mut state = State::new_snapshot(new_tree_hash, parents, attribution);
-        // Auto-sign this thread-materialization capture (heddle#482), the same
-        // as the primary capture path — it is a real author capture that
-        // bypasses `stage_snapshot_objects`. Last mutation before `put_state`.
-        self.sign_state_best_effort(&mut state);
-        self.store().put_state(&state)?;
+        // Auto-sign this thread-materialization capture (heddle#482) via the
+        // capture-path chokepoint, the same as the primary capture path — it is
+        // a real author capture that bypasses `stage_snapshot_objects`. Last
+        // mutation before the write.
+        self.record_captured_state(&mut state)?;
         self.refs().set_thread(&thread_name, &state.change_id)?;
 
         // 4. Rewrite the manifest to reflect the new state. `root` is

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -246,7 +246,11 @@ impl Repository {
             Some(prev) => vec![prev],
             None => vec![],
         };
-        let state = State::new_snapshot(new_tree_hash, parents, attribution);
+        let mut state = State::new_snapshot(new_tree_hash, parents, attribution);
+        // Auto-sign this thread-materialization capture (heddle#482), the same
+        // as the primary capture path — it is a real author capture that
+        // bypasses `stage_snapshot_objects`. Last mutation before `put_state`.
+        self.sign_state_best_effort(&mut state);
         self.store().put_state(&state)?;
         self.refs().set_thread(&thread_name, &state.change_id)?;
 

--- a/scripts/check-authored-states-signed.sh
+++ b/scripts/check-authored-states-signed.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# heddle#482 — authored-state signing-chokepoint guard.
+#
+# Every command that writes a *new authored state* must route through
+# `Repository::put_authored_state` (which auto-signs before persisting), never
+# call `store().put_state(...)` directly. A direct authored put bypasses
+# signing and reopens the coverage-leak class (heddle#482 r2): `heddle fork`,
+# `collapse`, `context set`, and the rebase replay paths each persisted an
+# UNSIGNED state because signing lived at the call site instead of the
+# repo-layer chokepoint. Lifting signing to the chokepoint closed the class;
+# this asserter keeps it closed by failing CI the moment a NEW authored writer
+# under the CLI command tree reaches `put_state` directly.
+#
+# Scope: `crates/cli/src/cli/commands` production code only. Test code builds
+# unsigned fixtures on purpose, so we exempt:
+#   - dedicated `tests.rs` files, and
+#   - the trailing `#[cfg(test)]` module in any file (test mods live at the
+#     file tail by convention).
+# `put_state_serialized(...)` is NOT matched: it is the non-authored,
+# signature-preserving replay/transfer API (sync, packfiles), which correctly
+# carries an existing signature forward rather than minting a fresh one.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_DIR="$ROOT/crates/cli/src/cli/commands"
+
+if [[ ! -d "$SCAN_DIR" ]]; then
+  echo "ERROR: scan dir not found: $SCAN_DIR" >&2
+  exit 2
+fi
+
+violations=0
+while IFS= read -r -d '' file; do
+  if [[ "$(basename "$file")" == "tests.rs" ]]; then
+    continue
+  fi
+  # Emit `lineno: content` for production lines that call `.put_state(`,
+  # stopping at the first `#[cfg(test)]` and skipping comment lines.
+  hits="$(awk '
+    /#\[cfg\(test\)\]/ { exit }
+    /^[[:space:]]*\/\// { next }
+    /\.put_state\(/ { printf "    %d: %s\n", FNR, $0 }
+  ' "$file")"
+  if [[ -n "$hits" ]]; then
+    echo "ERROR: direct store().put_state for an authored state in: ${file#"$ROOT"/}"
+    echo "$hits"
+    echo "    -> route authored states through Repository::put_authored_state (heddle#482)"
+    violations=$((violations + 1))
+  fi
+done < <(find "$SCAN_DIR" -name '*.rs' -type f -print0)
+
+if [[ "$violations" -gt 0 ]]; then
+  echo
+  echo "Found ${violations} authored-state signing-chokepoint bypass(es)."
+  echo "Each authored-state write must auto-sign via Repository::put_authored_state."
+  exit 1
+fi
+
+echo "OK: no authored-state signing-chokepoint bypasses under ${SCAN_DIR#"$ROOT"/}"


### PR DESCRIPTION
Closes #482. Implements the accepted biscuit-backed-signing design (spike #480, merged in #481). Wires the already-existing signing primitives into the capture/commit/merge path so **every recorded state is auto-signed** — making heddle's "every change is signed" claim true and the concrete differentiator vs Mesa (zero signing).

## What changed
- **`crates/repo/src/identity.rs` (new)** — the machine signing identity:
  - `LocalIdentity` — a per-repo ed25519 key auto-minted on first capture (`<repo>/.heddle/identity.toml`, `0600`).
  - `DeviceIdentity` — the device-binding ed25519 key recorded globally at login (`~/.heddle/device-identity.toml`, `0600`).
  - `resolve_signer()` precedence: **device key (if linked) → local key (mint on first use) → None** (degraded).
  - Never logs key bytes; all key files written `0600` via `write_file_atomic_secret`.
- **`Repository`** caches the resolved signer once per handle; `sign_state_best_effort()` signs `compute_hash()` as the **last mutation before `put_state`**, wired into all three author-capture paths: `stage_snapshot_objects` (capture/commit), `snapshot_merge_with_attribution` (merge), and the thread-materialization capture.
- **`heddle auth login`** calls `repo::identity::link_device_key(...)` to reconcile.
- **Capture output** gains `signed: bool` (+ an "Unsigned" human line) so a degraded signing path is never silent.

## Key-lifecycle model (zero user-managed keys)
- **Pre-auth / local-only:** first capture mints a per-repo local identity and signs with it. Offline, no setup. Every capture/commit/merge/materialization is signed.
- **Reconciliation at `auth login`:** the device key is recorded globally and **supersedes the local key for new states**. The local key stays recorded; **prior local-signed states keep verifying** because their public key is embedded in the state and verification just recomputes the content hash (no private key / registry needed). This is the "record both, prefer device key for new states" model.
- **Graceful degradation:** a missing/unreadable key warns and proceeds **unsigned-but-marked** (`signed:false` + warning), never failing capture.

## Verification & merge survival
`repo.verify_state_signature` resolves the embedded public key and validates the detached ed25519 signature over `state.compute_hash()` — offline-verifiable. Signatures survive a semantic merge: each state signs its own hash (which includes its parents) and merges don't rewrite ancestors, so every parent's author signature stays valid; the merge state carries its own.

## Security notes
- The device private key is **copied** into `~/.heddle/device-identity.toml` at login — same directory and same `0600` protection class as `credentials.toml`. This is a deliberate, documented second at-rest copy that lets the **offline** capture path resolve the device key without coupling `repo` to the hosted-client crate (`client` already depends on `repo`, so `repo` reading `credentials.toml` would be a circular dependency). Alternative considered: a duplicated credential-format reader inside `repo` (avoids the copy but leaks hosted-credential format into the substrate crate).
- No domain-separation tag was added (spike §12 Q1): kept the existing `state.sign()` primitive per the maintainer's "wiring, not new crypto" decision. The two uses of the device key sign disjoint, unambiguous payloads (auth proof strings vs a 32-byte content hash), so there's no payload-confusion path.

## Tests (DoD)
New tests in `repository_signing.rs` exercise the real capture/merge path:
- `capture_auto_signs_with_local_identity` — fresh repo, no login → signed by the auto-minted local key, verifies `Valid`.
- `auth_login_reconciles_local_to_device_key` — after linking a device key, subsequent captures sign with it; the prior local-signed state still verifies.
- `signature_survives_semantic_merge` — two-parent merge: merge state signed; all parents still verify.
- `capture_degrades_gracefully_when_signing_unavailable` — forced signing failure → capture succeeds, state is `Unsigned`, not silently unsigned.
Plus `identity.rs` unit tests (mint idempotence, `0600` perms, device-supersedes-local, corrupt-device fallback, unmintable → None).

## Marketing claim now true
*"Every captured state — including merges — carries an automatic ed25519 signature over its content hash from your Heddle identity key, verifiable offline. No flag, no key management."* (Tapestry copy correction is a follow-up per #479/the audit.)

## Gates (CI parity — no `cargo fmt`, per task)
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` ✅
- `cargo clippy --locked --workspace --all-targets -- -D warnings` ✅ (and `--features git-overlay,native,semantic` ✅)
- `scripts/check-no-silent-default-tree-load.sh` ✅ (clean, 543 files)
- `heddle doctor docs --all` ✅ (no drift, 57 files)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783124883&installation_id=132405951&pr_number=486&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F486&signature=8b4958c8973347273d1dafd35ac3a47e2194031581ee3a81609d751217188ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->