### PR TITLE
feat(cli): --output json-compact decision-surface projection (#470)

### DIFF
--- a/crates/cli/src/cli/cli_args/cli_base.rs
+++ b/crates/cli/src/cli/cli_args/cli_base.rs
@@ -48,9 +48,12 @@ pub struct Cli {
     pub command: Commands,
 
     /// Output format. Default is `text`. Pass `--output json` for the
-    /// machine contract (stable `output_kind`, exit codes, recovery
-    /// templates). No TTY/pipe auto-detection — the default never
-    /// switches under you.
+    /// full machine contract (stable `output_kind`, exit codes, recovery
+    /// templates), or `--output json-compact` for the decision surface
+    /// only (`output_kind`, `status`/`coordination_status`, `blockers`,
+    /// `next_action`, `changed_paths`, `conflicts`) — fewer tokens, same
+    /// `output_kind` so callers can still dispatch. No TTY/pipe
+    /// auto-detection — the default never switches under you.
     #[arg(long, global = true, value_enum)]
     pub output: Option<OutputMode>,
 
@@ -101,8 +104,11 @@ impl Cli {
     }
 }
 
-#[derive(Copy, Clone, Debug, ValueEnum)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum OutputMode {
     Json,
+    /// JSON, but only the decision-surface fields (heddle#470). Renders
+    /// as `--output json-compact` on the CLI.
+    JsonCompact,
     Text,
 }

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -302,6 +302,23 @@ impl RecoveryAdvice {
         }
     }
 
