### PR TITLE
refactor(objects): pack install returns installed ids via one validated seam

### DIFF
--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -100,6 +100,24 @@ fn validate_action_serialized(data: &[u8], id: ActionId) -> Result<Action> {
     validate_loaded_action(&id, action)
 }
 
+/// Validate every entry in a pack against its tagged id (checksum
+/// validation) and return the installed id list. This is the shared
+/// validated core for both install seams: the byte-buffer install
+/// (`install_pack`) and the memory-bounded temp-file install
+/// (`install_pack_streaming`) both run their pack through here, so
+/// both apply the same checksum validation and report the same
+/// installed ids regardless of how the bytes reach the store.
+fn validate_and_list_pack(reader: &crate::store::pack::PackReader) -> Result<Vec<PackObjectId>> {
+    let ids = reader.list_ids();
+    for id in &ids {
+        let Some((obj_type, data)) = reader.get_object_bytes(id)? else {
+            continue;
+        };
+        validate_pack_entry(id, obj_type, data.as_ref())?;
+    }
+    Ok(ids)
+}
+
 fn validate_pack_entry(id: &PackObjectId, obj_type: ObjectType, data: &[u8]) -> Result<()> {
     match (id, obj_type) {
         (PackObjectId::Hash(hash), ObjectType::Blob) => validate_blob_bytes(data, *hash),
@@ -906,14 +924,9 @@ impl ObjectStore for FsStore {
     #[instrument(skip(self, pack_data, index_data))]
     fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<PackObjectId>> {
         let reader = crate::store::pack::PackReader::from_slice(pack_data, index_data)?;
-        let ids = reader.list_ids();
-        for id in &ids {
-            let Some((obj_type, data)) = reader.get_object_bytes(id)? else {
-                continue;
-            };
-            validate_pack_entry(id, obj_type, data.as_ref())?;
-        }
+        let ids = validate_and_list_pack(&reader)?;
         self.install_pack_files(pack_data, index_data)?;
+        self.clear_recent_object_caches();
         Ok(ids)
     }
 
@@ -927,8 +940,18 @@ impl ObjectStore for FsStore {
         &self,
         pack_path: &std::path::Path,
         index_path: &std::path::Path,
-    ) -> Result<()> {
-        self.install_pack_files_streaming(pack_path, index_path)
+    ) -> Result<Vec<PackObjectId>> {
+        // Validate + list ids through the same core as the byte-buffer
+        // seam, but via an mmap-backed reader so the pack is never
+        // copied into the heap — the memory-bounded promise survives.
+        // Drop the reader (releasing the mmap) before the rename so
+        // the file move isn't racing an open mapping.
+        let ids = {
+            let reader = crate::store::pack::PackReader::open(pack_path, index_path)?;
+            validate_and_list_pack(&reader)?
+        };
+        self.install_pack_files_streaming(pack_path, index_path)?;
+        Ok(ids)
     }
 
     #[instrument(skip(self))]

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -166,7 +166,7 @@ impl ObjectStore for AnyStore {
         &self,
         pack_path: &std::path::Path,
         index_path: &std::path::Path,
-    ) -> Result<()> {
+    ) -> Result<Vec<pack::PackObjectId>> {
         any_store_dispatch!(self, install_pack_streaming(pack_path, index_path))
     }
     fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {
@@ -466,24 +466,24 @@ pub trait ObjectStore: Send + Sync {
     /// have been moved or removed depending on the backend; callers
     /// shouldn't continue to rely on them.
     ///
-    /// Returns nothing — callers that need the list of installed ids
-    /// can read the freshly-installed pack via the store. Most
-    /// callers (including `Importer`) already track inserted ids
-    /// out-of-band via the sha map and don't need a return value.
+    /// Returns the ids of the installed objects — the same set
+    /// `install_pack` reports for the equivalent byte-buffer install,
+    /// so callers (e.g. native sync) read the installed ids off the
+    /// install result instead of tracking them out-of-band.
     fn install_pack_streaming(
         &self,
         pack_path: &std::path::Path,
         index_path: &std::path::Path,
-    ) -> Result<()> {
+    ) -> Result<Vec<pack::PackObjectId>> {
         let pack_data = std::fs::read(pack_path).map_err(StoreError::from)?;
         let index_data = std::fs::read(index_path).map_err(StoreError::from)?;
-        self.install_pack(&pack_data, &index_data)?;
+        let ids = self.install_pack(&pack_data, &index_data)?;
         // Default impl: clean up the staged files. Override
         // implementations that move/rename should not call super and
         // should manage the file lifecycle themselves.
         let _ = std::fs::remove_file(pack_path);
         let _ = std::fs::remove_file(index_path);
-        Ok(())
+        Ok(ids)
     }
 
     fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {

--- a/crates/proto/src/native_pack.rs
+++ b/crates/proto/src/native_pack.rs
@@ -12,9 +12,10 @@ use crate::{ObjectId, ObjectInfo, ObjectType, ProtocolError, Result, load_object
 /// each decoded pack object is separately capped at 1 GiB in the pack
 /// reader. A 2 GiB compressed pack is materially above normal hosted
 /// sync use while still preventing an untrusted server from growing the
-/// in-memory receive buffer without limit. The receive path should move
-/// to temp-file spooling plus `install_pack_streaming` once that install
-/// API can report installed ids to callers that need them.
+/// in-memory receive buffer without limit. The receive path can now move
+/// to temp-file spooling plus `install_pack_streaming` — that install API
+/// reports the installed ids the receiver needs, so only the spooling of
+/// the receive buffer itself remains.
 pub const MAX_RECEIVED_PACK_SIZE: u64 = 2 * 1024 * 1024 * 1024;
 
 /// Maximum hosted native-pack index accepted by the receive primitive.
@@ -28,7 +29,6 @@ pub const MAX_RECEIVED_PACK_INDEX_SIZE: u64 = 256 * 1024 * 1024;
 pub struct NativePackBundle {
     pub pack_data: Vec<u8>,
     pub index_data: Vec<u8>,
-    pub ids: Vec<PackObjectId>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -52,7 +52,6 @@ pub fn build_native_pack(
     objects: &[ObjectInfo],
 ) -> Result<NativePackBundle> {
     let mut builder = PackBuilder::new(sync_pack_compression());
-    let mut ids = Vec::with_capacity(objects.len());
 
     for info in objects {
         // Redactions are sidecar records (live outside `.heddle/objects/`
@@ -64,7 +63,6 @@ pub fn build_native_pack(
         }
         let object = load_object_data(store, &info.id, info.obj_type)?;
         let pack_id = to_pack_object_id(&object.id);
-        ids.push(pack_id);
         builder.add_id(pack_id, to_pack_object_type(object.obj_type)?, object.data);
     }
 
@@ -72,7 +70,6 @@ pub fn build_native_pack(
     Ok(NativePackBundle {
         pack_data,
         index_data,
-        ids,
     })
 }
 
@@ -214,7 +211,7 @@ fn to_pack_object_type(obj_type: ObjectType) -> Result<PackObjectType> {
 mod tests {
     use objects::{
         object::Blob,
-        store::{FsStore, ObjectStore},
+        store::{FsStore, ObjectStore, pack::PackObjectId},
     };
     use tempfile::TempDir;
 
@@ -334,7 +331,7 @@ mod tests {
         let installed_ids =
             install_received_pack(&dest_store, &state.pack_data, &state.index_data).unwrap();
 
-        assert_eq!(installed_ids, bundle.ids);
+        assert_eq!(installed_ids, vec![PackObjectId::Hash(hash)]);
         let installed_blob = dest_store.get_blob(&hash).unwrap().unwrap();
         assert_eq!(installed_blob.content(), blob.content());
     }


### PR DESCRIPTION
Closes #502.

## Problem
Pack internals were deep but the install seam was shallow. The byte-buffer install (`install_pack`) validated every entry and returned installed ids; the memory-bounded temp-file install (`install_pack_streaming`) did neither — it just `rename(2)`'d the staged files into place and "returned nothing". Callers (native sync) therefore tracked installed ids out-of-band, and the two paths diverged on validation and cache behavior.

## Change — one shared validated seam
- **`validate_and_list_pack`** (new, in `fs_impl.rs`): the shared validated core — checksum-validates every pack entry against its tagged id and returns the installed id list. Both install seams run their pack through it.
- **`install_pack`** (byte-buffer) now delegates validation/listing to the shared core and clears the recent-object caches, matching the streaming path's cache invalidation.
- **`install_pack_streaming`** now returns `Vec<PackObjectId>` and validates via an **mmap-backed `PackReader::open`** before renaming — same validation + same id set as the byte-buffer path, while keeping the pack out of the heap (memory-bounded promise intact). The reader's mmap is dropped before the rename.
- **Trait default `install_pack_streaming`** updated to return the ids it gets from `install_pack`; `AnyStore` dispatch return type updated to match.

## native_pack
`NativePackBundle` drops its separately-tracked `ids` field. `build_native_pack` no longer accumulates ids, and the install result is the single source of truth for installed ids (the receive path reads them off `install_pack`/`install_pack_streaming`). Stale "API can't report ids yet" note updated.

## Behavior
Identical objects installed, same validation, same cache state. The streaming path is *strengthened* (it now validates valid packs transparently). Public `ObjectStore` surface unchanged in shape — only the streaming method's return type.

## Test plan
- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — green (pack/store/native-sync tests are the oracle).
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean.
- Updated native-sync receive test asserts `installed_ids == [PackObjectId::Hash(hash)]` from the install result instead of the dropped `bundle.ids`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783160638&installation_id=132405951&pr_number=512&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F512&signature=3e4508c5c06e91aec13f0ea065c9d6a57e150a48362342f586fab976ed00029d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->