### PR TITLE
docs: correct .agents/docs references to moved web/server paths (Weft/Tapestry split)

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -215,14 +215,17 @@ boundary is:
 
 ## Where the server enforces this
 
-- Authority + attenuation blocks: `crates/server/src/biscuit.rs::attenuate`
-- Verifier rule pack: `crates/server/src/biscuit/rules.biscuit`
+The hosted server moved to the sibling **weft** repo; the paths below are
+relative to that repo's server crate.
+
+- Authority + attenuation blocks: `src/biscuit.rs::attenuate`
+- Verifier rule pack: `src/biscuit/rules.biscuit`
 - Per-request facts (`time`, `operation`, `resource`) injected in:
-  `crates/server/src/biscuit.rs::authorize`
+  `src/biscuit.rs::authorize`
 - Revocation cache (cascade-revoke via parent rev_id):
-  `crates/server/src/biscuit/cache.rs`
+  `src/biscuit/cache.rs`
 - Integration tests for chain-three-deep, expiry, and cascade
-  revoke: `tests/grpc_hosted_integration.rs::agent_attenuation_*`
+  revoke: `agent_attenuation_*` in weft's hosted-gRPC integration suite
 
 ## Token size
 

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -11,7 +11,7 @@ crates/
   repo/       # repository operations and helpers
   refs/       # threads, markers, HEAD, packed refs
   oplog/      # undo/redo oplog logic
-  heddle-bridge/     # Git interoperability
+  cli/src/bridge/    # Git interoperability (module within the cli crate)
   semantic/   # semantic diff and parser-heavy analysis
   ...
 docs/              # architecture, hosted model, roadmap, future-state plans

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -11,15 +11,16 @@ crates/
   repo/       # repository operations and helpers
   refs/       # threads, markers, HEAD, packed refs
   oplog/      # undo/redo oplog logic
-  server/     # hosted server, admin/content APIs
   heddle-bridge/     # Git interoperability
   semantic/   # semantic diff and parser-heavy analysis
   ...
 docs/              # architecture, hosted model, roadmap, future-state plans
