### PR TITLE
refactor(client): deepen hosted-session setup (one session-open entry)

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1220,7 +1220,10 @@ async fn clone_network(
     server_key: Option<String>,
     endpoint_spec: String,
 ) -> Result<()> {
-    use crate::{client::HostedGrpcClient, config::UserConfig};
+    use crate::{
+        client::{HostedAuthMode, HostedSession},
+        config::UserConfig,
+    };
 
     let CloneOptions {
         thread,
@@ -1239,10 +1242,7 @@ async fn clone_network(
     // filesystem/repo mutation such as `create_dir_all`, `Repository::init`,
     // state writes, or ref publishes. A rejected security config must leave
     // no partial on-disk artifact.
-    let mut config = user_config.heddle_client_config(None)?;
-    if let Some(key) = server_key {
-        config = config.with_server_key(key);
-    }
+    let session = HostedSession::build(&user_config, server_key, HostedAuthMode::ConfigToken)?;
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
 
     let mut cleanup = CloneDestinationCleanup::new(local_path);
@@ -1253,8 +1253,7 @@ async fn clone_network(
     // Initialize the local repository only after TLS/auth prevalidation.
     let local_repo = Repository::init(local_path)?;
 
-    let mut client = HostedGrpcClient::connect(addr, &config).await?;
-    client.auto_rotate_if_needed().await;
+    let mut client = session.connect(addr).await?;
 
     if should_output_json(cli, Some(local_repo.config())) {
         println!(

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -12,8 +12,6 @@ use anyhow::Result;
 use objects::object::{MarkerName, ThreadName};
 #[cfg(feature = "client")]
 use objects::object::ChangeId;
-#[cfg(feature = "client")]
-use proto::AuthToken;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
 
@@ -22,12 +20,13 @@ use super::{
     remote::resolved_default_remote_name,
 };
 #[cfg(feature = "client")]
-use crate::client::HostedGrpcClient;
+use crate::client::{HostedAuthMode, HostedGrpcClient};
+#[cfg(feature = "client")]
+use crate::config::UserConfig;
 use crate::{
     bridge::GitBridge,
     cli::{Cli, should_output_json, style},
     client::LocalSync,
-    config::UserConfig,
     remote::{RemoteTarget, resolve_remote_with_key},
 };
 
@@ -119,10 +118,10 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
 
     let mut total_refs = 0;
     let mut total_objects = 0;
+    #[cfg(feature = "client")]
     let user_config = UserConfig::load_default()?;
 
     for remote_name in &remotes {
-        let token = user_config.remote_token()?;
         #[cfg(feature = "client")]
         let (target, server_key) = resolve_remote_with_key(&repo, Some(remote_name.as_str()))
             .map_err(anyhow::Error::msg)?;
@@ -145,7 +144,6 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
                             addr,
                             repo_path: repo_path.as_deref(),
                             user_config: &user_config,
-                            token,
                             server_key,
                             remote_name,
                             cli,
@@ -163,7 +161,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
                 }
                 #[cfg(not(feature = "client"))]
                 {
-                    let _ = (addr, repo_path, token);
+                    let _ = (addr, repo_path);
                     anyhow::bail!(RecoveryAdvice::network_feature_unavailable("fetch"));
                 }
             }
@@ -254,7 +252,6 @@ struct FetchNetworkOptions<'a> {
     addr: std::net::SocketAddr,
     repo_path: Option<&'a str>,
     user_config: &'a UserConfig,
-    token: Option<AuthToken>,
     server_key: Option<String>,
     remote_name: &'a str,
     cli: &'a Cli,
@@ -269,12 +266,13 @@ async fn fetch_network(
         .repo_path
         .context("network remotes must include a hosted repository path")?;
 
-    let mut config = options.user_config.heddle_client_config(options.token)?;
-    if let Some(key) = options.server_key {
-        config = config.with_server_key(key);
-    }
-    let mut client = HostedGrpcClient::connect(options.addr, &config).await?;
-    client.auto_rotate_if_needed().await;
+    let mut client = HostedGrpcClient::open_session(
+        options.addr,
+        options.user_config,
+        options.server_key,
+        HostedAuthMode::ConfigToken,
+    )
+    .await?;
 
     if !should_output_json(options.cli, Some(repo.config())) {
         println!(

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -11,8 +11,6 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use gix::{bstr::ByteSlice, refs::transaction::PreviousValue};
 use objects::{fs_atomic::write_file_atomic, object::ThreadName};
-#[cfg(feature = "client")]
-use proto::AuthToken;
 use refs::Head;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
@@ -25,7 +23,7 @@ use super::{
     snapshot::ensure_current_state,
 };
 #[cfg(feature = "client")]
-use crate::client::{ClientConfig, HostedGrpcClient};
+use crate::client::{HostedAuthMode, HostedSession};
 use crate::{
     bridge::{
         GitBridge,
@@ -334,40 +332,35 @@ pub async fn cmd_push(
 
     preflight_native_remote_transport(&repo, remote.as_deref(), "push")?;
 
+    #[cfg(not(feature = "client"))]
     let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
-    let mut token = token;
     let (target, server_key) =
         resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
-
-    // Fall back to the credential store if no token was provided via env/config.
-    #[cfg(feature = "client")]
-    let mut credential_proof_key: Option<String> = None;
     #[cfg(not(feature = "client"))]
-    let credential_proof_key: Option<String> = None;
-    #[cfg(feature = "client")]
-    if token.is_none()
-        && let Some(ref key) = server_key
-        && let Ok(Some(cred)) = heddle_client::credentials::resolve_credential_for_server(key)
-    {
-        token = Some(AuthToken::new(cred.token, "credential-store"));
-        credential_proof_key = cred.private_key_pem;
-    }
+    let (target, _server_key) =
+        resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
 
-    let network_client_config = if matches!(target, RemoteTarget::Network { .. }) {
-        let mut config = user_config.heddle_client_config(token.clone())?;
-        if let Some(ref key) = server_key {
-            config = config.with_server_key(key.clone());
-        }
-        if let Some(ref pem) = credential_proof_key
-            && config.auth_proof_key_pem.is_none()
-        {
-            config = config.with_auth_proof_key_pem(pem.clone());
-        }
-        Some(config)
+    // Prevalidate auth/TLS config (including the credential-store fallback)
+    // before any irreversible state mutation below; a rejected security
+    // config must leave no partial state behind.
+    #[cfg(feature = "client")]
+    let network_session = if matches!(target, RemoteTarget::Network { .. }) {
+        Some(HostedSession::build(
+            &user_config,
+            server_key,
+            HostedAuthMode::CredentialFallback,
+        )?)
     } else {
         None
     };
+    // Builds without the `client` feature can't push over the network, but
+    // must still fail closed on a bad TLS/auth config before bootstrapping
+    // local state — matching the prevalidation the `client` build runs above.
+    #[cfg(not(feature = "client"))]
+    if matches!(target, RemoteTarget::Network { .. }) {
+        user_config.heddle_client_config(token.clone())?;
+    }
 
     let state_id = if let Some(state_str) = state {
         if matches!(state_str.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {
@@ -399,7 +392,7 @@ pub async fn cmd_push(
                 PushNetworkOptions {
                     addr,
                     repo_path: repo_path.as_deref(),
-                    client_config: network_client_config
+                    session: network_session
                         .as_ref()
                         .context("network client config was not prevalidated")?,
                     state_id: &state_id,
@@ -410,7 +403,7 @@ pub async fn cmd_push(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, token, network_client_config);
+            let _ = (addr, repo_path, token);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("push"));
         }
@@ -1157,8 +1150,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         .repo_path
         .context("network remotes must include a hosted repository path")?;
 
-    let mut client = HostedGrpcClient::connect(options.addr, options.client_config).await?;
-    client.auto_rotate_if_needed().await;
+    let mut client = options.session.connect(options.addr).await?;
 
     if !should_output_json(options.cli, Some(repo.config())) {
         println!(
@@ -1211,7 +1203,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
 struct PushNetworkOptions<'a> {
     addr: SocketAddr,
     repo_path: Option<&'a str>,
-    client_config: &'a ClientConfig,
+    session: &'a HostedSession,
     state_id: &'a objects::object::ChangeId,
     track_name: &'a str,
     force: bool,

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -9,13 +9,11 @@ use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
 use anyhow::{Context, Result};
 use gix::bstr::{BStr, BString};
 #[cfg(feature = "client")]
-use heddle_client::grpc_hosted::PullMaterialization;
+use heddle_client::grpc_hosted::{HostedAuthMode, PullMaterialization};
 use objects::{
     fs_atomic::write_file_atomic,
     object::{ChangeId, ThreadName, Tree},
 };
-#[cfg(feature = "client")]
-use proto::AuthToken;
 use refs::Head;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
@@ -296,8 +294,6 @@ pub async fn cmd_pull(
     super::preflight_native_remote_transport(&repo, remote.as_deref(), "pull")?;
 
     let user_config = UserConfig::load_default()?;
-    #[cfg(feature = "client")]
-    let mut token = user_config.remote_token()?;
     #[cfg(not(feature = "client"))]
     let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
@@ -306,18 +302,6 @@ pub async fn cmd_pull(
     #[cfg(not(feature = "client"))]
     let (target, _server_key) =
         resolve_remote_with_key(&repo, remote.as_deref()).map_err(anyhow::Error::msg)?;
-
-    // Fall back to the credential store if no token was provided via env/config.
-    #[cfg(feature = "client")]
-    let mut credential_proof_key: Option<String> = None;
-    #[cfg(feature = "client")]
-    if token.is_none()
-        && let Some(ref key) = server_key
-        && let Ok(Some(cred)) = heddle_client::credentials::resolve_credential_for_server(key)
-    {
-        token = Some(AuthToken::new(cred.token, "credential-store"));
-        credential_proof_key = cred.private_key_pem;
-    }
 
     let remote_thread = thread.unwrap_or_else(|| "main".to_string());
     let local_thread_name = local_thread.as_deref();
@@ -341,9 +325,7 @@ pub async fn cmd_pull(
                     addr,
                     repo_path: repo_path.as_deref(),
                     user_config: &user_config,
-                    token,
                     server_key,
-                    credential_proof_key,
                     remote_thread: &remote_thread,
                     local_thread: local_thread_name,
                     lazy,
@@ -500,17 +482,13 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     let repo_path = options
         .repo_path
         .context("network remotes must include a hosted repository path")?;
-    let mut config = options.user_config.heddle_client_config(options.token)?;
-    if let Some(key) = options.server_key {
-        config = config.with_server_key(key);
-    }
-    if let Some(pem) = options.credential_proof_key
-        && config.auth_proof_key_pem.is_none()
-    {
-        config = config.with_auth_proof_key_pem(pem);
-    }
-    let mut client = HostedGrpcClient::connect(options.addr, &config).await?;
-    client.auto_rotate_if_needed().await;
+    let mut client = HostedGrpcClient::open_session(
+        options.addr,
+        options.user_config,
+        options.server_key,
+        HostedAuthMode::CredentialFallback,
+    )
+    .await?;
 
     if !should_output_json(options.cli, Some(repo.config())) {
         println!(
@@ -1261,9 +1239,7 @@ struct PullNetworkOptions<'a> {
     addr: SocketAddr,
     repo_path: Option<&'a str>,
     user_config: &'a UserConfig,
-    token: Option<AuthToken>,
     server_key: Option<String>,
-    credential_proof_key: Option<String>,
     remote_thread: &'a str,
     local_thread: Option<&'a str>,
     lazy: bool,

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -28,7 +28,7 @@ use crate::{
         },
         should_output_json,
     },
-    client::HostedGrpcClient,
+    client::{HostedAuthMode, HostedGrpcClient},
     config::UserConfig,
     remote::{RemoteTarget, resolve_remote_with_key},
 };
@@ -111,17 +111,9 @@ async fn open_heddle_client(
     };
 
     let user_config = UserConfig::load_default()?;
-    // If a token isn't in the user-level config, the per-server
-    // credential file (looked up via `server_key`) supplies it. Pass
-    // whatever the user-level config has and let `with_server_key`
-    // resolve the rest.
-    let token = user_config.remote_token()?;
-    let mut config = user_config.heddle_client_config(token)?;
-    if let Some(key) = server_key {
-        config = config.with_server_key(key);
-    }
-    let mut client = HostedGrpcClient::connect(addr, &config).await?;
-    client.auto_rotate_if_needed().await;
+    let client =
+        HostedGrpcClient::open_session(addr, &user_config, server_key, HostedAuthMode::ConfigToken)
+            .await?;
     Ok((client, repo_path))
 }
 

--- a/crates/cli/src/client/mod.rs
+++ b/crates/cli/src/client/mod.rs
@@ -8,7 +8,7 @@ pub mod local_sync;
 
 pub use cli_shared::ClientConfig;
 #[cfg(feature = "client")]
-pub use heddle_client::HostedGrpcClient;
+pub use heddle_client::{HostedAuthMode, HostedGrpcClient, HostedSession};
 #[cfg(unix)]
 pub use local_daemon::{
     LocalDaemonChannel, connect_local_daemon_channel, detect_local_daemon_with_connect_probe,

--- a/crates/client/src/grpc_hosted/hydration.rs
+++ b/crates/client/src/grpc_hosted/hydration.rs
@@ -11,7 +11,7 @@ use objects::{
 use proto::ProtocolError;
 use repo::{BlobHydrator, Repository};
 
-use super::HostedGrpcClient;
+use super::{HostedAuthMode, HostedGrpcClient, HostedSession};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PullMaterialization {
@@ -217,11 +217,15 @@ impl HydrationBridge {
         let user_config = cli_shared::UserConfig::load_default().map_err(|err| {
             HeddleError::Config(format!("lazy hosted hydrator: load user config: {err}"))
         })?;
-        let client_config = user_config.heddle_client_config(None).map_err(|err| {
-            HeddleError::Config(format!(
-                "lazy hosted hydrator: load TLS/auth client config: {err}"
-            ))
-        })?;
+        // Build + validate the session config on this thread so a rejected
+        // TLS/auth config surfaces synchronously, before the worker thread is
+        // spawned. The worker connects + rotates through `session.connect`.
+        let session = HostedSession::build(&user_config, None, HostedAuthMode::ConfigToken)
+            .map_err(|err| {
+                HeddleError::Config(format!(
+                    "lazy hosted hydrator: load TLS/auth client config: {err}"
+                ))
+            })?;
 
         // Build the worker thread first so the bridge can store the
         // tx side immediately. The worker's runtime + client are
@@ -252,21 +256,17 @@ impl HydrationBridge {
                 };
 
                 let connect_result = runtime.block_on(async {
-                    let mut client = HostedGrpcClient::connect(addr, &client_config)
-                        .await
-                        .map_err(|err: ProtocolError| {
-                            HeddleError::Config(format!(
-                                "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
-                                 (resolved to {addr}): {err}",
-                            ))
-                        })?;
-                    // Rotate the cached token if it's near expiry. The
-                    // other hosted entry points (clone, fetch, remote ops,
-                    // thread_approval) do this immediately after connect;
-                    // matching the pattern keeps lazy hydration reliable
-                    // across process boundaries when the persisted token
-                    // is stale at first use.
-                    client.auto_rotate_if_needed().await;
+                    // `session.connect` connects and runs mandatory rotation
+                    // together — the same seam every other hosted entry point
+                    // (clone, fetch, push, pull, support, approval) opens
+                    // through — so a process whose cached token has slipped
+                    // past expiry recovers on first lazy hydrate.
+                    let client = session.connect(addr).await.map_err(|err: ProtocolError| {
+                        HeddleError::Config(format!(
+                            "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
+                             (resolved to {addr}): {err}",
+                        ))
+                    })?;
                     Ok::<_, HeddleError>(client)
                 });
                 let mut client = match connect_result {
@@ -880,36 +880,23 @@ mod register_factory_tests {
 
 #[cfg(test)]
 mod connect_path_tests {
-    //! Source-presence test for the round-3 credential-rotation fix.
-    //! The lazy hydration connect path must call `auto_rotate_if_needed`
-    //! immediately after `HostedGrpcClient::connect` to match the pattern
-    //! every other hosted entry point (clone, fetch, remote ops,
-    //! thread_approval) uses; without it, a process whose cached token
-    //! has slipped past expiry hits an auth failure on first lazy
-    //! hydrate even though the rotation data is on disk.
-    //!
-    //! A spy-based behavioural test would require restructuring the
-    //! client to accept an injected rotation hook; this presence test
-    //! is the lighter-weight equivalent and surfaces a regression if a
-    //! future refactor silently drops the rotation call.
+    //! Source-presence test for the credential-rotation invariant. Lazy
+    //! hydration must open its session through the shared `HostedSession`
+    //! seam — whose `connect` connects and rotates together (guarded by a
+    //! source-presence test in `session.rs`) — rather than connecting by
+    //! hand and risking a dropped rotation. Without rotation, a process
+    //! whose cached token has slipped past expiry hits an auth failure on
+    //! first lazy hydrate even though the rotation data is on disk.
     #[test]
-    fn lazy_hosted_connect_rotates_credentials_if_needed() {
+    fn lazy_hosted_connect_opens_session_through_rotating_seam() {
         let source = include_str!("hydration.rs");
-        let connect_idx = source
-            .find("HostedGrpcClient::connect(addr, &client_config)")
-            .expect("hydration.rs must call HostedGrpcClient::connect with the resolved addr");
-        let after_connect = &source[connect_idx..];
-        let rotate_offset = after_connect
-            .find("auto_rotate_if_needed")
-            .expect("auto_rotate_if_needed must appear in hydration.rs");
-        // Bound the search: the rotation call must be in the same async
-        // block as the connect, not in some unrelated section of the
-        // file. 1200 chars is generous for the connect/rotate pair plus
-        // the surrounding error handling and inline doc comments.
         assert!(
-            rotate_offset < 1200,
-            "auto_rotate_if_needed must follow HostedGrpcClient::connect within the \
-             same async block (found {rotate_offset} chars later)",
+            source.contains("HostedSession::build(&user_config, None, HostedAuthMode::ConfigToken)"),
+            "hydration.rs must build its session through the shared HostedSession seam",
+        );
+        assert!(
+            source.contains("session.connect(addr)"),
+            "hydration.rs must connect via HostedSession::connect, which owns rotation",
         );
     }
 }

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -3,6 +3,7 @@
 mod content;
 mod helpers;
 mod hydration;
+mod session;
 mod sync;
 mod user;
 
@@ -344,3 +345,4 @@ impl HostedGrpcClient {
 }
 
 pub use hydration::{LazyHostedHydrator, PullMaterialization, register_hosted_factory};
+pub use session::{HostedAuthMode, HostedSession};

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -1,0 +1,134 @@
+//! Hosted-session open seam.
+//!
+//! "Open a usable hosted session for a remote" used to be hand-assembled at
+//! every hosted entry point (push, pull, fetch, clone, support, approval,
+//! lazy hydration): resolve the auth token, fall back to the credential
+//! store, attach the proof key, build the validated client config, connect,
+//! then run mandatory credential rotation. This module owns that assembly so
+//! the command modules choose only intent + remote and call one seam.
+
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use cli_shared::{ClientConfig, UserConfig};
+use proto::{AuthToken, ProtocolError};
+
+use crate::{credentials, grpc_hosted::HostedGrpcClient};
+
+/// How a hosted session resolves its auth token.
+pub enum HostedAuthMode {
+    /// Use only the token from env/user config (`remote_token`). Used by
+    /// fetch, support, approval, clone, and lazy hydration.
+    ConfigToken,
+    /// Use the config token, falling back to the per-server credential store
+    /// (and its proof key) when no config token is present. Used by push and
+    /// pull.
+    CredentialFallback,
+}
+
+/// A validated, connectable hosted-session configuration.
+///
+/// Building runs the fallible TLS/auth validation up front, so callers that
+/// must not leave partial on-disk artifacts (clone, push) — or that build the
+/// config on one thread and connect on another (lazy hydration) — can
+/// prevalidate before any irreversible work, then `connect()` afterwards.
+/// Callers with no such ordering constraint use
+/// [`HostedGrpcClient::open_session`], which builds and connects in one call.
+pub struct HostedSession {
+    config: ClientConfig,
+}
+
+impl HostedSession {
+    /// Resolve auth + build the validated client config for a hosted session.
+    /// Owns credential-store fallback (per `mode`), server-key attachment, and
+    /// proof-key attachment — the assembly the command modules used to
+    /// hand-roll.
+    pub fn build(
+        user_config: &UserConfig,
+        server_key: Option<String>,
+        mode: HostedAuthMode,
+    ) -> Result<Self> {
+        let (token, credential_proof_key) = match mode {
+            HostedAuthMode::ConfigToken => (user_config.remote_token()?, None),
+            HostedAuthMode::CredentialFallback => {
+                let mut token = user_config.remote_token()?;
+                let mut credential_proof_key = None;
+                if token.is_none()
+                    && let Some(ref key) = server_key
+                    && let Ok(Some(cred)) = credentials::resolve_credential_for_server(key)
+                {
+                    token = Some(AuthToken::new(cred.token, "credential-store"));
+                    credential_proof_key = cred.private_key_pem;
+                }
+                (token, credential_proof_key)
+            }
+        };
+
+        let mut config = user_config.heddle_client_config(token)?;
+        if let Some(key) = server_key {
+            config = config.with_server_key(key);
+        }
+        if let Some(pem) = credential_proof_key
+            && config.auth_proof_key_pem.is_none()
+        {
+            config = config.with_auth_proof_key_pem(pem);
+        }
+        Ok(Self { config })
+    }
+
+    /// Connect and run mandatory credential rotation.
+    ///
+    /// The rotation MUST run immediately after connect — every hosted entry
+    /// point relies on a fresh token before its first RPC. This is the single
+    /// place that pairs connect with rotation; see the source-presence guard
+    /// in this module's tests.
+    pub async fn connect(&self, addr: SocketAddr) -> Result<HostedGrpcClient, ProtocolError> {
+        let mut client = HostedGrpcClient::connect(addr, &self.config).await?;
+        client.auto_rotate_if_needed().await;
+        Ok(client)
+    }
+}
+
+impl HostedGrpcClient {
+    /// Open a usable hosted session in one call: resolve auth, build the
+    /// validated client config, connect, and run mandatory rotation. Callers
+    /// that must prevalidate the config before irreversible work build a
+    /// [`HostedSession`] first, then [`HostedSession::connect`].
+    pub async fn open_session(
+        addr: SocketAddr,
+        user_config: &UserConfig,
+        server_key: Option<String>,
+        mode: HostedAuthMode,
+    ) -> Result<Self> {
+        Ok(HostedSession::build(user_config, server_key, mode)?
+            .connect(addr)
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The connect/rotate invariant now lives here, in the one seam every
+    //! hosted entry point opens its session through. This source-presence
+    //! guard replaces the per-call-site rotation checks: rotation MUST run
+    //! immediately after `HostedGrpcClient::connect`, or a process whose
+    //! cached token has slipped past expiry hits an auth failure on its first
+    //! RPC even though the rotation data is on disk.
+
+    #[test]
+    fn session_connect_rotates_credentials_after_connect() {
+        let source = include_str!("session.rs");
+        let connect_idx = source
+            .find("HostedGrpcClient::connect(addr, &self.config)")
+            .expect("session.rs must connect with the resolved addr");
+        let after_connect = &source[connect_idx..];
+        let rotate_offset = after_connect
+            .find("auto_rotate_if_needed")
+            .expect("auto_rotate_if_needed must appear in session.rs");
+        assert!(
+            rotate_offset < 400,
+            "auto_rotate_if_needed must follow HostedGrpcClient::connect within the \
+             same async block (found {rotate_offset} chars later)",
+        );
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -19,7 +19,7 @@ pub use auth_cmd::cmd_auth;
 // callers using `weft_client::auth::{...}` resolve symbols at the
 // same path the cli used internally pre-move.
 pub use device_flow as auth;
-pub use grpc_hosted::HostedGrpcClient;
+pub use grpc_hosted::{HostedAuthMode, HostedGrpcClient, HostedSession};
 pub use presence::{
     PublisherConfig, cmd_presence_publish, resolve_publisher_config, run_publisher,
 };

--- a/crates/client/src/support.rs
+++ b/crates/client/src/support.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
 use crate::{
-    grpc_hosted::HostedGrpcClient,
+    grpc_hosted::{HostedAuthMode, HostedGrpcClient},
     support_args::{SupportCommands, SupportGrantArgs, SupportListArgs, SupportRevokeArgs},
 };
 
@@ -117,14 +117,7 @@ async fn open_client(repo: &Repository, remote: &str) -> Result<HostedGrpcClient
         }
     };
     let user_config = UserConfig::load_default()?;
-    let token = user_config.remote_token()?;
-    let mut config = user_config.heddle_client_config(token)?;
-    if let Some(key) = server_key {
-        config = config.with_server_key(key);
-    }
-    let mut client = HostedGrpcClient::connect(addr, &config).await?;
-    client.auto_rotate_if_needed().await;
-    Ok(client)
+    HostedGrpcClient::open_session(addr, &user_config, server_key, HostedAuthMode::ConfigToken).await
 }
 
 /// Parse a TTL string like `"24h"`, `"30m"`, `"4d"`, or a bare number


### PR DESCRIPTION
Closes #501.

## The seam
Adds `HostedSession` in `crates/client/src/grpc_hosted/session.rs` — the single entry that owns "open a usable hosted session for a remote":
- auth resolution (config token, with optional credential-store fallback via `HostedAuthMode`),
- proof-key attachment,
- validated `ClientConfig` build (`heddle_client_config` + `with_server_key` + `with_auth_proof_key_pem`),
- connect + **mandatory rotation** (`auto_rotate_if_needed`).

Two shapes:
- `HostedGrpcClient::open_session(addr, user_config, server_key, mode)` — build + connect in one call (fetch, support, approval, pull).
- `HostedSession::build(...)` then `.connect(addr)` — for callers that must prevalidate TLS/auth config *before* irreversible work (clone's `create_dir_all`/`init`, push's state bootstrap, lazy hydration's worker-thread spawn).

The connect/rotate invariant now lives in one place; a single source-presence test in `session.rs` guards it, replacing the per-call-site rotation check that used to live in `hydration.rs`.

## Migrated call sites (8)
- `remote/mod.rs` — **push** (credential-fallback; prevalidates before state bootstrap)
- `remote/remote_ops.rs` — **pull** (credential-fallback)
- `fetch.rs` — **fetch**
- `clone.rs` — **clone** (prevalidates before fs mutation)
- `client/support.rs` — **support**
- `thread_approval.rs` — **approval**
- `grpc_hosted/hydration.rs` — **lazy hydration** (builds on caller thread, connects in worker)

CLI command modules now choose intent + remote name and call the seam; they no longer hand-assemble the session.

## Behavior
Identical — same auth/proof/rotation order, same prevalidation-before-mutation ordering. The non-`client` build still fails closed on a bad TLS config before bootstrapping push state (preserved with a feature-gated prevalidation, since the seam itself is `client`-only).

## Test plan
- [x] `heddle-client` + `heddle-cli` lib tests green (incl. new `session.rs` invariant test + updated hydration self-check).
- [x] Oracle integration tests green under gate features: `cli_integration` (894), `core_functionality` (115), `production_features` (92) — including `push_bootstrap_validates_tls_config_before_creating_state` and all 52 `remotes::` tests.
- [x] `cargo clippy --all-targets` clean on the changed crates under gate features.
- [x] `heddle doctor docs --all` clean (no surface change).

Note: whole-workspace `cargo test` / `clippy --all-targets` is currently blocked by a pre-existing `heddle-repo` test-compile failure (missing `use oplog::OpLogBackend;` under workspace feature-unification) — confirmed reproducing on clean `main` with this branch's changes stashed, so it is orthogonal to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783156819&installation_id=132405951&pr_number=509&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F509&signature=76cc1b65859ab96a6788e5ad1082897d5aba2f8e72702829e1d330d150ed167a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->