### PR TITLE
refactor(ingest): one shared per-format event stream (~-150 LoC)

### DIFF
--- a/crates/ingest/src/reasoning_extract.rs
+++ b/crates/ingest/src/reasoning_extract.rs
@@ -34,12 +34,11 @@
 //!
 //! # Scope
 //!
-//! Claude is supported end-to-end. Codex support is scaffolded (same
-//! candidate pipeline) but the message reader for Codex rollouts is a
-//! stub — Codex rollouts emit reasoning as prose paragraphs without the
-//! Claude block taxonomy, and the signal is noisier. Landing Codex
-//! properly is follow-up work; the [`harvest_from_codex_events`]
-//! function is a placeholder so the shape is clear.
+//! Claude, Codex, and OpenCode are all supported end-to-end. Each format
+//! exposes one shared low-level [`StreamEvent`](crate::transcript::stream)
+//! walk (in the canonical transcript module) that both the `Transcript`
+//! builder and this harvester consume, so the parse/cwd/tool-gate
+//! machinery lives once per format and the two consumers can't drift.
 
 use std::{
     collections::VecDeque,
@@ -48,7 +47,6 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use objects::object::AnnotationKind;
-use serde::Deserialize;
 use tracing::debug;
 
 use crate::{
@@ -367,72 +365,37 @@ pub fn harvest(t: &Transcript, params: &HarvestParams) -> crate::Result<Vec<Harv
 }
 
 fn harvest_claude(path: &Path, params: &HarvestParams) -> crate::Result<Vec<HarvestedCandidate>> {
-    let text = std::fs::read_to_string(path).map_err(|e| {
-        IngestError::Io(std::io::Error::new(
-            e.kind(),
-            format!("reading claude session {}: {e}", path.display()),
-        ))
-    })?;
-    // Two passes: first collect the ordered assistant events, then scan
-    // them with a small look-ahead queue for target resolution.
-    let mut events: Vec<AssistantEvent> = Vec::new();
-    for raw in text.lines() {
-        if raw.trim().is_empty() {
-            continue;
-        }
-        let Ok(e) = serde_json::from_str::<ClaudeRawEvent>(raw) else {
-            continue;
-        };
-        if e.event_type.as_deref() != Some("assistant") {
-            continue;
-        }
-        let Some(msg) = e.message else {
-            continue;
-        };
-        let Some(content) = msg.content else {
-            continue;
-        };
-        let Some(ts) = e.timestamp else { continue };
-
-        let mut texts: Vec<String> = Vec::new();
-        let mut files: Vec<PathBuf> = Vec::new();
-        for b in content.blocks() {
-            match b.block_type.as_deref() {
-                Some("text") => {
-                    if let Some(s) = b.text.as_deref()
-                        && !s.trim().is_empty()
-                    {
-                        texts.push(s.to_string());
-                    }
-                }
-                Some("tool_use") => {
-                    if let Some(input) = b.input.as_ref() {
-                        let path_str = input
-                            .file_path
-                            .as_deref()
-                            .or(input.notebook_path.as_deref());
-                        if let Some(p) = path_str {
-                            files.push(PathBuf::from(p));
-                        }
-                    }
-                }
-                // `thinking` blocks are redacted at write-time; the
-                // `thinking` string is empty. Nothing to harvest.
-                _ => {}
-            }
-        }
-        if !texts.is_empty() || !files.is_empty() {
-            events.push(AssistantEvent {
-                timestamp: ts,
-                texts,
-                files,
-            });
-        }
-    }
-
+    let text = crate::transcript::stream::read_session_text(path, "claude session")?;
+    let events = assistant_events(crate::transcript::claude::stream_events(&text, path));
     let out = harvest_from_events(&events, params);
     debug!(path = %path.display(), candidates = out.len(), "claude harvest");
     Ok(out)
+}
+
+/// Project a shared format event stream into the harvester's
+/// [`AssistantEvent`]s. An event contributes one `AssistantEvent` when it
+/// has a timestamp and carries either assistant prose or file touches —
+/// the same gate both the Claude and Codex harvesters used to apply
+/// inline. File-touch kinds are dropped; only the paths matter for target
+/// resolution.
+fn assistant_events(
+    stream: Vec<crate::transcript::stream::StreamEvent>,
+) -> Vec<AssistantEvent> {
+    let mut out = Vec::new();
+    for ev in stream {
+        let Some(timestamp) = ev.timestamp else {
+            continue;
+        };
+        if ev.texts.is_empty() && ev.touches.is_empty() {
+            continue;
+        }
+        out.push(AssistantEvent {
+            timestamp,
+            texts: ev.texts,
+            files: ev.touches.into_iter().map(|t| t.path).collect(),
+        });
+    }
+    out
 }
 
 /// Provider-agnostic stage 1 once events are normalized. Both Claude and
@@ -611,13 +574,9 @@ fn harvest_opencode(
     session_id: &str,
     params: &HarvestParams,
 ) -> crate::Result<Vec<HarvestedCandidate>> {
-    use rusqlite::{Connection, OpenFlags};
-    let uri = format!("file:{}?mode=ro", db_path.display());
-    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI;
-    let conn = Connection::open_with_flags(&uri, flags).map_err(|e| {
+    let conn = crate::transcript::opencode::open_read_only(db_path).map_err(|e| {
         IngestError::Other(format!("opening opencode db {}: {e}", db_path.display()))
     })?;
-    let _ = conn.busy_timeout(std::time::Duration::from_millis(500));
 
     // Order by `(message_id, time_created, id)` so all parts of a single
     // assistant message arrive contiguously and within the message in the
@@ -723,144 +682,9 @@ fn harvest_opencode(
 ///    and `encrypted_content` is opaque. We skip them. There's nothing
 ///    we can extract that we don't already see in `message` events.
 ///
-/// `cwd` is tracked across `session_meta` and `turn_context` events so
-/// shell tokens that resolve relative to the current workdir get
-/// stamped against the right path.
 fn harvest_codex(path: &Path, params: &HarvestParams) -> crate::Result<Vec<HarvestedCandidate>> {
-    use serde_json::Value;
-    let text = std::fs::read_to_string(path).map_err(|e| {
-        IngestError::Io(std::io::Error::new(
-            e.kind(),
-            format!("reading codex rollout {}: {e}", path.display()),
-        ))
-    })?;
-
-    let mut current_cwd: Option<PathBuf> = None;
-    let mut events: Vec<AssistantEvent> = Vec::new();
-
-    for raw in text.lines() {
-        if raw.trim().is_empty() {
-            continue;
-        }
-        let Ok(event) = serde_json::from_str::<CodexRawEvent>(raw) else {
-            continue;
-        };
-        let Some(ts) = event.timestamp else {
-            continue;
-        };
-
-        match event.event_type.as_deref() {
-            Some("session_meta") => {
-                if let Some(p) = event.payload.as_ref()
-                    && current_cwd.is_none()
-                    && let Some(c) = p.get("cwd").and_then(Value::as_str)
-                {
-                    current_cwd = Some(PathBuf::from(c));
-                }
-            }
-            Some("turn_context") => {
-                // Mid-session workdir switch — later commands resolve
-                // against this cwd.
-                if let Some(p) = event.payload.as_ref()
-                    && let Some(c) = p.get("cwd").and_then(Value::as_str)
-                {
-                    current_cwd = Some(PathBuf::from(c));
-                }
-            }
-            Some("response_item") => {
-                let Some(p) = event.payload.as_ref() else {
-                    continue;
-                };
-                let payload_type = p.get("type").and_then(Value::as_str).unwrap_or("");
-                match payload_type {
-                    "message" => {
-                        // Only assistant turns carry harvest-able prose.
-                        // User and developer messages are inputs we don't
-                        // want to mistake for the model's reasoning.
-                        if p.get("role").and_then(Value::as_str) != Some("assistant") {
-                            continue;
-                        }
-                        let texts = collect_codex_message_texts(p);
-                        if !texts.is_empty() {
-                            events.push(AssistantEvent {
-                                timestamp: ts,
-                                texts,
-                                files: Vec::new(),
-                            });
-                        }
-                    }
-                    "function_call" => {
-                        // Only `exec_command` ever resolves to file
-                        // touches; the loader uses the same gate.
-                        let name = p.get("name").and_then(Value::as_str).unwrap_or("");
-                        if name != "exec_command" {
-                            continue;
-                        }
-                        let Some(args_str) = p.get("arguments").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        let Ok(args_json) = serde_json::from_str::<Value>(args_str) else {
-                            continue;
-                        };
-                        let Some(cmd) = args_json.get("cmd").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        // Per-call workdir override falls back to the
-                        // session's running cwd.
-                        let base_cwd: Option<PathBuf> = args_json
-                            .get("workdir")
-                            .and_then(Value::as_str)
-                            .map(PathBuf::from)
-                            .or_else(|| current_cwd.clone());
-                        let mut touches = Vec::new();
-                        crate::transcript::codex::extract_shell_touches(
-                            cmd,
-                            ts,
-                            base_cwd.as_deref(),
-                            &mut touches,
-                        );
-                        let files: Vec<PathBuf> = touches.into_iter().map(|t| t.path).collect();
-                        if !files.is_empty() {
-                            events.push(AssistantEvent {
-                                timestamp: ts,
-                                texts: Vec::new(),
-                                files,
-                            });
-                        }
-                    }
-                    "custom_tool_call" => {
-                        let name = p.get("name").and_then(Value::as_str).unwrap_or("");
-                        if name != "apply_patch" {
-                            continue;
-                        }
-                        let Some(input) = p.get("input").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        let mut touches = Vec::new();
-                        crate::transcript::codex::extract_shell_touches(
-                            input,
-                            ts,
-                            current_cwd.as_deref(),
-                            &mut touches,
-                        );
-                        let files: Vec<PathBuf> = touches.into_iter().map(|t| t.path).collect();
-                        if !files.is_empty() {
-                            events.push(AssistantEvent {
-                                timestamp: ts,
-                                texts: Vec::new(),
-                                files,
-                            });
-                        }
-                    }
-                    // `reasoning` events: server-redacted, content=null.
-                    // Anything else: not a harvestable shape.
-                    _ => {}
-                }
-            }
-            _ => {}
-        }
-    }
-
+    let text = crate::transcript::stream::read_session_text(path, "codex rollout")?;
+    let events = assistant_events(crate::transcript::codex::stream_events(&text, path));
     let out = harvest_from_events(&events, params);
     debug!(
         path = %path.display(),
@@ -869,44 +693,6 @@ fn harvest_codex(path: &Path, params: &HarvestParams) -> crate::Result<Vec<Harve
         "codex harvest"
     );
     Ok(out)
-}
-
-/// Pull every `output_text` block out of a Codex assistant message
-/// payload. Codex's content array can in principle carry other types
-/// (`refusal`, future tool-result variants); we ignore those and only
-/// surface the text the model actually showed the user.
-fn collect_codex_message_texts(payload: &serde_json::Value) -> Vec<String> {
-    let Some(content) = payload.get("content").and_then(|c| c.as_array()) else {
-        return Vec::new();
-    };
-    let mut out = Vec::with_capacity(content.len());
-    for block in content {
-        if block.get("type").and_then(|t| t.as_str()) != Some("output_text") {
-            continue;
-        }
-        let Some(text) = block.get("text").and_then(|t| t.as_str()) else {
-            continue;
-        };
-        if !text.trim().is_empty() {
-            out.push(text.to_string());
-        }
-    }
-    out
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct CodexRawEvent {
-    #[serde(rename = "type")]
-    event_type: Option<String>,
-    timestamp: Option<DateTime<Utc>>,
-    payload: Option<serde_json::Value>,
-}
-
-/// Public hook for a later Codex reader — kept as a named no-op so
-/// downstream callers can feature-detect.
-#[doc(hidden)]
-pub fn harvest_from_codex_events(_path: &Path) -> Vec<HarvestedCandidate> {
-    Vec::new()
 }
 
 // ---------- Keep: trim + score + seal ----------
@@ -1191,58 +977,6 @@ struct AssistantEvent {
     timestamp: DateTime<Utc>,
     texts: Vec<String>,
     files: Vec<PathBuf>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClaudeRawEvent {
-    #[serde(rename = "type")]
-    event_type: Option<String>,
-    timestamp: Option<DateTime<Utc>>,
-    message: Option<ClaudeRawMessage>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClaudeRawMessage {
-    /// Polymorphic, mirroring [`super::transcript::claude::RawContent`].
-    /// Most assistant turns are typed-block arrays; a non-trivial fraction
-    /// (and almost every user turn) flatten to a plain string. We model
-    /// both so the harvester doesn't drop events whose content is a
-    /// string — a regression that lost roughly half of all assistant
-    /// turns when the field was typed as `Vec<ClaudeRawBlock>`.
-    content: Option<ClaudeRawContent>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum ClaudeRawContent {
-    Text(String),
-    Blocks(Vec<ClaudeRawBlock>),
-}
-
-impl ClaudeRawContent {
-    /// Empty slice for the string case so the harvest loop iterates
-    /// uniformly. Strings carry no `tool_use` so they produce no
-    /// candidates either way; we lose nothing by treating them as empty.
-    fn blocks(&self) -> &[ClaudeRawBlock] {
-        match self {
-            ClaudeRawContent::Blocks(b) => b.as_slice(),
-            ClaudeRawContent::Text(_) => &[],
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct ClaudeRawBlock {
-    #[serde(rename = "type")]
-    block_type: Option<String>,
-    text: Option<String>,
-    input: Option<ClaudeRawToolInput>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClaudeRawToolInput {
-    file_path: Option<String>,
-    notebook_path: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/ingest/src/transcript/claude.rs
+++ b/crates/ingest/src/transcript/claude.rs
@@ -33,32 +33,33 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use tracing::debug;
 
-use super::types::{FileTouch, Provider, TouchKind, Transcript};
-use crate::IngestError;
+use super::stream::{CwdSignal, StreamEvent, fold_transcript, read_session_text};
+use super::types::{FileTouch, Provider, TouchKind};
+use crate::Transcript;
 
 /// Load a single session `.jsonl`, returning `Ok(None)` if the file
 /// contains no events we could normalize (empty sessions happen when a
 /// user hits Ctrl-C before the first turn).
 pub fn load(path: impl AsRef<Path>) -> crate::Result<Option<Transcript>> {
     let path = path.as_ref();
-    let text = std::fs::read_to_string(path).map_err(|e| {
-        IngestError::Io(std::io::Error::new(
-            e.kind(),
-            format!("reading claude session {}: {e}", path.display()),
-        ))
-    })?;
+    let text = read_session_text(path, "claude session")?;
     parse(&text, path)
 }
 
 /// Internal entry point, split out so tests don't need a file on disk.
 pub(super) fn parse(text: &str, source_path: &Path) -> crate::Result<Option<Transcript>> {
-    let mut session_id: Option<String> = None;
-    let mut cwd: Option<PathBuf> = None;
-    let mut started: Option<DateTime<Utc>> = None;
-    let mut ended: Option<DateTime<Utc>> = None;
-    let mut turn_count: u32 = 0;
-    let mut touches: Vec<FileTouch> = Vec::new();
+    Ok(fold_transcript(
+        Provider::Claude,
+        source_path,
+        stream_events(text, source_path),
+    ))
+}
 
+/// Walk a Claude session JSONL into the shared [`StreamEvent`] stream.
+/// This is the single low-level parse both the [`Transcript`] builder and
+/// the reasoning harvester consume.
+pub(crate) fn stream_events(text: &str, source_path: &Path) -> Vec<StreamEvent> {
+    let mut out = Vec::new();
     for (line_no, raw) in text.lines().enumerate() {
         if raw.trim().is_empty() {
             continue;
@@ -78,80 +79,69 @@ pub(super) fn parse(text: &str, source_path: &Path) -> crate::Result<Option<Tran
             }
         };
 
-        // Session id and cwd come from the first event that carries them
-        // (they're redundant across events but first-wins is deterministic).
-        if session_id.is_none() {
-            session_id = event.session_id.clone();
-        }
-        if cwd.is_none()
-            && let Some(c) = event.cwd.as_ref()
-        {
-            cwd = Some(PathBuf::from(c));
-        }
-
-        if let Some(ts) = event.timestamp {
-            started = Some(started.map_or(ts, |s| s.min(ts)));
-            ended = Some(ended.map_or(ts, |e| e.max(ts)));
-        }
-
-        match event.event_type.as_deref() {
-            Some("user") | Some("assistant") => turn_count += 1,
-            _ => {}
-        }
-
-        if event.event_type.as_deref() == Some("assistant")
+        let is_assistant = event.event_type.as_deref() == Some("assistant");
+        let mut texts = Vec::new();
+        let mut touches = Vec::new();
+        if is_assistant
             && let Some(content) = event.message.as_ref().and_then(|m| m.content.as_ref())
         {
             for block in content.blocks() {
-                if block.block_type.as_deref() != Some("tool_use") {
-                    continue;
+                match block.block_type.as_deref() {
+                    Some("text") => {
+                        if let Some(s) = block.text.as_deref()
+                            && !s.trim().is_empty()
+                        {
+                            texts.push(s.to_string());
+                        }
+                    }
+                    Some("tool_use") => {
+                        let kind = match block.name.as_deref() {
+                            // `Write` replaces, `Edit` modifies, `MultiEdit`
+                            // does several Edits in one call, `NotebookEdit`
+                            // targets a notebook cell. All count as writes.
+                            Some("Write" | "Edit" | "MultiEdit" | "NotebookEdit") => {
+                                TouchKind::Write
+                            }
+                            Some("Read") => TouchKind::Read,
+                            _ => continue,
+                        };
+                        let Some(input) = block.input.as_ref() else {
+                            continue;
+                        };
+                        // `NotebookEdit` uses `notebook_path`; the others
+                        // use `file_path`. Accept either.
+                        let path_str = input
+                            .file_path
+                            .as_deref()
+                            .or(input.notebook_path.as_deref());
+                        let Some(path) = path_str else { continue };
+                        let Some(ts) = event.timestamp else { continue };
+                        touches.push(FileTouch {
+                            path: PathBuf::from(path),
+                            timestamp: ts,
+                            kind,
+                        });
+                    }
+                    // `thinking` blocks are redacted at write-time; the
+                    // `thinking` string is empty. Nothing to harvest.
+                    _ => {}
                 }
-                let Some(name) = block.name.as_deref() else {
-                    continue;
-                };
-                let kind = match name {
-                    // `Write` replaces, `Edit` modifies, `MultiEdit` does
-                    // several Edits in one call, `NotebookEdit` targets a
-                    // notebook cell. All count as writes.
-                    "Write" | "Edit" | "MultiEdit" | "NotebookEdit" => TouchKind::Write,
-                    "Read" => TouchKind::Read,
-                    _ => continue,
-                };
-                let Some(input) = block.input.as_ref() else {
-                    continue;
-                };
-                // `NotebookEdit` uses `notebook_path`; the others
-                // use `file_path`. Accept either.
-                let path_str = input
-                    .file_path
-                    .as_deref()
-                    .or(input.notebook_path.as_deref());
-                let Some(path) = path_str else { continue };
-                let Some(ts) = event.timestamp else { continue };
-                touches.push(FileTouch {
-                    path: PathBuf::from(path),
-                    timestamp: ts,
-                    kind,
-                });
             }
         }
+
+        out.push(StreamEvent {
+            timestamp: event.timestamp,
+            // Session id and cwd come from the first event that carries
+            // them (redundant across events, but first-wins is deterministic).
+            session_id: event.session_id,
+            starting_commit: None,
+            cwd: event.cwd.map(|c| CwdSignal::IfUnset(PathBuf::from(c))),
+            is_turn: matches!(event.event_type.as_deref(), Some("user") | Some("assistant")),
+            texts,
+            touches,
+        });
     }
-
-    let (Some(session_id), Some(started_at), Some(ended_at)) = (session_id, started, ended) else {
-        return Ok(None);
-    };
-
-    Ok(Some(Transcript {
-        provider: Provider::Claude,
-        session_id,
-        source_path: source_path.to_path_buf(),
-        cwd,
-        started_at,
-        ended_at,
-        turn_count,
-        files_touched: touches,
-        starting_commit: None,
-    }))
+    out
 }
 
 /// Top-level JSONL event. Fields are `Option` because different event
@@ -207,6 +197,9 @@ struct RawBlock {
     #[serde(rename = "type")]
     block_type: Option<String>,
     name: Option<String>,
+    /// Narrative content of a `text` block. The harvester mines this;
+    /// the matcher ignores it.
+    text: Option<String>,
     input: Option<RawToolInput>,
 }
 

--- a/crates/ingest/src/transcript/codex.rs
+++ b/crates/ingest/src/transcript/codex.rs
@@ -35,28 +35,36 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::debug;
 
-use super::types::{FileTouch, Provider, TouchKind, Transcript};
-use crate::IngestError;
+use super::stream::{CwdSignal, StreamEvent, fold_transcript, read_session_text};
+use super::types::{FileTouch, Provider, TouchKind};
+use crate::Transcript;
 
 pub fn load(path: impl AsRef<Path>) -> crate::Result<Option<Transcript>> {
     let path = path.as_ref();
-    let text = std::fs::read_to_string(path).map_err(|e| {
-        IngestError::Io(std::io::Error::new(
-            e.kind(),
-            format!("reading codex session {}: {e}", path.display()),
-        ))
-    })?;
+    let text = read_session_text(path, "codex rollout")?;
     parse(&text, path)
 }
 
 pub(super) fn parse(text: &str, source_path: &Path) -> crate::Result<Option<Transcript>> {
-    let mut session_id: Option<String> = None;
-    let mut cwd: Option<PathBuf> = None;
-    let mut starting_commit: Option<String> = None;
-    let mut started: Option<DateTime<Utc>> = None;
-    let mut ended: Option<DateTime<Utc>> = None;
-    let mut turn_count: u32 = 0;
-    let mut touches: Vec<FileTouch> = Vec::new();
+    Ok(fold_transcript(
+        Provider::Codex,
+        source_path,
+        stream_events(text, source_path),
+    ))
+}
+
+/// Walk a Codex rollout JSONL into the shared [`StreamEvent`] stream.
+/// This is the single low-level parse both the [`Transcript`] builder and
+/// the reasoning harvester consume.
+///
+/// `cwd` is tracked across `session_meta` and `turn_context` events so
+/// shell tokens that resolve relative to the current workdir get stamped
+/// against the right path — the running cwd is used to resolve touches
+/// inline here, and also surfaced as a [`CwdSignal`] for the transcript's
+/// `cwd` field.
+pub(crate) fn stream_events(text: &str, source_path: &Path) -> Vec<StreamEvent> {
+    let mut current_cwd: Option<PathBuf> = None;
+    let mut out = Vec::new();
 
     for (line_no, raw) in text.lines().enumerate() {
         if raw.trim().is_empty() {
@@ -74,122 +82,137 @@ pub(super) fn parse(text: &str, source_path: &Path) -> crate::Result<Option<Tran
                 continue;
             }
         };
-
-        if let Some(ts) = event.timestamp {
-            started = Some(started.map_or(ts, |s| s.min(ts)));
-            ended = Some(ended.map_or(ts, |e| e.max(ts)));
-        }
+        let ts = event.timestamp;
 
         match event.event_type.as_deref() {
             Some("session_meta") => {
+                let mut ev = StreamEvent::bare(ts);
                 if let Some(p) = event.payload.as_ref() {
-                    if session_id.is_none() {
-                        session_id = p.get("id").and_then(Value::as_str).map(String::from);
-                    }
-                    if cwd.is_none() {
-                        cwd = p.get("cwd").and_then(Value::as_str).map(PathBuf::from);
-                    }
-                    if starting_commit.is_none() {
-                        starting_commit = p
-                            .get("git")
-                            .and_then(|g| g.get("commit_hash"))
-                            .and_then(Value::as_str)
-                            .map(String::from);
+                    ev.session_id = p.get("id").and_then(Value::as_str).map(String::from);
+                    ev.starting_commit = p
+                        .get("git")
+                        .and_then(|g| g.get("commit_hash"))
+                        .and_then(Value::as_str)
+                        .map(String::from);
+                    if let Some(c) = p.get("cwd").and_then(Value::as_str) {
+                        if current_cwd.is_none() {
+                            current_cwd = Some(PathBuf::from(c));
+                        }
+                        ev.cwd = Some(CwdSignal::IfUnset(PathBuf::from(c)));
                     }
                 }
+                out.push(ev);
             }
             Some("turn_context") => {
                 // A workdir switch mid-session: respect the newest cwd
                 // without clobbering the session_meta cwd if no switch is
                 // actually logged.
+                let mut ev = StreamEvent::bare(ts);
                 if let Some(p) = event.payload.as_ref()
                     && let Some(new_cwd) = p.get("cwd").and_then(Value::as_str)
                 {
-                    cwd = Some(PathBuf::from(new_cwd));
+                    current_cwd = Some(PathBuf::from(new_cwd));
+                    ev.cwd = Some(CwdSignal::Force(PathBuf::from(new_cwd)));
                 }
+                out.push(ev);
             }
             Some("response_item") => {
                 let Some(p) = event.payload.as_ref() else {
+                    out.push(StreamEvent::bare(ts));
                     continue;
                 };
-                let payload_type = p.get("type").and_then(Value::as_str).unwrap_or("");
-                match payload_type {
+                match p.get("type").and_then(Value::as_str).unwrap_or("") {
                     "message" => {
-                        turn_count += 1;
+                        // Every message counts as a turn; only assistant
+                        // turns carry harvest-able prose. User/developer
+                        // messages are inputs, not the model's reasoning.
+                        let texts = if p.get("role").and_then(Value::as_str) == Some("assistant") {
+                            collect_message_texts(p)
+                        } else {
+                            Vec::new()
+                        };
+                        let mut ev = StreamEvent::bare(ts);
+                        ev.is_turn = true;
+                        ev.texts = texts;
+                        out.push(ev);
                     }
                     "function_call" => {
-                        turn_count += 1;
-                        let name = p.get("name").and_then(Value::as_str).unwrap_or("");
-                        if name != "exec_command" {
-                            continue;
+                        // Every function_call counts as a turn; only
+                        // `exec_command` ever resolves to file touches.
+                        let mut ev = StreamEvent::bare(ts);
+                        ev.is_turn = true;
+                        if p.get("name").and_then(Value::as_str) == Some("exec_command")
+                            && let Some(ts) = ts
+                            && let Some(args_str) = p.get("arguments").and_then(Value::as_str)
+                            && let Ok(args_json) = serde_json::from_str::<Value>(args_str)
+                            && let Some(cmd) = args_json.get("cmd").and_then(Value::as_str)
+                        {
+                            // Per-call workdir override falls back to the
+                            // session's running cwd.
+                            let base_cwd = args_json
+                                .get("workdir")
+                                .and_then(Value::as_str)
+                                .map(PathBuf::from)
+                                .or_else(|| current_cwd.clone());
+                            extract_shell_touches(cmd, ts, base_cwd.as_deref(), &mut ev.touches);
                         }
-                        let Some(args_str) = p.get("arguments").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        let Ok(args_json) = serde_json::from_str::<Value>(args_str) else {
-                            continue;
-                        };
-                        let Some(cmd) = args_json.get("cmd").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        let ts = match event.timestamp {
-                            Some(ts) => ts,
-                            None => continue,
-                        };
-                        let base_cwd = args_json
-                            .get("workdir")
-                            .and_then(Value::as_str)
-                            .map(PathBuf::from)
-                            .or_else(|| cwd.clone());
-                        extract_shell_touches(cmd, ts, base_cwd.as_deref(), &mut touches);
+                        out.push(ev);
                     }
                     "custom_tool_call" => {
-                        let name = p.get("name").and_then(Value::as_str).unwrap_or("");
-                        if name != "apply_patch" {
-                            continue;
+                        // `apply_patch` touches files but does not count as
+                        // a turn (matching the loader's historical tally).
+                        let mut ev = StreamEvent::bare(ts);
+                        if p.get("name").and_then(Value::as_str) == Some("apply_patch")
+                            && let Some(ts) = ts
+                            && let Some(input) = p.get("input").and_then(Value::as_str)
+                        {
+                            extract_shell_touches(
+                                input,
+                                ts,
+                                current_cwd.as_deref(),
+                                &mut ev.touches,
+                            );
                         }
-                        let Some(input) = p.get("input").and_then(Value::as_str) else {
-                            continue;
-                        };
-                        let ts = match event.timestamp {
-                            Some(ts) => ts,
-                            None => continue,
-                        };
-                        extract_shell_touches(input, ts, cwd.as_deref(), &mut touches);
+                        out.push(ev);
                     }
-                    _ => {}
+                    // `reasoning` events are server-redacted; anything else
+                    // is not a harvestable shape. Window-only.
+                    _ => out.push(StreamEvent::bare(ts)),
                 }
             }
-            _ => {}
+            _ => out.push(StreamEvent::bare(ts)),
         }
     }
+    out
+}
 
-    let (Some(session_id), Some(started_at), Some(ended_at)) = (session_id, started, ended) else {
-        return Ok(None);
+/// Pull every `output_text` block out of a Codex assistant message
+/// payload. The content array can carry other types (`refusal`, future
+/// tool-result variants); we ignore those and surface only the text the
+/// model actually showed the user.
+fn collect_message_texts(payload: &Value) -> Vec<String> {
+    let Some(content) = payload.get("content").and_then(|c| c.as_array()) else {
+        return Vec::new();
     };
-
-    Ok(Some(Transcript {
-        provider: Provider::Codex,
-        session_id,
-        source_path: source_path.to_path_buf(),
-        cwd,
-        started_at,
-        ended_at,
-        turn_count,
-        files_touched: touches,
-        starting_commit,
-    }))
+    let mut out = Vec::with_capacity(content.len());
+    for block in content {
+        if block.get("type").and_then(|t| t.as_str()) != Some("output_text") {
+            continue;
+        }
+        if let Some(text) = block.get("text").and_then(|t| t.as_str())
+            && !text.trim().is_empty()
+        {
+            out.push(text.to_string());
+        }
+    }
+    out
 }
 
 /// Parse a single `exec_command` shell string for file references. Results
 /// are appended to `out`. This is deliberately conservative — false
 /// negatives (missed touches) are fine, false positives (noise) pollute
 /// the matcher.
-///
-/// Exposed `pub(crate)` so the reasoning harvester can reuse the exact
-/// same shell-parsing rules the matcher's loader uses, instead of
-/// re-deriving them and risking drift.
-pub(crate) fn extract_shell_touches(
+fn extract_shell_touches(
     cmd: &str,
     ts: DateTime<Utc>,
     base_cwd: Option<&Path>,

--- a/crates/ingest/src/transcript/mod.rs
+++ b/crates/ingest/src/transcript/mod.rs
@@ -20,6 +20,7 @@ pub mod codex;
 pub mod locator;
 pub mod matcher;
 pub mod opencode;
+pub(crate) mod stream;
 pub mod types;
 
 use std::path::{Path, PathBuf};

--- a/crates/ingest/src/transcript/opencode.rs
+++ b/crates/ingest/src/transcript/opencode.rs
@@ -124,7 +124,7 @@ pub fn load(opencode_home: &Path, repo_root: &Path) -> Vec<Transcript> {
     let total = sessions.len();
     let matching: Vec<_> = sessions
         .into_iter()
-        .filter(|s| directory_matches(&s.directory, repo_root))
+        .filter(|s| super::repo_matches_checkout(&s.directory, repo_root))
         .collect();
     debug!(
         total_sessions = total,
@@ -147,7 +147,11 @@ pub fn load(opencode_home: &Path, repo_root: &Path) -> Vec<Transcript> {
     out
 }
 
-fn open_read_only(path: &Path) -> rusqlite::Result<Connection> {
+/// Open an OpenCode SQLite file read-only. URI mode + the `?mode=ro`
+/// query param keep us from ever taking a write lock on a DB a running
+/// `opencode` may be mid-write on. Shared with the reasoning harvester so
+/// both readers open the DB identically.
+pub(crate) fn open_read_only(path: &Path) -> rusqlite::Result<Connection> {
     // URI mode lets rusqlite handle WAL sidecars the way SQLite expects.
     // The `?mode=ro` query param is belt-and-braces alongside the flag.
     let uri = format!("file:{}?mode=ro", path.display());
@@ -218,13 +222,6 @@ fn fetch_sessions(conn: &Connection) -> rusqlite::Result<Vec<SessionRow>> {
         })
     })?;
     rows.collect()
-}
-
-/// `true` if `dir` is inside `repo_root`, or `repo_root` is inside `dir`.
-/// Mirrors [`super::cwd_inside`] so repo-root/crates and crates/child-dir
-/// sessions both match.
-fn directory_matches(dir: &Path, repo_root: &Path) -> bool {
-    super::repo_matches_checkout(dir, repo_root)
 }
 
 fn load_session(conn: &Connection, s: &SessionRow, db_path: &Path) -> rusqlite::Result<Transcript> {

--- a/crates/ingest/src/transcript/stream.rs
+++ b/crates/ingest/src/transcript/stream.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//! One shared low-level event stream per transcript format.
+//!
+//! Each format (`claude`, `codex`) walks its on-disk shape exactly once
+//! and yields a sequence of normalized [`StreamEvent`]s. Both consumers
+//! fold over the same stream:
+//!
+//! - the [`Transcript`] builder ([`fold_transcript`]) — extracts the
+//!   session window, cwd, turn count, and file touches;
+//! - the reasoning harvester ([`crate::reasoning_extract`]) — projects
+//!   each event into its `AssistantEvent` shape.
+//!
+//! Keeping the parse / cwd-tracking / tool-gate machinery in one place
+//! per format removes the carbon-copied raw-event struct families and
+//! the second dispatch the two consumers used to maintain in parallel.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+
+use super::types::{FileTouch, Provider, Transcript};
+use crate::IngestError;
+
+/// One normalized event from a transcript format walk.
+///
+/// A single event may carry session metadata, a cwd signal, assistant
+/// prose, and/or file touches. Empty fields mean "this event doesn't
+/// contribute that signal" — e.g. a Claude `system` line has only a
+/// timestamp.
+pub(crate) struct StreamEvent {
+    /// Event time, when present. Bounds the session window. Events with
+    /// no timestamp still contribute metadata to the transcript but are
+    /// skipped entirely by the harvester (it has nothing to anchor).
+    pub timestamp: Option<DateTime<Utc>>,
+    /// First-wins session id hint.
+    pub session_id: Option<String>,
+    /// First-wins starting-commit hint (Codex `session_meta.git`).
+    pub starting_commit: Option<String>,
+    /// Working-directory signal for [`Transcript::cwd`].
+    pub cwd: Option<CwdSignal>,
+    /// Whether this event increments `turn_count`.
+    pub is_turn: bool,
+    /// Assistant narrative prose, verbatim. Populated only for assistant
+    /// messages; the harvester mines these for reasoning candidates.
+    pub texts: Vec<String>,
+    /// File interactions this event performed, already cwd-resolved and
+    /// kind-classified. The harvester discards the kind and keeps paths.
+    pub touches: Vec<FileTouch>,
+}
+
+impl StreamEvent {
+    /// A bare event that contributes only its timestamp to the window
+    /// (Claude `system`, Codex `event_msg`, redacted reasoning, …).
+    pub(crate) fn bare(timestamp: Option<DateTime<Utc>>) -> Self {
+        Self {
+            timestamp,
+            session_id: None,
+            starting_commit: None,
+            cwd: None,
+            is_turn: false,
+            texts: Vec::new(),
+            touches: Vec::new(),
+        }
+    }
+}
+
+/// How an event's cwd should fold into [`Transcript::cwd`].
+pub(crate) enum CwdSignal {
+    /// Set only if no cwd has been seen yet (Claude's per-line `cwd`,
+    /// Codex's `session_meta.cwd`).
+    IfUnset(PathBuf),
+    /// Overwrite unconditionally (Codex's mid-session `turn_context`).
+    Force(PathBuf),
+}
+
+/// Fold a format's event stream into a [`Transcript`]. Returns `None`
+/// when the stream carries no usable signal (no session id, or no event
+/// ever bounded the time window) — mirroring the loaders' "skip quietly"
+/// behavior for empty/aborted sessions.
+pub(crate) fn fold_transcript(
+    provider: Provider,
+    source_path: &Path,
+    events: impl IntoIterator<Item = StreamEvent>,
+) -> Option<Transcript> {
+    let mut session_id: Option<String> = None;
+    let mut cwd: Option<PathBuf> = None;
+    let mut starting_commit: Option<String> = None;
+    let mut started: Option<DateTime<Utc>> = None;
+    let mut ended: Option<DateTime<Utc>> = None;
+    let mut turn_count: u32 = 0;
+    let mut touches: Vec<FileTouch> = Vec::new();
+
+    for ev in events {
+        if let Some(ts) = ev.timestamp {
+            started = Some(started.map_or(ts, |s: DateTime<Utc>| s.min(ts)));
+            ended = Some(ended.map_or(ts, |e: DateTime<Utc>| e.max(ts)));
+        }
+        if session_id.is_none() {
+            session_id = ev.session_id;
+        }
+        if starting_commit.is_none() {
+            starting_commit = ev.starting_commit;
+        }
+        match ev.cwd {
+            Some(CwdSignal::IfUnset(c)) if cwd.is_none() => cwd = Some(c),
+            Some(CwdSignal::IfUnset(_)) => {}
+            Some(CwdSignal::Force(c)) => cwd = Some(c),
+            None => {}
+        }
+        if ev.is_turn {
+            turn_count += 1;
+        }
+        touches.extend(ev.touches);
+    }
+
+    let (Some(session_id), Some(started_at), Some(ended_at)) = (session_id, started, ended) else {
+        return None;
+    };
+
+    Some(Transcript {
+        provider,
+        session_id,
+        source_path: source_path.to_path_buf(),
+        cwd,
+        started_at,
+        ended_at,
+        turn_count,
+        files_touched: touches,
+        starting_commit,
+    })
+}
+
+/// Read a session file into a string, wrapping IO errors with the kind
+/// of source we were reading. Shared by the loaders and the harvesters
+/// so the error envelope is identical everywhere.
+pub(crate) fn read_session_text(path: &Path, what: &str) -> crate::Result<String> {
+    std::fs::read_to_string(path).map_err(|e| {
+        IngestError::Io(std::io::Error::new(
+            e.kind(),
+            format!("reading {what} {}: {e}", path.display()),
+        ))
+    })
+}


### PR DESCRIPTION
Closes #496.

## Summary

Each transcript format used to be parsed **twice** — once by the matcher loader (`transcript/{claude,codex}.rs` → `Transcript`) and once by the reasoning harvester (`reasoning_extract.rs` `harvest_{claude,codex}` → `AssistantEvent`) — each re-walking the same on-disk shape with carbon-copied serde raw-event struct families and a parallel event dispatch.

This introduces a shared `transcript::stream` module. For each format, one `pub(crate) stream_events()` walk yields a normalized `StreamEvent` (timestamp, session/cwd/commit hints, turn flag, assistant texts, kind-classified file touches). **Both** consumers fold over the same stream:

- the `Transcript` builder via the shared `fold_transcript()`;
- the reasoning harvester via a shared `assistant_events()` projection.

Subsumes the sweep findings:
- **Codex walk** unified (codex.rs vs harvest_codex) — single JSONL walk + cwd tracking + response_item dispatch + `extract_shell_touches` (now private).
- **Claude raw-event family** unified — deleted the duplicate `ClaudeRawEvent`/`ClaudeRawMessage`/`ClaudeRawContent`/`ClaudeRawBlock`/`ClaudeRawToolInput` structs; one `RawEvent` family in `claude.rs`.
- Shared `read_session_text(path, what)` helper (was 4 copies).
- Shared read-only SQLite opener (`opencode::open_read_only`, now `pub(crate)`; harvest_opencode reuses it).
- Inlined the `directory_matches` pass-through.
- Removed the unused `harvest_from_codex_events` no-op placeholder.

Behavior is unchanged — same `Transcript`s and `AssistantEvent`s for the same inputs.

Net ~-110 lines across the touched files (the shared `stream` module is new but replaces two inline folds + two dup struct families + 4 read helpers).

## Test plan
- [x] `cargo test --locked -p heddle-ingest` — 189 passed, 0 failed
- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — all suites 0 failed (one `heddle-cli` doctest hit a stale-rlib shared-target race; passes when re-run in isolation)
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783152500&installation_id=132405951&pr_number=507&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F507&signature=60baf7f569bfd01203c48886595e54c5fc5332877fb2be4f941600f9136a89f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->