-web/               # SvelteKit marketing site and hosted app
 specs/             # Quint formal specifications
 tests/             # integration and property tests
 ```
+
+The hosted server now lives in the sibling **weft** repo and the SvelteKit web
+product in the sibling **tapestry** repo — neither is part of this workspace.
 
 ## Key Design Patterns
 
@@ -113,18 +114,12 @@ Important current direction:
 
 ### 7. Web App (SvelteKit)
 
-The `web/` directory contains a SvelteKit frontend (hosted app prototype).
-
-Key files:
-- `web/src/lib/server/api.ts` — server-side typed client for admin and content APIs
-- `web/src/routes/app/repos/[...repoPath]/+page.server.ts` — repository workspace
-- `web/src/routes/app/repos/[...repoPath]/-/changes/+page.server.ts` — change list
-- `web/src/routes/app/repos/[...repoPath]/-/changes/[changeId]/+page.server.ts` — change detail
-- `web/src/routes/app/repos/[...repoPath]/-/files/[...path]/+page.server.ts` — file viewer
-- `web/src/routes/app/repos/[...repoPath]/-/context/+page.server.ts` — repository context view
-- `web/src/routes/app/namespaces/[...namespacePath]/+page.server.ts` — namespace detail
-
-All repo content pages use `+page.server.ts` so API credentials never reach the browser. Some authenticated surfaces are fully wired to the backend, while others are still mock-backed or partial. Check `web/PRODUCT_SPEC.md` and the route implementation before treating a web surface as shipped behavior.
+The SvelteKit web product (marketing site + hosted app prototype) lives in the
+sibling **tapestry** repo, not in this workspace. Its repo content pages use
+`+page.server.ts` loaders so API credentials never reach the browser. Some
+authenticated surfaces are fully wired to the backend, while others are still
+mock-backed or partial. Consult the tapestry repo's product spec and route
+implementations before treating a web surface as shipped behavior.
 
 ### 8. Packfile and Delta Compression
 

--- a/.agents/branch-protection.md
+++ b/.agents/branch-protection.md
@@ -236,17 +236,18 @@ diff touches crypto. Most-restrictive cumulative.
 
 ## Server-side touchpoints
 
-The hosted server moved to the sibling **weft** repo; the paths below are
-relative to that repo's server crate.
+The hosted server moved to the sibling **weft** repo; the `src/...` paths below
+are relative to that repo's server crate (`crates/weft-server/`), and the schema
+path is relative to the weft repo root.
 
 | Concern | File |
 |---|---|
 | Glob matcher | `src/access/glob.rs` |
 | Gate evaluator | `src/access/merge_gate.rs` |
 | Policy + group SQL | `src/pg_registry.rs` |
-| Admin RPC handlers | `src/server/grpc_hosted_impl/admin.rs` |
-| Approval RPC handlers | `src/server/grpc_hosted_impl/user.rs` |
-| Schema | `migrations/006_thread_policies.sql` |
+| Policy + group admin RPC handlers | `src/server/grpc_hosted_impl/user.rs` (e.g. `create_thread_policy`, `create_approval_group`) |
+| Approval RPC handlers | `src/server/grpc_hosted_impl/user.rs` (e.g. `approve_thread`, `revoke_approval`) |
+| Schema | `migrations/003_governance.sql` |
 
 The whole role-inheritance + group-membership lattice fits in two
 helpers (`role_satisfies`, `namespace_covers`) and a recursive CTE

--- a/.agents/branch-protection.md
+++ b/.agents/branch-protection.md
@@ -109,7 +109,7 @@ Two layers of path-conditioning, both CODEOWNERS-style globs:
   intersects. Empty = always fires.
 
 So you can write: "every merge to main needs 1 maintainer
-approval; if the diff touches `crates/server/src/biscuit/**`,
+approval; if the diff touches `crates/crypto/**`,
 *also* needs 1 approval from the `security-reviewers` group."
 
 If the caller passes `changed_paths: []` (we don't know what the
@@ -188,7 +188,7 @@ heddle thread approve feat/x main
 heddle thread approvals feat/x main
 
 # Query the gate
-heddle thread check-merge feat/x main --path crates/server/src/biscuit.rs
+heddle thread check-merge feat/x main --path crates/crypto/src/ed25519.rs
 
 # Take it back
 heddle thread revoke-approval <uuid>
@@ -236,13 +236,16 @@ diff touches crypto. Most-restrictive cumulative.
 
 ## Server-side touchpoints
 
+The hosted server moved to the sibling **weft** repo; the paths below are
+relative to that repo's server crate.
+
 | Concern | File |
 |---|---|
-| Glob matcher | `crates/server/src/access/glob.rs` |
-| Gate evaluator | `crates/server/src/access/merge_gate.rs` |
-| Policy + group SQL | `crates/server/src/pg_registry.rs` |
-| Admin RPC handlers | `crates/server/src/server/grpc_hosted_impl/admin.rs` |
-| Approval RPC handlers | `crates/server/src/server/grpc_hosted_impl/user.rs` |
+| Glob matcher | `src/access/glob.rs` |
+| Gate evaluator | `src/access/merge_gate.rs` |
+| Policy + group SQL | `src/pg_registry.rs` |
+| Admin RPC handlers | `src/server/grpc_hosted_impl/admin.rs` |
+| Approval RPC handlers | `src/server/grpc_hosted_impl/user.rs` |
 | Schema | `migrations/006_thread_policies.sql` |
 
 The whole role-inheritance + group-membership lattice fits in two

--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -150,5 +150,8 @@ docker run --rm heddle-enterprise-backend:test --help
 The SvelteKit web product moved to the sibling **tapestry** repo and is no longer
 part of this workspace. Run its dev/build/check commands (`bun install`,
 `bun run dev`, `bun run build`, `npx svelte-check`) and configure its `.env`
-(`HEDDLE_API_URL`, `HEDDLE_API_TOKEN`, `HEDDLE_SERVER_BISCUIT_PRIVATE_KEY`) from
-within the tapestry repo. The hosted Rust server it talks to lives in **weft**.
+(`HEDDLE_API_URL`, `HEDDLE_API_TOKEN`) from within the tapestry repo. The hosted
+Rust server it talks to lives in **weft**; its server secrets — including the
+Biscuit signing keypair (`HEDDLE_SERVER_BISCUIT_PRIVATE_KEY` /
+`HEDDLE_SERVER_BISCUIT_PUBLIC_KEYS`) — belong in weft's hosted config, not
+tapestry's web `.env`.

--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -147,18 +147,8 @@ docker run --rm heddle-enterprise-backend:test --help
 
 ## Web App (SvelteKit)
 
-```bash
-cd web
-bun install          # Install dependencies
-bun run dev          # Dev server (default port 5173)
-bun run build        # Production build
-bun run preview      # Preview production build
-npx svelte-check     # Type-check all Svelte + TS files
-```
-
-Environment variables for the web app (`.env` in `web/`):
-```
-HEDDLE_API_URL=http://localhost:8080    # Rust server base URL
-HEDDLE_API_TOKEN=<admin-token>          # Static admin token
-HEDDLE_SERVER_BISCUIT_PRIVATE_KEY=<pem> # Server-side only; used by hosted for Biscuit signing
-```
+The SvelteKit web product moved to the sibling **tapestry** repo and is no longer
+part of this workspace. Run its dev/build/check commands (`bun install`,
+`bun run dev`, `bun run build`, `npx svelte-check`) and configure its `.env`
+(`HEDDLE_API_URL`, `HEDDLE_API_TOKEN`, `HEDDLE_SERVER_BISCUIT_PRIVATE_KEY`) from
+within the tapestry repo. The hosted Rust server it talks to lives in **weft**.

--- a/.agents/common-tasks.md
+++ b/.agents/common-tasks.md
@@ -52,7 +52,7 @@ When making changes:
 
 ## Hosted Backend Changes
 
-1. Read `SPEC.md`, `docs/HOSTED_ADMIN.md`, and `docs/HOSTED_NAMESPACES.md` first
+1. Read `SPEC.md`, `docs/HOSTED_ADMIN.md`, and `docs/HOSTED_NAMESPACES.md` in the sibling **weft** repo first
 2. Keep durable metadata in Postgres and object content in shared object storage
 3. Prefer external/shared admission-control state for horizontally scaled behavior
 4. Add targeted tests for hosted authz, admin surfaces, and feature-gated Postgres paths

--- a/.agents/common-tasks.md
+++ b/.agents/common-tasks.md
@@ -64,15 +64,17 @@ Content routes live in the hosted server implementation and are intercepted befo
 1. Add the new content query/helper in the relevant hosted server module
 2. Wire it into both filesystem-backed and Postgres-backed paths if both modes are supported
 3. Add or update route interception for the content prefix if needed
-4. Add the corresponding typed method to `web/src/lib/server/api.ts`
-5. Create or update `+page.server.ts` in the relevant SvelteKit route to call the new method
+4. Add the corresponding typed method to the server-side API client in the sibling **tapestry** repo
+5. Create or update the relevant SvelteKit server loader in tapestry to call the new method
 
-Keep the implementation model consistent with the owning server path. Before changing sync/async boundaries, read the hosted server architecture docs and the current module shape.
+Keep the implementation model consistent with the owning server path. Before changing sync/async boundaries, read the hosted server architecture docs and the current module shape. Note the hosted server now lives in the sibling **weft** repo and the SvelteKit web product in **tapestry**.
 
 ## Wiring a New Web Page
 
-1. Create `+page.server.ts` (not `+page.ts`) in the route directory — server-only loaders keep API creds server-side
-2. Import `api` from `$lib/server/api` and call the appropriate content/admin methods
+> The SvelteKit web product lives in the sibling **tapestry** repo. The steps below describe its loader conventions; make the edits there, not in this workspace.
+
+1. Create a `+page.server.ts` (not `+page.ts`) in the route directory — server-only loaders keep API creds server-side
+2. Import the server-side `api` client and call the appropriate content/admin methods
 3. Handle errors with `throw error(status, message)` from `@sveltejs/kit`
 4. Wrap parallel fetches in `Promise.all([...]).catch(...)` for graceful degradation
 5. Update the corresponding `+page.svelte` to use the new `PageData` shape from `./$types`

--- a/.agents/redaction-primitive.md
+++ b/.agents/redaction-primitive.md
@@ -101,9 +101,9 @@ Match the pattern in `cli/src/cli/cli_args/commands_review.rs` for arg structs +
 
 ## Storage + replication
 
-- The local object store gets a new content type for `Redaction` objects. Same loose+packed strategy as Blob/Tree/State.
-- Sync protocol (the replication wire format, now in the sibling **weft** repo's repo-gRPC impl — verify) needs to handle `Redaction` propagation. Pulling a state pulls any redactions on its blobs.
-- `bridge git export` (in `crates/heddle-bridge`) must replace redacted-blob materialization with the stub when exporting to Git. The downstream Git commit then carries the stub, not the secret — even on push to GitHub.
+- The shared object/proto model stays in this repo: `crates/proto/src/object_graph.rs` defines `ObjectType::Redaction` and `crates/proto/src/native_pack.rs` carries the redaction pack handling. The local object store gets a new content type for `Redaction` objects. Same loose+packed strategy as Blob/Tree/State.
+- Sync protocol (only the replication/server wire format moved — it now lives in the sibling **weft** repo at `crates/weft-server/src/server/grpc_hosted_impl/sync.rs`) needs to handle `Redaction` propagation. Pulling a state pulls any redactions on its blobs.
+- `bridge git export` (in `crates/cli/src/bridge/git_export.rs`) must replace redacted-blob materialization with the stub when exporting to Git. The downstream Git commit then carries the stub, not the secret — even on push to GitHub.
 - `heddle maintenance gc --prune` should NEVER GC a `Redaction` even if its referenced blob has been purged. The tombstone is structurally permanent.
 
 ## Signing
@@ -162,11 +162,11 @@ A reviewer can answer "yes" to all of:
 | CLI args | `crates/cli/src/cli/cli_args/commands_redact.rs` (new) |
 | CLI command handlers | `crates/cli/src/cli/commands/redact.rs`, `purge.rs` (new) |
 | Materialization stub renderer | `crates/repo/src/materialize.rs` or wherever `read_file` lives — verify |
-| Replication | repo-gRPC impl in the sibling **weft** repo |
-| Bridge git stub-on-export | `crates/heddle-bridge/src/export.rs` (verify path) |
+| Replication | sibling **weft** repo, `crates/weft-server/src/server/grpc_hosted_impl/sync.rs` |
+| Bridge git stub-on-export | `crates/cli/src/bridge/git_export.rs` |
 | Property tests | `tests/property/redact_purge.rs` |
 | CLI integration tests | `crates/cli/tests/redact_purge.rs` |
-| Capability rules | Biscuit rule pack in the sibling **weft** repo |
+| Capability rules | sibling **weft** repo, `crates/weft-server/src/biscuit/rules.biscuit` |
 | `CLAIMS.md` (in the sibling **tapestry** repo) | Add `heddle redact apply` + `heddle purge apply` as shipped after this lands |
 
 Once shipped, update the /security Scene 05 page in the sibling **tapestry** repo to drop its PLANNED label and reference the real CLI.

--- a/.agents/redaction-primitive.md
+++ b/.agents/redaction-primitive.md
@@ -102,7 +102,7 @@ Match the pattern in `cli/src/cli/cli_args/commands_review.rs` for arg structs +
 ## Storage + replication
 
 - The local object store gets a new content type for `Redaction` objects. Same loose+packed strategy as Blob/Tree/State.
-- Sync protocol (`crates/server/src/grpc_repo_impl/replication.rs` or wherever the wire format lives — verify) needs to handle `Redaction` propagation. Pulling a state pulls any redactions on its blobs.
+- Sync protocol (the replication wire format, now in the sibling **weft** repo's repo-gRPC impl — verify) needs to handle `Redaction` propagation. Pulling a state pulls any redactions on its blobs.
 - `bridge git export` (in `crates/heddle-bridge`) must replace redacted-blob materialization with the stub when exporting to Git. The downstream Git commit then carries the stub, not the secret — even on push to GitHub.
 - `heddle maintenance gc --prune` should NEVER GC a `Redaction` even if its referenced blob has been purged. The tombstone is structurally permanent.
 
@@ -138,7 +138,7 @@ Integration tests in `crates/cli/tests/`:
 
 ## Out of scope for this build
 
-- UI surfaces in `web/`. The marketing copy is already in place; the hosted review surface will adopt the stub renderer via its existing materialize path once the backend ships.
+- UI surfaces in the sibling **tapestry** repo. The marketing copy is already in place; the hosted review surface will adopt the stub renderer via its existing materialize path once the backend ships.
 - Recovery of purged bytes from backups. Operators should know they need their own backup discipline for irreversible operations.
 - Cross-repo redaction propagation (e.g., if blob X is referenced from another Heddle repo via federation). Single-repo only for now.
 
@@ -162,11 +162,11 @@ A reviewer can answer "yes" to all of:
 | CLI args | `crates/cli/src/cli/cli_args/commands_redact.rs` (new) |
 | CLI command handlers | `crates/cli/src/cli/commands/redact.rs`, `purge.rs` (new) |
 | Materialization stub renderer | `crates/repo/src/materialize.rs` or wherever `read_file` lives — verify |
-| Replication | `crates/server/src/grpc_repo_impl/` |
+| Replication | repo-gRPC impl in the sibling **weft** repo |
 | Bridge git stub-on-export | `crates/heddle-bridge/src/export.rs` (verify path) |
 | Property tests | `tests/property/redact_purge.rs` |
 | CLI integration tests | `crates/cli/tests/redact_purge.rs` |
-| Capability rules | `crates/server/src/biscuit/rules.biscuit` |
-| `web/CLAIMS.md` | Add `heddle redact apply` + `heddle purge apply` as shipped after this lands |
+| Capability rules | Biscuit rule pack in the sibling **weft** repo |
+| `CLAIMS.md` (in the sibling **tapestry** repo) | Add `heddle redact apply` + `heddle purge apply` as shipped after this lands |
 
-Once shipped, update [/security Scene 05](web/src/routes/security/+page.svelte) to drop its PLANNED label and reference the real CLI.
+Once shipped, update the /security Scene 05 page in the sibling **tapestry** repo to drop its PLANNED label and reference the real CLI.

--- a/.agents/web-copy.md
+++ b/.agents/web-copy.md
@@ -1,6 +1,6 @@
 # Web Copy Guidelines
 
-This document captures the copywriting principles and patterns established for Heddle's web presence. Apply these whenever editing `web/src/` content.
+This document captures the copywriting principles and patterns established for Heddle's web presence. The web product now lives in the sibling **tapestry** repo; apply these whenever editing its content.
 
 ---
 
@@ -190,7 +190,7 @@ Heddle's web copy may speak about the future, but it must do so accurately.
 
 - **Shipped** - implemented and safe to describe as current behavior
 - **Foundation in place** - partially implemented or structurally supported, but not yet a complete user-facing product surface
-- **Planned** - clearly intended future-state documented in `docs/` or `web/PRODUCT_SPEC.md`
+- **Planned** - clearly intended future-state documented in `docs/` or the tapestry repo's product spec
 
 ### Rules for future-state copy
 
@@ -261,27 +261,27 @@ The final line of any section should close with the reader's identity, not a fea
 
 ## Key files for web copy
 
-All user-facing copy lives in:
+All user-facing copy lives in the sibling **tapestry** repo. Paths below are relative to that repo's root:
 
 | File | What it controls |
 |------|-----------------|
-| `web/src/lib/content.ts` | Hero stats, capabilities, product pillars, scene labels |
-| `web/src/lib/components/HeddleSequence.svelte` | Hero H1, lede, feature cards, stable CTA |
-| `web/src/lib/components/MarketingHeader.svelte` | Nav CTA label |
-| `web/src/lib/components/MarketingFooter.svelte` | Tagline, status line, nav links |
-| `web/src/routes/+page.svelte` | Page title, meta description, request-access section |
-| `web/src/routes/request-access/+page.svelte` | Dedicated access form copy |
-| `web/src/routes/product/+page.svelte` | Product page sections and pillars |
-| `web/src/routes/namespaces/+page.svelte` | Namespaces marketing page |
-| `web/src/routes/security/+page.svelte` | Security page hero and cards |
-| `web/src/routes/app/agents/+page.svelte` | Agents page descriptions |
-| `web/src/routes/app/namespaces/+page.svelte` | App namespaces description |
-| `web/src/routes/app/worktrees/+page.svelte` | Worktrees description and arch note |
-| `web/src/routes/app/activity/+page.svelte` | Activity feed description |
-| `web/src/routes/app/admin/+page.svelte` | Admin landing and cards |
-| `web/src/routes/app/admin/grants/+page.svelte` | Grants admin description |
-| `web/src/routes/app/admin/repositories/+page.svelte` | Repos admin description |
-| `web/src/lib/components/DashboardContent.svelte` | Dashboard empty states |
+| `src/lib/content.ts` | Hero stats, capabilities, product pillars, scene labels |
+| `src/lib/components/HeddleSequence.svelte` | Hero H1, lede, feature cards, stable CTA |
+| `src/lib/components/MarketingHeader.svelte` | Nav CTA label |
+| `src/lib/components/MarketingFooter.svelte` | Tagline, status line, nav links |
+| `src/routes/+page.svelte` | Page title, meta description, request-access section |
+| `src/routes/request-access/+page.svelte` | Dedicated access form copy |
+| `src/routes/product/+page.svelte` | Product page sections and pillars |
+| `src/routes/namespaces/+page.svelte` | Namespaces marketing page |
+| `src/routes/security/+page.svelte` | Security page hero and cards |
+| `src/routes/app/agents/+page.svelte` | Agents page descriptions |
+| `src/routes/app/namespaces/+page.svelte` | App namespaces description |
+| `src/routes/app/worktrees/+page.svelte` | Worktrees description and arch note |
+| `src/routes/app/activity/+page.svelte` | Activity feed description |
+| `src/routes/app/admin/+page.svelte` | Admin landing and cards |
+| `src/routes/app/admin/grants/+page.svelte` | Grants admin description |
+| `src/routes/app/admin/repositories/+page.svelte` | Repos admin description |
+| `src/lib/components/DashboardContent.svelte` | Dashboard empty states |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,13 +78,13 @@ Heddle uses separate config/state scopes instead of a single repository config f
 
 - `UserConfig` lives in the user's config directory and owns identity, agent defaults, output preferences, and client auth profiles
 - `RepoConfig` lives in `.heddle/config.toml` and owns repository-local behavior, storage coordinates, and remotes
-- `ServerConfig` lives with the hosted runtime and owns storage, database, auth, TLS, and admission settings
+- `ServerConfig` lives with the hosted runtime (in the sibling **weft** repo) and owns storage, database, auth, TLS, and admission settings
 - `WorktreeState` is checkout-local runtime state and should not be serialized into repo config
 
 Binary ownership follows the same split:
 
-- `heddle` owns local repository operations and hosted client access
-- `hosted` owns the hosted server runtime and hosted admin operations
+- `heddle` (this repo) owns local repository operations and hosted client access
+- the hosted server runtime and admin operations live in the sibling **weft** repo (no `hosted` binary in this workspace)
 
 ## Core Repository Model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,16 +61,16 @@ crates/
   repo/      # repository operations and helpers
   refs/      # threads, markers, HEAD, packed refs
   oplog/     # undo/redo oplog logic
-  server/    # hosted server, admin/content APIs
-  hosted/    # hosted server/admin binary
   heddle-bridge/    # Git interoperability
   semantic/  # semantic diff and parser-heavy analysis
   ...
 docs/             # architecture, hosted model, roadmap, future-state plans
-web/              # SvelteKit marketing site and hosted app
 specs/            # Quint formal specifications
 tests/            # integration and property tests
 ```
+
+The hosted server now lives in the sibling **weft** repo and the SvelteKit web
+product in the sibling **tapestry** repo — neither is part of this workspace.
 
 ## Configuration Boundaries
 
@@ -273,7 +273,7 @@ Hosted Heddle has two major layers.
 
 ## Web Product Positioning In The Architecture
 
-The `web/` app is not a browser IDE. It is an emerging hosted product for:
+The web app (now in the sibling **tapestry** repo) is not a browser IDE. It is an emerging hosted product for:
 
 - repository inspection
 - namespace and access operations
@@ -314,4 +314,4 @@ Core state machines are specified in `specs/quint/` and mirrored by Rust propert
 - `docs/ENTERPRISE_BACKEND_ROADMAP.md` - hosted platform roadmap
 - `docs/RUNNERS_AND_BUILDS.md` - hosted workflow and automation direction
 - `docs/LINE_PROVENANCE_PLAN.md` - provenance status and next-step roadmap
-- `web/PRODUCT_SPEC.md` - hosted web product scope and surface plan
+- `PRODUCT_SPEC.md` in the sibling **tapestry** repo - hosted web product scope and surface plan

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ CLI / Web UI
   -> immutable objects and hosted control-plane metadata
 ```
 
-Heddle is no longer best understood as a single `src/` tree. The repository is a Cargo workspace with separate crates for the local/client CLI, core types, repository helpers, refs, oplog, server, semantic analysis, bridge functionality, and the hosted server/admin binary.
+Heddle is no longer best understood as a single `src/` tree. The repository is a Cargo workspace with separate crates for the local/client CLI, core types, repository helpers, refs, oplog, semantic analysis, and bridge functionality. (The hosted server and admin binary moved to the sibling **weft** repo — see below.)
 
 ## Workspace Structure
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ crates/
   repo/      # repository operations and helpers
   refs/      # threads, markers, HEAD, packed refs
   oplog/     # undo/redo oplog logic
-  heddle-bridge/    # Git interoperability
+  cli/src/bridge/   # Git interoperability (module within the cli crate)
   semantic/  # semantic diff and parser-heavy analysis
   ...
 docs/             # architecture, hosted model, roadmap, future-state plans
@@ -308,10 +308,10 @@ Core state machines are specified in `specs/quint/` and mirrored by Rust propert
 
 ## Related Documentation
 
-- `SPEC.md` - formal behavior and storage/protocol truth
-- `docs/HOSTED_NAMESPACES.md` - hosted namespace and grant model
-- `docs/HOSTED_ADMIN.md` - hosted admin commands and API usage
-- `docs/ENTERPRISE_BACKEND_ROADMAP.md` - hosted platform roadmap
-- `docs/RUNNERS_AND_BUILDS.md` - hosted workflow and automation direction
-- `docs/LINE_PROVENANCE_PLAN.md` - provenance status and next-step roadmap
+- `SPEC.md` in the sibling **weft** repo - formal behavior and storage/protocol truth
+- `docs/HOSTED_NAMESPACES.md` in the sibling **weft** repo - hosted namespace and grant model
+- `docs/HOSTED_ADMIN.md` in the sibling **weft** repo - hosted admin commands and API usage
+- `docs/ENTERPRISE_BACKEND_ROADMAP.md` in the sibling **weft** repo - hosted platform roadmap
+- `docs/RUNNERS_AND_BUILDS.md` in the sibling **weft** repo - hosted workflow and automation direction
+- `docs/LINE_PROVENANCE_PLAN.md` in the sibling **weft** repo - provenance status and next-step roadmap
 - `PRODUCT_SPEC.md` in the sibling **tapestry** repo - hosted web product scope and surface plan


### PR DESCRIPTION
Closes #504.

The hosted server moved to the sibling **weft** repo and the SvelteKit web product to **tapestry**, but several `.agents/` and `docs/` files still cited the removed in-repo `web/` and `crates/server/` paths. Repointed them at the sibling repos conceptually — no invented structure.

## Files updated
- `.agents/architecture.md` — dropped removed `server/` crate + `web/` from the dir tree; rewrote §7 "Web App" to point at tapestry; added a weft/tapestry note.
- `.agents/common-tasks.md` — "Adding a Content API Endpoint" + "Wiring a New Web Page" now point at tapestry (was `web/src/lib/server/api.ts`, `$lib/server/api`).
- `.agents/commands.md` — "Web App (SvelteKit)" section now notes the app lives in tapestry (was `cd web`, `.env in web/`).
- `.agents/web-copy.md` — header + key-files table reframed as tapestry-relative (stripped `web/` prefix); PRODUCT_SPEC ref repointed.
- `.agents/redaction-primitive.md` — replication/biscuit pointers → weft; UI/CLAIMS/security-page pointers → tapestry.
- `.agents/agent-attenuation.md` — "Where the server enforces this" pointers reframed as weft-relative.
- `.agents/branch-protection.md` — "Server-side touchpoints" table reframed as weft-relative; two illustrative example paths repointed to the present-in-repo `crates/crypto/...`.
- `docs/ARCHITECTURE.md` — dir tree (dropped `server/`/`hosted/`/`web/`), web-positioning section, and PRODUCT_SPEC link updated.

## Notes / out of scope
- Dated historical records (`docs/CLI_DEP_AUDIT_2026-05-12.md`, `docs/WORKSPACE_SPLIT_PLAN.md`) left intact — editing point-in-time audit/plan docs would falsify the record.
- `docs/CLI_WORLD_CLASS_RUBRIC.md:139` "web/docs links" is web-documentation links, not the `web/` directory — left as-is.

## Gate
- `rg -n 'web/src|src/lib/server' .agents docs` → clean (no matches).
- `heddle doctor docs --all`: 109/74 drift unchanged before vs after; none of the edited files appear in the drift output (pre-existing unknown-verb drift in spike docs, unrelated to this change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783169643&installation_id=132405951&pr_number=515&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F515&signature=b5dc7532daa6df36869d69664a0883fa3a60c86ee721ad133df95261aed0e11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->