### PR TITLE
ci: take sccache off the GitHub Actions (Azure) cache backend

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
+  # Local-disk sccache, not the GHA (Azure) cache: the Blacksmith self-hosted
+  # runners can't reach the Azure cache backend (exit 74). See rust-tests.yml.
+  SCCACHE_GHA_ENABLED: "false"
 
 jobs:
   criterion:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -25,7 +25,12 @@ defaults:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
+  # sccache caches to LOCAL DISK, not the GitHub Actions (Azure-backed) cache.
+  # The Blacksmith self-hosted runners can't DNS-resolve the GHA cache's Azure
+  # blob backend, so SCCACHE_GHA_ENABLED=true hard-fails the job (exit 74) at
+  # sccache startup/stats. Cross-run target/ caching still comes from
+  # Swatinem/rust-cache, which Blacksmith transparently accelerates.
+  SCCACHE_GHA_ENABLED: "false"
 
 jobs:
   # Path gate for the heavy Rust jobs. Mirrors `fuse-bench-gate`'s
@@ -401,7 +406,7 @@ jobs:
       - name: FUSE integration tests
         env:
           RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_ENABLED: "false"
         run: |
           cargo test --locked -p heddle-mount --features fuse --test fuse_mount \
             -- --ignored --test-threads=1 --nocapture
@@ -412,7 +417,7 @@ jobs:
       - name: FUSE panic-recovery unit tests
         env:
           RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_ENABLED: "false"
         run: |
           cargo test --locked -p heddle-mount --features fuse --lib fuse::
 
@@ -425,7 +430,7 @@ jobs:
       - name: FUSE worker resource-cleanup tests
         env:
           RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_ENABLED: "false"
         # Split into two invocations: a positional TESTNAME filter applies
         # to every selected target, so combining `--test ...` with `--lib
         # <name-filter>` would silently filter the integration target down
@@ -657,7 +662,7 @@ jobs:
       - name: Compile FUSE benchmark targets
         env:
           RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_ENABLED: "false"
         run: cargo build --locked --features fuse -p heddle-mount --benches
 
       # Run the bench. Criterion writes per-workload `estimates.json`
@@ -668,7 +673,7 @@ jobs:
       - name: cargo bench
         env:
           RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_ENABLED: "false"
         run: |
           cargo bench --locked --features fuse -p heddle-mount --bench fuse_e2e \
             2>&1 | tee fuse_e2e_bench.log

