### PR TITLE
[codex] capture agent-native collaboration roadmap

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.agents/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.agents/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/.agents/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.agents/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms ([LANGUAGE.md](LANGUAGE.md)) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from [LANGUAGE.md](LANGUAGE.md). Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.agents/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, the same template as before, but rendered as a card:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.agents/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.agents/skills/setup-matt-pocock-skills/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: setup-matt-pocock-skills
+description: Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.
+disable-model-invocation: true
+---
+
+# Setup Matt Pocock's Skills
+
+Scaffold the per-repo configuration that the engineering skills assume:
+
+- **Issue tracker** — where issues live (GitHub by default; local markdown is also supported out of the box)
+- **Triage labels** — the strings used for the five canonical triage roles
+- **Domain docs** — where `CONTEXT.md` and ADRs live, and the consumer rules for reading them
+
+This is a prompt-driven skill, not a deterministic script. Explore, present what you found, confirm with the user, then write.
+
+## Process
+
+### 1. Explore
+
+Look at the current repo to understand its starting state. Read whatever exists; don't assume:
+
+- `git remote -v` and `.git/config` — is this a GitHub repo? Which one?
+- `AGENTS.md` and `CLAUDE.md` at the repo root — does either exist? Is there already an `## Agent skills` section in either?
+- `CONTEXT.md` and `CONTEXT-MAP.md` at the repo root
+- `docs/adr/` and any `src/*/docs/adr/` directories
+- `docs/agents/` — does this skill's prior output already exist?
+- `.scratch/` — sign that a local-markdown issue tracker convention is already in use
+
+### 2. Present findings and ask
+
+Summarise what's present and what's missing. Then walk the user through the three decisions **one at a time** — present a section, get the user's answer, then move to the next. Don't dump all three at once.
+
+Assume the user does not know what these terms mean. Each section starts with a short explainer (what it is, why these skills need it, what changes if they pick differently). Then show the choices and the default.
+
+**Section A — Issue tracker.**
+
+> Explainer: The "issue tracker" is where issues live for this repo. Skills like `to-issues`, `triage`, `to-prd`, and `qa` read from and write to it — they need to know whether to call `gh issue create`, write a markdown file under `.scratch/`, or follow some other workflow you describe. Pick the place you actually track work for this repo.
+
+Default posture: these skills were designed for GitHub. If a `git remote` points at GitHub, propose that. If a `git remote` points at GitLab (`gitlab.com` or a self-hosted host), propose GitLab. Otherwise (or if the user prefers), offer:
+
+- **GitHub** — issues live in the repo's GitHub Issues (uses the `gh` CLI)
+- **GitLab** — issues live in the repo's GitLab Issues (uses the [`glab`](https://gitlab.com/gitlab-org/cli) CLI)
+- **Local markdown** — issues live as files under `.scratch/<feature>/` in this repo (good for solo projects or repos without a remote)
+- **Other** (Jira, Linear, etc.) — ask the user to describe the workflow in one paragraph; the skill will record it as freeform prose
+
+**Section B — Triage label vocabulary.**
+
+> Explainer: When the `triage` skill processes an incoming issue, it moves it through a state machine — needs evaluation, waiting on reporter, ready for an AFK agent to pick up, ready for a human, or won't fix. To do that, it needs to apply labels (or the equivalent in your issue tracker) that match strings *you've actually configured*. If your repo already uses different label names (e.g. `bug:triage` instead of `needs-triage`), map them here so the skill applies the right ones instead of creating duplicates.
+
+The five canonical roles:
+
+- `needs-triage` — maintainer needs to evaluate
+- `needs-info` — waiting on reporter
+- `ready-for-agent` — fully specified, AFK-ready (an agent can pick it up with no human context)
+- `ready-for-human` — needs human implementation
+- `wontfix` — will not be actioned
+
+Default: each role's string equals its name. Ask the user if they want to override any. If their issue tracker has no existing labels, the defaults are fine.
+
+**Section C — Domain docs.**
+
+> Explainer: Some skills (`improve-codebase-architecture`, `diagnose`, `tdd`) read a `CONTEXT.md` file to learn the project's domain language, and `docs/adr/` for past architectural decisions. They need to know whether the repo has one global context or multiple (e.g. a monorepo with separate frontend/backend contexts) so they look in the right place.
+
+Confirm the layout:
+
+- **Single-context** — one `CONTEXT.md` + `docs/adr/` at the repo root. Most repos are this.
+- **Multi-context** — `CONTEXT-MAP.md` at the root pointing to per-context `CONTEXT.md` files (typically a monorepo).
+
+### 3. Confirm and edit
+
+Show the user a draft of:
+
+- The `## Agent skills` block to add to whichever of `CLAUDE.md` / `AGENTS.md` is being edited (see step 4 for selection rules)
+- The contents of `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`, `docs/agents/domain.md`
+
+Let them edit before writing.
+
+### 4. Write
+
+**Pick the file to edit:**
+
+- If `CLAUDE.md` exists, edit it.
+- Else if `AGENTS.md` exists, edit it.
+- If neither exists, ask the user which one to create — don't pick for them.
+
+Never create `AGENTS.md` when `CLAUDE.md` already exists (or vice versa) — always edit the one that's already there.
+
+If an `## Agent skills` block already exists in the chosen file, update its contents in-place rather than appending a duplicate. Don't overwrite user edits to the surrounding sections.
+
+The block:
+
+```markdown
+## Agent skills
+
+### Issue tracker
+
+[one-line summary of where issues are tracked]. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+[one-line summary of the label vocabulary]. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+[one-line summary of layout — "single-context" or "multi-context"]. See `docs/agents/domain.md`.
+```
+
+Then write the three docs files using the seed templates in this skill folder as a starting point:
+
+- [issue-tracker-github.md](./issue-tracker-github.md) — GitHub issue tracker
+- [issue-tracker-gitlab.md](./issue-tracker-gitlab.md) — GitLab issue tracker
+- [issue-tracker-local.md](./issue-tracker-local.md) — local-markdown issue tracker
+- [triage-labels.md](./triage-labels.md) — label mapping
+- [domain.md](./domain.md) — domain doc consumer rules + layout
+
+For "other" issue trackers, write `docs/agents/issue-tracker.md` from scratch using the user's description.
+
+### 5. Done
+
+Tell the user the setup is complete and which engineering skills will now read from these files. Mention they can edit `docs/agents/*.md` directly later — re-running this skill is only necessary if they want to switch issue trackers or restart from scratch.

