### PR TITLE
refactor(mount/objects/glue): mechanical dedup (part of #497)

### DIFF
--- a/crates/cli/src/cli/cli_args/cli_base.rs
+++ b/crates/cli/src/cli/cli_args/cli_base.rs
@@ -83,6 +83,24 @@ pub struct Cli {
     pub op_id: Option<String>,
 }
 
+impl Cli {
+    /// Open the Heddle repository the command should act on: the `--repo`
+    /// path if given, otherwise the current working directory (resolved
+    /// lazily so a supplied `--repo` never touches the cwd).
+    pub fn open_repo(&self) -> anyhow::Result<repo::Repository> {
+        use anyhow::Context as _;
+        let cwd;
+        let repo_path = match self.repo.as_ref() {
+            Some(path) => path,
+            None => {
+                cwd = std::env::current_dir().context("get current working directory")?;
+                &cwd
+            }
+        };
+        repo::Repository::open(repo_path).context("open Heddle repository")
+    }
+}
+
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum OutputMode {
     Json,

--- a/crates/cli/src/cli/commands/actor_cmd.rs
+++ b/crates/cli/src/cli/commands/actor_cmd.rs
@@ -272,7 +272,7 @@ pub async fn cmd_actor_spawn(
     if let Some(name) = thread.as_deref() {
         ThreadId::new(name).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
     }
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let base_state = repo.head()?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::repository_no_head_capture_first(
@@ -421,7 +421,7 @@ pub async fn cmd_actor_spawn(
 }
 
 pub async fn cmd_actor_list(cli: &Cli, active_only: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
 
     let mut entries = registry.list()?;
@@ -473,7 +473,7 @@ pub async fn cmd_actor_list(cli: &Cli, active_only: bool) -> Result<()> {
 }
 
 pub async fn cmd_actor_show(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
 
@@ -532,7 +532,7 @@ pub async fn cmd_actor_show(cli: &Cli, session_id: Option<String>) -> Result<()>
 }
 
 pub async fn cmd_actor_done(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
     registry.update_status(&entry.session_id, AgentStatus::Complete)?;
@@ -577,7 +577,7 @@ fn actor_done_recommended_action(thread: &str, coordination_status: &str) -> Opt
 }
 
 pub async fn cmd_actor_explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = match resolve_actor_entry(&repo, &registry, session_id.as_deref()) {
         Ok(entry) => entry,

--- a/crates/cli/src/cli/commands/agent.rs
+++ b/crates/cli/src/cli/commands/agent.rs
@@ -94,7 +94,7 @@ async fn run_serve(cli: &Cli, args: &AgentServeArgs) -> Result<()> {
     }
     #[cfg(unix)]
     {
-        let repo = open_repo(cli)?;
+        let repo = cli.open_repo()?;
         let mut config = LocalDaemonConfig::from_repo(&repo);
         if let Some(socket) = args.socket.clone() {
             config = config.with_socket(socket);
@@ -146,7 +146,7 @@ async fn run_serve(cli: &Cli, args: &AgentServeArgs) -> Result<()> {
 }
 
 async fn run_status(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let pid_path = pid_path(&repo);
     let socket_path = socket_path(&repo);
     let pid = read_pid(&pid_path);
@@ -180,7 +180,7 @@ async fn run_status(cli: &Cli) -> Result<()> {
 }
 
 async fn run_stop(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let pid_path = pid_path(&repo);
 
     // Read the pidfile and require the heddle marker. A pidfile lacking
@@ -320,11 +320,6 @@ async fn run_stop(cli: &Cli) -> Result<()> {
 fn print_stop_output(_repo: &Repository, output: AgentStopOutput) -> Result<()> {
     println!("{}", serde_json::to_string(&output)?);
     Ok(())
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let cwd = std::env::current_dir().context("get current working directory")?;
-    Repository::open(cli.repo.as_ref().unwrap_or(&cwd)).context("open Heddle repository")
 }
 
 #[cfg(unix)]

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -166,7 +166,7 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
     // record, so reject an unsafe thread name here too (same early-reject
     // rule as `start_thread` / `thread create`). (heddle#464 close-the-class.)
     ThreadId::new(args.thread.as_str()).map_err(|err| anyhow!(thread_name_invalid_advice(&err)))?;
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let anchor = match &args.anchor {
         Some(spec) => repo
             .resolve_state(spec)?
@@ -435,7 +435,7 @@ fn ensure_thread_record(
 }
 
 pub fn cmd_agent_heartbeat(cli: &Cli, args: AgentHeartbeatArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let entry = registry
         .update_entry(&args.session, |entry| {
@@ -447,7 +447,7 @@ pub fn cmd_agent_heartbeat(cli: &Cli, args: AgentHeartbeatArgs) -> Result<()> {
 }
 
 pub fn cmd_agent_release(cli: &Cli, args: AgentReleaseArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     let status = match args.status {
         AgentReleaseStatusArg::Complete => AgentStatus::Complete,
@@ -468,7 +468,7 @@ pub fn cmd_agent_release(cli: &Cli, args: AgentReleaseArgs) -> Result<()> {
 }
 
 pub fn cmd_agent_list(cli: &Cli, args: AgentApiListArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let registry = AgentRegistry::new(repo.heddle_dir());
     if args.alive_only {
         // Sweep dead reservations before reporting so callers asking

--- a/crates/cli/src/cli/commands/blame.rs
+++ b/crates/cli/src/cli/commands/blame.rs
@@ -118,7 +118,7 @@ impl LineInfo {
 }
 
 pub fn cmd_blame(cli: &Cli, file: String, state: Option<String>, show_context: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let target_state_id = if let Some(state_id) = state {
         if matches!(state_id.as_str(), "HEAD" | "@") && repo.current_state()?.is_none() {

--- a/crates/cli/src/cli/commands/cherry_pick.rs
+++ b/crates/cli/src/cli/commands/cherry_pick.rs
@@ -16,7 +16,7 @@ pub fn cmd_cherry_pick(
     no_commit: bool,
     force: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Cherry-pick rewrites the worktree to match a different tree. Without a
     // dirty-worktree guard, modified-but-unsnapshotted files and untracked

--- a/crates/cli/src/cli/commands/clean.rs
+++ b/crates/cli/src/cli/commands/clean.rs
@@ -19,7 +19,7 @@ struct CleanOutput {
 }
 
 pub fn cmd_clean(cli: &Cli, force: bool, dry_run: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     if !force && !dry_run {
         return Err(anyhow!(RecoveryAdvice::destructive_requires_force(

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use objects::object::State;
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
-use repo::Repository;
 use serde::Serialize;
 
 use super::{
@@ -43,7 +42,7 @@ pub fn cmd_collapse(
     into: String,
     confidence: Option<f32>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let json = should_output_json(cli, Some(repo.config()));
 
     if states.is_empty() {

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -328,40 +328,11 @@ pub struct CommandRuntimeContract {
     pub supports_op_id: bool,
     pub persists_op_id: bool,
     pub uses_bootstrap_op_id_store: bool,
-    pub mutates: bool,
-    pub observe_only: bool,
     pub help_visibility: &'static str,
     pub help_rank: u16,
     pub surface: &'static str,
     pub canonical_command: Option<&'static str>,
-    pub canonical_kind: Option<&'static str>,
-    pub canonical_note: Option<&'static str>,
-    pub advertised_action: Option<AdvertisedAction>,
-    pub feature_gate: Option<&'static str>,
-    pub exit_codes: &'static [(u8, &'static str)],
-    pub side_effects: Vec<&'static str>,
-    pub side_effect_class: &'static str,
-    pub first_run_behavior: &'static str,
     pub json_kind: &'static str,
-    pub schema_verbs: &'static [&'static str],
-    pub documented_schema_verbs: &'static [&'static str],
-    pub opaque_schema_verbs: &'static [&'static str],
-    pub may_initialize: bool,
-    pub may_import_git: bool,
-    pub may_write_worktree: bool,
-    pub may_move_ref: bool,
-    pub destructive_requires_force: bool,
-    pub writes_heddle_refs: bool,
-    pub writes_git_refs: bool,
-    pub writes_worktree: bool,
-    pub writes_config: bool,
-    pub writes_hooks: bool,
-    pub network_io: bool,
-    pub daemon_process: bool,
-    pub object_gc: bool,
-    pub external_command: bool,
-    pub requires_git_executable: bool,
-    pub destructive_data: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -752,41 +723,12 @@ const READ_JSON_OR_JSONL: CommandContract = CommandContract {
 };
 
 const MUTATING: CommandContract = CommandContract {
-    supports_json: true,
     mutates: true,
     supports_op_id: true,
-    persists_op_id: false,
     observe_only: false,
-    may_initialize: false,
-    may_import_git: false,
-    may_write_worktree: false,
     may_move_ref: true,
-    destructive_requires_force: false,
     writes_heddle_refs: true,
-    writes_git_refs: false,
-    writes_worktree: false,
-    writes_config: false,
-    writes_hooks: false,
-    network_io: false,
-    daemon_process: false,
-    object_gc: false,
-    external_command: false,
-    requires_git_executable: false,
-    destructive_data: false,
-    json_kind: "json",
-    json_discriminators: &[],
-    schema_verbs: &[],
-    documented_schema_verbs: &[],
-    opaque_schema_verbs: &[],
-    surface: "native",
-    help_visibility: "advanced",
-    help_rank: 1000,
-    canonical_command: None,
-    canonical_kind: None,
-    canonical_note: None,
-    advertised_action: None,
-    feature_gate: None,
-    exit_codes: &[],
+    ..READ_JSON
 };
 
 const MUTATING_NO_OP_ID: CommandContract = CommandContract {
@@ -3340,40 +3282,11 @@ fn runtime_contract(
         supports_op_id: contract.supports_op_id,
         persists_op_id: contract.persists_op_id,
         uses_bootstrap_op_id_store: uses_bootstrap_op_id_store(contract),
-        mutates: contract.mutates,
-        observe_only: contract.observe_only,
         help_visibility: contract.help_visibility,
         help_rank: contract.help_rank,
         surface: contract.surface,
         canonical_command: contract.canonical_command,
-        canonical_kind: contract.canonical_kind,
-        canonical_note: contract.canonical_note,
-        advertised_action: contract.advertised_action,
-        feature_gate: contract.feature_gate,
-        exit_codes: contract.exit_codes,
-        side_effects: side_effects(contract),
-        side_effect_class: side_effect_class(contract),
-        first_run_behavior: first_run_behavior(contract),
         json_kind: contract.json_kind,
-        schema_verbs: contract.schema_verbs,
-        documented_schema_verbs: contract.documented_schema_verbs,
-        opaque_schema_verbs: contract.opaque_schema_verbs,
-        may_initialize: contract.may_initialize,
-        may_import_git: contract.may_import_git,
-        may_write_worktree: contract.may_write_worktree,
-        may_move_ref: contract.may_move_ref,
-        destructive_requires_force: contract.destructive_requires_force,
-        writes_heddle_refs: contract.writes_heddle_refs,
-        writes_git_refs: contract.writes_git_refs,
-        writes_worktree: contract.writes_worktree,
-        writes_config: contract.writes_config,
-        writes_hooks: contract.writes_hooks,
-        network_io: contract.network_io,
-        daemon_process: contract.daemon_process,
-        object_gc: contract.object_gc,
-        external_command: contract.external_command,
-        requires_git_executable: contract.requires_git_executable,
-        destructive_data: contract.destructive_data,
     }
 }
 
@@ -5588,17 +5501,6 @@ mod tests {
         assert_eq!(runtime.help_visibility, entry.help_visibility);
         assert_eq!(runtime.help_rank, entry.help_rank);
         assert_eq!(runtime.surface, entry.surface);
-        assert_eq!(runtime.side_effect_class, entry.side_effect_class);
-        assert_eq!(
-            runtime.side_effects,
-            entry
-                .side_effects
-                .iter()
-                .map(String::as_str)
-                .collect::<Vec<_>>()
-        );
-        assert!(runtime.destructive_requires_force);
-        assert!(runtime.writes_worktree);
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -59,7 +59,7 @@ pub async fn run(cli: &Cli, command: &ConflictCommands) -> Result<()> {
 }
 
 async fn run_list(cli: &Cli) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(merge_state) = repo.merge_state_manager().load()? {
         let view = active_merge_conflict_view(&merge_state);
         render_conflict_list(cli, &repo, &view, true)?;
@@ -129,7 +129,7 @@ fn active_merge_conflict_view(merge_state: &MergeState) -> ConflictListOutput {
 }
 
 async fn run_show(cli: &Cli, args: &ConflictShowArgs) -> Result<()> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(merge_state) = repo.merge_state_manager().load()? {
         return render_active_merge_conflict(cli, &repo, &merge_state, args);
     }
@@ -246,17 +246,6 @@ fn render_active_merge_conflict(
         println!("  next: {}", view.next_action);
     }
     Ok(())
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let cwd;
-    let repo_path = if let Some(path) = cli.repo.as_ref() {
-        path
-    } else {
-        cwd = std::env::current_dir().context("get current working directory")?;
-        &cwd
-    };
-    Repository::open(repo_path).context("open Heddle repository")
 }
 
 fn load_head_conflicts(repo: &Repository) -> Result<StructuredConflict> {

--- a/crates/cli/src/cli/commands/context/context_mutate.rs
+++ b/crates/cli/src/cli/commands/context/context_mutate.rs
@@ -7,7 +7,7 @@ use objects::{
     lock::RepositoryLockExt,
     object::{Annotation, AnnotationStatus, ContextBlob},
 };
-use repo::{Repository, compute_rewrite_pct};
+use repo::compute_rewrite_pct;
 
 use super::{
     apply_new_state, build_context_state, compute_source_hash, parse_kind, parse_scope,
@@ -34,7 +34,7 @@ pub async fn cmd_context_set(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let target = resolve_target(&repo, path, state)?;
     let scope = parse_scope(scope.as_deref())?;
     target.validate_scope(&scope)?;
@@ -112,7 +112,7 @@ pub async fn cmd_context_edit(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let content = read_annotation_content(message, file)?;
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;
     let head_state = resolve_state(&repo, None)?;
@@ -194,7 +194,7 @@ pub async fn cmd_context_supersede(
     message: Option<String>,
     file: Option<std::path::PathBuf>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let content = read_annotation_content(message, file)?;
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;
     let head_state = resolve_state(&repo, None)?;
@@ -287,7 +287,7 @@ pub async fn cmd_context_rm(
     scope: Option<String>,
     all: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let target = resolve_target(&repo, path, state)?;
 
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/cli/src/cli/commands/context/context_query.rs
+++ b/crates/cli/src/cli/commands/context/context_query.rs
@@ -41,7 +41,7 @@ pub async fn cmd_context_get(
     tag: Option<String>,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let target = super::resolve_target(&repo, path, state)?;
     let Some(context_root) = &state_obj.context else {
@@ -72,7 +72,7 @@ pub async fn cmd_context_list(
     r#ref: Option<String>,
     include_superseded: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let Some(context_root) = &state_obj.context else {
         if should_output_json(cli, None) {
@@ -150,7 +150,7 @@ pub async fn cmd_context_history(
     annotation_id: String,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let context_root = state_obj
         .context
@@ -217,7 +217,7 @@ pub async fn cmd_context_check(
     tag: Option<String>,
     r#ref: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let context_root = state_obj
         .context
@@ -352,7 +352,7 @@ pub async fn cmd_context_check(
 }
 
 pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let suggestions = repo.suggest_context_targets(&state_obj, limit)?;
 
@@ -398,7 +398,7 @@ pub async fn cmd_context_suggest(cli: &Cli, r#ref: Option<String>, limit: usize)
 }
 
 pub async fn cmd_context_audit(cli: &Cli, r#ref: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let state_obj = resolve_state(&repo, r#ref.as_deref())?;
     let Some(context_root) = &state_obj.context else {
         if should_output_json(cli, None) {

--- a/crates/cli/src/cli/commands/diagnose.rs
+++ b/crates/cli/src/cli/commands/diagnose.rs
@@ -239,7 +239,7 @@ pub(crate) fn build_diagnose_output(cli: &Cli, include_profile: bool) -> Result<
     let total_start = Instant::now();
 
     let repo_open_start = Instant::now();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let repo_open_ms = repo_open_start.elapsed().as_millis();
 
     let current_state_start = Instant::now();

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -47,7 +47,7 @@ struct FetchOutput {
 }
 
 pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let remotes = if all {
             let configured = repo.refs().list_remotes()?;

--- a/crates/cli/src/cli/commands/fork.rs
+++ b/crates/cli/src/cli/commands/fork.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use objects::object::{State, ThreadName};
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
-use repo::Repository;
 use serde::Serialize;
 
 use super::{
@@ -35,7 +34,7 @@ struct ForkOutput {
 ///
 /// If `--name` is provided, a new thread is created pointing to the new state.
 pub fn cmd_fork(cli: &Cli, name: Option<String>, from: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let user_config = UserConfig::load_default()?;
 
     // Determine the source state

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -28,7 +28,7 @@ struct FsckOutput {
 }
 
 pub fn cmd_fsck(cli: &Cli, full: bool, thorough: bool, repair: bool, bridge: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let mut errors: Vec<FsckError> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();

--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -13,7 +13,6 @@
 
 use objects::store::ObjectStore;
 use anyhow::Result;
-use repo::Repository;
 use serde::Serialize;
 
 #[cfg(feature = "git-overlay")]
@@ -38,7 +37,7 @@ struct GcOutput {
 }
 
 pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let json = should_output_json(cli, Some(repo.config()));
     let mut summary = GcOutput {
         output_kind: "gc",

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1322,7 +1322,7 @@ pub async fn cmd_switch_compat(cli: &Cli, args: SwitchArgs) -> Result<()> {
             vec![primary],
         )));
     }
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if repo.refs().get_thread(&ThreadName::new(&args.target))?.is_some() {
         return cmd_thread(
             cli,

--- a/crates/cli/src/cli/commands/goto.rs
+++ b/crates/cli/src/cli/commands/goto.rs
@@ -32,7 +32,7 @@ pub fn cmd_goto(cli: &Cli, target: String, force: bool) -> Result<()> {
     // `thread switch modulo-race` the operator can run goto from any
     // directory and we still resolve the right checkout via metadata.
     // See `Repository::active_worktree_path`.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/hook.rs
+++ b/crates/cli/src/cli/commands/hook.rs
@@ -4,13 +4,13 @@
 use std::io::{self, IsTerminal, Read};
 
 use anyhow::{Context, Result, anyhow};
-use repo::{Hook, HookManager, Repository};
+use repo::{Hook, HookManager};
 
 use super::advice::RecoveryAdvice;
 use crate::cli::{Cli, HookCommands, HookInstallSource, should_output_json};
 
 pub fn cmd_hook(cli: &Cli, command: HookCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = HookManager::new(&repo);
 
     match command {

--- a/crates/cli/src/cli/commands/index.rs
+++ b/crates/cli/src/cli/commands/index.rs
@@ -2,7 +2,7 @@
 //! Index command - inspect and manage the worktree index.
 
 use anyhow::Result;
-use repo::{Repository, WorktreeIndex};
+use repo::WorktreeIndex;
 use serde::Serialize;
 
 use crate::cli::{Cli, should_output_json};
@@ -23,7 +23,7 @@ struct IndexOutput {
 }
 
 pub fn cmd_index(cli: &Cli, dump: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let index_path = repo.root().join(".heddle/state").join("index.bin");
     let journal_path = repo.root().join(".heddle/state").join("index.journal");

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -125,7 +125,7 @@ struct IntegrationStatus {
 }
 
 pub fn cmd_integration(cli: &Cli, command: IntegrationCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         IntegrationCommands::List => list_integrations(cli, &repo),
         IntegrationCommands::Install(args) => install_integrations(cli, &repo, args),

--- a/crates/cli/src/cli/commands/maintenance.rs
+++ b/crates/cli/src/cli/commands/maintenance.rs
@@ -8,7 +8,7 @@ use crate::cli::{
 };
 
 pub fn cmd_maintenance(cli: &Cli, command: MaintenanceCommands) -> Result<()> {
-    let repo = repo::Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let options = worktree_status_options(Some(repo.config()));
 
     match command {

--- a/crates/cli/src/cli/commands/marker.rs
+++ b/crates/cli/src/cli/commands/marker.rs
@@ -43,7 +43,7 @@ struct MarkerBulkDeleteOutput {
 }
 
 pub fn cmd_marker(cli: &Cli, command: MarkerCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     match command {
         MarkerCommands::List { filter } => cmd_marker_list(cli, &repo, filter),

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -191,7 +191,7 @@ pub fn cmd_merge(
     semantic: bool,
     git_commit: bool,
 ) -> Result<()> {
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/monitor.rs
+++ b/crates/cli/src/cli/commands/monitor.rs
@@ -16,7 +16,7 @@ struct MonitorOutput {
 }
 
 pub fn cmd_monitor(cli: &Cli, paths: bool, serve: bool) -> Result<()> {
-    let repo = repo::Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if serve {
         return repo::run_local_monitor_helper(repo.root()).map_err(Into::into);
     }

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub fn cmd_purge(cli: &Cli, command: PurgeCommands) -> Result<()> {
     let _user = UserConfig::load_default().unwrap_or_default();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         PurgeCommands::Apply(args) => cmd_purge_apply(cli, &repo, args),
         PurgeCommands::List(args) => cmd_purge_list(cli, &repo, args),

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -60,7 +60,7 @@ pub fn cmd_rebase(
     // metadata-recorded worktree so commits are replayed into the
     // thread's actual checkout. See `Repository::active_worktree_path`
     // for fallback semantics.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -40,7 +40,7 @@ use crate::{
 
 pub fn cmd_redact(cli: &Cli, command: RedactCommands) -> Result<()> {
     let _user = UserConfig::load_default().unwrap_or_default();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     match command {
         RedactCommands::Apply(args) => cmd_redact_apply(cli, &repo, args),
         RedactCommands::List(args) => cmd_redact_list(cli, &repo, args),

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -163,7 +163,7 @@ pub async fn cmd_push(
     all_threads: bool,
     mirror: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
         return Err(anyhow!(RecoveryAdvice::remote_not_configured("push")));
     }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -199,7 +199,7 @@ pub async fn cmd_pull(
     local_thread: Option<String>,
     lazy: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if remote.is_none() && resolved_default_remote_name(&repo)?.is_none() {
         return Err(anyhow::anyhow!(RecoveryAdvice::remote_not_configured("pull")));
     }

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -34,7 +34,7 @@ pub fn cmd_resolve(
     force: bool,
     abort: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let merge_manager = repo.merge_state_manager();
 
     if abort {

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -147,7 +147,7 @@ struct UndoEntry {
 }
 
 pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let head_state = repo.current_state()?;
 
     let (since_id, since_ts) = resolve_since_bound(&repo, options.since.as_deref(), &head_state)?;

--- a/crates/cli/src/cli/commands/revert.rs
+++ b/crates/cli/src/cli/commands/revert.rs
@@ -30,7 +30,7 @@ pub fn cmd_revert(
     message: Option<String>,
     no_commit: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     let target_id = resolve_state_id(&repo, &state_spec)?;
 

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -10,7 +10,7 @@ use grpc::heddle::v1::{
     ReviewScope as ProtoReviewScope, SignStateRequest, signal_service_server::SignalService,
     state_review_service_server::StateReviewService,
 };
-use repo::{HistoryQuery, Repository, operation_dedup::OperationDedupStore};
+use repo::{HistoryQuery, operation_dedup::OperationDedupStore};
 use serde::Serialize;
 
 use super::{
@@ -251,7 +251,7 @@ fn render_text(out: &ReviewShowOutput, all_signals: bool) {
 async fn run_sign(cli: &Cli, args: &ReviewSignArgs) -> Result<()> {
     use grpc::heddle::v1::review_scope::{Scope, SymbolList, WholeChange};
     let svc = open_state_review_service(cli)?;
-    let state_id_bytes = resolve_state_id_bytes(&open_repo(cli)?, &args.state)?;
+    let state_id_bytes = resolve_state_id_bytes(&cli.open_repo()?, &args.state)?;
     let scope_inner = if args.symbols.is_empty() {
         Scope::WholeChange(WholeChange {})
     } else {
@@ -316,7 +316,7 @@ async fn run_sign(cli: &Cli, args: &ReviewSignArgs) -> Result<()> {
 
 async fn run_next(cli: &Cli, args: &ReviewNextArgs) -> Result<()> {
     let svc = open_state_review_service(cli)?;
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let head = repo.head().context("read HEAD")?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::repository_no_head_capture_first(
             "review next"
@@ -470,25 +470,17 @@ async fn run_health(cli: &Cli, args: &ReviewHealthArgs) -> Result<()> {
 }
 
 fn open_state_review_service(cli: &Cli) -> Result<LocalStateReviewService> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let dedup = OperationDedupStore::open(repo.heddle_dir()).context("open dedup store")?;
     let inner = GrpcLocalService::new(Arc::new(repo), Arc::new(dedup));
     Ok(LocalStateReviewService::new(inner))
 }
 
 fn open_signal_service(cli: &Cli) -> Result<LocalSignalService> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     let dedup = OperationDedupStore::open(repo.heddle_dir()).context("open dedup store")?;
     let inner = GrpcLocalService::new(Arc::new(repo), Arc::new(dedup));
     Ok(LocalSignalService::new(inner))
-}
-
-fn open_repo(cli: &Cli) -> Result<Repository> {
-    let root = match cli.repo.as_ref() {
-        Some(repo) => repo.clone(),
-        None => std::env::current_dir().context("get current working directory")?,
-    };
-    Repository::open(&root).context("open Heddle repository")
 }
 
 fn signal_view(s: &grpc::heddle::v1::RiskSignal) -> SignalView {
@@ -528,7 +520,7 @@ fn opt_string(s: String) -> Option<String> {
 }
 
 fn resolve_state(cli: &Cli, explicit: Option<&str>) -> Result<Vec<u8>> {
-    let repo = open_repo(cli)?;
+    let repo = cli.open_repo()?;
     if let Some(s) = explicit {
         // Routes through the canonical resolver so short/full IDs and
         // marker names all work — matches `heddle log --output json` output.

--- a/crates/cli/src/cli/commands/run_cmd.rs
+++ b/crates/cli/src/cli/commands/run_cmd.rs
@@ -4,7 +4,7 @@
 use std::process::{Command, Stdio};
 
 use anyhow::{Result, anyhow};
-use repo::{Repository, SessionManager};
+use repo::SessionManager;
 
 use super::{
     advice::RecoveryAdvice,
@@ -22,7 +22,7 @@ pub fn cmd_run(cli: &Cli, thread: Option<String>, command: Vec<String>) -> Resul
         )));
     }
 
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let thread = match thread {
         Some(thread_id) => load_thread(&repo, &thread_id)?,
         None => current_thread(&repo)?.ok_or_else(|| {

--- a/crates/cli/src/cli/commands/semantic_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_cmd.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, anyhow};
-use repo::Repository;
 use semantic::analysis::{
     HotEventKind, HotSpotKey, HotSpotKeyValue, HotSpotParams, analyze_hot_spots,
 };
@@ -58,7 +57,7 @@ fn cmd_semantic_hot(
     top: usize,
     include_actors: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Resolve `from` (or HEAD) to a concrete ChangeId. Walking from
     // HEAD is the common case; allowing an explicit state lets users

--- a/crates/cli/src/cli/commands/session.rs
+++ b/crates/cli/src/cli/commands/session.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use objects::object::{Session, SessionSegment};
-use repo::{Repository, SessionManager};
+use repo::SessionManager;
 use serde::Serialize;
 
 use super::{
@@ -90,7 +90,7 @@ pub async fn cmd_session_start(
     model: String,
     policy: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
     let principal = repo.get_principal()?;
 
@@ -117,7 +117,7 @@ pub async fn cmd_session_segment(
     model: String,
     policy: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
 
     let current_id = manager.get_current_session_id()?.ok_or_else(|| {
@@ -144,7 +144,7 @@ pub async fn cmd_session_segment(
 }
 
 pub async fn cmd_session_end(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut manager = SessionManager::new(repo.root());
 
     let session = manager.end_session(session_id.as_deref())?;
@@ -163,7 +163,7 @@ pub async fn cmd_session_end(cli: &Cli, session_id: Option<String>) -> Result<()
 }
 
 pub async fn cmd_session_show(cli: &Cli, session_id: Option<String>) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = SessionManager::new(repo.root());
 
     let id = match session_id {
@@ -219,7 +219,7 @@ pub async fn cmd_session_show(cli: &Cli, session_id: Option<String>) -> Result<(
 }
 
 pub async fn cmd_session_list(cli: &Cli, active_only: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let manager = SessionManager::new(repo.root());
 
     let sessions = manager.list_sessions(active_only)?;

--- a/crates/cli/src/cli/commands/stack.rs
+++ b/crates/cli/src/cli/commands/stack.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use crate::cli::{should_output_json, Cli, StackArgs, StackCommands};
 
 pub fn cmd_stack(cli: &Cli, args: StackArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let outer_thread = args.thread.clone();
 
     match args.command {

--- a/crates/cli/src/cli/commands/stash.rs
+++ b/crates/cli/src/cli/commands/stash.rs
@@ -41,7 +41,7 @@ struct StashShowOutput {
 }
 
 pub fn cmd_stash(cli: &Cli, command: StashCommands) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     match command {
         StashCommands::Push { message } => cmd_stash_push(cli, &repo, message),

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -427,7 +427,7 @@ fn render_plain_git_status(cli: &Cli, output: &PlainGitStatusOutput, short: bool
 
 pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput> {
     let repo_open_start = Instant::now();
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let repo_open_ms = repo_open_start.elapsed().as_millis();
     let body_start = Instant::now();
     let as_json = should_output_json(cli, Some(repo.config()));
@@ -2265,8 +2265,7 @@ struct HostedPresenceWatch {
 #[cfg(feature = "client")]
 impl HostedPresenceWatch {
     async fn connect_if_configured(cli: &Cli) -> Option<Self> {
-        let cwd = std::env::current_dir().ok()?;
-        let repo = Repository::open(cli.repo.as_ref().unwrap_or(&cwd)).ok()?;
+        let repo = cli.open_repo().ok()?;
         let upstream = repo.config().hosted.upstream_url.as_deref()?.trim();
         let namespace = repo.config().hosted.namespace.as_deref()?.trim();
         if upstream.is_empty() || namespace.is_empty() {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -354,7 +354,7 @@ pub(crate) struct ThreadCaptureSummary {
 }
 
 pub fn cmd_start(cli: &Cli, args: ThreadStartArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     if args.path.is_some() {
         ensure_worktree_clean(&repo, "start thread")?;
     }

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -128,7 +128,7 @@ fn thread_head_state(repo: &Repository, thread: &str) -> Result<String> {
 }
 
 pub async fn cmd_thread_approve(cli: &Cli, args: ThreadApproveArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source_state = thread_head_state(&repo, &args.source)?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let approval = client
@@ -176,7 +176,7 @@ pub async fn cmd_thread_approve(cli: &Cli, args: ThreadApproveArgs) -> Result<()
 }
 
 pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let approvals = client
         .list_thread_approvals(&repo_path, &args.source, &args.target)
@@ -239,7 +239,7 @@ pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Resul
 }
 
 pub async fn cmd_thread_revoke_approval(cli: &Cli, args: ThreadRevokeApprovalArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let (mut client, _repo_path) = open_heddle_client(&repo, &args.remote).await?;
     client.revoke_approval(&args.id).await?;
     if should_output_json(cli, Some(repo.config())) {
@@ -256,7 +256,7 @@ pub async fn cmd_thread_revoke_approval(cli: &Cli, args: ThreadRevokeApprovalArg
 }
 
 pub async fn cmd_thread_check_merge(cli: &Cli, args: ThreadCheckMergeArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source_state = thread_head_state(&repo, &args.source)?;
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let resp = client

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -60,7 +60,7 @@ pub fn cmd_capture_split(
     prefixes: Vec<String>,
     intent: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let current = super::thread_cmd::current_thread(&repo)?.ok_or_else(|| {
         anyhow!(RecoveryAdvice::no_current_thread(
             "capture --split",
@@ -119,7 +119,7 @@ pub fn cmd_thread_move(
     prefixes: Vec<String>,
     message: Option<String>,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let source = load_thread(&repo, &from)?;
     let target = load_thread(&repo, &to)?;
     let source_repo = Repository::open(&source.execution_path)?;
@@ -204,7 +204,7 @@ pub fn cmd_thread_absorb(
     message: Option<String>,
     preview: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let child = load_thread(&repo, &thread)?;
     let parent_id = into
         .or(child.parent_thread.clone())
@@ -254,7 +254,7 @@ pub fn cmd_thread_absorb(
 }
 
 pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut thread = load_thread(&repo, &thread_id)?;
     refresh_thread_freshness(&repo, &mut thread)?;
     let source_root = if thread.execution_path.as_os_str().is_empty() {

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -99,7 +99,7 @@ pub fn cmd_undo(
     preview: bool,
     allow_redact_undo: bool,
 ) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     if list && preview {
         return Err(anyhow!(undo_mode_conflict_advice()));
@@ -274,7 +274,7 @@ pub fn cmd_undo(
 }
 
 pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
 
     // Serialize against concurrent undo/redo (mirror of `cmd_undo`; heddle#355
     // cid 3330867776).

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -97,8 +97,7 @@ fn valid_filter_kinds() -> Vec<&'static str> {
 ///    sends events into the main loop, which drains pending entries
 ///    (id > watermark) on each modify and exits cleanly on SIGINT.
 pub async fn cmd_watch(cli: &Cli, args: WatchArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))
-        .context("opening repository for watch")?;
+    let repo = cli.open_repo().context("opening repository for watch")?;
     let heddle_dir = repo.heddle_dir().to_path_buf();
     let oplog_path = oplog_file_path(&heddle_dir);
 

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -83,7 +83,7 @@ struct DelegateOutput {
 }
 
 pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let mut thread = resolve_thread(
         &repo,
         args.thread.as_deref(),
@@ -252,7 +252,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     // thread directory before landing. The capture/merge below run
     // against `repo`, so they all see the same checkout. See
     // `Repository::active_worktree_path`.
-    let cwd_repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let cwd_repo = cli.open_repo()?;
     let target_path = cwd_repo.active_worktree_path()?;
     let repo = if target_path == *cwd_repo.root() {
         cwd_repo
@@ -897,7 +897,7 @@ fn land_checkpoint_message(repo: &Repository, thread: &Thread, explicit: Option<
 }
 
 pub fn cmd_delegate(cli: &Cli, args: DelegateArgs) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     warn_if_path_prefix_inside_repo(&repo, args.path_prefix.as_deref());
     let parent = resolve_parent_thread(&repo, args.parent.as_deref())?;
 

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -125,7 +125,7 @@ fn detected_harness_argv_impl() -> Option<Vec<String>> {
 }
 
 pub fn cmd_harness_bridge(cli: &Cli) -> Result<()> {
-    let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+    let repo = cli.open_repo()?;
     let user_config = UserConfig::load_default().unwrap_or_default();
     let mut runtime = HarnessBridgeRuntime::new(repo, user_config);
 

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -100,7 +100,7 @@ pub fn run_local_idempotency_if_requested(
                 .context("open bootstrap op-id dedup store")?,
         )
     } else {
-        let repo = Repository::open(cli.repo.as_ref().unwrap_or(&std::env::current_dir()?))?;
+        let repo = cli.open_repo()?;
         let bootstrap_scope = bootstrap_op_id_scope_for_root(repo.root().to_path_buf())?;
         let bootstrap_store =
             OperationDedupStore::open(bootstrap_op_id_store_dir(&bootstrap_scope))

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -131,15 +131,7 @@ pub(super) fn parse_object_type(value: &str) -> Result<ObjectType, ProtocolError
 }
 
 pub(super) fn to_proto_object_info(info: &ObjectInfo) -> ObjectDescriptor {
-    ObjectDescriptor {
-        id: match &info.id {
-            ObjectId::Hash(hash) => hash.to_hex(),
-            ObjectId::ChangeId(change_id) => change_id.to_string_full(),
-        },
-        object_type: object_type_name(info.obj_type).to_string(),
-        availability_status: ObjectAvailabilityStatus::Present as i32,
-        availability_note: String::new(),
-    }
+    object_descriptor_with_status(info, ObjectAvailabilityStatus::Present, "")
 }
 
 pub(super) fn object_descriptor_with_status(

--- a/crates/client/src/grpc_hosted/user.rs
+++ b/crates/client/src/grpc_hosted/user.rs
@@ -19,6 +19,28 @@ use super::{
     },
 };
 
+/// Dispatch an authenticated unary RPC on `self.user`: wrap `$msg` in
+/// a `tonic::Request`, stamp the auth credential via `apply_auth`,
+/// await the call, map a transport `Status` to a `ProtocolError`, and
+/// unwrap the response to its inner message. Every authenticated
+/// user-service call shares this exact prologue; the macro is the one
+/// chokepoint so a change to the auth/await/error-map sequence lands
+/// once. `?`-propagates `ProtocolError` from `apply_auth` and the
+/// mapped status, so it must be invoked inside an `async fn` returning
+/// `Result<_, ProtocolError>`.
+macro_rules! authed_call {
+    ($self:ident, $rpc:ident, $msg:expr) => {{
+        let mut request = Request::new($msg);
+        $self.apply_auth(&mut request)?;
+        $self
+            .user
+            .$rpc(request)
+            .await
+            .map_err(status_to_protocol_error)?
+            .into_inner()
+    }};
+}
+
 impl HostedGrpcClient {
     pub async fn begin_login(
         &mut self,
@@ -44,28 +66,18 @@ impl HostedGrpcClient {
     pub async fn get_current_user_namespace(
         &mut self,
     ) -> Result<proto::HostedNamespaceInfo, ProtocolError> {
-        let mut request = Request::new(GetCurrentUserNamespaceRequest {});
-        self.apply_auth(&mut request)?;
-        let namespace = self
-            .user
-            .get_current_user_namespace(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let namespace = authed_call!(
+            self,
+            get_current_user_namespace,
+            GetCurrentUserNamespaceRequest {}
+        );
         Ok(to_protocol_namespace(namespace))
     }
 
     pub async fn list_namespaces(
         &mut self,
     ) -> Result<Vec<proto::HostedNamespaceInfo>, ProtocolError> {
-        let mut request = Request::new(ListNamespacesRequest {});
-        self.apply_auth(&mut request)?;
-        let response = self
-            .user
-            .list_namespaces(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let response = authed_call!(self, list_namespaces, ListNamespacesRequest {});
         Ok(response
             .namespaces
             .into_iter()
@@ -80,20 +92,17 @@ impl HostedGrpcClient {
         parent_path: Option<&str>,
         display_name: Option<String>,
     ) -> Result<proto::HostedNamespaceInfo, ProtocolError> {
-        let mut request = Request::new(grpc::heddle::v1::CreateNamespaceRequest {
-            kind: parse_namespace_kind_arg(kind)? as i32,
-            slug: slug.to_string(),
-            parent_path: parent_path.unwrap_or_default().to_string(),
-            display_name: display_name.unwrap_or_default(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let namespace = self
-            .user
-            .create_namespace(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let namespace = authed_call!(
+            self,
+            create_namespace,
+            grpc::heddle::v1::CreateNamespaceRequest {
+                kind: parse_namespace_kind_arg(kind)? as i32,
+                slug: slug.to_string(),
+                parent_path: parent_path.unwrap_or_default().to_string(),
+                display_name: display_name.unwrap_or_default(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_namespace(namespace))
     }
 
@@ -102,18 +111,15 @@ impl HostedGrpcClient {
         namespace_path: &str,
         slug: &str,
     ) -> Result<proto::HostedRepositoryInfo, ProtocolError> {
-        let mut request = Request::new(CreateRepositoryRequest {
-            namespace_path: namespace_path.to_string(),
-            slug: slug.to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let repo = self
-            .user
-            .create_repository(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let repo = authed_call!(
+            self,
+            create_repository,
+            CreateRepositoryRequest {
+                namespace_path: namespace_path.to_string(),
+                slug: slug.to_string(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_repository(repo))
     }
 
@@ -121,16 +127,13 @@ impl HostedGrpcClient {
         &mut self,
         namespace_path: Option<&str>,
     ) -> Result<Vec<proto::HostedRepositoryInfo>, ProtocolError> {
-        let mut request = Request::new(ListRepositoriesRequest {
-            namespace_path: namespace_path.unwrap_or_default().to_string(),
-        });
-        self.apply_auth(&mut request)?;
-        let response = self
-            .user
-            .list_repositories(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let response = authed_call!(
+            self,
+            list_repositories,
+            ListRepositoriesRequest {
+                namespace_path: namespace_path.unwrap_or_default().to_string(),
+            }
+        );
         Ok(response
             .repositories
             .into_iter()
@@ -149,33 +152,29 @@ impl HostedGrpcClient {
             Some(None) => (String::new(), true),
             None => (String::new(), false),
         };
-        let mut request = Request::new(UpdateNamespaceRequest {
-            full_path: full_path.to_string(),
-            new_slug: new_slug.unwrap_or_default().to_string(),
-            display_name,
-            clear_display_name,
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let namespace = self
-            .user
-            .update_namespace(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let namespace = authed_call!(
+            self,
+            update_namespace,
+            UpdateNamespaceRequest {
+                full_path: full_path.to_string(),
+                new_slug: new_slug.unwrap_or_default().to_string(),
+                display_name,
+                clear_display_name,
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_namespace(namespace))
     }
 
     pub async fn delete_namespace(&mut self, full_path: &str) -> Result<(), ProtocolError> {
-        let mut request = Request::new(DeleteNamespaceRequest {
-            full_path: full_path.to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        self.user
-            .delete_namespace(request)
-            .await
-            .map_err(status_to_protocol_error)?;
+        authed_call!(
+            self,
+            delete_namespace,
+            DeleteNamespaceRequest {
+                full_path: full_path.to_string(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(())
     }
 
@@ -184,31 +183,27 @@ impl HostedGrpcClient {
         full_path: &str,
         new_slug: &str,
     ) -> Result<proto::HostedRepositoryInfo, ProtocolError> {
-        let mut request = Request::new(UpdateRepositoryRequest {
-            full_path: full_path.to_string(),
-            new_slug: new_slug.to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let repo = self
-            .user
-            .update_repository(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let repo = authed_call!(
+            self,
+            update_repository,
+            UpdateRepositoryRequest {
+                full_path: full_path.to_string(),
+                new_slug: new_slug.to_string(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_repository(repo))
     }
 
     pub async fn delete_repository(&mut self, full_path: &str) -> Result<(), ProtocolError> {
-        let mut request = Request::new(DeleteRepositoryRequest {
-            full_path: full_path.to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        self.user
-            .delete_repository(request)
-            .await
-            .map_err(status_to_protocol_error)?;
+        authed_call!(
+            self,
+            delete_repository,
+            DeleteRepositoryRequest {
+                full_path: full_path.to_string(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(())
     }
 
@@ -220,19 +215,16 @@ impl HostedGrpcClient {
         repo_path: Option<&str>,
     ) -> Result<proto::HostedGrantInfo, ProtocolError> {
         let target = build_target_ref(namespace_path, repo_path)?;
-        let mut request = Request::new(CreateGrantRequest {
-            subject: subject.to_string(),
-            role: parse_hosted_role_arg(role)? as i32,
-            target,
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let grant = self
-            .user
-            .create_grant(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let grant = authed_call!(
+            self,
+            create_grant,
+            CreateGrantRequest {
+                subject: subject.to_string(),
+                role: parse_hosted_role_arg(role)? as i32,
+                target,
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_grant(grant))
     }
 
@@ -240,16 +232,13 @@ impl HostedGrpcClient {
         &mut self,
         resource: Option<&str>,
     ) -> Result<Vec<proto::HostedGrantInfo>, ProtocolError> {
-        let mut request = Request::new(ListGrantsRequest {
-            resource: resource.unwrap_or_default().to_string(),
-        });
-        self.apply_auth(&mut request)?;
-        let response = self
-            .user
-            .list_grants(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let response = authed_call!(
+            self,
+            list_grants,
+            ListGrantsRequest {
+                resource: resource.unwrap_or_default().to_string(),
+            }
+        );
         Ok(response.grants.into_iter().map(to_protocol_grant).collect())
     }
 
@@ -261,19 +250,16 @@ impl HostedGrpcClient {
         repo_path: Option<&str>,
     ) -> Result<proto::HostedGrantInfo, ProtocolError> {
         let target = build_target_ref(namespace_path, repo_path)?;
-        let mut request = Request::new(UpdateGrantRequest {
-            subject: subject.to_string(),
-            role: parse_hosted_role_arg(role)? as i32,
-            target,
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let grant = self
-            .user
-            .update_grant(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let grant = authed_call!(
+            self,
+            update_grant,
+            UpdateGrantRequest {
+                subject: subject.to_string(),
+                role: parse_hosted_role_arg(role)? as i32,
+                target,
+                client_operation_id: String::new(),
+            }
+        );
         Ok(to_protocol_grant(grant))
     }
 
@@ -284,16 +270,15 @@ impl HostedGrpcClient {
         repo_path: Option<&str>,
     ) -> Result<(), ProtocolError> {
         let target = build_target_ref(namespace_path, repo_path)?;
-        let mut request = Request::new(DeleteGrantRequest {
-            subject: subject.to_string(),
-            target,
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        self.user
-            .delete_grant(request)
-            .await
-            .map_err(status_to_protocol_error)?;
+        authed_call!(
+            self,
+            delete_grant,
+            DeleteGrantRequest {
+                subject: subject.to_string(),
+                target,
+                client_operation_id: String::new(),
+            }
+        );
         Ok(())
     }
 
@@ -305,21 +290,18 @@ impl HostedGrpcClient {
         namespace_path: &str,
         role: &str,
     ) -> Result<ProtoInvitation, ProtocolError> {
-        let mut request = Request::new(CreateInvitationRequest {
-            email: email.to_string(),
-            namespace_path: namespace_path.to_string(),
-            role: parse_hosted_role_arg(role)? as i32,
-            expires_at: None,
-            metadata: String::new(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        let invitation = self
-            .user
-            .create_invitation(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner();
+        let invitation = authed_call!(
+            self,
+            create_invitation,
+            CreateInvitationRequest {
+                email: email.to_string(),
+                namespace_path: namespace_path.to_string(),
+                role: parse_hosted_role_arg(role)? as i32,
+                expires_at: None,
+                metadata: String::new(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(invitation)
     }
 
@@ -335,35 +317,31 @@ impl HostedGrpcClient {
         source_state: &str,
         note: Option<&str>,
     ) -> Result<ThreadApproval, ProtocolError> {
-        let mut request = Request::new(ApproveThreadRequest {
-            repo_path: repo_path.to_string(),
-            source_thread: source_thread.to_string(),
-            target_thread: target_thread.to_string(),
-            source_state: objects::object::ChangeId::parse(source_state)
-                .map(|id| id.as_bytes().to_vec())
-                .unwrap_or_default(),
-            note: note.unwrap_or_default().to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        Ok(self
-            .user
-            .approve_thread(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner())
+        Ok(authed_call!(
+            self,
+            approve_thread,
+            ApproveThreadRequest {
+                repo_path: repo_path.to_string(),
+                source_thread: source_thread.to_string(),
+                target_thread: target_thread.to_string(),
+                source_state: objects::object::ChangeId::parse(source_state)
+                    .map(|id| id.as_bytes().to_vec())
+                    .unwrap_or_default(),
+                note: note.unwrap_or_default().to_string(),
+                client_operation_id: String::new(),
+            }
+        ))
     }
 
     pub async fn revoke_approval(&mut self, id: &str) -> Result<(), ProtocolError> {
-        let mut request = Request::new(RevokeApprovalRequest {
-            id: id.to_string(),
-            client_operation_id: String::new(),
-        });
-        self.apply_auth(&mut request)?;
-        self.user
-            .revoke_approval(request)
-            .await
-            .map_err(status_to_protocol_error)?;
+        authed_call!(
+            self,
+            revoke_approval,
+            RevokeApprovalRequest {
+                id: id.to_string(),
+                client_operation_id: String::new(),
+            }
+        );
         Ok(())
     }
 
@@ -373,19 +351,16 @@ impl HostedGrpcClient {
         source_thread: &str,
         target_thread: &str,
     ) -> Result<Vec<ThreadApproval>, ProtocolError> {
-        let mut request = Request::new(ListThreadApprovalsRequest {
-            repo_path: repo_path.to_string(),
-            source_thread: source_thread.to_string(),
-            target_thread: target_thread.to_string(),
-        });
-        self.apply_auth(&mut request)?;
-        Ok(self
-            .user
-            .list_thread_approvals(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner()
-            .approvals)
+        Ok(authed_call!(
+            self,
+            list_thread_approvals,
+            ListThreadApprovalsRequest {
+                repo_path: repo_path.to_string(),
+                source_thread: source_thread.to_string(),
+                target_thread: target_thread.to_string(),
+            }
+        )
+        .approvals)
     }
 
     /// Ask the server "can <source> merge into <target> at
@@ -403,24 +378,21 @@ impl HostedGrpcClient {
         changed_paths: Vec<String>,
         author_user_id: Option<&str>,
     ) -> Result<CheckMergeEligibilityResponse, ProtocolError> {
-        let mut request = Request::new(CheckMergeEligibilityRequest {
-            repo_path: repo_path.to_string(),
-            source_thread: source_thread.to_string(),
-            target_thread: target_thread.to_string(),
-            source_state: objects::object::ChangeId::parse(source_state)
-                .map(|id| id.as_bytes().to_vec())
-                .unwrap_or_default(),
-            gated_action: gated_action.to_string(),
-            changed_paths,
-            author_user_id: author_user_id.unwrap_or_default().to_string(),
-        });
-        self.apply_auth(&mut request)?;
-        Ok(self
-            .user
-            .check_merge_eligibility(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner())
+        Ok(authed_call!(
+            self,
+            check_merge_eligibility,
+            CheckMergeEligibilityRequest {
+                repo_path: repo_path.to_string(),
+                source_thread: source_thread.to_string(),
+                target_thread: target_thread.to_string(),
+                source_state: objects::object::ChangeId::parse(source_state)
+                    .map(|id| id.as_bytes().to_vec())
+                    .unwrap_or_default(),
+                gated_action: gated_action.to_string(),
+                changed_paths,
+                author_user_id: author_user_id.unwrap_or_default().to_string(),
+            }
+        ))
     }
 
     /// Phase C: grant a Heddle staff member temporary admin on a
@@ -436,23 +408,20 @@ impl HostedGrpcClient {
         client_operation_id: String,
     ) -> Result<SupportAccessGrant, ProtocolError> {
         let target = build_target_ref(namespace_path, repo_path)?;
-        let mut request = Request::new(GrantSupportAccessRequest {
-            operator_email: operator_email.to_string(),
-            target,
-            ttl_seconds: Some(prost_types::Duration {
-                seconds: i64::from(ttl_seconds),
-                nanos: 0,
-            }),
-            reason: reason.to_string(),
-            client_operation_id,
-        });
-        self.apply_auth(&mut request)?;
-        Ok(self
-            .user
-            .grant_support_access(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner())
+        Ok(authed_call!(
+            self,
+            grant_support_access,
+            GrantSupportAccessRequest {
+                operator_email: operator_email.to_string(),
+                target,
+                ttl_seconds: Some(prost_types::Duration {
+                    seconds: i64::from(ttl_seconds),
+                    nanos: 0,
+                }),
+                reason: reason.to_string(),
+                client_operation_id,
+            }
+        ))
     }
 
     pub async fn list_support_access_grants(
@@ -462,18 +431,15 @@ impl HostedGrpcClient {
         include_inactive: bool,
     ) -> Result<Vec<SupportAccessGrant>, ProtocolError> {
         let target = build_target_ref(namespace_path, repo_path)?;
-        let mut request = Request::new(ListSupportAccessGrantsRequest {
-            target,
-            include_inactive,
-        });
-        self.apply_auth(&mut request)?;
-        Ok(self
-            .user
-            .list_support_access_grants(request)
-            .await
-            .map_err(status_to_protocol_error)?
-            .into_inner()
-            .grants)
+        Ok(authed_call!(
+            self,
+            list_support_access_grants,
+            ListSupportAccessGrantsRequest {
+                target,
+                include_inactive,
+            }
+        )
+        .grants)
     }
 
     pub async fn revoke_support_access(
@@ -481,15 +447,14 @@ impl HostedGrpcClient {
         id: &str,
         client_operation_id: String,
     ) -> Result<(), ProtocolError> {
-        let mut request = Request::new(RevokeSupportAccessRequest {
-            id: id.to_string(),
-            client_operation_id,
-        });
-        self.apply_auth(&mut request)?;
-        self.user
-            .revoke_support_access(request)
-            .await
-            .map_err(status_to_protocol_error)?;
+        authed_call!(
+            self,
+            revoke_support_access,
+            RevokeSupportAccessRequest {
+                id: id.to_string(),
+                client_operation_id,
+            }
+        );
         Ok(())
     }
 }

--- a/crates/devtools/src/asserter.rs
+++ b/crates/devtools/src/asserter.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared plumbing for the AST-based `check_*` asserters.
+//!
+//! Every asserter reads the same two env vars (a colon-separated search
+//! path and a semicolon-separated `path:line` allowlist), differing only
+//! in the var *names*, and walks the same `.rs`-file tree under each
+//! search dir. This module owns that common shape; each `check_*` binary
+//! supplies only its env-key constants, its per-path skip predicate, and
+//! its `(path, source)` visitor.
+
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use walkdir::WalkDir;
+
+/// Default search root when the env var is unset or empty: the
+/// workspace `crates/` tree.
+const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+
+/// Read the colon-separated search-dir list from `env_key`. An unset or
+/// empty value falls back to [`DEFAULT_SEARCH_DIRS`] (`crates`).
+pub fn read_search_dirs(env_key: &str) -> Vec<PathBuf> {
+    match env::var(env_key) {
+        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
+        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
+    }
+}
+
+/// Read the semicolon-separated `path:line` allowlist from `env_key`.
+/// An explicitly-empty value disables the list; an unset var uses the
+/// built-in default (also empty).
+pub fn read_allowlist(env_key: &str) -> Vec<String> {
+    match env::var(env_key) {
+        Ok(value) if value.is_empty() => Vec::new(),
+        Ok(value) => value.split(';').map(str::to_string).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Walk every `.rs` file under `dir`, invoking `visit(path, source)` on
+/// each file that `skip` does not reject. A non-existent `dir` is a
+/// no-op (mirrors the legacy shell asserters, whose mutation harness
+/// sometimes points at empty trees). `files_scanned` is bumped once per
+/// file actually read — `skip`ped files are filtered *before* the read,
+/// so they don't count.
+pub fn for_each_rs_file(
+    dir: &Path,
+    files_scanned: &mut usize,
+    skip: impl Fn(&Path) -> bool,
+    mut visit: impl FnMut(&Path, &str) -> Result<()>,
+) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in WalkDir::new(dir).follow_links(false) {
+        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("rs") {
+            continue;
+        }
+        if skip(path) {
+            continue;
+        }
+        let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        *files_scanned += 1;
+        visit(path, &source)?;
+    }
+    Ok(())
+}

--- a/crates/devtools/src/check_atomic_ledger_encapsulation.rs
+++ b/crates/devtools/src/check_atomic_ledger_encapsulation.rs
@@ -27,9 +27,7 @@
 //! disables, unset uses the built-in default — currently empty).
 
 use std::{
-    env,
     ffi::OsStr,
-    fs,
     path::{Path, PathBuf},
 };
 
@@ -38,9 +36,8 @@ use syn::{
     Attribute, ImplItemFn, ItemFn, ItemMod, Meta, MetaList, Token, parse::Parser,
     punctuated::Punctuated, visit::Visit,
 };
-use walkdir::WalkDir;
 
-const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+use crate::asserter::{for_each_rs_file, read_allowlist, read_search_dirs};
 
 /// The raw ledger-registration method. Any call to a method of this name outside
 /// the atomic module is a hit (over-approximating toward flagging is the safe
@@ -56,7 +53,10 @@ vars: HEDDLE_LEDGER_ENCAP_SEARCH_DIRS, HEDDLE_LEDGER_ENCAP_ALLOWLIST)"
         );
     }
 
-    check(&read_search_dirs(), &read_allowlist())
+    check(
+        &read_search_dirs("HEDDLE_LEDGER_ENCAP_SEARCH_DIRS"),
+        &read_allowlist("HEDDLE_LEDGER_ENCAP_ALLOWLIST"),
+    )
 }
 
 /// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
@@ -105,21 +105,6 @@ HEDDLE_LEDGER_ENCAP_ALLOWLIST with a one-line justification."
     Ok(())
 }
 
-fn read_search_dirs() -> Vec<PathBuf> {
-    match env::var("HEDDLE_LEDGER_ENCAP_SEARCH_DIRS") {
-        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
-        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
-    }
-}
-
-fn read_allowlist() -> Vec<String> {
-    match env::var("HEDDLE_LEDGER_ENCAP_ALLOWLIST") {
-        Ok(value) if value.is_empty() => Vec::new(),
-        Ok(value) => value.split(';').map(str::to_string).collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
 #[derive(Debug)]
 struct Hit {
     path: PathBuf,
@@ -128,32 +113,12 @@ struct Hit {
 }
 
 fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    for entry in WalkDir::new(dir).follow_links(false) {
-        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(OsStr::to_str) != Some("rs") {
-            continue;
-        }
-        // The atomic module IS the ledger's home — `step`/`enroll`/
-        // `enroll_whole_op` legitimately call `on_rewind` there.
-        if is_atomic_module_path(path) {
-            continue;
-        }
-        // Tests legitimately drive the raw primitive to exercise ledger
-        // behavior; skip them.
-        if is_test_path(path) {
-            continue;
-        }
-        let source =
-            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-        *files_scanned += 1;
-        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    // Skip the atomic module (the ledger's home, where `step`/`enroll`/
+    // `enroll_whole_op` legitimately call `on_rewind`) and test code
+    // (which drives the raw primitive to exercise ledger behavior).
+    let skip = |path: &Path| is_atomic_module_path(path) || is_test_path(path);
+    for_each_rs_file(dir, files_scanned, skip, |path, source| {
+        let file = syn::parse_file(source).with_context(|| format!("parse {}", path.display()))?;
         let lines: Vec<&str> = source.lines().collect();
         let mut visitor = Finder {
             path: path.to_path_buf(),
@@ -161,8 +126,8 @@ fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Resul
             hits,
         };
         visitor.visit_file(&file);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// True iff the path is inside the atomic module (`.../repo/src/atomic/...`),

--- a/crates/devtools/src/check_no_silent_default_tree_load.rs
+++ b/crates/devtools/src/check_no_silent_default_tree_load.rs
@@ -26,17 +26,14 @@
 //! needed because the AST walker doesn't visit doc-comments.
 
 use std::{
-    env,
     ffi::OsStr,
-    fs,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
 use syn::{Expr, ExprMethodCall, Stmt, visit::Visit};
-use walkdir::WalkDir;
 
-const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+use crate::asserter::{for_each_rs_file, read_allowlist, read_search_dirs};
 
 pub fn run(args: Vec<String>) -> Result<()> {
     if let Some(arg) = args.first() {
@@ -45,8 +42,8 @@ pub fn run(args: Vec<String>) -> Result<()> {
         );
     }
 
-    let search_dirs = read_search_dirs();
-    let allowlist = read_allowlist();
+    let search_dirs = read_search_dirs("HEDDLE_ASSERTER_SEARCH_DIRS");
+    let allowlist = read_allowlist("HEDDLE_ASSERTER_ALLOWLIST");
 
     let mut hits: Vec<Hit> = Vec::new();
     let mut files_scanned = 0usize;
@@ -88,21 +85,6 @@ one-line justification."
     Ok(())
 }
 
-fn read_search_dirs() -> Vec<PathBuf> {
-    match env::var("HEDDLE_ASSERTER_SEARCH_DIRS") {
-        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
-        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
-    }
-}
-
-fn read_allowlist() -> Vec<String> {
-    match env::var("HEDDLE_ASSERTER_ALLOWLIST") {
-        Ok(value) if value.is_empty() => Vec::new(),
-        Ok(value) => value.split(';').map(str::to_string).collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
 #[derive(Debug)]
 struct Hit {
     path: PathBuf,
@@ -112,27 +94,8 @@ struct Hit {
 }
 
 fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
-    if !dir.exists() {
-        // Mirror the shell asserter: a non-existent search dir is a no-op,
-        // not an error. The mutation harness sometimes points at empty trees.
-        return Ok(());
-    }
-    for entry in WalkDir::new(dir).follow_links(false) {
-        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(OsStr::to_str) != Some("rs") {
-            continue;
-        }
-        if is_test_path(path) {
-            continue;
-        }
-        let source =
-            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-        *files_scanned += 1;
-        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    for_each_rs_file(dir, files_scanned, is_test_path, |path, source| {
+        let file = syn::parse_file(source).with_context(|| format!("parse {}", path.display()))?;
         let lines: Vec<&str> = source.lines().collect();
         let mut visitor = Finder {
             path: path.to_path_buf(),
@@ -140,8 +103,8 @@ fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Resul
             hits,
         };
         visitor.visit_file(&file);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Tests legitimately exercise the bug class — skip them. This formalizes the

--- a/crates/devtools/src/check_oprecord_exhaustiveness.rs
+++ b/crates/devtools/src/check_oprecord_exhaustiveness.rs
@@ -35,9 +35,7 @@
 //! empty, because there are no legitimate exceptions).
 
 use std::{
-    env,
     ffi::OsStr,
-    fs,
     path::{Path, PathBuf},
 };
 
@@ -45,9 +43,8 @@ use anyhow::{Context, Result, bail};
 use syn::{
     Attribute, ExprMatch, ImplItemFn, ItemFn, ItemMod, Meta, Pat, spanned::Spanned, visit::Visit,
 };
-use walkdir::WalkDir;
 
-const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+use crate::asserter::{for_each_rs_file, read_allowlist, read_search_dirs};
 
 /// Enums whose `match` consumers must be exhaustive. `OpKind` is listed
 /// proactively so a future emitted-kind enum is covered the day it lands.
@@ -61,7 +58,10 @@ HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS, HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOW
         );
     }
 
-    check(&read_search_dirs(), &read_allowlist())
+    check(
+        &read_search_dirs("HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS"),
+        &read_allowlist("HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST"),
+    )
 }
 
 /// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
@@ -115,21 +115,6 @@ scanned)",
     Ok(())
 }
 
-fn read_search_dirs() -> Vec<PathBuf> {
-    match env::var("HEDDLE_OPRECORD_EXHAUSTIVENESS_SEARCH_DIRS") {
-        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
-        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
-    }
-}
-
-fn read_allowlist() -> Vec<String> {
-    match env::var("HEDDLE_OPRECORD_EXHAUSTIVENESS_ALLOWLIST") {
-        Ok(value) if value.is_empty() => Vec::new(),
-        Ok(value) => value.split(';').map(str::to_string).collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
 #[derive(Debug)]
 struct Hit {
     path: PathBuf,
@@ -140,25 +125,8 @@ struct Hit {
 }
 
 fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    for entry in WalkDir::new(dir).follow_links(false) {
-        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(OsStr::to_str) != Some("rs") {
-            continue;
-        }
-        if is_test_path(path) {
-            continue;
-        }
-        let source =
-            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-        *files_scanned += 1;
-        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    for_each_rs_file(dir, files_scanned, is_test_path, |path, source| {
+        let file = syn::parse_file(source).with_context(|| format!("parse {}", path.display()))?;
         let lines: Vec<&str> = source.lines().collect();
         let mut visitor = Finder {
             path: path.to_path_buf(),
@@ -166,8 +134,8 @@ fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Resul
             hits,
         };
         visitor.visit_file(&file);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Skip test code: tests legitimately plant wildcard arms (this asserter's own

--- a/crates/devtools/src/check_snapshot_atomicity.rs
+++ b/crates/devtools/src/check_snapshot_atomicity.rs
@@ -49,17 +49,14 @@
 //! the two known sites are fixed, not exempted).
 
 use std::{
-    env,
     ffi::OsStr,
-    fs,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
 use syn::{Attribute, Expr, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
-use walkdir::WalkDir;
 
-const DEFAULT_SEARCH_DIRS: &[&str] = &["crates"];
+use crate::asserter::{for_each_rs_file, read_allowlist, read_search_dirs};
 
 /// Raw ref-publish methods reachable on a `refs` handle across crates. A call to
 /// any of these on a `.refs` / `.refs()` receiver is a "publish". Deliberately
@@ -89,7 +86,10 @@ HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS, HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST)"
         );
     }
 
-    check(&read_search_dirs(), &read_allowlist())
+    check(
+        &read_search_dirs("HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS"),
+        &read_allowlist("HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST"),
+    )
 }
 
 /// The testable core: scan `search_dirs`, filter hits by `allowlist`, print
@@ -141,21 +141,6 @@ HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST with a one-line justification."
     Ok(())
 }
 
-fn read_search_dirs() -> Vec<PathBuf> {
-    match env::var("HEDDLE_SNAPSHOT_ATOMICITY_SEARCH_DIRS") {
-        Ok(value) if !value.is_empty() => value.split(':').map(PathBuf::from).collect(),
-        _ => DEFAULT_SEARCH_DIRS.iter().map(PathBuf::from).collect(),
-    }
-}
-
-fn read_allowlist() -> Vec<String> {
-    match env::var("HEDDLE_SNAPSHOT_ATOMICITY_ALLOWLIST") {
-        Ok(value) if value.is_empty() => Vec::new(),
-        Ok(value) => value.split(';').map(str::to_string).collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
 #[derive(Debug)]
 struct Hit {
     path: PathBuf,
@@ -165,25 +150,8 @@ struct Hit {
 }
 
 fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    for entry in WalkDir::new(dir).follow_links(false) {
-        let entry = entry.with_context(|| format!("walkdir under {}", dir.display()))?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if path.extension().and_then(OsStr::to_str) != Some("rs") {
-            continue;
-        }
-        if is_test_path(path) {
-            continue;
-        }
-        let source =
-            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-        *files_scanned += 1;
-        let file = syn::parse_file(&source).with_context(|| format!("parse {}", path.display()))?;
+    for_each_rs_file(dir, files_scanned, is_test_path, |path, source| {
+        let file = syn::parse_file(source).with_context(|| format!("parse {}", path.display()))?;
         let lines: Vec<&str> = source.lines().collect();
         let mut visitor = Finder {
             path: path.to_path_buf(),
@@ -191,8 +159,8 @@ fn scan_dir(dir: &Path, hits: &mut Vec<Hit>, files_scanned: &mut usize) -> Resul
             hits,
         };
         visitor.visit_file(&file);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Tests legitimately exercise the bug class (they drive `set_thread` +

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 
+mod asserter;
 mod check_atomic_ledger_encapsulation;
 mod check_no_silent_default_tree_load;
 mod check_oprecord_exhaustiveness;

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -1245,11 +1245,7 @@ impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
     }
 
     fn entry_from_tree_entry(&self, parent_path: &Path, tree_entry: &TreeEntry) -> Result<Entry> {
-        let entry_path = if parent_path.as_os_str().is_empty() {
-            PathBuf::from(&tree_entry.name)
-        } else {
-            parent_path.join(&tree_entry.name)
-        };
+        let entry_path = join_child(parent_path, &tree_entry.name);
         let (kind, size, unix_mode, record) = match tree_entry.entry_type {
             EntryType::Tree => {
                 // We deliberately load the subtree here so the entry
@@ -1300,6 +1296,54 @@ impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
             size,
             unix_mode,
         })
+    }
+
+    /// Build an [`Entry`] from a [`PendingHit`]. `path` is the child's
+    /// mount-relative path (used to intern the `PendingFile` /
+    /// `PendingSymlink` record for warm/symlink hits); `name` is the
+    /// leaf name of the returned entry. Returns `None` for
+    /// [`PendingHit::Tombstone`] — the caller treats that as "entry
+    /// hidden". Shared by `lookup` and `enumerate`.
+    fn entry_from_pending_hit(&self, hit: PendingHit, path: &Path, name: &OsStr) -> Option<Entry> {
+        match hit {
+            PendingHit::Tombstone => None,
+            PendingHit::Hot { node, size, mode } => Some(Entry {
+                node,
+                name: name.to_os_string(),
+                kind: kind_for_mode(mode),
+                size,
+                unix_mode: mode.to_unix_mode(),
+            }),
+            PendingHit::Warm {
+                blob: _,
+                size,
+                mode,
+            } => {
+                let node = self.intern(NodeRecord::PendingFile {
+                    path: path.to_path_buf(),
+                    mode,
+                });
+                Some(Entry {
+                    node,
+                    name: name.to_os_string(),
+                    kind: kind_for_mode(mode),
+                    size,
+                    unix_mode: mode.to_unix_mode(),
+                })
+            }
+            PendingHit::Symlink { target_len } => {
+                let node = self.intern(NodeRecord::PendingSymlink {
+                    path: path.to_path_buf(),
+                });
+                Some(Entry {
+                    node,
+                    name: name.to_os_string(),
+                    kind: NodeKind::Symlink,
+                    size: target_len,
+                    unix_mode: FileMode::Symlink.to_unix_mode(),
+                })
+            }
+        }
     }
 
     fn tree_for_record(&self, record: &NodeRecord) -> Result<Tree> {
@@ -3066,53 +3110,19 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
         let Some(name_str) = name.to_str() else {
             return Ok(None);
         };
-        let child_path = if parent_path.as_os_str().is_empty() {
-            PathBuf::from(name_str)
-        } else {
-            parent_path.join(name_str)
-        };
+        let child_path = join_child(&parent_path, name_str);
 
         // Pending tier wins over the immutable tree for files —
         // that's what makes "write then read" return the new bytes.
         match self.pending_lookup(&child_path) {
             Some(PendingHit::Tombstone) => return Ok(None),
-            Some(PendingHit::Hot { node, size, mode }) => {
-                return Ok(Some(Entry {
-                    node,
-                    name: OsString::from(name_str),
-                    kind: kind_for_mode(mode),
-                    size,
-                    unix_mode: mode.to_unix_mode(),
-                }));
-            }
-            Some(PendingHit::Warm {
-                blob: _,
-                size,
-                mode,
-            }) => {
-                let node = self.intern(NodeRecord::PendingFile {
-                    path: child_path.clone(),
-                    mode,
-                });
-                return Ok(Some(Entry {
-                    node,
-                    name: OsString::from(name_str),
-                    kind: kind_for_mode(mode),
-                    size,
-                    unix_mode: mode.to_unix_mode(),
-                }));
-            }
-            Some(PendingHit::Symlink { target_len }) => {
-                let node = self.intern(NodeRecord::PendingSymlink {
-                    path: child_path.clone(),
-                });
-                return Ok(Some(Entry {
-                    node,
-                    name: OsString::from(name_str),
-                    kind: NodeKind::Symlink,
-                    size: target_len,
-                    unix_mode: FileMode::Symlink.to_unix_mode(),
-                }));
+            Some(hit) => {
+                // Non-tombstone hits always yield an entry; tombstone
+                // is handled above.
+                if let Some(entry) = self.entry_from_pending_hit(hit, &child_path, name) {
+                    return Ok(Some(entry));
+                }
+                return Ok(None);
             }
             None => {}
         }
@@ -3481,11 +3491,7 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
 
         // Pass 1: captured-tree entries, with pending overlay.
         for tree_entry in tree.entries() {
-            let entry_path = if parent_path.as_os_str().is_empty() {
-                PathBuf::from(&tree_entry.name)
-            } else {
-                parent_path.join(&tree_entry.name)
-            };
+            let entry_path = join_child(&parent_path, &tree_entry.name);
             // Whole-subtree rmdir on a captured dir entry.
             {
                 let pending = self.inner.pending.lock().expect("pending lock");
@@ -3495,52 +3501,12 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
             }
             match self.pending_lookup(&entry_path) {
                 Some(PendingHit::Tombstone) => continue,
-                Some(PendingHit::Hot { node, size, mode }) => {
-                    by_name.insert(
-                        tree_entry.name.clone(),
-                        Entry {
-                            node,
-                            name: OsString::from(&tree_entry.name),
-                            kind: kind_for_mode(mode),
-                            size,
-                            unix_mode: mode.to_unix_mode(),
-                        },
-                    );
-                    continue;
-                }
-                Some(PendingHit::Warm {
-                    blob: _,
-                    size,
-                    mode,
-                }) => {
-                    let node = self.intern(NodeRecord::PendingFile {
-                        path: entry_path,
-                        mode,
-                    });
-                    by_name.insert(
-                        tree_entry.name.clone(),
-                        Entry {
-                            node,
-                            name: OsString::from(&tree_entry.name),
-                            kind: kind_for_mode(mode),
-                            size,
-                            unix_mode: mode.to_unix_mode(),
-                        },
-                    );
-                    continue;
-                }
-                Some(PendingHit::Symlink { target_len }) => {
-                    let node = self.intern(NodeRecord::PendingSymlink { path: entry_path });
-                    by_name.insert(
-                        tree_entry.name.clone(),
-                        Entry {
-                            node,
-                            name: OsString::from(&tree_entry.name),
-                            kind: NodeKind::Symlink,
-                            size: target_len,
-                            unix_mode: FileMode::Symlink.to_unix_mode(),
-                        },
-                    );
+                Some(hit) => {
+                    if let Some(entry) =
+                        self.entry_from_pending_hit(hit, &entry_path, OsStr::new(&tree_entry.name))
+                    {
+                        by_name.insert(tree_entry.name.clone(), entry);
+                    }
                     continue;
                 }
                 None => {}
@@ -3558,11 +3524,7 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
             if by_name.contains_key(&name) {
                 continue;
             }
-            let full_path = if parent_path.as_os_str().is_empty() {
-                PathBuf::from(&name)
-            } else {
-                parent_path.join(&name)
-            };
+            let full_path = join_child(&parent_path, &name);
             match kind {
                 PendingChildKind::HotFile { node, size, mode } => {
                     by_name.insert(

--- a/crates/mount/src/error.rs
+++ b/crates/mount/src/error.rs
@@ -108,3 +108,25 @@ fn stale_errno() -> i32 {
 fn stale_errno() -> i32 {
     116
 }
+
+/// Best-effort stringification of a `catch_unwind` panic payload.
+/// Recovers the common `&'static str` / `String` panic messages and
+/// falls back to a placeholder for anything else. Shared by the
+/// per-OS shell guard wrappers (FUSE / FSKit / ProjFS), which each
+/// catch panics across an `extern "C"` frame and log the message.
+/// Gated to the union of the shell backends so a no-shell build (which
+/// compiles none of the callers) doesn't trip `dead_code`.
+#[cfg(any(
+    all(target_os = "linux", feature = "fuse"),
+    all(target_os = "macos", feature = "fskit"),
+    all(target_os = "windows", feature = "projfs"),
+))]
+pub(crate) fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}

--- a/crates/mount/src/fskit/mod.rs
+++ b/crates/mount/src/fskit/mod.rs
@@ -370,7 +370,7 @@ fn guarded_c_int<F: FnOnce() -> c_int>(label: &'static str, f: F) -> c_int {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
         Ok(rc) => rc,
         Err(payload) => {
-            let msg = panic_payload_str(&payload);
+            let msg = crate::error::panic_payload_str(&payload);
             tracing::error!(trampoline = label, %msg, "FSKit trampoline panicked; returning EIO");
             libc::EIO
         }
@@ -386,18 +386,8 @@ fn guarded_c_int<F: FnOnce() -> c_int>(label: &'static str, f: F) -> c_int {
 #[inline]
 fn guarded_drop<F: FnOnce()>(label: &'static str, f: F) {
     if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-        let msg = panic_payload_str(&payload);
+        let msg = crate::error::panic_payload_str(&payload);
         tracing::error!(trampoline = label, %msg, "FSKit trampoline panicked during drop");
-    }
-}
-
-fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "<non-string panic payload>".to_string()
     }
 }
 

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -304,21 +304,32 @@ fn file_type_for_kind(kind: NodeKind) -> FileType {
     }
 }
 
-fn file_attr_from(attrs: Attrs) -> FileAttr {
-    let kind = file_type_for_kind(attrs.kind);
+/// Shared `FileAttr` builder. The 14 constant-shape fields (block
+/// count, the four mirrored timestamps, uid/gid, rdev/blksize/flags,
+/// and the type-bit-masked `perm`) live here once; the two callers
+/// supply only the values that actually differ between an `Attrs`
+/// snapshot and a freshly-resolved `Entry`.
+fn make_file_attr(
+    node: NodeId,
+    size: u64,
+    mtime: std::time::SystemTime,
+    kind: NodeKind,
+    unix_mode: u32,
+    nlink: u32,
+) -> FileAttr {
     FileAttr {
-        ino: INodeNo(attrs.node.0),
-        size: attrs.size,
-        blocks: attrs.size.div_ceil(512),
-        atime: attrs.mtime,
-        mtime: attrs.mtime,
-        ctime: attrs.mtime,
-        crtime: attrs.mtime,
-        kind,
+        ino: INodeNo(node.0),
+        size,
+        blocks: size.div_ceil(512),
+        atime: mtime,
+        mtime,
+        ctime: mtime,
+        crtime: mtime,
+        kind: file_type_for_kind(kind),
         // The `unix_mode` we store includes the type bits; FUSE wants
         // just the permission bits in `perm`.
-        perm: (attrs.unix_mode & 0o7777) as u16,
-        nlink: attrs.nlink,
+        perm: (unix_mode & 0o7777) as u16,
+        nlink,
         uid: process_uid(),
         gid: process_gid(),
         rdev: 0,
@@ -327,24 +338,26 @@ fn file_attr_from(attrs: Attrs) -> FileAttr {
     }
 }
 
+fn file_attr_from(attrs: Attrs) -> FileAttr {
+    make_file_attr(
+        attrs.node,
+        attrs.size,
+        attrs.mtime,
+        attrs.kind,
+        attrs.unix_mode,
+        attrs.nlink,
+    )
+}
+
 fn entry_attr_from(entry: &Entry, mtime: std::time::SystemTime) -> FileAttr {
-    FileAttr {
-        ino: INodeNo(entry.node.0),
-        size: entry.size,
-        blocks: entry.size.div_ceil(512),
-        atime: mtime,
+    make_file_attr(
+        entry.node,
+        entry.size,
         mtime,
-        ctime: mtime,
-        crtime: mtime,
-        kind: file_type_for_kind(entry.kind),
-        perm: (entry.unix_mode & 0o7777) as u16,
-        nlink: 1,
-        uid: process_uid(),
-        gid: process_gid(),
-        rdev: 0,
-        blksize: 4096,
-        flags: 0,
-    }
+        entry.kind,
+        entry.unix_mode,
+        1,
+    )
 }
 
 /// Convert a `MountError`'s errno back into the `Errno` newtype that
@@ -371,7 +384,7 @@ fn guard_call<T>(label: &'static str, f: impl FnOnce() -> Result<T>) -> Result<T
     match std::panic::catch_unwind(AssertUnwindSafe(f)) {
         Ok(result) => result,
         Err(payload) => {
-            let msg = panic_payload_str(&payload);
+            let msg = crate::error::panic_payload_str(&payload);
             tracing::error!(callback = label, %msg, "FUSE callback panicked; returning EIO");
             Err(crate::error::MountError::Store(
                 objects::error::HeddleError::Io(std::io::Error::other(format!(
@@ -379,16 +392,6 @@ fn guard_call<T>(label: &'static str, f: impl FnOnce() -> Result<T>) -> Result<T
                 ))),
             ))
         }
-    }
-}
-
-fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "<non-string panic payload>".to_string()
     }
 }
 
@@ -765,20 +768,13 @@ impl Filesystem for FuseShell {
         // pre-check left a TOCTOU window between the lookup and the
         // rename — a concurrent writer could install the
         // destination in between and the rename would clobber it.
-        #[cfg(target_os = "linux")]
         if flags.contains(RenameFlags::RENAME_EXCHANGE)
             || flags.contains(RenameFlags::RENAME_WHITEOUT)
         {
             reply.error(Errno::from_i32(libc::EINVAL));
             return;
         }
-        #[cfg(target_os = "linux")]
         let no_replace = flags.contains(RenameFlags::RENAME_NOREPLACE);
-        #[cfg(not(target_os = "linux"))]
-        let no_replace = {
-            let _ = flags;
-            false
-        };
         let options = RenameOptions { no_replace };
         match guard_call("rename", || {
             self.inner.rename_entry_with_options(

--- a/crates/mount/src/projfs.rs
+++ b/crates/mount/src/projfs.rs
@@ -676,7 +676,7 @@ fn guarded_hresult<F: FnOnce() -> HRESULT>(label: &'static str, f: F) -> HRESULT
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
         Ok(rc) => rc,
         Err(payload) => {
-            let msg = panic_payload_str(&payload);
+            let msg = crate::error::panic_payload_str(&payload);
             tracing::error!(
                 trampoline = label,
                 %msg,
@@ -687,16 +687,6 @@ fn guarded_hresult<F: FnOnce() -> HRESULT>(label: &'static str, f: F) -> HRESULT
                 std::io::Error::from_raw_os_error(1117),
             )))
         }
-    }
-}
-
-fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "<non-string panic payload>".to_string()
     }
 }
 

--- a/crates/objects/src/object/discussion.rs
+++ b/crates/objects/src/object/discussion.rs
@@ -24,36 +24,13 @@ pub struct DiscussionsBlob {
     pub discussions: Vec<Discussion>,
 }
 
-impl DiscussionsBlob {
-    pub const FORMAT_VERSION: u8 = 1;
-
-    pub fn new(discussions: Vec<Discussion>) -> Self {
-        Self {
-            format_version: Self::FORMAT_VERSION,
-            discussions,
-        }
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, DiscussionError> {
-        rmp_serde::to_vec(self).map_err(|err| DiscussionError::Encoding(err.to_string()))
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self, DiscussionError> {
-        let blob: Self = rmp_serde::from_slice(bytes)
-            .map_err(|err| DiscussionError::Encoding(err.to_string()))?;
-        blob.validate()?;
-        Ok(blob)
-    }
-
-    pub fn validate(&self) -> Result<(), DiscussionError> {
-        if self.format_version != Self::FORMAT_VERSION {
-            return Err(DiscussionError::UnsupportedVersion(self.format_version));
-        }
-        for d in &self.discussions {
-            d.validate()?;
-        }
-        Ok(())
-    }
+versioned_msgpack_blob! {
+    blob: DiscussionsBlob,
+    item: Discussion,
+    field: discussions,
+    error: DiscussionError,
+    codec_err: Encoding,
+    version: 1,
 }
 
 /// Stable opaque identifier for a discussion. Generated server-side at open

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Core object primitives extracted from the monolith.
 
+#[macro_use]
+mod versioned_blob;
+
 mod action_id;
 mod action_operation;
 mod action_struct;

--- a/crates/objects/src/object/risk_signal.rs
+++ b/crates/objects/src/object/risk_signal.rs
@@ -33,36 +33,13 @@ pub struct RiskSignalBlob {
     pub signals: Vec<RiskSignal>,
 }
 
-impl RiskSignalBlob {
-    pub const FORMAT_VERSION: u8 = 1;
-
-    pub fn new(signals: Vec<RiskSignal>) -> Self {
-        Self {
-            format_version: Self::FORMAT_VERSION,
-            signals,
-        }
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, RiskSignalError> {
-        rmp_serde::to_vec(self).map_err(|err| RiskSignalError::Encoding(err.to_string()))
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self, RiskSignalError> {
-        let blob: Self = rmp_serde::from_slice(bytes)
-            .map_err(|err| RiskSignalError::Encoding(err.to_string()))?;
-        blob.validate()?;
-        Ok(blob)
-    }
-
-    pub fn validate(&self) -> Result<(), RiskSignalError> {
-        if self.format_version != Self::FORMAT_VERSION {
-            return Err(RiskSignalError::UnsupportedVersion(self.format_version));
-        }
-        for signal in &self.signals {
-            signal.validate()?;
-        }
-        Ok(())
-    }
+versioned_msgpack_blob! {
+    blob: RiskSignalBlob,
+    item: RiskSignal,
+    field: signals,
+    error: RiskSignalError,
+    codec_err: Encoding,
+    version: 1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/objects/src/object/state_context.rs
+++ b/crates/objects/src/object/state_context.rs
@@ -157,38 +157,15 @@ pub enum ContextError {
     InvalidEncoding(String),
 }
 
-impl ContextBlob {
-    /// Current encoded format version. Reject anything that isn't the
-    /// current value — no live deployments to migrate from.
-    pub const FORMAT_VERSION: u8 = 2;
-
-    pub fn new(annotations: Vec<Annotation>) -> Self {
-        Self {
-            format_version: Self::FORMAT_VERSION,
-            annotations,
-        }
-    }
-
-    pub fn validate(&self) -> Result<(), ContextError> {
-        if self.format_version != Self::FORMAT_VERSION {
-            return Err(ContextError::UnsupportedVersion(self.format_version));
-        }
-        for annotation in &self.annotations {
-            annotation.validate()?;
-        }
-        Ok(())
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, ContextError> {
-        rmp_serde::to_vec(self).map_err(|err| ContextError::InvalidEncoding(err.to_string()))
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self, ContextError> {
-        let blob: Self = rmp_serde::from_slice(bytes)
-            .map_err(|err| ContextError::InvalidEncoding(err.to_string()))?;
-        blob.validate()?;
-        Ok(blob)
-    }
+// Current encoded format version is 2. Reject anything that isn't the
+// current value — no live deployments to migrate from.
+versioned_msgpack_blob! {
+    blob: ContextBlob,
+    item: Annotation,
+    field: annotations,
+    error: ContextError,
+    codec_err: InvalidEncoding,
+    version: 2,
 }
 
 impl Annotation {

--- a/crates/objects/src/object/state_review.rs
+++ b/crates/objects/src/object/state_review.rs
@@ -27,38 +27,13 @@ pub struct ReviewSignaturesBlob {
     pub signatures: Vec<ReviewSignature>,
 }
 
-impl ReviewSignaturesBlob {
-    pub const FORMAT_VERSION: u8 = 1;
-
-    pub fn new(signatures: Vec<ReviewSignature>) -> Self {
-        Self {
-            format_version: Self::FORMAT_VERSION,
-            signatures,
-        }
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, ReviewSignatureError> {
-        rmp_serde::to_vec(self).map_err(|err| ReviewSignatureError::Encoding(err.to_string()))
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self, ReviewSignatureError> {
-        let blob: Self = rmp_serde::from_slice(bytes)
-            .map_err(|err| ReviewSignatureError::Encoding(err.to_string()))?;
-        blob.validate()?;
-        Ok(blob)
-    }
-
-    pub fn validate(&self) -> Result<(), ReviewSignatureError> {
-        if self.format_version != Self::FORMAT_VERSION {
-            return Err(ReviewSignatureError::UnsupportedVersion(
-                self.format_version,
-            ));
-        }
-        for sig in &self.signatures {
-            sig.validate()?;
-        }
-        Ok(())
-    }
+versioned_msgpack_blob! {
+    blob: ReviewSignaturesBlob,
+    item: ReviewSignature,
+    field: signatures,
+    error: ReviewSignatureError,
+    codec_err: Encoding,
+    version: 1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/objects/src/object/structured_conflict.rs
+++ b/crates/objects/src/object/structured_conflict.rs
@@ -25,36 +25,13 @@ pub struct StructuredConflict {
     pub conflicts: Vec<ConflictSymbol>,
 }
 
-impl StructuredConflict {
-    pub const FORMAT_VERSION: u8 = 1;
-
-    pub fn new(conflicts: Vec<ConflictSymbol>) -> Self {
-        Self {
-            format_version: Self::FORMAT_VERSION,
-            conflicts,
-        }
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, ConflictError> {
-        rmp_serde::to_vec(self).map_err(|err| ConflictError::Encoding(err.to_string()))
-    }
-
-    pub fn decode(bytes: &[u8]) -> Result<Self, ConflictError> {
-        let blob: Self =
-            rmp_serde::from_slice(bytes).map_err(|err| ConflictError::Encoding(err.to_string()))?;
-        blob.validate()?;
-        Ok(blob)
-    }
-
-    pub fn validate(&self) -> Result<(), ConflictError> {
-        if self.format_version != Self::FORMAT_VERSION {
-            return Err(ConflictError::UnsupportedVersion(self.format_version));
-        }
-        for c in &self.conflicts {
-            c.validate()?;
-        }
-        Ok(())
-    }
+versioned_msgpack_blob! {
+    blob: StructuredConflict,
+    item: ConflictSymbol,
+    field: conflicts,
+    error: ConflictError,
+    codec_err: Encoding,
+    version: 1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/objects/src/object/versioned_blob.rs
+++ b/crates/objects/src/object/versioned_blob.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared boilerplate for the versioned msgpack container blobs.
+//!
+//! The state-attached container blobs (structured conflicts,
+//! discussions, risk signals, review signatures, context annotations)
+//! all wrap a `Vec<Item>` behind an identical `format_version` byte +
+//! `rmp-serde` encode/decode + version-check prologue. The only things
+//! that differ are the concrete types, the field name, the error enum,
+//! the `format_version` constant, and which codec-error variant the
+//! enum spells. [`versioned_msgpack_blob!`] emits the common four
+//! methods (`new` / `encode` / `decode` / `validate`); each blob keeps
+//! only its per-item `Item::validate()` logic.
+
+/// Emit `new` / `encode` / `decode` / `validate` for a versioned
+/// msgpack container blob. The generated `validate` rejects any
+/// `format_version` other than the declared one, then defers to each
+/// item's own `validate()`. `decode` runs `validate` after
+/// deserializing, so a stale-version blob is rejected on read.
+macro_rules! versioned_msgpack_blob {
+    (
+        blob: $Blob:ty,
+        item: $Item:ty,
+        field: $field:ident,
+        error: $Err:ty,
+        codec_err: $codec:ident,
+        version: $ver:expr $(,)?
+    ) => {
+        impl $Blob {
+            pub const FORMAT_VERSION: u8 = $ver;
+
+            pub fn new($field: ::std::vec::Vec<$Item>) -> Self {
+                Self {
+                    format_version: Self::FORMAT_VERSION,
+                    $field,
+                }
+            }
+
+            pub fn encode(&self) -> ::core::result::Result<::std::vec::Vec<u8>, $Err> {
+                rmp_serde::to_vec(self).map_err(|err| <$Err>::$codec(err.to_string()))
+            }
+
+            pub fn decode(bytes: &[u8]) -> ::core::result::Result<Self, $Err> {
+                let blob: Self = rmp_serde::from_slice(bytes)
+                    .map_err(|err| <$Err>::$codec(err.to_string()))?;
+                blob.validate()?;
+                Ok(blob)
+            }
+
+            pub fn validate(&self) -> ::core::result::Result<(), $Err> {
+                if self.format_version != Self::FORMAT_VERSION {
+                    return Err(<$Err>::UnsupportedVersion(self.format_version));
+                }
+                for item in &self.$field {
+                    item.validate()?;
+                }
+                Ok(())
+            }
+        }
+    };
+}


### PR DESCRIPTION
Part of #497 (mount/objects/glue slices — does **NOT** close it; the semantic slice remains; the cli slice merged in #513).

Low-risk, same-logic dedups from the simplification sweep. Behavior is identical in every case — these are mechanical extractions, and the existing mount/objects/client/devtools test suites are the oracle.

## Items done

**mount (`crates/mount/src`)**
- 4 read-side empty-parent path joins (lookup/enumerate sites) → existing `join_child` helper.
- Triplicated `panic_payload_str` hoisted into the unconditionally-compiled `error.rs` as `pub(crate)` (gated to the union of shell backends so a no-shell build doesn't trip `dead_code`); fuse/fskit/projfs guard wrappers now call it.
- Duplicated `PendingHit`→`Entry` construction in `lookup` + `enumerate` collapsed behind one `entry_from_pending_hit` converter (intern/kind/size/mode derivation preserved exactly).
- Shared `make_file_attr(...)` builder between `file_attr_from`/`entry_attr_from` (14 identical fields).
- Dropped the dead `#[cfg(not(target_os="linux"))]` branch + redundant `#[cfg(target_os="linux")]` attrs in `fuse.rs` `rename` (module is already linux-gated).

**objects (`crates/objects/src`)**
- `versioned_msgpack_blob!` macro emitting `FORMAT_VERSION`/`new`/`encode`/`decode`/version-checked `validate` for the **5 uniform** container blobs: structured_conflict, discussion, risk_signal, state_review, state_context. Each keeps only its per-item `validate()`. Error variant + version preserved per type (state_context uses `InvalidEncoding` + version 2).

**glue (`crates/client`, `crates/devtools`)**
- `authed_call!` macro for the ~21 authenticated `grpc_hosted/user.rs` user-RPC dispatches (apply_auth → await → `map_err(status_to_protocol_error)` → `into_inner`), collapsing each call site.
- Shared `devtools::asserter` module (`for_each_rs_file` + `read_search_dirs`/`read_allowlist` env-readers); the 4 `check_*.rs` binaries now supply only their skip predicate + visitor + env-key constants. Skip runs before the read so `files_scanned` semantics are unchanged.
- `to_proto_object_info` delegates to `object_descriptor_with_status(info, Present, "")`.

## Items skipped (reported)

- **objects: fold `Blob::from_slice` onto `From<&[u8]>` / drop inherent `from_slice`.** Skipped. Dropping the inherent method forces `&[u8]`-exact arguments at ~16 call sites across 5 crates, several of which pass `&Vec<u8>` or `&[u8; N]` literals (`b"..."`) that rely on deref/unsizing coercion the generic `From<&[u8]>` impl can't provide. Converting them all adds `.as_slice()`/`[..]` noise and risks breaking test compiles across crates — net-negative churn for a -6 item, not a clean mechanical fold.
- **objects: redaction not folded into the macro.** `RedactionsBlob` diverges from the other 5 — its `decode` does no version check, it uses a separate `Decoding` error variant (no `UnsupportedVersion`), and it carries extra methods (`empty`/`push`/`has_active`/`latest`/`mark_all_purged`). Forcing it into the uniform macro would change behavior, so it's left as-is.

## Test plan

- [x] `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — green.
- [x] `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean.
- [x] `cargo clippy --locked -p heddle-mount --features fuse --all-targets -- -D warnings` — clean (exercises the OS-gated fuse shell edits).
- [x] `bash scripts/check-no-silent-default-tree-load.sh` — clean (538 files scanned).

Net **−195 LoC** (566 insertions / 761 deletions).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166101&installation_id=132405951&pr_number=514&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F514&signature=187ee6b197c469f8a7c92643c88b8d49289130764fda700879671c5414e74031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->