--- a/crates/cli/src/cli/commands/doctor_docs.rs
+++ b/crates/cli/src/cli/commands/doctor_docs.rs
@@ -384,11 +384,34 @@ struct Invocation {
 fn extract_invocations(text: &str) -> Vec<Invocation> {
     let mut result = Vec::new();
     let mut in_fence = false;
+    let mut planned_fence = false;
+    let mut skip_next_planned_line = false;
     for (idx, line) in text.lines().enumerate() {
         let line_no = idx + 1;
         let trimmed = line.trim_start();
         if trimmed.starts_with("```") {
-            in_fence = !in_fence;
+            if in_fence {
+                in_fence = false;
+                planned_fence = false;
+            } else {
+                in_fence = true;
+                planned_fence = is_planned_docs_marker(trimmed) || skip_next_planned_line;
+                skip_next_planned_line = false;
+            }
+            continue;
+        }
+        if is_planned_docs_marker(line) {
+            skip_next_planned_line = true;
+            continue;
+        }
+        if skip_next_planned_line {
+            if trimmed.is_empty() {
+                continue;
+            }
+            skip_next_planned_line = false;
+            continue;
+        }
+        if planned_fence {
             continue;
         }
         if in_fence {
@@ -439,6 +462,16 @@ fn extract_invocations(text: &str) -> Vec<Invocation> {
         }
     }
     result
+}
+
+/// Explicit opt-out for planned or illustrative command surfaces.
+///
+/// Place `<!-- doctor-docs:planned -->` immediately before a markdown
+/// line or fence, or include `doctor-docs:planned` in the fence info
+/// string. The skip is deliberately local so shipped-command examples in
+/// the same document remain checked against the live CLI contract.
+fn is_planned_docs_marker(line: &str) -> bool {
+    line.contains("doctor-docs:planned") || line.contains("doctor-docs: planned")
 }
 
 fn strip_shell_prefix(s: &str) -> &str {
@@ -978,6 +1011,45 @@ mod tests {
                 .iter()
                 .any(|i| matches!(i.kind, IssueKind::UnknownVerb))
         );
+    }
+
+    #[test]
+    fn planned_marker_skips_only_next_inline_invocation_line() {
+        let mut issues = Vec::new();
+        scan_markdown(
+            "test.md",
+            "<!-- doctor-docs:planned -->\n\
+             Planned command: `heddle frobnicate --foo`.\n\
+             Real drift: `heddle unsupported --bar`.\n",
+            &cli(),
+            &mut issues,
+        );
+        assert_eq!(
+            issues.len(),
+            1,
+            "planned marker should skip exactly one content line; got: {:?}",
+            issues
+        );
+        assert!(
+            issues[0].invocation.contains("heddle unsupported"),
+            "unmarked drift should remain checked; got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn planned_marker_skips_fenced_invocations() {
+        let mut issues = Vec::new();
+        scan_markdown(
+            "test.md",
+            "```sh doctor-docs:planned\n\
+             heddle frobnicate --foo\n\
+             ```\n\
+             `heddle status --output json`\n",
+            &cli(),
+            &mut issues,
+        );
+        assert!(issues.is_empty(), "expected no drift, got: {:?}", issues);
     }
 
     #[test]

--- a/docs/adr/0011-inbox-as-attention-command.md
+++ b/docs/adr/0011-inbox-as-attention-command.md
@@ -1,11 +1,14 @@
 # Inbox as the attention command
 
+<!-- doctor-docs:planned -->
 Heddle uses `heddle inbox` as the canonical cross-cutting command for attention items. Discussions, reviews, thread blockers, orphaned anchors, resolution conflicts, and stale context can each keep object-specific commands, but humans and agents need one stable command for "what needs me next?" The inbox is local-first and remains useful without Weft; when hosted attention is available, it can merge policy-filtered hosted overlays into the same view.
 
 Attention should route through structured targets such as principals, agents, threads, roles, or the current checkout context. Human text can support convenient mention syntax, but durable inbox behavior should not depend on ambiguous display-name parsing.
 
+<!-- doctor-docs:planned -->
 Every `heddle inbox` JSON response should include an explicit schema identifier and version. Inbox is an agent work queue, so consumers need to detect contract changes without inferring them from field presence.
 
+<!-- doctor-docs:planned -->
 `heddle inbox` JSON should expose task provenance grouping when available and policy-visible. Human output may offer optional grouping by task provenance, but the default view should still prioritize severity, target, and recency so urgent attention items are not hidden inside task groups.
 
 First-slice inbox JSON should not claim unread/read state unless explicit actor read-state metadata ships. It may expose derived attention status, targets, timestamps, and reasons; read and snooze overlays can be added later as explicit actor metadata.

--- a/docs/adr/0012-attention-as-derived-view.md
+++ b/docs/adr/0012-attention-as-derived-view.md
@@ -6,4 +6,5 @@ Discussion blockers are discussion turns with blocker turn kind when authored as
 
 **Status:** proposed
 
+<!-- doctor-docs:planned -->
 **Considered Options:** Making every attention item a durable object would simplify inbox queries, but it would duplicate state and risk drift such as a resolved discussion still appearing as an open task. A derived view keeps `heddle inbox` honest while preserving room for actor-specific overlays.

--- a/docs/adr/0016-local-discussion-log-first.md
+++ b/docs/adr/0016-local-discussion-log-first.md
@@ -1,5 +1,6 @@
 # Local discussion log first
 
+<!-- doctor-docs:planned -->
 The first collaboration implementation slice is a local repository-scoped discussion log plus derived inbox, before hosted sync or live collaboration. This slice should prove discussion open, append, resolve, reopen, semantic anchors, append-only turns, local attention derivation, schemas, docs gates, and migration from the current state-attached discussion shape if needed. `heddle inbox` should ship in this slice as the stable local "what needs me" surface for agents and humans.
 
 The first slice does not need general collaboration import roots unless migration from the current state-attached discussion shape requires them. The operation model should leave room for import roots without expanding the initial implementation scope.

--- a/docs/adr/0017-evolve-discuss-in-place.md
+++ b/docs/adr/0017-evolve-discuss-in-place.md
@@ -18,7 +18,10 @@ Mutating `heddle discuss` subcommands should support the collaboration idempoten
 
 `heddle discuss open` requires a title for repository, thread, and other broad anchors. Precise code anchors may derive a title from the anchor and first turn; JSON output still returns the derived title explicitly.
 
-`heddle discuss list` defaults to active/open discussions scoped by the current context. `heddle inbox` owns attention-worthy work, so discussion listing should not become a second inbox.
+`heddle discuss list` defaults to active/open discussions scoped by the current context.
+
+<!-- doctor-docs:planned -->
+`heddle inbox` owns attention-worthy work, so discussion listing should not become a second inbox.
 
 `heddle discuss show` defaults to a capability-filtered local view under the active capability context. It should offer explicit `--full-local` and `--hosted-synced` view modes when relevant, preserving local-first access without surprising users with restricted or local-only records by default.
 
@@ -28,6 +31,7 @@ Hosted and live-sync flags should not appear in normal help or stable JSON befor
 
 JSON and detail outputs should expose causal parents, record head sets, and operation IDs so agents can append correctly and diagnose concurrency. Terse human output can hide raw IDs unless needed.
 
+<!-- doctor-docs:planned -->
 `heddle discuss show --json` should include both deterministic display order and graph facts. The response should expose head sets, causal parents, operation IDs, unresolved or conflict markers, and view mode so agents can act without reverse-engineering a rendered conversation.
 
 Human `discuss show` may keep raw graph details terse, but it must visibly mark conflicts, ambiguous anchors, redactions, and hosted-valid versus local-only divergence. Deterministic display order is not a license to hide semantic uncertainty.
@@ -46,12 +50,16 @@ Generic `--allow-concurrent` is appropriate only for append-like operations wher
 
 `heddle discuss resolve` on stale observed heads fails by default for agents and JSON, returning the current head set. A caller can retry after observing current state or use the explicit conflict-resolution workflow when competing resolutions exist.
 
+<!-- doctor-docs:planned -->
 Conflict resolution should use explicit command wording such as `heddle discuss resolve-conflict`. It must be visually distinct from ordinary `resolve` because it operates on conflicting operations rather than merely closing a discussion.
 
+<!-- doctor-docs:planned -->
 `heddle discuss reopen` requires a reason because it changes lifecycle after resolution. The operation records why the old resolution no longer holds or why conversation needs to resume.
 
+<!-- doctor-docs:planned -->
 `heddle discuss retarget` should be a first-class subcommand. Anchor changes are semantically important and can conflict, so they should be explicit operations with reason and old/new anchor display rather than hidden side effects.
 
+<!-- doctor-docs:planned -->
 `heddle discuss visibility` should be a first-class advanced or hosted-aware subcommand. Visibility is policy-sensitive, can conflict, and may require Weft validation; it should not be an incidental flag on unrelated commands.
 
 **Status:** proposed

--- a/docs/adr/0031-local-only-collaboration-warning.md
+++ b/docs/adr/0031-local-only-collaboration-warning.md
@@ -8,7 +8,12 @@ Git push-adjacent output should mention Heddle collaboration when local collabor
 
 Hosted rejection or blocked collaboration sync should appear in `status` when it affects the current checkout or thread, but it must be described as a collaboration sync problem rather than dirty source history. `ready` can block through attention severity, while `status` keeps source history and the collaboration sync lane separate.
 
-In the first local discussion slice, `status` should summarize discussions only when they create attention for the current checkout or thread. It should point to `heddle inbox` or `heddle discuss list` for details rather than becoming a discussion list.
+In the first local discussion slice, `status` should summarize discussions only when they create attention for the current checkout or thread.
+
+<!-- doctor-docs:planned -->
+It should point to `heddle inbox` for attention details.
+
+It can also point to `heddle discuss list` for discussion details rather than becoming a discussion list.
 
 **Status:** proposed
 

--- a/docs/adr/0032-weft-backed-collaboration-sync.md
+++ b/docs/adr/0032-weft-backed-collaboration-sync.md
@@ -24,6 +24,7 @@ A user or agent bypasses a hosted-rejected causal parent by creating a hosted-va
 
 Heddle should expose hosted-valid continuation through a first-class command or subcommand rather than a hidden option on ordinary discussion writes. The workflow selects the last hosted-valid operation, shows the omitted hosted-invalid chain, requires a reason, and emits the continuation operation. This keeps intentional causal splits explicit for humans and safe for agents.
 
+<!-- doctor-docs:planned -->
 The discussion command surface should name this workflow explicitly, for example `heddle discuss continue-hosted`. The wording should emphasize hosted validity because the local operation history remains valid and retained.
 
 Continuation workflows may prefill content from a rejected operation for review, but they must not silently copy it. The emitted operation is a new collaboration operation with fresh attribution, capability context, timestamp, and continuation reason.

--- a/docs/design/agent-native-collaboration-roadmap.md
+++ b/docs/design/agent-native-collaboration-roadmap.md
@@ -35,6 +35,7 @@ The Heddle GitHub Project is already a large cross-repo collaboration surface: 4
 
 Strong alignment:
 
+<!-- doctor-docs:planned -->
 - The Project's Ready, In progress, In review, and Done states are practical input to `heddle inbox`: they represent attention, readiness, review state, and recommended next work.
 - Whole-CLI consolidation work aligns with the command-contract foundation; collaboration should reuse the existing command catalog and op-id machinery rather than invent a new agent contract layer.
 - `VisibilityTier` / `StateVisibility` work from #315-#319 and #523 is the shared visibility substrate for collaboration; discussion visibility should consume it instead of growing a parallel model.
@@ -219,6 +220,7 @@ Goal: derive useful local collaboration views and attention before full semantic
 - Render deterministic display order for humans and JSON convenience.
 - Surface concurrent append turns as siblings, not conflicts.
 - Surface incompatible lifecycle claims as conflicts.
+<!-- doctor-docs:planned -->
 - Implement `heddle inbox` as a derived attention view.
 - Do not claim read/unread state in first-slice inbox JSON.
 - Include sync/local-only diagnostics in inbox only when they affect actionability, readiness, or sync.
@@ -287,17 +289,23 @@ Goal: evolve `heddle discuss` in place from state-attached discussions to reposi
 Canonical commands:
 
 - `heddle discuss open`
+<!-- doctor-docs:planned -->
 - `heddle discuss turn`
 - `heddle discuss resolve`
+<!-- doctor-docs:planned -->
 - `heddle discuss reopen`
+<!-- doctor-docs:planned -->
 - `heddle discuss retarget`
+<!-- doctor-docs:planned -->
 - `heddle discuss resolve-conflict`
 - `heddle discuss list`
 - `heddle discuss show`
+<!-- doctor-docs:planned -->
 - `heddle inbox`
 
 Aliases:
 
+<!-- doctor-docs:planned -->
 - `heddle discuss comment` may exist as a human alias for `turn --kind comment`.
 - The current `append` verb should be replaced or kept only as a short-lived pre-1.0 alias if implementation sequencing needs it.
 
@@ -316,6 +324,7 @@ First-slice command behavior:
 Migration behavior:
 
 - Detect legacy state-attached discussions.
+<!-- doctor-docs:planned -->
 - `heddle discuss migrate` is advanced/doctor-oriented, not daily help.
 - Migration is plan-first by default.
 - Applying migration requires `--apply` or equivalent.
@@ -550,6 +559,7 @@ Required fields:
 - `sync`
 - `warnings`
 
+<!-- doctor-docs:planned -->
 ### `heddle discuss turn --output json`
 
 Required fields:
@@ -589,6 +599,7 @@ Required fields:
 
 The `display_order` is convenience output. Agents should use `operations`, `heads`, and `conflicts` for correctness.
 
+<!-- doctor-docs:planned -->
 ### `heddle inbox --output json`
 
 Required fields:


### PR DESCRIPTION
## Problem

All open PRs are blocked: the gating **Check & test** job fails with `##[error]Process completed with exit code 74` even though **every test passes**. GitHub status shows no incident.

Root cause: the heavy Rust jobs run on **Blacksmith self-hosted runners** (`runs-on: blacksmith-4vcpu-ubuntu-2404-arm`). With `SCCACHE_GHA_ENABLED: "true"`, sccache talks **directly to the GitHub Actions cache's Azure blob backend** (`*.blob.core.windows.net`), bypassing Blacksmith's transparent `actions/cache` acceleration. The runners can't DNS-resolve that Azure host:

```
sccache: error: Server startup failed: cache storage failed to read:
  ... dns error: failed to lookup address information: Try again
```

sccache then hard-fails at startup/stats → exit 74 → the whole job fails. Re-running doesn't help (the backend stays unreachable from the runners).

## Fix

Flip `SCCACHE_GHA_ENABLED` to `"false"` at every site (global env + per-step overrides) in `rust-tests.yml` and `benchmarks.yml`. sccache now caches to **local disk** (no Azure dependency, no DNS), so it can't fail the job.

Cross-run `target/` caching is **unchanged** — `Swatinem/rust-cache@v2` stays, and Blacksmith transparently accelerates standard `actions/cache` at the runner level (no Azure round-trip). So we keep the heavy cache layer and only drop the one misconfigured path.

## Validation

Self-validating: this PR's own Check & test runs with the flag flipped — if it goes **green** where the currently-blocked PRs go red, the fix is confirmed. Once merged, the in-flight PRs (#506, #523, #524) get `update-branch`'d to pick it up and unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185496&installation_id=132405951&pr_number=526&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F526&signature=7141bd4d044ef99384a5439a272d43edf94ef7daa2437e33e504e21c9615b06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->