--- a/.agents/skills/setup-matt-pocock-skills/domain.md
+++ b/.agents/skills/setup-matt-pocock-skills/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-gitlab.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-gitlab.md
@@ -1,0 +1,23 @@
+# Issue tracker: GitLab
+
+Issues and PRDs for this repo live as GitLab issues. Use the [`glab`](https://gitlab.com/gitlab-org/cli) CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `glab issue create --title "..." --description "..."`. Use a heredoc for multi-line descriptions. Pass `--description -` to open an editor.
+- **Read an issue**: `glab issue view <number> --comments`. Use `-F json` for machine-readable output.
+- **List issues**: `glab issue list -F json` with appropriate `--label` filters.
+- **Comment on an issue**: `glab issue note <number> --message "..."`. GitLab calls comments "notes".
+- **Apply / remove labels**: `glab issue update <number> --label "..."` / `--unlabel "..."`. Multiple labels can be comma-separated or by repeating the flag.
+- **Close**: `glab issue close <number>`. `glab issue close` does not accept a closing comment, so post the explanation first with `glab issue note <number> --message "..."`, then close.
+- **Merge requests**: GitLab calls PRs "merge requests". Use `glab mr create`, `glab mr view`, `glab mr note`, etc. — the same shape as `gh pr ...` with `mr` in place of `pr` and `note`/`--message` in place of `comment`/`--body`.
+
+Infer the repo from `git remote -v` — `glab` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitLab issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `glab issue view <number> --comments`.

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-local.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-local.md
@@ -1,0 +1,19 @@
+# Issue tracker: Local Markdown
+
+Issues and PRDs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The PRD is `.scratch/<feature-slug>/PRD.md`
+- Implementation issues are `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.

--- a/.agents/skills/setup-matt-pocock-skills/triage-labels.md
+++ b/.agents/skills/setup-matt-pocock-skills/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/.agents/skills/zoom-out/SKILL.md
+++ b/.agents/skills/zoom-out/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: zoom-out
+description: Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.
+disable-model-invocation: true
+---
+
+I don't know this area of code well. Go up a layer of abstraction. Give me a map of all the relevant modules and callers, using the project's domain glossary vocabulary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,20 @@ When editing docs, specs, or web copy, classify capabilities explicitly:
 
 Do not describe a capability as live if it is only mock-backed in the web app or only planned in docs. Future-state positioning is encouraged when it is grounded in the codebase and roadmap, but it must be labeled accurately.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `HeddleCo/heddle`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the canonical triage labels, with `question` retained as an additional GitHub issue label for general questions. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: use root `CONTEXT.md` and `docs/adr/` for domain language and ADRs, and read `AGENTS.md` plus relevant `.agents/*.md` files for operating guidance. See `docs/agents/domain.md`.
+
 ## Guidelines
 
 | Topic | Description |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,293 @@
+# Heddle
+
+Heddle is a local-first, agent-native version control context. It is useful without a hosted account, while hosted products add coordination and visibility around the same core ideas.
+
+## Language
+
+**Heddle**:
+The local-first, self-contained agent-native version control system and OSS CLI. Heddle must remain useful without a hosted account.
+_Avoid_: hosted-only Heddle, web app, hosted backend
+
+**Agent-Native Version Control**:
+Version control designed around durable agent workflows as first-class behavior: isolated work, explicit attribution, retryable operations, disposable attempts, provenance, and machine-readable contracts.
+_Avoid_: AI-native version control
+
+**CRDT Collaboration Record**:
+A concurrently editable collaboration artifact, such as a discussion or context annotation, that can merge independent local edits without replacing Heddle's immutable source history model.
+_Avoid_: CRDT state model, CRDT source history
+
+**Discussion**:
+A repository-scoped collaboration record for a human or agent conversation anchored to code, state, symbol, thread, or review context. A discussion has durable identity independent of any single immutable state.
+_Avoid_: state-attached discussion, comment thread
+
+**Discussion ID**:
+An opaque stable UUIDv7 identifier for a discussion. Human-readable meaning belongs in discussion titles, anchors, and list output, not in the identifier.
+_Avoid_: discussion slug, content-addressed discussion id
+
+**Collaboration Operation ID**:
+An opaque stable content-addressed identifier for a collaboration operation. It is distinct from a source history ChangeId even if it uses familiar Heddle short-prefix UX.
+_Avoid_: change id for collaboration
+
+**Collaboration Idempotency Key**:
+A stable command-attempt key used to deduplicate retried collaboration writes that have the same intended effect. It is separate from the collaboration operation ID, which hashes the exact canonical operation envelope bytes.
+_Avoid_: semantic operation id, normalized operation hash
+
+**Discussion Title**:
+A human-readable summary of a discussion. Broad anchors such as repository and thread discussions require a title; precise code anchors may derive one from the anchor and first turn.
+_Avoid_: slug, subject line
+
+**Context Annotation**:
+Distilled durable knowledge about the repository, such as a constraint, invariant, or rationale. A context annotation is a repository collaboration record that may be authored directly or extracted from a discussion.
+_Avoid_: discussion, comment, chat note
+
+**Context Extraction**:
+The explicit act of distilling a discussion into a context annotation. Decision turns do not automatically become context annotations.
+_Avoid_: automatic context extraction
+
+**Context Snapshot**:
+The frozen view of context annotations associated with an immutable source state. It records what guidance was known for provenance or replay, but it is not the live source of truth for context annotations.
+_Avoid_: live context store
+
+**Discussion Turn**:
+An append-only contribution to a discussion. Corrections are represented by later turns rather than editing the original turn.
+_Avoid_: editable message
+
+**Discussion Turn Kind**:
+The structured purpose of a discussion turn from a controlled set such as comment, question, answer, blocker, decision, handoff, or status. Turn kind gives agents and inbox views signal without replacing the turn body.
+_Avoid_: message type explosion
+
+**Discussion Turn Reference**:
+A structured link from one discussion turn to an earlier collaboration operation it answers, supersedes, hands off from, or otherwise responds to. It is a workflow edge, not a quotation of the earlier turn body.
+_Avoid_: text heuristic, quoted reply
+
+**Discussion Reopen**:
+An explicit operation that moves a resolved discussion back into active conversation while preserving the earlier resolution in the discussion history.
+_Avoid_: unresolve, edit resolution
+
+**Resolution Conflict**:
+A discussion state where concurrent resolution operations make incompatible claims about how the discussion was closed. A resolution conflict remains attention-worthy until a later operation chooses the intended resolution.
+_Avoid_: last-write-wins resolution, hidden resolution
+
+**Resolution Conflict Resolution**:
+A collaboration operation that chooses the intended outcome among incompatible resolution operations by citing the conflicting operations. It is distinct from ordinary discussion resolve or reopen operations.
+_Avoid_: silent winner, ordinary resolve
+
+**Collaboration Conflict Resolution**:
+A collaboration operation that resolves an explicit collaboration conflict by citing the conflict kind, conflicting operations, chosen outcome, and authority context. Resolution conflicts and visibility conflicts use this shared pattern with kind-specific payloads.
+_Avoid_: implicit conflict winner, last-write-wins
+
+**Collaboration Attestation**:
+A collaboration operation that signs or asserts a claim about earlier collaboration operations without mutating them. It can upgrade trust in old history while preserving content-addressed operation identity.
+_Avoid_: patching signature, rewriting operation
+
+**Collaboration Redaction**:
+A privileged collaboration operation or hosted policy action that suppresses sensitive operation content from normal views or sync while preserving enough audit metadata to explain what was redacted. It is not general editing.
+_Avoid_: edit, delete, rewrite
+
+**Visibility Conflict**:
+A collaboration state where concurrent visibility operations make incompatible policy-sensitive claims about who may see or act on a record. The effective view stays at the most restrictive safe visibility until a later operation resolves the conflict.
+_Avoid_: last-write-wins visibility, silent visibility change
+
+**Agent Resolution**:
+A discussion resolution operation performed by an agent under capability policy. Agent resolutions carry agent attribution, confidence, and an explicit resolution kind.
+_Avoid_: automatic closure
+
+**Agent Coordination Discussion**:
+A discussion used by agents working in parallel threads to exchange durable questions, blockers, decisions, and handoff context. Agent coordination discussions are visible to the delegating human or policy scope by default.
+_Avoid_: ephemeral agent chat, thread-local note
+
+**Agent Handoff**:
+A coordination pattern where an agent transfers durable context, blockers, or next steps through discussions and attention targets. It is not a separate Heddle primitive unless future lifecycle needs justify one.
+_Avoid_: handoff object
+
+**Capability-Interrupted Agent**:
+An agent whose in-flight work was interrupted because capability refresh removed authority needed for the task. It is not a completed agent, and it should be distinguishable from ordinary blockers in machine-readable state.
+_Avoid_: done agent, generic blocked agent
+
+**Agent Task Assignment**:
+Operational metadata that defines an agent's delegated work and execution policy, such as whether offline continuation is allowed. Its identifier can be referenced by collaboration operations as optional provenance, but it is not repository collaboration history in v1.
+_Avoid_: discussion task, collaboration assignment
+
+**Task Provenance**:
+Metadata that explains why or under which local delegation an agent produced collaboration operations. It is distinct from agent attribution, which names the actor that authored an operation.
+_Avoid_: agent attribution, task authority
+
+**Hosted Task Provenance Alias**:
+A Weft-minted hosted-safe identifier that groups collaboration operations from the same local agent task within a specific Weft repository and policy scope. It is provenance for hosted views, not task assignment authority or runner lifecycle state.
+_Avoid_: raw task assignment id, hosted task assignment
+
+**Cross-Domain Provenance View**:
+A derived view that correlates source attribution, collaboration operations, task assignment metadata, and sync metadata. It is not collaboration content unless a human or agent explicitly writes commentary about the relationship.
+_Avoid_: provenance discussion, task record
+
+**Durable Async Coordination**:
+The local Heddle collaboration model where humans and agents exchange persistent records that can be read, queried, merged, and reconciled without live connectivity.
+_Avoid_: real-time chat, presence
+
+**Attention Target**:
+A structured target for attention or readiness, such as a principal, agent, thread, role, or current checkout context. It may be entered through human-friendly mention syntax, but the durable meaning is the resolved target.
+_Avoid_: raw @mention text, display-name routing
+
+**Server-Validated Local Capability**:
+A locally minted Biscuit capability whose maximum permission scope has been validated by Weft. Heddle can derive attenuated child capabilities locally, but hosted trust comes from Weft validating the root capability's scope.
+_Avoid_: self-sovereign hosted token, locally trusted hosted token
+
+**Capability Refresh**:
+The automatic act of replacing the active server-validated local capability after Weft reports that hosted policy or grants have changed. Refresh creates a new capability identity linked to the prior active capability, is user-visible, affects future policy context and sync attempts, and does not mutate existing immutable Biscuit tokens or rewrite existing operation provenance.
+_Avoid_: mutating a biscuit, silently rewriting capability history
+
+**Derived Capability Narrowing**:
+The automatic reduction of effective scope for locally derived capabilities when the refreshed root capability is narrower. Heddle treats derived capability effectiveness as capped by the current server-validated root rather than mutating previously minted child Biscuits.
+_Avoid_: mutating child biscuits, stale derived authority
+
+**Operation Capability Context**:
+The capability context recorded in a collaboration operation when it is created. It contains capability identity and a canonical scope summary as local provenance about the actor's claimed authority and policy view at creation time, not full token material.
+_Avoid_: hosted acceptance, remote grant
+
+**Hosted Acceptance Context**:
+Sync metadata describing the capability context Weft accepted for a collaboration operation on a specific remote. It stores acceptance facts such as capability identity, accepted scope summary, remote identity, accepted time, and policy or grant version when available, not full token material.
+_Avoid_: operation capability context, creation authority
+
+**Capability-Aware Local Filtering**:
+Local CLI filtering that uses the active server-validated local capability to decide which collaboration records to show by default. It is policy context, not a hard security boundary over local filesystem data.
+_Avoid_: local access control, local hosted enforcement
+
+**Expired Capability Context**:
+A cached capability context whose freshness window has passed without a successful Weft refresh. It may be used for degraded local reads with clear labeling, but it is not presented as current hosted authority.
+_Avoid_: current permission, valid hosted scope
+
+**Restricted Collaboration Record**:
+A collaboration record that Heddle filters according to active capability policy. In the OSS local store, restriction does not imply encryption unless a future encrypted storage mode says so explicitly.
+_Avoid_: encrypted discussion
+
+**Collaboration Validity**:
+The acceptance state of a collaboration operation. Local validity means Heddle can parse and structurally apply the operation; hosted validity means Weft accepts it under hosted policy.
+_Avoid_: valid without scope
+
+**Unknown Collaboration Author**:
+A degraded local attribution state used when Heddle cannot resolve a principal or agent for a collaboration operation. Unknown authorship is visible and low-trust, and Weft may reject it under hosted policy.
+_Avoid_: anonymous trusted author
+
+**Import Actor**:
+The principal or agent that imported external or orphaned collaboration history into Heddle. It is distinct from the original author metadata carried by the imported content.
+_Avoid_: original author, anonymous importer
+
+**Repository Collaboration Log**:
+A repository-level collection of collaboration records that can reconcile independent local edits. Discussions are records in this log; their turns, resolutions, and anchor changes are part of the record's history.
+_Avoid_: state discussion blob, per-turn CRDT
+
+**Collaboration Store**:
+The Heddle-native local storage for collaboration operations, indexes, and derived views. It uses repository-local content-addressed objects and rebuildable indexes rather than an embedded database as the durable source of truth.
+_Avoid_: collaboration database, SQLite collaboration store
+
+**Collaboration Store Layout**:
+The local filesystem layout rooted at `.heddle/collaboration/`, with durable operations under `ops/` and rebuildable indexes, views, sync metadata, and temporary files under separate subdirectories.
+_Avoid_: collaboration in source objects, collaboration in oplog
+
+**Collaboration Retention**:
+The policy for keeping or removing locally valid collaboration operations. In v1, locally valid collaboration operations are retained even when Weft rejects them under hosted policy; cleanup only removes temporary artifacts or rebuilds disposable indexes and views.
+_Avoid_: collaboration garbage collection
+
+**Collaboration Sync Lane**:
+The Weft-backed repository synchronization lane that exchanges collaboration operations separately from immutable source objects while remaining part of normal Heddle push and pull behavior.
+_Avoid_: separate discussion product sync, chat sync
+
+**Collaboration Sync Metadata**:
+Local metadata about whether collaboration operations are pending, accepted, rejected, blocked by hosted-invalid causal history, or cursor-synced with Weft. A hosted rejection is sync metadata about a retained local operation, not collaboration content.
+_Avoid_: rejection operation
+
+**Unresolved Collaboration Operation**:
+A structurally valid local collaboration operation whose cited causal parents are not available locally. It is retained as pending/unresolved but is not applied to materialized views until parents arrive or an explicit import/orphan rule accounts for the gap.
+_Avoid_: applied orphan operation, missing-parent success
+
+**Invalid Collaboration Artifact**:
+Malformed or unverifiable collaboration bytes retained for diagnostics or quarantine. It is not a locally valid collaboration operation and is not applied to materialized views.
+_Avoid_: valid operation, silently deleted operation
+
+**Collaboration Import Root**:
+An explicit operation that introduces imported or orphaned collaboration history as a new causal root with recorded source, reason, and trust level.
+_Avoid_: silent orphan apply, missing parent workaround
+
+**Hosted Rejection Reason**:
+Sync metadata explaining why Weft rejected a collaboration operation, with a stable machine-readable code and a human display message. It is not collaboration content and may be refreshed by later sync attempts.
+_Avoid_: rejection comment, rejection turn
+
+**Hosted-Valid Continuation**:
+A new collaboration operation that continues a collaboration record without citing a hosted-rejected local operation or its hosted-invalid descendants as causal parents. It creates a Weft-acceptable causal path while preserving the rejected local history.
+_Avoid_: rewriting rejection, deleting rejected parent
+
+**Heddle-Hosted Collaboration**:
+Collaboration records shared through a Heddle remote backed by Weft. Heddle discussions, context, and attention do not project through Git hosting or Git bridge surfaces.
+_Avoid_: Git-hosted discussions, Git notes collaboration
+
+**Local-Only Collaboration**:
+Collaboration records that exist only in the local repository because no Heddle remote is configured or synchronized. Heddle should label this state when users might assume Git push shared the collaboration records.
+_Avoid_: unsynced Git comments
+
+**Linked Collaboration**:
+Collaboration records that are causally or semantically tied to source content being synchronized, such as discussions anchored to pushed states, changes, changed paths or symbols, active blockers or questions for the pushed thread, and operations that continue those records.
+_Avoid_: unrelated discussion sync
+
+**Live Collaboration Sync**:
+gRPC-backed synchronization that keeps already-synced collaboration records up to date while a Weft connection is active. Live sync updates the durable repository collaboration log; it is not a separate chat transport.
+_Avoid_: chat stream, presence
+
+**Collaboration Watch**:
+An explicit foreground command mode that keeps collaboration records current through live sync and renders updates for humans or agents. It is the first live-sync lifecycle before daemon ownership exists.
+_Avoid_: invisible background sync
+
+**Collaboration Operation**:
+An immutable event in the repository collaboration log, such as opening a discussion, appending a turn, resolving a discussion, retargeting an anchor, or changing visibility. Collaboration operations carry Heddle-style attribution for the acting principal, agent, capability context, and originating work context when known.
+_Avoid_: document overwrite, latest discussion document
+
+**Primary Collaboration Record**:
+The single collaboration record that a collaboration operation primarily targets for indexing and materialization. Operations may reference other records or source anchors, but they do not have multiple primary records.
+_Avoid_: multi-record operation target, implicit target
+
+**Source History**:
+The immutable version history of repository content states. Collaboration operations may reference source history, but they do not advance it.
+_Avoid_: collaboration history
+
+**Compensating Collaboration Operation**:
+A later collaboration operation that corrects, reverses, or supersedes an earlier collaboration operation without erasing it.
+_Avoid_: undo discussion, delete turn
+
+**Causal Ordering**:
+The ordering relationship between collaboration operations based on which prior operations each operation observed. Concurrent operations can both be valid without one overwriting the other.
+_Avoid_: global total order
+
+**Collaboration View**:
+A derived current view of collaboration records produced from collaboration operations. Views are caches or query outputs, not the durable source of truth.
+_Avoid_: source-of-truth discussion document
+
+**Semantic Anchor**:
+A discussion or annotation target that names the repository meaning it refers to, such as a repository, thread, state, file, line range, symbol, or review signal. It preserves the source state where the reference was made and the selector used to follow that meaning forward.
+_Avoid_: raw line comment, path-only comment
+
+**Anchor Status**:
+The current resolution of a semantic anchor: current, moved, changed, ambiguous, or orphaned. Anchor status tells users and agents whether Heddle can still prove where the conversation belongs.
+_Avoid_: stale flag
+
+**Attention Item**:
+Anything in a repository that needs a human or agent to notice and act, such as a discussion mention, resolution conflict, orphaned anchor, thread blocker, review requirement, hosted rejection, or stale context annotation. Attention items are derived views over underlying records, with explicit overlays for assignment, read state, or snooze when needed.
+_Avoid_: notification, task, todo
+
+**Attention Severity**:
+The readiness impact of an attention item, such as blocker, warning, or informational. Only targeted or high-severity attention items should block readiness.
+_Avoid_: priority
+
+**Attention Target**:
+The principal, agent, or thread expected to notice an attention item. Principal, agent, and thread targets are distinct because they represent accountability, actor identity, and work-unit relevance respectively.
+_Avoid_: assignee string, text mention
+
+**Agent-Native Loop**:
+The core Heddle workflow: inspect status, check inbox, isolate or fan out work, discuss uncertainty, distill context, capture attributable work, review risk, integrate, and recover or verify as needed.
+_Avoid_: developer loop, AI workflow
+
+**Weft**:
+The hosted collaboration and coordination product for Heddle repositories. Weft owns hosted identity, policy, multi-user coordination, and remote collaboration behavior.
+_Avoid_: Heddle server, Heddle core
+
+**Tapestry**:
+The hosted web product for Heddle collaboration, review, onboarding, and operational visibility.
+_Avoid_: Heddle web, Heddle core

--- a/docs/adr/0001-repository-scoped-discussions.md
+++ b/docs/adr/0001-repository-scoped-discussions.md
@@ -1,0 +1,7 @@
+# Repository-scoped discussions
+
+Discussions are repository-scoped collaboration records with durable identity, not blobs attached to a single immutable state. This keeps Heddle's source history immutable while allowing discussions to survive captures, rebases, thread promotion, concurrent local edits, and parallel-agent coordination; state, symbol, thread, and review anchors become references on the discussion rather than the discussion's storage home.
+
+**Status:** accepted
+
+**Considered Options:** State-attached discussions matched the existing implementation, but made append/resolve create new states and made cross-state lookup awkward. Thread-scoped discussions fit active work units, but conversations often need to follow code after a thread lands or is reshaped.

--- a/docs/adr/0001-repository-scoped-discussions.md
+++ b/docs/adr/0001-repository-scoped-discussions.md
@@ -2,6 +2,6 @@
 
 Discussions are repository-scoped collaboration records with durable identity, not blobs attached to a single immutable state. This keeps Heddle's source history immutable while allowing discussions to survive captures, rebases, thread promotion, concurrent local edits, and parallel-agent coordination; state, symbol, thread, and review anchors become references on the discussion rather than the discussion's storage home.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** State-attached discussions matched the existing implementation, but made append/resolve create new states and made cross-state lookup awkward. Thread-scoped discussions fit active work units, but conversations often need to follow code after a thread lands or is reshaped.

--- a/docs/adr/0002-repository-collaboration-log.md
+++ b/docs/adr/0002-repository-collaboration-log.md
@@ -2,6 +2,6 @@
 
 Heddle collaboration data is organized as a repository collaboration log made of independently addressable records, with discussions as the first record type. This avoids making the whole discussion one coarse CRDT object or making each turn its own top-level CRDT; turns, resolutions, visibility, and anchors can merge under the durable identity of one discussion while future collaboration records share the same repository-level sync shape.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Whole-discussion CRDTs were simpler but too coarse for concurrent append, resolve, and anchor changes. Per-turn CRDTs were precise for message ordering but too narrow for discussion metadata and future collaboration records.

--- a/docs/adr/0002-repository-collaboration-log.md
+++ b/docs/adr/0002-repository-collaboration-log.md
@@ -1,0 +1,7 @@
+# Repository collaboration log
+
+Heddle collaboration data is organized as a repository collaboration log made of independently addressable records, with discussions as the first record type. This avoids making the whole discussion one coarse CRDT object or making each turn its own top-level CRDT; turns, resolutions, visibility, and anchors can merge under the durable identity of one discussion while future collaboration records share the same repository-level sync shape.
+
+**Status:** accepted
+
+**Considered Options:** Whole-discussion CRDTs were simpler but too coarse for concurrent append, resolve, and anchor changes. Per-turn CRDTs were precise for message ordering but too narrow for discussion metadata and future collaboration records.

--- a/docs/adr/0003-durable-async-coordination.md
+++ b/docs/adr/0003-durable-async-coordination.md
@@ -4,6 +4,6 @@ Heddle discussions are durable asynchronous coordination records in the OSS CLI,
 
 After the repo split, Heddle documentation owns the CLI/local model and cross-repo contracts for collaboration records. Weft server internals and Tapestry web implementation details should live in their own repositories, with Heddle ADRs naming them only where a boundary or protocol contract matters.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Real-time chat in the OSS CLI would make discussions feel immediately collaborative, but it would pull hosted transport, presence, and notification semantics into the local core. State-only notes would preserve locality, but they would not support parallel-agent coordination across threads.

--- a/docs/adr/0003-durable-async-coordination.md
+++ b/docs/adr/0003-durable-async-coordination.md
@@ -1,0 +1,9 @@
+# Durable async coordination
+
+Heddle discussions are durable asynchronous coordination records in the OSS CLI, while real-time delivery, presence, notification routing, unread state, and web inboxes belong to Weft and Tapestry. This keeps the local CLI useful offline and scriptable for agents, while the hosted products can add live collaboration without making Heddle's core primitives depend on a hosted account.
+
+After the repo split, Heddle documentation owns the CLI/local model and cross-repo contracts for collaboration records. Weft server internals and Tapestry web implementation details should live in their own repositories, with Heddle ADRs naming them only where a boundary or protocol contract matters.
+
+**Status:** accepted
+
+**Considered Options:** Real-time chat in the OSS CLI would make discussions feel immediately collaborative, but it would pull hosted transport, presence, and notification semantics into the local core. State-only notes would preserve locality, but they would not support parallel-agent coordination across threads.

--- a/docs/adr/0004-operation-based-collaboration-log.md
+++ b/docs/adr/0004-operation-based-collaboration-log.md
@@ -38,6 +38,6 @@ If a malformed operation is encountered, Heddle fails that operation loudly and 
 
 Malformed collaboration bytes are retained as invalid collaboration artifacts for diagnostics or quarantine, not treated as valid collaboration operations. `doctor` may quarantine or move them, but should not silently delete bytes that may explain corruption or attack attempts.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Latest-document storage would be simpler to query, but it would make causality, audit, idempotent retry, and concurrent edits weaker. Per-field last-write-wins state would hide the sequence of decisions that matters for review and agent coordination.

--- a/docs/adr/0004-operation-based-collaboration-log.md
+++ b/docs/adr/0004-operation-based-collaboration-log.md
@@ -1,0 +1,43 @@
+# Operation-based collaboration log
+
+The repository collaboration log stores immutable collaboration operations and derives current collaboration views from those operations. This matches Heddle's existing strengths around immutable records, attribution, idempotency, provenance, and replay, while letting concurrent agents append independent discussion turns or metadata changes without overwriting each other; incompatible concurrent resolution operations materialize as explicit resolution conflicts rather than last-write-wins state.
+
+Resolution conflicts are cleared by a specific conflict-resolution operation that cites the incompatible resolution operations and chooses the intended outcome. Ordinary resolve and reopen operations express discussion lifecycle intent; resolving a conflict between lifecycle claims is a separate collaboration operation. The same collaboration conflict-resolution pattern can resolve other explicit conflict kinds, such as visibility conflicts, with kind-specific payloads.
+
+Collaboration conflict-resolution operations may themselves conflict when concurrent resolvers choose incompatible outcomes. The model treats conflicts as explicit operations over other operations, not hidden mutable state, so conflict materialization can recurse deterministically.
+
+Unresolved conflicts still have deterministic safe effective state, but the semantic state remains conflicted. Resolution conflicts keep the discussion attention-worthy and unresolved for readiness purposes. Visibility conflicts use the most restrictive safe visibility. Display can order conflicting claims deterministically, but it must not hide the conflict.
+
+The convergence model is repository-wide at the operation-log level and record-level at materialization time. Discussions, context annotations, and attention views can materialize independently where possible, while the shared repository log still supports cross-record operations, task provenance, anchors, and attention derivation without creating one giant mutable document.
+
+Every collaboration operation names exactly one primary collaboration record for indexing and materialization. It may reference other records, source anchors, task provenance, or attention targets, but cross-record behavior is expressed through explicit references rather than ambiguous multi-primary writes.
+
+Authorship, attention routing, and cross-operation references should use stable principal, agent, and operation identifiers rather than display names. Display names are render-time labels or provenance hints, not durable identity.
+
+Materialized collaboration views retain each record's current operation head set internally. Human UI may render a deterministic linearized conversation, but the materializer preserves heads so new operations can cite what they observed and sync can reason about concurrency.
+
+The materializer can produce multiple view modes from the same collaboration log plus sync metadata. Full local views include locally valid operations, including hosted-invalid ones with labels. Hosted-synced and capability-filtered views exclude or mark operations according to sync metadata and active policy context.
+
+View mode is a query and materialization parameter, not operation identity. It does not affect `CollabOpId`, causal parent relationships, or durable operation bytes.
+
+Operation timestamps are provenance and deterministic display tie-break inputs, not causality. Causal parents and operation identity define the operation graph; timestamps may be skewed or wrong.
+
+Timestamps should not decide capability authority, hosted policy ordering, or conflict winners. Policy and convergence use causal parents, operation IDs, hosted acceptance metadata, and capability context; clock skew must not grant authority or erase conflicts.
+
+Structurally valid operations that cite unknown causal parents are retained locally as unresolved operations, but they are not applied to materialized views until parents arrive or an explicit import/orphan rule accounts for the gap. Hosted sync rejects or blocks missing-parent operations unless the parent gap is explicitly supported.
+
+Imported or orphaned collaboration history can become applied only through an explicit collaboration import root that records source, reason, and trust level. This creates an intentional causal root rather than silently applying missing-parent operations.
+
+Imported collaboration roots are labeled in local views with source and trust information because their causal history is not native continuous Heddle history. Agents should be able to distinguish imported context from fully connected local collaboration history.
+
+Imported roots still carry Heddle actor attribution. They may also carry original-author metadata when known, but Heddle distinguishes the import actor from the original author.
+
+Original-author metadata from imports is provenance only and is not trusted for capability policy. Policy applies to the import actor and hosted validation context unless Weft explicitly validates the external authorship source.
+
+If a malformed operation is encountered, Heddle fails that operation loudly and continues materializing the valid prefix or subgraph where safe. The affected record view shows corruption or invalid-operation attention rather than making the entire collaboration log unusable.
+
+Malformed collaboration bytes are retained as invalid collaboration artifacts for diagnostics or quarantine, not treated as valid collaboration operations. `doctor` may quarantine or move them, but should not silently delete bytes that may explain corruption or attack attempts.
+
+**Status:** accepted
+
+**Considered Options:** Latest-document storage would be simpler to query, but it would make causality, audit, idempotent retry, and concurrent edits weaker. Per-field last-write-wins state would hide the sequence of decisions that matters for review and agent coordination.

--- a/docs/adr/0005-append-only-discussion-turns.md
+++ b/docs/adr/0005-append-only-discussion-turns.md
@@ -16,6 +16,6 @@ Only the operation that opens a discussion record may omit causal parents by def
 
 Concurrent discussion turns do not create a conflict state. They survive as sibling turns and are deterministically ordered for display. Conflict states are reserved for operations whose claims are mutually incompatible, such as competing resolutions or incompatible visibility or anchor changes.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Editable message bodies would match common chat tools, but they require additional CRDT text or last-write-wins edit semantics and weaken provenance. Hosted products may later add narrow presentation affordances, but the durable OSS record remains append-only.

--- a/docs/adr/0005-append-only-discussion-turns.md
+++ b/docs/adr/0005-append-only-discussion-turns.md
@@ -1,0 +1,21 @@
+# Append-only discussion turns
+
+Discussion turns are append-only in the OSS collaboration log; corrections are represented as later turns. This preserves auditability for human and agent coordination, keeps local-first merge semantics simple, and avoids hiding what an agent or person said behind mutable message edits.
+
+The v1 turn-kind set should be small and closed for machine behavior: `comment`, `question`, `answer`, `blocker`, `decision`, `handoff`, and `status`. New behavior-bearing kinds should arrive through schema evolution rather than arbitrary user-defined strings. Free-form labels can be added later without weakening turn kind as reliable agent signal.
+
+Discussion turns may include optional structured references to earlier collaboration operations they answer, supersede, hand off from, or otherwise respond to. Inbox and readiness behavior should prefer those references over body-text heuristics; the turn body explains the response but should not be the durable workflow edge.
+
+Accidentally sensitive content should not introduce general edit or delete semantics for discussion turns. Heddle should model suppression as a distinct collaboration redaction operation or hosted policy action, preserving audit metadata while hiding redacted content from normal views or sync according to policy.
+
+Redaction suppresses selected content; it does not delete causal graph structure. Descendant turns remain part of the discussion when policy allows them, and references to redacted operations render as redacted references rather than disappearing.
+
+Discussion turn materialization uses causal parent operation edges as the primary ordering signal. Timestamp and UUIDv7 order are deterministic display tie-breakers for concurrent turns, not substitutes for causality.
+
+Only the operation that opens a discussion record may omit causal parents by default. Imported or orphaned history may also omit parents when it records an import reason. Normal append operations cite the current observed record head set so convergence can distinguish concurrent branches.
+
+Concurrent discussion turns do not create a conflict state. They survive as sibling turns and are deterministically ordered for display. Conflict states are reserved for operations whose claims are mutually incompatible, such as competing resolutions or incompatible visibility or anchor changes.
+
+**Status:** accepted
+
+**Considered Options:** Editable message bodies would match common chat tools, but they require additional CRDT text or last-write-wins edit semantics and weaken provenance. Hosted products may later add narrow presentation affordances, but the durable OSS record remains append-only.

--- a/docs/adr/0006-server-validated-local-capabilities.md
+++ b/docs/adr/0006-server-validated-local-capabilities.md
@@ -1,0 +1,65 @@
+# Server-validated local capabilities
+
+Heddle can mint local Biscuit capabilities, but hosted authority comes from Weft validating the root capability's maximum permission scope against hosted identity and grants. Once validated, Heddle can derive immutable attenuated child capabilities locally for agents and policy context; hosted verification trusts the server-validated root scope and rejects attempts to exceed it. The OSS CLI may filter local collaboration views using the active capability, but Weft remains the hard enforcement point for remote sync and hosted access.
+
+Agents may resolve discussions only under the active capability policy, and those resolutions carry explicit agent attribution, confidence, and resolution kind.
+
+Local validity and hosted validity are distinct. Heddle may accept a structurally valid local collaboration operation while Weft later rejects it under hosted policy; the operation remains local and should be labeled rather than silently deleted.
+
+Collaboration operations store the operation capability context present at creation time as immutable local provenance. The operation envelope stores the capability id and a canonical scope summary, not the full Biscuit bytes. Full token material belongs in the local capability store and Weft auth path. Collaboration sync metadata separately stores the hosted acceptance context Weft accepted for that operation on a remote. A retry may complete sync with renewed or corrected authority, so hosted acceptance context must not be confused with creation authority.
+
+Hosted acceptance context stored locally contains Weft's acceptance facts rather than the full server-validated Biscuit proof: capability id, accepted scope summary, remote identity, accepted-at time, and policy or grant version when available. Weft owns full hosted audit proof server-side. Local sync metadata should explain and reproduce behavior without becoming a token vault.
+
+The local capability store discards or encrypt-retires expired and superseded Biscuit token material by default while retaining non-secret capability lineage metadata. Operation and sync records keep capability ids and scope summaries; full old token material increases local secret exposure and is not required for normal provenance. A future explicit audit mode may retain encrypted token proofs.
+
+A collaboration operation remains locally valid when its operation capability context references a capability id whose token material is no longer present in the local capability store. The operation carries its own capability id and scope summary as provenance. `fsck` may warn when referenced capability lineage metadata is missing, but missing token material does not invalidate the operation.
+
+Routine `fsck` verifies capability context shape, well-formed capability ids and scope summaries, and reference consistency. It does not require old token proofs or hosted audit access. A deeper audit mode may compare retained lineage metadata or ask Weft to verify historical acceptance facts.
+
+If Weft reports hosted policy or grant changes, Heddle automatically refreshes the active server-validated local capability and notifies the user that their permission scope changed. Refresh is automatic whether the scope narrows, broadens, or otherwise changes; the message makes the change visible without turning permission repair into a manual prerequisite.
+
+Each refreshed root capability gets a new capability id linked to the prior active capability id through refresh metadata. Refresh replaces active capability context for future operations and sync attempts; it does not mutate existing immutable Biscuit tokens or rewrite previously recorded operation capability context. If the refreshed root capability narrows, Heddle automatically narrows the effective scope of locally derived capabilities by capping them against the current server-validated root. Existing child Biscuits remain immutable artifacts, but they no longer confer effective local or hosted policy context beyond the refreshed root.
+
+Any command that contacts Weft and receives authoritative policy or grant freshness information may trigger automatic capability refresh. Pure local commands do not invent refreshes without Weft contact; they use the current cached capability context and can warn when it is expired or known stale.
+
+When a pure local command sees expired capability context and cannot contact Weft, read-only local views continue with degraded capability-aware filtering and clear labeling. Local writes that would later claim hosted authority must either be explicit local-only writes or record that they used expired capability context so Weft can validate or reject them later. Heddle must not silently present expired policy as current hosted authority.
+
+Operations created under expired capability context are shown in local views with a warning rather than hidden. They are locally valid records with uncertain hosted validity. Default hosted-synced views exclude them until Weft accepts them, while local views expose the expired-context provenance.
+
+Agents may continue writing under expired capability context only when their delegated task explicitly permits local-only or offline continuation. Otherwise Heddle interrupts or blocks the agent until capability refresh. Offline continuation must be visible to the delegating human because agents can otherwise create many hosted-uncertain operations quickly.
+
+Offline agent writes under expired capability context remain normal collaboration operations. Their operation capability context records the expired provenance, and derived warning or attention metadata surfaces the sync risk. Heddle does not create special discussion turn kinds for transport or policy state; turn kind continues to describe collaboration intent.
+
+Offline continuation permission is checked in both the derived capability and the task assignment. The derived capability answers whether the agent may create local-only collaboration writes under expired context at all; the task assignment answers whether this agent should use that permission for the current task.
+
+For server-validated root capabilities, Heddle uses a Weft-issued capability id as the stable hosted identity. Heddle may also record a local token hash as proof metadata, but hosted audit, refresh lineage, operation capability context, and hosted acceptance context should correlate on the Weft-issued id rather than a purely content-derived local token id.
+
+Locally derived child capabilities use local capability ids until they are first used with Weft. Requiring Weft-issued child ids at derivation time would weaken offline local-first delegation. When a child capability is used for hosted sync or validation, Weft can bind or recognize it against the server-validated root lineage and return hosted acceptance context for the operation.
+
+After Weft binds a locally derived child capability, future operations should use the Weft-bound child id while preserving an alias or lineage link to the original local child id. Existing operations keep their original operation capability context; new operations use the hosted-correlatable id.
+
+Local child capability ids should be derived from canonical child capability bytes plus enough root lineage context and nonce or task identity to distinguish separate delegations. If two offline clones produce the same child capability bytes and lineage, sharing the local id is acceptable because they represent the same delegation. Separate delegations must produce distinct local ids; Weft binding can later disambiguate aliases when necessary.
+
+When derived capability narrowing removes authority needed by an in-flight agent task, Heddle interrupts the task immediately and creates attention targeted to the agent and delegating human. The task should not keep creating operations that are predictably hosted-invalid. The agent can request renewed scope, continue under the narrowed scope through a hosted-valid continuation, or stop.
+
+Interrupted tasks use a specific machine-readable capability-interrupted agent state rather than `done`. UI may group this with blocked work, but the state must preserve that policy changed under the task so resume and reauthorization workflows can treat it differently from ordinary blockers.
+
+A capability-interrupted agent may write a final handoff or status discussion turn only if the narrowed capability still permits that coordination write. If not, Heddle creates local-only diagnostics or attention instead. Interruption does not grant an emergency write capability outside the refreshed scope.
+
+Local-only diagnostics created because a final handoff turn was not permitted are not later synced as collaboration operations. If capability broadens again, the agent or delegating human may create a new explicit handoff turn with fresh attribution and operation capability context.
+
+Capability-interruption diagnostics are operational metadata, not retained collaboration operations. Heddle retains enough local diagnostic detail for recovery and audit, while `doctor` or maintenance may summarize or expire old diagnostics according to operational metadata policy.
+
+Capability refresh and interruption diagnostics are repository-local operational metadata. Weft and Tapestry should show hosted-side policy-change and refresh events from Weft's audit log rather than syncing Heddle's local diagnostics as collaboration content. Local diagnostics and hosted audit records can correlate by actor, repository, time, and capability id, but they remain separate records.
+
+Capability refresh that broadens the root does not automatically broaden an in-flight agent beyond its derived attenuation. The refreshed root may permit more authority, but the child capability still caps the agent until a new derived capability is minted or assigned.
+
+A derived child capability can remain effectively valid across root capability refresh when its attenuated scope is still covered by the refreshed root. Future policy checks should treat its effective parent lineage as passing through the refreshed root, while old operations keep the root lineage they recorded at creation time.
+
+If the refreshed root no longer covers a child capability, Heddle preserves the child as inert historical metadata rather than active authority. It may explain old operations and interruption diagnostics, but it must not authorize future local filtering, writes, or hosted sync. Token material still follows the token-retention rule.
+
+Capability refresh events are policy and sync metadata, not collaboration operations. They can produce attention items and diagnostics, and future operations record the refreshed operation capability context, but refresh events do not appear as discussion turns or context annotations unless a user or agent explicitly writes one.
+
+**Status:** accepted
+
+**Considered Options:** Pure server-issued Biscuits centralize authority but make local derivation and offline policy context weaker. Pure self-sovereign Biscuits work for local-only trust anchors, but they cannot safely authorize hosted collaboration without Weft validating the root scope.

--- a/docs/adr/0006-server-validated-local-capabilities.md
+++ b/docs/adr/0006-server-validated-local-capabilities.md
@@ -60,6 +60,6 @@ If the refreshed root no longer covers a child capability, Heddle preserves the 
 
 Capability refresh events are policy and sync metadata, not collaboration operations. They can produce attention items and diagnostics, and future operations record the refreshed operation capability context, but refresh events do not appear as discussion turns or context annotations unless a user or agent explicitly writes one.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Pure server-issued Biscuits centralize authority but make local derivation and offline policy context weaker. Pure self-sovereign Biscuits work for local-only trust anchors, but they cannot safely authorize hosted collaboration without Weft validating the root scope.

--- a/docs/adr/0007-plaintext-local-collaboration-records.md
+++ b/docs/adr/0007-plaintext-local-collaboration-records.md
@@ -8,6 +8,6 @@ Creating a redaction is policy-sensitive. Local Heddle should require an active 
 
 Default human and JSON output for redacted content should show a redaction marker, target operation ID, visible reason or reason code, and actor or policy metadata allowed by the active capability. It should not include suppressed content unless the caller uses an explicit privileged diagnostic or forensic mode.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Encrypting restricted collaboration records locally would provide a stronger security story, but it would require key distribution and merge/search semantics that are not necessary for the first world-class OSS CLI. If local unreadability becomes a requirement, it should be introduced as an explicit encrypted storage mode rather than implied by visibility labels.

--- a/docs/adr/0007-plaintext-local-collaboration-records.md
+++ b/docs/adr/0007-plaintext-local-collaboration-records.md
@@ -1,0 +1,13 @@
+# Plaintext local collaboration records
+
+Heddle stores local collaboration records in plaintext for v1 and applies capability-aware filtering in the CLI, while Weft enforces hosted access on sync and API boundaries. This keeps local-first search, semantic anchoring, CRDT reconciliation, and agent workflows tractable; restricted visibility does not claim protection from someone with direct filesystem access.
+
+Redaction suppresses content from normal materialized views and sync behavior; it is not the same as physical purging of durable local bytes. Physical purge or encrypted-at-rest storage should be a separate explicit retention/security workflow rather than implied by collaboration visibility or redaction labels.
+
+Creating a redaction is policy-sensitive. Local Heddle should require an active capability that permits redaction for the target record, and hosted sync should let Weft accept or reject the redaction under hosted policy. Redaction commands should require exact operation targets and a reason.
+
+Default human and JSON output for redacted content should show a redaction marker, target operation ID, visible reason or reason code, and actor or policy metadata allowed by the active capability. It should not include suppressed content unless the caller uses an explicit privileged diagnostic or forensic mode.
+
+**Status:** accepted
+
+**Considered Options:** Encrypting restricted collaboration records locally would provide a stronger security story, but it would require key distribution and merge/search semantics that are not necessary for the first world-class OSS CLI. If local unreadability becomes a requirement, it should be introduced as an explicit encrypted storage mode rather than implied by visibility labels.

--- a/docs/adr/0008-collaboration-sync-lane.md
+++ b/docs/adr/0008-collaboration-sync-lane.md
@@ -1,0 +1,17 @@
+# Collaboration sync lane
+
+Collaboration operations sync through the same repository remote UX as source history, but over a distinct protocol lane from immutable source objects. Normal `push`, `pull`, and `fetch` should include collaboration operations by default, while advanced collaboration-only sync can exist for repair or debugging.
+
+A source `push` that succeeds for source objects but fails to sync linked collaboration records should fail by default with clear partial-lane reporting. Linked discussions, context, and attention may be needed to understand the pushed content, so silent collaboration loss is not acceptable. Operators can use an explicit `--allow-partial` override when they intentionally want the source lane to proceed despite collaboration sync failure.
+
+If a later retry finds the source lane already up to date, it should focus on the failed collaboration lane while still verifying the source target has not moved incompatibly. The user-facing command can remain `heddle push`; internally the retry is lane-aware and makes collaboration recovery explicit.
+
+Retrying failed linked collaboration sync does not require the exact capability context used for the original source push. It requires a current capability context that is valid for the collaboration records being synced. A stronger, renewed, or otherwise corrected capability can complete the collaboration lane, and sync metadata records the capability context Weft accepted.
+
+The collaboration operation envelope records the operation capability context from creation time. The collaboration sync lane records the hosted acceptance context separately in sync metadata for the specific remote. These may differ when sync is retried after grants or capabilities change.
+
+When Weft reports that hosted policy or grants changed, the sync result should perform automatic capability refresh and tell the user their permission scope changed. If the refreshed root capability narrows, derived local capability context is automatically capped by the refreshed root so future collaboration operations and sync attempts use policy context that matches current hosted policy.
+
+**Status:** accepted
+
+**Considered Options:** A separate Weft-only collaboration channel would simplify live hosted features, but it would make durable discussions feel like a separate product from repository synchronization. Folding collaboration operations into the exact same object lane as source history would blur very different consistency and cursor requirements.

--- a/docs/adr/0008-collaboration-sync-lane.md
+++ b/docs/adr/0008-collaboration-sync-lane.md
@@ -12,6 +12,6 @@ The collaboration operation envelope records the operation capability context fr
 
 When Weft reports that hosted policy or grants changed, the sync result should perform automatic capability refresh and tell the user their permission scope changed. If the refreshed root capability narrows, derived local capability context is automatically capped by the refreshed root so future collaboration operations and sync attempts use policy context that matches current hosted policy.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** A separate Weft-only collaboration channel would simplify live hosted features, but it would make durable discussions feel like a separate product from repository synchronization. Folding collaboration operations into the exact same object lane as source history would blur very different consistency and cursor requirements.

--- a/docs/adr/0009-collaboration-adjacent-to-source-history.md
+++ b/docs/adr/0009-collaboration-adjacent-to-source-history.md
@@ -1,0 +1,7 @@
+# Collaboration adjacent to source history
+
+Collaboration operations are adjacent repository metadata, not source history states. Opening, appending to, resolving, or retargeting a discussion does not create a new source state or advance `HEAD`; collaboration records have their own operation log, identities, attribution, and sync cursor while referencing source states when needed.
+
+**Status:** accepted
+
+**Considered Options:** Storing discussions on states matched the current implementation and made review payloads simple, but it made conversation updates mutate source history. Keeping collaboration adjacent preserves clean source history while allowing activity views to intentionally combine source and collaboration events.

--- a/docs/adr/0009-collaboration-adjacent-to-source-history.md
+++ b/docs/adr/0009-collaboration-adjacent-to-source-history.md
@@ -2,6 +2,6 @@
 
 Collaboration operations are adjacent repository metadata, not source history states. Opening, appending to, resolving, or retargeting a discussion does not create a new source state or advance `HEAD`; collaboration records have their own operation log, identities, attribution, and sync cursor while referencing source states when needed.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Storing discussions on states matched the current implementation and made review payloads simple, but it made conversation updates mutate source history. Keeping collaboration adjacent preserves clean source history while allowing activity views to intentionally combine source and collaboration events.

--- a/docs/adr/0010-context-annotations-as-collaboration-records.md
+++ b/docs/adr/0010-context-annotations-as-collaboration-records.md
@@ -1,0 +1,13 @@
+# Context annotations as collaboration records
+
+Context annotations are repository collaboration records, while source states preserve context snapshots for provenance and replay. Editing or superseding durable knowledge should not advance source history; immutable states still record which context view was known when the state was created.
+
+V1 context annotations should use operation-based create and supersede semantics rather than editable document CRDT text. Concurrent incompatible annotation updates should materialize as explicit ambiguity or conflict instead of silently merging prose into canonical guidance.
+
+Context extraction from discussions can ship after the first local discussion slice. Decision turns do not automatically become context annotations; extraction remains an explicit workflow that creates or updates context annotation records.
+
+When context extraction creates or updates a context annotation, the annotation operation should cite the source discussion operations it was extracted from. Those references preserve provenance without making the original discussion turns themselves canonical context.
+
+**Status:** accepted
+
+**Considered Options:** Keeping context annotations only on source states matched the current implementation, but it makes durable knowledge edits behave like source-history mutations. Moving live context to the collaboration log keeps annotations mergeable and queryable while preserving historical context views on states.

--- a/docs/adr/0010-context-annotations-as-collaboration-records.md
+++ b/docs/adr/0010-context-annotations-as-collaboration-records.md
@@ -8,6 +8,6 @@ Context extraction from discussions can ship after the first local discussion sl
 
 When context extraction creates or updates a context annotation, the annotation operation should cite the source discussion operations it was extracted from. Those references preserve provenance without making the original discussion turns themselves canonical context.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Keeping context annotations only on source states matched the current implementation, but it makes durable knowledge edits behave like source-history mutations. Moving live context to the collaboration log keeps annotations mergeable and queryable while preserving historical context views on states.

--- a/docs/adr/0011-inbox-as-attention-command.md
+++ b/docs/adr/0011-inbox-as-attention-command.md
@@ -1,0 +1,19 @@
+# Inbox as the attention command
+
+Heddle uses `heddle inbox` as the canonical cross-cutting command for attention items. Discussions, reviews, thread blockers, orphaned anchors, resolution conflicts, and stale context can each keep object-specific commands, but humans and agents need one stable command for "what needs me next?" The inbox is local-first and remains useful without Weft; when hosted attention is available, it can merge policy-filtered hosted overlays into the same view.
+
+Attention should route through structured targets such as principals, agents, threads, roles, or the current checkout context. Human text can support convenient mention syntax, but durable inbox behavior should not depend on ambiguous display-name parsing.
+
+Every `heddle inbox` JSON response should include an explicit schema identifier and version. Inbox is an agent work queue, so consumers need to detect contract changes without inferring them from field presence.
+
+`heddle inbox` JSON should expose task provenance grouping when available and policy-visible. Human output may offer optional grouping by task provenance, but the default view should still prioritize severity, target, and recency so urgent attention items are not hidden inside task groups.
+
+First-slice inbox JSON should not claim unread/read state unless explicit actor read-state metadata ships. It may expose derived attention status, targets, timestamps, and reasons; read and snooze overlays can be added later as explicit actor metadata.
+
+Unresolved collaboration operations appear in `inbox` as diagnostics or attention when they affect current work or sync. They do not appear as normal discussion content until their causal parents are available or explicitly accounted for.
+
+Local-only and hosted-rejected collaboration should appear in `inbox` when they affect actionability, readiness, or sync, but as typed diagnostics with reason codes and lane metadata. They should not be disguised as discussion turns or generic warnings.
+
+**Status:** accepted
+
+**Considered Options:** Keeping attention only under `discuss`, `review`, and `thread` would avoid another top-level command, but it would force agents to poll several surfaces and reconstruct priority themselves. `status` already owns the current checkout condition and next action, not a personal or agent work queue.

--- a/docs/adr/0011-inbox-as-attention-command.md
+++ b/docs/adr/0011-inbox-as-attention-command.md
@@ -14,6 +14,6 @@ Unresolved collaboration operations appear in `inbox` as diagnostics or attentio
 
 Local-only and hosted-rejected collaboration should appear in `inbox` when they affect actionability, readiness, or sync, but as typed diagnostics with reason codes and lane metadata. They should not be disguised as discussion turns or generic warnings.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Keeping attention only under `discuss`, `review`, and `thread` would avoid another top-level command, but it would force agents to poll several surfaces and reconstruct priority themselves. `status` already owns the current checkout condition and next action, not a personal or agent work queue.

--- a/docs/adr/0012-attention-as-derived-view.md
+++ b/docs/adr/0012-attention-as-derived-view.md
@@ -1,0 +1,9 @@
+# Attention as a derived view
+
+Attention items are derived views over underlying repository records, not an independent task database. Discussions, review requirements, thread state, anchor health, and context checks remain the source of truth; assignment, read state, and snooze can be explicit per-actor overlays when needed.
+
+Discussion blockers are discussion turns with blocker turn kind when authored as conversation content. Assignment, read state, and snooze remain attention overlays. This preserves the durable fact that a human or agent explicitly declared a blocker.
+
+**Status:** accepted
+
+**Considered Options:** Making every attention item a durable object would simplify inbox queries, but it would duplicate state and risk drift such as a resolved discussion still appearing as an open task. A derived view keeps `heddle inbox` honest while preserving room for actor-specific overlays.

--- a/docs/adr/0012-attention-as-derived-view.md
+++ b/docs/adr/0012-attention-as-derived-view.md
@@ -4,6 +4,6 @@ Attention items are derived views over underlying repository records, not an ind
 
 Discussion blockers are discussion turns with blocker turn kind when authored as conversation content. Assignment, read state, and snooze remain attention overlays. This preserves the durable fact that a human or agent explicitly declared a blocker.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Making every attention item a durable object would simplify inbox queries, but it would duplicate state and risk drift such as a resolved discussion still appearing as an open task. A derived view keeps `heddle inbox` honest while preserving room for actor-specific overlays.

--- a/docs/adr/0013-agent-native-help-surface.md
+++ b/docs/adr/0013-agent-native-help-surface.md
@@ -6,6 +6,6 @@ First-slice local discussion and inbox help should live in the normal CLI help s
 
 Legacy discussion migration should be discoverable when relevant but not promoted as an everyday workflow. It belongs in advanced or doctor-oriented help because it is transitional repository maintenance, not a daily collaboration action.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Keeping `discuss` and `context` entirely behind advanced help matched the previous restraint principle, but agent-native coordination is now part of the core loop. Promoting every collaboration verb would make first-run help too broad, so `inbox` and `discuss` are the everyday entry points while context and deeper review remain more deliberate.

--- a/docs/adr/0013-agent-native-help-surface.md
+++ b/docs/adr/0013-agent-native-help-surface.md
@@ -1,0 +1,11 @@
+# Agent-native help surface
+
+The curated everyday help surface should include `inbox` and `discuss` as first-class coordination commands. `context` remains behind advanced/topic help until its UX is harder to misuse, and `review` may be surfaced through `inbox`, `ready`, and review-specific help rather than always occupying first-day help.
+
+First-slice local discussion and inbox help should live in the normal CLI help surface once tests and docs gates pass. Conflict resolution, visibility, and migration can appear in advanced sections, but core local `discuss` and `inbox` workflows should not be hidden behind experimental or internal help.
+
+Legacy discussion migration should be discoverable when relevant but not promoted as an everyday workflow. It belongs in advanced or doctor-oriented help because it is transitional repository maintenance, not a daily collaboration action.
+
+**Status:** accepted
+
+**Considered Options:** Keeping `discuss` and `context` entirely behind advanced help matched the previous restraint principle, but agent-native coordination is now part of the core loop. Promoting every collaboration verb would make first-run help too broad, so `inbox` and `discuss` are the everyday entry points while context and deeper review remain more deliberate.

--- a/docs/adr/0014-command-surface-before-collaboration-expansion.md
+++ b/docs/adr/0014-command-surface-before-collaboration-expansion.md
@@ -8,6 +8,6 @@ The command catalog should mark collaboration writes as mutating operations and 
 
 Collaboration JSON errors should carry a stable machine-readable code, a human message, the command schema identifier/version, and actionable recovery fields. Stale-head errors return current heads, ambiguous-id errors return candidates, and hosted rejection errors include the hosted rejection code plus retry or hosted-valid-continuation hints when available.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Shipping collaboration commands first would move product direction faster, but it would multiply drift across help, JSON schemas, runtime contracts, command catalog entries, and docs. Tightening the command surface first gives the collaboration expansion a stable CLI API foundation.

--- a/docs/adr/0014-command-surface-before-collaboration-expansion.md
+++ b/docs/adr/0014-command-surface-before-collaboration-expansion.md
@@ -1,0 +1,13 @@
+# Command surface before collaboration expansion
+
+Heddle should deepen the command surface before broadly expanding collaboration commands such as `inbox`, richer `discuss`, collaboration sync, and capability-aware filtering. The current command metadata, dispatch, schema, runtime-contract, and help surfaces are too scattered; collaboration features should land only after command facts can stay local and schema/docs gates can cover the new surface reliably.
+
+Every agent-facing collaboration JSON response should include an explicit schema identifier and version. This is required before `discuss` evolves in place, because machine consumers need to distinguish the repository collaboration contract from older state-attached discussion semantics.
+
+The command catalog should mark collaboration writes as mutating operations and declare whether they support a collaboration idempotency key. Agents need command metadata that exposes side effects and retry semantics before they can safely automate discussion, inbox, and future collaboration workflows.
+
+Collaboration JSON errors should carry a stable machine-readable code, a human message, the command schema identifier/version, and actionable recovery fields. Stale-head errors return current heads, ambiguous-id errors return candidates, and hosted rejection errors include the hosted rejection code plus retry or hosted-valid-continuation hints when available.
+
+**Status:** accepted
+
+**Considered Options:** Shipping collaboration commands first would move product direction faster, but it would multiply drift across help, JSON schemas, runtime contracts, command catalog entries, and docs. Tightening the command surface first gives the collaboration expansion a stable CLI API foundation.

--- a/docs/adr/0015-heddle-native-discussions.md
+++ b/docs/adr/0015-heddle-native-discussions.md
@@ -1,0 +1,7 @@
+# Heddle-native discussions
+
+Heddle discussions are canonical Heddle records and are shared through Heddle-hosted collaboration, not through GitHub, GitLab, Git notes, or Git bridge projections. The source of truth remains the repository collaboration log so semantic anchors, causal operations, resolution conflicts, agent attribution, capability filtering, and offline merge semantics remain intact.
+
+**Status:** accepted
+
+**Considered Options:** Using GitHub, GitLab, Git notes, or bridge exports as projection targets would improve interoperability with existing review workflows, but it would make collaboration feel like a Git-hosted feature and lose Heddle-specific semantics. Sharing discussions is a reason to host on Heddle.

--- a/docs/adr/0015-heddle-native-discussions.md
+++ b/docs/adr/0015-heddle-native-discussions.md
@@ -2,6 +2,6 @@
 
 Heddle discussions are canonical Heddle records and are shared through Heddle-hosted collaboration, not through GitHub, GitLab, Git notes, or Git bridge projections. The source of truth remains the repository collaboration log so semantic anchors, causal operations, resolution conflicts, agent attribution, capability filtering, and offline merge semantics remain intact.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Using GitHub, GitLab, Git notes, or bridge exports as projection targets would improve interoperability with existing review workflows, but it would make collaboration feel like a Git-hosted feature and lose Heddle-specific semantics. Sharing discussions is a reason to host on Heddle.

--- a/docs/adr/0016-local-discussion-log-first.md
+++ b/docs/adr/0016-local-discussion-log-first.md
@@ -1,0 +1,49 @@
+# Local discussion log first
+
+The first collaboration implementation slice is a local repository-scoped discussion log plus derived inbox, before hosted sync or live collaboration. This slice should prove discussion open, append, resolve, reopen, semantic anchors, append-only turns, local attention derivation, schemas, docs gates, and migration from the current state-attached discussion shape if needed. `heddle inbox` should ship in this slice as the stable local "what needs me" surface for agents and humans.
+
+The first slice does not need general collaboration import roots unless migration from the current state-attached discussion shape requires them. The operation model should leave room for import roots without expanding the initial implementation scope.
+
+The first local-only slice does not need the hosted-valid continuation command because Weft rejection and blocking states do not exist yet. The operation model can leave room for hosted-valid continuation without adding the command before hosted sync.
+
+The first slice does not need explicit per-actor read state unless inbox usability requires it. Heddle can start with derived attention from operation timestamps, targets, and turn kinds; explicit read state can follow once actor and principal UX is clearer.
+
+The first slice does not need snooze. Snooze is an actor overlay and can follow after local discussion, derived inbox, and readiness behavior prove the core semantics.
+
+The first slice does not need full context extraction. It may allow decision turns and simple manual context annotation creation if already cheap, but extraction workflows should follow after discussions and annotations are stable.
+
+The first slice should not become a general issue tracker. Labels, assignees, milestones, and project-board state can be modeled later if needed; the first slice should prove anchored conversation, structured turn kinds, lifecycle operations, attention derivation, and conflict handling.
+
+The first local-only slice does not have to implement full redaction, but its schema should leave room for redaction operations and its docs should state plainly that v1 local collaboration records are plaintext and append-only. Hosted collaboration sync should not broadly ship without a clear redaction and policy-suppression story.
+
+First-slice tests should cover both lower-level materialization and CLI contracts. Materialization property tests protect convergence behavior, while CLI golden JSON tests protect the agent-facing command contract. Human text output can start with lighter smoke coverage.
+
+The first local discussion slice counts as shipped only when command metadata is in place, JSON golden tests cover the agent contract, materialization/property tests cover core convergence behavior, basic collaboration `fsck`/`doctor` checks pass, migration plan/apply tests exist if legacy data exists, docs label local-only versus Weft-backed versus planned behavior, and at least one end-to-end agent workflow example is documented.
+
+Release notes and docs for the first discussion slice must explicitly label what is local-only, what requires Weft-backed sync, and what remains planned. This prevents users from assuming Git hosting shares Heddle collaboration records.
+
+First-slice docs should include JSON-first agent examples for opening a discussion, appending a turn, reading heads, resolving, checking inbox, and handling conflicts. Human examples are useful, but the agent-native value depends on clear machine workflows.
+
+For automation-critical workflows, first-slice user-facing docs should show the JSON example before the terse human command example. Humans still get readable examples, but the agent contract should be easy to copy, test, and validate.
+
+First-slice docs should state the verification status clearly: local discussion behavior starts with Rust/property tests, while remote CRDT sync requires the formal convergence model before shipping.
+
+Local discussion commands should not be hidden as experimental once the first slice passes its tests and docs gates. They are core pre-1.0 commands. Hosted sync and live collaboration should be labeled separately as foundation or planned until shipped.
+
+The first slice should expose conflict resolution for any conflict kind it can create. If resolve and reopen ship, resolution-conflict resolution must ship too. Visibility-conflict resolution can wait until visibility commands ship.
+
+Migration from existing state-attached discussion objects should not be silent. `heddle discuss` can detect legacy discussions and offer or run an explicit migration command. Explicit migration makes it clear when legacy state-attached discussion history becomes repository collaboration history.
+
+Legacy discussion migration should be plan-first by default. The migration command should show the proposed import roots and aliases, return the same plan in JSON for agents, and require an explicit `--apply` or equivalent before writing repository collaboration operations.
+
+Legacy discussion migration should be idempotent. Re-running migration should return the already-created imported discussion IDs and operation IDs instead of creating duplicate import roots; deterministic source-derived collaboration idempotency keys are appropriate for migration writes.
+
+If migration apply stops halfway, Heddle should not roll back already-written collaboration operations. The apply path should be crash-safe and idempotent: rerunning the same plan completes missing operations, reports existing imported records, and leaves legacy source objects untouched until a separate cleanup.
+
+Legacy state-attached discussions migrate as collaboration import roots, not as if they were originally native operations. The import root records source metadata pointing to the legacy state and discussion objects.
+
+`heddle discuss` output should expose migrated legacy history as imported history. JSON includes import source and trust metadata; human detail views show the legacy/import label, while terse list output can keep it compact.
+
+**Status:** accepted
+
+**Considered Options:** Starting with Weft sync would show hosted collaboration sooner, but it would multiply any mistakes in the local record model. Starting local-first preserves the agreed Heddle boundary and lets the OSS CLI validate the core collaboration semantics before introducing remote cursors, policy filtering over sync, and live hosted delivery.

--- a/docs/adr/0016-local-discussion-log-first.md
+++ b/docs/adr/0016-local-discussion-log-first.md
@@ -44,6 +44,6 @@ Legacy state-attached discussions migrate as collaboration import roots, not as 
 
 `heddle discuss` output should expose migrated legacy history as imported history. JSON includes import source and trust metadata; human detail views show the legacy/import label, while terse list output can keep it compact.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Starting with Weft sync would show hosted collaboration sooner, but it would multiply any mistakes in the local record model. Starting local-first preserves the agreed Heddle boundary and lets the OSS CLI validate the core collaboration semantics before introducing remote cursors, policy filtering over sync, and live hosted delivery.

--- a/docs/adr/0017-evolve-discuss-in-place.md
+++ b/docs/adr/0017-evolve-discuss-in-place.md
@@ -54,6 +54,6 @@ Conflict resolution should use explicit command wording such as `heddle discuss 
 
 `heddle discuss visibility` should be a first-class advanced or hosted-aware subcommand. Visibility is policy-sensitive, can conflict, and may require Weft validation; it should not be an incidental flag on unrelated commands.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Introducing a new command would avoid breaking the current `discuss` output, but it would fragment the collaboration surface. The name already matches the intended concept, and Heddle is pre-1.0, so the command should keep the name while changing internals and schemas deliberately.

--- a/docs/adr/0017-evolve-discuss-in-place.md
+++ b/docs/adr/0017-evolve-discuss-in-place.md
@@ -1,0 +1,59 @@
+# Evolve discuss in place
+
+Heddle keeps `heddle discuss` as the canonical command for anchored discussions and evolves its model in place before 1.0. The existing state-attached implementation can be replaced by the repository collaboration log without adding a second command name or preserving compatibility shims.
+
+The command name stays `discuss`, but machine-readable JSON schemas should get a new schema version or name for the repository collaboration model. Machine consumers need an explicit schema break rather than silently receiving state-attached and repository-log semantics under one contract.
+
+Every `heddle discuss` JSON response should include the schema identifier and version, not just mutating command responses. Agents need the contract marker on reads, lists, diagnostics, conflict output, and write results.
+
+Old `discuss` flags should be kept only when their meaning maps cleanly to the repository collaboration model. Misleading state-attached flags should be removed or renamed before 1.0 rather than preserved as compatibility shims; docs and the command catalog should explain the new contract.
+
+`heddle discuss` should expose explicit lifecycle subcommands such as `open`, `turn`, `resolve`, and `reopen` rather than overloading one command mode. Agents need stable verbs, and humans benefit from discoverable workflows.
+
+`turn` is the canonical append verb because it matches the domain language and supports comment, question, answer, blocker, handoff, and status turn kinds. `comment` can exist as a human alias only if it does not obscure turn-kind semantics.
+
+Human text-mode append can default turn kind to `comment`. JSON and agent workflows should require or strongly encourage explicit turn kind so Heddle does not have to infer blockers, questions, answers, handoffs, or status updates.
+
+Mutating `heddle discuss` subcommands should support the collaboration idempotency key surface from the first repository-log slice. `open`, `turn`, `resolve`, `reopen`, `retarget`, migration, and conflict-resolution writes should all have a replay-safe command-attempt identity rather than treating retry safety as a later hosted-only concern.
+
+`heddle discuss open` requires a title for repository, thread, and other broad anchors. Precise code anchors may derive a title from the anchor and first turn; JSON output still returns the derived title explicitly.
+
+`heddle discuss list` defaults to active/open discussions scoped by the current context. `heddle inbox` owns attention-worthy work, so discussion listing should not become a second inbox.
+
+`heddle discuss show` defaults to a capability-filtered local view under the active capability context. It should offer explicit `--full-local` and `--hosted-synced` view modes when relevant, preserving local-first access without surprising users with restricted or local-only records by default.
+
+Hosted and live-sync flags should not appear in normal help or stable JSON before the behavior ships. Documentation can describe hosted sync and live collaboration as planned or foundation, but the command surface should not expose aspirational flags that cannot perform the described behavior.
+
+`--full-local` does not require confirmation for read-only display, but it labels restricted, local-only, and hosted-rejected content clearly. Confirmation belongs on writes or sync actions, not local read inspection.
+
+JSON and detail outputs should expose causal parents, record head sets, and operation IDs so agents can append correctly and diagnose concurrency. Terse human output can hide raw IDs unless needed.
+
+`heddle discuss show --json` should include both deterministic display order and graph facts. The response should expose head sets, causal parents, operation IDs, unresolved or conflict markers, and view mode so agents can act without reverse-engineering a rendered conversation.
+
+Human `discuss show` may keep raw graph details terse, but it must visibly mark conflicts, ambiguous anchors, redactions, and hosted-valid versus local-only divergence. Deterministic display order is not a license to hide semantic uncertainty.
+
+JSON and detail or verbose text should expose copyable operation IDs. Conflict resolution, hosted-valid continuation, `fsck`, and diagnostics need exact operation references; terse text can use short IDs with expansion hints.
+
+CLI input may accept unambiguous short prefixes for discussion IDs and collaboration operation IDs, matching Heddle source object UX. Ambiguous prefixes fail with candidate details. JSON should prefer full IDs.
+
+Append commands support defaulting causal parents to the current materialized heads for human use, while agent and JSON workflows should pass observed heads explicitly. Explicit observed heads let Heddle detect stale writes or intentionally create concurrent turns.
+
+When explicit observed heads are stale, agent and JSON workflows fail by default unless concurrency is explicitly allowed. Human text mode can prompt or explain. Silent concurrent turns from stale agent state are too easy to miss.
+
+Generic `--allow-concurrent` is appropriate only for append-like operations where concurrency is safe. Resolve, visibility, and retarget operations use operation-specific conflict semantics rather than a generic concurrency override.
+
+`heddle discuss resolve` should require resolution kind and reason for agents and hosted sync. Human text mode may allow a short default reason for simple local closure, but JSON should carry explicit resolution metadata, including confidence when agent-authored.
+
+`heddle discuss resolve` on stale observed heads fails by default for agents and JSON, returning the current head set. A caller can retry after observing current state or use the explicit conflict-resolution workflow when competing resolutions exist.
+
+Conflict resolution should use explicit command wording such as `heddle discuss resolve-conflict`. It must be visually distinct from ordinary `resolve` because it operates on conflicting operations rather than merely closing a discussion.
+
+`heddle discuss reopen` requires a reason because it changes lifecycle after resolution. The operation records why the old resolution no longer holds or why conversation needs to resume.
+
+`heddle discuss retarget` should be a first-class subcommand. Anchor changes are semantically important and can conflict, so they should be explicit operations with reason and old/new anchor display rather than hidden side effects.
+
+`heddle discuss visibility` should be a first-class advanced or hosted-aware subcommand. Visibility is policy-sensitive, can conflict, and may require Weft validation; it should not be an incidental flag on unrelated commands.
+
+**Status:** accepted
+
+**Considered Options:** Introducing a new command would avoid breaking the current `discuss` output, but it would fragment the collaboration surface. The name already matches the intended concept, and Heddle is pre-1.0, so the command should keep the name while changing internals and schemas deliberately.

--- a/docs/adr/0018-separate-collaboration-log.md
+++ b/docs/adr/0018-separate-collaboration-log.md
@@ -2,6 +2,6 @@
 
 Heddle stores collaboration operations in a separate repository collaboration log, linked to source states or oplog entries where relevant. The existing oplog remains focused on undo/redo and source, worktree, and repository mutations; collaboration operations have different sync, query, retention, conflict, and attention semantics.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Reusing the existing oplog would reduce storage surfaces, but it would couple discussion turns and context edits to source-history undo behavior. A separate collaboration log can index by discussion, anchor, thread, actor, attention target, and causal parents while still referencing source history when needed.

--- a/docs/adr/0018-separate-collaboration-log.md
+++ b/docs/adr/0018-separate-collaboration-log.md
@@ -1,0 +1,7 @@
+# Separate collaboration log
+
+Heddle stores collaboration operations in a separate repository collaboration log, linked to source states or oplog entries where relevant. The existing oplog remains focused on undo/redo and source, worktree, and repository mutations; collaboration operations have different sync, query, retention, conflict, and attention semantics.
+
+**Status:** accepted
+
+**Considered Options:** Reusing the existing oplog would reduce storage surfaces, but it would couple discussion turns and context edits to source-history undo behavior. A separate collaboration log can index by discussion, anchor, thread, actor, attention target, and causal parents while still referencing source history when needed.

--- a/docs/adr/0019-collaboration-compensation-not-source-undo.md
+++ b/docs/adr/0019-collaboration-compensation-not-source-undo.md
@@ -4,6 +4,6 @@
 
 Migration into the repository collaboration log follows the same rule. Migration can support dry-run and can leave legacy objects untouched, but once repository collaboration operations are written, reversal is a compensating collaboration operation or local imported-history cleanup before sync, not source-history undo.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Letting source undo reverse collaboration changes would make some mistakes easy to recover from, but it would weaken append-only discussion auditability and couple two different histories. Explicit compensating operations preserve provenance while still allowing the current collaboration view to change.

--- a/docs/adr/0019-collaboration-compensation-not-source-undo.md
+++ b/docs/adr/0019-collaboration-compensation-not-source-undo.md
@@ -1,0 +1,9 @@
+# Collaboration compensation, not source undo
+
+`heddle undo` does not erase collaboration operations by default. Collaboration records use compensating operations such as reopen, supersede, visibility change, or later correction turns; source undo can create attention when it invalidates a discussion resolution, but it does not delete the discussion history.
+
+Migration into the repository collaboration log follows the same rule. Migration can support dry-run and can leave legacy objects untouched, but once repository collaboration operations are written, reversal is a compensating collaboration operation or local imported-history cleanup before sync, not source-history undo.
+
+**Status:** accepted
+
+**Considered Options:** Letting source undo reverse collaboration changes would make some mistakes easy to recover from, but it would weaken append-only discussion auditability and couple two different histories. Explicit compensating operations preserve provenance while still allowing the current collaboration view to change.

--- a/docs/adr/0020-explicit-cross-domain-transactions.md
+++ b/docs/adr/0020-explicit-cross-domain-transactions.md
@@ -1,0 +1,7 @@
+# Explicit cross-domain transactions
+
+Collaboration operations can participate in explicit cross-domain transactions with source mutations, but remain independent by default. Workflows such as resolving a discussion by edit, extracting context from a discussion, or creating an agent handoff may link source and collaboration effects atomically; ordinary source undo, source capture, and discussion turns do not implicitly absorb each other.
+
+**Status:** accepted
+
+**Considered Options:** Automatically folding collaboration operations into source transactions would make some workflows convenient, but it would couple source history and collaboration history too tightly. Keeping all operations independent would be simpler, but it would make important semantic transitions like "resolved by this edit" easier to tear.

--- a/docs/adr/0020-explicit-cross-domain-transactions.md
+++ b/docs/adr/0020-explicit-cross-domain-transactions.md
@@ -2,6 +2,6 @@
 
 Collaboration operations can participate in explicit cross-domain transactions with source mutations, but remain independent by default. Workflows such as resolving a discussion by edit, extracting context from a discussion, or creating an agent handoff may link source and collaboration effects atomically; ordinary source undo, source capture, and discussion turns do not implicitly absorb each other.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Automatically folding collaboration operations into source transactions would make some workflows convenient, but it would couple source history and collaboration history too tightly. Keeping all operations independent would be simpler, but it would make important semantic transitions like "resolved by this edit" easier to tear.

--- a/docs/adr/0021-agent-coordination-visibility.md
+++ b/docs/adr/0021-agent-coordination-visibility.md
@@ -2,6 +2,11 @@
 
 Agent coordination discussions are visible by default to the delegating human or policy scope that authorized the agent. Agents may create restricted discussions only when their active capability permits it; Heddle should not create invisible durable agent side channels outside explicit policy.
 
+Collaboration visibility must consume the shared E5 visibility substrate
+tracked by #315-#319 and #523. Discussion and agent-coordination visibility
+project into `VisibilityTier` / `StateVisibility` rather than defining a
+parallel tier enum or hosted policy model.
+
 Agent task assignment is operational metadata for v1, not a collaboration operation. It drives execution policy and local runner behavior, including whether offline continuation is allowed. Collaboration operations may reference the agent/task identity for provenance, but the assignment itself does not become durable repository collaboration history unless a later design makes synced task delegation a first-class collaboration record.
 
 Local task assignment metadata should use a versioned local id/envelope so future runner-policy changes do not break provenance grouping. Local task assignment ids should be opaque UUIDv7 values: sortable and collision-resistant without embedding task meaning. Human-readable task meaning belongs in task metadata or discussion titles. This versioning remains operational metadata; the collaboration operation schema only records opaque local task provenance when available.
@@ -102,6 +107,6 @@ Task provenance inspection should live under `doctor` or an advanced `actor expl
 
 If Heddle later adds a handoff command, local task provenance should be optional context for that workflow rather than the handoff itself. The handoff turn remains collaboration content authored under capability policy; task provenance can prefill context or attach allowed provenance, but the handoff body should stand on its own.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Private agent-only coordination could reduce noise, but it would weaken human oversight and trust. Ephemeral model scratch can remain outside Heddle; once an agent writes a discussion, it becomes durable collaboration history under the relevant capability policy.

--- a/docs/adr/0021-agent-coordination-visibility.md
+++ b/docs/adr/0021-agent-coordination-visibility.md
@@ -1,0 +1,107 @@
+# Agent coordination visibility
+
+Agent coordination discussions are visible by default to the delegating human or policy scope that authorized the agent. Agents may create restricted discussions only when their active capability permits it; Heddle should not create invisible durable agent side channels outside explicit policy.
+
+Agent task assignment is operational metadata for v1, not a collaboration operation. It drives execution policy and local runner behavior, including whether offline continuation is allowed. Collaboration operations may reference the agent/task identity for provenance, but the assignment itself does not become durable repository collaboration history unless a later design makes synced task delegation a first-class collaboration record.
+
+Local task assignment metadata should use a versioned local id/envelope so future runner-policy changes do not break provenance grouping. Local task assignment ids should be opaque UUIDv7 values: sortable and collision-resistant without embedding task meaning. Human-readable task meaning belongs in task metadata or discussion titles. This versioning remains operational metadata; the collaboration operation schema only records opaque local task provenance when available.
+
+Agent task completion is also local runner metadata in v1, not a collaboration operation. If completion matters to humans or other agents, the agent should write an explicit handoff or status discussion turn under its active capability; otherwise completion remains operational state.
+
+After task completion, Heddle should retain a compact local task provenance summary while collaboration operations reference the task assignment. Detailed runner state such as prompts, transient configuration, scratch state, and verbose logs may expire through maintenance according to operational retention.
+
+Compact local task provenance summaries may include model and provider details when known because they help explain agent behavior. Hosted sharing of those details is policy-filtered. Operation actor attribution remains the collaboration identity; task summaries provide diagnostic runner context, not collaboration truth.
+
+Model and provider details may inform risk or review heuristics, but they do not replace attribution, signatures, capability policy, or verification results. Model metadata is context, not authority.
+
+Compact task provenance summaries do not retain full prompt text by default. Prompts can contain secrets, user intent, and unrelated context. Heddle may keep prompt hashes or short user-approved labels when useful; full prompt retention requires explicit diagnostic or audit mode.
+
+Compact task provenance summaries do not retain full tool-call logs by default. They may retain coarse counts, statuses, or links to explicit diagnostics when enabled. Full tool logs are operational debug artifacts with separate retention and privacy concerns.
+
+Task labels are user-editable local operational metadata. Changing a label affects local display and diagnostics, not immutable operation provenance or hosted aliases. If a label is shared to Weft, Weft treats it as policy-filtered hosted projection metadata.
+
+Changing a task label does not create a collaboration operation in v1. If the change matters to collaborators, a user or agent can explicitly write a discussion note.
+
+If the compact task provenance summary is missing, Heddle still shows locally valid collaboration operations that reference the task assignment and marks task provenance as unavailable. Missing local operational metadata is a diagnostic warning, not a reason to hide collaboration history.
+
+V1 task assignment does not sync through Weft. Parallel agents on different machines coordinate through discussions and attention, which are collaboration records. If cross-machine agent orchestration becomes a product feature, task assignment should be promoted deliberately to a collaboration record or Weft-owned orchestration record.
+
+When available, collaboration operation envelopes may include `task_provenance` as optional provenance. This helps explain why an agent wrote an operation and lets inbox or diagnostics group operations by delegated work. The field name should not be `task_assignment_id`, because the assignment itself is local operational metadata rather than synced authority. Missing task provenance does not invalidate an operation because humans and ambient agents may write without local task assignment metadata.
+
+When `task_provenance` is present in the collaboration operation envelope, it is part of the canonical bytes and therefore part of `CollabOpId`. Hosted task provenance aliases remain sync metadata and do not retroactively change the operation hash.
+
+Human-authored operations include task provenance only when the human is acting through an explicit task assignment or tool workflow. Ordinary human discussion turns omit task provenance by default so grouping stays meaningful.
+
+Task provenance is not required for every agent-authored operation in v1. Ambient agents, older clients, and local scripts may write without task assignment metadata. Hosted policy may require task provenance for specific contexts, but local validity does not.
+
+Public JSON schemas for the first collaboration slice should include optional nullable task provenance fields. They can be absent in operation data, but making the shape explicit early lets agents and tests handle provenance consistently.
+
+If task provenance was omitted from an existing operation, Heddle does not patch it into that operation. Adding it would create a different canonical envelope and therefore a different `CollabOpId`. Diagnostics may link the operation to local task metadata as derived view state, but the original operation bytes stay immutable.
+
+A later collaboration operation cannot mutate task provenance for earlier operations. It may explicitly comment that earlier operations belonged to a task, but that statement is collaboration content, not a provenance rewrite. Derived local views may group earlier operations heuristically with warnings.
+
+Heuristic task grouping is local derived view state and does not sync to Weft by default. Only explicit `task_provenance` in operation envelopes or Weft-minted hosted aliases participate in hosted grouping.
+
+Weft does not receive raw local task assignment ids by default during sync. Sync may include opaque task provenance only when policy permits, but local runner assignment details should not leak automatically. Hashing the local id is not sufficient if the value remains stable and linkable; shared task provenance should use a deliberate hosted-safe alias rather than a raw or trivially correlated local id. Hosted validity relies on agent identity, capability context, and operation content; task grouping can remain local unless explicitly shared.
+
+When hosted-safe task provenance is shared, Weft mints the alias during sync under namespace policy. Heddle may request aliasing, but Weft owns the hosted alias so it can avoid cross-remote correlation and enforce sharing rules. Local Heddle stores the alias mapping as sync metadata.
+
+Hosted-safe task provenance aliases are stable for multiple operations from the same local task within the same Weft repository and policy scope. They should not be stable across unrelated remotes or namespaces unless policy explicitly links those scopes. They do not need to preserve UUIDv7 sortability; ordering comes from operation timestamps, operation IDs, and hosted audit metadata. Local sync metadata maps a local task assignment id to per-remote hosted aliases.
+
+Hosted-safe task provenance aliases do not embed display labels. Alias identity stays opaque; optional labels are separate policy-filtered projection metadata so labels can change without changing alias identity.
+
+Default hosted alias mapping is one local task assignment to one hosted alias per remote and policy scope. Many-to-one grouping is allowed only when Weft policy explicitly coalesces local tasks, such as for a hosted campaign, and Heddle records that coalescing in sync metadata.
+
+One local task assignment may map to multiple hosted aliases on the same remote only across policy-scope changes. If Weft policy changes enough that the old alias is no longer appropriate, future operations can receive a new hosted alias, with sync metadata linking the old and new aliases as a scope transition.
+
+Task provenance grouping can cross discussion boundaries within the same repository and policy scope. A single agent task may open discussions, append turns, and create attention-relevant operations across several collaboration records. This grouping does not create causal relationships; causal relationships remain in the collaboration operation graph.
+
+V1 task provenance grouping applies to collaboration operations, not source history operations. Source history already has its own attribution and provenance model with different storage and sync semantics. A later cross-domain provenance view may correlate task assignment with source captures, but collaboration task provenance does not change source operation identity.
+
+A future cross-domain provenance view should be derived by default, not a collaboration record. It can correlate source attribution, collaboration operations, task assignment metadata, and sync metadata. Only explicit human or agent commentary about that relationship becomes collaboration content.
+
+The hosted-safe task provenance alias is hosted sync metadata and hosted projection data, not part of the immutable collaboration operation envelope. The local operation envelope may carry local task assignment provenance; Weft records the hosted alias for accepted operations when policy permits sharing.
+
+Each Weft remote or namespace may mint a different hosted-safe alias for the same local task. Heddle treats alias mappings as per-remote sync metadata so task provenance cannot accidentally correlate unrelated hosted scopes.
+
+Task provenance aliasing is optional hosted grouping. Missing, withheld, or policy-denied task provenance does not invalidate an otherwise valid collaboration operation unless repository policy explicitly requires task provenance for a class of agent writes.
+
+Weft may reject or omit task provenance sharing while accepting the collaboration operation itself. In that case Heddle records the denied or omitted alias as sync metadata, not as a failed collaboration write.
+
+If repository policy requires hosted task provenance for a class of agent writes and aliasing is denied or unavailable, the operation is hosted-invalid under that policy while remaining locally valid. Heddle records the rejection or blocked state in sync metadata and surfaces attention to the agent and delegating human.
+
+Task provenance policy failures use the same hosted rejection reason system as other collaboration sync rejections: stable shared machine-readable codes plus human messages. Agents should not need a separate error taxonomy for task provenance failures.
+
+When policy permits task provenance sharing, Weft should return a stable hosted-safe alias once for that local task and policy scope, and Heddle should reuse the local mapping for subsequent operations. When policy later stops permitting sharing, future sync omits the alias and marks the local mapping inactive, while previously accepted hosted grouping remains historical audit data.
+
+Hosted task provenance sharing can be disabled for future operations, but aliases already recorded on accepted hosted operations remain audit data. If policy later requires hiding them from a viewer, Tapestry suppresses display through policy filtering rather than rewriting accepted operation or sync history.
+
+If Heddle loses its local alias mapping, it can ask Weft for a fresh hosted-safe alias for future operations under current policy. It must not reconstruct hosted task provenance by leaking raw local task assignment ids unless policy explicitly permits that disclosure. Previously accepted hosted operations keep whatever grouping Weft already recorded.
+
+Hosted task provenance aliases survive local task metadata deletion. Once Weft accepts operations with an alias, the alias remains hosted audit and projection data. Local deletion only removes Heddle's ability to explain or reuse the local mapping without asking Weft again.
+
+Hosted views should show hosted-safe task provenance aliases, not raw local task assignment ids. Full local views may show local task provenance when the local metadata is present and the active capability context permits it.
+
+Hosted-safe task provenance aliases should appear in JSON outputs for inbox and discussion views when present and policy-visible, so agents can group work reliably. Terse human output omits them by default; verbose or detail views may show task grouping when it helps explain agent activity.
+
+Verbose text output may show a concise task label or hosted alias when available and policy-visible, but full task provenance belongs in JSON or diagnostic commands. Human text should not become a provenance dump.
+
+Tapestry may search, filter, and group by hosted-safe task provenance alias within the same repository and policy scope. It must not expose raw local task ids or use aliases to cross-correlate unrelated namespaces.
+
+Hosted task provenance is not assignment authority. Weft and Tapestry may use aliases for grouping, audit, and navigation, but v1 task assignment remains local operational metadata and hosted aliases do not drive permissions, access control, runner lifecycle, or agent interruption state. Access control comes from identity, grants, capability context, and repository policy.
+
+Hosted task provenance is not causal collaboration history. Aliases cannot be causal parents, merge inputs, or resolution evidence for discussions; they only group and explain operations for hosted audit, navigation, and diagnostics.
+
+If synced task delegation later becomes a first-class product feature, Heddle should add explicit collaboration records or Weft orchestration records that link to historical hosted task provenance aliases. Historical collaboration operation envelopes are not rewritten to retrofit task assignment semantics.
+
+`fsck` and `doctor` should check task provenance shape and alias mapping consistency, but missing local task assignment metadata or missing hosted alias mappings are warnings, not collaboration operation validity failures.
+
+Heddle should provide an advanced diagnostic surface to inspect local task provenance summaries and hosted alias mappings. Agents and operators need to explain why operations grouped together or why hosted aliasing failed, while normal discussion commands should remain focused on collaboration content.
+
+Task provenance inspection should live under `doctor` or an advanced `actor explain` style surface rather than a new top-level command. `inbox` and discussion JSON expose enough for normal agent workflows; deep mapping inspection is troubleshooting.
+
+If Heddle later adds a handoff command, local task provenance should be optional context for that workflow rather than the handoff itself. The handoff turn remains collaboration content authored under capability policy; task provenance can prefill context or attach allowed provenance, but the handoff body should stand on its own.
+
+**Status:** accepted
+
+**Considered Options:** Private agent-only coordination could reduce noise, but it would weaken human oversight and trust. Ephemeral model scratch can remain outside Heddle; once an agent writes a discussion, it becomes durable collaboration history under the relevant capability policy.

--- a/docs/adr/0022-collaboration-operation-signing-staging.md
+++ b/docs/adr/0022-collaboration-operation-signing-staging.md
@@ -1,0 +1,21 @@
+# Collaboration operation signing staging
+
+Collaboration operations should eventually be signed with the same identity direction as source states, but signatures are not required for the first local discussion-log slice. Slice 1 records attribution and stable operation IDs; later work can reuse automatic identity signing for tamper-evident collaboration operations and allow Weft policy to require signatures for hosted writes.
+
+The v1 operation envelope should reserve explicit signature fields even when they are empty, so later signature requirements do not require a surprising schema reshaping. Weft may require signatures for hosted writes before the local-only slice requires them for local validity.
+
+Adding signature requirements later does not invalidate old unsigned operations locally. They remain historical operations with unsigned provenance. Hosted policy may reject unsigned operations for new sync or sensitive records, but local materialization preserves old history.
+
+Signatures are not attached later by mutating old operation bytes. If Heddle needs to upgrade trust in old unsigned history, it creates a collaboration attestation operation that cites the old operation and signs a claim about it.
+
+Attestations affect trust and display overlays, and may affect hosted validity, but they do not alter the attested operation's discussion text, lifecycle effect, anchors, or visibility.
+
+Competing attestations can coexist and materialize as trust-overlay disagreement. One attestation does not erase another unless a later revocation or attestation operation explicitly supersedes it under policy.
+
+Operation signatures cover the canonical operation envelope, not sync metadata. Sync metadata varies by remote and over time; signing it would either break signatures or freeze remote policy state into local content.
+
+When signatures are present, operation capability context is signed because it is part of the canonical operation envelope and provenance claim. Hosted acceptance context remains unsigned sync metadata.
+
+**Status:** accepted
+
+**Considered Options:** Requiring signatures immediately would strengthen integrity, but it would block the local storage and merge model on signing plumbing. Never signing collaboration operations would leave agent coordination weaker than source history, which conflicts with Heddle's provenance direction.

--- a/docs/adr/0022-collaboration-operation-signing-staging.md
+++ b/docs/adr/0022-collaboration-operation-signing-staging.md
@@ -16,6 +16,6 @@ Operation signatures cover the canonical operation envelope, not sync metadata. 
 
 When signatures are present, operation capability context is signed because it is part of the canonical operation envelope and provenance claim. Hosted acceptance context remains unsigned sync metadata.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Requiring signatures immediately would strengthen integrity, but it would block the local storage and merge model on signing plumbing. Never signing collaboration operations would leave agent coordination weaker than source history, which conflicts with Heddle's provenance direction.

--- a/docs/adr/0023-attention-feeds-readiness.md
+++ b/docs/adr/0023-attention-feeds-readiness.md
@@ -1,0 +1,17 @@
+# Attention feeds readiness
+
+Attention severity feeds `ready`, but only targeted or high-severity attention items block readiness. Resolution conflicts, visibility conflicts linked to current work or hosted sync, explicit blocker turns targeting the current thread, targeted unanswered questions, hosted rejections that affect sync or actionability, and blocked hosted-valid continuations can block; broader discussions, low-impact historical rejections, or informational items remain visible through `inbox` or diagnostics without stopping integration.
+
+Task provenance grouping does not itself block readiness. `ready` blocks from item-level severity, target, and current-thread relevance. Grouping can summarize related attention, but it must not hide a blocker or make a whole task group block merely because one informational item is related.
+
+The first local discussion slice should let `ready` block on blocker turns that target the current thread or actor, and on resolution conflicts that affect current work. `ready` should not block merely because a discussion is open.
+
+A blocker turn remains readiness-impacting until a later explicit operation answers, supersedes, clears, or resolves it. Recency alone does not clear a blocker, because agents need durable coordination state rather than a best-effort notification feed.
+
+A targeted question can stop being an attention item when a later answer cites that question, even if the discussion remains open. Clearing a question from inbox is separate from resolving the discussion lifecycle.
+
+Context annotation conflicts should create attention, but they should block readiness only when the conflicted annotation is linked to the current thread, changed content, or an explicit policy gate. Heddle should not globally block integration because unrelated repository knowledge needs curation.
+
+**Status:** accepted
+
+**Considered Options:** Ignoring attention during readiness would let agents land work while unresolved coordination blockers exist. Blocking on every open discussion would make durable collaboration too noisy. Severity plus target keeps readiness honest without making discussion volume a workflow tax.

--- a/docs/adr/0023-attention-feeds-readiness.md
+++ b/docs/adr/0023-attention-feeds-readiness.md
@@ -12,6 +12,6 @@ A targeted question can stop being an attention item when a later answer cites t
 
 Context annotation conflicts should create attention, but they should block readiness only when the conflicted annotation is linked to the current thread, changed content, or an explicit policy gate. Heddle should not globally block integration because unrelated repository knowledge needs curation.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Ignoring attention during readiness would let agents land work while unresolved coordination blockers exist. Blocking on every open discussion would make durable collaboration too noisy. Severity plus target keeps readiness honest without making discussion volume a workflow tax.

--- a/docs/adr/0024-formal-collaboration-convergence-before-sync.md
+++ b/docs/adr/0024-formal-collaboration-convergence-before-sync.md
@@ -16,6 +16,6 @@ The first model treats capability scope as abstract permissions or predicates ov
 
 The formal model should use Quint if that remains Heddle's formal-spec convention. Collaboration should fit the existing verification practice rather than introduce a second modeling tool.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Relying only on implementation tests would move faster, but it would make the CRDT claim less defensible. Requiring a full formal model before any local discussion work would delay learning about command and storage ergonomics unnecessarily.

--- a/docs/adr/0024-formal-collaboration-convergence-before-sync.md
+++ b/docs/adr/0024-formal-collaboration-convergence-before-sync.md
@@ -1,0 +1,21 @@
+# Formal collaboration convergence before sync
+
+Heddle should have a formal convergence model before collaboration sync ships. The local-only discussion-log slice can begin with Rust tests, but remote CRDT collaboration requires a model covering concurrent append survival, incompatible resolution conflicts, reopen semantics, idempotent replay, conflict resolution, and deterministic materialized views.
+
+The model should cover both semantic materialization and deterministic display linearization. Replicas with the same accepted operation set must produce the same record head sets and the same display order, regardless of operation arrival order.
+
+The model should also cover recursive conflict materialization: concurrent conflict-resolution operations can create a new explicit conflict when they choose incompatible outcomes.
+
+The model should distinguish command idempotency from operation identity. Command/RPC idempotency keys prevent duplicate execution, while content-addressed `CollabOpId`s deduplicate identical operation bytes during sync or import.
+
+Hosted rejection and blocking states should be modeled as a sync-policy layer over local convergence. The local CRDT model converges over locally valid operations; the hosted model converges over accepted subsets, rejected operations, blocked descendants, and hosted-valid continuations.
+
+The first formal convergence model treats signature validity as an operation predicate or policy filter rather than modeling cryptographic details. The first formal risk is convergence and materialization, not cryptographic correctness.
+
+The first model treats capability scope as abstract permissions or predicates over operation kinds and records. Full Biscuit semantics belong in auth-specific tests or specs; collaboration convergence needs policy accept/reject behavior.
+
+The formal model should use Quint if that remains Heddle's formal-spec convention. Collaboration should fit the existing verification practice rather than introduce a second modeling tool.
+
+**Status:** accepted
+
+**Considered Options:** Relying only on implementation tests would move faster, but it would make the CRDT claim less defensible. Requiring a full formal model before any local discussion work would delay learning about command and storage ergonomics unnecessarily.

--- a/docs/adr/0025-heddle-native-collaboration-operations.md
+++ b/docs/adr/0025-heddle-native-collaboration-operations.md
@@ -2,6 +2,6 @@
 
 Heddle uses a Heddle-native operation model for discussions, context annotations, attention, and collaboration convergence. External CRDT libraries may be tactical implementation aids, but they must not define the domain model; collaboration operations need Heddle-specific attribution, capability context, causal parents, source anchors, and resolution-conflict semantics.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** A general-purpose CRDT library could accelerate implementation, but it would likely impose document/list semantics that do not match Heddle's repository collaboration model. Heddle-native operations preserve control over the model and leave room to reimplement tactical dependencies later.

--- a/docs/adr/0025-heddle-native-collaboration-operations.md
+++ b/docs/adr/0025-heddle-native-collaboration-operations.md
@@ -1,0 +1,7 @@
+# Heddle-native collaboration operations
+
+Heddle uses a Heddle-native operation model for discussions, context annotations, attention, and collaboration convergence. External CRDT libraries may be tactical implementation aids, but they must not define the domain model; collaboration operations need Heddle-specific attribution, capability context, causal parents, source anchors, and resolution-conflict semantics.
+
+**Status:** accepted
+
+**Considered Options:** A general-purpose CRDT library could accelerate implementation, but it would likely impose document/list semantics that do not match Heddle's repository collaboration model. Heddle-native operations preserve control over the model and leave room to reimplement tactical dependencies later.

--- a/docs/adr/0026-content-addressed-collaboration-operation-ids.md
+++ b/docs/adr/0026-content-addressed-collaboration-operation-ids.md
@@ -1,0 +1,33 @@
+# Content-addressed collaboration operation IDs
+
+Collaboration operation IDs are content-addressed over the canonical operation envelope, while remaining distinct from source-history `ChangeId`s. The envelope includes the operation kind, target record, causal parents, attribution, capability context, payload, and timestamp or nonce as needed.
+
+Heddle parses enough canonical envelope structure to compute or confirm the content-addressed id, then validates schema, references, signatures, and policy. Invalid bytes may have a diagnostic hash, but they do not receive a trusted `CollabOpId` unless they satisfy the canonical envelope rules.
+
+Writing duplicate canonical operation bytes is not an error. If the same bytes yield an existing `CollabOpId`, the writer treats the operation as already present and returns an idempotent success while ensuring indexes can observe the existing operation.
+
+An existing `CollabOpId` with different bytes is corruption or a hash-collision class failure and must fail closed. Heddle never replaces existing operation bytes under the same id; `fsck` or `doctor` should quarantine the conflicting artifact and report high severity.
+
+Because the operation ID hashes the canonical envelope, accepted operation bytes are immutable. Schema evolution happens through versioned decoding into the current in-memory model, not by rewriting old operation bytes in place. Future pack or segment compaction must preserve the original envelope bytes for each operation ID unless it explicitly creates new operation IDs and records that mapping.
+
+Redaction does not rewrite or replace the original operation bytes. A redaction operation or hosted policy overlay can change what materialized views and sync expose, but the original `CollabOpId` remains the hash of the original canonical envelope.
+
+Two operations with different canonical envelope bytes have different operation IDs even if they decode to the same current in-memory operation. Cross-version semantic equivalence is not folded into the hash.
+
+Retry and duplicate-write handling uses an explicit collaboration idempotency key rather than normalized operation identity. Collaboration commands reuse Heddle's existing `--op-id` CLI surface and `client_operation_id` RPC surface for this key, then store the same value explicitly in the collaboration operation envelope. The key is generated at the command-attempt boundary, included in the operation envelope, and checked in an idempotency index scoped to the collaboration record, operation kind, actor, and capability context. A retried write with the same key returns the already-accepted operation instead of appending a duplicate.
+
+For one-shot human CLI writes, omitting `--op-id` means Heddle provides no replay guarantee, matching the existing mutating-command contract. For multi-step or crash-sensitive collaboration writes, Heddle may auto-generate the idempotency key and persist it in local pending state so a crash retry can complete the same write instead of creating a duplicate.
+
+Reusing the same collaboration idempotency key with different request content is an idempotency conflict and must be rejected locally before writing. The operation hash can distinguish the bytes, but the idempotency key promises the same command attempt; changing the body under that key indicates a caller bug.
+
+Validation failures that do not create an operation do not make the key safe to reuse for different content. A caller may retry the same failed request with the same key, but if it changes observed heads, payload, target, or operation kind, it should generate a new collaboration idempotency key.
+
+Weft applies the same rule when validating hosted collaboration operations. A well-formed operation with a valid `CollabOpId` is still hosted-invalid if its idempotency key conflicts with an already accepted operation for the same actor/capability scope.
+
+Independent actors submitting the same visible content with the same anchor and causal parents still create distinct collaboration operations unless they share the same idempotency key and actor/capability scope. Heddle does not deduplicate collaboration by semantic content because repeated agreement, duplicate human comments, and parallel agent conclusions can be meaningful records.
+
+Collaboration idempotency keys are operational metadata. Normal human-facing discussion output shows the resulting operation ID, actor, timestamp, turn kind, and content; idempotency keys appear only in verbose/debug JSON and `fsck`/`doctor` diagnostics.
+
+**Status:** accepted
+
+**Considered Options:** Random IDs would be simple and avoid duplicate-content edge cases, but they would not provide the same deduplication, idempotent retry, and tamper-evidence properties as Heddle's content-addressed model. If intentionally duplicate operations need distinction, the operation envelope can include a nonce.

--- a/docs/adr/0026-content-addressed-collaboration-operation-ids.md
+++ b/docs/adr/0026-content-addressed-collaboration-operation-ids.md
@@ -28,6 +28,6 @@ Independent actors submitting the same visible content with the same anchor and 
 
 Collaboration idempotency keys are operational metadata. Normal human-facing discussion output shows the resulting operation ID, actor, timestamp, turn kind, and content; idempotency keys appear only in verbose/debug JSON and `fsck`/`doctor` diagnostics.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Random IDs would be simple and avoid duplicate-content edge cases, but they would not provide the same deduplication, idempotent retry, and tamper-evidence properties as Heddle's content-addressed model. If intentionally duplicate operations need distinction, the operation envelope can include a nonce.

--- a/docs/adr/0027-uuidv7-discussion-ids.md
+++ b/docs/adr/0027-uuidv7-discussion-ids.md
@@ -1,0 +1,9 @@
+# UUIDv7 discussion IDs
+
+Discussion IDs are generated UUIDv7 record identifiers, while collaboration operation IDs are content-addressed. UUIDv7 gives discussions stable locally generated identity with useful time-sort behavior without tying the discussion's identity to its opening title, anchor, first turn, or attribution. UUIDv7 order is only an indexing and display convenience; causal ordering remains the semantic ordering model.
+
+Migrated legacy state-attached discussions receive new UUIDv7 discussion IDs. Legacy IDs are preserved as source metadata or lookup aliases when useful, but they do not become canonical repository discussion identity.
+
+**Status:** accepted
+
+**Considered Options:** Content-addressing the opening operation could derive the discussion ID from immutable data, but it would make record identity depend on opening payload details. Random UUIDs would work, but UUIDv7 gives better ordering and locality for listings, indexes, and sync cursors while keeping the ID opaque.

--- a/docs/adr/0027-uuidv7-discussion-ids.md
+++ b/docs/adr/0027-uuidv7-discussion-ids.md
@@ -4,6 +4,6 @@ Discussion IDs are generated UUIDv7 record identifiers, while collaboration oper
 
 Migrated legacy state-attached discussions receive new UUIDv7 discussion IDs. Legacy IDs are preserved as source metadata or lookup aliases when useful, but they do not become canonical repository discussion identity.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Content-addressing the opening operation could derive the discussion ID from immutable data, but it would make record identity depend on opening payload details. Random UUIDs would work, but UUIDv7 gives better ordering and locality for listings, indexes, and sync cursors while keeping the ID opaque.

--- a/docs/adr/0028-heddle-native-collaboration-store.md
+++ b/docs/adr/0028-heddle-native-collaboration-store.md
@@ -6,6 +6,6 @@ The local collaboration log uses Heddle-native content-addressed storage, append
 
 `doctor` may automatically rebuild disposable collaboration indexes and materialized views. It does not repair durable operation bytes by guesswork. If operation bytes are invalid or missing, `doctor` reports or quarantines the problem and points to restore or explicit import rather than synthesizing history.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** SQLite would make querying and indexing straightforward, but it would introduce a second local source-of-truth model for core OSS behavior. Heddle-native storage keeps collaboration aligned with content addressing, fsck/doctor repair, and the longer-term direction of owning core dependencies.

--- a/docs/adr/0028-heddle-native-collaboration-store.md
+++ b/docs/adr/0028-heddle-native-collaboration-store.md
@@ -1,0 +1,11 @@
+# Heddle-native collaboration store
+
+The local collaboration log uses Heddle-native content-addressed storage, append/index files, and rebuildable materialized views rather than SQLite or another embedded database as the source of truth. Collaboration indexes can optimize lookup by discussion, anchor, thread, actor, attention target, and causal parents, but operation objects remain the durable record. `fsck` verifies operation integrity and references; `doctor` can diagnose and rebuild disposable indexes and views.
+
+`fsck` recomputes every `CollabOpId` from canonical operation bytes as the primary durable-object integrity check. It also verifies shard path placement, supported schema versions, causal references, and whether indexes and views can be rebuilt.
+
+`doctor` may automatically rebuild disposable collaboration indexes and materialized views. It does not repair durable operation bytes by guesswork. If operation bytes are invalid or missing, `doctor` reports or quarantines the problem and points to restore or explicit import rather than synthesizing history.
+
+**Status:** accepted
+
+**Considered Options:** SQLite would make querying and indexing straightforward, but it would introduce a second local source-of-truth model for core OSS behavior. Heddle-native storage keeps collaboration aligned with content addressing, fsck/doctor repair, and the longer-term direction of owning core dependencies.

--- a/docs/adr/0029-retain-valid-collaboration-operations.md
+++ b/docs/adr/0029-retain-valid-collaboration-operations.md
@@ -2,6 +2,6 @@
 
 Locally valid collaboration operations are retained in v1; Heddle does not garbage-collect durable discussion, context, or attention history by default. Operations that Weft rejects under hosted policy remain in the local collaboration log and are marked through sync metadata rather than deleted or rewritten. Cleanup can remove incomplete temporary artifacts and rebuild disposable indexes or materialized views, but retention policy for valid collaboration history is deferred.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Pruning old collaboration operations would limit repository growth, but it would weaken auditability, append-only turns, compensating operations, capability history, and agent coordination provenance. Retention should be introduced later as explicit policy, likely with Weft namespace support.

--- a/docs/adr/0029-retain-valid-collaboration-operations.md
+++ b/docs/adr/0029-retain-valid-collaboration-operations.md
@@ -1,0 +1,7 @@
+# Retain valid collaboration operations
+
+Locally valid collaboration operations are retained in v1; Heddle does not garbage-collect durable discussion, context, or attention history by default. Operations that Weft rejects under hosted policy remain in the local collaboration log and are marked through sync metadata rather than deleted or rewritten. Cleanup can remove incomplete temporary artifacts and rebuild disposable indexes or materialized views, but retention policy for valid collaboration history is deferred.
+
+**Status:** accepted
+
+**Considered Options:** Pruning old collaboration operations would limit repository growth, but it would weaken auditability, append-only turns, compensating operations, capability history, and agent coordination provenance. Retention should be introduced later as explicit policy, likely with Weft namespace support.

--- a/docs/adr/0030-no-git-collaboration-export.md
+++ b/docs/adr/0030-no-git-collaboration-export.md
@@ -1,0 +1,9 @@
+# No Git collaboration export
+
+The Git bridge does not export Heddle collaboration records by default or as an optional projection. Discussions, context annotations, attention views, and collaboration operations are Heddle-only capabilities; sharing them across machines or people requires a Heddle remote backed by Weft.
+
+The Git bridge also should not import GitHub, GitLab, Git notes, or other Git-adjacent comments into Heddle discussions by default. If imported collaboration is needed later, it should be an explicit import workflow using collaboration import roots with source and trust labels, not bridge magic.
+
+**Status:** accepted
+
+**Considered Options:** Git notes, commit trailers, and GitHub/GitLab comment mirroring would make collaboration visible in existing Git hosting tools, but they would flatten Heddle's semantic anchors, capability policy, causal operations, and agent attribution. Collaboration is part of the Heddle product boundary, not a Git compatibility feature.

--- a/docs/adr/0030-no-git-collaboration-export.md
+++ b/docs/adr/0030-no-git-collaboration-export.md
@@ -4,6 +4,6 @@ The Git bridge does not export Heddle collaboration records by default or as an 
 
 The Git bridge also should not import GitHub, GitLab, Git notes, or other Git-adjacent comments into Heddle discussions by default. If imported collaboration is needed later, it should be an explicit import workflow using collaboration import roots with source and trust labels, not bridge magic.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Git notes, commit trailers, and GitHub/GitLab comment mirroring would make collaboration visible in existing Git hosting tools, but they would flatten Heddle's semantic anchors, capability policy, causal operations, and agent attribution. Collaboration is part of the Heddle product boundary, not a Git compatibility feature.

--- a/docs/adr/0031-local-only-collaboration-warning.md
+++ b/docs/adr/0031-local-only-collaboration-warning.md
@@ -10,6 +10,6 @@ Hosted rejection or blocked collaboration sync should appear in `status` when it
 
 In the first local discussion slice, `status` should summarize discussions only when they create attention for the current checkout or thread. It should point to `heddle inbox` or `heddle discuss list` for details rather than becoming a discussion list.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Staying silent would preserve output restraint, but users in Git-overlay repos could wrongly assume Git push shared discussions or attention. Warning on every command would be noisy, so the label belongs on orientation and sync-adjacent surfaces.

--- a/docs/adr/0031-local-only-collaboration-warning.md
+++ b/docs/adr/0031-local-only-collaboration-warning.md
@@ -1,0 +1,15 @@
+# Local-only collaboration warning
+
+When collaboration records exist locally without a configured or synchronized Heddle remote, Heddle should label that state in surfaces such as `status`, `inbox`, `doctor`, and Git push-adjacent output. The warning appears only when local collaboration exists and should not block readiness unless policy requires hosted sync.
+
+When a `discuss` write creates local-only collaboration without a configured or synchronized Heddle remote, output should include a concise local-only notice and point to Heddle remote sync. Read-only commands can be quieter and rely on orientation surfaces.
+
+Git push-adjacent output should mention Heddle collaboration when local collaboration exists. The message should be specific that Git push does not share Heddle discussions, context, or attention records; Heddle-hosted sync is required.
+
+Hosted rejection or blocked collaboration sync should appear in `status` when it affects the current checkout or thread, but it must be described as a collaboration sync problem rather than dirty source history. `ready` can block through attention severity, while `status` keeps source history and the collaboration sync lane separate.
+
+In the first local discussion slice, `status` should summarize discussions only when they create attention for the current checkout or thread. It should point to `heddle inbox` or `heddle discuss list` for details rather than becoming a discussion list.
+
+**Status:** accepted
+
+**Considered Options:** Staying silent would preserve output restraint, but users in Git-overlay repos could wrongly assume Git push shared discussions or attention. Warning on every command would be noisy, so the label belongs on orientation and sync-adjacent surfaces.

--- a/docs/adr/0032-weft-backed-collaboration-sync.md
+++ b/docs/adr/0032-weft-backed-collaboration-sync.md
@@ -1,0 +1,45 @@
+# Weft-backed collaboration sync
+
+Collaboration sync requires a Weft-backed Heddle remote capability. Local Heddle repositories can store collaboration records, but sharing discussions, context annotations, attention overlays, and collaboration operations across machines or people is a Heddle-hosted capability, not a Git remote or generic source-object remote feature. Weft-backed `push` and `pull` include collaboration by default when policy permits it, while output reports source sync and collaboration sync results separately. Partial lane success is allowed, but the default command exits non-zero unless every requested lane succeeds; `--allow-partial` can make partial success an explicit operator choice. Source pushes auto-include collaboration records causally or semantically linked to pushed source content, and synced discussions can receive live gRPC updates while a Weft connection is active.
+
+Source push should not sync every unrelated local discussion by default. Linked collaboration records travel with the pushed content; unrelated collaboration requires an explicit collaboration sync command or a later policy-driven default that makes the sharing boundary visible.
+
+The initial linked-collaboration rule should be narrow: records anchored to pushed states, changes, changed paths or symbols, active blockers or questions for the pushed thread, and operations that causally continue those records. Broad repository discussions should not sync merely because their text mentions the branch.
+
+Auto-sync sends the required causal closure for the hosted-valid path, not only the latest visible operation. Weft needs enough accepted parent history to validate and materialize records; hosted-rejected branches stay local unless a hosted-valid continuation deliberately bypasses them.
+
+If source push succeeds but collaboration sync fails, Heddle should not roll back the source push. It reports partial lane success, records collaboration sync metadata, exits non-zero by default, and supports an explicit partial-success mode when the operator accepts that split state.
+
+Retry after partial source/collaboration success resumes the collaboration lane from stored sync metadata and idempotency state. Heddle does not replay the successful source push merely to retry pending or blocked collaboration operations; it uses remote cursors and the hosted-valid causal closure needed by the collaboration lane.
+
+Weft can reject locally accepted collaboration operations under hosted policy. Such operations stay local and are surfaced as rejected-by-remote or local-only until policy or operation content changes. Default hosted-synced views exclude them, while local diagnostics and attention surfaces report them as sync problems. Remote acceptance, rejection, pending status, and sync cursors are collaboration sync metadata, not collaboration operations.
+
+Weft rejection reasons include both a stable machine-readable code for agents and policy workflows, and a human message for CLI/Tapestry display. Rejection reason codes are part of the shared collaboration sync contract across Weft, Heddle, and Tapestry; individual surfaces may translate display messages but must not invent incompatible code names. The code and message are sync metadata; the message can be refreshed by Weft and is not durable collaboration content.
+
+Hosted rejections create attention items when they affect the user or agent's ability to sync or act, such as rejected operations, blocked descendants, or a required hosted-valid continuation. These attention items are derived from sync metadata and target the actor, delegating human, or relevant thread. Low-impact historical rejections can remain diagnostic-only.
+
+Operations that causally depend on a hosted-rejected operation remain locally valid but cannot sync to Weft while their hosted causal history is invalid. Heddle marks them as blocked by hosted-invalid causal history until the rejected parent is accepted, replaced, or bypassed by a later hosted-valid operation. Weft does not accept an operation whose causal parent is outside the hosted-valid graph for that repository and policy scope.
+
+A user or agent bypasses a hosted-rejected causal parent by creating a hosted-valid continuation: a new collaboration operation on the same collaboration record that intentionally cites the last hosted-valid operation it observed, omits the rejected operation and any hosted-invalid descendants from its causal parents, and records why the hosted-valid path is being resumed, such as recreating the turn under a valid capability. This does not erase or rewrite the rejected local operation.
+
+Heddle should expose hosted-valid continuation through a first-class command or subcommand rather than a hidden option on ordinary discussion writes. The workflow selects the last hosted-valid operation, shows the omitted hosted-invalid chain, requires a reason, and emits the continuation operation. This keeps intentional causal splits explicit for humans and safe for agents.
+
+The discussion command surface should name this workflow explicitly, for example `heddle discuss continue-hosted`. The wording should emphasize hosted validity because the local operation history remains valid and retained.
+
+Continuation workflows may prefill content from a rejected operation for review, but they must not silently copy it. The emitted operation is a new collaboration operation with fresh attribution, capability context, timestamp, and continuation reason.
+
+After a hosted-valid continuation is created, rejected local operations remain visible in full local views with local-only or rejected styling, separated from the hosted-valid path. Hosted-synced and capability-filtered views show the accepted continuation path by default so users can distinguish retained local history from Weft-accepted collaboration history.
+
+Local-only, rejected, blocked, and capability-filtered display status is derived from sync metadata and active capability context, not stored in the immutable collaboration operation. Remote policy changes or capability changes can therefore update views without rewriting collaboration history.
+
+If policy or grants later make a rejected operation acceptable, Heddle syncs the original operation as-is. A hosted-valid continuation is only needed when the original operation remains hosted-invalid or the user intentionally resumes from a different hosted-valid path.
+
+Collaboration import roots sync to Weft only when hosted policy accepts the import source and trust level. Otherwise they remain local imported history. Weft should not silently ingest arbitrary orphaned collaboration history.
+
+Invalid collaboration artifacts do not sync to Weft as collaboration operations. They remain local diagnostics or quarantine artifacts unless an explicit support bundle or export command includes them for investigation.
+
+Hosted collaboration sync should have an explicit redaction and policy-suppression story before broad rollout. Weft should not rely on local users rewriting or deleting append-only collaboration operations to handle accidentally sensitive content.
+
+**Status:** accepted
+
+**Considered Options:** Letting every Heddle remote transport carry collaboration would make the feature feel more universal, but it would blur policy, capability, live coordination, and hosted product boundaries. Weft-backed sync keeps collaboration tied to the Heddle-hosted value proposition.

--- a/docs/adr/0032-weft-backed-collaboration-sync.md
+++ b/docs/adr/0032-weft-backed-collaboration-sync.md
@@ -40,6 +40,6 @@ Invalid collaboration artifacts do not sync to Weft as collaboration operations.
 
 Hosted collaboration sync should have an explicit redaction and policy-suppression story before broad rollout. Weft should not rely on local users rewriting or deleting append-only collaboration operations to handle accidentally sensitive content.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Letting every Heddle remote transport carry collaboration would make the feature feel more universal, but it would blur policy, capability, live coordination, and hosted product boundaries. Weft-backed sync keeps collaboration tied to the Heddle-hosted value proposition.

--- a/docs/adr/0033-live-collaboration-sync.md
+++ b/docs/adr/0033-live-collaboration-sync.md
@@ -1,0 +1,17 @@
+# Live collaboration sync
+
+Synced discussions can receive live gRPC-backed updates while a Weft connection is active. Live collaboration sync updates the durable repository collaboration log and materialized views; it does not replace operation-log storage, push/pull catch-up, offline reconciliation, or capability policy.
+
+Live sync starts as explicit foreground/watch command behavior, such as inbox or discussion watch modes. Daemon integration can come later once lifecycle, status, and recovery are clear; Heddle should not start invisible background collaboration sync.
+
+Watch modes should not ship in the first local-only discussion slice. They depend on Weft-backed live sync; local durable async coordination should ship without presenting itself as a live collaboration surface.
+
+Agent communication correctness relies on durable collaboration operations, not live sync. Watch modes reduce latency for already-shared discussions, but offline writes, push/pull catch-up, and operation-log reconciliation remain the source of truth.
+
+Live updates merge through the same operation-log convergence path as push/pull. Remote operations are imported, local unsynced operations remain, materialized views recompute, ordinary concurrent appends coexist, and incompatible resolutions become resolution conflicts.
+
+Presence, typing indicators, and similar live UI affordances are not collaboration records. They may become ephemeral hosted UI data later, but Heddle live sync should deliver durable operations and sync state rather than chat transport state.
+
+**Status:** accepted
+
+**Considered Options:** Requiring manual push/pull for every discussion turn would preserve a simple sync model, but it would make hosted Heddle feel less collaborative than the product intends. Treating live updates as a separate chat transport would fragment the model, so live delivery remains a transport over the same collaboration operations.

--- a/docs/adr/0033-live-collaboration-sync.md
+++ b/docs/adr/0033-live-collaboration-sync.md
@@ -12,6 +12,6 @@ Live updates merge through the same operation-log convergence path as push/pull.
 
 Presence, typing indicators, and similar live UI affordances are not collaboration records. They may become ephemeral hosted UI data later, but Heddle live sync should deliver durable operations and sync state rather than chat transport state.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Requiring manual push/pull for every discussion turn would preserve a simple sync model, but it would make hosted Heddle feel less collaborative than the product intends. Treating live updates as a separate chat transport would fragment the model, so live delivery remains a transport over the same collaboration operations.

--- a/docs/adr/0034-unknown-collaboration-authors.md
+++ b/docs/adr/0034-unknown-collaboration-authors.md
@@ -1,0 +1,9 @@
+# Unknown collaboration authors
+
+Heddle may accept collaboration operations with unknown authors locally as degraded records, but the unknown attribution is visible, low-trust, and may be rejected, quarantined, or accepted with degraded trust by Weft policy. This preserves offline usefulness without presenting unauthored discussion or context changes as equally trustworthy.
+
+Unknown-author operations create attention items only when they affect current work, hosted sync, or policy-sensitive records. Otherwise they remain visible as low-trust provenance without turning every imported or local-only record into inbox noise.
+
+**Status:** accepted
+
+**Considered Options:** Requiring configured identity for every local collaboration operation would improve audit quality, but it would break local-first workflows before identity is configured. Treating unknown authors as normal would weaken provenance and hosted policy enforcement.

--- a/docs/adr/0034-unknown-collaboration-authors.md
+++ b/docs/adr/0034-unknown-collaboration-authors.md
@@ -4,6 +4,6 @@ Heddle may accept collaboration operations with unknown authors locally as degra
 
 Unknown-author operations create attention items only when they affect current work, hosted sync, or policy-sensitive records. Otherwise they remain visible as low-trust provenance without turning every imported or local-only record into inbox noise.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Requiring configured identity for every local collaboration operation would improve audit quality, but it would break local-first workflows before identity is configured. Treating unknown authors as normal would weaken provenance and hosted policy enforcement.

--- a/docs/adr/0035-collaboration-store-layout.md
+++ b/docs/adr/0035-collaboration-store-layout.md
@@ -16,6 +16,6 @@ Routine collaboration `fsck` should recompute operation IDs from canonical bytes
 
 Collaboration `doctor` may rebuild derived indexes and views, recreate missing idempotency metadata from durable operations when unambiguous, and quarantine malformed artifacts for diagnostics. It must not invent replacement operation bytes, silently delete locally valid operations, or rewrite content-addressed operation envelopes.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Storing collaboration operations under `.heddle/objects/` would align them with content addressing, but it would blur source-history objects with collaboration metadata. Storing them under `.heddle/oplog/` would reuse an append log, but it would confuse collaboration history with undo/redo history. A dedicated root keeps the boundary clear while staying Heddle-native.

--- a/docs/adr/0035-collaboration-store-layout.md
+++ b/docs/adr/0035-collaboration-store-layout.md
@@ -1,0 +1,21 @@
+# Collaboration store layout
+
+The local collaboration store is rooted at `.heddle/collaboration/`. Durable collaboration operations live under `ops/`, while `indexes/`, `views/`, `sync/`, and `tmp/` hold rebuildable query structures, materialized views, Weft sync metadata, and temporary files.
+
+V1 stores each collaboration operation as an individual content-addressed file under prefix-sharded `ops/` directories. Operation files contain immutable versioned operation envelopes; indexes and views may be rebuilt or normalized, but durable operation bytes are not rewritten in place. Append segments or pack compaction can be introduced later if scale requires it without changing the logical operation model or operation IDs.
+
+V1 should not introduce append segments or pack compaction beyond the individual operation-file layout. Individual files are easier to audit while collaboration convergence, `fsck`, and repair invariants settle. Packing can follow after the formal convergence model and store invariants are stable.
+
+Collaboration operation writes use a temp file, atomic rename, and directory sync before updating indexes or views. Index rebuild must tolerate durable operation files that exist without matching index entries.
+
+Index and view updates are not transactionally coupled to operation writes. The operation file is the durable commit point; indexes and views are derived, may lag, and can be rebuilt after crashes.
+
+Concurrent local writers use a repository collaboration lock around idempotency checks, operation-file creation, and minimal sync/idempotency metadata updates. Derived index and view rebuild work should stay outside the critical path when safe.
+
+Routine collaboration `fsck` should recompute operation IDs from canonical bytes, decode supported schema versions, verify primary-record and parent references, verify idempotency index consistency, distinguish unresolved parents from malformed bytes, and prove indexes and views are rebuildable. It should not require Weft access or historical token material.
+
+Collaboration `doctor` may rebuild derived indexes and views, recreate missing idempotency metadata from durable operations when unambiguous, and quarantine malformed artifacts for diagnostics. It must not invent replacement operation bytes, silently delete locally valid operations, or rewrite content-addressed operation envelopes.
+
+**Status:** accepted
+
+**Considered Options:** Storing collaboration operations under `.heddle/objects/` would align them with content addressing, but it would blur source-history objects with collaboration metadata. Storing them under `.heddle/oplog/` would reuse an append log, but it would confuse collaboration history with undo/redo history. A dedicated root keeps the boundary clear while staying Heddle-native.

--- a/docs/adr/0036-versioned-collaboration-operation-encoding.md
+++ b/docs/adr/0036-versioned-collaboration-operation-encoding.md
@@ -1,0 +1,15 @@
+# Versioned collaboration operation encoding
+
+Collaboration operations use a typed Heddle in-memory model and a canonical MessagePack local encoding. Each durable operation envelope carries an explicit collaboration operation schema version from v1. JSON, protobuf, or gRPC message forms are adapters for user interfaces and transport; they are not the durable local source of truth.
+
+The collaboration codec should reuse the packed oplog's schema-versioning pattern: one latest encoder, explicit version dispatch, frozen decode-only historical schema snapshots, and no blind unversioned decode path for newly written data. The canonical operation envelope should also carry an explicit operation kind rather than relying on Rust enum declaration order or rmp-serde enum discriminant indexes for long-lived identity.
+
+Unlike packed oplog migration, collaboration operation migration must not rewrite old durable operation bytes in place. `CollabOpId` is content-addressed over the canonical envelope, so rewriting bytes would change identity. Historical operation schemas are decoded into the current in-memory model for materialized views, indexes, display, and sync validation. Future compaction must either preserve each operation's original envelope bytes or explicitly create new operation IDs with a recorded migration relationship.
+
+A v1 operation and a v2 operation that decode to the same current in-memory operation still have distinct operation IDs when their canonical envelope bytes differ. Semantic or retry deduplication belongs in explicit idempotency fields and indexes, not in cross-version hash normalization. The idempotency key is part of the operation envelope so local retry handling and Weft validation can reason about the same command-attempt identity.
+
+Schema tests should pin version numbers, round-trip the latest schema, map each historical schema into the current model, reject unsupported versions, prove legacy shapes do not decode as current by accident, and maintain golden canonical byte/hash fixtures for representative operation kinds.
+
+**Status:** accepted
+
+**Considered Options:** Reusing the oplog implementation directly would bring a proven pattern, but its rewrite-to-latest migration behavior conflicts with content-addressed collaboration operation identity. Storing only current Rust serde enum bytes would be simpler, but it would make enum reordering, field reshaping, and accidental defaulting part of the durable compatibility contract. JSON would be easier to inspect manually, but canonical MessagePack keeps the local store compact and closer to existing Heddle binary storage while still allowing JSON as an adapter.

--- a/docs/adr/0036-versioned-collaboration-operation-encoding.md
+++ b/docs/adr/0036-versioned-collaboration-operation-encoding.md
@@ -10,6 +10,6 @@ A v1 operation and a v2 operation that decode to the same current in-memory oper
 
 Schema tests should pin version numbers, round-trip the latest schema, map each historical schema into the current model, reject unsupported versions, prove legacy shapes do not decode as current by accident, and maintain golden canonical byte/hash fixtures for representative operation kinds.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Reusing the oplog implementation directly would bring a proven pattern, but its rewrite-to-latest migration behavior conflicts with content-addressed collaboration operation identity. Storing only current Rust serde enum bytes would be simpler, but it would make enum reordering, field reshaping, and accidental defaulting part of the durable compatibility contract. JSON would be easier to inspect manually, but canonical MessagePack keeps the local store compact and closer to existing Heddle binary storage while still allowing JSON as an adapter.

--- a/docs/adr/0037-semantic-anchor-convergence.md
+++ b/docs/adr/0037-semantic-anchor-convergence.md
@@ -14,6 +14,6 @@ Concurrent anchor retarget operations survive when the record type can represent
 
 Anchor ambiguity creates an attention item when it affects actionability, such as review comments, blockers, or context annotations tied to changed code. Purely informational ambiguity remains visible on the record without blocking readiness.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Last-writer-wins anchor retargeting would keep views simple, but it would hide ambiguity and make concurrent agent work less trustworthy. Treating every concurrent retarget as a conflict would be noisy when multiple anchors can legitimately describe the same discussion.

--- a/docs/adr/0037-semantic-anchor-convergence.md
+++ b/docs/adr/0037-semantic-anchor-convergence.md
@@ -1,0 +1,19 @@
+# Semantic anchor convergence
+
+Discussion and context anchors should preserve semantic intent, not only a resolved file and line snapshot. Resolved locations are display and lookup aids; durable anchors need enough target information to retarget across source changes and to surface ambiguity when Heddle cannot resolve the target confidently.
+
+A semantic anchor should cite the source state or version where the reference was created and the semantic selector used to follow it forward. Current anchor resolution is derived from those facts and repository history; it is not the durable anchor identity by itself.
+
+OSS CLI anchor resolution should be deterministic from Heddle repository data and should not depend on external hosted services or live language-server state. Richer language-aware resolvers can be added later as optional local extensions or hosted projections without changing durable anchor identity.
+
+Anchor resolver confidence should be deterministic and visible. High-confidence movement can materialize as current or moved, while lower-confidence matches become ambiguous or orphaned attention. Heddle should not silently mutate durable anchors to a guessed target.
+
+Anchor resolver thresholds should not be per-user configuration in v1. Materialized anchor status should be stable for a repository version so humans, agents, tests, and hosted projections agree; user preferences may affect display density, not the semantic status.
+
+Concurrent anchor retarget operations survive when the record type can represent multiple plausible anchors; the materialized view shows anchor ambiguity rather than silently picking a winner. A conflict state appears only when the record requires a single canonical anchor and concurrent retargets are incompatible.
+
+Anchor ambiguity creates an attention item when it affects actionability, such as review comments, blockers, or context annotations tied to changed code. Purely informational ambiguity remains visible on the record without blocking readiness.
+
+**Status:** accepted
+
+**Considered Options:** Last-writer-wins anchor retargeting would keep views simple, but it would hide ambiguity and make concurrent agent work less trustworthy. Treating every concurrent retarget as a conflict would be noisy when multiple anchors can legitimately describe the same discussion.

--- a/docs/adr/0038-collaboration-visibility-convergence.md
+++ b/docs/adr/0038-collaboration-visibility-convergence.md
@@ -1,0 +1,11 @@
+# Collaboration visibility convergence
+
+Collaboration visibility changes do not use last-writer-wins. Visibility is policy-sensitive, so concurrent incompatible visibility changes materialize as a visibility conflict and the effective view should choose the most restrictive safe visibility until the conflict is resolved.
+
+Visibility conflicts create attention items and can block readiness when the record is linked to current work or hosted sync. Unrelated historical visibility conflicts can remain diagnostic-only.
+
+Visibility conflicts use the shared collaboration conflict-resolution pattern with a visibility-specific payload. The operation cites the conflicting visibility operations, the chosen effective visibility, and the authority context for making that choice.
+
+**Status:** accepted
+
+**Considered Options:** Last-writer-wins visibility would be easy to implement, but it could silently expose restricted collaboration content. Always requiring single-writer visibility would reduce concurrency too much for local-first collaboration.

--- a/docs/adr/0038-collaboration-visibility-convergence.md
+++ b/docs/adr/0038-collaboration-visibility-convergence.md
@@ -2,10 +2,16 @@
 
 Collaboration visibility changes do not use last-writer-wins. Visibility is policy-sensitive, so concurrent incompatible visibility changes materialize as a visibility conflict and the effective view should choose the most restrictive safe visibility until the conflict is resolved.
 
+Collaboration visibility reuses the E5 `VisibilityTier` / `StateVisibility`
+substrate tracked by #315-#319 and #523. This ADR defines collaboration
+operation convergence semantics on top of that substrate; it does not introduce
+a second visibility lattice for discussions, agent coordination, or hosted
+projection.
+
 Visibility conflicts create attention items and can block readiness when the record is linked to current work or hosted sync. Unrelated historical visibility conflicts can remain diagnostic-only.
 
 Visibility conflicts use the shared collaboration conflict-resolution pattern with a visibility-specific payload. The operation cites the conflicting visibility operations, the chosen effective visibility, and the authority context for making that choice.
 
-**Status:** accepted
+**Status:** proposed
 
 **Considered Options:** Last-writer-wins visibility would be easy to implement, but it could silently expose restricted collaboration content. Always requiring single-writer visibility would reduce concurrency too much for local-first collaboration.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+This directory holds proposed and accepted Architecture Decision Records for
+Heddle-native collaboration and related repository model decisions.
+
+Use `docs/adr/` for durable decisions that future agents and maintainers should
+check before changing architecture. Use `docs/design/` for implementation
+roadmaps, design notes, spikes, and plans that can evolve as work lands.
+
+ADRs start as `proposed` while a PR is under review. Move an ADR to `accepted`
+only when a maintainer explicitly ratifies the decision or when implementation
+lands in a way that settles the architecture.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation and existing agent guidance when exploring the codebase.
+
+## Layout
+
+This is a single-context repo for the mattpocock engineering skills:
+
+- **Domain glossary**: `CONTEXT.md` at the repo root.
+- **Architecture decisions**: `docs/adr/`.
+- **Repo operating guidance**: `AGENTS.md` and the relevant files under `.agents/`.
+
+`CONTEXT.md` and `docs/adr/` are created lazily. If they do not exist, proceed silently unless the current work resolves a domain term or an architectural decision worth recording.
+
+## Before Exploring
+
+Read `AGENTS.md` first. Then read the `.agents/*.md` files relevant to the work area, such as:
+
+- `.agents/architecture.md` for workspace layout, core patterns, hosted layers, web routes, packfiles, agent checkouts, and formal specs.
+- `.agents/rust-guidelines.md` for Rust style, error handling, dependency, security, and performance rules.
+- `.agents/common-tasks.md` for command, object, spec, state-machine, hosted, API, and web-page workflows.
+- `.agents/testing.md` and `.agents/formal-specs.md` for test and Quint verification expectations.
+- `.agents/hosted-operations.md` for hosted namespace, grant, content API, and deployment guidance.
+- `.agents/agent-workflows.md` for thread, actor, session, checkout, and attribution guidance.
+- `.agents/code-review.md` and `.agents/review-pitfalls.md` for review methodology and known false-positive traps.
+- `.agents/web-copy.md` when editing web copy or user-facing hosted product surfaces.
+
+Then read `CONTEXT.md` if it exists, and read any ADRs in `docs/adr/` that touch the area you are about to work in.
+
+## Use the Glossary's Vocabulary
+
+When output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined in `CONTEXT.md`. Do not drift to synonyms the glossary explicitly avoids.
+
+If a needed domain concept is missing, create or update `CONTEXT.md` only when the term has been resolved with enough confidence to record.
+
+## Flag ADR Conflicts
+
+If output contradicts an existing ADR, surface it explicitly rather than silently overriding the decision.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,11 +4,19 @@ How the engineering skills should consume this repo's domain documentation and e
 
 ## Layout
 
-This is a single-context repo for the mattpocock engineering skills:
+This is the Heddle CLI/local model repository. Agent skills should treat this
+repo as the source of truth for Heddle-native version-control concepts,
+cross-repo collaboration contracts, and local CLI behavior.
 
 - **Domain glossary**: `CONTEXT.md` at the repo root.
 - **Architecture decisions**: `docs/adr/`.
 - **Repo operating guidance**: `AGENTS.md` and the relevant files under `.agents/`.
+- **Implementation roadmaps and design notes**: `docs/design/`.
+
+After the repo split, Weft server internals and Tapestry web routes live in
+their sibling repositories. Heddle docs may describe their contracts and
+boundaries, but agents should not use stale Heddle-side hosted/web notes as
+implementation guidance for those repos.
 
 `CONTEXT.md` and `docs/adr/` are created lazily. If they do not exist, proceed silently unless the current work resolves a domain term or an architectural decision worth recording.
 
@@ -16,11 +24,11 @@ This is a single-context repo for the mattpocock engineering skills:
 
 Read `AGENTS.md` first. Then read the `.agents/*.md` files relevant to the work area, such as:
 
-- `.agents/architecture.md` for workspace layout, core patterns, hosted layers, web routes, packfiles, agent checkouts, and formal specs.
+- `.agents/architecture.md` for Heddle workspace layout, core local patterns, packfiles, agent checkouts, and formal specs.
 - `.agents/rust-guidelines.md` for Rust style, error handling, dependency, security, and performance rules.
-- `.agents/common-tasks.md` for command, object, spec, state-machine, hosted, API, and web-page workflows.
+- `.agents/common-tasks.md` for Heddle command, object, spec, and state-machine workflows.
 - `.agents/testing.md` and `.agents/formal-specs.md` for test and Quint verification expectations.
-- `.agents/hosted-operations.md` for hosted namespace, grant, content API, and deployment guidance.
+- `.agents/hosted-operations.md` for hosted namespace, grant, content API, and Heddle/Weft boundary guidance.
 - `.agents/agent-workflows.md` for thread, actor, session, checkout, and attribution guidance.
 - `.agents/code-review.md` and `.agents/review-pitfalls.md` for review methodology and known false-positive traps.
 - `.agents/web-copy.md` when editing web copy or user-facing hosted product surfaces.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `HeddleCo/heddle`. Use the `gh` CLI for issue-tracker operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, fetching comments and labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply or remove labels**: `gh issue edit <number> --add-label "..."` or `gh issue edit <number> --remove-label "..."`
+- **Close an issue**: `gh issue close <number> --comment "..."`
+
+Run `gh` from inside this clone so it infers the repository from `git remote -v`.
+
+## When a Skill Says "Publish to the Issue Tracker"
+
+Create a GitHub issue in `HeddleCo/heddle`.
+
+## When a Skill Says "Fetch the Relevant Ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,19 +1,39 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+Use only labels that exist in `HeddleCo/heddle`. Do not apply placeholder
+labels from upstream skill templates unless a maintainer creates them first.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning |
+## Existing Labels
+
+| Label | Meaning |
 | --- | --- | --- |
-| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
-| `needs-info` | `needs-info` | Waiting on reporter for more information |
-| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
-| `ready-for-human` | `ready-for-human` | Requires human implementation |
-| `wontfix` | `wontfix` | Will not be actioned |
+| `p0` | Immediate priority or release-blocking failure |
+| `p1` | High-priority work |
+| `p2` | Normal-priority work |
+| `p3` | Low-priority or opportunistic work |
+| `epic` | Umbrella issue that groups related work |
+| `spike` | Research, design, or uncertainty-reduction work |
+| `tdd` | Work should proceed test-first or has explicit test-design value |
+| `blocked` | Cannot proceed until another dependency or decision lands |
+| `bug` | Defect or regression |
+| `enhancement` | New capability or product improvement |
+| `documentation` | Documentation-only work |
+| `question` | Clarification, support, or decision request |
+| `wontfix` | Intentionally not actioned |
+| `duplicate` | Duplicate of another issue |
+| `invalid` | Not actionable in this repository |
+| `good first issue` | Good entry point for a new contributor |
+| `help wanted` | Maintainers welcome outside implementation help |
 
-When a skill mentions a role, use the corresponding label string from this table.
+## Skill Role Mapping
 
-## Additional Labels
+If a skill mentions generic triage roles, map them into the repo vocabulary:
 
-`question` remains available as a general GitHub issue label for support, discussion, or clarification-style issues. Do not use `question` as a replacement for the `needs-info` triage state.
+- `needs-triage`: do not apply a label. Choose a priority label only when the issue already contains enough signal.
+- `needs-info`: use `question` only when the issue is primarily asking for clarification. Otherwise leave a comment requesting the missing information.
+- `ready-for-agent` / `ready-for-human`: do not apply labels. Readiness belongs in the GitHub Project status and issue body, not in this repo's labels.
+- `wontfix`: use `wontfix`.
 
-At setup time, GitHub already had `wontfix` and `question`. The other canonical labels may need to be created in GitHub before automated triage can apply them successfully.
+Project fields such as Status, Priority, Size, Epic, Scope, and DoD Type are
+separate from labels. When a task requires project-field updates, use the
+Project workflow instead of inventing a label.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,19 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+## Additional Labels
+
+`question` remains available as a general GitHub issue label for support, discussion, or clarification-style issues. Do not use `question` as a replacement for the `needs-info` triage state.
+
+At setup time, GitHub already had `wontfix` and `question`. The other canonical labels may need to be created in GitHub before automated triage can apply them successfully.

--- a/docs/design/agent-native-collaboration-roadmap.md
+++ b/docs/design/agent-native-collaboration-roadmap.md
@@ -37,6 +37,7 @@ Strong alignment:
 
 - The Project's Ready, In progress, In review, and Done states are practical input to `heddle inbox`: they represent attention, readiness, review state, and recommended next work.
 - Whole-CLI consolidation work aligns with the command-contract foundation; collaboration should reuse the existing command catalog and op-id machinery rather than invent a new agent contract layer.
+- `VisibilityTier` / `StateVisibility` work from #315-#319 and #523 is the shared visibility substrate for collaboration; discussion visibility should consume it instead of growing a parallel model.
 - StateVisibility, self-sovereign auth, signing, Weft hardening, and Tapestry review work align with the planned capability, policy, attestation, and hosted projection layers.
 - Semantic merge correctness and anchor-travel work are prerequisites for trustworthy semantic anchors.
 
@@ -270,7 +271,7 @@ Goal: derive useful local collaboration views from the operation log.
   - `orphaned`
 - Do not make anchor resolver thresholds per-user in v1.
 - Do not depend on hosted services or live language-server state for OSS anchor resolution.
-- Treat the existing anchor-travel decision as a prerequisite. Heddle should wire useful anchor-travel fields into semantic anchor status or explicitly retire them before migrating state-attached discussions.
+- Treat #492, the existing anchor-travel decision, as a prerequisite. Heddle should wire useful anchor-travel fields into semantic anchor status or explicitly retire them before migrating state-attached discussions.
 - Add ambiguous or orphaned anchor attention when anchor status affects actionability.
 
 Exit criteria:

--- a/docs/design/agent-native-collaboration-roadmap.md
+++ b/docs/design/agent-native-collaboration-roadmap.md
@@ -1,0 +1,555 @@
+# Agent-native collaboration implementation roadmap
+
+**Status:** Planned implementation roadmap  
+**Scope:** Heddle OSS CLI and local repository model. Weft and Tapestry are named only where the Heddle contract crosses repository boundaries.  
+**Source decisions:** ADRs [0001](../adr/0001-repository-scoped-discussions.md)-[0038](../adr/0038-collaboration-visibility-convergence.md), especially [0016](../adr/0016-local-discussion-log-first.md), [0017](../adr/0017-evolve-discuss-in-place.md), [0032](../adr/0032-weft-backed-collaboration-sync.md), [0035](../adr/0035-collaboration-store-layout.md), [0036](../adr/0036-versioned-collaboration-operation-encoding.md), and [0037](../adr/0037-semantic-anchor-convergence.md).
+
+## Current baseline
+
+The current `heddle discuss` implementation is state-attached:
+
+- CLI verbs are `open`, `append`, `resolve`, `list`, and `show`.
+- Discussion data is stored in `DiscussionsBlob` on source states.
+- IDs are string discussion IDs, not UUIDv7 discussion IDs.
+- Turns are ordered in a mutable discussion blob, not operation-based causal history.
+- Anchor travel exists for symbol anchors, but durable anchors are still tied to the old state-attached shape.
+- Command catalog, schema registry, JSON docs, error envelopes, and op-id plumbing already exist and should be reused.
+
+The roadmap below replaces the state-attached model with a repository collaboration log before 1.0. Heddle should not add compatibility shims for the old model unless explicitly requested.
+
+## Post-rebase alignment notes
+
+The branch was rebased onto `origin/main` after the collaboration ADRs were written. The incoming commits line up with the roadmap and provide a few implementation seams to reuse:
+
+- `CommandRuntimeContract` is now slimmer, and mutating command metadata is concentrated through existing command catalog contracts such as `MUTATING`. Collaboration commands should use that existing contract path instead of adding a separate command metadata mechanism.
+- `Cli::open_repo()` is now the common repository-open helper. New collaboration commands should use it rather than repeating cwd/`--repo` resolution.
+- `objects::object::versioned_blob` now centralizes versioned MessagePack boilerplate for state-attached container blobs, including the legacy `DiscussionsBlob`. This is useful context for migration and validation, but it is not enough for durable collaboration operations because collaboration needs explicit kind dispatch, historical schema snapshots, and content-addressed envelope identity.
+- Automatic ed25519 state signing is now shipped for authored source states. Collaboration operation signing should reuse the same identity direction and crypto seams where possible, but it remains staged separately: unsigned v1 collaboration operations are locally valid, and later attestations must not rewrite old operation bytes.
+- Hosted session setup now has a deeper single session-open entry. Future collaboration sync should plug into that session boundary rather than creating a parallel hosted-session lifecycle.
+- Oplog undo/redo semantics were consolidated per variant. Collaboration operations should stay out of source-history undo/redo and keep using compensating collaboration operations for corrections.
+- Recent CLI cleanup removed dead commands and deprecated surface area. That reinforces the pre-1.0 decision to evolve `discuss` in place and remove misleading state-attached flags instead of preserving compatibility shims.
+
+## Milestones
+
+### M0: Command contract foundation
+
+Goal: make the CLI surface ready for agent-native collaboration before changing the storage model.
+
+- Add collaboration schema identifiers and versions to every `discuss` and `inbox` JSON response.
+- Extend command catalog metadata for collaboration writes:
+  - reuse the existing `MUTATING` contract path
+  - `mutates: true`
+  - `supports_op_id: true`
+  - `op_id_behavior: "explicit_replay"`
+  - collaboration side-effect class
+- Make collaboration JSON errors carry:
+  - stable machine-readable `code`
+  - human `message`
+  - `schema` and `schema_version`
+  - recovery fields specific to the error
+- Define error codes before implementation:
+  - `collab_stale_heads`
+  - `collab_ambiguous_id`
+  - `collab_unknown_parent`
+  - `collab_invalid_artifact`
+  - `collab_idempotency_conflict`
+  - `collab_hosted_rejected`
+  - `collab_capability_expired`
+  - `collab_capability_interrupted`
+  - `collab_anchor_ambiguous`
+  - `collab_anchor_orphaned`
+- Update `docs/json-schemas.md` only after concrete schemas are registered in `crates/cli/src/cli/commands/schemas.rs`.
+
+Exit criteria:
+
+- `heddle commands --output json` exposes side-effect and op-id metadata for discussion writes.
+- `heddle doctor schemas` can validate the new collaboration JSON samples.
+- Existing state-attached `discuss` commands still work until M4 migration replaces them.
+
+### M1: Local collaboration operation model
+
+Goal: introduce the durable Heddle-native operation model without hosted sync.
+
+- Add typed in-memory collaboration model:
+  - `Discussion`
+  - `ContextAnnotation`
+  - `CollaborationOperation`
+  - `CollaborationEnvelope`
+  - `CollaborationOperationKind`
+  - `OperationCapabilityContext`
+  - `TaskProvenance`
+  - `SemanticAnchor`
+  - `AttentionTarget`
+- Use canonical MessagePack envelopes with explicit schema version and operation kind.
+- Reuse the packed oplog versioning pattern:
+  - latest encoder
+  - explicit version dispatch
+  - frozen decode-only historical schema modules
+  - no unversioned decode path
+- Borrow validation discipline from `versioned_msgpack_blob!`, but implement a dedicated collaboration operation codec rather than storing repository operations as state-attached container blobs.
+- Compute `CollabOpId` from exact canonical envelope bytes.
+- Include the collaboration idempotency key in the envelope.
+- Use UUIDv7 for `DiscussionId`.
+- Reserve operation kinds for later redaction, attestation, visibility, and import roots even if the first slice implements only a subset.
+
+First implemented operation kinds:
+
+- `discussion.open`
+- `discussion.turn`
+- `discussion.resolve`
+- `discussion.reopen`
+- `discussion.retarget`
+- `collaboration.resolve_conflict`
+- `collaboration.import_root` if migration needs it
+
+Deferred operation kinds:
+
+- `discussion.visibility`
+- `collaboration.redaction`
+- `collaboration.attestation`
+- `hosted_valid_continuation`
+- synced task delegation records
+
+Exit criteria:
+
+- Golden canonical byte and hash fixtures exist for representative operation kinds.
+- Same semantic operation encoded as different schema versions produces different `CollabOpId`s.
+- Same idempotency key with changed request content rejects locally.
+- Missing token material does not invalidate an operation that has capability id and scope summary.
+
+### M2: Local collaboration store
+
+Goal: store collaboration operations as a repository-local durable log.
+
+- Create `.heddle/collaboration/` with:
+  - `ops/` for prefix-sharded immutable operation files
+  - `indexes/` for rebuildable indexes
+  - `views/` for rebuildable materialized views
+  - `sync/` for Weft sync metadata later
+  - `tmp/` for temp writes
+- Write operation files with temp file, atomic rename, and directory sync.
+- Treat the operation file as the durable commit point.
+- Keep indexes and views derived and rebuildable.
+- Use a repository collaboration lock around:
+  - idempotency checks
+  - operation file creation
+  - minimal idempotency/sync metadata updates
+- Keep pack/segment compaction out of v1.
+
+Required indexes:
+
+- op id to operation path
+- record id to operation ids
+- record id to current head set
+- idempotency key scope to op id
+- source anchor to record ids
+- attention target to record ids or attention items
+
+`fsck` minimum checks:
+
+- recompute operation IDs from canonical bytes
+- decode supported schema versions
+- verify primary record references
+- verify parent references
+- distinguish unresolved parents from malformed bytes
+- verify idempotency index consistency
+- prove indexes/views are rebuildable
+
+`doctor` allowed repairs:
+
+- rebuild indexes and views
+- recreate missing idempotency metadata from durable operations when unambiguous
+- quarantine malformed artifacts
+
+`doctor` forbidden repairs:
+
+- invent replacement operation bytes
+- rewrite content-addressed envelopes
+- silently delete locally valid operations
+
+Exit criteria:
+
+- Crash after operation write but before index update is recoverable.
+- Duplicate canonical operation bytes return idempotent success.
+- Hash collision or same `CollabOpId` with different bytes fails closed.
+- `fsck` and `doctor` do not require Weft access.
+
+### M3: Materialization, anchors, and inbox
+
+Goal: derive useful local collaboration views from the operation log.
+
+- Materialize records by causal graph, not timestamp order.
+- Preserve current head sets internally.
+- Render deterministic display order for humans and JSON convenience.
+- Surface concurrent append turns as siblings, not conflicts.
+- Surface incompatible lifecycle, visibility, and single-anchor claims as conflicts.
+- Keep conflict resolution as an explicit operation that cites conflicting operations.
+- Implement semantic anchors with:
+  - source state/version where the reference was created
+  - semantic selector
+  - derived current resolution
+  - deterministic confidence/status
+- Anchor statuses:
+  - `current`
+  - `moved`
+  - `changed`
+  - `ambiguous`
+  - `orphaned`
+- Do not make anchor resolver thresholds per-user in v1.
+- Do not depend on hosted services or live language-server state for OSS anchor resolution.
+- Implement `heddle inbox` as a derived attention view.
+- Do not claim read/unread state in first-slice inbox JSON.
+- Include sync/local-only diagnostics in inbox only when they affect actionability, readiness, or sync.
+
+First-slice attention sources:
+
+- blocker turns targeted at current actor/thread
+- targeted unanswered questions
+- resolution conflicts that affect current work
+- ambiguous or orphaned anchors that affect actionability
+- unresolved operations that affect current work or sync
+- hosted rejection diagnostics once sync exists
+
+Exit criteria:
+
+- Same accepted operation set materializes to the same view regardless of arrival order.
+- Deterministic display order does not hide conflicts, ambiguity, redactions, or local-only divergence.
+- `ready` blocks only on targeted or high-severity attention, not every open discussion.
+
+### M4: CLI replacement and migration
+
+Goal: evolve `heddle discuss` in place from state-attached discussions to repository collaboration records.
+
+Canonical commands:
+
+- `heddle discuss open`
+- `heddle discuss turn`
+- `heddle discuss resolve`
+- `heddle discuss reopen`
+- `heddle discuss retarget`
+- `heddle discuss resolve-conflict`
+- `heddle discuss list`
+- `heddle discuss show`
+- `heddle inbox`
+
+Aliases:
+
+- `heddle discuss comment` may exist as a human alias for `turn --kind comment`.
+- The current `append` verb should be replaced or kept only as a short-lived pre-1.0 alias if implementation sequencing needs it.
+
+First-slice command behavior:
+
+- JSON and agent workflows pass explicit observed heads.
+- Human text mode may default observed heads to current heads for append-like turns.
+- Stale explicit heads fail by default and return current heads.
+- `--allow-concurrent` applies only to append-like operations.
+- Resolve, visibility, and retarget use conflict semantics, not generic concurrency override.
+- Human text-mode turns may default `kind` to `comment`.
+- JSON and agent workflows require or strongly encourage explicit turn kind.
+- `show --json` returns both deterministic display order and graph facts.
+- `show` human output visibly marks conflicts, ambiguous anchors, redactions, hosted-valid divergence, and local-only status.
+
+Migration behavior:
+
+- Detect legacy state-attached discussions.
+- `heddle discuss migrate` is advanced/doctor-oriented, not daily help.
+- Migration is plan-first by default.
+- Applying migration requires `--apply` or equivalent.
+- Migration creates import roots with source metadata.
+- New discussions receive UUIDv7 ids.
+- Legacy ids remain source metadata and aliases.
+- Migration is idempotent through source-derived collaboration idempotency keys.
+- If migration stops halfway, rerunning the same plan completes missing operations and reports already-created records.
+- Legacy source objects remain untouched until a separate cleanup.
+
+Exit criteria:
+
+- State-attached `DiscussionsBlob` is no longer the live discussion source of truth.
+- Migration output labels imported history in JSON/detail output.
+- `discuss list` defaults to active/open discussions scoped by current context.
+- `inbox` owns attention-worthy work.
+
+### M5: Tests and release gate
+
+Goal: make the first local discussion slice shippable as a core pre-1.0 CLI feature.
+
+Required test groups:
+
+- Codec tests:
+  - latest round-trip
+  - historical decode snapshots
+  - unsupported version rejection
+  - golden canonical bytes
+  - golden `CollabOpId`s
+- Operation identity tests:
+  - same bytes deduplicate
+  - same id different bytes fails closed
+  - same idempotency key same request returns existing op
+  - same idempotency key different request rejects
+- Store tests:
+  - temp/rename/directory-sync path
+  - crash after op write before index update
+  - index rebuild
+  - malformed artifact quarantine
+  - unresolved parent retention
+- Materialization/property tests:
+  - concurrent append survival
+  - stale observed heads failure
+  - resolution conflicts
+  - recursive conflict resolution conflicts
+  - deterministic display order
+  - anchor ambiguity/orphan attention
+- CLI golden JSON tests:
+  - `discuss open`
+  - `discuss turn`
+  - `discuss resolve`
+  - `discuss reopen`
+  - `discuss retarget`
+  - `discuss resolve-conflict`
+  - `discuss list`
+  - `discuss show`
+  - `inbox`
+  - stale-head error
+  - ambiguous-id error
+  - idempotency conflict error
+- Migration tests:
+  - plan output
+  - apply output
+  - rerun idempotency
+  - interrupted apply recovery
+  - imported-history labels
+- Readiness tests:
+  - blocker turn blocks current thread
+  - answer citing question clears question attention
+  - unrelated open discussion does not block
+  - context conflict blocks only when linked to current work or policy gate
+
+First-slice release gate:
+
+- Command metadata is updated.
+- Concrete schemas are registered.
+- JSON samples are documented and pass `heddle doctor schemas`.
+- Materialization/property tests pass.
+- Basic collaboration `fsck`/`doctor` checks pass.
+- Migration plan/apply tests exist if legacy data exists.
+- User docs label local-only, Weft-backed, and planned capabilities.
+- At least one end-to-end JSON-first agent workflow is documented.
+
+### M6: Weft sync preparation
+
+Goal: prepare local collaboration for hosted sync without shipping live collaboration early.
+
+- Build the formal convergence model before remote CRDT sync ships.
+- Model:
+  - concurrent append survival
+  - resolution conflicts
+  - recursive conflict materialization
+  - command idempotency versus operation identity
+  - hosted acceptance/rejection layer
+  - blocked descendants
+  - hosted-valid continuations
+  - signatures and capabilities as predicates
+- Add sync metadata states:
+  - pending
+  - accepted
+  - rejected
+  - blocked by hosted-invalid causal history
+  - cursor-synced
+- Keep hosted rejection reasons as sync metadata with stable codes and refreshable messages.
+- Source push auto-includes only linked collaboration records.
+- Auto-sync sends the required hosted-valid causal closure.
+- Source push success is not rolled back if collaboration sync fails.
+- Retry resumes collaboration lane from sync metadata and remote cursors.
+- Add redaction and policy-suppression story before broad hosted collaboration rollout.
+
+Exit criteria:
+
+- Local-only and hosted-synced views are distinct.
+- Hosted-rejected local operations remain retained locally.
+- Descendants of hosted-rejected operations are blocked from sync until accepted, bypassed, or replaced.
+- Linked collaboration auto-sync does not send unrelated repository discussions.
+
+### M7: Live sync and hosted projection
+
+Goal: add live collaboration only after durable sync is correct.
+
+- Add explicit foreground watch modes for inbox or discussion records.
+- Use gRPC-backed live sync to deliver durable operations and sync state.
+- Do not add invisible background daemon sync in the first live slice.
+- Do not store presence, typing indicators, or ephemeral hosted UI state as collaboration operations.
+- Let Tapestry consume hosted-safe aliases, policy-filtered projection metadata, and Weft rejection codes from Weft contracts, not Heddle local internals.
+
+Exit criteria:
+
+- Watch mode is a transport over the same operation log.
+- Push/pull catch-up and live updates converge through the same materializer.
+- Live sync can be disabled without losing correctness.
+
+## Command schema sketches
+
+These are design sketches, not registered schemas. Concrete schemas belong in `crates/cli/src/cli/commands/schemas.rs` and documented samples belong in `docs/json-schemas.md`.
+
+### Common success envelope
+
+```json
+{
+  "schema": "heddle.collaboration.discuss.show",
+  "schema_version": 1,
+  "output_kind": "discuss_show",
+  "view_mode": "capability_filtered_local",
+  "local_only": true,
+  "warnings": []
+}
+```
+
+Rules:
+
+- `schema` and `schema_version` are required.
+- `output_kind` remains the command-shaped discriminator used by existing Heddle JSON.
+- `view_mode` is required for reads.
+- `local_only` is required when the user might assume Git or hosted sync shared the record.
+- Empty arrays serialize as `[]`.
+- Semantically permanent unset fields serialize as `null`.
+
+### Common error envelope
+
+```json
+{
+  "schema": "heddle.collaboration.error",
+  "schema_version": 1,
+  "output_kind": "error",
+  "code": "collab_stale_heads",
+  "message": "observed heads are stale for discussion 018f...",
+  "recovery": {
+    "current_heads": ["co_abc..."],
+    "retry": "rerun with the current heads or use --allow-concurrent for a turn"
+  }
+}
+```
+
+Rules:
+
+- `code` is stable and machine-readable.
+- `message` is human-readable and may change.
+- `recovery` shape depends on `code`.
+- Stale-head errors include `current_heads`.
+- Ambiguous-id errors include `candidates`.
+- Hosted rejection errors include `hosted_rejection_code`, `remote`, and continuation hints when available.
+
+### `heddle discuss open --output json`
+
+Required fields:
+
+- `schema`
+- `schema_version`
+- `output_kind: "discuss_open"`
+- `discussion_id`
+- `operation_id`
+- `idempotency_key`
+- `title`
+- `anchor`
+- `turn`
+- `heads`
+- `local_only`
+- `sync`
+- `warnings`
+
+### `heddle discuss turn --output json`
+
+Required fields:
+
+- `schema`
+- `schema_version`
+- `output_kind: "discuss_turn"`
+- `discussion_id`
+- `operation_id`
+- `idempotency_key`
+- `turn`
+- `observed_heads`
+- `heads`
+- `concurrent`
+- `attention_delta`
+- `local_only`
+- `sync`
+- `warnings`
+
+### `heddle discuss show --output json`
+
+Required fields:
+
+- `schema`
+- `schema_version`
+- `output_kind: "discuss_show"`
+- `discussion`
+- `display_order`
+- `operations`
+- `heads`
+- `conflicts`
+- `anchor_status`
+- `attention`
+- `view_mode`
+- `sync`
+- `warnings`
+
+The `display_order` is convenience output. Agents should use `operations`, `heads`, and `conflicts` for correctness.
+
+### `heddle inbox --output json`
+
+Required fields:
+
+- `schema`
+- `schema_version`
+- `output_kind: "inbox"`
+- `view_mode`
+- `items`
+- `groups`
+- `sync_diagnostics`
+- `warnings`
+
+Each item includes:
+
+- `item_id`
+- `kind`
+- `severity`
+- `target`
+- `record_id`
+- `operation_ids`
+- `reason_code`
+- `blocks_ready`
+- `task_provenance`
+- `sync`
+- `recommended_actions`
+
+No `read` or `unread` field appears until explicit read-state metadata exists.
+
+## User-facing docs tasks
+
+- Add a local discussion quickstart with JSON-first examples.
+- Add a human-oriented short workflow after the JSON examples.
+- Add a migration guide for state-attached discussions.
+- Add a troubleshooting guide for:
+  - stale heads
+  - local-only collaboration
+  - Git push not sharing discussions
+  - unresolved parents
+  - hosted rejection once sync exists
+- Add `fsck`/`doctor` collaboration diagnostics docs.
+- Update `docs/json-schemas.md` after concrete schema registration.
+- Update release notes to classify each capability:
+  - shipped local behavior
+  - foundation in place
+  - planned Weft/Tapestry behavior
+
+## Non-goals for the first local slice
+
+- Hosted sync.
+- Live watch mode.
+- Presence or typing indicators.
+- General issue tracker labels, assignees, milestones, or project boards.
+- Full context extraction.
+- Read/unread state.
+- Snooze.
+- Local encrypted collaboration storage.
+- Pack/segment compaction.
+- General import roots except what migration needs.
+- GitHub/GitLab/Git notes import or export.

--- a/docs/design/agent-native-collaboration-roadmap.md
+++ b/docs/design/agent-native-collaboration-roadmap.md
@@ -29,6 +29,27 @@ The branch was rebased onto `origin/main` after the collaboration ADRs were writ
 - Oplog undo/redo semantics were consolidated per variant. Collaboration operations should stay out of source-history undo/redo and keep using compensating collaboration operations for corrections.
 - Recent CLI cleanup removed dead commands and deprecated surface area. That reinforces the pre-1.0 decision to evolve `discuss` in place and remove misleading state-attached flags instead of preserving compatibility shims.
 
+## Heddle Project alignment notes
+
+The Heddle GitHub Project is already a large cross-repo collaboration surface: 440 items across Heddle, Weft, and Tapestry, with Status, Priority, Size, Epic, Scope, DoD Type, parent/sub-issue progress, linked pull requests, and reviewers. That project shape validates the roadmap's attention and provenance direction, but it also shows where the first version was too narrow.
+
+Strong alignment:
+
+- The Project's Ready, In progress, In review, and Done states are practical input to `heddle inbox`: they represent attention, readiness, review state, and recommended next work.
+- Whole-CLI consolidation work aligns with the command-contract foundation; collaboration should reuse the existing command catalog and op-id machinery rather than invent a new agent contract layer.
+- StateVisibility, self-sovereign auth, signing, Weft hardening, and Tapestry review work align with the planned capability, policy, attestation, and hosted projection layers.
+- Semantic merge correctness and anchor-travel work are prerequisites for trustworthy semantic anchors.
+
+Roadmap adjustments from the Project review:
+
+- Add minimal external artifact references in the first operation-model slice. Heddle does not need default GitHub mirroring, but it does need durable references to external issues, pull requests, review comments, and project items when those artifacts explain imported or linked collaboration history.
+- Make `collaboration.import_root` a required early operation kind, not only a migration contingency. Legacy state-attached discussions and later explicit GitHub/Tapestry imports both need a first-class source and trust boundary.
+- Split inbox from full semantic anchor convergence. A minimal inbox should work for targeted blockers, unanswered questions, follow-up tasks, review states, and unanchored operational work before every semantic anchor case is solved.
+- Model review lifecycle as machine-actionable attention. Requested reviewers, changes requested, re-review requested, unresolved review threads, linked PRs, and CI gates should not collapse into discussion prose.
+- Keep full project-board parity deferred. Labels, assignees, priority, size, epic, scope, DoD type, and project status can enter as projection/import metadata before Heddle decides whether they deserve native collaboration operations.
+- Add a later explicit GitHub Project/Issue/PR-review import and cutover milestone for dogfooding. This is not default Git bridge import/export; it is an intentional migration path with import roots, source references, and policy labels.
+- Treat project dependencies and rollups as a separate planning graph from collaboration operation causality. Parent/sub-issue progress and "ready after parent lands" should inform inbox/readiness, but they are not causal parents in the CRDT operation graph.
+
 ## Milestones
 
 ### M0: Command contract foundation
@@ -80,6 +101,7 @@ Goal: introduce the durable Heddle-native operation model without hosted sync.
   - `TaskProvenance`
   - `SemanticAnchor`
   - `AttentionTarget`
+  - `ExternalArtifactRef`
 - Use canonical MessagePack envelopes with explicit schema version and operation kind.
 - Reuse the packed oplog versioning pattern:
   - latest encoder
@@ -90,7 +112,8 @@ Goal: introduce the durable Heddle-native operation model without hosted sync.
 - Compute `CollabOpId` from exact canonical envelope bytes.
 - Include the collaboration idempotency key in the envelope.
 - Use UUIDv7 for `DiscussionId`.
-- Reserve operation kinds for later redaction, attestation, visibility, and import roots even if the first slice implements only a subset.
+- Include minimal external artifact references when a collaboration operation is imported from or linked to a source outside the local Heddle repository.
+- Reserve operation kinds for later redaction, attestation, and visibility even if the first slice implements only a subset.
 
 First implemented operation kinds:
 
@@ -100,7 +123,18 @@ First implemented operation kinds:
 - `discussion.reopen`
 - `discussion.retarget`
 - `collaboration.resolve_conflict`
-- `collaboration.import_root` if migration needs it
+- `collaboration.import_root`
+
+Minimum `ExternalArtifactRef` fields:
+
+- provider, such as `github`
+- repository or namespace
+- artifact kind, such as issue, pull request, review, review comment, project item, or discussion
+- external id
+- URL
+- parent artifact when relevant
+- imported or linked time
+- source trust label
 
 Deferred operation kinds:
 
@@ -116,6 +150,7 @@ Exit criteria:
 - Same semantic operation encoded as different schema versions produces different `CollabOpId`s.
 - Same idempotency key with changed request content rejects locally.
 - Missing token material does not invalidate an operation that has capability id and scope summary.
+- Imported or externally linked operations retain source metadata without trusting external authorship for Heddle capability policy.
 
 ### M2: Local collaboration store
 
@@ -174,14 +209,52 @@ Exit criteria:
 - Hash collision or same `CollabOpId` with different bytes fails closed.
 - `fsck` and `doctor` do not require Weft access.
 
-### M3: Materialization, anchors, and inbox
+### M3a: Minimal materialization and inbox
 
-Goal: derive useful local collaboration views from the operation log.
+Goal: derive useful local collaboration views and attention before full semantic anchor convergence.
 
-- Materialize records by causal graph, not timestamp order.
+- Materialize discussion records by causal graph, not timestamp order.
 - Preserve current head sets internally.
 - Render deterministic display order for humans and JSON convenience.
 - Surface concurrent append turns as siblings, not conflicts.
+- Surface incompatible lifecycle claims as conflicts.
+- Implement `heddle inbox` as a derived attention view.
+- Do not claim read/unread state in first-slice inbox JSON.
+- Include sync/local-only diagnostics in inbox only when they affect actionability, readiness, or sync.
+- Include review lifecycle and project-state projection inputs where available:
+  - requested reviewers
+  - changes requested
+  - re-review requested
+  - unresolved review threads
+  - CI gate state
+  - linked pull requests
+  - parent/sub-issue or dependency readiness
+  - imported project status, priority, epic, scope, and DoD metadata as non-authoritative projection data
+- Keep planning dependencies separate from collaboration causality. A planning dependency can block readiness or route attention, but it is not a causal parent in the collaboration operation graph.
+
+First-slice attention sources:
+
+- blocker turns targeted at current actor/thread
+- targeted unanswered questions
+- resolution conflicts that affect current work
+- follow-up tasks imported from or linked to review comments
+- requested review or re-review on linked source work
+- unresolved review threads linked to current work
+- CI gate failures linked to current work
+- unresolved operations that affect current work or sync
+- hosted rejection diagnostics once sync exists
+
+Exit criteria:
+
+- Same accepted operation set materializes to the same view regardless of arrival order.
+- Deterministic display order does not hide conflicts, ambiguity, redactions, or local-only divergence.
+- `ready` blocks only on targeted or high-severity attention, not every open discussion.
+- Review and project projection metadata can inform inbox/readiness without becoming native project-board operations.
+
+### M3b: Semantic anchor convergence
+
+Goal: derive useful local collaboration views from the operation log.
+
 - Surface incompatible lifecycle, visibility, and single-anchor claims as conflicts.
 - Keep conflict resolution as an explicit operation that cites conflicting operations.
 - Implement semantic anchors with:
@@ -197,24 +270,14 @@ Goal: derive useful local collaboration views from the operation log.
   - `orphaned`
 - Do not make anchor resolver thresholds per-user in v1.
 - Do not depend on hosted services or live language-server state for OSS anchor resolution.
-- Implement `heddle inbox` as a derived attention view.
-- Do not claim read/unread state in first-slice inbox JSON.
-- Include sync/local-only diagnostics in inbox only when they affect actionability, readiness, or sync.
-
-First-slice attention sources:
-
-- blocker turns targeted at current actor/thread
-- targeted unanswered questions
-- resolution conflicts that affect current work
-- ambiguous or orphaned anchors that affect actionability
-- unresolved operations that affect current work or sync
-- hosted rejection diagnostics once sync exists
+- Treat the existing anchor-travel decision as a prerequisite. Heddle should wire useful anchor-travel fields into semantic anchor status or explicitly retire them before migrating state-attached discussions.
+- Add ambiguous or orphaned anchor attention when anchor status affects actionability.
 
 Exit criteria:
 
-- Same accepted operation set materializes to the same view regardless of arrival order.
-- Deterministic display order does not hide conflicts, ambiguity, redactions, or local-only divergence.
-- `ready` blocks only on targeted or high-severity attention, not every open discussion.
+- Anchor status is deterministic for a repository version.
+- Existing state-attached anchor-travel fields have an explicit migration or retirement rule.
+- Ambiguous or orphaned anchors feed inbox/readiness only when they affect current work or policy gates.
 
 ### M4: CLI replacement and migration
 
@@ -323,6 +386,8 @@ Required test groups:
   - answer citing question clears question attention
   - unrelated open discussion does not block
   - context conflict blocks only when linked to current work or policy gate
+  - requested review or unresolved review thread blocks linked work
+  - parent/dependency state affects readiness without becoming a causal parent
 
 First-slice release gate:
 
@@ -334,6 +399,7 @@ First-slice release gate:
 - Migration plan/apply tests exist if legacy data exists.
 - User docs label local-only, Weft-backed, and planned capabilities.
 - At least one end-to-end JSON-first agent workflow is documented.
+- At least one fixture covers review comment to follow-up task to inbox item to resolution.
 
 ### M6: Weft sync preparation
 
@@ -361,6 +427,7 @@ Goal: prepare local collaboration for hosted sync without shipping live collabor
 - Source push success is not rolled back if collaboration sync fails.
 - Retry resumes collaboration lane from sync metadata and remote cursors.
 - Add redaction and policy-suppression story before broad hosted collaboration rollout.
+- Prepare hosted review collaboration before Tapestry Review MVP depends on it. Threaded discussion, approval/block state, review signatures, and policy-filtered visibility should share the same collaboration sync and rejection vocabulary.
 
 Exit criteria:
 
@@ -384,6 +451,34 @@ Exit criteria:
 - Watch mode is a transport over the same operation log.
 - Push/pull catch-up and live updates converge through the same materializer.
 - Live sync can be disabled without losing correctness.
+
+### M8: Explicit GitHub import and dogfood cutover
+
+Goal: support deliberate migration from GitHub-hosted planning/review artifacts into Heddle-hosted collaboration without turning Git bridge into an automatic comment mirror.
+
+- Add an explicit import workflow for selected GitHub issues, pull requests, review comments, and project items.
+- Represent imported artifacts with `ExternalArtifactRef` and `collaboration.import_root`.
+- Preserve source URL, source id, author metadata, imported time, parent artifact, and trust/source labels.
+- Keep the import actor distinct from original external authors.
+- Map GitHub Project fields to projection metadata first:
+  - status
+  - priority
+  - size
+  - epic
+  - scope
+  - DoD type
+  - parent/sub-issue progress
+  - linked pull requests
+  - reviewers
+- Let imported project metadata inform inbox, readiness, filters, and migration reports without making full project-board parity a first-slice Heddle primitive.
+- Support a dogfood cutover report that shows which GitHub artifacts are imported, linked, stale, local-only, or still GitHub-authoritative.
+- Keep default GitHub/GitLab/Git notes import/export disabled.
+
+Exit criteria:
+
+- A selected GitHub review comment can become a Heddle follow-up discussion or attention item with source provenance.
+- Imported Project items retain enough metadata for agents to understand status, review state, and dependencies.
+- Dogfood cutover can run as an explicit command or report without silently ingesting unrelated GitHub content.
 
 ## Command schema sketches
 
@@ -519,14 +614,18 @@ Each item includes:
 - `task_provenance`
 - `sync`
 - `recommended_actions`
+- `projection`
 
 No `read` or `unread` field appears until explicit read-state metadata exists.
+
+Projection metadata may include imported or hosted project/review fields such as status, priority, epic, scope, DoD type, linked pull requests, requested reviewers, and parent/sub-issue progress. Projection fields are query and attention inputs, not collaboration operation causality.
 
 ## User-facing docs tasks
 
 - Add a local discussion quickstart with JSON-first examples.
 - Add a human-oriented short workflow after the JSON examples.
 - Add a migration guide for state-attached discussions.
+- Add an explicit GitHub import/cutover guide once M8 starts.
 - Add a troubleshooting guide for:
   - stale heads
   - local-only collaboration
@@ -545,11 +644,10 @@ No `read` or `unread` field appears until explicit read-state metadata exists.
 - Hosted sync.
 - Live watch mode.
 - Presence or typing indicators.
-- General issue tracker labels, assignees, milestones, or project boards.
+- Full native project-board parity.
 - Full context extraction.
 - Read/unread state.
 - Snooze.
 - Local encrypted collaboration storage.
 - Pack/segment compaction.
-- General import roots except what migration needs.
-- GitHub/GitLab/Git notes import or export.
+- Default GitHub/GitLab/Git notes import or export.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "eb0e91e84277283dc2b23ed544399e53afd6b5287e5b6929f25fe8aa608e164b"
+    },
+    "handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/handoff/SKILL.md",
+      "computedHash": "1a78d774f8a59db5daa6e65e20a6596872fa8cde769f9a6e3a09b678dd5ae8cc"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
+    },
+    "setup-matt-pocock-skills": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
+      "computedHash": "0164a8b1ef998abca426056c6ed8a7716a9d4692fc6daa5378f68381a6dafd24"
+    },
+    "zoom-out": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/zoom-out/SKILL.md",
+      "computedHash": "8357aeaece3b709c442eab67e64b86844e05e2f1ea95b109565eba50b6def36e"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add local agent skill setup docs and root agent guidance for GitHub issue tracking, triage labels, and domain docs.
- Add `CONTEXT.md` glossary and ADRs for Heddle-native collaboration, discussions, attention, capabilities, sync, visibility, and operation storage.
- Add an agent-native collaboration implementation roadmap, then align it with the live Heddle GitHub Project workflow.

## Impact

This is documentation and planning work only. It captures the collaboration model decisions, first-slice release gates, GitHub project alignment, and future Heddle/Weft/Tapestry boundaries before implementation begins.

## Validation

- Rebased onto latest `origin/main` before committing.
- Ran `git diff --check` after the roadmap follow-up.
- No code tests run; changes are docs and agent-skill assets only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783175690&installation_id=132405951&pr_number=522&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F522&signature=2bbd9259fb2b89aa6dad783f17b7418e2035a942e9dbbb5ae5cd1a9b6765bc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->