### PR TITLE
refactor(oplog): concentrate OpRecord undo/redo per-variant semantics

### DIFF
--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -4,7 +4,7 @@
 use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::{ChangeId, ContentHash};
-use oplog::{OpBatch, OpRecord};
+use oplog::{OpBatch, RedactionUndoClass};
 use refs::UNDO_RECOVERY_HANDLE;
 use repo::{Repository, ThreadManager};
 use serde::Serialize;
@@ -605,7 +605,7 @@ fn ensure_undo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
     let mut missing: Vec<(u64, ChangeId)> = Vec::new();
     for batch in batches {
         for entry in &batch.entries {
-            for needed in states_required_for_undo(&entry.operation) {
+            for needed in entry.operation.states_required_for_undo() {
                 if !repo.store().has_state(&needed)? {
                     missing.push((entry.id, needed));
                 }
@@ -635,53 +635,6 @@ fn ensure_undo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
     )))
 }
 
-/// Identify the state IDs that an inverse for `op` would need to load.
-/// Variants whose undo is a no-op (e.g. `Fork`, `Collapse`, `Checkpoint`)
-/// or which only mutate sidecars (`Redact`) return an empty list —
-/// they don't reach into the object store, so a missing state can't
-/// trip them. `Purge` is irreversible and handled by
-/// `ensure_redaction_undo_safe`; it returns nothing here too.
-fn states_required_for_undo(op: &OpRecord) -> Vec<ChangeId> {
-    match op {
-        OpRecord::Snapshot {
-            prev_head: Some(prev),
-            ..
-        } => vec![*prev],
-        OpRecord::Goto {
-            prev_head: Some(prev),
-            ..
-        } => vec![*prev],
-        OpRecord::ThreadDelete { state, .. } => vec![*state],
-        OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
-        OpRecord::MarkerDelete { state, .. } => vec![*state],
-        OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
-        OpRecord::FastForwardV2 { pre_target_id, .. } => vec![*pre_target_id],
-        // No prior state to load: the inverse is a no-op, touches only
-        // sidecars / Git OIDs, or is irreversible. Enumerated explicitly (no
-        // wildcard) so a new state-carrying variant must declare what its undo
-        // needs to load, instead of silently skipping the reachability check
-        // (heddle#354 r9).
-        OpRecord::Snapshot { prev_head: None, .. }
-        | OpRecord::Goto { prev_head: None, .. }
-        | OpRecord::ThreadCreate { .. }
-        | OpRecord::ThreadCreateV2 { .. }
-        | OpRecord::Fork { .. }
-        | OpRecord::Collapse { .. }
-        | OpRecord::MarkerCreate { .. }
-        | OpRecord::Checkpoint { .. }
-        | OpRecord::TransactionAbort { .. }
-        | OpRecord::EphemeralThreadCollapse { .. }
-        | OpRecord::ConflictResolved { .. }
-        | OpRecord::TransactionCommit { .. }
-        | OpRecord::Redact { .. }
-        | OpRecord::Purge { .. }
-        | OpRecord::GitCheckpoint { .. }
-        | OpRecord::RemoteThreadUpdate { .. }
-        | OpRecord::RemoteThreadDelete { .. }
-        | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
-    }
-}
-
 /// Symmetric to `ensure_undo_states_reachable`: walk every batch we'd
 /// redo and verify the post-state it would advance to is still in the
 /// object store. Without this check, a `gc --prune` that reached past