+    pub fn json_compact_unsupported(command: &str) -> Self {
+        Self {
+            kind: "json_compact_unsupported",
+            error: format!("--output json-compact is not supported by `heddle {command}`"),
+            hint: "Use `--output json` for the full machine contract, or choose a command that exposes a compact decision surface.".to_string(),
+            unsafe_condition: "the command has no compact decision-surface projection".to_string(),
+            would_change: "falling back to the full JSON contract would leak non-decision-surface fields under json-compact".to_string(),
+            preserved: "no command body was executed".to_string(),
+            primary_command: format!("heddle {command} --output json"),
+            recovery_commands: vec![
+                format!("heddle {command} --output json"),
+                "heddle commands --output json".to_string(),
+            ],
+            extra_json_fields: Map::new(),
+        }
+    }
+
     pub(crate) fn machine_contract_drift(
         error: impl Into<String>,
         unsafe_condition: impl Into<String>,

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -5274,7 +5274,7 @@ mod tests {
             .iter()
             .find(|option| option.long.as_deref() == Some("output"))
             .expect("global --output should be included in command options");
-        assert_eq!(output.possible_values, vec!["json", "text"]);
+        assert_eq!(output.possible_values, vec!["json", "json-compact", "text"]);
         for command in &catalog.commands {
             assert!(
                 !command

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -262,6 +262,7 @@ impl CommandCatalogOutput {
 #[derive(Debug, Clone, Copy)]
 struct CommandContract {
     supports_json: bool,
+    supports_json_compact: bool,
     mutates: bool,
     supports_op_id: bool,
     persists_op_id: bool,
@@ -325,6 +326,7 @@ pub struct CommandRuntimeContract {
     pub path: Vec<&'static str>,
     pub display: String,
     pub supports_json: bool,
+    pub supports_json_compact: bool,
     pub supports_op_id: bool,
     pub persists_op_id: bool,
     pub uses_bootstrap_op_id_store: bool,
@@ -664,6 +666,7 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
 
 const READ_JSON: CommandContract = CommandContract {
     supports_json: true,
+    supports_json_compact: false,
     mutates: false,
     supports_op_id: false,
     persists_op_id: false,
@@ -752,6 +755,13 @@ const INIT: CommandContract = CommandContract {
 };
 
 const CAPTURE: CommandContract = CommandContract { ..MUTATING };
+
+const fn compact_json(contract: CommandContract) -> CommandContract {
+    CommandContract {
+        supports_json_compact: true,
+        ..contract
+    }
+}
 
 const WORKTREE_MUTATION: CommandContract = CommandContract {
     may_write_worktree: true,
@@ -998,7 +1008,10 @@ const fn advertised_action(
 }
 
 const CONTRACTS: &[CommandContractEntry] = &[
-    entry(&["abort"], documented_schemas(MUTATING, &["abort"])),
+    entry(
+        &["abort"],
+        documented_schemas(compact_json(MUTATING), &["abort"]),
+    ),
     entry(
         &["adopt"],
         front_door(
@@ -1266,7 +1279,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["capture"],
         json_discriminators(
-            documented_schemas(CAPTURE, &["capture"]),
+            documented_schemas(compact_json(CAPTURE), &["capture"]),
             &[json_discriminator(
                 Some("capture"),
                 "output_kind",
@@ -1401,7 +1414,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["conflict", "show"],
         opaque_schemas(READ_JSON, &["conflict show"]),
     ),
-    entry(&["continue"], documented_schemas(MUTATING, &["continue"])),
+    entry(
+        &["continue"],
+        documented_schemas(compact_json(MUTATING), &["continue"]),
+    ),
     entry(&["context"], GROUP),
     entry(
         &["context", "set"],
@@ -1784,7 +1800,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         exits(
             surface(
                 advertised_action(
-                    documented_schemas(WORKTREE_MUTATION, &["merge --preview"]),
+                    documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
                     "heddle merge <thread> --preview",
                     &["heddle", "merge", "<thread>", "--preview"],
                     &["thread"],
@@ -1917,7 +1933,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["query"], documented_schemas(READ_JSON, &["query"])),
     entry(
         &["ready"],
-        front_door(documented_schemas(CAPTURE, &["ready"]), 50),
+        front_door(documented_schemas(compact_json(CAPTURE), &["ready"]), 50),
     ),
     entry(&["rebase"], opaque_schemas(WORKTREE_MUTATION, &["rebase"])),
     entry(&["redact"], GROUP),
@@ -2140,7 +2156,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
                 CommandContract {
                     writes_git_refs: true,
                     network_io: true,
-                    ..MUTATING
+                    ..compact_json(MUTATING)
                 },
                 &["land"],
             ),
@@ -2250,7 +2266,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         exits(
             front_door(
                 json_discriminators(
-                    documented_schemas(READ_JSON_OR_JSONL, &["status"]),
+                    documented_schemas(compact_json(READ_JSON_OR_JSONL), &["status"]),
                     &[json_discriminator(Some("status"), "output_kind", "status")],
                 ),
                 10,
@@ -2275,7 +2291,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "thread switch",
         ),
     ),
-    entry(&["sync"], documented_schemas(MUTATING, &["sync"])),
+    entry(
+        &["sync"],
+        documented_schemas(compact_json(MUTATING), &["sync"]),
+    ),
     entry(&["thread"], surface(GROUP, "native")),
     entry(
         &["thread", "create"],
@@ -3279,6 +3298,7 @@ fn runtime_contract(
         path: path.to_vec(),
         display: path.join(" "),
         supports_json: contract.supports_json,
+        supports_json_compact: contract.supports_json_compact,
         supports_op_id: contract.supports_op_id,
         persists_op_id: contract.persists_op_id,
         uses_bootstrap_op_id_store: uses_bootstrap_op_id_store(contract),
@@ -4787,6 +4807,68 @@ mod tests {
             );
             assert_eq!(runtime.display, expected.path.join(" "));
             assert_eq!(runtime.display, command_path(&cli.command).join(" "));
+        }
+    }
+
+    #[test]
+    fn json_compact_runtime_contract_is_projection_or_rejection() {
+        let expected_compact = BTreeSet::from([
+            "abort".to_string(),
+            "capture".to_string(),
+            "continue".to_string(),
+            "land".to_string(),
+            "merge".to_string(),
+            "ready".to_string(),
+            "status".to_string(),
+            "sync".to_string(),
+        ]);
+        let actual_compact = active_command_contract_entries()
+            .iter()
+            .filter(|entry| entry.contract.supports_json_compact)
+            .map(|entry| entry.path.join(" "))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(actual_compact, expected_compact);
+
+        let json_output_commands = active_command_contract_entries()
+            .iter()
+            .filter(|entry| entry.contract.supports_json)
+            .map(|entry| entry.path.join(" "))
+            .collect::<BTreeSet<_>>();
+        let compact_rejections = active_command_contract_entries()
+            .iter()
+            .filter(|entry| entry.contract.supports_json && !entry.contract.supports_json_compact)
+            .map(|entry| entry.path.join(" "))
+            .collect::<BTreeSet<_>>();
+        let classified_commands = actual_compact
+            .union(&compact_rejections)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            classified_commands, json_output_commands,
+            "every JSON-output command must either project json-compact or reject it before execution"
+        );
+        assert!(
+            compact_rejections.contains("commands"),
+            "the harness must include commands that accept --output json but reject json-compact"
+        );
+
+        for sample in RUNTIME_CONTRACT_PARSE_SAMPLES {
+            let mut argv = vec!["heddle", "--output", "json-compact"];
+            argv.extend_from_slice(sample.argv_tail);
+            let cli = Cli::try_parse_from(argv.clone())
+                .unwrap_or_else(|err| panic!("failed to parse sample {argv:?}: {err}"));
+            let runtime = command_runtime_contract_for_command(&cli.command);
+            assert!(
+                runtime.supports_json_compact
+                    || !expected_compact.contains(&runtime.display),
+                "`{}` accepts json-compact at parse time but lacks an explicit compact projection; main must reject it before command execution",
+                runtime.display
+            );
+            assert!(
+                runtime.supports_json || !runtime.supports_json_compact,
+                "`{}` cannot support json-compact without supporting json",
+                runtime.display
+            );
         }
     }
 

--- a/crates/cli/src/cli/commands/compact.rs
+++ b/crates/cli/src/cli/commands/compact.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Compact JSON projection for `--output json-compact` (heddle#470).
+//!
+//! `--output json` is the full machine contract. An agent driving
+//! Heddle only acts on a handful of those fields — `output_kind`,
+//! `status`/`coordination_status`, `blockers`, `next_action`,
+//! `changed_paths`/`changed_path_count`, `conflicts`/`conflict_count`.
+//! Everything else is metadata it has to re-parse and discard.
+//!
+//! [`CompactOutput`] is the single shared shape that projection emits.
+//! [`CompactProjection`] is implemented by every full command output
+//! that has a decision surface; the operator family (`merge`, `ready`,
+//! `continue`, `abort`, `sync`, `land`) derives its core fields from the
+//! one shared [`OperatorCommandOutput`] projection so the compact shape
+//! stays in lockstep as the full envelope grows, rather than each verb
+//! hand-rolling its own subset.
+
+use serde::Serialize;
+
+use super::command_catalog::ActionTemplate;
+use super::thread::CoordinationStatus;
+
+/// The decision-surface projection emitted by `--output json-compact`.
+///
+/// Fields absent from a given command stay `None`/empty and are skipped
+/// on the wire, so a command only emits the axes it actually has.
+/// `output_kind` is always present so callers can still dispatch on the
+/// discriminator exactly as they do for the full contract.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CompactOutput {
+    pub output_kind: String,
+    /// Operator-command lifecycle status (`landed`, `blocked`, `noop`,
+    /// …). Mutually exclusive in practice with `coordination_status`,
+    /// which is `status`'s analogue.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coordination_status: Option<CoordinationStatus>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<String>,
+    /// Always serialized (even `null`) so callers have a stable field to
+    /// read the recommended next command from.
+    pub next_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action_template: Option<ActionTemplate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_paths: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_path_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conflicts: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conflict_count: Option<usize>,
+}
+
+impl CompactOutput {
+    pub(crate) fn new(output_kind: impl Into<String>) -> Self {
+        Self {
+            output_kind: output_kind.into(),
+            status: None,
+            coordination_status: None,
+            blockers: Vec::new(),
+            next_action: None,
+            next_action_template: None,
+            changed_paths: None,
+            changed_path_count: None,
+            conflicts: None,
+            conflict_count: None,
+        }
+    }
+}
+
+/// A full command output that can project down to the compact decision
+/// surface. Routing every compact-capable emit site through this trait
+/// (via [`super::next_action::write_command_json`]) is the chokepoint
+/// that keeps a new operator verb from silently shipping the full
+/// envelope under `--output json-compact`.
+pub(crate) trait CompactProjection {
+    fn compact(&self) -> CompactOutput;
+}

--- a/crates/cli/src/cli/commands/compact.rs
+++ b/crates/cli/src/cli/commands/compact.rs
@@ -16,9 +16,29 @@
 //! hand-rolling its own subset.
 
 use serde::Serialize;
+use serde_json::Value;
 
 use super::command_catalog::ActionTemplate;
 use super::thread::CoordinationStatus;
+
+const COMPACT_ALLOWED_KEYS: &[&str] = &[
+    "output_kind",
+    "status",
+    "coordination_status",
+    "blockers",
+    "next_action",
+    "next_action_template",
+    "changed_paths",
+    "changed_path_count",
+    "conflicts",
+    "conflict_count",
+];
+
+pub(crate) fn retain_compact_surface_fields(value: &mut Value) {
+    if let Some(object) = value.as_object_mut() {
+        object.retain(|key, _| COMPACT_ALLOWED_KEYS.contains(&key.as_str()));
+    }
+}
 
 /// The decision-surface projection emitted by `--output json-compact`.
 ///

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -33,7 +33,7 @@ use super::{
         override_trust_recommended_action, plain_git_mutation_preflight_advice,
         repository_verification_blocked_advice,
     },
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_full_command_json},
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
         preflight_large_capture_for_compat_commit, resolve_principal,
@@ -1186,7 +1186,7 @@ fn render_commit_compat(
     repository_capability: RepositoryCapability,
 ) -> Result<()> {
     if json {
-        write_validated_json_stdout(
+        write_full_command_json(
             output,
             NextActionValidationContext::new(&["commit"], repository_capability),
         )?;

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -27,7 +27,7 @@ use super::{
         override_trust_recommended_action,
         repository_verification_blocked_advice,
     },
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_command_json},
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
     ready_cmd::{worktree_dirty, worktree_dirty_paths},
     snapshot::ensure_current_state,
@@ -36,7 +36,7 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::{
-    cli::{Cli, should_output_json, style, worktree_status_options},
+    cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
     config::UserConfig,
 };
 
@@ -2481,10 +2481,22 @@ fn merge_preview_blocked_advice(output: &MergeOutput) -> RecoveryAdvice {
     advice
 }
 
+impl super::compact::CompactProjection for MergeOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        let mut compact = self.operator.compact();
+        compact.changed_paths = Some(self.changed_paths.clone());
+        compact.changed_path_count = Some(self.changed_path_count);
+        compact.conflicts = Some(self.conflicts.clone());
+        compact.conflict_count = Some(self.conflict_count);
+        compact
+    }
+}
+
 fn render_merge_output(cli: &Cli, repo: &Repository, output: MergeOutput) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_command_json(
             &output,
+            output_is_compact(cli),
             NextActionValidationContext::new(&["merge"], repo.capability()),
         )?;
     } else {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -17,6 +17,7 @@ mod clean;
 mod clone;
 mod collapse;
 mod command_catalog;
+mod compact;
 mod completion;
 mod conflict;
 mod context;

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -17,7 +17,7 @@ mod clean;
 mod clone;
 mod collapse;
 mod command_catalog;
-mod compact;
+pub(crate) mod compact;
 mod completion;
 mod conflict;
 mod context;

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -66,13 +66,22 @@ pub(crate) fn validated_json_string<T: Serialize>(
     Ok(encoded)
 }
 
-pub(crate) fn write_validated_json_stdout<T: Serialize>(
+fn write_validated_json_stdout<T: Serialize>(
     output: &T,
     context: NextActionValidationContext<'_>,
 ) -> Result<()> {
     let mut encoded = validated_json_string(output, context)?;
     encoded.push('\n');
     write_stdout(&encoded)
+}
+
+/// Emit a full command JSON contract after the runtime command gate has
+/// rejected `--output json-compact` for commands without a projection.
+pub(crate) fn write_full_command_json<T: Serialize>(
+    output: &T,
+    context: NextActionValidationContext<'_>,
+) -> Result<()> {
+    write_validated_json_stdout(output, context)
 }
 
 /// Emit a command's JSON, choosing the full contract or the compact

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -75,6 +75,27 @@ pub(crate) fn write_validated_json_stdout<T: Serialize>(
     write_stdout(&encoded)
 }
 
+/// Emit a command's JSON, choosing the full contract or the compact
+/// decision-surface projection (heddle#470). The `T: CompactProjection`
+/// bound is the chokepoint: any output routed through here is guaranteed
+/// to have a compact projection, so a new operator verb cannot silently
+/// ship the full envelope under `--output json-compact`. The compact
+/// payload is only built when `compact` is set.
+pub(crate) fn write_command_json<T>(
+    output: &T,
+    compact: bool,
+    context: NextActionValidationContext<'_>,
+) -> Result<()>
+where
+    T: Serialize + super::compact::CompactProjection,
+{
+    if compact {
+        write_validated_json_stdout(&output.compact(), context)
+    } else {
+        write_validated_json_stdout(output, context)
+    }
+}
+
 pub(crate) fn validate_next_actions_in_value(
     value: &Value,
     context: NextActionValidationContext<'_>,

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -189,6 +189,28 @@ fn normalized_action(action: Option<&str>) -> Option<&str> {
     action.filter(|action| !action.trim().is_empty())
 }
 
+impl super::compact::CompactProjection for OperatorCommandOutput {
+    /// The shared compact core for the whole operator family. `merge`,
+    /// `ready`, `continue`, `abort`, `sync`, and `land` all build their
+    /// compact projection from this so the decision surface stays in
+    /// lockstep with the embedded `OperatorCommandOutput`. Commands that
+    /// also carry changed-path / conflict axes layer those on top of the
+    /// returned value.
+    fn compact(&self) -> super::compact::CompactOutput {
+        // Prefer the validated `recommended_action`; fall back to
+        // `next_action`. Both are the same canonical breadcrumb in the
+        // full envelope — compact emits exactly one, as `next_action`.
+        let action = normalized_action(self.recommended_action.as_deref())
+            .or_else(|| normalized_action(self.next_action.as_deref()));
+        let mut compact = super::compact::CompactOutput::new(self.action.clone());
+        compact.status = Some(self.status.clone());
+        compact.blockers = self.blockers.clone();
+        compact.next_action = action.map(str::to_string);
+        compact.next_action_template = action.and_then(action_template);
+        compact
+    }
+}
+
 pub(crate) fn open_operator_repo_from_path(path: &Path) -> Result<Repository> {
     let cwd_repo = Repository::open(path)?;
     let target_path = cwd_repo.active_worktree_path()?;

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -6,8 +6,7 @@ use super::{
     action_line::print_next_step,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     next_action::{
-        NextActionInput, NextActionValidationContext, effective_next_action,
-        write_validated_json_stdout,
+        NextActionInput, NextActionValidationContext, effective_next_action, write_command_json,
     },
     operator_core::{
         OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
@@ -19,7 +18,7 @@ use super::{
 };
 use crate::{
     bridge::GitBridge,
-    cli::{Cli, cli_args::SyncArgs, should_output_json, style},
+    cli::{Cli, cli_args::SyncArgs, output_is_compact, should_output_json, style},
 };
 
 pub async fn cmd_continue(cli: &Cli) -> Result<()> {
@@ -153,8 +152,9 @@ fn emit(
     emitting_command: &[&str],
 ) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_command_json(
             &output,
+            output_is_compact(cli),
             NextActionValidationContext::new(emitting_command, repo.capability()),
         )?;
     } else {

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -19,8 +19,7 @@ use super::{
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},
     next_action::{
-        NextActionInput, NextActionValidationContext, effective_next_action,
-        write_validated_json_stdout,
+        NextActionInput, NextActionValidationContext, effective_next_action, write_command_json,
     },
     operator_core::{
         OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
@@ -31,7 +30,7 @@ use super::{
     thread_landing::land_local_command,
 };
 use crate::{
-    cli::{Cli, ReadyArgs, should_output_json, style, worktree_status_options},
+    cli::{Cli, ReadyArgs, output_is_compact, should_output_json, style, worktree_status_options},
     config::UserConfig,
 };
 
@@ -353,6 +352,7 @@ fn write_ready_output(cli: &Cli, repo: &Repository, output: &ReadyOutput) -> Res
     write_ready_output_inner(
         output,
         should_output_json(cli, Some(repo.config())),
+        output_is_compact(cli),
         NextActionValidationContext::new(&["ready"], repo.capability()),
     )
 }
@@ -361,17 +361,30 @@ fn write_ready_output_without_repo(cli: &Cli, output: &ReadyOutput) -> Result<()
     write_ready_output_inner(
         output,
         should_output_json(cli, None),
+        output_is_compact(cli),
         NextActionValidationContext::without_repo(&["ready"]),
     )
+}
+
+impl super::compact::CompactProjection for ReadyOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        let mut compact = self.operator.compact();
+        compact.changed_paths = Some(self.report.changed_paths.clone());
+        compact.changed_path_count = Some(self.report.changed_path_count);
+        compact.conflicts = Some(self.report.conflicts.clone());
+        compact.conflict_count = Some(self.report.conflict_count);
+        compact
+    }
 }
 
 fn write_ready_output_inner(
     output: &ReadyOutput,
     json: bool,
+    compact: bool,
     context: NextActionValidationContext<'_>,
 ) -> Result<()> {
     if json {
-        write_validated_json_stdout(output, context)?;
+        write_command_json(output, compact, context)?;
     } else {
         let missing_intent = ready_blocked_by_missing_intent(output);
         if !missing_intent {

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -28,14 +28,14 @@ use super::{
         build_repository_verification_state, git_overlay_mutation_preflight_advice,
         plain_git_mutation_preflight_advice, unimported_git_history_advice,
     },
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_command_json},
     thread::find_active_thread_entry,
     thread_cmd::current_thread,
 };
 use crate::{
     attribution::clean_attribution_value,
     bridge::GitBridge,
-    cli::{Cli, should_output_json, style},
+    cli::{Cli, output_is_compact, should_output_json, style},
     config::UserConfig,
 };
 
@@ -64,6 +64,29 @@ pub(crate) struct SnapshotOutput {
     pub recommended_action_template: Option<ActionTemplate>,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationState,
+}
+
+impl super::compact::CompactProjection for SnapshotOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        let mut compact = super::compact::CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        let action = self
+            .recommended_action
+            .as_ref()
+            .filter(|action| !action.trim().is_empty())
+            .map(|action| (action, &self.recommended_action_template))
+            .or_else(|| {
+                self.next_action
+                    .as_ref()
+                    .filter(|action| !action.trim().is_empty())
+                    .map(|action| (action, &self.next_action_template))
+            });
+        if let Some((action, template)) = action {
+            compact.next_action = Some(action.clone());
+            compact.next_action_template = template.clone();
+        }
+        compact
+    }
 }
 
 #[derive(Serialize)]
@@ -209,8 +232,9 @@ pub async fn cmd_snapshot(
     }
 
     if as_json {
-        write_validated_json_stdout(
+        write_command_json(
             &output,
+            output_is_compact(cli),
             NextActionValidationContext::new(&["capture"], repo.capability()),
         )?;
     } else {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -105,6 +105,8 @@ pub(crate) struct StatusOutput {
     promotion_suggested: bool,
     impact_categories: Vec<ThreadImpactCategory>,
     heavy_impact_paths: Vec<String>,
+    #[serde(skip)]
+    changed_paths: Vec<String>,
     changed_path_count: usize,
     worktree_changed_path_count: usize,
     thread_changed_path_count: usize,
@@ -589,6 +591,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             promotion_suggested: false,
             impact_categories: Vec::new(),
             heavy_impact_paths: Vec::new(),
+            changed_paths: changes_paths(&changes).into_iter().collect(),
             changed_path_count: 0,
             worktree_changed_path_count: changes_path_count(&changes),
             thread_changed_path_count: 0,
@@ -820,6 +823,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             .as_ref()
             .map(|thread| thread.heavy_impact_paths.clone())
             .unwrap_or_default(),
+        changed_paths: Vec::new(),
         changed_path_count: thread_summary
             .as_ref()
             .map(|thread| thread.changed_paths.len())
@@ -1036,6 +1040,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         // same thread/instant (heddle#306). The verification/dirty-worktree
         // blocker is a health signal, surfaced via `coordination_status` above.
         thread_state: output.thread_state,
+        changed_paths: changed_paths(thread_summary.as_ref(), &output.changes),
         changed_path_count: if trust.verified {
             changed_path_count(thread_summary.as_ref(), &output.changes)
         } else {
@@ -1102,6 +1107,7 @@ impl super::compact::CompactProjection for StatusOutput {
         compact.blockers = self.blockers.clone();
         compact.next_action = next_action;
         compact.next_action_template = next_action_template;
+        compact.changed_paths = Some(self.changed_paths.clone());
         compact.changed_path_count = Some(self.changed_path_count);
         compact
     }
@@ -1114,6 +1120,7 @@ impl super::compact::CompactProjection for PlainGitStatusOutput {
         let mut compact = super::compact::CompactOutput::new(self.output_kind);
         compact.next_action = next_action;
         compact.next_action_template = next_action_template;
+        compact.changed_paths = Some(changes_paths(&self.changes).into_iter().collect());
         compact.changed_path_count = Some(self.changed_path_count);
         compact
     }
@@ -1961,6 +1968,20 @@ fn changed_path_count(
     paths.extend(changes.added.iter().cloned());
     paths.extend(changes.deleted.iter().cloned());
     paths.len()
+}
+
+fn changed_paths(
+    thread: Option<&super::thread::ThreadSummary>,
+    changes: &ChangesInfo,
+) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+    if let Some(thread) = thread {
+        paths.extend(thread.changed_paths.iter().cloned());
+    }
+    paths.extend(changes.modified.iter().cloned());
+    paths.extend(changes.added.iter().cloned());
+    paths.extend(changes.deleted.iter().cloned());
+    paths.into_iter().collect()
 }
 
 fn changes_path_count(changes: &ChangesInfo) -> usize {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -592,7 +592,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             impact_categories: Vec::new(),
             heavy_impact_paths: Vec::new(),
             changed_paths: changes_paths(&changes).into_iter().collect(),
-            changed_path_count: 0,
+            changed_path_count: changes_path_count(&changes),
             worktree_changed_path_count: changes_path_count(&changes),
             thread_changed_path_count: 0,
             blockers: if trust.verified {
@@ -1108,7 +1108,7 @@ impl super::compact::CompactProjection for StatusOutput {
         compact.next_action = next_action;
         compact.next_action_template = next_action_template;
         compact.changed_paths = Some(self.changed_paths.clone());
-        compact.changed_path_count = Some(self.changed_path_count);
+        compact.changed_path_count = Some(self.changed_paths.len());
         compact
     }
 }
@@ -1117,11 +1117,12 @@ impl super::compact::CompactProjection for PlainGitStatusOutput {
     fn compact(&self) -> super::compact::CompactOutput {
         let (next_action, next_action_template) =
             compact_next_action(&self.recommended_action, &self.recommended_action_template);
+        let changed_paths: Vec<String> = changes_paths(&self.changes).into_iter().collect();
         let mut compact = super::compact::CompactOutput::new(self.output_kind);
         compact.next_action = next_action;
         compact.next_action_template = next_action_template;
-        compact.changed_paths = Some(changes_paths(&self.changes).into_iter().collect());
-        compact.changed_path_count = Some(self.changed_path_count);
+        compact.changed_path_count = Some(changed_paths.len());
+        compact.changed_paths = Some(changed_paths);
         compact
     }
 }

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -37,7 +37,7 @@ use super::{
         remote_tracking_with_verification_action, repository_setup_guidance,
         serialize_empty_action_as_null,
     },
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_command_json},
     operator_loop::primary_next_action_with_verification,
     snapshot::resolve_principal,
     thread::{
@@ -48,7 +48,7 @@ use super::{
 };
 use crate::{
     bridge::git_core::principal_is_default_unknown,
-    cli::{Cli, should_output_json, style, worktree_status_options},
+    cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
     config::UserConfig,
     perf::{ProfileField, emit_profile, profile_enabled},
 };
@@ -382,8 +382,9 @@ fn build_plain_git_status_probe(cli: &Cli) -> Result<Option<PlainGitStatusOutput
 
 fn render_plain_git_status(cli: &Cli, output: &PlainGitStatusOutput, short: bool) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_command_json(
             output,
+            output_is_compact(cli),
             NextActionValidationContext::without_repo(&["status"]),
         )?;
         return Ok(());
@@ -1078,11 +1079,52 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
     Ok(output)
 }
 
+/// Project a `recommended_action` String into the compact
+/// `next_action` (+ template) pair: an empty action is the contract's
+/// "no action" and maps to `None` so the template is dropped too.
+fn compact_next_action(
+    recommended_action: &str,
+    template: &Option<super::command_catalog::ActionTemplate>,
+) -> (Option<String>, Option<super::command_catalog::ActionTemplate>) {
+    if recommended_action.trim().is_empty() {
+        (None, None)
+    } else {
+        (Some(recommended_action.to_string()), template.clone())
+    }
+}
+
+impl super::compact::CompactProjection for StatusOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        let (next_action, next_action_template) =
+            compact_next_action(&self.recommended_action, &self.recommended_action_template);
+        let mut compact = super::compact::CompactOutput::new(self.output_kind);
+        compact.coordination_status = Some(self.coordination_status.clone());
+        compact.blockers = self.blockers.clone();
+        compact.next_action = next_action;
+        compact.next_action_template = next_action_template;
+        compact.changed_path_count = Some(self.changed_path_count);
+        compact
+    }
+}
+
+impl super::compact::CompactProjection for PlainGitStatusOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        let (next_action, next_action_template) =
+            compact_next_action(&self.recommended_action, &self.recommended_action_template);
+        let mut compact = super::compact::CompactOutput::new(self.output_kind);
+        compact.next_action = next_action;
+        compact.next_action_template = next_action_template;
+        compact.changed_path_count = Some(self.changed_path_count);
+        compact
+    }
+}
+
 pub(crate) fn render_status(cli: &Cli, output: &StatusOutput, short: bool) -> Result<()> {
     let render_start = Instant::now();
     if output.render_json {
-        write_validated_json_stdout(
+        write_command_json(
             output,
+            output_is_compact(cli),
             NextActionValidationContext::new(&["status"], output.validation_capability),
         )?;
     } else if short {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -39,7 +39,7 @@ use super::{
     next_action::{
         NextActionInput, NextActionValidationContext, effective_next_action,
         thread_recovery_action_is_primary as shared_thread_recovery_action_is_primary,
-        write_validated_json_stdout,
+        write_full_command_json,
     },
     operator_loop::{primary_next_action, primary_next_action_with_verification},
     snapshot::{ensure_current_state, summarize_confidence, summarize_verification},
@@ -1306,7 +1306,7 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
     };
 
     if as_json {
-        write_validated_json_stdout(
+        write_full_command_json(
             &output,
             NextActionValidationContext::new(&["thread", "list"], repo.capability()),
         )?;
@@ -2910,7 +2910,7 @@ pub(crate) fn show_thread_summary(
             recovery_commands: trust.recovery_commands.clone(),
             trust,
         };
-        write_validated_json_stdout(
+        write_full_command_json(
             &output,
             NextActionValidationContext::new(&["thread", "show"], repo.capability()),
         )?;

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2512,7 +2512,10 @@ pub(crate) fn cmd_thread_current(cli: &Cli, repo: &Repository) -> Result<()> {
     // stdout is piped — would be actively counterproductive here. Match
     // `thread cd` and emit plain text by default; only honor an
     // *explicit* request for JSON.
-    let explicit_json = matches!(cli.output, Some(crate::cli::OutputMode::Json));
+    let explicit_json = matches!(
+        cli.output,
+        Some(crate::cli::OutputMode::Json | crate::cli::OutputMode::JsonCompact)
+    );
     if explicit_json {
         #[derive(Serialize)]
         struct CurrentOutput<'a> {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -16,14 +16,17 @@ use super::{
     merge::merge_thread_into_current,
     operator_core::OperatorCommandOutput,
     operator_loop::primary_next_action,
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_command_json},
     ready_cmd::worktree_dirty,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread_cmd::{load_thread, refresh_thread, refresh_thread_freshness, thread_not_found_advice},
     thread_landing::{land_command_for_thread, land_command_with_push_target},
 };
 use crate::{
-    cli::{Cli, render::shell_quote, should_output_json, style, worktree_status_options},
+    cli::{
+        Cli, output_is_compact, render::shell_quote, should_output_json, style,
+        worktree_status_options,
+    },
     config::UserConfig,
 };
 
@@ -42,6 +45,12 @@ pub struct ThreadResolveOutput {
     #[serde(flatten)]
     pub operator: OperatorCommandOutput,
     pub thread: String,
+}
+
+impl super::compact::CompactProjection for ThreadResolveOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        <OperatorCommandOutput as super::compact::CompactProjection>::compact(&self.operator)
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -762,8 +771,9 @@ fn emit_thread_resolve(
     output: &ThreadResolveOutput,
 ) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_command_json(
             output,
+            output_is_compact(cli),
             NextActionValidationContext::new(&["thread", "resolve"], repo.capability()),
         )?;
     } else {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -22,14 +22,14 @@ use super::{
     thread_cmd::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
-    next_action::{NextActionValidationContext, write_validated_json_stdout},
+    next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
     thread_landing::{land_local_command, switch_thread_command},
 };
 use crate::{
     cli::{
         Cli, ThreadStartArgs, WorkspaceModeArg,
         cli_args::{DelegateArgs, LandArgs, SyncArgs},
-        should_output_json, style, worktree_status_options,
+        output_is_compact, should_output_json, style, worktree_status_options,
     },
     config::UserConfig,
 };
@@ -242,7 +242,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
         VerificationClaimPolicy::strict(),
     );
 
-    emit_with_next_action_validation(cli, &repo, &output, &["sync"])
+    write_sync_output(cli, &repo, &output)
 }
 
 pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
@@ -1443,7 +1443,7 @@ fn emit_with_next_action_validation<T: Serialize>(
     emitting_command: &[&str],
 ) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_full_command_json(
             output,
             NextActionValidationContext::new(emitting_command, repo.capability()),
         )
@@ -1451,6 +1451,31 @@ fn emit_with_next_action_validation<T: Serialize>(
         println!("{}", serde_json::to_string_pretty(output)?);
         Ok(())
     }
+}
+
+impl super::compact::CompactProjection for SyncOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        <OperatorCommandOutput as super::compact::CompactProjection>::compact(&self.operator)
+    }
+}
+
+impl super::compact::CompactProjection for LandOutput {
+    fn compact(&self) -> super::compact::CompactOutput {
+        <OperatorCommandOutput as super::compact::CompactProjection>::compact(&self.operator)
+    }
+}
+
+fn write_sync_output(cli: &Cli, repo: &Repository, output: &SyncOutput) -> Result<()> {
+    if should_output_json(cli, None) {
+        write_command_json(
+            output,
+            output_is_compact(cli),
+            NextActionValidationContext::new(&["sync"], repo.capability()),
+        )?;
+    } else {
+        println!("{}", serde_json::to_string_pretty(output)?);
+    }
+    Ok(())
 }
 
 fn non_empty_next_action(action: &str) -> Option<String> {
@@ -1491,8 +1516,9 @@ fn scoped_resolve_list_command(thread: &Thread) -> String {
 
 fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Result<()> {
     if should_output_json(cli, None) {
-        write_validated_json_stdout(
+        write_command_json(
             output,
+            output_is_compact(cli),
             NextActionValidationContext::new(&["land"], repo.capability()),
         )?;
     } else {

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -123,8 +123,9 @@ pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> 
             writeln!(
                 out,
                 "Output: text is the default; pass `--output json` for the \
-                 machine contract (stable `output_kind`, exit codes, recovery \
-                 templates). No TTY/pipe auto-detection."
+                 full machine contract (stable `output_kind`, exit codes, recovery \
+                 templates), or `--output json-compact` for the decision surface \
+                 only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection."
             )?;
             writeln!(out)?;
             writeln!(

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -83,12 +83,23 @@ pub fn should_output_json(cli: &Cli, config: Option<&Config>) -> bool {
 
     if let Some(output) = cli.output {
         format = match output {
-            OutputMode::Json => OutputFormat::Json,
+            // `json-compact` is still JSON output — it only narrows
+            // *which* fields are emitted (see `output_is_compact`).
+            OutputMode::Json | OutputMode::JsonCompact => OutputFormat::Json,
             OutputMode::Text => OutputFormat::Text,
         };
     }
 
     matches!(format, OutputFormat::Json)
+}
+
+/// Whether the caller asked for the compact decision-surface projection
+/// (`--output json-compact`, heddle#470). Compact is a CLI-only modifier
+/// on top of JSON output — it is never reachable from config
+/// (`output.format` is `json`/`text` only), so the full machine contract
+/// stays the default for piped/configured JSON.
+pub fn output_is_compact(cli: &Cli) -> bool {
+    matches!(cli.output, Some(OutputMode::JsonCompact))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -111,7 +122,10 @@ pub fn json_output_mode_for_kind(
 ) -> JsonOutputMode {
     match json_kind {
         "jsonl" => {
-            if matches!(cli.output, Some(OutputMode::Json)) {
+            // Stream-shaped commands (e.g. `watch`) have no compact
+            // projection; `json-compact` falls back to the full jsonl
+            // stream rather than silently downgrading to text.
+            if matches!(cli.output, Some(OutputMode::Json | OutputMode::JsonCompact)) {
                 JsonOutputMode::Jsonl
             } else {
                 JsonOutputMode::Text

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -244,6 +244,14 @@ async fn async_main() -> Result<()> {
         print_error_with_hint(&cli, &err);
         std::process::exit(HeddleExitCode::Usage.into());
     }
+    if cli::cli::output_is_compact(&cli) && !command_contract.supports_json_compact {
+        telemetry.shutdown();
+        let err = anyhow::anyhow!(
+            cli::cli::commands::RecoveryAdvice::json_compact_unsupported(&command_name)
+        );
+        print_error_with_hint(&cli, &err);
+        std::process::exit(HeddleExitCode::Usage.into());
+    }
 
     match run_local_idempotency_if_requested(&cli, &command_name, command_supports_op_id) {
         Ok(true) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1028,7 +1028,10 @@ fn global_arg_takes_value(arg: &Arg) -> bool {
 }
 
 fn explicit_json_requested(cli: &Cli) -> bool {
-    matches!(cli.output, Some(cli::cli::OutputMode::Json))
+    matches!(
+        cli.output,
+        Some(cli::cli::OutputMode::Json | cli::cli::OutputMode::JsonCompact)
+    )
 }
 
 fn is_plain_git_without_heddle(start: &std::path::Path) -> bool {

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -139,6 +139,7 @@ pub fn run_local_idempotency_if_requested(
                     command_name,
                     status: "replayed",
                     replayed: true,
+                    child_succeeded: replay.status_code == 0,
                     mode,
                 }),
             )?;
@@ -184,6 +185,7 @@ pub fn run_local_idempotency_if_requested(
                     command_name,
                     status: "executed",
                     replayed: false,
+                    child_succeeded: response.status_code == 0,
                     mode,
                 }),
             )?;
@@ -201,6 +203,7 @@ struct OpIdDisplayContext<'a> {
     command_name: &'a str,
     status: &'a str,
     replayed: bool,
+    child_succeeded: bool,
     mode: JsonDisplayMode,
 }
 
@@ -238,6 +241,9 @@ fn json_display_mode(cli: &Cli) -> Option<JsonDisplayMode> {
 fn decorate_json_stream(bytes: &[u8], context: OpIdDisplayContext) -> Result<Vec<u8>> {
     if bytes.is_empty() {
         return Ok(Vec::new());
+    }
+    if matches!(context.mode, JsonDisplayMode::Compact) && !context.child_succeeded {
+        return Ok(bytes.to_vec());
     }
     let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
         return Ok(bytes.to_vec());

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -120,7 +120,7 @@ pub fn run_local_idempotency_if_requested(
         repo_for_eager = Some(repo);
         store
     };
-    let json_mode = explicit_json_requested(cli);
+    let json_mode = json_display_mode(cli);
 
     let reserve_outcome = if let Some(repo) = repo_for_eager.as_ref() {
         reserve_operation_id_eager(repo, Arc::clone(&store), op_id, command_name, request_hash)?
@@ -134,11 +134,12 @@ pub fn run_local_idempotency_if_requested(
                 serde_json::from_slice(&response).context("decode cached op-id response")?;
             replay_response(
                 &replay,
-                json_mode.then_some(OpIdDisplayContext {
+                json_mode.map(|mode| OpIdDisplayContext {
                     op_id: &op_id,
                     command_name,
                     status: "replayed",
                     replayed: true,
+                    mode,
                 }),
             )?;
             if replay.status_code != 0 {
@@ -178,11 +179,12 @@ pub fn run_local_idempotency_if_requested(
             store.record(op_id, command_name, request_hash, encoded)?;
             replay_response(
                 &response,
-                json_mode.then_some(OpIdDisplayContext {
+                json_mode.map(|mode| OpIdDisplayContext {
                     op_id: &op_id,
                     command_name,
                     status: "executed",
                     replayed: false,
+                    mode,
                 }),
             )?;
             if response.status_code != 0 {
@@ -199,6 +201,7 @@ struct OpIdDisplayContext<'a> {
     command_name: &'a str,
     status: &'a str,
     replayed: bool,
+    mode: JsonDisplayMode,
 }
 
 fn replay_response(
@@ -218,8 +221,18 @@ fn replay_response(
     Ok(())
 }
 
-fn explicit_json_requested(cli: &Cli) -> bool {
-    matches!(cli.output, Some(OutputMode::Json | OutputMode::JsonCompact))
+#[derive(Clone, Copy)]
+enum JsonDisplayMode {
+    Full,
+    Compact,
+}
+
+fn json_display_mode(cli: &Cli) -> Option<JsonDisplayMode> {
+    match cli.output {
+        Some(OutputMode::Json) => Some(JsonDisplayMode::Full),
+        Some(OutputMode::JsonCompact) => Some(JsonDisplayMode::Compact),
+        _ => None,
+    }
 }
 
 fn decorate_json_stream(bytes: &[u8], context: OpIdDisplayContext) -> Result<Vec<u8>> {
@@ -232,6 +245,12 @@ fn decorate_json_stream(bytes: &[u8], context: OpIdDisplayContext) -> Result<Vec
     let Some(object) = value.as_object_mut() else {
         return Ok(bytes.to_vec());
     };
+    if matches!(context.mode, JsonDisplayMode::Compact) {
+        crate::cli::commands::compact::retain_compact_surface_fields(&mut value);
+        let mut compact = serde_json::to_vec(&value)?;
+        compact.push(b'\n');
+        return Ok(compact);
+    }
     let op_id = context.op_id.to_string();
     object.insert(
         "op_id".to_string(),

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -219,7 +219,7 @@ fn replay_response(
 }
 
 fn explicit_json_requested(cli: &Cli) -> bool {
-    matches!(cli.output, Some(OutputMode::Json))
+    matches!(cli.output, Some(OutputMode::Json | OutputMode::JsonCompact))
 }
 
 fn decorate_json_stream(bytes: &[u8], context: OpIdDisplayContext) -> Result<Vec<u8>> {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -28,6 +28,8 @@ mod bridge;
 mod cli_help_consistency;
 #[path = "cli_integration/cli_premium_output.rs"]
 mod cli_premium_output;
+#[path = "cli_integration/compact_output.rs"]
+mod compact_output;
 #[path = "cli_integration/context_recovery_advice.rs"]
 mod context_recovery_advice;
 #[path = "cli_integration/current_context_advice.rs"]

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `--output json-compact` projects the decision surface only.
+//!
+//! heddle#470: `--output json` is the full machine contract — great for
+//! machines, but extremely noisy for an agent driving Heddle, where the
+//! actionable surface is just `output_kind`, `status`/`coordination_status`,
+//! `blockers`, `next_action`, `changed_paths`/`changed_path_count`, and
+//! `conflicts`/`conflict_count`. `--output json-compact` emits ONLY those
+//! fields; the full `--output json` contract is unchanged.
+
+use std::str;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{heddle, heddle_output};
+
+/// Every key the compact decision surface is allowed to emit. Any key
+/// outside this set leaking into a compact payload is a regression —
+/// the whole point of the mode is that the surface stays small as the
+/// full envelope grows.
+const COMPACT_ALLOWED_KEYS: &[&str] = &[
+    "output_kind",
+    "status",
+    "coordination_status",
+    "blockers",
+    "next_action",
+    "next_action_template",
+    "changed_paths",
+    "changed_path_count",
+    "conflicts",
+    "conflict_count",
+];
+
+fn assert_only_compact_keys(value: &Value, context: &str) {
+    let obj = value
+        .as_object()
+        .unwrap_or_else(|| panic!("{context}: compact payload must be a JSON object: {value}"));
+    for key in obj.keys() {
+        assert!(
+            COMPACT_ALLOWED_KEYS.contains(&key.as_str()),
+            "{context}: compact payload leaked non-decision-surface key `{key}`: {value}"
+        );
+    }
+}
+
+fn compact_json(args: &[&str], temp: &TempDir) -> Value {
+    let mut argv: Vec<&str> = vec!["--output", "json-compact"];
+    argv.extend(args.iter().copied());
+    let out =
+        heddle_output(&argv, Some(temp.path())).unwrap_or_else(|err| panic!("spawn failed: {err}"));
+    let stdout = str::from_utf8(&out.stdout).expect("stdout utf8");
+    let line = stdout
+        .lines()
+        .next()
+        .unwrap_or_else(|| panic!("heddle {argv:?} produced no stdout; stderr={}", String::from_utf8_lossy(&out.stderr)));
+    serde_json::from_str(line)
+        .unwrap_or_else(|err| panic!("heddle {argv:?} stdout not JSON: {err}\n  line: {line}"))
+}
+
+fn full_json(args: &[&str], temp: &TempDir) -> Value {
+    let mut argv: Vec<&str> = vec!["--output", "json"];
+    argv.extend(args.iter().copied());
+    let stdout = heddle(&argv, Some(temp.path())).unwrap_or_else(|err| panic!("heddle {argv:?} failed: {err}"));
+    let line = stdout.lines().next().expect("full json stdout");
+    serde_json::from_str(line).expect("full json parses")
+}
+
+#[test]
+fn status_compact_emits_only_decision_surface() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+
+    let compact = compact_json(&["status"], &temp);
+    assert_eq!(
+        compact["output_kind"].as_str(),
+        Some("status"),
+        "compact status must carry output_kind: {compact}"
+    );
+    assert!(
+        compact.get("coordination_status").is_some(),
+        "compact status must carry coordination_status: {compact}"
+    );
+    assert!(
+        compact.get("changed_path_count").is_some(),
+        "compact status must carry changed_path_count: {compact}"
+    );
+    assert_only_compact_keys(&compact, "status");
+
+    // Contrast: the full contract still carries the noisy metadata the
+    // compact projection drops.
+    let full = full_json(&["status"], &temp);
+    assert!(
+        full.get("git_overlay_health").is_some() && full.get("verification").is_some(),
+        "full status must keep the metadata compact drops: {full}"
+    );
+    assert!(
+        compact.get("git_overlay_health").is_none() && compact.get("verification").is_none(),
+        "compact status must drop git_overlay_health/verification: {compact}"
+    );
+}
+
+#[test]
+fn continue_compact_drops_operator_metadata() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+
+    let compact = compact_json(&["continue"], &temp);
+    assert_eq!(compact["output_kind"].as_str(), Some("continue"));
+    assert_eq!(compact["status"].as_str(), Some("noop"));
+    assert_only_compact_keys(&compact, "continue");
+
+    // The full operator envelope carries `message`, `action`, and
+    // `recommended_action`; compact keeps only `next_action`.
+    let full = full_json(&["continue"], &temp);
+    assert!(full.get("message").is_some() && full.get("action").is_some());
+    assert!(
+        compact.get("message").is_none() && compact.get("action").is_none()
+            && compact.get("recommended_action").is_none(),
+        "compact continue must drop message/action/recommended_action: {compact}"
+    );
+}
+
+#[test]
+fn json_compact_is_a_valid_output_value() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    let out = heddle_output(&["--output", "json-compact", "status"], Some(temp.path()))
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "--output json-compact must parse and run: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -58,6 +58,24 @@ fn compact_json(args: &[&str], temp: &TempDir) -> Value {
         .unwrap_or_else(|err| panic!("heddle {argv:?} stdout not JSON: {err}\n  line: {line}"))
 }
 
+fn compact_json_output(args: &[&str], temp: &TempDir) -> Value {
+    let out =
+        heddle_output(args, Some(temp.path())).unwrap_or_else(|err| panic!("spawn failed: {err}"));
+    assert!(
+        out.status.success(),
+        "heddle {args:?} should succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = str::from_utf8(&out.stdout).expect("stdout utf8");
+    let line = stdout
+        .lines()
+        .next()
+        .unwrap_or_else(|| panic!("heddle {args:?} produced no stdout"));
+    serde_json::from_str(line)
+        .unwrap_or_else(|err| panic!("heddle {args:?} stdout not JSON: {err}\n  line: {line}"))
+}
+
 fn full_json(args: &[&str], temp: &TempDir) -> Value {
     let mut argv: Vec<&str> = vec!["--output", "json"];
     argv.extend(args.iter().copied());
@@ -101,6 +119,70 @@ fn status_compact_emits_only_decision_surface() {
     assert!(
         compact.get("git_overlay_health").is_none() && compact.get("verification").is_none(),
         "compact status must drop git_overlay_health/verification: {compact}"
+    );
+}
+
+#[test]
+fn status_compact_keeps_uncaptured_changed_path_count_consistent() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    std::fs::write(temp.path().join("work.txt"), "pending\n").unwrap();
+
+    let compact = compact_json(&["status"], &temp);
+    let changed_paths = compact["changed_paths"]
+        .as_array()
+        .unwrap_or_else(|| panic!("compact status must carry changed_paths: {compact}"));
+    assert_eq!(
+        compact["changed_path_count"].as_u64(),
+        Some(changed_paths.len() as u64),
+        "compact status count must match changed_paths in a dirty uncaptured repo: {compact}"
+    );
+    assert_eq!(
+        changed_paths.as_slice(),
+        [Value::String("work.txt".to_string())],
+        "dirty uncaptured repo should report the pending worktree path: {compact}"
+    );
+    assert_only_compact_keys(&compact, "dirty uncaptured status");
+}
+
+#[test]
+fn capture_op_id_compact_replay_emits_only_decision_surface() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    std::fs::write(temp.path().join("work.txt"), "pending\n").unwrap();
+    let op_id = "550e8400-e29b-41d4-a716-446655440470";
+    let args = [
+        "--output",
+        "json-compact",
+        "--op-id",
+        op_id,
+        "capture",
+        "-m",
+        "compact op-id capture",
+    ];
+
+    let first = compact_json_output(&args, &temp);
+    assert_only_compact_keys(&first, "capture op-id executed");
+    assert!(
+        first.get("operation_record").is_none()
+            && first.get("op_id").is_none()
+            && first.get("idempotency_status").is_none()
+            && first.get("replayed").is_none(),
+        "compact executed op-id output must not leak idempotency fields: {first}"
+    );
+
+    let replayed = compact_json_output(&args, &temp);
+    assert_only_compact_keys(&replayed, "capture op-id replayed");
+    assert_eq!(
+        replayed, first,
+        "compact op-id replay should return the cached compact payload without wrapper decoration"
+    );
+    assert!(
+        replayed.get("operation_record").is_none()
+            && replayed.get("op_id").is_none()
+            && replayed.get("idempotency_status").is_none()
+            && replayed.get("replayed").is_none(),
+        "compact replayed op-id output must not leak idempotency fields: {replayed}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -76,12 +76,54 @@ fn compact_json_output(args: &[&str], temp: &TempDir) -> Value {
         .unwrap_or_else(|err| panic!("heddle {args:?} stdout not JSON: {err}\n  line: {line}"))
 }
 
+fn assert_compact_op_id_error_envelope(args: &[&str], temp: &TempDir, context: &str) -> Value {
+    let out =
+        heddle_output(args, Some(temp.path())).unwrap_or_else(|err| panic!("spawn failed: {err}"));
+    assert!(
+        !out.status.success(),
+        "{context}: heddle {args:?} should fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "{context}: failed compact op-id command should not emit stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = str::from_utf8(&out.stderr).expect("stderr utf8");
+    let envelope: Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|err| panic!("{context}: stderr not JSON: {err}\n  stderr: {stderr}"));
+    for key in ["code", "error", "exit_code", "hint"] {
+        assert!(
+            envelope.get(key).is_some(),
+            "{context}: compact op-id failure stripped `{key}` from error envelope: {envelope}"
+        );
+    }
+    envelope
+}
+
 fn full_json(args: &[&str], temp: &TempDir) -> Value {
     let mut argv: Vec<&str> = vec!["--output", "json"];
     argv.extend(args.iter().copied());
     let stdout = heddle(&argv, Some(temp.path())).unwrap_or_else(|err| panic!("heddle {argv:?} failed: {err}"));
     let line = stdout.lines().next().expect("full json stdout");
     serde_json::from_str(line).expect("full json parses")
+}
+
+#[test]
+fn capture_op_id_compact_failure_preserves_error_envelope() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    let op_id = "550e8400-e29b-41d4-a716-446655440471";
+    let args = ["--output", "json-compact", "--op-id", op_id, "capture"];
+
+    let first = assert_compact_op_id_error_envelope(&args, &temp, "capture op-id failure");
+    let replayed =
+        assert_compact_op_id_error_envelope(&args, &temp, "capture op-id failure replay");
+    assert_eq!(
+        replayed, first,
+        "compact op-id replay should preserve the cached error envelope verbatim"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -85,6 +85,10 @@ fn status_compact_emits_only_decision_surface() {
         compact.get("changed_path_count").is_some(),
         "compact status must carry changed_path_count: {compact}"
     );
+    assert!(
+        compact.get("changed_paths").is_some(),
+        "compact status must carry changed_paths: {compact}"
+    );
     assert_only_compact_keys(&compact, "status");
 
     // Contrast: the full contract still carries the noisy metadata the
@@ -131,5 +135,23 @@ fn json_compact_is_a_valid_output_value() {
         out.status.success(),
         "--output json-compact must parse and run: stderr={}",
         String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn json_compact_rejects_commands_without_projection() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+
+    let out = heddle_output(&["--output", "json-compact", "commands"], Some(temp.path()))
+        .expect("spawn");
+    assert!(
+        !out.status.success(),
+        "compact-less command must reject json-compact"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("json-compact is not supported"),
+        "rejection should explain unsupported compact mode: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- Add `OutputMode::JsonCompact` (`--output json-compact`) — a third value on the existing `--output` flag (no new flag), emitting ONLY the decision surface an agent acts on: `output_kind`, `status`/`coordination_status`, `blockers`, `next_action` (+ template), `changed_paths`/`changed_path_count`, `conflicts`/`conflict_count`.
- New `compact` module with a shared `CompactOutput` shape + `CompactProjection` trait. `OperatorCommandOutput::compact()` is the one shared serializer for the operator family; `merge`/`ready` layer their changed-path/conflict axes on top, so the compact shape stays in lockstep as the full envelope grows instead of being hand-rolled per verb.
- Every in-scope emit site (`status`, plain-git status, `merge`, `ready`, `continue`/`abort`/`sync`/`land`) routes through a new `write_command_json` helper whose `T: CompactProjection` bound is the chokepoint preventing a new operator verb from silently shipping the full envelope under compact.
- Compact is CLI-only; config `output.format` stays `json`/`text`, so the full contract remains the default for piped/configured JSON.

The full `--output json` contract is unchanged.

Closes HeddleCo/heddle#470

## Red commit
`5a0ec1b3`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration compact_output
running 3 tests
test compact_output::json_compact_is_a_valid_output_value ... ok
test compact_output::continue_compact_drops_operator_metadata ... ok
test compact_output::status_compact_emits_only_decision_surface ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 911 filtered out

$ cargo clippy -p heddle-cli --all-targets -- -D warnings        # exit 0, no warnings
$ bash scripts/check-no-silent-default-tree-load.sh              # asserter clean (539 files)
$ cargo test -p heddle-mount                                     # ok
$ cargo test -p heddle-cli --test cli_integration -- doctor_docs output_kind output_mode_no_auto cli_help_consistency next_action_contract compact_output
test result: ok. 58 passed; 0 failed; 1 ignored
$ cargo test -p heddle-cli --lib command_catalog                 # ok. 27 passed
$ heddle doctor docs --all                                       # no drift found
```

Manual spot-check (`--output json-compact`):
```
status : {"output_kind":"status","coordination_status":"clean","next_action":"...","next_action_template":{...},"changed_path_count":0}
continue: {"output_kind":"continue","status":"noop","next_action":null}
ready  : {"output_kind":"ready","status":"completed","next_action":null,"changed_paths":[],"changed_path_count":0,"conflicts":[],"conflict_count":0}
merge  : {"output_kind":"merge","status":"preview","next_action":"heddle land --thread feat --no-push","next_action_template":{...},"changed_paths":["f.txt"],"changed_path_count":1,"conflicts":[],"conflict_count":0}
```

## Manual verification
N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783180251&installation_id=132405951&pr_number=524&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F524&signature=9111f8760bb194f7cb0c93c2b883f9d04ee6cb4b901df55a69abef7ccafed977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->