### PR TITLE
fix(semantic): stop function-merge silently corrupting trailing/nested items (#484)

### DIFF
--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -21,7 +21,7 @@
 //!
 //! See HeddleCo/heddle#133 for the audit motivation.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::rc::Rc;
 
 use tree_sitter::Node;
@@ -198,6 +198,316 @@ fn assign_struct_scope_instances(
             .zip(enclosing.iter())
             .map(|(name, &ci)| (name.clone(), ordinal_of[ci]))
             .collect();
+    }
+}
+
+/// The chain prefix of `chain` up to and including depth `d` (length `d + 1`).
+type InstChain = Vec<(String, usize)>;
+
+/// Per-side cross-side match key: an [`ItemKey`] paired with its per-key
+/// occurrence index within the side (source order). Identical to
+/// `reconstruct::MatchKey`; recomputed here so the alignment pass matches the
+/// SAME item pairings the reconstructor will use.
+type AlignKey = (ItemKey, usize);
+
+/// Tag every item in source order with its `(ItemKey, occurrence)` align key.
+fn align_match_keys(seg: &FileSegments) -> Vec<AlignKey> {
+    let mut counters: HashMap<ItemKey, usize> = HashMap::new();
+    seg.items
+        .iter()
+        .map(|item| {
+            let n = counters.entry(item.key.clone()).or_insert(0);
+            let occurrence = *n;
+            *n += 1;
+            (item.key.clone(), occurrence)
+        })
+        .collect()
+}
+
+/// Outcome of [`align_container_instances`].
+pub(crate) enum InstanceAlignment {
+    /// Ordinals were re-anchored to base; `ours`/`theirs` now carry
+    /// cross-side-consistent `struct_scope_inst`.
+    Aligned,
+    /// The container-instance correspondence is ambiguous: a side container
+    /// holds matched items belonging to two different base containers (a
+    /// block *merge*), two side containers hold items of one base container (a
+    /// *split*), or a matched item's physical container chain diverges across
+    /// sides. The instance model cannot decide whether two same-name spans are
+    /// one instance or two, so the caller MUST route to the textual conflict
+    /// path rather than risk a silent collapse (heddle#484 r3 part 2).
+    Ambiguous,
+}
+
+/// Re-anchor each side's container-instance ordinals
+/// ([`Item::struct_scope_inst`]) to BASE spans, making instance identity a
+/// 3-way-aligned notion instead of a per-side count (heddle#484 r3, Codex P1).
+///
+/// [`assign_struct_scope_instances`] numbers each side's containers in source
+/// order *independently*. That is correct within a side but not across sides:
+/// when one side prepends a new same-name container before an existing base
+/// container, the prepended block draws ordinal 0 while the matched base block
+/// (still 0 in base) becomes 1 — so the reconstructor paired base's matched
+/// block with the side's *prepended* block and collapsed two distinct
+/// containers into one. This pass fixes the cross-side numbering:
+///
+/// * A side container that **matches** a base container — i.e. holds an item
+///   whose [`AlignKey`] also sits in that base container — inherits the base
+///   container's ordinal. (The correspondence is read off the matched items'
+///   instance chains, the same pairing the reconstructor uses.)
+/// * A side container with **no** base counterpart (added) draws a **fresh**
+///   ordinal at or above the base range for its `(canonical-parent, name)`, so
+///   it can never collide with a base ordinal. Added containers of the same
+///   name are paired positionally across `ours`/`theirs`, so an add/add of the
+///   *same* new container unions into one instance while a prepend on one side
+///   and an append on the other stay separable.
+///
+/// Returns [`InstanceAlignment::Ambiguous`] without mutating anything when the
+/// matched-item correspondence is not a partial bijection between a side's
+/// containers and base's (a block merge/split, or a matched item that changed
+/// container chains across sides) — the detect-and-bail half of the close-
+/// the-class fix.
+pub(crate) fn align_container_instances(
+    base: &FileSegments,
+    ours: &mut FileSegments,
+    theirs: &mut FileSegments,
+) -> InstanceAlignment {
+    // base AlignKey -> base container chain (its `struct_scope_inst`).
+    let base_keys = align_match_keys(base);
+    let base_chain_of: HashMap<AlignKey, &[(String, usize)]> = base_keys
+        .iter()
+        .zip(base.items.iter())
+        .map(|(mk, it)| (mk.clone(), it.struct_scope_inst.as_slice()))
+        .collect();
+
+    // Build each side's matched correspondence; bail on any non-bijection.
+    let Some(corr_ours) = build_correspondence(ours, &base_chain_of) else {
+        return InstanceAlignment::Ambiguous;
+    };
+    let Some(corr_theirs) = build_correspondence(theirs, &base_chain_of) else {
+        return InstanceAlignment::Ambiguous;
+    };
+
+    // Fresh-ordinal floor per (canonical-parent, name): one past base's
+    // highest ordinal there, so added containers never reuse a base ordinal.
+    let mut base_next: BTreeMap<(InstChain, String), usize> = BTreeMap::new();
+    for c in distinct_container_prefixes(base) {
+        let (parent, (name, ord)) = split_prefix(&c);
+        let slot = base_next.entry((parent, name)).or_insert(0);
+        *slot = (*slot).max(ord + 1);
+    }
+
+    // Canonical (base-anchored) chain for every side container prefix.
+    let canon_ours = canonicalize_side(ours, &corr_ours);
+    let canon_theirs = canonicalize_side(theirs, &corr_theirs);
+    let (canon_ours, canon_theirs) =
+        allocate_added_ordinals(ours, theirs, &corr_ours, &corr_theirs, &base_next, canon_ours, canon_theirs);
+
+    rewrite_side(ours, &canon_ours);
+    rewrite_side(theirs, &canon_theirs);
+    InstanceAlignment::Aligned
+}
+
+/// `(prefix[..last], prefix[last])` — the parent chain and the deepest level.
+fn split_prefix(prefix: &[(String, usize)]) -> (InstChain, (String, usize)) {
+    let last = prefix.len() - 1;
+    (prefix[..last].to_vec(), prefix[last].clone())
+}
+
+/// Every distinct container-instance chain prefix (all depths) that any item in
+/// `seg` physically sits inside.
+fn distinct_container_prefixes(seg: &FileSegments) -> BTreeSet<InstChain> {
+    let mut out = BTreeSet::new();
+    for it in &seg.items {
+        let ch = &it.struct_scope_inst;
+        for d in 0..ch.len() {
+            out.insert(ch[0..=d].to_vec());
+        }
+    }
+    out
+}
+
+/// Map each matched side container prefix to its base counterpart, or `None`
+/// if the correspondence is not a partial bijection (the ambiguous-bail case).
+fn build_correspondence(
+    side: &FileSegments,
+    base_chain_of: &HashMap<AlignKey, &[(String, usize)]>,
+) -> Option<BTreeMap<InstChain, InstChain>> {
+    let side_keys = align_match_keys(side);
+    let mut forward: BTreeMap<InstChain, InstChain> = BTreeMap::new();
+    let mut reverse: BTreeMap<InstChain, InstChain> = BTreeMap::new();
+    for (mk, it) in side_keys.iter().zip(side.items.iter()) {
+        let Some(bchain) = base_chain_of.get(mk) else {
+            continue; // added item — no base container to anchor to.
+        };
+        let schain = &it.struct_scope_inst;
+        // A matched item whose physical container chain changed shape across
+        // sides (different depth or different names) is itself ambiguous.
+        if schain.len() != bchain.len() {
+            return None;
+        }
+        for d in 0..schain.len() {
+            if schain[d].0 != bchain[d].0 {
+                return None;
+            }
+            let sp = schain[0..=d].to_vec();
+            let bp = bchain[0..=d].to_vec();
+            // Functional: a side container maps to exactly one base container.
+            if let Some(prev) = forward.get(&sp) {
+                if *prev != bp {
+                    return None;
+                }
+            } else {
+                forward.insert(sp.clone(), bp.clone());
+            }
+            // Injective: a base container is claimed by at most one side
+            // container.
+            if let Some(prev) = reverse.get(&bp) {
+                if *prev != sp {
+                    return None;
+                }
+            } else {
+                reverse.insert(bp, sp);
+            }
+        }
+    }
+    // A side that *reorders* two matched same-name containers (their source
+    // order disagrees with base's) can't be brace-woven cleanly: the matched
+    // item in the moved block carries a structurally-wrong preceding gap (it
+    // opens where base closes), and the weave would drop a `}` and emit an
+    // unparseable file. That is a silent corruption, so route it to the
+    // textual path instead (heddle#484 r3 part 2). Detect by checking, within
+    // each `(parent, name)` group, that side source order and base source
+    // order agree.
+    if reorders_matched_containers(&forward) {
+        return None;
+    }
+    Some(forward)
+}
+
+/// Whether `forward` (side container prefix → base container prefix) reorders
+/// two matched containers that share a parent and name — i.e. their deepest
+/// ordinals are not co-monotonic between side and base source order.
+fn reorders_matched_containers(forward: &BTreeMap<InstChain, InstChain>) -> bool {
+    let mut groups: BTreeMap<(InstChain, String), Vec<(usize, usize)>> = BTreeMap::new();
+    for (sp, bp) in forward {
+        let (parent, (name, side_ord)) = split_prefix(sp);
+        let base_ord = bp[bp.len() - 1].1;
+        groups
+            .entry((parent, name))
+            .or_default()
+            .push((side_ord, base_ord));
+    }
+    groups.values_mut().any(|pairs| {
+        pairs.sort_by_key(|&(s, _)| s);
+        pairs.windows(2).any(|w| w[0].1 >= w[1].1)
+    })
+}
+
+/// Seed the canonical map with matched containers (inherit base ordinals).
+/// Added containers are left out here and filled by [`allocate_added_ordinals`].
+fn canonicalize_side(
+    seg: &FileSegments,
+    corr: &BTreeMap<InstChain, InstChain>,
+) -> BTreeMap<InstChain, InstChain> {
+    let mut canon: BTreeMap<InstChain, InstChain> = BTreeMap::new();
+    for sp in distinct_container_prefixes(seg) {
+        if let Some(bp) = corr.get(&sp) {
+            canon.insert(sp, bp.clone());
+        }
+    }
+    canon
+}
+
+/// Assign fresh ordinals to every *added* container (depth by depth, so a
+/// child's canonical parent is known before it). Added containers of the same
+/// `(canonical-parent, name)` are paired positionally across the two sides:
+/// `ours`'s k-th and `theirs`'s k-th draw the same fresh ordinal, so an add/add
+/// of the same new container unions while divergent additions stay distinct.
+fn allocate_added_ordinals(
+    ours: &FileSegments,
+    theirs: &FileSegments,
+    corr_ours: &BTreeMap<InstChain, InstChain>,
+    corr_theirs: &BTreeMap<InstChain, InstChain>,
+    base_next: &BTreeMap<(InstChain, String), usize>,
+    mut canon_ours: BTreeMap<InstChain, InstChain>,
+    mut canon_theirs: BTreeMap<InstChain, InstChain>,
+) -> (BTreeMap<InstChain, InstChain>, BTreeMap<InstChain, InstChain>) {
+    let prefixes_ours = distinct_container_prefixes(ours);
+    let prefixes_theirs = distinct_container_prefixes(theirs);
+    let max_depth = prefixes_ours
+        .iter()
+        .chain(prefixes_theirs.iter())
+        .map(Vec::len)
+        .max()
+        .unwrap_or(0);
+
+    for depth in 0..max_depth {
+        // (canonical-parent, name) -> added side prefixes on each side, kept in
+        // source order (their deepest within-side ordinal).
+        let mut buckets: BTreeMap<(InstChain, String), (Vec<InstChain>, Vec<InstChain>)> =
+            BTreeMap::new();
+        for (which, prefixes, corr, canon) in [
+            (0usize, &prefixes_ours, corr_ours, &canon_ours),
+            (1usize, &prefixes_theirs, corr_theirs, &canon_theirs),
+        ] {
+            for sp in prefixes.iter().filter(|p| p.len() == depth + 1) {
+                if corr.contains_key(sp) {
+                    continue; // matched — already canonical.
+                }
+                let canon_parent = canonical_parent(sp, canon);
+                let name = sp[depth].0.clone();
+                let entry = buckets.entry((canon_parent, name)).or_default();
+                if which == 0 {
+                    entry.0.push(sp.clone());
+                } else {
+                    entry.1.push(sp.clone());
+                }
+            }
+        }
+        for ((canon_parent, name), (mut ours_list, mut theirs_list)) in buckets {
+            ours_list.sort_by_key(|p| p[depth].1);
+            theirs_list.sort_by_key(|p| p[depth].1);
+            let start = base_next
+                .get(&(canon_parent.clone(), name.clone()))
+                .copied()
+                .unwrap_or(0);
+            let n = ours_list.len().max(theirs_list.len());
+            for i in 0..n {
+                let ord = start + i;
+                let mut cc = canon_parent.clone();
+                cc.push((name.clone(), ord));
+                if let Some(sp) = ours_list.get(i) {
+                    canon_ours.insert(sp.clone(), cc.clone());
+                }
+                if let Some(sp) = theirs_list.get(i) {
+                    canon_theirs.insert(sp.clone(), cc.clone());
+                }
+            }
+        }
+    }
+    (canon_ours, canon_theirs)
+}
+
+/// Canonical chain of `sp`'s parent (`sp` minus its deepest level), read from
+/// the already-computed `canon` map. The empty chain for a top-level container.
+fn canonical_parent(sp: &[(String, usize)], canon: &BTreeMap<InstChain, InstChain>) -> InstChain {
+    if sp.len() <= 1 {
+        return Vec::new();
+    }
+    let parent = sp[..sp.len() - 1].to_vec();
+    canon.get(&parent).cloned().unwrap_or(parent)
+}
+
+/// Replace each item's `struct_scope_inst` with its canonical chain.
+fn rewrite_side(seg: &mut FileSegments, canon: &BTreeMap<InstChain, InstChain>) {
+    for it in &mut seg.items {
+        if it.struct_scope_inst.is_empty() {
+            continue;
+        }
+        if let Some(c) = canon.get(&it.struct_scope_inst) {
+            it.struct_scope_inst = c.clone();
+        }
     }
 }
 

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -70,6 +70,17 @@ pub(crate) struct Item {
     /// (heddle#484: cross-side additions at different depths must not strand
     /// a child outside its module).
     pub struct_scope: Vec<String>,
+    /// `struct_scope` with each level paired to the *source-order ordinal of
+    /// the concrete [`ContainerSpan`]* the item physically sits inside at that
+    /// depth. A container closed and reopened under the same name is a
+    /// different source span, so it draws a fresh ordinal — making two
+    /// back-to-back (or comment-/whitespace-separated) `impl Foo {…} impl Foo
+    /// {…}` blocks distinct *by construction*. This is the seam that
+    /// reconstruction keys both its emit-order grouping AND its brace-weave
+    /// depth on, so no arrangement of reopened same-name containers can
+    /// collapse. Derived in [`assign_struct_scope_instances`] from the real
+    /// spans — never inferred from neighbouring items' scopes (heddle#484).
+    pub struct_scope_inst: Vec<(String, usize)>,
 }
 
 /// A structural container (`mod`/`impl`/`trait`/`class` … with a body) and
