### PR TITLE
impl(objects/repo): StateVisibility object + per-state sidecar + shared VisibilityTier (#315)

### DIFF
--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -97,9 +97,9 @@ impl LocalSync {
         let state_already_present = target.store().has_state(state_id)?;
 
         // Source-side state read drives both the object copy (when
-        // needed) and the redaction-propagation tree walk (always).
+        // needed) and sidecar propagation (always).
         // If the source no longer has the state but the target does,
-        // we can't enumerate blob hashes for propagation — skip with
+        // we can't enumerate sidecars for propagation — skip with
         // no error in that case.
         let state = match self.source.store().get_state(state_id)? {
             Some(state) => state,
@@ -107,11 +107,9 @@ impl LocalSync {
             None => return Err(anyhow!("State {} not found in source", state_id)),
         };
 
-        // Always propagate redactions for every blob in the state's
-        // trees, regardless of whether the trees themselves need
-        // copying. `propagate_redactions_in_tree` walks the trees
-        // without the has_tree fast-path so re-syncs after a redact
-        // still ferry the sidecar.
+        // Always propagate per-state visibility and per-blob redactions,
+        // regardless of whether the objects themselves need copying.
+        self.propagate_state_visibility_for_state(target, state_id)?;
         let mut propagated_trees: HashSet<ContentHash> = HashSet::new();
         self.propagate_redactions_in_tree(target, &state.tree, &mut propagated_trees)?;
         if let Some(provenance_root) = state.provenance {
@@ -267,6 +265,21 @@ impl LocalSync {
             return Ok(());
         };
         target.accept_wire_redactions(*blob, &bytes)?;
+        Ok(())
+    }
+
+    /// If the source repository has state-visibility records for `state`,
+    /// ferry the sidecar bytes through the same repository boundary used by
+    /// the network path.
+    fn propagate_state_visibility_for_state(
+        &self,
+        target: &Repository,
+        state: &ChangeId,
+    ) -> Result<()> {
+        let Some(bytes) = self.source.get_state_visibility_bytes_for_state(state)? else {
+            return Ok(());
+        };
+        target.accept_wire_state_visibility(*state, &bytes)?;
         Ok(())
     }
 

--- a/crates/cli/src/harness/claude_hook.rs
+++ b/crates/cli/src/harness/claude_hook.rs
@@ -406,7 +406,7 @@ mod tests {
             }],
             supersedes_annotation_id: None,
             supersedes_rewrite_pct: None,
-            visibility: objects::object::AnnotationVisibility::default(),
+            visibility: objects::object::VisibilityTier::default(),
             resolved_from_discussion: None,
         }
     }

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -599,6 +599,11 @@ fn encode_native_pack(objects: &[ObjectData]) -> (Vec<u8>, Vec<u8>) {
                 // pack; the test fixture doesn't construct them.
                 unreachable!("performance harness does not synthesize Redaction objects");
             }
