### PR TITLE
fix(proto): bound received redaction/state-visibility transfer blobs (#418)

### DIFF
--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -73,7 +73,14 @@ impl HostedGrpcClient {
             .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
         let transport = helpers::HostedTransportPolicy::from_client_config(config);
         Ok(Self {
-            inner: RepoSyncServiceClient::new(channel.clone()),
+            // Bound the single-shot, server-controlled sidecar allocation at
+            // the gRPC decode boundary: tonic rejects an oversized inbound
+            // `PullMessage` before its `redactions_blob`/`state_visibility_blob`
+            // `Vec<u8>` is ever materialized. The post-decode
+            // `check_received_transfer_blob_size` calls are kept as cheap
+            // defense-in-depth, but this is the load-bearing guard.
+            inner: RepoSyncServiceClient::new(channel.clone())
+                .max_decoding_message_size(proto::MAX_PULL_DECODE_MESSAGE_SIZE),
             user: HostedUserServiceClient::new(channel.clone()),
             auth: AuthServiceClient::new(channel.clone()),
             content: ContentServiceClient::new(channel),

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -709,6 +709,11 @@ impl HostedGrpcClient {
                     // for signature + trust-list verification. The
                     // server emitted these only for blobs in our want
                     // set that carry an active redaction.
+                    proto::check_received_transfer_blob_size(
+                        transfer.redactions_blob.len(),
+                        proto::MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
+                        "redactions",
+                    )?;
                     profile.bytes_received = profile
                         .bytes_received
                         .saturating_add(transfer.redactions_blob.len());
@@ -730,6 +735,11 @@ impl HostedGrpcClient {
                     profile.store_receive_object += decode_elapsed;
                 }
                 Some(pull_message::Body::StateVisibility(transfer)) => {
+                    proto::check_received_transfer_blob_size(
+                        transfer.state_visibility_blob.len(),
+                        proto::MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE,
+                        "state-visibility",
+                    )?;
                     profile.bytes_received = profile
                         .bytes_received
                         .saturating_add(transfer.state_visibility_blob.len());

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -1845,6 +1845,139 @@ mod tests {
         );
     }
 
+    // A sidecar blob larger than tonic's 4 MiB default decode limit but well
+    // under the 64 MiB receive cap must still decode + install: the raised
+    // `max_decoding_message_size` is the bound, and it isn't set too tight.
+    #[tokio::test]
+    async fn legitimate_large_sidecar_blob_decodes_and_installs() {
+        let (_dir, repo) = temp_repo();
+        let tree_hash = repo.store().put_tree(&Tree::new()).expect("put tree");
+        let state = State::new_snapshot(
+            tree_hash,
+            vec![],
+            Attribution::human(Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            }),
+        );
+        let state_id = state.change_id;
+        repo.store().put_state(&state).expect("put state");
+
+        // ~8 MiB blob: above tonic's 4 MiB default (which would reject at
+        // decode without the raised limit), below the 64 MiB sidecar cap.
+        let mut record = sample_state_visibility(state_id);
+        record.tier = VisibilityTier::Restricted {
+            scope_label: "x".repeat(8 * 1024 * 1024),
+        };
+        let state_visibility_blob = StateVisibilityBlob::new(vec![record])
+            .encode()
+            .expect("encode large state visibility blob");
+        assert!(
+            state_visibility_blob.len() > 4 * 1024 * 1024,
+            "blob must exceed tonic's 4 MiB default to exercise the raised decode limit"
+        );
+        assert!(
+            (state_visibility_blob.len() as u64) <= proto::MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE,
+            "blob must stay within the legitimate sidecar receive cap"
+        );
+
+        let (mut client, server) = connect_sidecar_only_service(SidecarOnlyPullService {
+            state: state_id,
+            state_visibility_blob,
+        })
+        .await;
+
+        let exchange = tokio::time::timeout(
+            Duration::from_secs(30),
+            client.pull_exchange(
+                &repo,
+                "owner/repo",
+                "main",
+                PullOptions {
+                    local_thread: None,
+                    depth: None,
+                    target_state: Some(state_id),
+                    materialization: PullMaterialization::Full,
+                },
+            ),
+        )
+        .await
+        .expect("large-sidecar pull must not hang")
+        .expect("large but legitimate sidecar pull succeeds");
+        server.abort();
+
+        assert!(exchange.result.success);
+        assert!(
+            repo.get_state_visibility_for_state(&state_id)
+                .expect("load accepted sidecar")
+                .has_record(),
+            "pull must accept a legitimately-large StateVisibility sidecar"
+        );
+    }
+
+    // A sidecar blob beyond the pull-stream decode limit must be rejected at
+    // the gRPC decode boundary — before its `Vec<u8>` is materialized — not by
+    // the cheaper post-decode `check_received_transfer_blob_size` guard.
+    #[tokio::test]
+    async fn oversized_sidecar_blob_rejected_at_grpc_decode_boundary() {
+        let (_dir, repo) = temp_repo();
+        let tree_hash = repo.store().put_tree(&Tree::new()).expect("put tree");
+        let state = State::new_snapshot(
+            tree_hash,
+            vec![],
+            Attribution::human(Principal {
+                name: "Grace Hopper".into(),
+                email: "grace@example.com".into(),
+            }),
+        );
+        let state_id = state.change_id;
+        repo.store().put_state(&state).expect("put state");
+
+        // One byte past the decode limit. Content is irrelevant: decode is
+        // refused before the blob is ever handed to the accept path.
+        let oversized = vec![0u8; proto::MAX_PULL_DECODE_MESSAGE_SIZE + 1];
+        let (mut client, server) = connect_sidecar_only_service(SidecarOnlyPullService {
+            state: state_id,
+            state_visibility_blob: oversized,
+        })
+        .await;
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            client.pull_exchange(
+                &repo,
+                "owner/repo",
+                "main",
+                PullOptions {
+                    local_thread: None,
+                    depth: None,
+                    target_state: Some(state_id),
+                    materialization: PullMaterialization::Full,
+                },
+            ),
+        )
+        .await
+        .expect("oversized-sidecar pull must not hang");
+        server.abort();
+
+        let err = match result {
+            Err(err) => err,
+            Ok(_) => panic!("oversized sidecar PullMessage must be rejected at decode"),
+        };
+        let message = err.to_string();
+        assert!(
+            !message.contains("exceeds receive size limit"),
+            "rejection must come from the decode-size limit, before the post-decode check: {message}"
+        );
+        assert!(
+            repo.get_state_visibility_for_state(&state_id)
+                .expect("load sidecar")
+                .latest()
+                .is_none(),
+            "an oversized sidecar must never be installed"
+        );
+    }
+
     #[derive(Clone)]
     struct StateAndVisibilityPullService {
         state: ChangeId,

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -55,9 +55,10 @@ pub use object_graph::{
     enumerate_state_closure_with_options, is_ancestor,
 };
 pub use object_transfer::{
-    MAX_RECEIVED_REDACTIONS_BLOB_SIZE, MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, chunk_bounds,
-    chunk_count, chunk_offset, check_received_transfer_blob_size, load_object_data,
-    load_requested_object, store_received_object,
+    MAX_PULL_DECODE_MESSAGE_SIZE, MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
+    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, chunk_bounds, chunk_count, chunk_offset,
+    check_received_transfer_blob_size, load_object_data, load_requested_object,
+    store_received_object,
 };
 
 /// Default port for Heddle protocol.

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -55,8 +55,9 @@ pub use object_graph::{
     enumerate_state_closure_with_options, is_ancestor,
 };
 pub use object_transfer::{
-    chunk_bounds, chunk_count, chunk_offset, load_object_data, load_requested_object,
-    store_received_object,
+    MAX_RECEIVED_REDACTIONS_BLOB_SIZE, MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, chunk_bounds,
+    chunk_count, chunk_offset, check_received_transfer_blob_size, load_object_data,
+    load_requested_object, store_received_object,
 };
 
 /// Default port for Heddle protocol.

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -6,6 +6,47 @@ use objects::{
 
 use crate::{ObjectData, ObjectId, ObjectRequest, ObjectType, ProtocolError, Result};
 
+/// Maximum redaction sidecar blob accepted from the pull stream, per blob.
+///
+/// Redaction sidecars are signed range lists for a single blob — orders of
+/// magnitude smaller than the blob payload they describe. 64 MiB bounds the
+/// server-controlled receive buffer on the pull stream (the same
+/// unbounded-allocation OOM class #366 closed for the native pack/index
+/// buffers) while leaving generous headroom for any legitimate record.
+pub const MAX_RECEIVED_REDACTIONS_BLOB_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Maximum state-visibility sidecar blob accepted from the pull stream, per
+/// state.
+///
+/// State-visibility sidecars are per-state tier records, not object payloads.
+/// 64 MiB bounds this second server-controlled pull-stream buffer with the
+/// same receive-side cap.
+pub const MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Reject a received per-object transfer sidecar blob whose length exceeds
+/// `max_bytes`, before it is handed to the repository accept path.
+///
+/// Sidecar blobs (redaction, state-visibility) arrive as single
+/// server-controlled buffers on the pull stream. This is the single-shot
+/// analogue of [`crate::receive_pack_chunk`]'s running-total check: it bounds
+/// the in-memory allocation a hostile or buggy server can drive on the receive
+/// side. `kind` names the blob in the error (e.g. `"redactions"`).
+pub fn check_received_transfer_blob_size(
+    blob_len: usize,
+    max_bytes: u64,
+    kind: &str,
+) -> Result<()> {
+    let len = u64::try_from(blob_len).map_err(|_| {
+        ProtocolError::InvalidState(format!("{kind} blob length does not fit in u64"))
+    })?;
+    if len > max_bytes {
+        return Err(ProtocolError::InvalidState(format!(
+            "{kind} blob exceeds receive size limit: {len} bytes (max {max_bytes})"
+        )));
+    }
+    Ok(())
+}
+
 #[allow(dead_code)]
 pub fn chunk_count(object_size: usize, chunk_size: usize) -> usize {
     if object_size == 0 || chunk_size == 0 {

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -23,6 +23,39 @@ pub const MAX_RECEIVED_REDACTIONS_BLOB_SIZE: u64 = 64 * 1024 * 1024;
 /// same receive-side cap.
 pub const MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE: u64 = 64 * 1024 * 1024;
 
+/// Envelope headroom added on top of the largest legitimate sidecar blob when
+/// sizing the pull-stream gRPC decode limit. Covers the protobuf fields that
+/// wrap a max-size sidecar blob in a `PullMessage` — the oneof tag, the
+/// `blob_hash`/`state_id` string, and the transfer checkpoint — none of which
+/// approach a MiB. Kept generously round so a legitimately-max blob never
+/// trips the decode cap.
+const PULL_DECODE_ENVELOPE_HEADROOM: u64 = 8 * 1024 * 1024;
+
+const fn max_u64(a: u64, b: u64) -> u64 {
+    if a > b { a } else { b }
+}
+
+/// Inbound gRPC decode limit for the pull stream (tonic's
+/// `max_decoding_message_size`).
+///
+/// This is the *load-bearing* bound on the single-shot, server-controlled
+/// sidecar allocation. tonic refuses to decode an inbound `PullMessage` larger
+/// than this, so an oversized `redactions_blob` / `state_visibility_blob` is
+/// rejected at the decode boundary *before* its `Vec<u8>` is materialized.
+/// [`check_received_transfer_blob_size`] is retained as a cheap post-decode
+/// defense-in-depth check, but the allocation itself is bounded here.
+///
+/// Sized to the largest legitimate single message — a sidecar transfer carrying
+/// a max-size blob ([`MAX_RECEIVED_REDACTIONS_BLOB_SIZE`] /
+/// [`MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE`], 64 MiB) — plus
+/// [`PULL_DECODE_ENVELOPE_HEADROOM`]. Native pack chunks share this stream but
+/// are bounded far below this by the negotiated chunk size, so they are
+/// unaffected.
+pub const MAX_PULL_DECODE_MESSAGE_SIZE: usize = (max_u64(
+    MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
+    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE,
+) + PULL_DECODE_ENVELOPE_HEADROOM) as usize;
+
 /// Reject a received per-object transfer sidecar blob whose length exceeds
 /// `max_bytes`, before it is handed to the repository accept path.
 ///

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -27,9 +27,13 @@ pub const MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE: u64 = 64 * 1024 * 1024;
 /// sizing the pull-stream gRPC decode limit. Covers the protobuf fields that
 /// wrap a max-size sidecar blob in a `PullMessage` — the oneof tag, the
 /// `blob_hash`/`state_id` string, and the transfer checkpoint — none of which
-/// approach a MiB. Kept generously round so a legitimately-max blob never
-/// trips the decode cap.
-const PULL_DECODE_ENVELOPE_HEADROOM: u64 = 8 * 1024 * 1024;
+/// approach a MiB. Kept deliberately tight (not generously round): the decode
+/// limit is a per-*message* bound, so the unavoidable slop above the precise
+/// per-blob cap equals this headroom. Minimizing it keeps the worst-case
+/// attacker-forced allocation within ~1 MiB of the 64 MiB blob cap; the exact
+/// per-blob cap for that residual window is enforced by the post-decode
+/// `check_received_transfer_blob_size` defense-in-depth check.
+const PULL_DECODE_ENVELOPE_HEADROOM: u64 = 1024 * 1024;
 
 const fn max_u64(a: u64, b: u64) -> u64 {
     if a > b { a } else { b }

--- a/crates/proto/src/object_transfer.rs
+++ b/crates/proto/src/object_transfer.rs
@@ -199,4 +199,39 @@ mod tests {
         assert_eq!(chunk_offset(3, 64), Some(192));
         assert_eq!(chunk_offset(usize::MAX, 2), None);
     }
+
+    #[test]
+    fn received_transfer_blob_at_limit_is_accepted() {
+        check_received_transfer_blob_size(8, 8, "redactions").unwrap();
+    }
+
+    #[test]
+    fn received_transfer_blob_over_limit_is_rejected() {
+        let error = check_received_transfer_blob_size(9, 8, "redactions").unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("redactions blob exceeds receive size limit"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("9 bytes (max 8)"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn received_transfer_blob_caps_are_enforced_against_production_limits() {
+        check_received_transfer_blob_size(
+            MAX_RECEIVED_REDACTIONS_BLOB_SIZE as usize,
+            MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
+            "redactions",
+        )
+        .unwrap();
+        check_received_transfer_blob_size(
+            MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE as usize,
+            MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE,
+            "state-visibility",
+        )
+        .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- The pull stream carries two server-controlled single-shot sidecar buffers — `RedactionTransfer.redactions_blob` and `StateVisibilityTransfer.state_visibility_blob` — with no receive-side size cap, the same unbounded-allocation OOM class #366 closed for the native pack/index buffers.
- Add a shared `check_received_transfer_blob_size` primitive in `crates/proto/src/object_transfer.rs` (the single-shot analogue of `receive_pack_chunk`'s running-total check) plus documented `MAX_RECEIVED_REDACTIONS_BLOB_SIZE` / `MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE` caps (64 MiB each).
- Enforce the cap at **both** receive sites in `crates/client/src/grpc_hosted/sync.rs` before the blob reaches `accept_wire_redactions` / `accept_wire_state_visibility` — closing the whole class, not just the redactions instance the issue named.

Closes HeddleCo/heddle#418

## Red commit
\`bf86f47d\`

## Test evidence
\`\`\`
$ cargo test -p heddle-proto object_transfer
running 6 tests
test object_transfer::tests::received_transfer_blob_at_limit_is_accepted ... ok
test object_transfer::tests::received_transfer_blob_caps_are_enforced_against_production_limits ... ok
test object_transfer::tests::received_transfer_blob_over_limit_is_rejected ... ok
test object_transfer::tests::test_chunk_bounds_returns_ranges ... ok
test object_transfer::tests::test_chunk_count_rounds_up ... ok
test object_transfer::tests::test_chunk_offset_returns_position ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out

$ cargo test -p heddle-proto      # full suite
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ bash scripts/check-no-silent-default-tree-load.sh
asserter clean: no silent-default tree load sites in production code (542 file(s) scanned)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished (0 warnings)
\`\`\`

## Manual verification
N/A — covered by tests.

## Relates to
- #366 (the pack/index buffer fix this extends to the sidecar blobs on the same stream)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783213683&installation_id=132405951&pr_number=530&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F530&signature=f3296594600f73e86a18012c02644b47fe7a2a0bca87b6cce0784ba0df169078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->