@@ -696,7 +649,7 @@ fn ensure_redo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
     let mut missing: Vec<(u64, ChangeId)> = Vec::new();
     for batch in batches {
         for entry in &batch.entries {
-            for needed in states_required_for_redo(&entry.operation) {
+            for needed in entry.operation.states_required_for_redo() {
                 if !repo.store().has_state(&needed)? {
                     missing.push((entry.id, needed));
                 }
@@ -724,40 +677,6 @@ fn ensure_redo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
         "heddle log",
         vec!["heddle log".to_string()],
     )))
-}
-
-fn states_required_for_redo(op: &OpRecord) -> Vec<ChangeId> {
-    match op {
-        OpRecord::Snapshot { new_state, .. } => vec![*new_state],
-        OpRecord::Goto { target, .. } => vec![*target],
-        OpRecord::ThreadCreate { state, .. } => vec![*state],
-        OpRecord::ThreadCreateV2 { state, .. } => vec![*state],
-        OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
-        OpRecord::MarkerCreate { state, .. } => vec![*state],
-        OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
-        // No post-state to load at redo time: the redo is a no-op, deletes a
-        // ref, touches only sidecars / Git OIDs, or (legacy V1 `FastForward`)
-        // re-resolves `source_thread → tip` through its own error path.
-        // Enumerated explicitly (no wildcard) so a new state-carrying variant
-        // must declare its redo target instead of silently skipping the
-        // reachability check (heddle#354 r9).
-        OpRecord::ThreadDelete { .. }
-        | OpRecord::MarkerDelete { .. }
-        | OpRecord::Fork { .. }
-        | OpRecord::Collapse { .. }
-        | OpRecord::Checkpoint { .. }
-        | OpRecord::TransactionAbort { .. }
-        | OpRecord::EphemeralThreadCollapse { .. }
-        | OpRecord::ConflictResolved { .. }
-        | OpRecord::TransactionCommit { .. }
-        | OpRecord::Redact { .. }
-        | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. }
-        | OpRecord::GitCheckpoint { .. }
-        | OpRecord::RemoteThreadUpdate { .. }
-        | OpRecord::RemoteThreadDelete { .. }
-        | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
-    }
 }
 
 /// Pre-flight check for redaction-related ops in the batch chain.