+            ObjectType::StateVisibility => {
+                // StateVisibility sidecars never enter the content-addressed
+                // pack; the test fixture doesn't construct them.
+                unreachable!("performance harness does not synthesize StateVisibility objects");
+            }
         };
         builder.add_id(id, obj_type, object.data.clone());
     }

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -106,7 +106,8 @@ pub(super) fn parse_object_id(
     obj_type: ObjectType,
 ) -> Result<ObjectId, ProtocolError> {
     match obj_type {
-        ObjectType::State => Ok(ObjectId::ChangeId(
+        // State and its per-state visibility sidecar are both keyed by ChangeId.
+        ObjectType::State | ObjectType::StateVisibility => Ok(ObjectId::ChangeId(
             ChangeId::parse(value).map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
         )),
         ObjectType::Blob | ObjectType::Tree | ObjectType::Action | ObjectType::Redaction => {
@@ -124,6 +125,7 @@ pub(super) fn parse_object_type(value: &str) -> Result<ObjectType, ProtocolError
         "state" => Ok(ObjectType::State),
         "action" => Ok(ObjectType::Action),
         "redaction" => Ok(ObjectType::Redaction),
+        "state_visibility" => Ok(ObjectType::StateVisibility),
         _ => Err(ProtocolError::InvalidState(format!(
             "unknown object type: {value}"
         ))),
@@ -164,6 +166,7 @@ pub(super) fn object_type_name(obj_type: ObjectType) -> &'static str {
         ObjectType::State => "state",
         ObjectType::Action => "action",
         ObjectType::Redaction => "redaction",
+        ObjectType::StateVisibility => "state_visibility",
     }
 }
 

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -7,9 +7,9 @@ use std::{
 use grpc::heddle::v1::{
     GetBlobRequest, ListRefsRequest, ObjectAvailabilityStatus, ObjectDescriptor, PackChunk,
     PackStreamKind, PartialFetchStatus, PullMessage, PullRequest, PushMessage, PushRequest,
-    RedactionTransfer, ThreadConfidenceSummary, ThreadIntegrationPolicy, ThreadMetadata,
-    ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects, pull_message,
-    push_message,
+    RedactionTransfer, StateVisibilityTransfer, ThreadConfidenceSummary, ThreadIntegrationPolicy,
+    ThreadMetadata, ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects,
+    pull_message, push_message,
 };
 use objects::{
     object::{ChangeId, ContentHash, MarkerName, ThreadName},
@@ -249,13 +249,12 @@ impl HostedGrpcClient {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Split want_objects: blob/tree/state/action → native pack;
-        // redactions → out-of-pack `RedactionTransfer` channel (the
-        // sidecar lives outside `.heddle/objects/` so GC can't reach
-        // it and it can't ride the pack — `build_native_pack` already
-        // skips Redaction entries on the sender side).
-        let (wanted_redactions, wanted_packable): (Vec<_>, Vec<_>) = wanted_infos
+        // sidecars → out-of-pack transfer channels. Sidecars live outside
+        // `.heddle/objects/` so GC can't reach them and they can't ride the
+        // pack — `build_native_pack` skips the same object-type set.
+        let (wanted_sidecars, wanted_packable): (Vec<_>, Vec<_>) = wanted_infos
             .into_iter()
-            .partition(|info| info.obj_type == proto::ObjectType::Redaction);
+            .partition(|info| is_out_of_pack_transfer_object_type(info.obj_type));
 
         if !wanted_packable.is_empty() {
             let bundle = proto::build_native_pack(repo.store(), &wanted_packable)?;
@@ -272,8 +271,8 @@ impl HostedGrpcClient {
             }
         }
 
-        for info in wanted_redactions {
-            let message = redaction_push_message(repo, info)?;
+        for info in wanted_sidecars {
+            let message = sidecar_push_message(repo, info)?;
             tx.send(message).await.map_err(|_| {
                 ProtocolError::InvalidState("push stream closed unexpectedly".to_string())
             })?;
@@ -727,6 +726,27 @@ impl HostedGrpcClient {
                     let decode_elapsed = decode_start.elapsed();
                     profile.store_receive_object += decode_elapsed;
                 }
+                Some(pull_message::Body::StateVisibility(transfer)) => {
+                    profile.bytes_received = profile
+                        .bytes_received
+                        .saturating_add(transfer.state_visibility_blob.len());
+                    profile.object_mix.record(ObjectType::StateVisibility);
+                    let state = ChangeId::parse(&transfer.state_id).map_err(|err| {
+                        ProtocolError::InvalidState(format!(
+                            "StateVisibilityTransfer.state_id is not a valid ChangeId: {err}"
+                        ))
+                    })?;
+                    let decode_start = Instant::now();
+                    repo.accept_wire_state_visibility(state, &transfer.state_visibility_blob)
+                        .map_err(|err| {
+                            ProtocolError::InvalidState(format!(
+                                "accept_wire_state_visibility for state {}: {err}",
+                                transfer.state_id
+                            ))
+                        })?;
+                    let decode_elapsed = decode_start.elapsed();
+                    profile.store_receive_object += decode_elapsed;
+                }
                 Some(pull_message::Body::Complete(complete)) => {
                     profile.receive_and_apply = receive_start.elapsed();
                     let final_state = if complete.new_state.is_empty() {
@@ -923,6 +943,57 @@ fn redaction_push_message(
             blob_hash: hex,
             redactions_blob: bytes,
         })),
+    })
+}
+
+fn is_out_of_pack_transfer_object_type(obj_type: ObjectType) -> bool {
+    matches!(obj_type, ObjectType::Redaction | ObjectType::StateVisibility)
+}
+
+fn sidecar_push_message(
+    repo: &Repository,
+    info: proto::ObjectInfo,
+) -> Result<PushMessage, ProtocolError> {
+    match info.obj_type {
+        ObjectType::Redaction => redaction_push_message(repo, info),
+        ObjectType::StateVisibility => state_visibility_push_message(repo, info),
+        obj_type => Err(ProtocolError::InvalidState(format!(
+            "{obj_type:?} is not an out-of-pack sidecar object"
+        ))),
+    }
+}
+
+fn state_visibility_push_message(
+    repo: &Repository,
+    info: proto::ObjectInfo,
+) -> Result<PushMessage, ProtocolError> {
+    let proto::ObjectId::ChangeId(state) = info.id else {
+        return Err(ProtocolError::InvalidState(
+            "wanted StateVisibility must be keyed by ObjectId::ChangeId(state)".to_string(),
+        ));
+    };
+    let state_id = state.to_string_full();
+    let bytes = repo
+        .get_state_visibility_bytes_for_state(&state)
+        .map_err(|err| {
+            ProtocolError::InvalidState(format!(
+                "load state-visibility sidecar for {}: {err}",
+                state_id
+            ))
+        })?
+        .ok_or_else(|| {
+            ProtocolError::InvalidState(format!(
+                "server wants state visibility for state {} but sender has no sidecar",
+                state_id
+            ))
+        })?;
+    Ok(PushMessage {
+        body: Some(push_message::Body::StateVisibility(
+            StateVisibilityTransfer {
+                state_id,
+                state_visibility_blob: bytes,
+            },
+        )),
     })
 }
 
@@ -1337,7 +1408,10 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use grpc::heddle::v1::push_message;
     use objects::{
-        object::{Blob, ChangeId, ContentHash, Principal, Redaction, Tree, TreeEntry},
+        object::{
+            Blob, ChangeId, ContentHash, Principal, Redaction, StateVisibility, Tree, TreeEntry,
+            VisibilityTier,
+        },
         store::ObjectStore,
     };
     use proto::{ObjectId, ObjectInfo};
@@ -1355,6 +1429,15 @@ mod tests {
         ObjectInfo {
             id: ObjectId::Hash(blob),
             obj_type: ObjectType::Redaction,
+            size: 0,
+            delta_base: None,
+        }
+    }
+
+    fn state_visibility_info(state: ChangeId) -> ObjectInfo {
+        ObjectInfo {
+            id: ObjectId::ChangeId(state),
+            obj_type: ObjectType::StateVisibility,
             size: 0,
             delta_base: None,
         }
@@ -1388,6 +1471,33 @@ mod tests {
             signature: None,
             purged_at: None,
             supersedes: None,
+        }
+    }
+
+    fn sample_state_visibility(state: ChangeId) -> StateVisibility {
+        StateVisibility {
+            state,
+            tier: VisibilityTier::Restricted {
+                scope_label: "security-embargo".into(),
+            },
+            embargo_until: None,
+            declarer: Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            },
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap(),
+            signature: None,
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn non_packable_object_types_are_in_out_of_pack_transfer_partition() {
+        for obj_type in proto::native_pack_excluded_object_types() {
+            assert!(
+                is_out_of_pack_transfer_object_type(*obj_type),
+                "{obj_type:?} is excluded from native packs but missing from the out-of-pack transfer partition"
+            );
         }
     }
 
@@ -1494,5 +1604,26 @@ mod tests {
                 .contains(&format!("load redactions sidecar for {}:", blob.to_hex())),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn state_visibility_push_message_uses_state_keyed_sidecar_payload() {
+        let (_dir, repo) = temp_repo();
+        let state = ChangeId::from_bytes([17u8; 16]);
+        repo.put_state_visibility(sample_state_visibility(state))
+            .expect("put state visibility");
+        let expected_bytes = repo
+            .get_state_visibility_bytes_for_state(&state)
+            .expect("load sidecar")
+            .expect("sidecar exists");
+
+        let message =
+            state_visibility_push_message(&repo, state_visibility_info(state)).expect("message");
+
+        let Some(push_message::Body::StateVisibility(transfer)) = message.body else {
+            panic!("expected state visibility transfer");
+        };
+        assert_eq!(transfer.state_id, state.to_string_full());
+        assert_eq!(transfer.state_visibility_blob, expected_bytes);
     }
 }

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -50,6 +50,7 @@ pub struct PullObjectMix {
     pub states: usize,
     pub actions: usize,
     pub redactions: usize,
+    pub state_visibilities: usize,
 }
 
 impl PullObjectMix {
@@ -60,11 +61,17 @@ impl PullObjectMix {
             ObjectType::State => self.states += 1,
             ObjectType::Action => self.actions += 1,
             ObjectType::Redaction => self.redactions += 1,
+            ObjectType::StateVisibility => self.state_visibilities += 1,
         }
     }
 
     pub fn total(&self) -> usize {
-        self.blobs + self.trees + self.states + self.actions + self.redactions
+        self.blobs
+            + self.trees
+            + self.states
+            + self.actions
+            + self.redactions
+            + self.state_visibilities
     }
 }
 

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -645,6 +645,7 @@ impl HostedGrpcClient {
             ready.objects_to_fetch,
             allow_partial_fetch,
         )?;
+        let native_pack_required = native_pack_required_for_pull(want_full_closure, &wanted_types);
 
         tx.send(PullMessage {
             body: Some(pull_message::Body::Want(WantObjects {
@@ -759,7 +760,7 @@ impl HostedGrpcClient {
                     };
 
                     if complete.success {
-                        if want_full_closure || !wants.is_empty() {
+                        if native_pack_required {
                             if !pack_state.is_complete() {
                                 return Err(ProtocolError::InvalidState(
                                     "pull completed before native pack stream finished".to_string(),
@@ -948,6 +949,17 @@ fn redaction_push_message(
 
 fn is_out_of_pack_transfer_object_type(obj_type: ObjectType) -> bool {
     matches!(obj_type, ObjectType::Redaction | ObjectType::StateVisibility)
+}
+
+fn native_pack_required_for_pull(
+    want_full_closure: bool,
+    wanted_types: &HashMap<PackObjectId, ObjectType>,
+) -> bool {
+    want_full_closure
+        || wanted_types
+            .values()
+            .copied()
+            .any(proto::is_native_packable_object_type)
 }
 
 fn sidecar_push_message(
@@ -1406,16 +1418,23 @@ fn preferred_transport_mode(
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
-    use grpc::heddle::v1::push_message;
+    use cli_shared::ClientConfig;
+    use grpc::heddle::v1::{
+        ListRefsRequest, ListRefsResponse, PullComplete as GrpcPullComplete, PullReady,
+        TransferCheckpoint, UpdateRefRequest, UpdateRefResponse,
+        repo_sync_service_server::{RepoSyncService, RepoSyncServiceServer},
+        push_message,
+    };
     use objects::{
         object::{
-            Blob, ChangeId, ContentHash, Principal, Redaction, StateVisibility, Tree, TreeEntry,
-            VisibilityTier,
+            Attribution, Blob, ChangeId, ContentHash, Principal, Redaction, State,
+            StateVisibility, StateVisibilityBlob, Tree, TreeEntry, VisibilityTier,
         },
         store::ObjectStore,
     };
     use proto::{ObjectId, ObjectInfo};
     use tempfile::TempDir;
+    use tonic::{Response, Status, transport::Server};
 
     use super::*;
 
@@ -1499,6 +1518,243 @@ mod tests {
                 "{obj_type:?} is excluded from native packs but missing from the out-of-pack transfer partition"
             );
         }
+    }
+
+    #[test]
+    fn native_pack_required_tracks_packable_pull_wants() {
+        let blob = sample_blob();
+        let state = ChangeId::from_bytes([9u8; 16]);
+
+        let sidecar_only = HashMap::from([(
+            PackObjectId::ChangeId(state),
+            ObjectType::StateVisibility,
+        )]);
+        assert!(!native_pack_required_for_pull(false, &sidecar_only));
+
+        let redaction_only = HashMap::from([(PackObjectId::Hash(blob), ObjectType::Redaction)]);
+        assert!(!native_pack_required_for_pull(false, &redaction_only));
+
+        let packable = HashMap::from([(PackObjectId::Hash(blob), ObjectType::Blob)]);
+        assert!(native_pack_required_for_pull(false, &packable));
+        assert!(native_pack_required_for_pull(true, &HashMap::new()));
+    }
+
+    #[derive(Clone)]
+    struct SidecarOnlyPullService {
+        state: ChangeId,
+        state_visibility_blob: Vec<u8>,
+    }
+
+    #[tonic::async_trait]
+    impl RepoSyncService for SidecarOnlyPullService {
+        async fn list_refs(
+            &self,
+            _request: tonic::Request<ListRefsRequest>,
+        ) -> Result<Response<ListRefsResponse>, Status> {
+            Ok(Response::new(ListRefsResponse::default()))
+        }
+
+        async fn update_ref(
+            &self,
+            _request: tonic::Request<UpdateRefRequest>,
+        ) -> Result<Response<UpdateRefResponse>, Status> {
+            Ok(Response::new(UpdateRefResponse::default()))
+        }
+
+        type PushStream = tokio_stream::wrappers::ReceiverStream<Result<PushMessage, Status>>;
+
+        async fn push(
+            &self,
+            _request: tonic::Request<tonic::Streaming<PushMessage>>,
+        ) -> Result<Response<Self::PushStream>, Status> {
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+        }
+
+        type PullStream = tokio_stream::wrappers::ReceiverStream<Result<PullMessage, Status>>;
+
+        async fn pull(
+            &self,
+            request: tonic::Request<tonic::Streaming<PullMessage>>,
+        ) -> Result<Response<Self::PullStream>, Status> {
+            let state = self.state;
+            let state_visibility_blob = self.state_visibility_blob.clone();
+            let (tx, rx) = mpsc::channel(4);
+
+            tokio::spawn(async move {
+                let mut inbound = request.into_inner();
+                match inbound.message().await {
+                    Ok(Some(PullMessage {
+                        body: Some(pull_message::Body::Request(_)),
+                    })) => {}
+                    other => {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument(format!(
+                                "expected pull request, got {other:?}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+
+                let descriptor = object_descriptor_with_status(
+                    &state_visibility_info(state),
+                    ObjectAvailabilityStatus::Missing,
+                    "missing state visibility",
+                );
+                let ready = PullMessage {
+                    body: Some(pull_message::Body::Ready(PullReady {
+                        remote_state: state.to_string_full(),
+                        objects_to_fetch: vec![descriptor],
+                        transfer: None,
+                        partial_fetch_status: PartialFetchStatus::Disabled as i32,
+                        missing_objects: Vec::new(),
+                        full_closure_available: false,
+                        object_count: 1,
+                    })),
+                };
+                if tx.send(Ok(ready)).await.is_err() {
+                    return;
+                }
+
+                match inbound.message().await {
+                    Ok(Some(PullMessage {
+                        body: Some(pull_message::Body::Want(want)),
+                    })) if !want.want_full_closure
+                        && want.objects.len() == 1
+                        && want.objects[0].object_type == "state_visibility" => {}
+                    other => {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument(format!(
+                                "expected sidecar-only want, got {other:?}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+
+                let transfer = PullMessage {
+                    body: Some(pull_message::Body::StateVisibility(
+                        StateVisibilityTransfer {
+                            state_id: state.to_string_full(),
+                            state_visibility_blob,
+                        },
+                    )),
+                };
+                if tx.send(Ok(transfer)).await.is_err() {
+                    return;
+                }
+
+                let complete = PullMessage {
+                    body: Some(pull_message::Body::Complete(GrpcPullComplete {
+                        success: true,
+                        new_state: state.to_string_full(),
+                        error: String::new(),
+                        transfer: Some(TransferCheckpoint {
+                            transfer_id: "sidecar-only-test".to_string(),
+                            transport_mode: TransportMode::NativePack as i32,
+                            resume_offset: 0,
+                            chunk_index: 0,
+                            checkpoint: b"heddle-markers-v1\n".to_vec(),
+                            is_complete: true,
+                        }),
+                    })),
+                };
+                let _ = tx.send(Ok(complete)).await;
+            });
+
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+        }
+    }
+
+    async fn connect_sidecar_only_service(
+        service: SidecarOnlyPullService,
+    ) -> (HostedGrpcClient, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let incoming = futures::stream::unfold(listener, |listener| async {
+            match listener.accept().await {
+                Ok((stream, _addr)) => Some((Ok::<_, std::io::Error>(stream), listener)),
+                Err(err) => Some((Err(err), listener)),
+            }
+        });
+
+        let handle = tokio::spawn(async move {
+            Server::builder()
+                .add_service(RepoSyncServiceServer::new(service))
+                .serve_with_incoming(incoming)
+                .await
+                .expect("serve sidecar-only test service");
+        });
+
+        let client = HostedGrpcClient::connect(addr, &ClientConfig::default())
+            .await
+            .expect("connect client");
+        (client, handle)
+    }
+
+    #[tokio::test]
+    async fn state_visibility_sidecar_only_pull_completes_without_native_pack() {
+        let (_dir, repo) = temp_repo();
+        let tree_hash = repo.store().put_tree(&Tree::new()).expect("put tree");
+        let state = State::new_snapshot(
+            tree_hash,
+            vec![],
+            Attribution::human(Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            }),
+        );
+        let state_id = state.change_id;
+        repo.store().put_state(&state).expect("put state");
+        assert!(
+            repo.get_state_visibility_bytes_for_state(&state_id)
+                .expect("load local sidecar")
+                .is_none(),
+            "test starts with state present and StateVisibility sidecar absent"
+        );
+
+        let state_visibility_blob =
+            StateVisibilityBlob::new(vec![sample_state_visibility(state_id)])
+                .encode()
+                .expect("encode state visibility blob");
+        let (mut client, server) = connect_sidecar_only_service(SidecarOnlyPullService {
+            state: state_id,
+            state_visibility_blob,
+        })
+        .await;
+
+        let exchange = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.pull_exchange(
+                &repo,
+                "owner/repo",
+                "main",
+                PullOptions {
+                    local_thread: None,
+                    depth: None,
+                    target_state: Some(state_id),
+                    materialization: PullMaterialization::Full,
+                },
+            ),
+        )
+        .await
+        .expect("sidecar-only pull must not hang waiting for native pack")
+        .expect("sidecar-only pull succeeds");
+        server.abort();
+
+        assert!(exchange.result.success);
+        assert_eq!(exchange.object_count, 0);
+        assert_eq!(exchange.profile.pack_bytes_received, 0);
+        assert_eq!(exchange.profile.object_mix.state_visibilities, 1);
+        assert!(
+            repo.get_state_visibility_for_state(&state_id)
+                .expect("load accepted sidecar")
+                .has_record(),
+            "pull must accept the out-of-pack StateVisibility sidecar"
+        );
     }
 
     #[test]

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -39,9 +39,11 @@ struct PullOptions<'a> {
 
 struct PullWantPlan {
     wants: Vec<ObjectDescriptor>,
-    wanted_types: HashMap<PackObjectId, ObjectType>,
+    wanted_types: WantedTypes,
     want_full_closure: bool,
 }
+
+type WantedTypes = HashMap<PackObjectId, Vec<ObjectType>>;
 
 #[derive(Debug, Clone, Default)]
 pub struct PullObjectMix {
@@ -775,7 +777,7 @@ impl HostedGrpcClient {
                             profile.store_receive_object += store_start.elapsed();
                             received = installed_ids.len();
                             for id in installed_ids {
-                                match (id, wanted_types.get(&id).copied()) {
+                                match (id, wanted_packable_type(&wanted_types, &id)) {
                                     (PackObjectId::Hash(hash), Some(ObjectType::Blob)) => {
                                         profile.object_mix.record(ObjectType::Blob);
                                         repo.clear_missing_blob(&hash)?;
@@ -953,13 +955,39 @@ fn is_out_of_pack_transfer_object_type(obj_type: ObjectType) -> bool {
 
 fn native_pack_required_for_pull(
     want_full_closure: bool,
-    wanted_types: &HashMap<PackObjectId, ObjectType>,
+    wanted_types: &WantedTypes,
 ) -> bool {
     want_full_closure
         || wanted_types
             .values()
+            .flatten()
             .copied()
             .any(proto::is_native_packable_object_type)
+}
+
+fn record_wanted_type(
+    wanted_types: &mut WantedTypes,
+    pack_id: PackObjectId,
+    obj_type: ObjectType,
+) {
+    let types = wanted_types.entry(pack_id).or_default();
+    if !types.contains(&obj_type) {
+        types.push(obj_type);
+    }
+}
+
+fn wanted_packable_type(
+    wanted_types: &WantedTypes,
+    pack_id: &PackObjectId,
+) -> Option<ObjectType> {
+    wanted_types
+        .get(pack_id)
+        .and_then(|types| {
+            types
+                .iter()
+                .copied()
+                .find(|obj_type| proto::is_native_packable_object_type(*obj_type))
+        })
 }
 
 fn sidecar_push_message(
@@ -1051,7 +1079,7 @@ fn plan_pull_wants(
         };
 
         if include {
-            wanted_types.insert(pack_id, info.obj_type);
+            record_wanted_type(&mut wanted_types, pack_id, info.obj_type);
             wants.push(object_descriptor_with_status(
                 &info,
                 ObjectAvailabilityStatus::Missing,
@@ -1453,6 +1481,15 @@ mod tests {
         }
     }
 
+    fn state_info(state: ChangeId) -> ObjectInfo {
+        ObjectInfo {
+            id: ObjectId::ChangeId(state),
+            obj_type: ObjectType::State,
+            size: 0,
+            delta_base: None,
+        }
+    }
+
     fn state_visibility_info(state: ChangeId) -> ObjectInfo {
         ObjectInfo {
             id: ObjectId::ChangeId(state),
@@ -1527,16 +1564,57 @@ mod tests {
 
         let sidecar_only = HashMap::from([(
             PackObjectId::ChangeId(state),
-            ObjectType::StateVisibility,
+            vec![ObjectType::StateVisibility],
         )]);
         assert!(!native_pack_required_for_pull(false, &sidecar_only));
 
-        let redaction_only = HashMap::from([(PackObjectId::Hash(blob), ObjectType::Redaction)]);
+        let redaction_only = HashMap::from([(PackObjectId::Hash(blob), vec![ObjectType::Redaction])]);
         assert!(!native_pack_required_for_pull(false, &redaction_only));
 
-        let packable = HashMap::from([(PackObjectId::Hash(blob), ObjectType::Blob)]);
+        let packable = HashMap::from([(PackObjectId::Hash(blob), vec![ObjectType::Blob])]);
         assert!(native_pack_required_for_pull(false, &packable));
+
+        let state_with_sidecar = HashMap::from([(
+            PackObjectId::ChangeId(state),
+            vec![ObjectType::State, ObjectType::StateVisibility],
+        )]);
+        assert!(native_pack_required_for_pull(false, &state_with_sidecar));
         assert!(native_pack_required_for_pull(true, &HashMap::new()));
+    }
+
+    #[test]
+    fn plan_pull_wants_accumulates_state_and_visibility_for_same_change_id() {
+        let (_dir, repo) = temp_repo();
+        let state = ChangeId::from_bytes([9u8; 16]);
+        let plan = plan_pull_wants(
+            &repo,
+            &state,
+            false,
+            vec![
+                object_descriptor_with_status(
+                    &state_info(state),
+                    ObjectAvailabilityStatus::Missing,
+                    "missing state",
+                ),
+                object_descriptor_with_status(
+                    &state_visibility_info(state),
+                    ObjectAvailabilityStatus::Missing,
+                    "missing state visibility",
+                ),
+            ],
+            false,
+        )
+        .expect("plan pull wants");
+
+        let wanted = plan
+            .wanted_types
+            .get(&PackObjectId::ChangeId(state))
+            .expect("same ChangeId want entry");
+        assert_eq!(wanted.as_slice(), &[ObjectType::State, ObjectType::StateVisibility]);
+        assert!(native_pack_required_for_pull(
+            plan.want_full_closure,
+            &plan.wanted_types
+        ));
     }
 
     #[derive(Clone)]
@@ -1751,6 +1829,338 @@ mod tests {
         assert_eq!(exchange.profile.object_mix.state_visibilities, 1);
         assert!(
             repo.get_state_visibility_for_state(&state_id)
+                .expect("load accepted sidecar")
+                .has_record(),
+            "pull must accept the out-of-pack StateVisibility sidecar"
+        );
+    }
+
+    #[derive(Clone)]
+    struct StateAndVisibilityPullService {
+        state: ChangeId,
+        pack_bundle: proto::NativePackBundle,
+        state_visibility_blob: Vec<u8>,
+    }
+
+    #[tonic::async_trait]
+    impl RepoSyncService for StateAndVisibilityPullService {
+        async fn list_refs(
+            &self,
+            _request: tonic::Request<ListRefsRequest>,
+        ) -> Result<Response<ListRefsResponse>, Status> {
+            Ok(Response::new(ListRefsResponse::default()))
+        }
+
+        async fn update_ref(
+            &self,
+            _request: tonic::Request<UpdateRefRequest>,
+        ) -> Result<Response<UpdateRefResponse>, Status> {
+            Ok(Response::new(UpdateRefResponse::default()))
+        }
+
+        type PushStream = tokio_stream::wrappers::ReceiverStream<Result<PushMessage, Status>>;
+
+        async fn push(
+            &self,
+            _request: tonic::Request<tonic::Streaming<PushMessage>>,
+        ) -> Result<Response<Self::PushStream>, Status> {
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+        }
+
+        type PullStream = tokio_stream::wrappers::ReceiverStream<Result<PullMessage, Status>>;
+
+        async fn pull(
+            &self,
+            request: tonic::Request<tonic::Streaming<PullMessage>>,
+        ) -> Result<Response<Self::PullStream>, Status> {
+            let state = self.state;
+            let pack_bundle = self.pack_bundle.clone();
+            let state_visibility_blob = self.state_visibility_blob.clone();
+            let (tx, rx) = mpsc::channel(8);
+
+            tokio::spawn(async move {
+                let mut inbound = request.into_inner();
+                match inbound.message().await {
+                    Ok(Some(PullMessage {
+                        body: Some(pull_message::Body::Request(_)),
+                    })) => {}
+                    other => {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument(format!(
+                                "expected pull request, got {other:?}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+
+                let ready = PullMessage {
+                    body: Some(pull_message::Body::Ready(PullReady {
+                        remote_state: state.to_string_full(),
+                        objects_to_fetch: vec![
+                            object_descriptor_with_status(
+                                &state_info(state),
+                                ObjectAvailabilityStatus::Missing,
+                                "missing state",
+                            ),
+                            object_descriptor_with_status(
+                                &state_visibility_info(state),
+                                ObjectAvailabilityStatus::Missing,
+                                "missing state visibility",
+                            ),
+                        ],
+                        transfer: None,
+                        partial_fetch_status: PartialFetchStatus::Disabled as i32,
+                        missing_objects: Vec::new(),
+                        full_closure_available: false,
+                        object_count: 2,
+                    })),
+                };
+                if tx.send(Ok(ready)).await.is_err() {
+                    return;
+                }
+
+                match inbound.message().await {
+                    Ok(Some(PullMessage {
+                        body: Some(pull_message::Body::Want(want)),
+                    })) if !want.want_full_closure
+                        && want.objects.len() == 2
+                        && want.objects.iter().any(|object| object.object_type == "state")
+                        && want
+                            .objects
+                            .iter()
+                            .any(|object| object.object_type == "state_visibility") => {}
+                    other => {
+                        let _ = tx
+                            .send(Err(Status::invalid_argument(format!(
+                                "expected state + sidecar wants, got {other:?}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+
+                for message in encode_pull_native_pack_messages(
+                    &pack_bundle,
+                    "state-and-visibility-test",
+                    16,
+                ) {
+                    if tx.send(Ok(message)).await.is_err() {
+                        return;
+                    }
+                }
+
+                let transfer = PullMessage {
+                    body: Some(pull_message::Body::StateVisibility(
+                        StateVisibilityTransfer {
+                            state_id: state.to_string_full(),
+                            state_visibility_blob,
+                        },
+                    )),
+                };
+                if tx.send(Ok(transfer)).await.is_err() {
+                    return;
+                }
+
+                let complete = PullMessage {
+                    body: Some(pull_message::Body::Complete(GrpcPullComplete {
+                        success: true,
+                        new_state: state.to_string_full(),
+                        error: String::new(),
+                        transfer: Some(TransferCheckpoint {
+                            transfer_id: "state-and-visibility-test".to_string(),
+                            transport_mode: TransportMode::NativePack as i32,
+                            resume_offset: 0,
+                            chunk_index: 0,
+                            checkpoint: b"heddle-markers-v1\n".to_vec(),
+                            is_complete: true,
+                        }),
+                    })),
+                };
+                let _ = tx.send(Ok(complete)).await;
+            });
+
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+        }
+    }
+
+    fn encode_pull_native_pack_messages(
+        bundle: &proto::NativePackBundle,
+        transfer_id: &str,
+        chunk_size: usize,
+    ) -> Vec<PullMessage> {
+        let mut messages = Vec::new();
+        let chunk_size = chunk_size.max(1);
+
+        let pack_total_chunks = proto::chunk_count(bundle.pack_data.len(), chunk_size);
+        for chunk_index in 0..pack_total_chunks.max(1) {
+            let Some((start, len)) =
+                proto::chunk_bounds(bundle.pack_data.len(), chunk_size, chunk_index)
+            else {
+                break;
+            };
+            messages.push(PullMessage {
+                body: Some(pull_message::Body::Pack(PackChunk {
+                    stream_kind: PackStreamKind::Pack as i32,
+                    data: bundle.pack_data[start..start + len].to_vec(),
+                    transfer: Some(TransferCheckpoint {
+                        transfer_id: transfer_id.to_string(),
+                        transport_mode: TransportMode::NativePack as i32,
+                        resume_offset: start as u64,
+                        chunk_index: chunk_index as u32,
+                        checkpoint: Vec::new(),
+                        is_complete: chunk_index + 1 == pack_total_chunks,
+                    }),
+                    chunk_length: len as u32,
+                    is_final_chunk: chunk_index + 1 == pack_total_chunks,
+                })),
+            });
+        }
+
+        let index_total_chunks = proto::chunk_count(bundle.index_data.len(), chunk_size);
+        for chunk_index in 0..index_total_chunks.max(1) {
+            let Some((start, len)) =
+                proto::chunk_bounds(bundle.index_data.len(), chunk_size, chunk_index)
+            else {
+                break;
+            };
+            messages.push(PullMessage {
+                body: Some(pull_message::Body::Pack(PackChunk {
+                    stream_kind: PackStreamKind::Index as i32,
+                    data: bundle.index_data[start..start + len].to_vec(),
+                    transfer: Some(TransferCheckpoint {
+                        transfer_id: transfer_id.to_string(),
+                        transport_mode: TransportMode::NativePack as i32,
+                        resume_offset: start as u64,
+                        chunk_index: chunk_index as u32,
+                        checkpoint: Vec::new(),
+                        is_complete: chunk_index + 1 == index_total_chunks,
+                    }),
+                    chunk_length: len as u32,
+                    is_final_chunk: chunk_index + 1 == index_total_chunks,
+                })),
+            });
+        }
+
+        messages
+    }
+
+    async fn connect_state_and_visibility_service(
+        service: StateAndVisibilityPullService,
+    ) -> (HostedGrpcClient, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let incoming = futures::stream::unfold(listener, |listener| async {
+            match listener.accept().await {
+                Ok((stream, _addr)) => Some((Ok::<_, std::io::Error>(stream), listener)),
+                Err(err) => Some((Err(err), listener)),
+            }
+        });
+
+        let handle = tokio::spawn(async move {
+            Server::builder()
+                .add_service(RepoSyncServiceServer::new(service))
+                .serve_with_incoming(incoming)
+                .await
+                .expect("serve state-and-visibility test service");
+        });
+
+        let client = HostedGrpcClient::connect(addr, &ClientConfig::default())
+            .await
+            .expect("connect client");
+        (client, handle)
+    }
+
+    #[tokio::test]
+    async fn state_and_visibility_same_change_id_pull_requests_pack_and_sidecar() {
+        let (_source_dir, source_repo) = temp_repo();
+        let (_target_dir, target_repo) = temp_repo();
+        let tree_hash = source_repo.store().put_tree(&Tree::new()).expect("put tree");
+        let state = State::new_snapshot(
+            tree_hash,
+            vec![],
+            Attribution::human(Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            }),
+        );
+        let state_id = state.change_id;
+        source_repo.store().put_state(&state).expect("put source state");
+        let state_visibility_blob =
+            StateVisibilityBlob::new(vec![sample_state_visibility(state_id)])
+                .encode()
+                .expect("encode state visibility blob");
+        source_repo
+            .accept_wire_state_visibility(state_id, &state_visibility_blob)
+            .expect("put source state visibility");
+        let pack_bundle = proto::build_native_pack(
+            source_repo.store(),
+            &[state_info(state_id)],
+        )
+        .expect("build state pack");
+
+        assert!(
+            target_repo
+                .store()
+                .get_state(&state_id)
+                .expect("load target state")
+                .is_none(),
+            "test starts with state absent"
+        );
+        assert!(
+            target_repo
+                .get_state_visibility_bytes_for_state(&state_id)
+                .expect("load target sidecar")
+                .is_none(),
+            "test starts with StateVisibility sidecar absent"
+        );
+
+        let (mut client, server) =
+            connect_state_and_visibility_service(StateAndVisibilityPullService {
+                state: state_id,
+                pack_bundle,
+                state_visibility_blob,
+            })
+            .await;
+
+        let exchange = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.pull_exchange(
+                &target_repo,
+                "owner/repo",
+                "main",
+                PullOptions {
+                    local_thread: None,
+                    depth: None,
+                    target_state: Some(state_id),
+                    materialization: PullMaterialization::Full,
+                },
+            ),
+        )
+        .await
+        .expect("state + sidecar pull must not hang waiting for native pack")
+        .expect("state + sidecar pull succeeds");
+        server.abort();
+
+        assert!(exchange.result.success);
+        assert_eq!(exchange.object_count, 1);
+        assert!(exchange.profile.pack_bytes_received > 0);
+        assert_eq!(exchange.profile.object_mix.states, 1);
+        assert_eq!(exchange.profile.object_mix.state_visibilities, 1);
+        assert!(
+            target_repo
+                .store()
+                .get_state(&state_id)
+                .expect("load installed state")
+                .is_some(),
+            "native pack must install the State"
+        );
+        assert!(
+            target_repo
+                .get_state_visibility_for_state(&state_id)
                 .expect("load accepted sidecar")
                 .has_record(),
             "pull must accept the out-of-pack StateVisibility sidecar"

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -20,7 +20,7 @@ use grpc::heddle::v1::{
     discussion_service_server::DiscussionService,
 };
 use objects::object::{
-    AnnotationVisibility, Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn,
+    VisibilityTier, Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn,
     DiscussionsBlob, Principal, State, SymbolAnchor,
 };
 use prost::Message;
@@ -47,23 +47,23 @@ fn now_secs() -> i64 {
         .unwrap_or(0)
 }
 
-/// Wire vocabulary mirrors `AnnotationVisibility::as_str`. Empty / unknown
+/// Wire vocabulary mirrors `VisibilityTier::as_str`. Empty / unknown
 /// strings collapse to `Public` (the proto convention is "empty means
 /// default"). `team_scoped` and `restricted` round-trip through this path
 /// without an associated label — they're admitted for forward-compat with
 /// the namespace policy override path; callers wanting a labelled value
 /// must go through a richer surface that doesn't yet exist on this RPC.
-fn parse_visibility(s: &str) -> AnnotationVisibility {
+fn parse_visibility(s: &str) -> VisibilityTier {
     match s {
-        "internal" => AnnotationVisibility::Internal,
-        "team_scoped" => AnnotationVisibility::TeamScoped {
+        "internal" => VisibilityTier::Internal,
+        "team_scoped" => VisibilityTier::TeamScoped {
             team_id: String::new(),
         },
-        "restricted" => AnnotationVisibility::Restricted {
+        "restricted" => VisibilityTier::Restricted {
             scope_label: String::new(),
         },
         // "public", "", or anything else.
-        _ => AnnotationVisibility::Public,
+        _ => VisibilityTier::Public,
     }
 }
 

--- a/crates/grpc/proto/heddle/v1/service.proto
+++ b/crates/grpc/proto/heddle/v1/service.proto
@@ -353,6 +353,18 @@ message RedactionTransfer {
   bytes redactions_blob = 2;
 }
 
+// Out-of-pack transport for state-visibility sidecars. State visibility
+// records live outside `.heddle/objects/` and are keyed by the state id
+// whose audience tier they declare.
+//
+// `state_id` is the hex-encoded ChangeId of the state.
+// `state_visibility_blob` is the rmp-encoded `StateVisibilityBlob` byte
+// payload.
+message StateVisibilityTransfer {
+  string state_id = 1;
+  bytes state_visibility_blob = 2;
+}
+
 message PushMessage {
   oneof body {
     PushRequest request = 1;
@@ -360,6 +372,7 @@ message PushMessage {
     PackChunk pack = 3;
     PushComplete complete = 4;
     RedactionTransfer redaction = 5;
+    StateVisibilityTransfer state_visibility = 6;
   }
 }
 
@@ -410,6 +423,7 @@ message PullMessage {
     PackChunk pack = 4;
     PullComplete complete = 5;
     RedactionTransfer redaction = 6;
+    StateVisibilityTransfer state_visibility = 7;
   }
 }
 

--- a/crates/objects/src/object/discussion.rs
+++ b/crates/objects/src/object/discussion.rs
@@ -14,8 +14,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::object::{
-    hash::ChangeId, state_attribution::Principal, state_context::AnnotationVisibility,
-    state_review::SymbolAnchor,
+    hash::ChangeId, state_attribution::Principal, state_review::SymbolAnchor,
+    visibility_tier::VisibilityTier,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,7 +61,7 @@ pub struct Discussion {
     pub orphaned: bool,
     /// Inherits from namespace policy unless explicitly overridden.
     #[serde(default)]
-    pub visibility: AnnotationVisibility,
+    pub visibility: VisibilityTier,
     /// Bidirectional link populated when [`DiscussionResolution::ResolvedIntoAnnotation`]
     /// fires. Lets viewers jump from the discussion to the annotation it
     /// produced (and vice versa, via a back-pointer on the annotation).
@@ -180,7 +180,7 @@ mod tests {
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
             orphaned: false,
-            visibility: AnnotationVisibility::default(),
+            visibility: VisibilityTier::default(),
             resolved_annotation_id: None,
         }
     }

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -22,9 +22,11 @@ mod state_context;
 mod state_core;
 mod state_provenance;
 mod state_review;
+mod state_visibility;
 mod structured_conflict;
 mod tree;
 mod tree_diff;
+mod visibility_tier;
 
 pub use action_id::ActionId;
 pub use action_operation::Operation;
@@ -49,8 +51,8 @@ pub use semantic_change::{ChangeImportance, ModificationKind, SemanticChange};
 pub use session::{Session, SessionSegment, generate_session_id};
 pub use state_attribution::{Agent, Attribution, Principal};
 pub use state_context::{
-    Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus,
-    AnnotationVisibility, ContextBlob, ContextError, ContextTarget,
+    Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus, ContextBlob,
+    ContextError, ContextTarget,
 };
 pub use state_core::{
     SignatureStatus, State, StateSignature, Status, Verification,
@@ -60,6 +62,11 @@ pub use state_review::{
     ReviewKind, ReviewScope, ReviewSignature, ReviewSignatureError, ReviewSignaturesBlob,
     SymbolAnchor, signing_payload,
 };
+pub use state_visibility::{
+    STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG, StateVisibility, StateVisibilityBlob,
+    StateVisibilityError,
+};
+pub use visibility_tier::VisibilityTier;
 pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
 };

--- a/crates/objects/src/object/state_context.rs
+++ b/crates/objects/src/object/state_context.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::object::hash::{ChangeId, ContentHash};
+use crate::object::visibility_tier::VisibilityTier;
 
 const FILE_TARGET_ROOT: &str = "__files";
 const STATE_TARGET_ROOT: &str = "__states";
@@ -30,46 +31,15 @@ pub struct Annotation {
     pub supersedes_rewrite_pct: Option<u32>,
     // --- tail-only optional fields below; new fields go here. ---
     /// Visibility scope. Pre-W1 annotations have no field on disk; rmp-serde
-    /// fills the default ([`AnnotationVisibility::Public`]), preserving the
+    /// fills the default ([`VisibilityTier::Public`]), preserving the
     /// pre-existing meaning ("annotations are publicly visible").
     #[serde(default)]
-    pub visibility: AnnotationVisibility,
+    pub visibility: VisibilityTier,
     /// Back-pointer set when this annotation was produced by resolving a
     /// discussion. Lets viewers jump from the annotation back to the
     /// discussion that produced it.
     #[serde(default)]
     pub resolved_from_discussion: Option<String>,
-}
-
-/// Visibility scope for an annotation. Determines which audiences see it on
-/// read paths and during bridge export.
-///
-/// `Public` is the default — that matches pre-W1 behavior, where every
-/// annotation was effectively public, so legacy data decodes unchanged.
-/// External references (annotations that point to external systems) inherit
-/// the scope of their parent annotation.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AnnotationVisibility {
-    #[default]
-    Public,
-    Internal,
-    TeamScoped {
-        team_id: String,
-    },
-    Restricted {
-        scope_label: String,
-    },
-}
-
-impl AnnotationVisibility {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Public => "public",
-            Self::Internal => "internal",
-            Self::TeamScoped { .. } => "team_scoped",
-            Self::Restricted { .. } => "restricted",
-        }
-    }
 }
 
 /// A single revision of a logical annotation.
@@ -196,7 +166,7 @@ impl Annotation {
             }],
             supersedes_annotation_id: None,
             supersedes_rewrite_pct: None,
-            visibility: AnnotationVisibility::default(),
+            visibility: VisibilityTier::default(),
             resolved_from_discussion: None,
         }
     }

--- a/crates/objects/src/object/state_visibility.rs
+++ b/crates/objects/src/object/state_visibility.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+//! StateVisibility — a declaration that a state (commit) carries a
+//! non-public audience tier.
+//!
+//! Modeled on [`Redaction`](crate::object::Redaction): an *additive*
+//! sidecar record that lives outside the hashed `State` bytes, so changing a
+//! state's tier never mutates the state or invalidates its signature. The
+//! record is keyed by `ChangeId` (the state), not by a blob hash — commit
+//! visibility is a per-state property, where redaction is per-blob.
+//!
+//! **Absence ≡ public.** A public resolution stays record-free: the public
+//! tier is the default, and a state with no `StateVisibility` record is
+//! served to every audience. Only resolutions more restrictive than public
+//! are persisted, so the per-state sidecar is empty for the common case.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::object::{ChangeId, ContentHash, Principal, StateSignature, VisibilityTier};
+
+/// Stable byte prefix the signing payload begins with. Bumping this versions
+/// the payload format itself; old signatures with the old prefix continue to
+/// verify exactly as they did when written.
+pub const STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-statevis-v1\x00";
+
+/// A visibility-tier declaration on a single state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateVisibility {
+    /// The state (commit) this tier applies to.
+    pub state: ChangeId,
+    /// The audience tier the state's content is served at.
+    pub tier: VisibilityTier,
+    /// When set, the host materializes a superseding public record at this
+    /// instant (auto-promote). Advisory schedule only — the *effective*
+    /// tier is always read from the persisted records, never recomputed
+    /// from wall-clock at read time.
+    #[serde(default)]
+    pub embargo_until: Option<DateTime<Utc>>,
+    /// Who declared the tier.
+    pub declarer: Principal,
+    /// When the tier was declared. RFC3339 at the wire boundary;
+    /// `DateTime<Utc>` internally.
+    pub declared_at: DateTime<Utc>,
+    /// Optional cryptographic signature over the canonical signing payload
+    /// (see [`canonical_signing_payload`](StateVisibility::canonical_signing_payload)).
+    /// `None` for unsigned declarations.
+    #[serde(default)]
+    pub signature: Option<StateSignature>,
+    /// The record this one supersedes, if any — promotion appends a
+    /// superseding record rather than mutating a prior one. Identified by
+    /// the prior record's content hash.
+    #[serde(default)]
+    pub supersedes: Option<ContentHash>,
+}
+
+impl StateVisibility {
+    /// Build the canonical bytes a signer covers. The `signature` field is
+    /// intentionally excluded (a signature can't sign itself).
+    pub fn canonical_signing_payload(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(128);
+        buf.extend_from_slice(STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG);
+        buf.extend_from_slice(self.state.as_bytes());
+        buf.extend_from_slice(self.tier.as_str().as_bytes());
+        buf.push(0);
+        match &self.tier {
+            VisibilityTier::TeamScoped { team_id } => buf.extend_from_slice(team_id.as_bytes()),
+            VisibilityTier::Restricted { scope_label } => {
+                buf.extend_from_slice(scope_label.as_bytes())
+            }
+            VisibilityTier::Public | VisibilityTier::Internal => {}
+        }
+        buf.push(0);
+        if let Some(embargo_until) = &self.embargo_until {
+            buf.extend_from_slice(embargo_until.to_rfc3339().as_bytes());
+        }
+        buf.push(0);
+        buf.extend_from_slice(self.declarer.name.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(self.declarer.email.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(self.declared_at.to_rfc3339().as_bytes());
+        if let Some(supersedes) = &self.supersedes {
+            buf.extend_from_slice(supersedes.as_bytes());
+        }
+        buf
+    }
+
+    /// Per-item validation hook required by [`versioned_msgpack_blob!`].
+    /// A `TeamScoped`/`Restricted` tier must carry a non-empty label —
+    /// an empty label is meaningless and would silently widen the
+    /// audience to "any team / any restricted scope".
+    pub fn validate(&self) -> Result<(), StateVisibilityError> {
+        match &self.tier {
+            VisibilityTier::TeamScoped { team_id } if team_id.trim().is_empty() => {
+                Err(StateVisibilityError::EmptyTierLabel("team_scoped"))
+            }
+            VisibilityTier::Restricted { scope_label } if scope_label.trim().is_empty() => {
+                Err(StateVisibilityError::EmptyTierLabel("restricted"))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// On-disk blob containing all visibility records for a single state. One
+/// file per state, encoded with `rmp-serde` — mirrors the
+/// [`RedactionsBlob`](crate::object::RedactionsBlob) sidecar pattern.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateVisibilityBlob {
+    pub format_version: u8,
+    pub records: Vec<StateVisibility>,
+}
+
+// `new` / `encode` / `decode` / `validate` + `FORMAT_VERSION`. `decode`
+// rejects any blob whose `format_version` isn't the current one.
+versioned_msgpack_blob! {
+    blob: StateVisibilityBlob,
+    item: StateVisibility,
+    field: records,
+    error: StateVisibilityError,
+    codec_err: Codec,
+    version: 1,
+}
+
+impl StateVisibilityBlob {
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+
+    pub fn push(&mut self, record: StateVisibility) {
+        self.records.push(record);
+    }
+
+    /// `true` iff this state carries any visibility record — i.e. it is not
+    /// public-by-absence. Used by the sidecar's `has_visibility_for_state`.
+    pub fn has_record(&self) -> bool {
+        !self.records.is_empty()
+    }
+
+    /// The effective record: the most recent declaration by `declared_at`.
+    /// Pure over the persisted records, never wall-clock.
+    pub fn latest(&self) -> Option<&StateVisibility> {
+        self.records.iter().max_by_key(|r| r.declared_at)
+    }
+}
+
+/// Errors produced while encoding/decoding/validating state visibility.
+#[derive(Debug, thiserror::Error)]
+pub enum StateVisibilityError {
+    #[error("unsupported state-visibility format version {0}")]
+    UnsupportedVersion(u8),
+    #[error("state-visibility codec error: {0}")]
+    Codec(String),
+    #[error("{0} tier requires a non-empty label")]
+    EmptyTierLabel(&'static str),
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn principal() -> Principal {
+        Principal {
+            name: "Grace Hopper".into(),
+            email: "grace@example.com".into(),
+        }
+    }
+
+    fn record(tier: VisibilityTier) -> StateVisibility {
+        StateVisibility {
+            state: ChangeId::from_bytes([3u8; 16]),
+            tier,
+            embargo_until: None,
+            declarer: principal(),
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap(),
+            signature: None,
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn round_trips_through_msgpack() {
+        let original = StateVisibilityBlob::new(vec![record(VisibilityTier::Restricted {
+            scope_label: "security-embargo".into(),
+        })]);
+        let encoded = original.encode().expect("encode");
+        let decoded = StateVisibilityBlob::decode(&encoded).expect("decode");
+        assert_eq!(decoded, original);
+        // Format-version is load-bearing: future readers branch on it.
+        assert_eq!(decoded.format_version, StateVisibilityBlob::FORMAT_VERSION);
+    }
+
+    #[test]
+    fn round_trips_with_embargo_and_supersedes() {
+        let mut r = record(VisibilityTier::TeamScoped {
+            team_id: "infra".into(),
+        });
+        r.embargo_until = Some(Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap());
+        r.supersedes = Some(ContentHash::from_bytes([9u8; 32]));
+        let original = StateVisibilityBlob::new(vec![r]);
+        let encoded = original.encode().expect("encode");
+        let decoded = StateVisibilityBlob::decode(&encoded).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_version() {
+        // Hand-encode a blob whose format_version is not the current one;
+        // decode must reject it via the macro's version-check prologue.
+        let bad = StateVisibilityBlob {
+            format_version: StateVisibilityBlob::FORMAT_VERSION + 7,
+            records: vec![record(VisibilityTier::Internal)],
+        };
+        let bytes = rmp_serde::to_vec(&bad).expect("raw encode");
+        let err = StateVisibilityBlob::decode(&bytes).expect_err("must reject wrong version");
+        assert!(matches!(
+            err,
+            StateVisibilityError::UnsupportedVersion(v) if v == StateVisibilityBlob::FORMAT_VERSION + 7
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_empty_label() {
+        let blob = StateVisibilityBlob::new(vec![record(VisibilityTier::Restricted {
+            scope_label: "  ".into(),
+        })]);
+        assert!(matches!(
+            blob.validate(),
+            Err(StateVisibilityError::EmptyTierLabel("restricted"))
+        ));
+    }
+
+    #[test]
+    fn canonical_payload_is_versioned_and_carries_tier() {
+        let r = record(VisibilityTier::Restricted {
+            scope_label: "security-embargo".into(),
+        });
+        let payload = r.canonical_signing_payload();
+        assert!(payload.starts_with(STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG));
+        let text = String::from_utf8_lossy(&payload);
+        assert!(text.contains("restricted"));
+        assert!(text.contains("security-embargo"));
+        assert!(text.contains("grace@example.com"));
+    }
+
+    #[test]
+    fn latest_picks_the_most_recent() {
+        let early = record(VisibilityTier::Internal);
+        let late = StateVisibility {
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 2, 9, 0, 0).unwrap(),
+            tier: VisibilityTier::Public,
+            ..record(VisibilityTier::Public)
+        };
+        let blob = StateVisibilityBlob::new(vec![early, late.clone()]);
+        assert_eq!(blob.latest().unwrap(), &late);
+    }
+
+    #[test]
+    fn empty_blob_has_no_record() {
+        assert!(!StateVisibilityBlob::empty().has_record());
+    }
+}

--- a/crates/objects/src/object/visibility_tier.rs
+++ b/crates/objects/src/object/visibility_tier.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared audience-tier vocabulary.
+//!
+//! [`VisibilityTier`] is the single content-side visibility vocabulary used
+//! across annotations, discussions, and per-state commit visibility. The
+//! *reader's* tier (who is asking) is `repo::AudienceTier`; this enum is the
+//! *content's* tier (who the content is for). The who-sees-what mapping
+//! between the two lives in `repo::visibility::visible`.
+//!
+//! `Public` is the default — it matches the pre-unification behavior where
+//! every annotation was effectively public, so legacy data on disk decodes
+//! unchanged.
+
+use serde::{Deserialize, Serialize};
+
+/// Content-side visibility tier. Shared by annotations, discussions, and
+/// states so the per-commit visibility tiers and annotation/discussion
+/// visibility draw from one vocabulary rather than parallel enums.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VisibilityTier {
+    #[default]
+    Public,
+    Internal,
+    TeamScoped {
+        team_id: String,
+    },
+    Restricted {
+        scope_label: String,
+    },
+}
+
+impl VisibilityTier {
+    /// Stable wire/storage token for the tier discriminant. The labelled
+    /// variants collapse to their kind name here; the label travels in a
+    /// separate field. Shared by the discussion RPC vocabulary and the
+    /// state-visibility signing payload, so it must stay stable.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Internal => "internal",
+            Self::TeamScoped { .. } => "team_scoped",
+            Self::Restricted { .. } => "restricted",
+        }
+    }
+}

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -13,7 +13,7 @@ use super::{
     fs_io::{list_hashes_from_dir, read_file_bytes, read_file_header},
     fs_paths::{
         action_path, actions_dir, blobs_dir, hash_path, redaction_path, redactions_dir, state_path,
-        states_dir, trees_dir,
+        state_visibility_dir, state_visibility_path, states_dir, trees_dir,
     },
 };
 use crate::{
@@ -1014,6 +1014,55 @@ impl ObjectStore for FsStore {
             };
             if let Ok(hash) = ContentHash::from_hex(stem) {
                 out.push(hash);
+            }
+        }
+        Ok(out)
+    }
+
+    fn has_state_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
+        Ok(state_visibility_path(&self.root, state).exists())
+    }
+
+    fn get_state_visibility_bytes_for_state(&self, state: &ChangeId) -> Result<Option<Vec<u8>>> {
+        let path = state_visibility_path(&self.root, state);
+        match fs::read(&path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(HeddleError::Io(err)),
+        }
+    }
+
+    fn put_state_visibility_bytes_for_state(
+        &self,
+        state: &ChangeId,
+        bytes: &[u8],
+    ) -> Result<()> {
+        let dir = state_visibility_dir(&self.root);
+        if !dir.exists() {
+            fs::create_dir_all(&dir)?;
+        }
+        let path = state_visibility_path(&self.root, state);
+        crate::fs_atomic::write_file_atomic(&path, bytes)?;
+        Ok(())
+    }
+
+    fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
+        let dir = state_visibility_dir(&self.root);
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("bin") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Ok(state) = ChangeId::parse(stem) {
+                out.push(state);
             }
         }
         Ok(out)

--- a/crates/objects/src/store/fs/fs_paths.rs
+++ b/crates/objects/src/store/fs/fs_paths.rs
@@ -50,3 +50,11 @@ pub(super) fn redactions_dir(root: &Path) -> PathBuf {
 pub(super) fn redaction_path(root: &Path, blob: &ContentHash) -> PathBuf {
     redactions_dir(root).join(format!("{}.bin", blob.to_hex()))
 }
+
+pub(super) fn state_visibility_dir(root: &Path) -> PathBuf {
+    root.join("visibility")
+}
+
+pub(super) fn state_visibility_path(root: &Path, state: &ChangeId) -> PathBuf {
+    state_visibility_dir(root).join(format!("{}.bin", state.to_string_full()))
+}

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -35,6 +35,7 @@ pub struct InMemoryStore {
     states: RwLock<HashMap<ChangeId, Vec<u8>>>,
     actions: RwLock<HashMap<ActionId, Vec<u8>>>,
     redactions: RwLock<HashMap<ContentHash, Vec<u8>>>,
+    state_visibility: RwLock<HashMap<ChangeId, Vec<u8>>>,
 }
 
 impl InMemoryStore {
@@ -172,6 +173,30 @@ impl ObjectStore for InMemoryStore {
 
     fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
         Ok(self.redactions.read().unwrap().keys().copied().collect())
+    }
+
+    fn has_state_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
+        Ok(self.state_visibility.read().unwrap().contains_key(state))
+    }
+
+    fn get_state_visibility_bytes_for_state(&self, state: &ChangeId) -> Result<Option<Vec<u8>>> {
+        Ok(self.state_visibility.read().unwrap().get(state).cloned())
+    }
+
+    fn put_state_visibility_bytes_for_state(
+        &self,
+        state: &ChangeId,
+        bytes: &[u8],
+    ) -> Result<()> {
+        self.state_visibility
+            .write()
+            .unwrap()
+            .insert(*state, bytes.to_vec());
+        Ok(())
+    }
+
+    fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
+        Ok(self.state_visibility.read().unwrap().keys().copied().collect())
     }
 }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -196,6 +196,22 @@ impl ObjectStore for AnyStore {
     fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
         any_store_dispatch!(self, list_blobs_with_redactions())
     }
+    fn has_state_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
+        any_store_dispatch!(self, has_state_visibility_for_state(state))
+    }
+    fn get_state_visibility_bytes_for_state(&self, state: &ChangeId) -> Result<Option<Vec<u8>>> {
+        any_store_dispatch!(self, get_state_visibility_bytes_for_state(state))
+    }
+    fn put_state_visibility_bytes_for_state(
+        &self,
+        state: &ChangeId,
+        bytes: &[u8],
+    ) -> Result<()> {
+        any_store_dispatch!(self, put_state_visibility_bytes_for_state(state, bytes))
+    }
+    fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
+        any_store_dispatch!(self, list_states_with_visibility())
+    }
 }
 
 /// Trait for object storage backends.
@@ -554,6 +570,49 @@ pub trait ObjectStore: Send + Sync {
     fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
         Ok(Vec::new())
     }
+
+    /// Whether the store holds any state-visibility record for `state`.
+    ///
+    /// Like redactions, state-visibility records live in a sidecar outside
+    /// the content-addressed object graph and cannot ride native packs.
+    /// Sync uses this probe while enumerating a state closure so a non-public
+    /// state can advertise the sidecar that must travel out-of-pack.
+    ///
+    /// Default impl returns `Ok(false)` for stores that do not model this
+    /// sidecar.
+    fn has_state_visibility_for_state(&self, _state: &ChangeId) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Return the raw rmp-encoded `StateVisibilityBlob` bytes for `state`,
+    /// or `Ok(None)` if no sidecar exists. The bytes are the wire-transfer
+    /// payload for state visibility.
+    ///
+    /// Default impl returns `Ok(None)`.
+    fn get_state_visibility_bytes_for_state(&self, _state: &ChangeId) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// Persist raw `StateVisibilityBlob` bytes for `state`.
+    ///
+    /// Default impl returns an "unsupported" error so stores that do not
+    /// model the sidecar refuse instead of dropping it.
+    fn put_state_visibility_bytes_for_state(
+        &self,
+        _state: &ChangeId,
+        _bytes: &[u8],
+    ) -> Result<()> {
+        Err(HeddleError::InvalidObject(
+            "this object store does not support persisting state visibility".to_string(),
+        ))
+    }
+
+    /// List every state with at least one state-visibility record.
+    ///
+    /// Default impl returns `Ok(vec![])`.
+    fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
+        Ok(Vec::new())
+    }
 }
 
 #[cfg(test)]
@@ -692,6 +751,26 @@ mod any_store_tests {
             Some(redaction.as_slice())
         );
         assert!(store.list_blobs_with_redactions().unwrap().contains(&blob_hash));
+
+        // ── State visibility ──
+        let state_visibility = b"any-store state visibility bytes";
+        store
+            .put_state_visibility_bytes_for_state(&change_id, state_visibility)
+            .unwrap();
+        assert!(store.has_state_visibility_for_state(&change_id).unwrap());
+        assert_eq!(
+            store
+                .get_state_visibility_bytes_for_state(&change_id)
+                .unwrap()
+                .as_deref(),
+            Some(state_visibility.as_slice())
+        );
+        assert!(
+            store
+                .list_states_with_visibility()
+                .unwrap()
+                .contains(&change_id)
+        );
 
         // ── Caches ──
         store.clear_recent_caches();

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -44,7 +44,8 @@ pub use message_pushpull::{
 pub use message_refs::{HeadInfo, ListRefs, RefEntry, RefFilter, RefUpdated, RefsList, UpdateRef};
 pub use message_status::{Error, ErrorCode, Status, StatusCode};
 pub use native_pack::{
-    NativePackBundle, PackChunkState, build_native_pack, install_received_pack, next_pack_chunk,
+    NativePackBundle, PackChunkState, build_native_pack, install_received_pack,
+    is_native_packable_object_type, native_pack_excluded_object_types, next_pack_chunk,
     receive_pack_chunk,
 };
 pub use object_availability::{ObjectAvailabilityPlan, has_object, plan_object_availability};

--- a/crates/proto/src/native_pack.rs
+++ b/crates/proto/src/native_pack.rs
@@ -47,6 +47,14 @@ impl PackChunkState {
     }
 }
 
+pub fn native_pack_excluded_object_types() -> &'static [ObjectType] {
+    &[ObjectType::Redaction, ObjectType::StateVisibility]
+}
+
+pub fn is_native_packable_object_type(obj_type: ObjectType) -> bool {
+    !native_pack_excluded_object_types().contains(&obj_type)
+}
+
 pub fn build_native_pack(
     store: &impl ObjectStore,
     objects: &[ObjectInfo],
@@ -59,10 +67,7 @@ pub fn build_native_pack(
         // folded into the content-addressed pack. They ship via the
         // per-object transfer path instead; callers split them out before
         // packing.
-        if matches!(
-            info.obj_type,
-            ObjectType::Redaction | ObjectType::StateVisibility
-        ) {
+        if !is_native_packable_object_type(info.obj_type) {
             continue;
         }
         let object = load_object_data(store, &info.id, info.obj_type)?;

--- a/crates/proto/src/native_pack.rs
+++ b/crates/proto/src/native_pack.rs
@@ -54,11 +54,15 @@ pub fn build_native_pack(
     let mut builder = PackBuilder::new(sync_pack_compression());
 
     for info in objects {
-        // Redactions are sidecar records (live outside `.heddle/objects/`
-        // so GC cannot touch them) and must not be folded into the
-        // content-addressed pack. They ship via the per-object transfer
-        // path instead; callers split them out before packing.
-        if info.obj_type == ObjectType::Redaction {
+        // Sidecar records (redaction + state-visibility) live outside
+        // `.heddle/objects/` so GC cannot touch them, and must not be
+        // folded into the content-addressed pack. They ship via the
+        // per-object transfer path instead; callers split them out before
+        // packing.
+        if matches!(
+            info.obj_type,
+            ObjectType::Redaction | ObjectType::StateVisibility
+        ) {
             continue;
         }
         let object = load_object_data(store, &info.id, info.obj_type)?;
@@ -202,6 +206,10 @@ fn to_pack_object_type(obj_type: ObjectType) -> Result<PackObjectType> {
         ObjectType::Action => Ok(PackObjectType::Action),
         ObjectType::Redaction => Err(ProtocolError::InvalidState(
             "Redaction sidecar records cannot be packed into the content-addressed object pack"
+                .to_string(),
+        )),
+        ObjectType::StateVisibility => Err(ProtocolError::InvalidState(
+            "StateVisibility sidecar records cannot be packed into the content-addressed object pack"
                 .to_string(),
         )),
     }

--- a/crates/proto/src/object_availability.rs
+++ b/crates/proto/src/object_availability.rs
@@ -26,6 +26,10 @@ pub fn has_object(store: &impl ObjectStore, info: &ObjectInfo) -> Result<bool> {
         // deduplicates via the content-addressed `put_redaction`
         // idempotency rule. Cheap to refetch; correct under merge.
         (ObjectId::Hash(_), ObjectType::Redaction) => Ok(false),
+        // StateVisibility is a per-state sidecar with append/merge
+        // semantics. Like Redaction, conservatively refetch and let the
+        // repository boundary validate + dedupe.
+        (ObjectId::ChangeId(_), ObjectType::StateVisibility) => Ok(false),
         _ => Ok(false),
     }
 }

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -41,6 +41,13 @@ pub enum ObjectType {
     /// the *redacted blob*, since `Repository`'s sidecar store is
     /// indexed that way.
     Redaction,
+    /// A `StateVisibilityBlob` sidecar — the rmp-encoded record(s)
+    /// declaring a non-public audience tier for a specific state. Keyed
+    /// on the wire by `ObjectId::ChangeId` of the *state*, since the
+    /// per-state sidecar store is indexed that way. Like `Redaction`, it
+    /// is a sidecar record that lives outside the content-addressed pack
+    /// and ships via the per-object transfer path, not the pack.
+    StateVisibility,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -95,6 +95,7 @@ pub fn enumerate_state_closure_with_options(
             size: state_bytes.len() as u64,
             delta_base: None,
         });
+        emit_state_visibility_info(store, &id, &mut out)?;
 
         if options.depth.map(|max| depth < max).unwrap_or(true) {
             for parent in &state.parents {
@@ -168,6 +169,7 @@ pub fn enumerate_state_closure_plan_with_options(
             id: ObjectId::ChangeId(id),
             obj_type: ObjectType::State,
         });
+        emit_state_visibility_plan(store, &id, &mut out)?;
 
         if options.depth.map(|max| depth < max).unwrap_or(true) {
             for parent in &state.parents {
@@ -275,6 +277,39 @@ fn enumerate_tree_closure_filtered(
         }
     }
 
+    Ok(())
+}
+
+/// If `state` carries a state-visibility sidecar, push a StateVisibility
+/// `ObjectInfo` keyed by the state id. No-op when the state is public by
+/// absence.
+fn emit_state_visibility_info(
+    store: &impl ObjectStore,
+    state: &ChangeId,
+    out: &mut Vec<ObjectInfo>,
+) -> Result<()> {
+    if let Some(bytes) = store.get_state_visibility_bytes_for_state(state)? {
+        out.push(ObjectInfo {
+            id: ObjectId::ChangeId(*state),
+            obj_type: ObjectType::StateVisibility,
+            size: bytes.len() as u64,
+            delta_base: None,
+        });
+    }
+    Ok(())
+}
+
+fn emit_state_visibility_plan(
+    store: &impl ObjectStore,
+    state: &ChangeId,
+    out: &mut Vec<PlannedObject>,
+) -> Result<()> {
+    if store.has_state_visibility_for_state(state)? {
+        out.push(PlannedObject {
+            id: ObjectId::ChangeId(*state),
+            obj_type: ObjectType::StateVisibility,
+        });
+    }
     Ok(())
 }
 
@@ -469,7 +504,7 @@ pub fn is_ancestor(
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use objects::object::{Principal, Redaction};
+    use objects::object::{Principal, Redaction, StateVisibility, VisibilityTier};
     use objects::store::ObjectStore;
     use repo::Repository;
     use tempfile::TempDir;
@@ -580,6 +615,54 @@ mod tests {
             plan.iter()
                 .any(|p| p.obj_type == ObjectType::Redaction && p.id == ObjectId::Hash(blob_hash)),
             "plan closure must include a Redaction entry for the redacted blob"
+        );
+    }
+
+    #[test]
+    fn enumerate_state_closure_emits_state_visibility_for_visible_state() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("README.md"), "hello\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+
+        repo.put_state_visibility(StateVisibility {
+            state: state.change_id,
+            tier: VisibilityTier::Restricted {
+                scope_label: "security-embargo".into(),
+            },
+            embargo_until: None,
+            declarer: Principal {
+                name: "Tester".into(),
+                email: "tester@heddle.sh".into(),
+            },
+            declared_at: Utc::now(),
+            signature: None,
+            supersedes: None,
+        })
+        .unwrap();
+
+        let full = enumerate_state_closure_with_options(
+            repo.store(),
+            state.change_id,
+            StateClosureOptions::default(),
+        )
+        .unwrap();
+        let plan = enumerate_state_closure_plan_with_options(
+            repo.store(),
+            state.change_id,
+            StateClosureOptions::default(),
+        )
+        .unwrap();
+
+        assert!(
+            full.iter().any(|info| info.obj_type == ObjectType::StateVisibility
+                && info.id == ObjectId::ChangeId(state.change_id)),
+            "full closure must include a StateVisibility entry for the visible state"
+        );
+        assert!(
+            plan.iter().any(|p| p.obj_type == ObjectType::StateVisibility
+                && p.id == ObjectId::ChangeId(state.change_id)),
+            "plan closure must include a StateVisibility entry for the visible state"
         );
     }
 }

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -38,12 +38,12 @@ pub fn chunk_offset(chunk_index: usize, chunk_size: usize) -> Option<usize> {
 }
 
 pub fn load_requested_object(store: &impl ObjectStore, req: &ObjectRequest) -> Result<ObjectData> {
-    // Note on Redaction objects: a redaction sidecar is content-addressed by
-    // the *redacted blob's* hash, which also identifies a real blob in the
-    // store. `load_requested_object` resolves blob-vs-tree by content
-    // probe; it cannot disambiguate a Redaction request from a Blob request
-    // by ObjectId alone. Callers that need to fetch a redaction must use
-    // `load_object_data` with an explicit `ObjectType::Redaction`.
+    // Note on sidecar objects: redactions and state visibility are keyed by
+    // ids that also identify primary objects. `load_requested_object`
+    // resolves blob-vs-tree or state by id shape/probe; it cannot
+    // disambiguate a sidecar request by ObjectId alone. Callers that need to
+    // fetch a sidecar must use `load_object_data` with an explicit object
+    // type.
     let (obj_type, data) = match &req.id {
         ObjectId::Hash(hash) => {
             if let Some(blob) = store.get_blob(hash)? {
@@ -96,6 +96,9 @@ pub fn load_object_data(
         (ObjectId::Hash(hash), ObjectType::Redaction) => store
             .get_redactions_bytes_for_blob(hash)?
             .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?,
+        (ObjectId::ChangeId(change_id), ObjectType::StateVisibility) => store
+            .get_state_visibility_bytes_for_state(change_id)?
+            .ok_or_else(|| ProtocolError::ObjectNotFound(change_id.to_string_full()))?,
         _ => {
             return Err(ProtocolError::InvalidState(
                 "object id/type mismatch".to_string(),
@@ -146,6 +149,16 @@ pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Res
             return Err(ProtocolError::InvalidState(
                 "Redaction objects must be persisted via Repository::accept_wire_redactions, \
                  not store_received_object — signature verification is required"
+                    .to_string(),
+            ));
+        }
+        (_, ObjectType::StateVisibility) => {
+            // State visibility must be validated and normalized at the
+            // Repository boundary (`put_state_visibility` enforces
+            // public-by-absence). Refuse raw sidecar writes here.
+            return Err(ProtocolError::InvalidState(
+                "StateVisibility objects must be persisted via Repository::accept_wire_state_visibility, \
+                 not store_received_object — sidecar validation is required"
                     .to_string(),
             ));
         }

--- a/crates/repo/src/discussion_anchor_travel.rs
+++ b/crates/repo/src/discussion_anchor_travel.rs
@@ -236,7 +236,7 @@ mod tests {
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
             orphaned: false,
-            visibility: objects::object::AnnotationVisibility::default(),
+            visibility: objects::object::VisibilityTier::default(),
             resolved_annotation_id: None,
         }
     }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -22,6 +22,7 @@ mod repository;
 mod repository_redaction;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
+mod repository_state_visibility;
 mod session_storage;
 pub mod snapshot_metadata;
 pub mod staleness;

--- a/crates/repo/src/namespace_policy.rs
+++ b/crates/repo/src/namespace_policy.rs
@@ -8,10 +8,10 @@
 //!    handled by the caller, not this module.
 //! 2. Namespace policy (`[namespace.<name>] default_visibility = "..."`).
 //! 3. Repo-wide default (`[review.discussion] default_visibility = "..."`).
-//! 4. Hard-coded fallback: [`AnnotationVisibility::Internal`] — the safer
+//! 4. Hard-coded fallback: [`VisibilityTier::Internal`] — the safer
 //!    choice for the "we have no idea who should see this" case.
 
-use objects::object::AnnotationVisibility;
+use objects::object::VisibilityTier;
 use serde::{Deserialize, Serialize};
 
 /// Per-namespace overrides for default visibility. Loaded from the
@@ -24,7 +24,7 @@ pub struct NamespacePolicy {
     /// Default visibility applied to annotations whose anchor falls
     /// inside this namespace and whose creator didn't pass
     /// `--visibility` explicitly.
-    pub default_visibility: AnnotationVisibility,
+    pub default_visibility: VisibilityTier,
     /// When `true`, annotations on external references inherit the
     /// parent annotation's visibility instead of falling through to
     /// this policy. Mirrors the plan's
@@ -38,7 +38,7 @@ fn default_external_refs_inherit_parent() -> bool {
 }
 
 impl NamespacePolicy {
-    pub fn new(name: impl Into<String>, default_visibility: AnnotationVisibility) -> Self {
+    pub fn new(name: impl Into<String>, default_visibility: VisibilityTier) -> Self {
         Self {
             name: name.into(),
             default_visibility,
@@ -53,7 +53,7 @@ impl NamespacePolicy {
 #[derive(Clone, Debug, Default)]
 pub struct VisibilityResolutionContext<'a> {
     /// Repo-wide default from `[review.discussion] default_visibility`.
-    pub repo_default: Option<AnnotationVisibility>,
+    pub repo_default: Option<VisibilityTier>,
     /// Namespace policy applicable to the anchor, if any.
     pub namespace: Option<&'a NamespacePolicy>,
 }
@@ -65,14 +65,14 @@ pub struct VisibilityResolutionContext<'a> {
 /// Explicit-from-the-caller is layered on top of this by the caller —
 /// `resolve_default_visibility` never sees an explicit value because by
 /// definition the caller didn't supply one.
-pub fn resolve_default_visibility(ctx: &VisibilityResolutionContext<'_>) -> AnnotationVisibility {
+pub fn resolve_default_visibility(ctx: &VisibilityResolutionContext<'_>) -> VisibilityTier {
     if let Some(policy) = ctx.namespace {
         return policy.default_visibility.clone();
     }
     if let Some(repo_default) = &ctx.repo_default {
         return repo_default.clone();
     }
-    AnnotationVisibility::Internal
+    VisibilityTier::Internal
 }
 
 #[cfg(test)]
@@ -84,19 +84,19 @@ mod tests {
         let ctx = VisibilityResolutionContext::default();
         assert_eq!(
             resolve_default_visibility(&ctx),
-            AnnotationVisibility::Internal
+            VisibilityTier::Internal
         );
     }
 
     #[test]
     fn repo_default_used_without_namespace() {
         let ctx = VisibilityResolutionContext {
-            repo_default: Some(AnnotationVisibility::Public),
+            repo_default: Some(VisibilityTier::Public),
             namespace: None,
         };
         assert_eq!(
             resolve_default_visibility(&ctx),
-            AnnotationVisibility::Public
+            VisibilityTier::Public
         );
     }
 
@@ -104,17 +104,17 @@ mod tests {
     fn namespace_policy_overrides_repo_default() {
         let policy = NamespacePolicy::new(
             "infra",
-            AnnotationVisibility::TeamScoped {
+            VisibilityTier::TeamScoped {
                 team_id: "infra".into(),
             },
         );
         let ctx = VisibilityResolutionContext {
-            repo_default: Some(AnnotationVisibility::Public),
+            repo_default: Some(VisibilityTier::Public),
             namespace: Some(&policy),
         };
         assert_eq!(
             resolve_default_visibility(&ctx),
-            AnnotationVisibility::TeamScoped {
+            VisibilityTier::TeamScoped {
                 team_id: "infra".into()
             }
         );

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -17,37 +17,60 @@
 //!
 //! The public tier is the default and stays **record-free**: a public
 //! resolution never writes a file here, and [`Repository::has_visibility_for_state`]
-//! returns `false` when no record exists. Only resolutions more restrictive
-//! than public are persisted. Callers must therefore not persist a
-//! `VisibilityTier::Public` record — the absence *is* the public signal.
+//! returns `false` when the effective tier is public. Only resolutions more
+//! restrictive than public are persisted. This is *enforced* at the write
+//! boundary — [`Repository::put_state_visibility`] normalizes a
+//! `VisibilityTier::Public` put to public-by-absence rather than trusting
+//! callers to keep public off disk — so the absence genuinely *is* the
+//! public signal.
 
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 use objects::{
     fs_atomic::write_file_atomic,
-    object::{ChangeId, ContentHash, StateVisibility, StateVisibilityBlob},
+    lock::RepositoryLockExt,
+    object::{ChangeId, ContentHash, StateVisibility, StateVisibilityBlob, VisibilityTier},
 };
 
 use crate::repository::Repository;
 
 impl Repository {
-    /// Append a visibility record for its state. Returns the record's
+    /// Record a visibility declaration for its state. Returns the record's
     /// content-addressed id.
+    ///
+    /// The whole read → dedupe → write sequence runs under the repository
+    /// write lock, so two concurrent puts on the same state can't both load
+    /// the same blob and have the second `write_file_atomic` clobber the
+    /// first (a lost update would silently drop an embargo or a promotion).
+    /// This mirrors the `SignState` handler, which serializes its per-state
+    /// read-modify-write the same way — reusing the existing repo lock, not
+    /// a new one.
     ///
     /// Idempotent: if a record with the same canonical bytes already exists
     /// on the state, no second entry is written and the existing id is
     /// returned.
     ///
-    /// Callers must not pass a `VisibilityTier::Public` record — public is
-    /// represented by *absence* (see the module docs). Persisting a public
-    /// record would make [`has_visibility_for_state`](Self::has_visibility_for_state)
-    /// report a state as non-public when it is not.
+    /// **Absence ≡ public, enforced here.** When the *effective* (latest)
+    /// tier resolves to [`VisibilityTier::Public`], the state's sidecar is
+    /// removed so it returns to public-by-absence and
+    /// [`has_visibility_for_state`](Self::has_visibility_for_state) reports
+    /// `false`. This holds whether the Public put is fresh or supersedes a
+    /// prior private record — no caller can leave a Public record that makes
+    /// a public state read as non-public.
     pub fn put_state_visibility(&self, record: StateVisibility) -> Result<ContentHash> {
         let state = record.state;
-        let mut existing = self.get_state_visibility_for_state(&state)?;
+
+        // Serialize the full read-modify-write behind the repo write lock so
+        // concurrent appends on the same state can't clobber each other.
+        let _lock = self
+            .locker()
+            .write()
+            .with_context(|| "acquire repo write lock for state-visibility put")?;
 
         let id = state_visibility_content_hash(&record)?;
+        let mut existing = self.get_state_visibility_for_state(&state)?;
+
         for existing_record in &existing.records {
             if state_visibility_content_hash(existing_record)? == id {
                 return Ok(id);
@@ -55,10 +78,28 @@ impl Repository {
         }
 
         existing.push(record);
+
+        let path = self.state_visibility_path_for_state(&state);
+
+        // Absence ≡ public: if the effective (latest) tier is public, drop the
+        // state back to public-by-absence by removing the sidecar rather than
+        // persisting a record that would classify a public state as non-public.
+        let effective_public = match existing.latest() {
+            Some(latest) => latest.tier == VisibilityTier::Public,
+            None => true,
+        };
+        if effective_public {
+            if path.exists() {
+                fs::remove_file(&path).with_context(|| {
+                    format!("remove state-visibility sidecar '{}'", path.display())
+                })?;
+            }
+            return Ok(id);
+        }
+
         let bytes = existing
             .encode()
             .with_context(|| "encoding state-visibility blob")?;
-        let path = self.state_visibility_path_for_state(&state);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).with_context(|| format!("create '{}'", parent.display()))?;
         }
@@ -79,12 +120,20 @@ impl Repository {
             .with_context(|| format!("decode '{}'", path.display()))
     }
 
-    /// Whether `state` carries any persisted visibility record. `false`
-    /// means **public-by-absence** — the public resolution is record-free,
-    /// so a missing (or empty) sidecar resolves to the public tier. This is
-    /// the keystone query the serve-side gate keys off.
+    /// Whether `state` resolves to a **non-public** effective tier. `false`
+    /// means **public-by-absence** — either no record exists, or the latest
+    /// declaration resolves to [`VisibilityTier::Public`]. By construction
+    /// (see [`put_state_visibility`](Self::put_state_visibility)) a public
+    /// resolution is never persisted, so this is equivalent to "a record
+    /// exists"; computing it from the effective tier keeps the keystone
+    /// invariant — true iff the effective tier is non-public — explicit and
+    /// robust against any blob a future path might introduce. This is the
+    /// query the serve-side gate keys off.
     pub fn has_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
-        Ok(self.get_state_visibility_for_state(state)?.has_record())
+        Ok(self
+            .get_state_visibility_for_state(state)?
+            .latest()
+            .is_some_and(|r| r.tier != VisibilityTier::Public))
     }
 
     /// Walk every visibility sidecar file in the repo. Returns
@@ -145,6 +194,8 @@ fn state_visibility_content_hash(record: &StateVisibility) -> Result<ContentHash
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::Arc, thread};
+
     use chrono::{TimeZone, Utc};
     use objects::object::{Principal, VisibilityTier};
     use tempfile::TempDir;
@@ -295,5 +346,119 @@ mod tests {
         let mut want = vec![a, b];
         want.sort_by_key(|c| c.to_string_full());
         assert_eq!(listed, want);
+    }
+
+    #[test]
+    fn concurrent_puts_on_same_state_do_not_lose_updates() {
+        // Finding 1: the read → dedupe → write must be serialized behind the
+        // repo write lock. Eight threads each append a *distinct* non-public
+        // record to the SAME state. Without the lock, concurrent appends load
+        // the same base blob and the last `write_file_atomic` wins, silently
+        // dropping the others. With it, every record survives.
+        let (_dir, repo) = fresh_repo();
+        let repo = Arc::new(repo);
+        let state = ChangeId::from_bytes([42u8; 16]);
+
+        const N: u32 = 8;
+        let mut handles = Vec::new();
+        for i in 0..N {
+            let repo = Arc::clone(&repo);
+            handles.push(thread::spawn(move || {
+                // Distinct declared_at per thread → distinct content hash, so
+                // each append accretes (none is a dedup no-op).
+                let record = StateVisibility {
+                    declared_at: Utc.with_ymd_and_hms(2026, 6, 1, 12, i, 0).unwrap(),
+                    ..sample_record(state, VisibilityTier::Internal)
+                };
+                repo.put_state_visibility(record).expect("concurrent put");
+            }));
+        }
+        for h in handles {
+            h.join().expect("join put thread");
+        }
+
+        let stored = repo
+            .get_state_visibility_for_state(&state)
+            .expect("read back");
+        assert_eq!(
+            stored.records.len() as u32,
+            N,
+            "every concurrent append on the same state must survive — no lost update"
+        );
+        assert!(
+            repo.has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "a non-public effective tier must report has_visibility_for_state == true"
+        );
+    }
+
+    #[test]
+    fn public_put_resolves_to_public_by_absence() {
+        // Finding 2: a Public put must not persist a record. The state stays
+        // public-by-absence, so has_visibility_for_state is false and get
+        // resolves to an empty (public) blob.
+        let (_dir, repo) = fresh_repo();
+        let state = ChangeId::from_bytes([20u8; 16]);
+        repo.put_state_visibility(sample_record(state, VisibilityTier::Public))
+            .expect("public put");
+
+        assert!(
+            !repo
+                .has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "a Public put must resolve to public-by-absence (has_visibility_for_state == false)"
+        );
+        assert!(
+            !repo.state_visibility_path_for_state(&state).exists(),
+            "a Public put must not persist a sidecar file"
+        );
+        assert!(
+            repo.get_state_visibility_for_state(&state)
+                .expect("read back")
+                .records
+                .is_empty(),
+            "get must resolve a Public state to an empty (public) blob"
+        );
+    }
+
+    #[test]
+    fn supersede_with_public_drops_back_to_public_by_absence() {
+        // Finding 2 (supersede arm): a private record makes the state
+        // non-public; superseding it with a later Public declaration must
+        // drop the whole state back to public-by-absence (record removed),
+        // not leave a lingering non-public classification.
+        let (_dir, repo) = fresh_repo();
+        let state = ChangeId::from_bytes([21u8; 16]);
+        let private = sample_record(
+            state,
+            VisibilityTier::Restricted {
+                scope_label: "embargo".into(),
+            },
+        );
+        let private_id = repo.put_state_visibility(private).expect("put private");
+        assert!(
+            repo.has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "an embargo/private record must report has_visibility_for_state == true"
+        );
+
+        let public = StateVisibility {
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 2, 9, 0, 0).unwrap(),
+            supersedes: Some(private_id),
+            ..sample_record(state, VisibilityTier::Public)
+        };
+        repo.put_state_visibility(public)
+            .expect("supersede with public");
+
+        assert!(
+            !repo
+                .has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "supersede-to-Public must restore public-by-absence (has_visibility_for_state == false)"
+        );
+        assert!(
+            !repo.state_visibility_path_for_state(&state).exists(),
+            "supersede-to-Public must remove the sidecar entirely"
+        );
     }
 }

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Repository helpers for the per-state visibility sidecar.
+//!
+//! Storage layout (one file per state that carries a non-public tier):
+//!
+//! ```text
+//! <heddle_dir>/visibility/<change-id>.bin
+//! ```
+//!
+//! The file is an rmp-serde-encoded [`StateVisibilityBlob`] — every
+//! visibility declaration on the same state lives in the same file, keyed by
+//! the state's `ChangeId`. This mirrors the per-blob redactions sidecar
+//! (`crates/repo/src/repository_redaction.rs`), one level up: redaction is
+//! keyed by a blob hash, commit visibility by a state id.
+//!
+//! ## Absence ≡ public
+//!
+//! The public tier is the default and stays **record-free**: a public
+//! resolution never writes a file here, and [`Repository::has_visibility_for_state`]
+//! returns `false` when no record exists. Only resolutions more restrictive
+//! than public are persisted. Callers must therefore not persist a
+//! `VisibilityTier::Public` record — the absence *is* the public signal.
+
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use objects::{
+    fs_atomic::write_file_atomic,
+    object::{ChangeId, ContentHash, StateVisibility, StateVisibilityBlob},
+};
+
+use crate::repository::Repository;
+
+impl Repository {
+    /// Append a visibility record for its state. Returns the record's
+    /// content-addressed id.
+    ///
+    /// Idempotent: if a record with the same canonical bytes already exists
+    /// on the state, no second entry is written and the existing id is
+    /// returned.
+    ///
+    /// Callers must not pass a `VisibilityTier::Public` record — public is
+    /// represented by *absence* (see the module docs). Persisting a public
+    /// record would make [`has_visibility_for_state`](Self::has_visibility_for_state)
+    /// report a state as non-public when it is not.
+    pub fn put_state_visibility(&self, record: StateVisibility) -> Result<ContentHash> {
+        let state = record.state;
+        let mut existing = self.get_state_visibility_for_state(&state)?;
+
+        let id = state_visibility_content_hash(&record)?;
+        for existing_record in &existing.records {
+            if state_visibility_content_hash(existing_record)? == id {
+                return Ok(id);
+            }
+        }
+
+        existing.push(record);
+        let bytes = existing
+            .encode()
+            .with_context(|| "encoding state-visibility blob")?;
+        let path = self.state_visibility_path_for_state(&state);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("create '{}'", parent.display()))?;
+        }
+        write_file_atomic(&path, &bytes).with_context(|| format!("write '{}'", path.display()))?;
+        Ok(id)
+    }
+
+    /// Load all visibility records targeting `state`. Returns an empty
+    /// [`StateVisibilityBlob`] (not an error) when none exist — callers can
+    /// treat the result uniformly.
+    pub fn get_state_visibility_for_state(&self, state: &ChangeId) -> Result<StateVisibilityBlob> {
+        let path = self.state_visibility_path_for_state(state);
+        if !path.exists() {
+            return Ok(StateVisibilityBlob::empty());
+        }
+        let bytes = fs::read(&path).with_context(|| format!("read '{}'", path.display()))?;
+        StateVisibilityBlob::decode(&bytes)
+            .with_context(|| format!("decode '{}'", path.display()))
+    }
+
+    /// Whether `state` carries any persisted visibility record. `false`
+    /// means **public-by-absence** — the public resolution is record-free,
+    /// so a missing (or empty) sidecar resolves to the public tier. This is
+    /// the keystone query the serve-side gate keys off.
+    pub fn has_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
+        Ok(self.get_state_visibility_for_state(state)?.has_record())
+    }
+
+    /// Walk every visibility sidecar file in the repo. Returns
+    /// `(state_id, blob)` pairs so callers can correlate. Used by listing
+    /// surfaces and the GC's "never collect a visibility record" guard.
+    pub fn list_all_state_visibility(&self) -> Result<Vec<(ChangeId, StateVisibilityBlob)>> {
+        let dir = self.state_visibility_dir();
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&dir).with_context(|| format!("read '{}'", dir.display()))? {
+            let entry = entry.with_context(|| format!("entry in '{}'", dir.display()))?;
+            let path = entry.path();
+            // Only `.bin` files whose stem parses as a ChangeId. Editor
+            // backups and partial writes are skipped, never fatal.
+            if path.extension().and_then(|e| e.to_str()) != Some("bin") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Ok(state) = ChangeId::parse(stem) else {
+                continue;
+            };
+            let bytes = fs::read(&path).with_context(|| format!("read '{}'", path.display()))?;
+            let blob = StateVisibilityBlob::decode(&bytes)
+                .with_context(|| format!("decode '{}'", path.display()))?;
+            out.push((state, blob));
+        }
+        Ok(out)
+    }
+
+    /// `<heddle_dir>/visibility/` — root of the per-state visibility store.
+    pub(crate) fn state_visibility_dir(&self) -> PathBuf {
+        self.heddle_dir().join("visibility")
+    }
+
+    /// `<heddle_dir>/visibility/<change-id>.bin` — the visibility sidecar
+    /// for a specific state.
+    pub(crate) fn state_visibility_path_for_state(&self, state: &ChangeId) -> PathBuf {
+        self.state_visibility_dir()
+            .join(format!("{}.bin", state.to_string_full()))
+    }
+}
+
+/// Content hash of a single visibility record. The hash covers the
+/// rmp-encoded bytes of a one-element [`StateVisibilityBlob`], so the id
+/// format is stable across schema additions that extend the container.
+fn state_visibility_content_hash(record: &StateVisibility) -> Result<ContentHash> {
+    let single = StateVisibilityBlob::new(vec![record.clone()]);
+    let bytes = single
+        .encode()
+        .with_context(|| "encode single state-visibility for content addressing")?;
+    let digest = blake3::hash(&bytes);
+    Ok(ContentHash::from_bytes(*digest.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use objects::object::{Principal, VisibilityTier};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn fresh_repo() -> (TempDir, Repository) {
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    fn sample_record(state: ChangeId, tier: VisibilityTier) -> StateVisibility {
+        StateVisibility {
+            state,
+            tier,
+            embargo_until: None,
+            declarer: Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            },
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap(),
+            signature: None,
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn put_then_read_back_and_has_visibility_true() {
+        let (_dir, repo) = fresh_repo();
+        let state = ChangeId::from_bytes([5u8; 16]);
+        let record = sample_record(
+            state,
+            VisibilityTier::Restricted {
+                scope_label: "security-embargo".into(),
+            },
+        );
+        repo.put_state_visibility(record.clone())
+            .expect("put visibility");
+
+        let stored = repo
+            .get_state_visibility_for_state(&state)
+            .expect("read back");
+        assert_eq!(stored.records.len(), 1);
+        assert_eq!(stored.records[0], record);
+        assert!(
+            repo.has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "a state with a persisted record must report has_visibility_for_state == true"
+        );
+    }
+
+    #[test]
+    fn absence_is_public_has_visibility_false() {
+        // The keystone: a state with no record resolves to public, so the
+        // query returns false. No file is written for the public tier.
+        let (_dir, repo) = fresh_repo();
+        let with_record = ChangeId::from_bytes([1u8; 16]);
+        repo.put_state_visibility(sample_record(with_record, VisibilityTier::Internal))
+            .expect("put visibility");
+
+        let no_record = ChangeId::from_bytes([2u8; 16]);
+        assert!(
+            !repo
+                .has_visibility_for_state(&no_record)
+                .expect("has visibility on record-free state"),
+            "a state with no record must be public-by-absence (has_visibility_for_state == false)"
+        );
+        // And its sidecar load is an empty blob, never an error.
+        assert!(
+            repo.get_state_visibility_for_state(&no_record)
+                .expect("read record-free state")
+                .records
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn put_is_idempotent_on_identical_record() {
+        let (_dir, repo) = fresh_repo();
+        let state = ChangeId::from_bytes([7u8; 16]);
+        let record = sample_record(state, VisibilityTier::Internal);
+        let id1 = repo.put_state_visibility(record.clone()).expect("put");
+        let id2 = repo.put_state_visibility(record).expect("re-put");
+        assert_eq!(id1, id2, "identical record must return the same id");
+
+        let stored = repo
+            .get_state_visibility_for_state(&state)
+            .expect("read back");
+        assert_eq!(
+            stored.records.len(),
+            1,
+            "idempotent put must not duplicate the record"
+        );
+    }
+
+    #[test]
+    fn distinct_records_on_same_state_accrete() {
+        // A promotion appends a superseding record; both live in the same
+        // per-state sidecar file.
+        let (_dir, repo) = fresh_repo();
+        let state = ChangeId::from_bytes([8u8; 16]);
+        let first = sample_record(
+            state,
+            VisibilityTier::Restricted {
+                scope_label: "embargo".into(),
+            },
+        );
+        let first_id = repo.put_state_visibility(first).expect("put first");
+        let second = StateVisibility {
+            tier: VisibilityTier::Internal,
+            declared_at: Utc.with_ymd_and_hms(2026, 6, 2, 9, 0, 0).unwrap(),
+            supersedes: Some(first_id),
+            ..sample_record(state, VisibilityTier::Internal)
+        };
+        repo.put_state_visibility(second).expect("put second");
+
+        let stored = repo
+            .get_state_visibility_for_state(&state)
+            .expect("read back");
+        assert_eq!(stored.records.len(), 2);
+        // `latest` resolves the effective tier by declared_at.
+        assert_eq!(stored.latest().unwrap().tier, VisibilityTier::Internal);
+    }
+
+    #[test]
+    fn list_all_returns_every_state_with_a_record() {
+        let (_dir, repo) = fresh_repo();
+        let a = ChangeId::from_bytes([10u8; 16]);
+        let b = ChangeId::from_bytes([11u8; 16]);
+        repo.put_state_visibility(sample_record(a, VisibilityTier::Internal))
+            .unwrap();
+        repo.put_state_visibility(sample_record(
+            b,
+            VisibilityTier::TeamScoped {
+                team_id: "infra".into(),
+            },
+        ))
+        .unwrap();
+
+        let mut listed: Vec<ChangeId> = repo
+            .list_all_state_visibility()
+            .expect("list all")
+            .into_iter()
+            .map(|(state, _)| state)
+            .collect();
+        listed.sort_by_key(|c| c.to_string_full());
+        let mut want = vec![a, b];
+        want.sort_by_key(|c| c.to_string_full());
+        assert_eq!(listed, want);
+    }
+}

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -59,6 +59,9 @@ impl Repository {
     /// prior private record — no caller can leave a Public record that makes
     /// a public state read as non-public.
     pub fn put_state_visibility(&self, record: StateVisibility) -> Result<ContentHash> {
+        record
+            .validate()
+            .with_context(|| "validate state-visibility record before put")?;
         let state = record.state;
 
         // Serialize the full read-modify-write behind the repo write lock so
@@ -105,6 +108,53 @@ impl Repository {
         }
         write_file_atomic(&path, &bytes).with_context(|| format!("write '{}'", path.display()))?;
         Ok(id)
+    }
+
+    /// Return the raw rmp-encoded `StateVisibilityBlob` bytes for the given
+    /// state, or `Ok(None)` if no sidecar exists. The bytes are the
+    /// wire-transfer payload, not a re-serialized view.
+    pub fn get_state_visibility_bytes_for_state(
+        &self,
+        state: &ChangeId,
+    ) -> Result<Option<Vec<u8>>> {
+        let path = self.state_visibility_path_for_state(state);
+        match fs::read(&path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err).with_context(|| format!("read '{}'", path.display())),
+        }
+    }
+
+    /// Accept a wire-transferred `StateVisibilityBlob` for a specific state.
+    /// The payload must decode, every contained record must target `state`,
+    /// and each record is persisted through `put_state_visibility` so
+    /// validation and public-by-absence normalization run at the same
+    /// boundary as local writes.
+    pub fn accept_wire_state_visibility(&self, state: ChangeId, bytes: &[u8]) -> Result<()> {
+        let incoming = StateVisibilityBlob::decode(bytes).with_context(|| {
+            format!(
+                "decode incoming state visibility for state {}",
+                state.to_string_full()
+            )
+        })?;
+
+        for record in &incoming.records {
+            if record.state != state {
+                anyhow::bail!(
+                    "incoming state visibility claims state {} but was transferred under {}",
+                    record.state.to_string_full(),
+                    state.to_string_full()
+                );
+            }
+            record
+                .validate()
+                .with_context(|| "validate incoming state-visibility record")?;
+        }
+
+        for record in incoming.records {
+            self.put_state_visibility(record)?;
+        }
+        Ok(())
     }
 
     /// Load all visibility records targeting `state`. Returns an empty
@@ -246,6 +296,66 @@ mod tests {
                 .expect("has visibility"),
             "a state with a persisted record must report has_visibility_for_state == true"
         );
+    }
+
+    #[test]
+    fn put_rejects_invalid_records_before_persisting_and_round_trips_valid_record() {
+        let (_dir, repo) = fresh_repo();
+        let team_state = ChangeId::from_bytes([31u8; 16]);
+        let restricted_state = ChangeId::from_bytes([32u8; 16]);
+
+        let empty_team = sample_record(
+            team_state,
+            VisibilityTier::TeamScoped {
+                team_id: String::new(),
+            },
+        );
+        let team_err = repo
+            .put_state_visibility(empty_team)
+            .expect_err("empty team id must be rejected");
+        let team_err_chain = format!("{team_err:#}");
+        assert!(
+            team_err_chain.contains("team_scoped"),
+            "unexpected error: {team_err}"
+        );
+        assert!(
+            !repo.state_visibility_path_for_state(&team_state).exists(),
+            "invalid team-scoped record must not persist a sidecar"
+        );
+
+        let empty_scope = sample_record(
+            restricted_state,
+            VisibilityTier::Restricted {
+                scope_label: " ".into(),
+            },
+        );
+        let scope_err = repo
+            .put_state_visibility(empty_scope)
+            .expect_err("empty restricted scope must be rejected");
+        let scope_err_chain = format!("{scope_err:#}");
+        assert!(
+            scope_err_chain.contains("restricted"),
+            "unexpected error: {scope_err}"
+        );
+        assert!(
+            !repo
+                .state_visibility_path_for_state(&restricted_state)
+                .exists(),
+            "invalid restricted record must not persist a sidecar"
+        );
+
+        let valid = sample_record(
+            restricted_state,
+            VisibilityTier::Restricted {
+                scope_label: "security-embargo".into(),
+            },
+        );
+        repo.put_state_visibility(valid.clone())
+            .expect("valid put must persist");
+        let stored = repo
+            .get_state_visibility_for_state(&restricted_state)
+            .expect("read valid record");
+        assert_eq!(stored.records, vec![valid]);
     }
 
     #[test]

--- a/crates/repo/src/visibility.rs
+++ b/crates/repo/src/visibility.rs
@@ -8,7 +8,7 @@
 //! footer can report a count and the web page can show "N annotations
 //! hidden by your audience tier".
 //!
-//! The mapping from [`AnnotationVisibility`] to [`AudienceTier`] is the
+//! The mapping from [`VisibilityTier`] to [`AudienceTier`] is the
 //! single source of truth for "who sees what":
 //!
 //! | annotation visibility    | shown to `Internal` | `Public` | `Team(X)`               | `Restricted` |
@@ -24,7 +24,7 @@
 
 use std::str::FromStr;
 
-use objects::object::{Annotation, AnnotationVisibility};
+use objects::object::{Annotation, VisibilityTier};
 
 /// Audience reading the annotation set. Matches the CLI's
 /// `--audience <internal|public|team:NAME>` flag and the web's payload-
@@ -131,10 +131,10 @@ pub fn filter_for_audience_with_drops<'a>(
             kept.push(ann);
         } else {
             match &ann.visibility {
-                AnnotationVisibility::Public => {}
-                AnnotationVisibility::Internal => drops.internal += 1,
-                AnnotationVisibility::TeamScoped { .. } => drops.team += 1,
-                AnnotationVisibility::Restricted { .. } => drops.restricted += 1,
+                VisibilityTier::Public => {}
+                VisibilityTier::Internal => drops.internal += 1,
+                VisibilityTier::TeamScoped { .. } => drops.team += 1,
+                VisibilityTier::Restricted { .. } => drops.restricted += 1,
             }
         }
     }
@@ -145,37 +145,37 @@ pub fn filter_for_audience_with_drops<'a>(
 /// out so the borrowing and dropping variants share the exact same
 /// rules — drift between them would be invisible at the call site and
 /// catastrophic for the bridge export footer.
-fn visible(visibility: &AnnotationVisibility, audience: &AudienceTier) -> bool {
+fn visible(visibility: &VisibilityTier, audience: &AudienceTier) -> bool {
     match (visibility, audience) {
         // Public is universally visible.
-        (AnnotationVisibility::Public, _) => true,
+        (VisibilityTier::Public, _) => true,
         // Internal sees everything (internal viewers are the trusted set).
         (_, AudienceTier::Internal) => true,
         // Internal annotations to a public/restricted viewer are hidden.
-        (AnnotationVisibility::Internal, AudienceTier::Public)
-        | (AnnotationVisibility::Internal, AudienceTier::Restricted(_)) => false,
+        (VisibilityTier::Internal, AudienceTier::Public)
+        | (VisibilityTier::Internal, AudienceTier::Restricted(_)) => false,
         // Internal annotations to a team viewer are visible — the team
         // is part of the workspace-internal trusted set. (Public-only
         // export still hides them via the previous arm.)
-        (AnnotationVisibility::Internal, AudienceTier::Team(_)) => true,
+        (VisibilityTier::Internal, AudienceTier::Team(_)) => true,
         // Team-scoped: visible only to that exact team.
-        (AnnotationVisibility::TeamScoped { team_id }, AudienceTier::Team(name)) => team_id == name,
-        (AnnotationVisibility::TeamScoped { .. }, _) => false,
+        (VisibilityTier::TeamScoped { team_id }, AudienceTier::Team(name)) => team_id == name,
+        (VisibilityTier::TeamScoped { .. }, _) => false,
         // Restricted: visible only to a viewer holding the matching label.
         (
-            AnnotationVisibility::Restricted { scope_label },
+            VisibilityTier::Restricted { scope_label },
             AudienceTier::Restricted(viewer_label),
         ) => scope_label == viewer_label,
-        (AnnotationVisibility::Restricted { .. }, _) => false,
+        (VisibilityTier::Restricted { .. }, _) => false,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use objects::object::{Annotation, AnnotationScope, AnnotationStatus, AnnotationVisibility};
+    use objects::object::{Annotation, AnnotationScope, AnnotationStatus, VisibilityTier};
 
-    fn ann(id: &str, vis: AnnotationVisibility) -> Annotation {
+    fn ann(id: &str, vis: VisibilityTier) -> Annotation {
         Annotation {
             annotation_id: id.into(),
             scope: AnnotationScope::File,
@@ -191,17 +191,17 @@ mod tests {
     #[test]
     fn public_audience_sees_only_public() {
         let anns = vec![
-            ann("a", AnnotationVisibility::Public),
-            ann("b", AnnotationVisibility::Internal),
+            ann("a", VisibilityTier::Public),
+            ann("b", VisibilityTier::Internal),
             ann(
                 "c",
-                AnnotationVisibility::TeamScoped {
+                VisibilityTier::TeamScoped {
                     team_id: "infra".into(),
                 },
             ),
             ann(
                 "d",
-                AnnotationVisibility::Restricted {
+                VisibilityTier::Restricted {
                     scope_label: "legal".into(),
                 },
             ),
@@ -222,11 +222,11 @@ mod tests {
     #[test]
     fn internal_audience_sees_everything() {
         let anns = vec![
-            ann("a", AnnotationVisibility::Public),
-            ann("b", AnnotationVisibility::Internal),
+            ann("a", VisibilityTier::Public),
+            ann("b", VisibilityTier::Internal),
             ann(
                 "c",
-                AnnotationVisibility::Restricted {
+                VisibilityTier::Restricted {
                     scope_label: "legal".into(),
                 },
             ),
@@ -241,18 +241,18 @@ mod tests {
         let anns = vec![
             ann(
                 "infra",
-                AnnotationVisibility::TeamScoped {
+                VisibilityTier::TeamScoped {
                     team_id: "infra".into(),
                 },
             ),
             ann(
                 "design",
-                AnnotationVisibility::TeamScoped {
+                VisibilityTier::TeamScoped {
                     team_id: "design".into(),
                 },
             ),
-            ann("public", AnnotationVisibility::Public),
-            ann("internal", AnnotationVisibility::Internal),
+            ann("public", VisibilityTier::Public),
+            ann("internal", VisibilityTier::Internal),
         ];
         let (kept, drops) =
             filter_for_audience_with_drops(&anns, &AudienceTier::Team("infra".into()));
@@ -270,18 +270,18 @@ mod tests {
         let anns = vec![
             ann(
                 "legal",
-                AnnotationVisibility::Restricted {
+                VisibilityTier::Restricted {
                     scope_label: "legal".into(),
                 },
             ),
             ann(
                 "security",
-                AnnotationVisibility::Restricted {
+                VisibilityTier::Restricted {
                     scope_label: "security".into(),
                 },
             ),
-            ann("public", AnnotationVisibility::Public),
-            ann("internal", AnnotationVisibility::Internal),
+            ann("public", VisibilityTier::Public),
+            ann("internal", VisibilityTier::Internal),
         ];
         let (kept, drops) =
             filter_for_audience_with_drops(&anns, &AudienceTier::Restricted("legal".into()));
@@ -319,8 +319,8 @@ mod tests {
     #[test]
     fn borrowing_filter_matches_drop_filter_kept_set() {
         let anns = vec![
-            ann("a", AnnotationVisibility::Public),
-            ann("b", AnnotationVisibility::Internal),
+            ann("a", VisibilityTier::Public),
+            ann("b", VisibilityTier::Internal),
         ];
         let kept_only = filter_for_audience(&anns, &AudienceTier::Public);
         let (kept_drops, _) = filter_for_audience_with_drops(&anns, &AudienceTier::Public);


### PR DESCRIPTION
Closes #315 (subsumes #320).

Foundational substrate for the commit-visibility-tiers epic E5 — the persisted per-state visibility record the serve-side gate (#4/#5), tier records (#3), and audience plumbing (#2) all key off. Implements spike #266 §5.1 (data model) and §O4 (shared-tier-vocabulary decision).

## What landed

### 1. `StateVisibility` / `StateVisibilityBlob` object (`crates/objects/src/object/state_visibility.rs`)
Modeled field-for-field on `Redaction`/`RedactionsBlob`, one level up (keyed by `ChangeId`/state, where redaction is keyed by a blob hash):

```rust
pub struct StateVisibility {
    pub state: ChangeId,
    pub tier: VisibilityTier,
    pub embargo_until: Option<DateTime<Utc>>,
    pub declarer: Principal,
    pub declared_at: DateTime<Utc>,
    pub signature: Option<StateSignature>,
    pub supersedes: Option<ContentHash>,
}
pub struct StateVisibilityBlob { pub format_version: u8, pub records: Vec<StateVisibility> }
```

- Versioned msgpack codec via the post-#514 `versioned_msgpack_blob!` macro (`new`/`encode`/`decode`/`validate`; `decode` rejects a wrong `format_version`).
- Canonical signing payload (`hd-statevis-v1`), additive supersede chain, `latest()` by `declared_at` (pure over persisted records, never wall-clock).
- `ObjectType::StateVisibility` registered (`crates/proto/src/object_graph.rs`). Keyed on the wire by `ObjectId::ChangeId`; like `Redaction` it is a sidecar — excluded from the content-addressed pack, ships via the per-object transfer path. All exhaustive `ObjectType` matches handled (`native_pack`, client `helpers`/`sync`, perf test).

### 2. Per-state `visibility/` sidecar store (`crates/repo/src/repository_state_visibility.rs`)
`<heddle_dir>/visibility/<change-id>.bin`, modeled on the redactions sidecar:
- `put_state_visibility` (content-addressed, idempotent), `get_state_visibility_for_state`, `has_visibility_for_state`, `list_all_state_visibility`.
- **Absence ≡ public**: no record is written for the public tier, and `has_visibility_for_state` returns `false` when none exists.

### 3. `AnnotationVisibility` → shared `VisibilityTier` (subsumes #320)
Per the 2026-06-02 maintainer decision, the #320 unification lands here. One shared enum (`crates/objects/src/object/visibility_tier.rs`) across annotations, discussions, **and** states — same 4 variants (`Public`/`Internal`/`TeamScoped`/`Restricted`), same `visible()` table, same wire/storage strings. Every call site migrated in place (annotations, discussions, namespace policy, daemon discussion RPC, anchor-travel, claude-hook) — **no parallel-enum compat shim**. Behavior is identical; the strictest `Private` tier + its `visible()` arm are deferred to the serve-gate work (#316–#319), keeping this change behavior-preserving.

## Test plan
- `StateVisibilityBlob`: encode→decode round-trip (incl. embargo + supersedes), decode rejects a wrong format version, validate rejects empty tier labels, signing-payload versioning, `latest()`.
- Sidecar: write→read-back + `has_visibility_for_state == true`; record-free state → `has_visibility_for_state == false` (absence ≡ public); idempotent put; accreting supersede records; `list_all`.
- `VisibilityTier` unification: existing annotation + discussion visibility tests pass unchanged with the shared enum.

## Gates (all green, `--locked`, features `git-overlay,native,semantic,zstd`)
- `cargo test --workspace` — 79 suites ok, 0 failed (doctests included).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `scripts/check-no-silent-default-tree-load.sh` — clean (541 files).
- `heddle doctor docs --all` — no drift (57 files). No object-format snapshot affected (agent-API schema does not enumerate object types / tiers), so no re-bless needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783176458&installation_id=132405951&pr_number=523&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F523&signature=c4328f0dad378884da66d1cd8bdac45713966544649c6dbe81a5a4de06c250db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->