### PR TITLE
refactor(cli): Cli::open_repo() + MUTATING spread + CommandRuntimeContract trim (part of #497)

### DIFF
--- a/crates/cli/src/cli/cli_args/cli_base.rs
+++ b/crates/cli/src/cli/cli_args/cli_base.rs
@@ -83,6 +83,24 @@ pub struct Cli {
     pub op_id: Option<String>,
 }
 
+impl Cli {
+    /// Open the Heddle repository the command should act on: the `--repo`
+    /// path if given, otherwise the current working directory (resolved
+    /// lazily so a supplied `--repo` never touches the cwd).
+    pub fn open_repo(&self) -> anyhow::Result<repo::Repository> {
+        use anyhow::Context as _;
+        let cwd;
+        let repo_path = match self.repo.as_ref() {
+            Some(path) => path,
+            None => {
+                cwd = std::env::current_dir().context("get current working directory")?;
+                &cwd
+            }
+        };
+        repo::Repository::open(repo_path).context("open Heddle repository")
+    }
+}
+
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum OutputMode {
     Json,

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -272,7 +272,7 @@ pub async fn cmd_actor_spawn(
     if let Some(name) = thread.as_deref() {
         ThreadId::new(name).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
     }
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let base_state = repo.head()?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::repository_no_head_capture_first(
@@ -421,7 +421,7 @@ pub async fn cmd_actor_spawn(
 }
 
 pub async fn cmd_actor_list(cli: &Cli, active_only: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
 
     let mut entries = registry.list()?;
@@ -473,7 +473,7 @@ pub async fn cmd_actor_list(cli: &Cli, active_only: bool) -> Result<()> {
 }
 
 pub async fn cmd_actor_show(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
 
@@ -532,7 +532,7 @@ pub async fn cmd_actor_show(cli: &Cli, session_id: Option<String>) -> Result<()>
 }
 
 pub async fn cmd_actor_done(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
     registry.update_status(&entry.session_id, AgentStatus::Complete)?;
@@ -577,7 +577,7 @@ fn actor_done_recommended_action(thread: &str, coordination_status: &str) -> Opt
 }
 
 pub async fn cmd_actor_explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = match resolve_actor_entry(&repo, &registry, session_id.as_deref()) {
         Ok(entry) => entry,

--- a/crates/cli/src/cli/commands/agent.rs
+++ b/crates/cli/src/cli/commands/agent.rs
@@ -94,7 +94,7 @@ async fn run_serve(cli: &Cli, args: &AgentServeArgs) -> Result<()> {
     }
     #[cfg(unix)]
     {
-        let repo = open_repo(cli)?;
+        let repo = cli.open_repo()?;
         let mut config = LocalDaemonConfig::from_repo(&repo);
         if let Some(socket) = args.socket.clone() {
             config = config.with_socket(socket);
@@ -146,7 +146,7 @@ async fn run_serve(cli: &Cli, args: &AgentServeArgs) -> Result<()> {
 }
 
 async fn run_status(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let pid_path = pid_path(&repo);
     let socket_path = socket_path(&repo);
     let pid = read_pid(&pid_path);
@@ -180,7 +180,7 @@ async fn run_status(cli: &Cli) -> Result<()> {
 }
 
 async fn run_stop(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let pid_path = pid_path(&repo);
 
     // Read the pidfile and require the heddle marker. A pidfile lacking
@@ -320,11 +320,6 @@ async fn run_stop(cli: &Cli) -> Result<()> {
 fn print_stop_output(_repo: &Repository, output: AgentStopOutput) -> Result<()> {
     println!("{}", serde_json::to_string(&output)?);
     Ok(())
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let cwd = std::env::current_dir().context("get current working directory")?;
-    Repository::open(cli.repo.as_ref().unwrap_or(&cwd)).context("open Heddle repository")
 }
 
 #[cfg(unix)]

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -166,7 +166,7 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
     // record, so reject an unsafe thread name here too (same early-reject
     // rule as `start_thread` / `thread create`). (heddle#464 close-the-class.)
     ThreadId::new(args.thread.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let anchor = match &args.anchor {
         Some(spec) => repo
             .resolve_state(spec)?
@@ -435,7 +435,7 @@ fn ensure_thread_record(
 }
 
 pub fn cmd_agent_heartbeat(cli: &Cli, args: AgentHeartbeatArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = registry
         .update_entry(&args.session, |entry| {
@@ -447,7 +447,7 @@ pub fn cmd_agent_heartbeat(cli: &Cli, args: AgentHeartbeatArgs) -> Result<()> {
 }
 
 pub fn cmd_agent_release(cli: &Cli, args: AgentReleaseArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let status = match args.status {
         AgentReleaseStatusArg::Complete => AgentStatus::Complete,
@@ -468,7 +468,7 @@ pub fn cmd_agent_release(cli: &Cli, args: AgentReleaseArgs) -> Result<()> {
 }
 
 pub fn cmd_agent_list(cli: &Cli, args: AgentApiListArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     if args.alive_only {
         // Sweep dead reservations before reporting so callers asking

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -118,7 +118,7 @@ impl LineInfo {
 }
 
 pub fn cmd_blame(cli: &Cli, file: String, state: Option<String>, show_context: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let target_state_id = if let Some(state_id) = state {
         if matches!(state_id.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {

--- a/crates/cli/src/cli/commands/cherry_pick.rs
+++ b/crates/cli/src/cli/commands/cherry_pick.rs
@@ -16,7 +16,7 @@ pub fn cmd_cherry_pick(
     no_commit: bool,
     force: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Cherry-pick rewrites the worktree to match a different tree. Without a
     // dirty-worktree guard, modified-but-unsnapshotted files and untracked

--- a/crates/cli/src/cli/commands/clean.rs
+++ b/crates/cli/src/cli/commands/clean.rs
@@ -19,7 +19,7 @@ struct CleanOutput {
 }
 
 pub fn cmd_clean(cli: &Cli, force: bool, dry_run: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     if !force && !dry_run {
         return Err(anyhow!(RecoveryAdvice::destructive_requires_force(

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use objects::object::State;
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
-use repo::Repository;
 use serde::Serialize;
 
 use super::{
@@ -43,7 +42,7 @@ pub fn cmd_collapse(
     into: String,
     confidence: Option<f32>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let json = should_output_json(cli, Some(repo.config()));
 
     if states.is_empty() {

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -328,40 +328,11 @@ pub struct CommandRuntimeContract {
     pub supports_op_id: bool,
     pub persists_op_id: bool,
     pub uses_bootstrap_op_id_store: bool,
-    pub mutates: bool,
-    pub observe_only: bool,
     pub help_visibility: &'static str,
     pub help_rank: u16,
     pub surface: &'static str,
     pub canonical_command: Option<&'static str>,
-    pub canonical_kind: Option<&'static str>,
-    pub canonical_note: Option<&'static str>,
-    pub advertised_action: Option<AdvertisedAction>,
-    pub feature_gate: Option<&'static str>,
-    pub exit_codes: &'static [(u8, &'static str)],
-    pub side_effects: Vec<&'static str>,
-    pub side_effect_class: &'static str,
-    pub first_run_behavior: &'static str,
     pub json_kind: &'static str,
-    pub schema_verbs: &'static [&'static str],
-    pub documented_schema_verbs: &'static [&'static str],
-    pub opaque_schema_verbs: &'static [&'static str],
-    pub may_initialize: bool,
-    pub may_import_git: bool,
-    pub may_write_worktree: bool,
-    pub may_move_ref: bool,
-    pub destructive_requires_force: bool,
-    pub writes_heddle_refs: bool,
-    pub writes_git_refs: bool,
-    pub writes_worktree: bool,
-    pub writes_config: bool,
-    pub writes_hooks: bool,
-    pub network_io: bool,
-    pub daemon_process: bool,
-    pub object_gc: bool,
-    pub external_command: bool,
-    pub requires_git_executable: bool,
-    pub destructive_data: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -752,41 +723,12 @@ const READ_JSON_OR_JSONL: CommandContract = CommandContract {
 };
 
 const MUTATING: CommandContract = CommandContract {
-    supports_json: true,
     mutates: true,
     supports_op_id: true,
-    persists_op_id: false,
     observe_only: false,
-    may_initialize: false,
-    may_import_git: false,
-    may_write_worktree: false,
     may_move_ref: true,
-    destructive_requires_force: false,
     writes_heddle_refs: true,
-    writes_git_refs: false,
-    writes_worktree: false,
-    writes_config: false,
-    writes_hooks: false,
-    network_io: false,
-    daemon_process: false,
-    object_gc: false,
-    external_command: false,
-    requires_git_executable: false,
-    destructive_data: false,
-    json_kind: "json",
-    json_discriminators: &[],
-    schema_verbs: &[],
-    documented_schema_verbs: &[],
-    opaque_schema_verbs: &[],
-    surface: "native",
-    help_visibility: "advanced",
-    help_rank: 1000,
-    canonical_command: None,
-    canonical_kind: None,
-    canonical_note: None,
-    advertised_action: None,
-    feature_gate: None,
-    exit_codes: &[],
+    ..READ_JSON
 };
 
 const MUTATING_NO_OP_ID: CommandContract = CommandContract {
@@ -3340,40 +3282,11 @@ fn runtime_contract(
         supports_op_id: contract.supports_op_id,
         persists_op_id: contract.persists_op_id,
         uses_bootstrap_op_id_store: uses_bootstrap_op_id_store(contract),
-        mutates: contract.mutates,
-        observe_only: contract.observe_only,
         help_visibility: contract.help_visibility,
         help_rank: contract.help_rank,
         surface: contract.surface,
         canonical_command: contract.canonical_command,
-        canonical_kind: contract.canonical_kind,
-        canonical_note: contract.canonical_note,
-        advertised_action: contract.advertised_action,
-        feature_gate: contract.feature_gate,
-        exit_codes: contract.exit_codes,
-        side_effects: side_effects(contract),
-        side_effect_class: side_effect_class(contract),
-        first_run_behavior: first_run_behavior(contract),
         json_kind: contract.json_kind,
-        schema_verbs: contract.schema_verbs,
-        documented_schema_verbs: contract.documented_schema_verbs,
-        opaque_schema_verbs: contract.opaque_schema_verbs,
-        may_initialize: contract.may_initialize,
-        may_import_git: contract.may_import_git,
-        may_write_worktree: contract.may_write_worktree,
-        may_move_ref: contract.may_move_ref,
-        destructive_requires_force: contract.destructive_requires_force,
-        writes_heddle_refs: contract.writes_heddle_refs,
-        writes_git_refs: contract.writes_git_refs,
-        writes_worktree: contract.writes_worktree,
-        writes_config: contract.writes_config,
-        writes_hooks: contract.writes_hooks,
-        network_io: contract.network_io,
-        daemon_process: contract.daemon_process,
-        object_gc: contract.object_gc,
-        external_command: contract.external_command,
-        requires_git_executable: contract.requires_git_executable,
-        destructive_data: contract.destructive_data,
     }
 }
 
@@ -5588,17 +5501,6 @@ mod tests {
         assert_eq!(runtime.help_visibility, entry.help_visibility);
         assert_eq!(runtime.help_rank, entry.help_rank);
         assert_eq!(runtime.surface, entry.surface);
-        assert_eq!(runtime.side_effect_class, entry.side_effect_class);
-        assert_eq!(
-            runtime.side_effects,
-            entry
-                .side_effects
-                .iter()
-                .map(String::as_str)
-                .collect::<Vec<_>>()
-        );
-        assert!(runtime.destructive_requires_force);
-        assert!(runtime.writes_worktree);
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -59,7 +59,7 @@ pub async fn run(cli: &Cli, command: &ConflictCommands) -> Result<()> {
 }
 
 async fn run_list(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(merge_state) = repo.merge_state_manager().load()? {
         let view = active_merge_conflict_view(&merge_state);
         render_conflict_list(cli, &repo, &view, true)?;
@@ -129,7 +129,7 @@ fn active_merge_conflict_view(merge_state: &MergeState) -> ConflictListOutput {
 }
 
 async fn run_show(cli: &Cli, args: &ConflictShowArgs) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(merge_state) = repo.merge_state_manager().load()? {
         return render_active_merge_conflict(cli, &repo, &merge_state, args);
     }
@@ -246,17 +246,6 @@ fn render_active_merge_conflict(
         println!("  next: {}", view.next_action);
     }
     Ok(())
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let cwd;
-    let repo_path = if let Some(path) = cli.repo.as_ref() {
-        path
-    } else {
-        cwd = std::env::current_dir().context("get current working directory")?;
-        &cwd
-    };
-    Repository::open(repo_path).context("open Heddle repository")
 }
 
 fn load_head_conflicts(repo: &Repository) -> Result<StructuredConflict> {

--- a/crates/cli/src/cli/commands/context/context_mutate.rs
+++ b/crates/cli/src/cli/commands/context/context_mutate.rs
@@ -7,7 +7,7 @@ use objects::{
     lock::RepositoryLockExt,
     object::{Annotation, AnnotationStatus, ContextBlob},
 };
-use repo::{Repository, compute_rewrite_pct};
+use repo::compute_rewrite_pct;
 
 use super::{
     apply_new_state, build_context_state, compute_source_hash, parse_kind, parse_scope,
@@ -34,7 +34,7 @@ pub async fn cmd_context_set(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let target = resolve_target(&repo, path, state)?;
     let scope = parse_scope(scope.as_deref())?;
     target.validate_scope(&scope)?;
@@ -112,7 +112,7 @@ pub async fn cmd_context_edit(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let content = read_annotation_content(message, file)?;
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;
     let head_state = resolve_state(&repo, None)?;
@@ -194,7 +194,7 @@ pub async fn cmd_context_supersede(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let content = read_annotation_content(message, file)?;
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;
     let head_state = resolve_state(&repo, None)?;
@@ -287,7 +287,7 @@ pub async fn cmd_context_rm(
     scope: Option<String>,
     all: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let target = resolve_target(&repo, path, state)?;
 
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/cli/src/cli/commands/context/context_query.rs
+++ b/crates/cli/src/cli/commands/context/context_query.rs
@@ -41,7 +41,7 @@ pub async fn cmd_context_get(
     tag: Option<String>,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let target = super::resolve_target(&repo, path, state)?;
     let Some(context_root) = &state_obj.context else {
@@ -72,7 +72,7 @@ pub async fn cmd_context_list(
     r#ref: Option<String>,
     include_superseded: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let Some(context_root) = &state_obj.context else {
         if should_output_json(cli, None) {
@@ -150,7 +150,7 @@ pub async fn cmd_context_history(
     annotation_id: String,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let context_root = state_obj
         .context
@@ -217,7 +217,7 @@ pub async fn cmd_context_check(
     tag: Option<String>,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let context_root = state_obj
         .context
@@ -352,7 +352,7 @@ pub async fn cmd_context_check(
 }
 
 pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let suggestions = repo.suggest_context_targets(&state_obj, limit)?;
 
@@ -398,7 +398,7 @@ pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize)
 }
 
 pub async fn cmd_context_audit(cli: &Cli, r#ref: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let Some(context_root) = &state_obj.context else {
         if should_output_json(cli, None) {

--- a/crates/cli/src/cli/commands/diagnose.rs
+++ b/crates/cli/src/cli/commands/diagnose.rs
@@ -239,7 +239,7 @@ pub(crate) fn build_diagnose_output(cli: &Cli, include_profile: bool) -> Result<
     let total_start = Instant::now();
 
     let repo_open_start = Instant::now();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let repo_open_ms = repo_open_start.elapsed().as_millis();
 
     let current_state_start = Instant::now();

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -47,7 +47,7 @@ struct FetchOutput {
 }
 
 pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let remotes = if all {
             let configured = repo.refs().list_remotes()?;

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use objects::object::{State, ThreadName};
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
-use repo::Repository;
 use serde::Serialize;
 
 use super::{
@@ -35,7 +34,7 @@ struct ForkOutput {
 ///
 /// If `--name` is provided, a new thread is created pointing to the new state.
 pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let user_config = UserConfig::load_default()?;
 
     // Determine the source state

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -28,7 +28,7 @@ struct FsckOutput {
 }
 
 pub fn cmd_fsck(cli: &Cli, full: bool, thorough: bool, repair: bool, bridge: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let mut errors: Vec<FsckError> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();

--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -13,7 +13,6 @@
 
 use objects::store::ObjectStore;
 use anyhow::Result;
-use repo::Repository;
 use serde::Serialize;
 
 #[cfg(feature = "git-overlay")]
@@ -38,7 +37,7 @@ struct GcOutput {
 }
 
 pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let json = should_output_json(cli, Some(repo.config()));
     let mut summary = GcOutput {
         output_kind: "gc",

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1322,7 +1322,7 @@ pub async fn cmd_switch_compat(cli: &Cli, args: SwitchArgs) -> Result<()> {
             vec![primary],
         )));
     }
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if repo.refs().get_thread(&ThreadName::new(&args.target))?.is_some() {
         return cmd_thread(
             cli,

--- a/crates/cli/src/cli/commands/goto.rs
+++ b/crates/cli/src/cli/commands/goto.rs
@@ -32,7 +32,7 @@ pub fn cmd_goto(cli: &Cli, target: String, force: bool) -> Result<()> {
     // `thread switch modulo-race` the operator can run goto from any
     // directory and we still resolve the right checkout via metadata.
     // See `Repository::active_worktree_path`.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/hook.rs
+++ b/crates/cli/src/cli/commands/hook.rs
@@ -4,13 +4,13 @@
 use std::io::{self, IsTerminal, Read};
 
 use anyhow::{Context, Result, anyhow};
-use repo::{Hook, HookManager, Repository};
+use repo::{Hook, HookManager};
 
 use super::advice::RecoveryAdvice;
 use crate::cli::{Cli, HookCommands, HookInstallSource, should_output_json};
 
 pub fn cmd_hook(cli: &Cli, command: HookCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = HookManager::new(&repo);
 
     match command {

--- a/crates/cli/src/cli/commands/index.rs
+++ b/crates/cli/src/cli/commands/index.rs
@@ -2,7 +2,7 @@
 //! Index command - inspect and manage the worktree index.
 
 use anyhow::Result;
-use repo::{Repository, WorktreeIndex};
+use repo::WorktreeIndex;
 use serde::Serialize;
 
 use crate::cli::{Cli, should_output_json};
@@ -23,7 +23,7 @@ struct IndexOutput {
 }
 
 pub fn cmd_index(cli: &Cli, dump: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let index_path = repo.root().join(".heddle/state").join("index.bin");
     let journal_path = repo.root().join(".heddle/state").join("index.journal");

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -125,7 +125,7 @@ struct IntegrationStatus {
 }
 
 pub fn cmd_integration(cli: &Cli, command: IntegrationCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         IntegrationCommands::List => list_integrations(cli, &repo),
         IntegrationCommands::Install(args) => install_integrations(cli, &repo, args),

--- a/crates/cli/src/cli/commands/maintenance.rs
+++ b/crates/cli/src/cli/commands/maintenance.rs
@@ -8,7 +8,7 @@ use crate::cli::{
 };
 
 pub fn cmd_maintenance(cli: &Cli, command: MaintenanceCommands) -> Result<()> {
-    let repo = repo::Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let options = worktree_status_options(Some(repo.config()));
 
     match command {

--- a/crates/cli/src/cli/commands/marker.rs
+++ b/crates/cli/src/cli/commands/marker.rs
@@ -43,7 +43,7 @@ struct MarkerBulkDeleteOutput {
 }
 
 pub fn cmd_marker(cli: &Cli, command: MarkerCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     match command {
         MarkerCommands::List { filter } => cmd_marker_list(cli, &repo, filter),

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -191,7 +191,7 @@ pub fn cmd_merge(
     semantic: bool,
     git_commit: bool,
 ) -> Result<()> {
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/monitor.rs
+++ b/crates/cli/src/cli/commands/monitor.rs
@@ -16,7 +16,7 @@ struct MonitorOutput {
 }
 
 pub fn cmd_monitor(cli: &Cli, paths: bool, serve: bool) -> Result<()> {
-    let repo = repo::Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if serve {
         return repo::run_local_monitor_helper(repo.root()).map_err(Into::into);
     }

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub fn cmd_purge(cli: &Cli, command: PurgeCommands) -> Result<()> {
     let _user = UserConfig::load_default().unwrap_or_default();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         PurgeCommands::Apply(args) => cmd_purge_apply(cli, &repo, args),
         PurgeCommands::List(args) => cmd_purge_list(cli, &repo, args),

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -60,7 +60,7 @@ pub fn cmd_rebase(
     // metadata-recorded worktree so commits are replayed into the
     // thread's actual checkout. See `Repository::active_worktree_path`
     // for fallback semantics.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -40,7 +40,7 @@ use crate::{
 
 pub fn cmd_redact(cli: &Cli, command: RedactCommands) -> Result<()> {
     let _user = UserConfig::load_default().unwrap_or_default();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         RedactCommands::Apply(args) => cmd_redact_apply(cli, &repo, args),
         RedactCommands::List(args) => cmd_redact_list(cli, &repo, args),

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -163,7 +163,7 @@ pub async fn cmd_push(
     all_threads: bool,
     mirror: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
         return Err(anyhow!(RecoveryAdvice::remote_not_configured("push")));
     }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -199,7 +199,7 @@ pub async fn cmd_pull(
     local_thread: Option<String>,
     lazy: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
         return Err(anyhow::anyhow!(RecoveryAdvice::remote_not_configured("pull")));
     }

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -34,7 +34,7 @@ pub fn cmd_resolve(
     force: bool,
     abort: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let merge_manager = repo.merge_state_manager();
 
     if abort {

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -147,7 +147,7 @@ struct UndoEntry {
 }
 
 pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let head_state = repo.current_state()?;
 
     let (since_id, since_ts) = resolve_since_bound(&repo, options.since.as_deref(), &head_state)?;

--- a/crates/cli/src/cli/commands/revert.rs
+++ b/crates/cli/src/cli/commands/revert.rs
@@ -30,7 +30,7 @@ pub fn cmd_revert(
     message: Option<String>,
     no_commit: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let target_id = resolve_state_id(&repo, &state_spec)?;
 

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -10,7 +10,7 @@ use grpc::heddle::v1::{
     ReviewScope as ProtoReviewScope, SignStateRequest, signal_service_server::SignalService,
     state_review_service_server::StateReviewService,
 };
-use repo::{HistoryQuery, Repository, operation_dedup::OperationDedupStore};
+use repo::{HistoryQuery, operation_dedup::OperationDedupStore};
 use serde::Serialize;
 
 use super::{
@@ -251,7 +251,7 @@ fn render_text(out: &ReviewShowOutput, all_signals: bool) {
 async fn run_sign(cli: &Cli, args: &ReviewSignArgs) -> Result<()> {
     use grpc::heddle::v1::review_scope::{Scope, SymbolList, WholeChange};
     let svc = open_state_review_service(cli)?;
-    let state_id_bytes = resolve_state_id_bytes(&open_repo(cli)?, &args.state)?;
+    let state_id_bytes = resolve_state_id_bytes(&cli.open_repo()?, &args.state)?;
     let scope_inner = if args.symbols.is_empty() {
         Scope::WholeChange(WholeChange {})
     } else {
@@ -316,7 +316,7 @@ async fn run_sign(cli: &Cli, args: &ReviewSignArgs) -> Result<()> {
 
 async fn run_next(cli: &Cli, args: &ReviewNextArgs) -> Result<()> {
     let svc = open_state_review_service(cli)?;
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let head = repo.head().context("read HEAD")?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::repository_no_head_capture_first(
             "review next"
@@ -470,25 +470,17 @@ async fn run_health(cli: &Cli, args: &ReviewHealthArgs) -> Result<()> {
 }
 
 fn open_state_review_service(cli: &Cli) -> Result<LocalStateReviewService> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let dedup = OperationDedupStore::open(repo.heddle_dir()).context("open dedup store")?;
     let inner = GrpcLocalService::new(Arc::new(repo), Arc::new(dedup));
     Ok(LocalStateReviewService::new(inner))
 }
 
 fn open_signal_service(cli: &Cli) -> Result<LocalSignalService> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let dedup = OperationDedupStore::open(repo.heddle_dir()).context("open dedup store")?;
     let inner = GrpcLocalService::new(Arc::new(repo), Arc::new(dedup));
     Ok(LocalSignalService::new(inner))
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let root = match cli.repo.as_ref() {
-        Some(repo) => repo.clone(),
-        None => std::env::current_dir().context("get current working directory")?,
-    };
-    Repository::open(&root).context("open Heddle repository")
 }
 
 fn signal_view(s: &grpc::heddle::v1::RiskSignal) -> SignalView {
@@ -528,7 +520,7 @@ fn opt_string(s: String) -> Option<String> {
 }
 
 fn resolve_state(cli: &Cli, explicit: Option<&str>) -> Result<Vec<u8>> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(s) = explicit {
         // Routes through the canonical resolver so short/full IDs and
         // marker names all work — matches `heddle log --output json` output.

--- a/crates/cli/src/cli/commands/run_cmd.rs
+++ b/crates/cli/src/cli/commands/run_cmd.rs
@@ -4,7 +4,7 @@
 use std::process::{Command, Stdio};
 
 use anyhow::{Result, anyhow};
-use repo::{Repository, SessionManager};
+use repo::SessionManager;
 
 use super::{
     advice::RecoveryAdvice,
@@ -22,7 +22,7 @@ pub fn cmd_run(cli: &Cli, thread: Option<String>, command: Vec<String>) -> Resul
         )));
     }
 
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let thread = match thread {
         Some(thread_id) => load_thread(&repo, &thread_id)?,
         None => current_thread(&repo)?.ok_or_else(|| {

--- a/crates/cli/src/cli/commands/semantic_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_cmd.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, anyhow};
-use repo::Repository;
 use semantic::analysis::{
     HotEventKind, HotSpotKey, HotSpotKeyValue, HotSpotParams, analyze_hot_spots,
 };
@@ -58,7 +57,7 @@ fn cmd_semantic_hot(
     top: usize,
     include_actors: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Resolve `from` (or HEAD) to a concrete ChangeId. Walking from
     // HEAD is the common case; allowing an explicit state lets users

--- a/crates/cli/src/cli/commands/session.rs
+++ b/crates/cli/src/cli/commands/session.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use objects::object::{Session, SessionSegment};
-use repo::{Repository, SessionManager};
+use repo::SessionManager;
 use serde::Serialize;
 
 use super::{
@@ -90,7 +90,7 @@ pub async fn cmd_session_start(
     model: String,
     policy: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
     let principal = repo.get_principal()?;
 
@@ -117,7 +117,7 @@ pub async fn cmd_session_segment(
     model: String,
     policy: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
 
     let current_id = manager.get_current_session_id()?.ok_or_else(|| {
@@ -144,7 +144,7 @@ pub async fn cmd_session_segment(
 }
 
 pub async fn cmd_session_end(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
 
     let session = manager.end_session(session_id.as_deref())?;
@@ -163,7 +163,7 @@ pub async fn cmd_session_end(cli: &Cli, session_id: Option<String>) -> Result<()
 }
 
 pub async fn cmd_session_show(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = SessionManager::new(repo.root());
 
     let id = match session_id {
@@ -219,7 +219,7 @@ pub async fn cmd_session_show(cli: &Cli, session_id: Option<String>) -> Result<(
 }
 
 pub async fn cmd_session_list(cli: &Cli, active_only: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = SessionManager::new(repo.root());
 
     let sessions = manager.list_sessions(active_only)?;

--- a/crates/cli/src/cli/commands/stack.rs
+++ b/crates/cli/src/cli/commands/stack.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use crate::cli::{should_output_json, Cli, StackArgs, StackCommands};
 
 pub fn cmd_stack(cli: &Cli, args: StackArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let outer_thread = args.thread.clone();
 
     match args.command {

--- a/crates/cli/src/cli/commands/stash.rs
+++ b/crates/cli/src/cli/commands/stash.rs
@@ -41,7 +41,7 @@ struct StashShowOutput {
 }
 
 pub fn cmd_stash(cli: &Cli, command: StashCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     match command {
         StashCommands::Push { message } => cmd_stash_push(cli, &repo, message),

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -427,7 +427,7 @@ fn render_plain_git_status(cli: &Cli, output: &PlainGitStatusOutput, short: bool
 
 pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput> {
     let repo_open_start = Instant::now();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let repo_open_ms = repo_open_start.elapsed().as_millis();
     let body_start = Instant::now();
     let as_json = should_output_json(cli, Some(repo.config()));
@@ -2265,8 +2265,7 @@ struct HostedPresenceWatch {
 #[cfg(feature = "client")]
 impl HostedPresenceWatch {
     async fn connect_if_configured(cli: &Cli) -> Option<Self> {
-        let cwd = std::env::current_dir().ok()?;
-        let repo = Repository::open(cli.repo.as_ref().unwrap_or(&cwd)).ok()?;
+        let repo = cli.open_repo().ok()?;
         let upstream = repo.config().hosted.upstream_url.as_deref()?.trim();
         let namespace = repo.config().hosted.namespace.as_deref()?.trim();
         if upstream.is_empty() || namespace.is_empty() {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -354,7 +354,7 @@ pub(crate) struct ThreadCaptureSummary {
 }
 
 pub fn cmd_start(cli: &Cli, args: ThreadStartArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if args.path.is_some() {
         ensure_worktree_clean(&repo, "start thread")?;
     }

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -128,7 +128,7 @@ fn thread_head_state(repo: &Repository, thread: &str) -> Result<String> {
 }
 
 pub async fn cmd_thread_approve(cli: &Cli, args: ThreadApproveArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source_state = thread_head_state(&repo, &args.source)?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let approval = client
@@ -176,7 +176,7 @@ pub async fn cmd_thread_approve(cli: &Cli, args: ThreadApproveArgs) -> Result<()
 }
 
 pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let approvals = client
         .list_thread_approvals(&repo_path, &args.source, &args.target)
@@ -239,7 +239,7 @@ pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Resul
 }
 
 pub async fn cmd_thread_revoke_approval(cli: &Cli, args: ThreadRevokeApprovalArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let (mut client, _repo_path) = open_heddle_client(&repo, &args.remote).await?;
     client.revoke_approval(&args.id).await?;
     if should_output_json(cli, Some(repo.config())) {
@@ -256,7 +256,7 @@ pub async fn cmd_thread_revoke_approval(cli: &Cli, args: ThreadRevokeApprovalArg
 }
 
 pub async fn cmd_thread_check_merge(cli: &Cli, args: ThreadCheckMergeArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source_state = thread_head_state(&repo, &args.source)?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let resp = client

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -60,7 +60,7 @@ pub fn cmd_capture_split(
     prefixes: Vec<String>,
     intent: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let current = super::thread_cmd::current_thread(&repo)?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::no_current_thread(
             "capture --split",
@@ -119,7 +119,7 @@ pub fn cmd_thread_move(
     prefixes: Vec<String>,
     message: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source = load_thread(&repo, &from)?;
     let target = load_thread(&repo, &to)?;
     let source_repo = Repository::open(&source.execution_path)?;
@@ -204,7 +204,7 @@ pub fn cmd_thread_absorb(
     message: Option<String>,
     preview: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let child = load_thread(&repo, &thread)?;
     let parent_id = into
         .or(child.parent_thread.clone())
@@ -254,7 +254,7 @@ pub fn cmd_thread_absorb(
 }
 
 pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut thread = load_thread(&repo, &thread_id)?;
     refresh_thread_freshness(&repo, &mut thread)?;
     let source_root = if thread.execution_path.as_os_str().is_empty() {

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -99,7 +99,7 @@ pub fn cmd_undo(
     preview: bool,
     allow_redact_undo: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     if list && preview {
         return Err(anyhow!(undo_mode_conflict_advice()));
@@ -274,7 +274,7 @@ pub fn cmd_undo(
 }
 
 pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Serialize against concurrent undo/redo (mirror of `cmd_undo`; heddle#355
     // cid 3330867776).

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -97,8 +97,7 @@ fn valid_filter_kinds() -> Vec<&'static str> {
 ///    sends events into the main loop, which drains pending entries
 ///    (id > watermark) on each modify and exits cleanly on SIGINT.
 pub async fn cmd_watch(cli: &Cli, args: WatchArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))
-        .context("opening repository for watch")?;
+    let repo = cli.open_repo().context("opening repository for watch")?;
     let heddle_dir = repo.heddle_dir().to_path_buf();
     let oplog_path = oplog_file_path(&heddle_dir);
 

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -83,7 +83,7 @@ struct DelegateOutput {
 }
 
 pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut thread = resolve_thread(
         &repo,
         args.thread.as_deref(),
@@ -252,7 +252,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     // thread directory before landing. The capture/merge below run
     // against `repo`, so they all see the same checkout. See
     // `Repository::active_worktree_path`.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo
@@ -897,7 +897,7 @@ fn land_checkpoint_message(repo: &Repository, thread: &Thread, explicit: Option<
 }
 
 pub fn cmd_delegate(cli: &Cli, args: DelegateArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     warn_if_path_prefix_inside_repo(&repo, args.path_prefix.as_deref());
     let parent = resolve_parent_thread(&repo, args.parent.as_deref())?;
 

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -125,7 +125,7 @@ fn detected_harness_argv_impl() -> Option<Vec<String>> {
 }
 
 pub fn cmd_harness_bridge(cli: &Cli) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let user_config = UserConfig::load_default().unwrap_or_default();
     let mut runtime = HarnessBridgeRuntime::new(repo, user_config);
 

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -100,7 +100,7 @@ pub fn run_local_idempotency_if_requested(
                 .context("open bootstrap op-id dedup store")?,
         )
     } else {
-        let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+        let repo = cli.open_repo()?;
         let bootstrap_scope = bootstrap_op_id_scope_for_root(repo.root().to_path_buf())?;
         let bootstrap_store =
             OperationDedupStore::open(bootstrap_op_id_store_dir(&bootstrap_scope))


### PR DESCRIPTION
Part of #497 (CLI mechanical-dedup slice — does **NOT** close it; the semantic/mount/objects/glue slices remain for separate PRs).

## Summary
Three same-logic CLI dedups from the simplification backlog:

1. **`Cli::open_repo()`** — added one `impl Cli` method (lazy cwd resolution + `.context("open Heddle repository")`) and replaced **83** call sites: ~74 copy-pasted `Repository::open(cli.repo.as_ref().unwrap_or(&cwd))?` inlines across ~45 files + the 10 call sites of the 3 private `open_repo(cli)` helpers (`agent.rs`/`review.rs`/`conflict.rs`), whose definitions are deleted. The two non-canonical variants (`watch.rs` keeps its `.context("opening repository for watch")`; `status.rs` keeps `.ok()?`) route through the chokepoint too.
2. **`MUTATING` base contract** — rewritten as `CommandContract { mutates: true, supports_op_id: true, observe_only: false, may_move_ref: true, writes_heddle_refs: true, ..READ_JSON }`. Verified the other 30 fields match `READ_JSON` exactly, so the value is provably identical.
3. **`CommandRuntimeContract` dead-field trim** — dropped the never-read fields from the struct + `runtime_contract()` builder, keeping the 11 live ones (`path`, `display`, `supports_json`, `supports_op_id`, `persists_op_id`, `uses_bootstrap_op_id_store`, `json_kind`, `help_visibility`, `help_rank`, `surface`, `canonical_command`). The lockstep test `parsed_command_runtime_contract_exposes_catalog_fields` trimmed to match (kept `help_rank`). Every dropped field was confirmed read-free outside tests — all `.<field>` hits were on `CommandContract`/the catalog entry struct, not a live `CommandRuntimeContract`. **No fields skipped.**

Behavior identical; catalog JSON output reads the lightweight `CommandContract` directly and is unaffected by the runtime-contract trim. Net ~108 LoC removed.

## Test plan
- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — green (one doctest hiccup was shared-target contention; passes in isolation)
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean
- [x] `heddle doctor docs --all` — no drift across 57 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783162815&installation_id=132405951&pr_number=513&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F513&signature=9ddc5aea8848611a9e5684bff0df2fb723d5d845cd282ff9916f8c6562c4fc19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->