@@ -118,6 +129,10 @@ impl FileSegments {
 fn extract_items_and_containers(parsed: &ParsedFile) -> (Vec<Item>, Vec<ContainerSpan>) {
     let mut items = Vec::new();
     let mut containers = Vec::new();
+    // Full scope-prefix (outermost-first names) of each container, parallel to
+    // `containers`. Lets the post-pass tag each item with the real container
+    // instance it sits inside without re-deriving nesting from item adjacency.
+    let mut container_prefixes = Vec::new();
     let root = parsed.root_node();
     collect_items(
         parsed.language,
@@ -126,11 +141,64 @@ fn extract_items_and_containers(parsed: &ParsedFile) -> (Vec<Item>, Vec<Containe
         &[],
         &mut items,
         &mut containers,
+        &mut container_prefixes,
     );
     // Items can be reported in any DFS order; ensure source order for
     // deterministic reconstruction.
     items.sort_by_key(|item| item.start_byte);
+    assign_struct_scope_instances(&mut items, &containers, &container_prefixes);
     (items, containers)
+}
+
+/// Tag every item with its [`Item::struct_scope_inst`]: for each enclosing
+/// container span, pair the container's own name with the source-order ordinal
+/// of that span among containers sharing its full scope-prefix.
+///
+/// Two same-name containers that close and reopen are distinct source spans, so
+/// they draw distinct ordinals — the invariant that makes back-to-back /
+/// comment- / whitespace-separated reopens impossible to collapse. Ordinals are
+/// assigned in source order (by opening brace) so a side that merely *adds* an
+/// item to an existing container reproduces the same ordinals as base, keeping
+/// matched and added items in the same instance group across sides.
+fn assign_struct_scope_instances(
+    items: &mut [Item],
+    containers: &[ContainerSpan],
+    prefixes: &[Vec<String>],
+) {
+    // Source-order ordinal per full container prefix.
+    let mut source_order: Vec<usize> = (0..containers.len()).collect();
+    source_order.sort_by_key(|&i| containers[i].open);
+    let mut per_prefix_count: HashMap<&[String], usize> = HashMap::new();
+    let mut ordinal_of = vec![0usize; containers.len()];
+    for &i in &source_order {
+        let count = per_prefix_count.entry(prefixes[i].as_slice()).or_insert(0);
+        ordinal_of[i] = *count;
+        *count += 1;
+    }
+    // Each item's enclosing containers (real span containment), outermost
+    // first. This is the same nesting chain as `struct_scope`, so we pair each
+    // authoritative scope name with the source-order ordinal of the real span
+    // it sits in — the instance is read off the span, never inferred from
+    // neighbouring items.
+    for item in items.iter_mut() {
+        let mut enclosing: Vec<usize> = (0..containers.len())
+            .filter(|&i| {
+                containers[i].open <= item.start_byte && item.start_byte < containers[i].close
+            })
+            .collect();
+        enclosing.sort_by_key(|&i| containers[i].open);
+        debug_assert_eq!(
+            enclosing.len(),
+            item.struct_scope.len(),
+            "span-derived nesting must match struct_scope depth"
+        );
+        item.struct_scope_inst = item
+            .struct_scope
+            .iter()
+            .zip(enclosing.iter())
+            .map(|(name, &ci)| (name.clone(), ordinal_of[ci]))
+            .collect();
+    }
 }
 
 /// Top-level entry: segment a parsed file into items + record the source
@@ -158,6 +226,7 @@ fn collect_items(
     base_scope: &[String],
     out: &mut Vec<Item>,
     containers: &mut Vec<ContainerSpan>,
+    container_prefixes: &mut Vec<Vec<String>>,
 ) {
     // Iterative DFS over the AST. Avoids the unbounded recursion shape
     // a deeply-parseable file could otherwise trigger — collect_items
@@ -191,6 +260,7 @@ fn collect_items(
                         open: body.start_byte(),
                         close: body.end_byte(),
                     });
+                    container_prefixes.push(next_scope.clone());
                     stack.push((body, Rc::new(next_scope), depth + 1));
                 } else {
                     let struct_scope = (*scope).clone();
@@ -214,6 +284,9 @@ fn collect_items(
                         end_byte: child.end_byte(),
                         use_identity,
                         struct_scope,
+                        // Filled by `assign_struct_scope_instances` once all
+                        // container spans are known.
+                        struct_scope_inst: Vec::new(),
                     });
                 }
             } else {

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -60,6 +60,28 @@ pub(crate) struct Item {
     /// add/add resolution in [`super::reconstruct`] then dedups only on exact
     /// bytes and conflicts on every other difference.
     pub use_identity: Option<UseIdentity>,
+    /// Path of enclosing *structural* containers (module / impl / trait /
+    /// class bodies this item physically sits inside), outermost first.
+    /// Distinct from [`ItemKey::scope`], which is the LOGICAL match scope: a
+    /// C++ out-of-class method `void Foo::bar()` has `key.scope == ["Foo"]`
+    /// (so it matches the inline `bar`) but `struct_scope == []` (it sits at
+    /// file top level). Reconstruction groups + weaves by this physical
+    /// nesting so a container's `{ … }` wraps exactly its source children
+    /// (heddle#484: cross-side additions at different depths must not strand
+    /// a child outside its module).
+    pub struct_scope: Vec<String>,
+}
+
+/// A structural container (`mod`/`impl`/`trait`/`class` … with a body) and
+/// the byte offsets of its braces. Used by reconstruction to know where a
+/// scope opens and closes so the weave can keep added items on the correct
+/// side of a brace.
+#[derive(Clone, Debug)]
+pub(crate) struct ContainerSpan {
+    /// Byte offset of the opening `{`.
+    pub open: usize,
+    /// Byte offset one past the closing `}`.
+    pub close: usize,
 }
 
 /// The result of segmenting a file: items in source order, exposed via the
@@ -69,6 +91,10 @@ pub(crate) struct Item {
 pub(crate) struct FileSegments {
     pub items: Vec<Item>,
     pub source_len: usize,
+    /// Structural containers (module / impl / trait / class bodies) in the
+    /// source, in extraction order. Lets reconstruction locate the `{`/`}`
+    /// of each scope an item sits inside.
+    pub containers: Vec<ContainerSpan>,
 }
 
 impl FileSegments {
@@ -88,24 +114,33 @@ impl FileSegments {
     }
 }
 
-/// Extract items from a parsed file. Public for the `debug_items` hatch and
-/// for `segment_file`.
-pub(crate) fn extract_items(parsed: &ParsedFile) -> Vec<Item> {
+/// Extract items + structural container spans from a parsed file.
+fn extract_items_and_containers(parsed: &ParsedFile) -> (Vec<Item>, Vec<ContainerSpan>) {
     let mut items = Vec::new();
+    let mut containers = Vec::new();
     let root = parsed.root_node();
-    collect_items(parsed.language, &parsed.source, root, &[], &mut items);
+    collect_items(
+        parsed.language,
+        &parsed.source,
+        root,
+        &[],
+        &mut items,
+        &mut containers,
+    );
     // Items can be reported in any DFS order; ensure source order for
     // deterministic reconstruction.
     items.sort_by_key(|item| item.start_byte);
-    items
+    (items, containers)
 }
 
 /// Top-level entry: segment a parsed file into items + record the source
 /// length so reconstruction can recover inter-item content.
 pub(crate) fn segment_file(parsed: &ParsedFile) -> FileSegments {
+    let (items, containers) = extract_items_and_containers(parsed);
     FileSegments {
-        items: extract_items(parsed),
+        items,
         source_len: parsed.source.len(),
+        containers,
     }
 }
 
@@ -122,6 +157,7 @@ fn collect_items(
     root: Node<'_>,
     base_scope: &[String],
     out: &mut Vec<Item>,
+    containers: &mut Vec<ContainerSpan>,
 ) {
     // Iterative DFS over the AST. Avoids the unbounded recursion shape
     // a deeply-parseable file could otherwise trigger — collect_items
@@ -151,9 +187,14 @@ fn collect_items(
                 if let Some(body) = container_body {
                     let mut next_scope = (*scope).clone();
                     next_scope.push(name);
+                    containers.push(ContainerSpan {
+                        open: body.start_byte(),
+                        close: body.end_byte(),
+                    });
                     stack.push((body, Rc::new(next_scope), depth + 1));
                 } else {
-                    let mut item_scope = (*scope).clone();
+                    let struct_scope = (*scope).clone();
+                    let mut item_scope = struct_scope.clone();
                     item_scope.extend(extra_scope);
                     let use_identity = if matches!(kind, ItemKind::Use) {
                         super::language_rules::use_identity(language, source, child)
@@ -172,6 +213,7 @@ fn collect_items(
                         start_byte,
                         end_byte: child.end_byte(),
                         use_identity,
+                        struct_scope,
                     });
                 }
             } else {

--- a/crates/semantic/src/merge_driver/mod.rs
+++ b/crates/semantic/src/merge_driver/mod.rs
@@ -137,6 +137,7 @@ pub fn semantic_three_way_merge(
         &base_segments,
         &ours_segments,
         &theirs_segments,
+        language,
         markers,
     )
 }

--- a/crates/semantic/src/merge_driver/mod.rs
+++ b/crates/semantic/src/merge_driver/mod.rs
@@ -21,7 +21,7 @@ mod reconstruct;
 #[cfg(test)]
 mod tests;
 
-use items::segment_file;
+use items::{InstanceAlignment, align_container_instances, segment_file};
 use reconstruct::reconstruct_merged_file;
 
 /// Three-way merge of `base`, `ours`, `theirs` using AST-defined item boundaries
@@ -113,6 +113,21 @@ pub fn semantic_three_way_merge(
         if !addadd_in_empty_base {
             return text_hunk_merge_with_markers(base, ours, theirs, markers);
         }
+    }
+
+    // Anchor each side's container-instance ordinals to base spans so a
+    // prepended / appended / reordered same-name container keeps an identity
+    // distinct from the matched base block (heddle#484 r3, part 1). When the
+    // matched-item correspondence is non-bijective — a side merged two base
+    // containers into one, split one across two, or moved a matched item
+    // between containers — the instance model cannot decide whether two
+    // same-name spans are one instance or two. Rather than risk a silent
+    // collapse, route to the textual conflict path: a conflict the user
+    // resolves is safe; a silent collapse is the P0 (part 2).
+    if let InstanceAlignment::Ambiguous =
+        align_container_instances(&base_segments, &mut ours_segments, &mut theirs_segments)
+    {
+        return text_hunk_merge_with_markers(base, ours, theirs, markers);
     }
 
     reconstruct_merged_file(

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -160,31 +160,26 @@ pub(crate) fn reconstruct_merged_file(
         }
     }
 
-    // Structural (physical) scope of each match-key — the chain of
-    // module/impl/trait/class bodies the item sits inside. Distinct from
-    // `ItemKey::scope` (the logical match scope). Base wins when present so
-    // matched items keep a stable placement; otherwise the adding side's
-    // nesting is used.
-    let mut struct_scope_of: BTreeMap<MatchKey, &[String]> = BTreeMap::new();
-    // Instance-annotated structural scope: the same path with each level
-    // tagged by a per-prefix occurrence index that distinguishes a scope
-    // closed and *reopened* around an intervening item. Built per side in
-    // source order (see `scope_instances`); base wins for matched keys — the
-    // same priority as `struct_scope_of` — so a matched block keeps a stable
-    // instance and an added block gets its own. The grouping below keys on
-    // this, not the bare name, so two reopened `namespace N {}` (or `mod m`)
-    // blocks separated by a top-level item are NOT collapsed into one group
-    // and reordered across that item (heddle#484 P1).
+    // Instance-annotated structural scope of each match-key — the chain of
+    // module/impl/trait/class bodies the item sits inside, with each level
+    // tagged by the source-order ordinal of the concrete container span it
+    // physically lives in (see [`Item::struct_scope_inst`], assigned from the
+    // real parse spans in `items.rs`). Distinct from `ItemKey::scope` (the
+    // logical match scope). Base wins when present so matched items keep a
+    // stable placement; otherwise the adding side's nesting is used. Both the
+    // emit-order grouping AND the brace-weave depth below key on this — never
+    // the bare name — so two reopened `impl Foo {}` / `namespace N {}` blocks
+    // stay distinct no matter what separates them (nothing, a comment,
+    // whitespace, or a top-level item), and a clean merge never collapses or
+    // reorders one reopened block across another (heddle#484).
     let mut struct_scope_inst_of: BTreeMap<MatchKey, Vec<(String, usize)>> = BTreeMap::new();
     for (mks, seg) in [
         (&theirs_mks, theirs_segments),
         (&ours_mks, ours_segments),
         (&base_mks, base_segments),
     ] {
-        let instances = scope_instances(seg);
-        for ((mk, item), instance) in mks.iter().zip(seg.items.iter()).zip(instances) {
-            struct_scope_of.insert(mk.clone(), item.struct_scope.as_slice());
-            struct_scope_inst_of.insert(mk.clone(), instance);
+        for (mk, item) in mks.iter().zip(seg.items.iter()) {
+            struct_scope_inst_of.insert(mk.clone(), item.struct_scope_inst.clone());
         }
     }
 
@@ -240,18 +235,29 @@ pub(crate) fn reconstruct_merged_file(
         side_ranges[2].len() - 1,
     ];
     let mut output: Vec<u8> = Vec::new();
-    let empty_scope: &[String] = &[];
-    let mut prev_struct: &[String] = empty_scope;
+    let empty_scope: &[(String, usize)] = &[];
+    let mut prev_struct: &[(String, usize)] = empty_scope;
     let mut prev_key: Option<&MatchKey> = None;
 
     for key in item_emit_order.iter() {
-        let y_struct = struct_scope_of.get(key).copied().unwrap_or(empty_scope);
+        let y_struct = struct_scope_inst_of
+            .get(key)
+            .map(Vec::as_slice)
+            .unwrap_or(empty_scope);
         // Containers the gap before this item should structurally close /
         // open: the depths dropped from / added to the previously-emitted
         // item's scope, relative to the scope they share. A side whose own
         // preceding item sat at a different depth (because the merged
         // predecessor was inserted from another side) carries extra braces
         // in its raw gap; those are trimmed so each `{`/`}` is emitted once.
+        //
+        // Crucially this depth is over the INSTANCE-tagged scope: a level
+        // matches only when both its name and its container-instance ordinal
+        // match. So the gap between two reopened same-name containers
+        // (`impl Foo {…}` then `impl Foo {…}`) sees `needed_exits ==
+        // needed_enters == 1` — closing the first and opening the second —
+        // instead of the name-only `0`/`0` that made `trim_redundant_structure`
+        // drop both braces and silently collapse the blocks (heddle#484).
         let common = common_prefix_len(prev_struct, y_struct);
         let needed_exits = prev_struct.len() - common;
         let needed_enters = y_struct.len() - common;
@@ -364,8 +370,14 @@ fn inter_slice<'a>(source: &'a str, ranges: &[(usize, usize)], idx: usize) -> &'
     &source[start..end]
 }
 
-/// Length of the shared leading prefix of two scope paths.
-fn common_prefix_len(a: &[String], b: &[String]) -> usize {
+/// Length of the shared leading prefix of two *instance-tagged* scope paths.
+/// A level matches only when BOTH its container name and its source-order
+/// instance ordinal match, so two reopened same-name containers share a prefix
+/// length of 0 at that level — forcing the gap between them to close one
+/// container and open the other rather than be trimmed as redundant (heddle#484:
+/// the back-to-back / comment- / whitespace-separated reopens that a name-only
+/// prefix silently collapsed).
+fn common_prefix_len(a: &[(String, usize)], b: &[(String, usize)]) -> usize {
     a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
 }
 
@@ -433,49 +445,11 @@ fn trim_redundant_structure<'a>(
     &source[start..end]
 }
 
-/// Annotate every item on one side with its *instance-tagged* structural
-/// scope: the physical scope path, but each level paired with a per-prefix
-/// occurrence index that counts how many times that exact scope-prefix has
-/// been entered, in source order, on this side.
-///
-/// A prefix is "entered" whenever the previous item did not already sit
-/// inside it at the same depth — i.e. the first item of a block, or the
-/// first item after the scope was left and reopened. So in
-/// `namespace N { a } top(); namespace N { b }` the `a` gets `[("N", 0)]`
-/// and the `b` gets `[("N", 1)]`: the intervening top-level `top()` ends the
-/// first run, and the second `namespace N` opens a new instance. Two items
-/// that share an instance at every level are physically in the same block;
-/// grouping on this distinguishes reopened blocks the bare name would
-/// collapse (heddle#484 P1). Returned in `seg.items` order.
-fn scope_instances(seg: &FileSegments) -> Vec<Vec<(String, usize)>> {
-    let mut run_index: BTreeMap<Vec<String>, usize> = BTreeMap::new();
-    let mut prev: &[String] = &[];
-    let mut out = Vec::with_capacity(seg.items.len());
-    for item in &seg.items {
-        let scope = item.struct_scope.as_slice();
-        let mut annotated = Vec::with_capacity(scope.len());
-        for d in 0..scope.len() {
-            let prefix = &scope[..=d];
-            // Same block we were already in at this depth → reuse its index;
-            // otherwise this is a fresh entry into the prefix, so bump it.
-            let same_as_prev = prev.len() > d && &prev[..=d] == prefix;
-            if !same_as_prev {
-                let slot = run_index.entry(prefix.to_vec()).or_insert(usize::MAX);
-                *slot = slot.wrapping_add(1);
-            }
-            let idx = run_index.get(prefix).copied().unwrap_or(0);
-            annotated.push((scope[d].clone(), idx));
-        }
-        prev = scope;
-        out.push(annotated);
-    }
-    out
-}
-
 /// Re-order a flat emit order so items physically nested in the same
 /// container *instance* are contiguous, yielding a valid pre-order over the
 /// structural scope tree. Items are grouped one level at a time by their
-/// instance-tagged scope (see [`scope_instances`]), preserving
+/// instance-tagged scope ([`Item::struct_scope_inst`], derived from the real
+/// parse spans in `items.rs`), preserving
 /// first-appearance order of groups and of items within a group, then each
 /// group recurses one level deeper. Keying on `(name, instance)` rather than
 /// the bare name keeps a reopened scope a distinct group, so a clean merge

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -19,7 +19,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use merge::{text_hunk_merge_with_markers, ConflictMarkers, MergeOutcome};
 
-use super::items::{ContainerSpan, FileSegments, Item, ItemKey, ItemKind};
+use super::items::{segment_file, ContainerSpan, FileSegments, Item, ItemKey, ItemKind};
+use crate::parser::{Language, ParsedFile};
 
 /// Three sides of the merge: `[base, ours, theirs]`. Each per-iteration
 /// segment contribution is indexed by [`Side`] so emission tracking can
@@ -45,7 +46,17 @@ const N_SIDES: usize = 3;
 /// (heddle#468 r5: the duplicate-import class the positional path produced).
 type MatchKey = (ItemKey, usize);
 
+/// An instance-tagged structural-scope chain: each level pairs a container name
+/// with the source-order ordinal of the concrete span it sits in (see
+/// [`Item::struct_scope_inst`]).
+type InstChain = Vec<(String, usize)>;
+
+/// An item's conservation identity for the heddle#484 output-boundary floor:
+/// its [`ItemKey`] plus the instance-tagged container chain it sits in.
+type TaggedItem = (ItemKey, InstChain);
+
 /// Stitch three sides together via per-item resolution + inter-item hunk merge.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn reconstruct_merged_file(
     base: &str,
     ours: &str,
@@ -53,6 +64,7 @@ pub(crate) fn reconstruct_merged_file(
     base_segments: &FileSegments,
     ours_segments: &FileSegments,
     theirs_segments: &FileSegments,
+    language: Language,
     markers: ConflictMarkers<'_>,
 ) -> MergeOutcome {
     // Per-side match keys walked in source order. Each item gets a
@@ -333,13 +345,174 @@ pub(crate) fn reconstruct_merged_file(
     reconcile_trailing_newline(&mut output, sides);
 
     if total_conflicts == 0 {
-        MergeOutcome::Clean(output)
+        // Model-independent safety floor (heddle#484). Every prior round
+        // (r1/r2/r3) fixed a *model-internal* re-derivation of container-
+        // instance identity, and each was defeated by the next file
+        // arrangement. This check sits at the OUTPUT boundary and is blind to
+        // the instance machinery: re-parse the bytes we are about to return
+        // and assert they conserve the item set + container nesting the merge
+        // resolved to emit. Any reconstruction defect — present or future —
+        // that drops, duplicates, moves, or collapses/splits a container
+        // instance fails the check, and we fall back to a textual conflict
+        // instead of returning a silently-wrong clean merge. A conflict the
+        // user resolves is safe; a silent structural collapse is the P0.
+        if output_conserves_structure(
+            &output,
+            language,
+            &item_emit_order,
+            &resolved,
+            &struct_scope_inst_of,
+        ) {
+            MergeOutcome::Clean(output)
+        } else {
+            text_hunk_merge_with_markers(
+                base.as_bytes(),
+                ours.as_bytes(),
+                theirs.as_bytes(),
+                markers,
+            )
+        }
     } else {
         MergeOutcome::Conflicts {
             merged_bytes_with_markers: output,
             conflict_count: total_conflicts,
         }
     }
+}
+
+/// Output-boundary safety floor (heddle#484): re-parse the reconstructed
+/// `output` and verify it conserves the item set + container nesting the merge
+/// resolved to emit. Returns `true` when conservation holds (safe to return
+/// `Clean`), `false` when the output dropped, duplicated, moved an item, or
+/// collapsed/split a container instance — in which case the caller MUST fall
+/// back to a textual conflict.
+///
+/// # The invariant (precise)
+///
+/// Let `E` be the *expected emitted set*: every NON-`use` item the merge placed
+/// with bytes (`item_emit_order` filtered to keys whose `resolved` entry holds
+/// `Some(bytes)`), each tagged by its `ItemKey` and instance-annotated scope
+/// chain (`struct_scope_inst_of`). Let `O` be the items found by re-parsing
+/// `output` with the SAME extraction the driver uses ([`segment_file`]),
+/// likewise NON-`use` and tagged by `(ItemKey, struct_scope_inst)`.
+///
+/// Conservation holds iff, after [`canonicalize_instance_chains`] normalizes
+/// both sides' instance ordinals by first-appearance in output/source order,
+/// the `(ItemKey, canonical-chain)` **multisets are equal**:
+///
+/// * the `ItemKey` component enforces **item-set conservation** — no non-`use`
+///   item dropped, duplicated, or moved to a different-named scope;
+/// * the canonical-chain component enforces **container / nesting
+///   conservation** — two items share a chain iff they physically sit in the
+///   same container instance, so a collapse (two instances → one) or split
+///   (one → two) changes a chain and breaks multiset equality. This is exactly
+///   the r1/r2/r3 class.
+///
+/// Canonicalization is required because the ordinals in `E` are base-anchored
+/// (3-way aligned) while a fresh re-parse numbers instances per-file in source
+/// order; only the *partition* of items into instances is invariant, not the
+/// absolute ordinal values. Normalizing both by first-appearance makes
+/// structurally-identical reconstructions compare equal while any reparenting
+/// compares unequal.
+///
+/// `use` items are EXCLUDED on both sides: their `ItemKey::name` is rekeyed
+/// across the three sides by `canonicalize_use_keys` (a 3-way leaf-set union)
+/// and cannot be recovered from a single-file re-parse, and a single resolved
+/// `use` component can emit several declarations — so the resolved-unit ↔
+/// re-parsed-declaration mapping is not 1:1. Their conservation is the
+/// separately-hardened set-valued `resolve_use_component` path (heddle#468).
+///
+/// # Why conservation, not a `has_error` gate, is the trigger
+///
+/// The re-parse is error-TOLERANT ([`ParsedFile::parse_allow_errors`]): the
+/// driver already guarantees all three INPUTS parse cleanly, but a clean
+/// reconstruction can carry benign error-recovery noise — e.g. a deleted
+/// single-line method leaves a stray `;` empty statement that tree-sitter flags
+/// as an error even though every surviving item is present and correctly
+/// nested. Gating on `has_error` would conflict that genuinely-clean merge (a
+/// false positive). Conservation is the real guarantee: a structural collapse
+/// that produces an unparseable file (Bug 2/3's unclosed / stray delimiters)
+/// still fails conservation, because tree-sitter's error recovery re-nests or
+/// duplicates the swallowed items and the recovered `(key, chain)` multiset no
+/// longer matches `E`.
+fn output_conserves_structure(
+    output: &[u8],
+    language: Language,
+    item_emit_order: &[MatchKey],
+    resolved: &BTreeMap<MatchKey, (Option<Vec<u8>>, usize)>,
+    struct_scope_inst_of: &BTreeMap<MatchKey, InstChain>,
+) -> bool {
+    // Expected emitted set, in output order.
+    let mut expected: Vec<TaggedItem> = Vec::new();
+    for key in item_emit_order {
+        if key.0.kind == ItemKind::Use {
+            continue;
+        }
+        if let Some((Some(_), _)) = resolved.get(key) {
+            let chain = struct_scope_inst_of.get(key).cloned().unwrap_or_default();
+            expected.push((key.0.clone(), chain));
+        }
+    }
+
+    // Re-parse the output with the SAME extraction the driver uses, tolerating
+    // error nodes (see the doc comment): tree-sitter's recovery still surfaces
+    // a structural collapse as a conservation mismatch below. Non-UTF-8 output
+    // or a parser that can't be built can't be checked at all — trip the floor.
+    let Ok(text) = std::str::from_utf8(output) else {
+        return false;
+    };
+    let Some(parsed) = ParsedFile::parse_allow_errors(text, language) else {
+        return false;
+    };
+    let seg = segment_file(&parsed);
+    let mut actual: Vec<TaggedItem> = Vec::new();
+    for item in &seg.items {
+        if item.key.kind == ItemKind::Use {
+            continue;
+        }
+        actual.push((item.key.clone(), item.struct_scope_inst.clone()));
+    }
+
+    let mut e = canonicalize_instance_chains(&expected);
+    let mut a = canonicalize_instance_chains(&actual);
+    e.sort();
+    a.sort();
+    e == a
+}
+
+/// Renumber the instance ordinals in a sequence of `(key, instance-chain)` by
+/// first-appearance within each `(canonical-parent, container-name)` group, in
+/// the order the items appear. Two differently-numbered but structurally-
+/// identical chains then compare equal: only the *partition* of items into
+/// instances (and their order) matters, not the absolute ordinal values, which
+/// differ between the base-anchored emit metadata and a fresh re-parse. Each
+/// level is canonicalized against its already-canonicalized parent, so the
+/// normalization is consistent depth-by-depth.
+fn canonicalize_instance_chains(seq: &[TaggedItem]) -> Vec<TaggedItem> {
+    // (canonical-parent, name, original-ordinal) -> canonical ordinal.
+    let mut remap: BTreeMap<(InstChain, String, usize), usize> = BTreeMap::new();
+    // (canonical-parent, name) -> next free canonical ordinal.
+    let mut next: BTreeMap<(InstChain, String), usize> = BTreeMap::new();
+    let mut out = Vec::with_capacity(seq.len());
+    for (key, chain) in seq {
+        let mut canon: InstChain = Vec::with_capacity(chain.len());
+        for (name, ord) in chain {
+            let parent = canon.clone();
+            let remap_key = (parent.clone(), name.clone(), *ord);
+            let canon_ord = if let Some(&c) = remap.get(&remap_key) {
+                c
+            } else {
+                let slot = next.entry((parent.clone(), name.clone())).or_insert(0);
+                let c = *slot;
+                *slot += 1;
+                remap.insert(remap_key, c);
+                c
+            };
+            canon.push((name.clone(), canon_ord));
+        }
+        out.push((key.clone(), canon));
+    }
+    out
 }
 
 /// Walk a side's items in source order and tag each with its
@@ -987,4 +1160,153 @@ fn emit_addadd_conflict(
     out.extend_from_slice(markers.theirs.as_bytes());
     out.extend_from_slice(eol);
     out
+}
+
+#[cfg(test)]
+mod floor_tests {
+    //! Unit tests for the heddle#484 output-boundary safety floor
+    //! ([`output_conserves_structure`]). They exercise the floor directly with
+    //! a crafted "emit plan" vs a chosen output byte string, so a deliberate
+    //! reconstruction fault (collapse / drop / unparseable) can be injected
+    //! without needing the model to actually regress.
+    use super::*;
+
+    /// Build the `(item_emit_order, resolved, struct_scope_inst_of)` triple the
+    /// floor consumes, treating every item in `src` as if the merge placed it
+    /// verbatim (the shape of a faithful reconstruction whose output IS `src`).
+    #[allow(clippy::type_complexity)]
+    fn plan(
+        src: &str,
+        language: Language,
+    ) -> (
+        Vec<MatchKey>,
+        BTreeMap<MatchKey, (Option<Vec<u8>>, usize)>,
+        BTreeMap<MatchKey, InstChain>,
+    ) {
+        let parsed = ParsedFile::parse(src, language).expect("plan source must parse");
+        let seg = segment_file(&parsed);
+        let mks = build_match_keys(&seg);
+        let mut order = Vec::new();
+        let mut resolved: BTreeMap<MatchKey, (Option<Vec<u8>>, usize)> = BTreeMap::new();
+        let mut sinst: BTreeMap<MatchKey, InstChain> = BTreeMap::new();
+        for (mk, item) in mks.iter().zip(seg.items.iter()) {
+            order.push(mk.clone());
+            let bytes = src.as_bytes()[item.start_byte..item.end_byte].to_vec();
+            resolved.insert(mk.clone(), (Some(bytes), 0));
+            sinst.insert(mk.clone(), item.struct_scope_inst.clone());
+        }
+        (order, resolved, sinst)
+    }
+
+    #[test]
+    fn floor_is_noop_on_faithful_output() {
+        // The output byte-for-byte matches the plan: conservation must hold so
+        // a correct merge stays Clean (no false positive).
+        let src = "impl Foo {\n    fn a() {}\n}\nimpl Foo {\n    fn b() {}\n}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(output_conserves_structure(
+            src.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_is_noop_on_faithful_output_with_top_level_between_reopens() {
+        // A top-level item separates two reopened `impl Foo` blocks — the
+        // heddle#484 P1 shape. A faithful reconstruction conserves it.
+        let src = "impl Foo {\n    fn a() {}\n}\nfn x() {}\nimpl Foo {\n    fn b() {}\n}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(output_conserves_structure(
+            src.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_catches_container_collapse() {
+        // The plan resolves TWO distinct `impl Foo` instances (a in #0, b in
+        // #1). A regression collapses them into a single `impl Foo` holding
+        // both methods. The canonical instance chains differ (b moves from
+        // Foo#1 to Foo#0), so conservation fails → the caller falls back to a
+        // textual conflict instead of returning the silently-collapsed merge.
+        let src = "impl Foo {\n    fn a() {}\n}\nimpl Foo {\n    fn b() {}\n}\n";
+        let collapsed = "impl Foo {\n    fn a() {}\n    fn b() {}\n}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(!output_conserves_structure(
+            collapsed.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_catches_dropped_item() {
+        let src = "fn a() {}\nfn b() {}\n";
+        let dropped = "fn a() {}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(!output_conserves_structure(
+            dropped.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_catches_duplicated_item() {
+        let src = "fn a() {}\n";
+        let duplicated = "fn a() {}\nfn a() {}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(!output_conserves_structure(
+            duplicated.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_catches_item_moved_to_different_scope() {
+        // Plan: `fn b` sits inside `impl Foo`. Output strands it at top level.
+        let src = "impl Foo {\n    fn b() {}\n}\n";
+        let moved = "impl Foo {\n}\nfn b() {}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(!output_conserves_structure(
+            moved.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
+
+    #[test]
+    fn floor_catches_unparseable_collapse() {
+        // An unparseable output that ALSO collapses structure: the closing `}`
+        // of the first `impl Foo` is missing, so both methods land in one impl.
+        // Error-tolerant re-parse recovers the items; the recovered chains
+        // (b moved from Foo#1 to Foo#0) break conservation. This is the Bug 2/3
+        // shape (unclosed delimiter) caught via conservation, not a has_error
+        // gate.
+        let src = "impl Foo {\n    fn a() {}\n}\nimpl Foo {\n    fn b() {}\n}\n";
+        let unclosed = "impl Foo {\n    fn a() {}\n    fn b() {}\n";
+        let (order, resolved, sinst) = plan(src, Language::Rust);
+        assert!(!output_conserves_structure(
+            unclosed.as_bytes(),
+            Language::Rust,
+            &order,
+            &resolved,
+            &sinst
+        ));
+    }
 }

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use merge::{text_hunk_merge_with_markers, ConflictMarkers, MergeOutcome};
 
-use super::items::{FileSegments, Item, ItemKey, ItemKind};
+use super::items::{ContainerSpan, FileSegments, Item, ItemKey, ItemKind};
 
 /// Three sides of the merge: `[base, ours, theirs]`. Each per-iteration
 /// segment contribution is indexed by [`Side`] so emission tracking can
@@ -160,7 +160,30 @@ pub(crate) fn reconstruct_merged_file(
         }
     }
 
-    let item_emit_order = compute_item_emit_order(&base_mks, &ours_mks, &theirs_mks, &all_keys);
+    // Structural (physical) scope of each match-key — the chain of
+    // module/impl/trait/class bodies the item sits inside. Distinct from
+    // `ItemKey::scope` (the logical match scope). Base wins when present so
+    // matched items keep a stable placement; otherwise the adding side's
+    // nesting is used.
+    let mut struct_scope_of: BTreeMap<MatchKey, &[String]> = BTreeMap::new();
+    for (mks, seg) in [
+        (&theirs_mks, theirs_segments),
+        (&ours_mks, ours_segments),
+        (&base_mks, base_segments),
+    ] {
+        for (mk, item) in mks.iter().zip(seg.items.iter()) {
+            struct_scope_of.insert(mk.clone(), item.struct_scope.as_slice());
+        }
+    }
+
+    let flat_order = compute_item_emit_order(&base_mks, &ours_mks, &theirs_mks, &all_keys);
+    // Re-group so items physically inside the same container stay
+    // contiguous (a valid pre-order over the scope tree). The positional
+    // splice in `compute_item_emit_order` can otherwise drop a top-level
+    // added item between two children of a module added on the other side,
+    // stranding a later child outside the module's `}` (heddle#484 Bug 3).
+    // For files with no cross-scope interleaving this is the identity.
+    let item_emit_order = group_by_struct_scope(&flat_order, &struct_scope_of);
 
     // For each side, record each item's index so we can look up the
     // inter-item segment that preceded it in source.
@@ -175,37 +198,92 @@ pub(crate) fn reconstruct_merged_file(
         theirs_segments.inter_item_ranges(),
     ];
     let side_sources = [base, ours, theirs];
-
-    // Per-side set of inter-item range indices already emitted into
-    // `output`. A side's range is contributed to at most one slot —
-    // either the per-item preceding-segment merge for an item the
-    // side has, the bridging slot for an item the side lacks (next
-    // item the side has owns this range too — so the first occupant
-    // wins), or the postamble. Without this tracking the same range
-    // can be pulled into multiple slots — both Codex r2 P2 #2
-    // (leading-added-item preamble duplication) and P1 #2 (zero-items
-    // side postamble duplication) are this single shape.
-    let mut emitted: [BTreeSet<usize>; N_SIDES] =
-        [BTreeSet::new(), BTreeSet::new(), BTreeSet::new()];
+    let side_containers = [
+        base_segments.containers.as_slice(),
+        ours_segments.containers.as_slice(),
+        theirs_segments.containers.as_slice(),
+    ];
 
     // Walk emit_order. For each item, emit:
-    //   1. The inter-item segment that PRECEDED it in each side. When
-    //      the side has the item, that's the side's range immediately
-    //      before; when it doesn't, the "bridging" range (the range in
-    //      the side that spans where this item would be in emit order)
-    //      stands in. Either way, a range is only contributed if it
-    //      hasn't already been emitted on a prior iteration.
+    //   1. The inter-item segment that PRECEDED it in each side that
+    //      HAS the item — that side's range immediately before it. A
+    //      side that lacks the item contributes nothing for this slot.
     //   2. The merged item bytes.
-    // After the last item, emit the postamble (each side's final range,
-    // skipped per-side if already consumed).
+    // After the last item, emit the postamble (each side's final range).
+    //
+    // Every side range maps to exactly one purpose: range `i` (for
+    // `i < n_items`) is the preceding gap of the one item it sits
+    // before, and the final range (`n_items`) is the postamble. Because
+    // a lacking side never borrows a neighbouring range, no range can be
+    // pulled into two slots — which is what made the prior "bridging"
+    // model emit a one-item side's trailing postamble BOTH as the gap
+    // before an added item AND again as the postamble (heddle#484: the
+    // duplicated `// MARK` / `mod tests {…}` / closing-brace class).
+    let side_n: [usize; N_SIDES] = [
+        side_ranges[0].len() - 1,
+        side_ranges[1].len() - 1,
+        side_ranges[2].len() - 1,
+    ];
     let mut output: Vec<u8> = Vec::new();
+    let empty_scope: &[String] = &[];
+    let mut prev_struct: &[String] = empty_scope;
+    let mut prev_key: Option<&MatchKey> = None;
 
-    for (emit_idx, key) in item_emit_order.iter().enumerate() {
+    for key in item_emit_order.iter() {
+        let y_struct = struct_scope_of.get(key).copied().unwrap_or(empty_scope);
+        // Containers the gap before this item should structurally close /
+        // open: the depths dropped from / added to the previously-emitted
+        // item's scope, relative to the scope they share. A side whose own
+        // preceding item sat at a different depth (because the merged
+        // predecessor was inserted from another side) carries extra braces
+        // in its raw gap; those are trimmed so each `{`/`}` is emitted once.
+        let common = common_prefix_len(prev_struct, y_struct);
+        let needed_exits = prev_struct.len() - common;
+        let needed_enters = y_struct.len() - common;
         let mut segs: [Option<&str>; N_SIDES] = [None, None, None];
+        let mut any_preceding = false;
         for s in 0..N_SIDES {
-            let r = side_range_for_emit(&side_idx_maps[s], key, &item_emit_order, emit_idx);
-            if emitted[s].insert(r) {
-                segs[s] = Some(inter_slice(side_sources[s], &side_ranges[s], r));
+            if let Some(&r) = side_idx_maps[s].get(key) {
+                // `r == 0` is the file preamble, which belongs to the FIRST
+                // emitted item only; for a later item it is not a separator,
+                // so a side on which this item leads contributes nothing.
+                if r > 0 || prev_key.is_none() {
+                    segs[s] = Some(trim_redundant_structure(
+                        side_sources[s],
+                        &side_ranges[s],
+                        side_containers[s],
+                        r,
+                        needed_exits,
+                        needed_enters,
+                    ));
+                    any_preceding |= r > 0;
+                }
+            }
+        }
+        // No side offers a real preceding separator — this item leads every
+        // side that has it (both sides independently prepended a new item
+        // before the first shared item). Source the separator from the
+        // merged predecessor's own trailing between-gap (never its
+        // postamble), so the two prepended items stay separated rather than
+        // being concatenated (heddle#484 regression guard).
+        if let Some(pk) = prev_key
+            && !any_preceding
+        {
+            for s in 0..N_SIDES {
+                if let Some(&j) = side_idx_maps[s].get(pk)
+                    && j + 1 < side_n[s]
+                {
+                    // Only the leading whitespace: the rest of the
+                    // predecessor's trailing gap belongs to ITS real
+                    // successor (e.g. a `mod {` header) and is emitted with
+                    // that item — pulling it here would drag the following
+                    // item into the wrong scope.
+                    segs[s] = Some(leading_whitespace(inter_slice(
+                        side_sources[s],
+                        &side_ranges[s],
+                        j + 1,
+                    )));
+                }
             }
         }
         let (seg_bytes, seg_conflicts) = merge_segment(segs[0], segs[1], segs[2], markers);
@@ -215,24 +293,20 @@ pub(crate) fn reconstruct_merged_file(
         if let Some((Some(item_bytes), _)) = resolved.get(key) {
             output.extend_from_slice(item_bytes);
         }
+        prev_struct = y_struct;
+        prev_key = Some(key);
     }
 
-    // Postamble: each side's last range, but only if that range
-    // wasn't already pulled in as a bridge above (the zero-items-side
-    // shape from P1 #2).
+    // Postamble: each side's final range, merged once. Every side has
+    // exactly one (its last range) and it is never an item's preceding
+    // gap, so there is nothing to dedup against.
     let mut post: [Option<&str>; N_SIDES] = [None, None, None];
     for s in 0..N_SIDES {
         let last = side_ranges[s].len() - 1;
-        if emitted[s].insert(last) {
-            post[s] = Some(inter_slice(side_sources[s], &side_ranges[s], last));
-        }
+        post[s] = Some(inter_slice(side_sources[s], &side_ranges[s], last));
     }
     let (post_bytes, post_conflicts) = merge_segment(post[0], post[1], post[2], markers);
-    // Only emit the postamble if it adds bytes — otherwise we risk
-    // duplicating the trailing newline already in the last item's bytes.
-    if !post_bytes.is_empty() {
-        output.extend_from_slice(&post_bytes);
-    }
+    output.extend_from_slice(&post_bytes);
     total_conflicts += post_conflicts;
 
     reconcile_trailing_newline(&mut output, sides);
@@ -275,29 +349,131 @@ fn inter_slice<'a>(source: &'a str, ranges: &[(usize, usize)], idx: usize) -> &'
     &source[start..end]
 }
 
-/// Pick the inter-item range index that represents `key`'s preceding
-/// segment on one side. If the side has `key`, that's the range
-/// immediately before it. If not, the bridging range is used: the
-/// range in the side that spans `key`'s position in `emit_order`. The
-/// bridging range is found by walking left in `emit_order` to the
-/// nearest prior key the side does have, then taking the range after
-/// that key's item; if no prior key exists, the side's preamble
-/// (range 0) bridges.
-fn side_range_for_emit(
-    side_idx_map: &BTreeMap<MatchKey, usize>,
-    key: &MatchKey,
-    emit_order: &[MatchKey],
-    emit_idx: usize,
-) -> usize {
-    if let Some(i) = side_idx_map.get(key) {
-        return *i;
+/// Length of the shared leading prefix of two scope paths.
+fn common_prefix_len(a: &[String], b: &[String]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// The leading run of whitespace in `s` (up to the first non-whitespace
+/// byte). Used to extract just the blank-line separator from a gap whose
+/// remainder belongs to a following item.
+fn leading_whitespace(s: &str) -> &str {
+    let end = s.find(|c: char| !c.is_whitespace()).unwrap_or(s.len());
+    &s[..end]
+}
+
+/// The inter-item gap before an item on one side, with any *redundant*
+/// leading container braces trimmed off.
+///
+/// `ranges[range_idx]` is the raw gap (`pred.end .. item.start`). On the
+/// originating side it closes every container that ended between this item
+/// and its source predecessor, and opens every container the item newly sits
+/// inside. But in the merged emit order the predecessor may be a different
+/// item — inserted from another side at a different scope — so some of those
+/// containers are *already* closed (or already open) in the output.
+///
+/// `needed_exits` / `needed_enters` are how many closes / opens the gap
+/// *should* perform, derived from the merged predecessor's and this item's
+/// shared scope depth. Extra leading closing braces (over-closing a scope
+/// that is already closed) and extra leading opening braces (re-opening a
+/// scope that is already open) are dropped by advancing the gap start past
+/// them, so each `{` / `}` is emitted exactly once across the merge
+/// (heddle#484 Bug 3 + the add/add-module shape).
+fn trim_redundant_structure<'a>(
+    source: &'a str,
+    ranges: &[(usize, usize)],
+    containers: &[ContainerSpan],
+    range_idx: usize,
+    needed_exits: usize,
+    needed_enters: usize,
+) -> &'a str {
+    let (orig_start, end) = ranges[range_idx];
+    let mut start = orig_start;
+
+    // Drop extra leading closing braces: containers that opened before the
+    // gap and close inside it (innermost / earliest close first).
+    let mut closes: Vec<usize> = containers
+        .iter()
+        .filter(|c| c.open < orig_start && orig_start < c.close && c.close <= end)
+        .map(|c| c.close)
+        .collect();
+    closes.sort_unstable();
+    if closes.len() > needed_exits {
+        start = closes[closes.len() - needed_exits - 1];
     }
-    for j in (0..emit_idx).rev() {
-        if let Some(i) = side_idx_map.get(&emit_order[j]) {
-            return i + 1;
+
+    // Drop extra leading opening braces: containers that open inside the
+    // (already exit-trimmed) gap and still enclose the item (outermost /
+    // earliest open first).
+    let mut opens: Vec<usize> = containers
+        .iter()
+        .filter(|c| c.open >= start && c.open < end && c.close > end)
+        .map(|c| c.open)
+        .collect();
+    opens.sort_unstable();
+    if opens.len() > needed_enters {
+        start = opens[opens.len() - needed_enters - 1] + 1;
+    }
+
+    &source[start..end]
+}
+
+/// Re-order a flat emit order so items physically nested in the same
+/// container are contiguous, yielding a valid pre-order over the structural
+/// scope tree. Items are grouped by their structural scope path one level at
+/// a time, preserving first-appearance order of groups and of items within a
+/// group, then each group recurses one level deeper. For an order whose
+/// scopes are already contiguous (every file with no cross-side
+/// scope-interleaving) this is the identity.
+fn group_by_struct_scope(
+    order: &[MatchKey],
+    struct_scope_of: &BTreeMap<MatchKey, &[String]>,
+) -> Vec<MatchKey> {
+    let empty: &[String] = &[];
+    let annotated: Vec<(MatchKey, &[String])> = order
+        .iter()
+        .map(|k| (k.clone(), struct_scope_of.get(k).copied().unwrap_or(empty)))
+        .collect();
+    group_by_struct_scope_depth(annotated, 0)
+}
+
+fn group_by_struct_scope_depth(
+    items: Vec<(MatchKey, &[String])>,
+    depth: usize,
+) -> Vec<MatchKey> {
+    // A unit at this depth is either a leaf (scope length == depth) or a
+    // module group keyed by `scope[depth]`. Units are kept in
+    // first-appearance order; a module group gathers every item that shares
+    // `scope[depth]` regardless of interleaving, then recurses.
+    enum Unit<'a> {
+        Leaf(MatchKey),
+        Group(Vec<(MatchKey, &'a [String])>),
+    }
+    let mut units: Vec<Unit> = Vec::new();
+    let mut group_at: BTreeMap<String, usize> = BTreeMap::new();
+    for (key, scope) in items {
+        if scope.len() <= depth {
+            units.push(Unit::Leaf(key));
+        } else {
+            let name = scope[depth].clone();
+            if let Some(&idx) = group_at.get(&name) {
+                if let Unit::Group(v) = &mut units[idx] {
+                    v.push((key, scope));
+                }
+            } else {
+                group_at.insert(name, units.len());
+                units.push(Unit::Group(vec![(key, scope)]));
+            }
         }
     }
-    0
+    let mut out = Vec::new();
+    for unit in units {
+        match unit {
+            Unit::Leaf(k) => out.push(k),
+            Unit::Group(v) => out.extend(group_by_struct_scope_depth(v, depth + 1)),
+        }
+    }
+    out
 }
 
 /// 3-way merge a single inter-item segment. Handles "side doesn't have

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -166,24 +166,39 @@ pub(crate) fn reconstruct_merged_file(
     // matched items keep a stable placement; otherwise the adding side's
     // nesting is used.
     let mut struct_scope_of: BTreeMap<MatchKey, &[String]> = BTreeMap::new();
+    // Instance-annotated structural scope: the same path with each level
+    // tagged by a per-prefix occurrence index that distinguishes a scope
+    // closed and *reopened* around an intervening item. Built per side in
+    // source order (see `scope_instances`); base wins for matched keys — the
+    // same priority as `struct_scope_of` — so a matched block keeps a stable
+    // instance and an added block gets its own. The grouping below keys on
+    // this, not the bare name, so two reopened `namespace N {}` (or `mod m`)
+    // blocks separated by a top-level item are NOT collapsed into one group
+    // and reordered across that item (heddle#484 P1).
+    let mut struct_scope_inst_of: BTreeMap<MatchKey, Vec<(String, usize)>> = BTreeMap::new();
     for (mks, seg) in [
         (&theirs_mks, theirs_segments),
         (&ours_mks, ours_segments),
         (&base_mks, base_segments),
     ] {
-        for (mk, item) in mks.iter().zip(seg.items.iter()) {
+        let instances = scope_instances(seg);
+        for ((mk, item), instance) in mks.iter().zip(seg.items.iter()).zip(instances) {
             struct_scope_of.insert(mk.clone(), item.struct_scope.as_slice());
+            struct_scope_inst_of.insert(mk.clone(), instance);
         }
     }
 
     let flat_order = compute_item_emit_order(&base_mks, &ours_mks, &theirs_mks, &all_keys);
-    // Re-group so items physically inside the same container stay
+    // Re-group so items physically inside the same container *instance* stay
     // contiguous (a valid pre-order over the scope tree). The positional
     // splice in `compute_item_emit_order` can otherwise drop a top-level
     // added item between two children of a module added on the other side,
     // stranding a later child outside the module's `}` (heddle#484 Bug 3).
-    // For files with no cross-scope interleaving this is the identity.
-    let item_emit_order = group_by_struct_scope(&flat_order, &struct_scope_of);
+    // Grouping is keyed by `(scope, instance)` so a scope reopened around an
+    // intervening item stays a distinct group — a clean merge never reorders
+    // a reopened block across that item (heddle#484 P1). For files with no
+    // cross-scope interleaving this is the identity.
+    let item_emit_order = group_by_struct_scope(&flat_order, &struct_scope_inst_of);
 
     // For each side, record each item's index so we can look up the
     // inter-item segment that preceded it in source.
@@ -418,50 +433,103 @@ fn trim_redundant_structure<'a>(
     &source[start..end]
 }
 
+/// Annotate every item on one side with its *instance-tagged* structural
+/// scope: the physical scope path, but each level paired with a per-prefix
+/// occurrence index that counts how many times that exact scope-prefix has
+/// been entered, in source order, on this side.
+///
+/// A prefix is "entered" whenever the previous item did not already sit
+/// inside it at the same depth — i.e. the first item of a block, or the
+/// first item after the scope was left and reopened. So in
+/// `namespace N { a } top(); namespace N { b }` the `a` gets `[("N", 0)]`
+/// and the `b` gets `[("N", 1)]`: the intervening top-level `top()` ends the
+/// first run, and the second `namespace N` opens a new instance. Two items
+/// that share an instance at every level are physically in the same block;
+/// grouping on this distinguishes reopened blocks the bare name would
+/// collapse (heddle#484 P1). Returned in `seg.items` order.
+fn scope_instances(seg: &FileSegments) -> Vec<Vec<(String, usize)>> {
+    let mut run_index: BTreeMap<Vec<String>, usize> = BTreeMap::new();
+    let mut prev: &[String] = &[];
+    let mut out = Vec::with_capacity(seg.items.len());
+    for item in &seg.items {
+        let scope = item.struct_scope.as_slice();
+        let mut annotated = Vec::with_capacity(scope.len());
+        for d in 0..scope.len() {
+            let prefix = &scope[..=d];
+            // Same block we were already in at this depth → reuse its index;
+            // otherwise this is a fresh entry into the prefix, so bump it.
+            let same_as_prev = prev.len() > d && &prev[..=d] == prefix;
+            if !same_as_prev {
+                let slot = run_index.entry(prefix.to_vec()).or_insert(usize::MAX);
+                *slot = slot.wrapping_add(1);
+            }
+            let idx = run_index.get(prefix).copied().unwrap_or(0);
+            annotated.push((scope[d].clone(), idx));
+        }
+        prev = scope;
+        out.push(annotated);
+    }
+    out
+}
+
 /// Re-order a flat emit order so items physically nested in the same
-/// container are contiguous, yielding a valid pre-order over the structural
-/// scope tree. Items are grouped by their structural scope path one level at
-/// a time, preserving first-appearance order of groups and of items within a
-/// group, then each group recurses one level deeper. For an order whose
-/// scopes are already contiguous (every file with no cross-side
-/// scope-interleaving) this is the identity.
+/// container *instance* are contiguous, yielding a valid pre-order over the
+/// structural scope tree. Items are grouped one level at a time by their
+/// instance-tagged scope (see [`scope_instances`]), preserving
+/// first-appearance order of groups and of items within a group, then each
+/// group recurses one level deeper. Keying on `(name, instance)` rather than
+/// the bare name keeps a reopened scope a distinct group, so a clean merge
+/// never reorders one reopened block across the item that separates it from
+/// the other (heddle#484 P1). For an order whose scopes are already
+/// contiguous (every file with no cross-side scope-interleaving) this is the
+/// identity.
 fn group_by_struct_scope(
     order: &[MatchKey],
-    struct_scope_of: &BTreeMap<MatchKey, &[String]>,
+    struct_scope_inst_of: &BTreeMap<MatchKey, Vec<(String, usize)>>,
 ) -> Vec<MatchKey> {
-    let empty: &[String] = &[];
-    let annotated: Vec<(MatchKey, &[String])> = order
+    let empty: &[(String, usize)] = &[];
+    let annotated: Vec<(MatchKey, &[(String, usize)])> = order
         .iter()
-        .map(|k| (k.clone(), struct_scope_of.get(k).copied().unwrap_or(empty)))
+        .map(|k| {
+            (
+                k.clone(),
+                struct_scope_inst_of
+                    .get(k)
+                    .map(Vec::as_slice)
+                    .unwrap_or(empty),
+            )
+        })
         .collect();
     group_by_struct_scope_depth(annotated, 0)
 }
 
 fn group_by_struct_scope_depth(
-    items: Vec<(MatchKey, &[String])>,
+    items: Vec<(MatchKey, &[(String, usize)])>,
     depth: usize,
 ) -> Vec<MatchKey> {
     // A unit at this depth is either a leaf (scope length == depth) or a
-    // module group keyed by `scope[depth]`. Units are kept in
-    // first-appearance order; a module group gathers every item that shares
-    // `scope[depth]` regardless of interleaving, then recurses.
+    // module group keyed by `scope[depth]` — the `(name, instance)` pair.
+    // Units are kept in first-appearance order; a group gathers every item
+    // that shares that exact `(name, instance)` regardless of interleaving,
+    // then recurses. A different instance of the same name starts a fresh
+    // group, so reopened scopes never merge (heddle#484 P1).
     enum Unit<'a> {
         Leaf(MatchKey),
-        Group(Vec<(MatchKey, &'a [String])>),
+        Group(Vec<(MatchKey, &'a [(String, usize)])>),
     }
     let mut units: Vec<Unit> = Vec::new();
-    let mut group_at: BTreeMap<String, usize> = BTreeMap::new();
+    let mut group_at: BTreeMap<(String, usize), usize> = BTreeMap::new();
     for (key, scope) in items {
         if scope.len() <= depth {
             units.push(Unit::Leaf(key));
         } else {
-            let name = scope[depth].clone();
-            if let Some(&idx) = group_at.get(&name) {
+            let level = scope[depth].clone();
+            if let Some(&idx) = group_at.get(&level) {
                 if let Unit::Group(v) = &mut units[idx] {
                     v.push((key, scope));
                 }
             } else {
-                group_at.insert(name, units.len());
+                group_at.insert(level, units.len());
                 units.push(Unit::Group(vec![(key, scope)]));
             }
         }

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -5437,3 +5437,169 @@ impl Foo {
         "top-level fn must sit between the two impl blocks:\n{merged}"
     );
 }
+
+// =====================================================================
+// heddle#484 close-the-class — REOPENED same-name container SEPARATOR
+// MATRIX. Round 1 only distinguished two reopened blocks when a top-level
+// *item* sat between them (the heuristic keyed instance identity off
+// neighbouring items' scopes). It could NOT see a close→reopen boundary
+// when the blocks were back-to-back, comment-separated, or whitespace-
+// separated — `struct_scope` carries no signal there — so the brace-weave
+// computed `needed_exits == needed_enters == 0` and `trim_redundant_structure`
+// dropped the intervening `}` / `{` (and any comment), silently collapsing
+// the second block into the first.
+//
+// The structural fix derives each item's container instance from the real
+// parse span (`Item::struct_scope_inst`), so EVERY separator yields distinct
+// instances by construction. This matrix pins that: for each separator, a
+// clean disjoint merge (ours adds to block 1, theirs to block 2) must keep
+// the two blocks distinct, preserve the braces + any separator text, re-parse
+// with the conserved item set, and keep source order. A regression in ANY
+// cell fails CI.
+//
+// Fail-pre / pass-post: on the pre-fix tree (name-only brace depth) the
+// back-to-back and whitespace/comment cells collapse to a SINGLE `impl Foo`,
+// so the `count() == 2` assertion fails; with the span-instance fix they pass.
+// =====================================================================
+
+/// A reopened-`impl Foo` base/ours/theirs triple whose two blocks are joined
+/// by `sep` (placed between block 1's closing `}` and block 2's `impl`). ours
+/// adds `fn a2` to the first block; theirs adds `fn b2` to the second — a
+/// disjoint, clean merge.
+fn impl_reopen_triple(sep: &str) -> (String, String, String) {
+    let base = format!(
+        "struct Foo;\n\nimpl Foo {{\n    fn a(&self) {{}}\n}}{sep}impl Foo {{\n    fn b(&self) {{}}\n}}\n"
+    );
+    let ours = format!(
+        "struct Foo;\n\nimpl Foo {{\n    fn a(&self) {{}}\n    fn a2(&self) {{}}\n}}{sep}impl Foo {{\n    fn b(&self) {{}}\n}}\n"
+    );
+    let theirs = format!(
+        "struct Foo;\n\nimpl Foo {{\n    fn a(&self) {{}}\n}}{sep}impl Foo {{\n    fn b(&self) {{}}\n    fn b2(&self) {{}}\n}}\n"
+    );
+    (base, ours, theirs)
+}
+
+#[test]
+fn conformance_484_reopened_rust_impl_separator_matrix() {
+    // (label, separator between block 1's `}` and block 2's `impl`).
+    let cases: &[(&str, &str)] = &[
+        ("back-to-back", "\n"),
+        ("whitespace-separated", "\n\n"),
+        ("comment-separated", "\n// section\n"),
+        ("item-separated", "\n\nfn top_level() {}\n\n"),
+    ];
+    for (label, sep) in cases {
+        let (base, ours, theirs) = impl_reopen_triple(sep);
+        let merged = assert_conformant(&base, &ours, &theirs);
+        // The two reopened blocks stay distinct — the core invariant the
+        // collapse violated. Pre-fix the non-item separators fold this to 1.
+        assert_eq!(
+            merged.matches("impl Foo").count(),
+            2,
+            "[{label}] reopened impls collapsed:\n{merged}"
+        );
+        // Both disjoint additions landed.
+        assert!(
+            merged.contains("fn a2(&self) {}"),
+            "[{label}] ours add lost:\n{merged}"
+        );
+        assert!(
+            merged.contains("fn b2(&self) {}"),
+            "[{label}] theirs add lost:\n{merged}"
+        );
+        // Source order: a2 belongs to the first block (before the second
+        // `impl`), b2 to the second (after it).
+        let second_impl = merged.rfind("impl Foo").unwrap();
+        assert!(
+            merged.find("fn a2(&self) {}").unwrap() < second_impl,
+            "[{label}] a2 escaped the first block:\n{merged}"
+        );
+        assert!(
+            merged.find("fn b2(&self) {}").unwrap() > second_impl,
+            "[{label}] b2 escaped the second block:\n{merged}"
+        );
+        // The separator text is preserved verbatim where it carries content.
+        if sep.contains("// section") {
+            assert_eq!(
+                merged.matches("// section").count(),
+                1,
+                "[{label}] comment separator dropped/duplicated:\n{merged}"
+            );
+        }
+        if sep.contains("fn top_level") {
+            let first_impl = merged.find("impl Foo").unwrap();
+            let top = merged.find("fn top_level()").unwrap();
+            assert!(
+                first_impl < top && top < second_impl,
+                "[{label}] top-level item must stay between the blocks:\n{merged}"
+            );
+        }
+    }
+}
+
+// C++ `namespace N {…} namespace N {…}` is the same close-the-class shape in
+// another language; gated behind `lang-cpp` like the sibling reopen test.
+#[cfg(feature = "lang-cpp")]
+fn namespace_reopen_triple(sep: &str) -> (String, String, String) {
+    let base = format!("namespace N {{\nvoid a() {{}}\n}}{sep}namespace N {{\nvoid b() {{}}\n}}\n");
+    let ours = format!(
+        "namespace N {{\nvoid a() {{}}\nvoid a2() {{}}\n}}{sep}namespace N {{\nvoid b() {{}}\n}}\n"
+    );
+    let theirs = format!(
+        "namespace N {{\nvoid a() {{}}\n}}{sep}namespace N {{\nvoid b() {{}}\nvoid b2() {{}}\n}}\n"
+    );
+    (base, ours, theirs)
+}
+
+#[cfg(feature = "lang-cpp")]
+#[test]
+fn conformance_484_reopened_cpp_namespace_separator_matrix() {
+    let cases: &[(&str, &str)] = &[
+        ("back-to-back", "\n"),
+        ("whitespace-separated", "\n\n"),
+        ("comment-separated", "\n// section\n"),
+        ("item-separated", "\n\nint top_level() { return 0; }\n\n"),
+    ];
+    for (label, sep) in cases {
+        let (base, ours, theirs) = namespace_reopen_triple(sep);
+        let merged =
+            assert_conformant_at(&base, &ours, &theirs, "f.cpp", crate::parser::Language::Cpp);
+        assert_eq!(
+            merged.matches("namespace N").count(),
+            2,
+            "[{label}] reopened namespaces collapsed:\n{merged}"
+        );
+        assert!(
+            merged.contains("void a2() {}"),
+            "[{label}] ours add lost:\n{merged}"
+        );
+        assert!(
+            merged.contains("void b2() {}"),
+            "[{label}] theirs add lost:\n{merged}"
+        );
+        let second_ns = merged.rfind("namespace N").unwrap();
+        assert!(
+            merged.find("void a2() {}").unwrap() < second_ns,
+            "[{label}] a2 escaped the first block:\n{merged}"
+        );
+        assert!(
+            merged.find("void b2() {}").unwrap() > second_ns,
+            "[{label}] b2 escaped the second block:\n{merged}"
+        );
+        if sep.contains("// section") {
+            assert_eq!(
+                merged.matches("// section").count(),
+                1,
+                "[{label}] comment separator dropped/duplicated:\n{merged}"
+            );
+        }
+        if sep.contains("top_level") {
+            let first_ns = merged.find("namespace N").unwrap();
+            let top = merged.find("int top_level()").unwrap();
+            assert!(
+                first_ns < top && top < second_ns,
+                "[{label}] top-level item must stay between the blocks:\n{merged}"
+            );
+        }
+    }
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4984,9 +4984,11 @@ fn rust_use_identical_glob_both_sides_dedups_clean() {
 /// (structural-scope, kind, name) identity of every item in `source`,
 /// taken from the raw segmentation (no `use` canonicalization, so output
 /// and inputs are compared on the same footing).
-fn item_identities(source: &str) -> std::collections::BTreeSet<(Vec<String>, String, String)> {
-    let parsed = crate::parser::ParsedFile::parse(source, crate::parser::Language::Rust)
-        .expect("input must parse");
+fn item_identities(
+    source: &str,
+    language: crate::parser::Language,
+) -> std::collections::BTreeSet<(Vec<String>, String, String)> {
+    let parsed = crate::parser::ParsedFile::parse(source, language).expect("input must parse");
     let segs = super::items::segment_file(&parsed);
     segs.items
         .iter()
@@ -5013,13 +5015,26 @@ fn line_counts(source: &str) -> std::collections::HashMap<String, usize> {
 }
 
 /// Run the three close-the-class conformance checks against a clean
-/// semantic merge of `base`/`ours`/`theirs` (all additive — no deletions).
+/// semantic merge of a Rust `base`/`ours`/`theirs` (all additive — no
+/// deletions).
 fn assert_conformant(base: &str, ours: &str, theirs: &str) -> String {
-    let out = assert_clean(merge_rust(base, ours, theirs));
+    assert_conformant_at(base, ours, theirs, "a.rs", crate::parser::Language::Rust)
+}
+
+/// Language-parameterized form of [`assert_conformant`]: merge under `path`
+/// (which selects the parser) and run all three checks parsing as `language`.
+fn assert_conformant_at(
+    base: &str,
+    ours: &str,
+    theirs: &str,
+    path: &str,
+    language: crate::parser::Language,
+) -> String {
+    let out = assert_clean(merge_at(base, ours, theirs, path));
 
     // Check 3: the merged file must re-parse.
     assert!(
-        crate::parser::ParsedFile::parse(&out, crate::parser::Language::Rust).is_some(),
+        crate::parser::ParsedFile::parse(&out, language).is_some(),
         "clean merge produced an unparseable file:\n{out}"
     );
 
@@ -5027,10 +5042,10 @@ fn assert_conformant(base: &str, ours: &str, theirs: &str) -> String {
     // merged item set is exactly the union across the three sides, and each
     // item keeps the structural scope (its tuple's first element) a
     // contributing side gave it.
-    let mut expected = item_identities(base);
-    expected.extend(item_identities(ours));
-    expected.extend(item_identities(theirs));
-    let got = item_identities(&out);
+    let mut expected = item_identities(base, language);
+    expected.extend(item_identities(ours, language));
+    expected.extend(item_identities(theirs, language));
+    let got = item_identities(&out, language);
     assert_eq!(
         got, expected,
         "item-set / nesting not conserved\n got: {got:?}\n want: {expected:?}\n output:\n{out}"
@@ -5184,4 +5199,241 @@ fn repro_484_bug3_nested_pub_use_stays_inside_module() {
     );
     assert_eq!(merged.matches("pub mod prelude").count(), 1);
     assert!(crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some());
+}
+
+// =====================================================================
+// heddle#484 P1 (Codex regression on the P0 fix) — REOPENED same-name
+// scopes. The P0 fix grouped emit order by the struct-scope NAME, which
+// collapsed two *non-contiguous* blocks of the same scope — e.g. a
+// namespace/impl closed, a top-level item, then the same scope reopened —
+// into a single group. Even an unrelated clean merge then reordered the
+// second block's items ahead of the intervening top-level item and wove
+// the surrounding text from the wrong gap. The fix keys grouping by
+// `(scope, instance)`, so each reopened block is its own group and source
+// order is preserved.
+//
+// These corruptions are a pure REORDER: item-set / nesting / line-count /
+// re-parse can all still hold, so the guard here pins the relative order
+// (the intervening top-level item stays between the two blocks) on top of
+// the standard conformance invariants.
+// =====================================================================
+
+// C++ parsing is gated behind the non-default `lang-cpp` feature, so this
+// case only runs under `--features lang-cpp` (extended-languages). The
+// grouping fix it exercises is language-agnostic and is also covered by the
+// Rust `impl`-reopen tests below, which run under the default feature set.
+#[cfg(feature = "lang-cpp")]
+#[test]
+fn repro_484_reopened_cpp_namespace_keeps_top_level_between_blocks() {
+    // Two `namespace N { … }` blocks separated by a top-level function.
+    // ours adds to the FIRST block, theirs adds to the SECOND — disjoint,
+    // clean. Pre-fix the two blocks collapsed into one and the second's
+    // items jumped ahead of `top_level_thing`.
+    let base = "\
+namespace N {
+void a() {}
+}
+
+int top_level_thing() { return 0; }
+
+namespace N {
+void b() {}
+}
+";
+    let ours = "\
+namespace N {
+void a() {}
+void a2() {}
+}
+
+int top_level_thing() { return 0; }
+
+namespace N {
+void b() {}
+}
+";
+    let theirs = "\
+namespace N {
+void a() {}
+}
+
+int top_level_thing() { return 0; }
+
+namespace N {
+void b() {}
+void b2() {}
+}
+";
+    let merged =
+        assert_conformant_at(base, ours, theirs, "f.cpp", crate::parser::Language::Cpp);
+    // Both additions landed in their own block.
+    assert!(merged.contains("void a2() {}"), "ours add lost:\n{merged}");
+    assert!(merged.contains("void b2() {}"), "theirs add lost:\n{merged}");
+    // The two reopened blocks stay distinct (NOT collapsed to one).
+    assert_eq!(
+        merged.matches("namespace N").count(),
+        2,
+        "reopened blocks collapsed:\n{merged}"
+    );
+    // The top-level item stays BETWEEN the two blocks — the core invariant
+    // the reorder bug violated.
+    let first = merged.find("namespace N").unwrap();
+    let top = merged.find("int top_level_thing").unwrap();
+    let last = merged.rfind("namespace N").unwrap();
+    assert!(
+        first < top && top < last,
+        "top-level item must sit between the two namespace blocks:\n{merged}"
+    );
+    // a2 belongs to the first block (before top); b2 to the second (after).
+    assert!(
+        merged.find("void a2() {}").unwrap() < top,
+        "a2 escaped the first block:\n{merged}"
+    );
+    assert!(
+        merged.find("void b2() {}").unwrap() > top,
+        "b2 escaped the second block:\n{merged}"
+    );
+}
+
+#[test]
+fn repro_484_reopened_rust_impl_keeps_top_level_between_blocks() {
+    // Rust analogue: two inherent `impl Foo { … }` blocks (legal, unlike
+    // duplicate `mod m`) separated by a top-level fn. ours adds a method to
+    // the first impl; theirs to the second. Pre-fix the impls collapsed and
+    // the second impl's method reordered ahead of `top_level`.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+    fn a2(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) {}
+    fn b2(&self) {}
+}
+";
+    let merged = assert_conformant(base, ours, theirs);
+    assert!(merged.contains("fn a2(&self) {}"), "ours add lost:\n{merged}");
+    assert!(
+        merged.contains("fn b2(&self) {}"),
+        "theirs add lost:\n{merged}"
+    );
+    // Two distinct impl blocks survive.
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "reopened impls collapsed:\n{merged}"
+    );
+    let first = merged.find("impl Foo").unwrap();
+    let top = merged.find("fn top_level()").unwrap();
+    let last = merged.rfind("impl Foo").unwrap();
+    assert!(
+        first < top && top < last,
+        "top-level fn must sit between the two impl blocks:\n{merged}"
+    );
+    assert!(
+        merged.find("fn a2(&self) {}").unwrap() < top,
+        "a2 escaped the first impl:\n{merged}"
+    );
+    assert!(
+        merged.find("fn b2(&self) {}").unwrap() > top,
+        "b2 escaped the second impl:\n{merged}"
+    );
+}
+
+#[test]
+fn repro_484_reopened_rust_impl_add_first_modify_second_keeps_order() {
+    // ours adds a method to the FIRST impl; theirs modifies the existing
+    // method body in the SECOND impl. Both sides differ from base (so the
+    // file-level short-circuits don't fire and reconstruction actually runs),
+    // but neither touches the other's block. The intervening `top_level` must
+    // stay between the two impls and theirs's body edit must survive.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+    fn a2(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+fn top_level() {}
+
+impl Foo {
+    fn b(&self) { let _ = 1; }
+}
+";
+    let merged = assert_conformant(base, ours, theirs);
+    assert!(merged.contains("fn a2(&self) {}"), "ours add lost:\n{merged}");
+    assert!(
+        merged.contains("fn b(&self) { let _ = 1; }"),
+        "theirs body edit lost:\n{merged}"
+    );
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "reopened impls collapsed:\n{merged}"
+    );
+    let first = merged.find("impl Foo").unwrap();
+    let top = merged.find("fn top_level()").unwrap();
+    let last = merged.rfind("impl Foo").unwrap();
+    assert!(
+        first < top && top < last,
+        "top-level fn must sit between the two impl blocks:\n{merged}"
+    );
 }

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -4959,3 +4959,229 @@ fn rust_use_identical_glob_both_sides_dedups_clean() {
     assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
     assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
 }
+
+// =====================================================================
+// heddle#484 — function-level merge silently corrupted subdirectory-file
+// merges: the reconstruction wove a side's trailing postamble in twice
+// (duplicating `// MARK` / a trailing `mod tests {…}`) and, for items
+// added at different structural depths on each side, stranded a child
+// outside its module (`pub use` escaping `pub mod prelude`). These were
+// invisible to the marker-based checks: clean, zero conflict markers.
+//
+// The harness below is the close-the-class guard. For every CLEAN
+// semantic merge it asserts, on the PARSED output:
+//   1. item-set + nesting conservation — every merged item is present
+//      with the structural scope a contributing side gave it, and no
+//      item is invented or dropped (catches the mis-nesting in Bug 2/3);
+//   2. no invented / duplicated lines — a line can appear in the output
+//      no more often than base plus each side's additions over base
+//      justify (catches the duplicated postamble in Bug 1);
+//   3. the output re-parses — a clean merge that yields an unparseable
+//      file is by definition a corruption (catches Bug 2/3's unclosed /
+//      stray delimiters).
+// =====================================================================
+
+/// (structural-scope, kind, name) identity of every item in `source`,
+/// taken from the raw segmentation (no `use` canonicalization, so output
+/// and inputs are compared on the same footing).
+fn item_identities(source: &str) -> std::collections::BTreeSet<(Vec<String>, String, String)> {
+    let parsed = crate::parser::ParsedFile::parse(source, crate::parser::Language::Rust)
+        .expect("input must parse");
+    let segs = super::items::segment_file(&parsed);
+    segs.items
+        .iter()
+        .map(|i| {
+            (
+                i.struct_scope.clone(),
+                format!("{:?}", i.key.kind),
+                i.key.name.clone(),
+            )
+        })
+        .collect()
+}
+
+/// Count of each non-blank, trimmed line in `source`.
+fn line_counts(source: &str) -> std::collections::HashMap<String, usize> {
+    let mut counts = std::collections::HashMap::new();
+    for line in source.lines() {
+        let t = line.trim();
+        if !t.is_empty() {
+            *counts.entry(t.to_string()).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+/// Run the three close-the-class conformance checks against a clean
+/// semantic merge of `base`/`ours`/`theirs` (all additive — no deletions).
+fn assert_conformant(base: &str, ours: &str, theirs: &str) -> String {
+    let out = assert_clean(merge_rust(base, ours, theirs));
+
+    // Check 3: the merged file must re-parse.
+    assert!(
+        crate::parser::ParsedFile::parse(&out, crate::parser::Language::Rust).is_some(),
+        "clean merge produced an unparseable file:\n{out}"
+    );
+
+    // Check 1: item-set + nesting conservation. With only additions, the
+    // merged item set is exactly the union across the three sides, and each
+    // item keeps the structural scope (its tuple's first element) a
+    // contributing side gave it.
+    let mut expected = item_identities(base);
+    expected.extend(item_identities(ours));
+    expected.extend(item_identities(theirs));
+    let got = item_identities(&out);
+    assert_eq!(
+        got, expected,
+        "item-set / nesting not conserved\n got: {got:?}\n want: {expected:?}\n output:\n{out}"
+    );
+
+    // Check 2: no invented / duplicated lines. A line may appear in the
+    // output at most `base + max(0, ours-base) + max(0, theirs-base)`
+    // times — base's copies plus whatever each side added over base.
+    let (cb, co, ct) = (line_counts(base), line_counts(ours), line_counts(theirs));
+    for (line, &n) in &line_counts(&out) {
+        let b = cb.get(line).copied().unwrap_or(0);
+        let o = co.get(line).copied().unwrap_or(0);
+        let t = ct.get(line).copied().unwrap_or(0);
+        let allowed = b + o.saturating_sub(b) + t.saturating_sub(b);
+        assert!(
+            n <= allowed,
+            "line {line:?} appears {n}× (allowed {allowed}: base {b}, ours {o}, theirs {t})\n{out}"
+        );
+    }
+    out
+}
+
+#[test]
+fn conformance_484_structural_matrix() {
+    // {flat-top-level, trailing-mod, nested-pub-use} × {added-above,
+    // added-below, added-inside}. Each side makes a disjoint additive edit;
+    // every cell must survive all three conformance checks.
+    let cases: &[(&str, &str, &str)] = &[
+        // flat / added-above a trailing comment marker (Bug 1 shape).
+        (
+            "pub fn a() {}\n\n// MARK\n",
+            "pub fn a() {}\n\npub fn c() {}\n\n// MARK\n",
+            "pub fn a() {}\n\npub fn b() {}\n\n// MARK\n",
+        ),
+        // flat / added-below an item.
+        (
+            "pub fn a() {}\n",
+            "pub fn a() {}\n\npub fn c() {}\n",
+            "pub fn a() {}\n\npub fn b() {}\n",
+        ),
+        // flat / added-above the first item.
+        (
+            "pub fn z() {}\n",
+            "pub fn c() {}\n\npub fn z() {}\n",
+            "pub fn b() {}\n\npub fn z() {}\n",
+        ),
+        // trailing-mod / added-above the module (Bug 2 shape).
+        (
+            "pub fn a() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n",
+            "pub fn a() {}\n\npub fn c() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n",
+            "pub fn a() {}\n\npub fn b() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n",
+        ),
+        // trailing-mod / added-below the module.
+        (
+            "#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n",
+            "#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n\npub fn ours_after() {}\n",
+            "#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n\npub fn theirs_after() {}\n",
+        ),
+        // trailing-mod / added-inside the module body.
+        (
+            "mod tests {\n    fn t() {}\n}\n",
+            "mod tests {\n    fn t() {}\n    fn ours_t() {}\n}\n",
+            "mod tests {\n    fn t() {}\n    fn theirs_t() {}\n}\n",
+        ),
+        // nested-pub-use / added-inside the module + a sibling top-level fn
+        // below (Bug 3 shape).
+        (
+            "pub mod prelude {\n    pub use crate::a;\n}\n",
+            "pub mod prelude {\n    pub use crate::a;\n    pub use crate::b;\n}\n\npub fn ours_fn() {}\n",
+            "pub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n}\n\npub fn theirs_fn() {}\n",
+        ),
+        // nested-pub-use / added-above the module (top-level fn before it).
+        (
+            "pub mod prelude {\n    pub use crate::a;\n}\n",
+            "pub fn ours_fn() {}\n\npub mod prelude {\n    pub use crate::a;\n    pub use crate::b;\n}\n",
+            "pub fn theirs_fn() {}\n\npub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n}\n",
+        ),
+        // nested / two-level module, added-inside the innermost + sibling.
+        (
+            "pub mod outer {\n    pub mod inner {\n        pub use crate::a;\n    }\n}\n",
+            "pub mod outer {\n    pub mod inner {\n        pub use crate::a;\n        pub use crate::b;\n    }\n}\n\npub fn ours_fn() {}\n",
+            "pub mod outer {\n    pub mod inner {\n        pub use crate::a;\n        pub use crate::c;\n    }\n}\n\npub fn theirs_fn() {}\n",
+        ),
+        // both sides CREATE the same module (add/add) with disjoint uses.
+        (
+            "pub fn a() {}\n",
+            "pub fn a() {}\n\npub mod m {\n    pub use crate::x;\n}\n",
+            "pub fn a() {}\n\npub mod m {\n    pub use crate::y;\n}\n",
+        ),
+        // impl version of Bug 3: method added inside impl + sibling top-level
+        // fn, on each side.
+        (
+            "struct S;\nimpl S {\n    fn base(&self) {}\n}\n",
+            "struct S;\nimpl S {\n    fn base(&self) {}\n    fn ours_m(&self) {}\n}\n\nfn ours_top() {}\n",
+            "struct S;\nimpl S {\n    fn base(&self) {}\n    fn theirs_m(&self) {}\n}\n\nfn theirs_top() {}\n",
+        ),
+    ];
+    for (base, ours, theirs) in cases {
+        assert_conformant(base, ours, theirs);
+    }
+}
+
+#[test]
+fn repro_484_bug1_trailing_postamble_not_duplicated() {
+    // Each side adds a function above a trailing `// MARK`. Pre-fix the
+    // postamble (`\n\n// MARK\n`) was woven in twice and the second added
+    // function landed after the first marker copy.
+    let base = "pub fn a() {}\n\n// MARK\n";
+    let ours = "pub fn a() {}\n\npub fn c() {}\n\n// MARK\n";
+    let theirs = "pub fn a() {}\n\npub fn b() {}\n\n// MARK\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged, "pub fn a() {}\n\npub fn b() {}\n\npub fn c() {}\n\n// MARK\n",
+        "got:\n{merged}"
+    );
+    assert_eq!(merged.matches("// MARK").count(), 1);
+}
+
+#[test]
+fn repro_484_bug2_trailing_module_not_nested_or_duplicated() {
+    // Each side adds a top-level fn above a trailing `#[cfg(test)] mod
+    // tests {…}`. Pre-fix one fn nested INSIDE mod tests and the module +
+    // its preamble duplicated, producing an unclosed delimiter.
+    let base = "pub fn a() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+    let ours = "pub fn a() {}\n\npub fn c() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+    let theirs = "pub fn a() {}\n\npub fn b() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged,
+        "pub fn a() {}\n\npub fn b() {}\n\npub fn c() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n",
+        "got:\n{merged}"
+    );
+    assert_eq!(merged.matches("mod tests").count(), 1);
+    assert!(crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some());
+}
+
+#[test]
+fn repro_484_bug3_nested_pub_use_stays_inside_module() {
+    // Each side adds a `pub use` inside `pub mod prelude` AND a sibling
+    // top-level fn. Pre-fix one re-export escaped `prelude` (landed after a
+    // top-level fn) followed by a dangling `}`.
+    let base = "pub mod prelude {\n    pub use crate::a;\n}\n";
+    let ours = "pub mod prelude {\n    pub use crate::a;\n    pub use crate::b;\n}\n\npub fn ours_fn() {}\n";
+    let theirs =
+        "pub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n}\n\npub fn theirs_fn() {}\n";
+    let merged = assert_clean(merge_rust(base, ours, theirs));
+    assert_eq!(
+        merged,
+        "pub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n    pub use crate::b;\n}\n\npub fn theirs_fn() {}\n\npub fn ours_fn() {}\n",
+        "got:\n{merged}"
+    );
+    assert_eq!(merged.matches("pub mod prelude").count(), 1);
+    assert!(crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some());
+}

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -5603,3 +5603,364 @@ fn conformance_484_reopened_cpp_namespace_separator_matrix() {
         }
     }
 }
+
+// C++ analogue of the cross-side container-alignment matrix: one side prepends
+// a new same-name `namespace N` before the existing base block. Gated behind
+// `lang-cpp` like the sibling reopen tests; the alignment it exercises is
+// language-agnostic (also covered by the default-feature Rust cases above).
+#[cfg(feature = "lang-cpp")]
+#[test]
+fn conformance_484_r3_cross_side_cpp_namespace_prepend_no_collapse() {
+    // base has one `namespace N { void b(); }`. ours prepends a NEW
+    // `namespace N { void a(); }`; theirs edits b's body. Pre-fix the
+    // prepended block collapsed into the base block.
+    let base = "namespace N {\nvoid b() {}\n}\n";
+    let ours = "namespace N {\nvoid a() {}\n}\n\nnamespace N {\nvoid b() {}\n}\n";
+    let theirs = "namespace N {\nvoid b() { int x = 1; }\n}\n";
+    let merged = assert_conformant_at(base, ours, theirs, "f.cpp", crate::parser::Language::Cpp);
+    assert_eq!(
+        merged.matches("namespace N").count(),
+        2,
+        "prepended namespace collapsed into base block:\n{merged}"
+    );
+    assert!(merged.contains("void a() {}"), "ours add lost:\n{merged}");
+    assert!(
+        merged.contains("void b() { int x = 1; }"),
+        "theirs body edit lost:\n{merged}"
+    );
+    assert!(
+        merged.find("void a()").unwrap() < merged.find("void b()").unwrap(),
+        "prepended block must precede the base block:\n{merged}"
+    );
+}
+
+// =====================================================================
+// heddle#484 r3 (Codex P1, items.rs container-instance identity) —
+// CROSS-SIDE ordinal alignment. Round 2 made `struct_scope_inst` ordinals
+// span-derived, but counted them *independently within each side*. That is
+// correct within a side yet NOT aligned across sides: when one side
+// prepends a new same-name container before an existing base container,
+// the prepended block draws ordinal 0 on that side while the matched base
+// block (still 0 in base) becomes 1 — so reconstruction paired base's
+// matched block with the side's *prepended* block (both "Foo#0"), trimmed
+// the close/reopen gap, and collapsed two physically-distinct `impl Foo`
+// blocks into one silently-clean (wrong) merge.
+//
+// The fix anchors matched-container ordinals to the BASE span (a container
+// holding matched base items inherits that base container's ordinal) and
+// gives an *added* container a fresh ordinal above the base range, so a
+// prepended/appended/reordered same-name container keeps an identity
+// distinct from the matched base block. These cases must merge CLEAN with
+// no collapse; the standard conformance invariants (item-set + nesting
+// conserved, no duplicated lines, output re-parses) hold throughout.
+// =====================================================================
+
+#[test]
+fn repro_484_r3_prepend_new_impl_before_base_block_no_collapse() {
+    // THE named base case from the finding. base has one `impl Foo { fn b }`.
+    // ours prepends a NEW `impl Foo { fn a }` before it; theirs edits fn b's
+    // body (a disjoint change so reconstruction actually runs). Pre-fix the
+    // prepended block and the base block collapse into a single `impl Foo`.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn b(&self) { let _ = 1; }
+}
+";
+    let merged = assert_conformant(base, ours, theirs);
+    // Two distinct impl blocks survive — the prepended one did NOT collapse
+    // into the base block.
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "prepended impl collapsed into base block:\n{merged}"
+    );
+    assert!(merged.contains("fn a(&self) {}"), "ours add lost:\n{merged}");
+    assert!(
+        merged.contains("fn b(&self) { let _ = 1; }"),
+        "theirs body edit lost:\n{merged}"
+    );
+    // Source order: the prepended `fn a` block comes before the `fn b` block.
+    assert!(
+        merged.find("fn a(&self) {}").unwrap() < merged.find("fn b(&self)").unwrap(),
+        "prepended block must precede the base block:\n{merged}"
+    );
+}
+
+#[test]
+fn conformance_484_r3_cross_side_container_alignment_matrix() {
+    // Each case is a same-name-container arrangement that the per-side
+    // ordinal count mis-aligned. All must merge CLEAN and conformant.
+    // (label, base, ours, theirs).
+    let cases: &[(&str, &str, &str, &str)] = &[
+        // ours PREPENDS a new impl before the base block; theirs edits base.
+        (
+            "prepend",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) { let _ = 1; }\n}\n",
+        ),
+        // ours APPENDS a new impl after the base block; theirs edits base.
+        (
+            "append",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn a(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) { let _ = 1; }\n}\n",
+        ),
+        // BOTH sides add a different same-name container (ours before, theirs
+        // after the base block).
+        (
+            "both-add-different",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n",
+            "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn c(&self) {}\n}\n",
+        ),
+    ];
+    for (label, base, ours, theirs) in cases {
+        let merged = assert_conformant(base, ours, theirs);
+        // Every added/base method survives somewhere in an `impl Foo` scope.
+        for needle in ["fn a", "fn b"] {
+            assert!(
+                merged.contains(needle),
+                "[{label}] {needle} lost:\n{merged}"
+            );
+        }
+        // Output is well-formed Rust (no stray/unbalanced braces from a
+        // mis-trimmed reopen gap).
+        assert!(
+            crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some(),
+            "[{label}] unparseable merge:\n{merged}"
+        );
+    }
+}
+
+#[test]
+fn repro_484_r3_reordered_container_bails_no_silent_collapse() {
+    // ours REORDERS the two same-name `impl Foo` blocks (swaps a-block and
+    // b-block); theirs edits the first block disjointly. The matched
+    // containers' source order disagrees with base, so the brace-weave cannot
+    // place the `}` / `impl Foo {` boundaries cleanly. Pre-fix this produced a
+    // CLEAN but UNPARSEABLE file (a dropped `}`). The instance model bails to
+    // the textual path: the result either conflicts or re-parses with both
+    // blocks intact — never a silent corruption.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) {}
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn b(&self) {}
+}
+
+impl Foo {
+    fn a(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) { let _ = 1; }
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let outcome = merge_rust(base, ours, theirs);
+    let text = match outcome {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
+            assert!(conflict_count >= 1);
+            String::from_utf8(merged_bytes_with_markers).unwrap()
+        }
+        MergeOutcome::Clean(bytes) => {
+            let text = String::from_utf8(bytes).unwrap();
+            // A clean outcome must be well-formed (no dropped brace) — the
+            // pre-fix corruption produced an UNPARSEABLE clean merge.
+            assert!(
+                crate::parser::ParsedFile::parse(&text, crate::parser::Language::Rust).is_some(),
+                "clean merge is unparseable (silent corruption):\n{text}"
+            );
+            text
+        }
+        other => panic!("unexpected outcome: {other:?}"),
+    };
+    assert!(text.contains("fn a(&self)"), "fn a lost:\n{text}");
+    assert!(text.contains("fn b(&self)"), "fn b lost:\n{text}");
+}
+
+// =====================================================================
+// heddle#484 r3 part 2 — DETECT-AND-BAIL safety net. The instance model
+// pairs a side container with a base container via the matched items inside
+// it. When a side *merges* two base containers into one (its single block
+// holds items matched to two different base blocks) or *splits* one base
+// container across two side blocks, the correspondence is non-bijective:
+// the reconstructor cannot decide whether the spans are one instance or
+// two. Rather than emit a silently-clean collapse, it must route the file
+// to the textual conflict path — a conflict the user resolves is safe; a
+// silent collapse is the P0. The bail is NARROW: the add-before/add-after/
+// reorder cases above stay clean (they yield a bijection).
+// =====================================================================
+
+#[test]
+fn repro_484_r3_ambiguous_block_merge_bails_to_conflict() {
+    // base has TWO `impl Foo` blocks. ours MERGES them into one block (its
+    // single `impl Foo` now holds both `a` and `b`, matched to two distinct
+    // base blocks) AND edits a's body; theirs edits a's body differently and
+    // keeps the two blocks. The container-instance correspondence is
+    // ambiguous (one ours-block ↦ two base-blocks), so we must NOT emit a
+    // clean collapse. We bail to text_hunk_merge, whose overlapping edits to
+    // a's line surface a conflict.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 0 }
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 9 }
+    fn b(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 1 }
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let outcome = merge_rust(base, ours, theirs);
+    // Never a silent collapse: the outcome is EITHER a conflict (markers
+    // present) OR a clean merge that re-parses with both methods intact.
+    match outcome {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
+            let text = String::from_utf8(merged_bytes_with_markers).unwrap();
+            assert!(conflict_count >= 1, "expected a real conflict");
+            assert!(
+                text.contains("<<<<<<<") && text.contains(">>>>>>>"),
+                "conflict markers missing:\n{text}"
+            );
+            // No block silently dropped.
+            assert!(text.contains("fn a(&self)"), "fn a lost:\n{text}");
+            assert!(text.contains("fn b(&self)"), "fn b lost:\n{text}");
+        }
+        MergeOutcome::Clean(bytes) => {
+            let text = String::from_utf8(bytes).unwrap();
+            // A clean outcome is only acceptable if it did NOT collapse —
+            // both methods present and the file re-parses.
+            assert!(
+                crate::parser::ParsedFile::parse(&text, crate::parser::Language::Rust).is_some(),
+                "clean merge is unparseable:\n{text}"
+            );
+            assert!(
+                text.contains("fn a(&self)") && text.contains("fn b(&self)"),
+                "clean merge dropped a block:\n{text}"
+            );
+        }
+        other => panic!("unexpected outcome: {other:?}"),
+    }
+}
+
+#[test]
+fn repro_484_r3_ambiguous_block_split_bails_no_silent_collapse() {
+    // Mirror of the merge case: base has ONE `impl Foo` holding a and b.
+    // ours SPLITS it into two blocks (a in the first, b in the second) and
+    // edits a; theirs edits a differently in the single block. Two ours
+    // blocks both correspond to base's single block — ambiguous. The result
+    // must not be a silent collapse.
+    let base = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 0 }
+    fn b(&self) {}
+}
+";
+    let ours = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 9 }
+}
+
+impl Foo {
+    fn b(&self) {}
+}
+";
+    let theirs = "\
+struct Foo;
+
+impl Foo {
+    fn a(&self) -> u32 { 1 }
+    fn b(&self) {}
+}
+";
+    let outcome = merge_rust(base, ours, theirs);
+    let text = match outcome {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
+            assert!(conflict_count >= 1);
+            String::from_utf8(merged_bytes_with_markers).unwrap()
+        }
+        MergeOutcome::Clean(bytes) => {
+            let text = String::from_utf8(bytes).unwrap();
+            assert!(
+                crate::parser::ParsedFile::parse(&text, crate::parser::Language::Rust).is_some(),
+                "clean merge unparseable:\n{text}"
+            );
+            text
+        }
+        other => panic!("unexpected outcome: {other:?}"),
+    };
+    // In neither outcome is a method silently dropped.
+    assert!(text.contains("fn a(&self)"), "fn a lost:\n{text}");
+    assert!(text.contains("fn b(&self)"), "fn b lost:\n{text}");
+}

--- a/crates/semantic/src/parser/parser_core.rs
+++ b/crates/semantic/src/parser/parser_core.rs
@@ -17,8 +17,28 @@ pub struct ParsedFile {
 }
 
 impl ParsedFile {
-    /// Parse a file's contents.
+    /// Parse a file's contents. Returns `None` when the parser declines OR the
+    /// resulting tree contains any error node — the driver uses this strict form
+    /// for the three merge inputs so an unparseable side routes to the text
+    /// fallback.
     pub fn parse(source: impl Into<String>, language: Language) -> Option<Self> {
+        Self::parse_inner(source, language, true)
+    }
+
+    /// Like [`ParsedFile::parse`] but tolerant of error nodes: returns the
+    /// (error-recovered) tree even when `has_error()`. Used by the heddle#484
+    /// output-boundary conservation floor, which must extract whatever items the
+    /// reconstructed output contains — benign recovery noise (e.g. a stray `;`
+    /// from a deleted single-line item) must not be mistaken for a dropped item.
+    pub(crate) fn parse_allow_errors(source: impl Into<String>, language: Language) -> Option<Self> {
+        Self::parse_inner(source, language, false)
+    }
+
+    fn parse_inner(
+        source: impl Into<String>,
+        language: Language,
+        reject_errors: bool,
+    ) -> Option<Self> {
         let source = source.into();
         let lang = language.parser()?;
 
@@ -26,7 +46,7 @@ impl ParsedFile {
         parser.set_language(&lang).ok()?;
         let tree = parser.parse(&source, None)?;
 
-        if tree.root_node().has_error() {
+        if reject_errors && tree.root_node().has_error() {
             return None;
         }
 


### PR DESCRIPTION
Fixes #484 (P0). The function-level / `thread refresh` 3-way merge silently corrupted any file whose added items sat near a trailing block or inside a module — i.e. essentially all real Rust under `src/`. It printed `merge type: fast-forward`, emitted **0 conflict markers**, and `status` read clean, yet produced structurally corrupt (often unparseable) output. This PR fixes the corruption itself (defect 1), which is path-independent and the gating fix.

## Red commit
`56824561`

## Test evidence
New tests against the buggy reconstruction (red commit `56824561`) — all fail:
```
repro_484_bug1_trailing_postamble_not_duplicated ... FAILED
repro_484_bug2_trailing_module_not_nested_or_duplicated ... FAILED
repro_484_bug3_nested_pub_use_stays_inside_module ... FAILED
conformance_484_structural_matrix ... FAILED
test result: FAILED. 0 passed; 4 failed
```
After the fix (green commit `7489d905`):
```
test result: ok. 234 passed; 0 failed; 1 ignored   # full heddle-semantic suite
```
Gates (all green, `--locked`, no `cargo fmt`):
- `cargo test -p heddle-semantic` → 234 passed (231 prior + harness + 3 repros), 0 failed
- `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` → clean
- `bash scripts/check-no-silent-default-tree-load.sh` → clean (542 files)
- `cargo test --locked -p heddle-merge -p heddle-repo -p heddle-mount` → green; `cli_integration` 887/887 green at `--test-threads=4` (the whole-workspace mega-run shows ~93 failures purely from parallel resource contention — each fails-in-aggregate test passes in isolation/low-parallelism).

End-to-end, the issue's exact CLI repro now yields correct, re-parseable output for `lib.rs`, `src/lib.rs`, **and** `src/foo/lib.rs` (all `MARK_lines=1`):
```
pub fn a() {}

pub fn b() {}

pub fn c() {}

// MARK
```

## What changed (defect 1 — `crates/semantic/src/merge_driver/reconstruct.rs`)
The user-visible corruption was the reconstruction weave; the fix is contained to it (+ inert extraction metadata in `items.rs`):
- **Drop the "bridging" model.** Each side's inter-item range now maps to exactly one slot — the preceding gap of the one item it sits before, or the postamble (emitted once). The old bridge pulled a one-item side's trailing postamble in twice (as the bridge before an added item *and* as the postamble) → the duplicated `// MARK`.
- **Structural-scope-aware emit order.** Items are grouped by *physical* container nesting (`Item::struct_scope` + `ContainerSpan`, recorded in `items.rs`), kept distinct from the logical `ItemKey::scope` so C++ out-of-class methods are unaffected. Keeps a module's children contiguous inside its `{ }` (fixes the escaped nested `pub use` and the mis-nested fn under `mod tests`).
- **Trim redundant container braces** from each side's gap so each `{`/`}` is emitted exactly once across the merge (covers both the escaped nested `pub use` and the add/add-module duplicated header).
- **Leading-separator synthesis** for two independently-prepended items, restoring a gap the bridging model used to provide.

Close-the-class guard: `conformance_484_structural_matrix` asserts on the **parsed** output (item-set + nesting conservation, no invented/duplicated lines, re-parses) across `{flat, trailing-mod, nested-pub-use, add/add-module, impl-sibling} × {above, below, inside}` — it caught a real regression mid-development (a lost separator between two prepended leading items) before this landed.

## Defect 2 (rebase subdir false-conflict) — DEFERRED
Confirmed and root-caused, deferred per the issue's guidance (defect 1 is the gating fix; the corruption is gone regardless of routing). The content is now correct for subdir files, but blame still collapses to 1 state for them (top-level → 3) because subdir files route into the semantic fallback which re-snapshots.

Root cause: `crates/cli/src/cli/commands/rebase/rebase_ops.rs` — `compute_tree_diff` (L619), `find_entry_in_tree` (L656), and `apply_changes_to_tree` (L668) all operate on **top-level tree entries by basename only**. A whole subdirectory `src/` is treated as one opaque entry, so any two commits touching *anything* under `src/` collide during rebase replay (top-level files, being separate entries, don't). That spurious conflict routes subdir refreshes into the fallback.

Deferred because a correct fix makes the entire diff→lookup→apply pipeline path-recursive — including **nested subtree reconstruction with content-addressing** (the hard part) — inside the core rebase engine used by `thread refresh`/`rebase` across a large CLI test surface. That is a separate subsystem from the semantic merge driver and carries materially more regression risk than the corruption fix; it should be its own scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783125502&installation_id=132405951&pr_number=487&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F487&signature=409ee4e6486cd774797e63dfb2324457e228f2f196bb1909aef7b9f031457cac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->