### PR TITLE
fix(cli): route transaction sentinel write through write_file_atomic (#498)

### DIFF
--- a/crates/cli/src/cli/transaction_sentinel.rs
+++ b/crates/cli/src/cli/transaction_sentinel.rs
@@ -255,6 +255,49 @@ buffered_ops = []
         assert!(feature_after.buffered_ops.is_empty());
     }
 
+    /// The CLI must persist the sentinel through the same atomic
+    /// write-tmp-then-rename protocol the daemon uses
+    /// (`objects::fs_atomic::write_file_atomic`), not a plain in-place
+    /// `fs::write`. A plain write truncates and rewrites the *same*
+    /// inode, so a crash mid-write leaves a torn `<id>.toml` — a state
+    /// `daemon::transaction_replay` is not designed to recover. The
+    /// atomic rename publishes a *fresh* inode, leaving the old file
+    /// intact until the rename commits. Inode replacement is the
+    /// observable signature of that rename, and is root-proof (unlike a
+    /// permission-based probe).
+    #[cfg(unix)]
+    #[test]
+    fn append_publishes_fresh_inode_proving_atomic_rename() {
+        use std::os::unix::fs::MetadataExt;
+
+        let (_t, repo) = fresh_repo();
+        let dir = repo.heddle_dir().join("state").join("transactions");
+        write_sentinel(&dir, "tx-main", "main", "active");
+        let path = dir.join("tx-main.toml");
+
+        let ino_before = fs::metadata(&path).unwrap().ino();
+        let updated = append_op_to_active_for_thread(&repo, "main", "capture");
+        assert_eq!(updated, vec!["tx-main".to_string()]);
+        let ino_after = fs::metadata(&path).unwrap().ino();
+
+        assert_ne!(
+            ino_before, ino_after,
+            "sentinel must be published via atomic rename (fresh inode), \
+             not rewritten in place"
+        );
+
+        // The rename must leave no orphan temp file behind in the
+        // sentinel directory — replay treats stray entries as
+        // interrupted-write orphans.
+        let stray: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name())
+            .filter(|n| n != "tx-main.toml")
+            .collect();
+        assert!(stray.is_empty(), "atomic write left orphans: {stray:?}");
+    }
+
     #[test]
     fn append_appends_in_order() {
         let (_t, repo) = fresh_repo();

--- a/crates/cli/src/cli/transaction_sentinel.rs
+++ b/crates/cli/src/cli/transaction_sentinel.rs
@@ -147,7 +147,7 @@ pub fn append_op_to_active_for_thread(
                 continue;
             }
         };
-        if let Err(err) = std::fs::write(&path, serialized) {
+        if let Err(err) = objects::fs_atomic::write_file_atomic(&path, serialized.as_bytes()) {
             tracing::warn!(error = %err, txn = %txn.transaction_id,
                 "transaction-sentinel: failed to persist appended op");
             continue;


### PR DESCRIPTION
## Summary
- The CLI append path wrote the on-disk transaction sentinel with a plain, non-atomic `std::fs::write` (`crates/cli/src/cli/transaction_sentinel.rs:150`), while the daemon writes the same files atomically via `objects::fs_atomic::write_file_atomic` (write tmp → fsync → rename → fsync parent).
- A crash during the CLI's in-place write could leave a torn `<id>.toml` — a fourth state `daemon::transaction_replay` is not designed to recover (it anticipates only old-state / new-state / orphaned-tmp).
- Routes the CLI sentinel write through `write_file_atomic`, so every sentinel writer shares the same atomic protocol.

Closes HeddleCo/heddle#498

## Red commit
`46c32dc031f1729c020ddf252d828993bee89ac7`

## Test evidence
```
$ cargo test -p heddle-cli transaction_sentinel
running 6 tests
test cli::transaction_sentinel::tests::append_publishes_fresh_inode_proving_atomic_rename ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 622 filtered out; finished in 0.09s

$ cargo clippy -p heddle-cli --all-targets -- -D warnings
Finished `dev` profile

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (542 file(s) scanned)
```

The new test `append_publishes_fresh_inode_proving_atomic_rename` asserts the sentinel is published via atomic rename (fresh inode + no orphan temp left behind) — the observable signature of write-tmp-then-rename. It fails against the old plain `fs::write` (same-inode truncate) and passes after the fix.

## Manual verification
N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783210269&installation_id=132405951&pr_number=527&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F527&signature=023f58fa5ef6f0ab4ff81a0e1482e1db7f757018c7edbf943709a6fd3d5a08c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->