@@ -798,41 +717,17 @@ fn ensure_redaction_undo_safe(
 
     for batch in batches {
         for entry in &batch.entries {
-            match &entry.operation {
-                OpRecord::Purge { redaction_id, .. } => purge_ops.push((entry.id, *redaction_id)),
-                OpRecord::Redact {
-                    blob, state, path, ..
-                } => redact_ops.push(RedactSummary {
+            match entry.operation.redaction_undo_class() {
+                RedactionUndoClass::Purge { redaction_id } => {
+                    purge_ops.push((entry.id, *redaction_id))
+                }
+                RedactionUndoClass::Redact { blob, state, path } => redact_ops.push(RedactSummary {
                     op_id: entry.id,
                     blob: *blob,
                     state: *state,
-                    path: path.clone(),
+                    path: path.to_string(),
                 }),
-                // This preflight only concerns redaction bookkeeping; every
-                // other record is irrelevant to undo safety. Enumerated
-                // explicitly (no wildcard) so a future redaction-adjacent
-                // variant must be classified here (heddle#354 r9).
-                OpRecord::Snapshot { .. }
-                | OpRecord::Goto { .. }
-                | OpRecord::ThreadCreate { .. }
-                | OpRecord::ThreadCreateV2 { .. }
-                | OpRecord::ThreadDelete { .. }
-                | OpRecord::ThreadUpdate { .. }
-                | OpRecord::Fork { .. }
-                | OpRecord::Collapse { .. }
-                | OpRecord::MarkerCreate { .. }
-                | OpRecord::MarkerDelete { .. }
-                | OpRecord::Checkpoint { .. }
-                | OpRecord::TransactionAbort { .. }
-                | OpRecord::EphemeralThreadCollapse { .. }
-                | OpRecord::ConflictResolved { .. }
-                | OpRecord::TransactionCommit { .. }
-                | OpRecord::FastForward { .. }
-                | OpRecord::FastForwardV2 { .. }
-                | OpRecord::GitCheckpoint { .. }
-                | OpRecord::RemoteThreadUpdate { .. }
-                | OpRecord::RemoteThreadDelete { .. }
-                | OpRecord::UndoRecoveryUpdate { .. } => {}
+                RedactionUndoClass::Other => {}
             }
         }
     }
@@ -930,34 +825,8 @@ fn ensure_redaction_redo_supported(batches: &[OpBatch]) -> Result<()> {
     let mut blocking: Vec<(u64, &'static str)> = Vec::new();
     for batch in batches {
         for entry in &batch.entries {
-            match &entry.operation {
-                OpRecord::Redact { .. } => blocking.push((entry.id, "Redact")),
-                OpRecord::Purge { .. } => blocking.push((entry.id, "Purge")),
-                // Only Redact/Purge lack a faithful redo path; every other
-                // record redoes normally. Enumerated explicitly (no wildcard)
-                // so a future variant without a redo path must be classified
-                // here (heddle#354 r9).
-                OpRecord::Snapshot { .. }
-                | OpRecord::Goto { .. }
-                | OpRecord::ThreadCreate { .. }
-                | OpRecord::ThreadCreateV2 { .. }
-                | OpRecord::ThreadDelete { .. }
-                | OpRecord::ThreadUpdate { .. }
-                | OpRecord::Fork { .. }
-                | OpRecord::Collapse { .. }
-                | OpRecord::MarkerCreate { .. }
-                | OpRecord::MarkerDelete { .. }
-                | OpRecord::Checkpoint { .. }
-                | OpRecord::TransactionAbort { .. }
-                | OpRecord::EphemeralThreadCollapse { .. }
-                | OpRecord::ConflictResolved { .. }
-                | OpRecord::TransactionCommit { .. }
-                | OpRecord::FastForward { .. }
-                | OpRecord::FastForwardV2 { .. }
-                | OpRecord::GitCheckpoint { .. }
-                | OpRecord::RemoteThreadUpdate { .. }
-                | OpRecord::RemoteThreadDelete { .. }
-                | OpRecord::UndoRecoveryUpdate { .. } => {}
+            if let Some(label) = entry.operation.redo_unsupported_label() {
+                blocking.push((entry.id, label));
             }
         }
     }
@@ -1008,36 +877,11 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
 
     for batch in batches {
         for entry in &batch.entries {
-            // Match V1 and V2 — the rename batch's new-name arm and all
-            // post-heddle#23-r2 creates record as V2. Both have the
-            // same worktree-orphan hazard on undo.
-            let name = match &entry.operation {
-                OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => name,
-                // Only thread creates carry the worktree-orphan hazard on undo;
-                // every other record is irrelevant to this preflight.
-                // Enumerated explicitly (no wildcard) so a future
-                // worktree-creating variant must be classified (heddle#354 r9).
-                OpRecord::Snapshot { .. }
-                | OpRecord::Goto { .. }
-                | OpRecord::ThreadDelete { .. }
-                | OpRecord::ThreadUpdate { .. }
-                | OpRecord::Fork { .. }
-                | OpRecord::Collapse { .. }
-                | OpRecord::MarkerCreate { .. }
-                | OpRecord::MarkerDelete { .. }
-                | OpRecord::Checkpoint { .. }
-                | OpRecord::TransactionAbort { .. }
-                | OpRecord::EphemeralThreadCollapse { .. }
-                | OpRecord::ConflictResolved { .. }
-                | OpRecord::TransactionCommit { .. }
-                | OpRecord::Redact { .. }
-                | OpRecord::Purge { .. }
-                | OpRecord::FastForward { .. }
-                | OpRecord::FastForwardV2 { .. }
-                | OpRecord::GitCheckpoint { .. }
-                | OpRecord::RemoteThreadUpdate { .. }
-                | OpRecord::RemoteThreadDelete { .. }
-                | OpRecord::UndoRecoveryUpdate { .. } => continue,
+            // V1 and V2 thread-creates (the rename batch's new-name arm and all
+            // post-heddle#23-r2 creates) share the worktree-orphan hazard on
+            // undo; every other record is irrelevant to this preflight.
+            let Some(name) = entry.operation.thread_worktree_undo_hazard_name() else {
+                continue;
             };
             // The `ThreadCreate` inverse converges the name to EMPTY — it removes
             // EVERY record filed under the name, not just the `find_by_thread`
@@ -1049,7 +893,7 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
                     continue;
                 };
                 if path.exists() {
-                    blocking.push((entry.id, name.clone(), path.clone()));
+                    blocking.push((entry.id, name.to_string(), path.clone()));
                 }
             }
         }
@@ -1093,7 +937,7 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
 
 #[cfg(test)]
 mod tests {
-    use oplog::OpLogBackend;
+    use oplog::{OpLogBackend, OpRecord};
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -17,7 +17,7 @@ pub use oplog_backend::OpLogBackend;
 pub use oplog_core::OpLog;
 pub use oplog_types::{
     ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    isolation_keys_for_record,
+    RedactionUndoClass, isolation_keys_for_record,
 };
 #[cfg(feature = "postgres")]
 pub use pg_oplog::PgOpLogBackend;

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -624,6 +624,210 @@ impl OpRecord {
     }
 }
 
+/// How a record participates in undo's redaction-safety preflight.
+///
+/// Returned by [`OpRecord::redaction_undo_class`] so the CLI preflight reads
+/// the classification off the variant instead of re-deriving it from an
+/// exhaustive match (heddle#500). The borrowed fields are exactly what the
+/// CLI needs to build its refusal messages and `redaction_is_purged` lookups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactionUndoClass<'a> {
+    /// `Purge` — irreversible; undo of the whole chain is refused.
+    Purge { redaction_id: &'a ContentHash },
+    /// `Redact` — reversible but gated: undo re-exposes hidden content, so it
+    /// runs only with `--allow-redact-undo`, and is refused outright if the
+    /// blob bytes have since been purged.
+    Redact {
+        blob: &'a ContentHash,
+        state: &'a ChangeId,
+        path: &'a str,
+    },
+    /// Every other record is irrelevant to redaction-undo safety.
+    Other,
+}
+
+/// Per-variant undo/redo semantics, classified beside `OpRecord` so adding a
+/// variant updates these rules in one place rather than editing CLI safety
+/// matches (heddle#500, architecture-deepening C3). Each match enumerates
+/// every variant with no wildcard, so the compiler forces a new variant to
+/// declare its undo/redo semantics here.
+impl OpRecord {
+    /// State IDs the *undo* inverse must load from the object store. Variants
+    /// whose undo is a no-op, only mutates sidecars/Git OIDs, or is
+    /// irreversible return an empty list — they can't trip a missing-state
+    /// reachability check. Enumerated explicitly (no wildcard) so a new
+    /// state-carrying variant must declare what its undo needs to load
+    /// (heddle#354 r9).
+    pub fn states_required_for_undo(&self) -> Vec<ChangeId> {
+        match self {
+            OpRecord::Snapshot {
+                prev_head: Some(prev),
+                ..
+            } => vec![*prev],
+            OpRecord::Goto {
+                prev_head: Some(prev),
+                ..
+            } => vec![*prev],
+            OpRecord::ThreadDelete { state, .. } => vec![*state],
+            OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
+            OpRecord::MarkerDelete { state, .. } => vec![*state],
+            OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
+            OpRecord::FastForwardV2 { pre_target_id, .. } => vec![*pre_target_id],
+            OpRecord::Snapshot { prev_head: None, .. }
+            | OpRecord::Goto { prev_head: None, .. }
+            | OpRecord::ThreadCreate { .. }
+            | OpRecord::ThreadCreateV2 { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
+        }
+    }
+
+    /// State IDs the *redo* replay must load from the object store. Variants
+    /// whose redo is a no-op, deletes a ref, touches only sidecars/Git OIDs,
+    /// or (legacy V1 `FastForward`) re-resolves `source_thread → tip` through
+    /// its own error path return an empty list. Enumerated explicitly so a new
+    /// state-carrying variant must declare its redo target (heddle#354 r9).
+    pub fn states_required_for_redo(&self) -> Vec<ChangeId> {
+        match self {
+            OpRecord::Snapshot { new_state, .. } => vec![*new_state],
+            OpRecord::Goto { target, .. } => vec![*target],
+            OpRecord::ThreadCreate { state, .. } => vec![*state],
+            OpRecord::ThreadCreateV2 { state, .. } => vec![*state],
+            OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
+            OpRecord::MarkerCreate { state, .. } => vec![*state],
+            OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
+            OpRecord::ThreadDelete { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => Vec::new(),
+        }
+    }
+
+    /// Label of the operation kind when this record has *no* faithful redo
+    /// path, else `None`. `Redact`/`Purge` can't be replayed — the OpRecord
+    /// doesn't preserve the full `Redaction` (reason, redactor, signature) and
+    /// `Purge` is irreversible. Enumerated explicitly so a future variant
+    /// without a redo path must be classified here (heddle#354 r9).
+    pub fn redo_unsupported_label(&self) -> Option<&'static str> {
+        match self {
+            OpRecord::Redact { .. } => Some("Redact"),
+            OpRecord::Purge { .. } => Some("Purge"),
+            OpRecord::Snapshot { .. }
+            | OpRecord::Goto { .. }
+            | OpRecord::ThreadCreate { .. }
+            | OpRecord::ThreadCreateV2 { .. }
+            | OpRecord::ThreadDelete { .. }
+            | OpRecord::ThreadUpdate { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::FastForwardV2 { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => None,
+        }
+    }
+
+    /// This record's role in undo's redaction-safety preflight. Enumerated
+    /// explicitly so a future redaction-adjacent variant must be classified
+    /// here (heddle#354 r9).
+    pub fn redaction_undo_class(&self) -> RedactionUndoClass<'_> {
+        match self {
+            OpRecord::Purge { redaction_id, .. } => RedactionUndoClass::Purge { redaction_id },
+            OpRecord::Redact {
+                blob, state, path, ..
+            } => RedactionUndoClass::Redact { blob, state, path },
+            OpRecord::Snapshot { .. }
+            | OpRecord::Goto { .. }
+            | OpRecord::ThreadCreate { .. }
+            | OpRecord::ThreadCreateV2 { .. }
+            | OpRecord::ThreadDelete { .. }
+            | OpRecord::ThreadUpdate { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::FastForwardV2 { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => RedactionUndoClass::Other,
+        }
+    }
+
+    /// The thread name if undoing this record carries the worktree-orphan
+    /// hazard — i.e. a thread-create (V1 or V2) whose inverse only removes the
+    /// ref, leaving any materialized worktree orphaned. `None` for every other
+    /// record. Enumerated explicitly so a future worktree-creating variant
+    /// must be classified here (heddle#354 r9).
+    pub fn thread_worktree_undo_hazard_name(&self) -> Option<&str> {
+        match self {
+            OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
+                Some(name)
+            }
+            OpRecord::Snapshot { .. }
+            | OpRecord::Goto { .. }
+            | OpRecord::ThreadDelete { .. }
+            | OpRecord::ThreadUpdate { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::FastForward { .. }
+            | OpRecord::FastForwardV2 { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. } => None,
+        }
+    }
+}
+
 /// Entry in the operation log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpEntry {


### PR DESCRIPTION
Closes #500. Architecture-deepening C3.

## What moved
The pure per-variant undo/redo *classification* lived in exhaustive `match &op` blocks inside `crates/cli/src/cli/commands/undo.rs`, leaking OpRecord implementation detail (safety rules + required-state rules) into the CLI. This moves that classification onto `OpRecord`, beside the variant definition in `crates/oplog/src/oplog/oplog_types.rs`:

- `OpRecord::states_required_for_undo()` — states the undo inverse must load (reachability check)
- `OpRecord::states_required_for_redo()` — states the redo replay must load
- `OpRecord::redo_unsupported_label()` — `Some("Redact"|"Purge")` for records with no faithful redo path
- `OpRecord::redaction_undo_class()` → new `RedactionUndoClass` enum (`Purge`/`Redact`/`Other`) — redaction-undo safety role
- `OpRecord::thread_worktree_undo_hazard_name()` — thread name when undo could orphan a materialized worktree

Each match enumerates every variant with **no wildcard**, so compiler exhaustiveness still forces a new variant to declare its undo/redo semantics — now in one place beside `OpRecord` instead of across five CLI matches.

## What stayed in the CLI
`undo.rs` / `undo_apply.rs` still orchestrate user flow, object-store lookups (`has_state`, `redaction_is_purged`), refusal-message rendering, and the inverse-operation apply dispatch. The five preflights (`ensure_undo_states_reachable`, `ensure_redo_states_reachable`, `ensure_redaction_undo_safe`, `ensure_redaction_redo_supported`, `ensure_thread_worktree_undo_safe`) now call the OpRecord methods instead of owning the exhaustive classification.

Net: CLI `undo.rs` −176 LoC of duplicated matches; oplog +204 LoC of authoritative semantics.

## Behavior
Identical — same undo/redo eligibility, redaction/hazard refusals, replay. No message strings changed.

## Test plan
- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — green (undo/undo_apply + cross-thread-undo + worktree-orphan tests are the oracle)
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean
- [x] `heddle doctor docs --all` — no drift across 57 files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783158330&installation_id=132405951&pr_number=510&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F510&signature=320fbd39d54a8b5902db22d63dd3d895c7c6499e4c78db81ac0017183f7ee35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->