### PR TITLE
docs(readme): refresh Capability status (semantic merge, signing, visibility tiers, round-trip gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ Heddle's CLI follows five operating principles — verification, disposability, 
 - Explicit principal and agent attribution
 - Provenance-backed local blame with rewrite preservation across snapshot, collapse, and merge flows
 - Semantic diff and compare
+- Semantic merge: AST-item-level merge within a file (first-class Rust/Python/JS/TS; Go/C/C++/Java opt-in); does not auto-rewrite cross-file imports or call-sites
+- Automatic state signing: device-local ed25519 identity minted on first use signs every authored state — provenance with no manual key setup
 - Git adapter/bridge: adopt, import, export, sync
+- Byte-identical Git round-trip, CI-enforced: adopt→export reproduces identical commit/tree/blob/tag SHAs with a `git fsck`-clean result, gated per-PR by 10 deterministic fixtures
 - Multi-agent worktrees and agent registry
 
 ### Foundation in place
 
 - Hosted client (`heddle-cli`'s optional `client` feature enables `dep:heddle-client` for talking to a hosted backend; `weft-client-shim` is always present as a non-optional dep)
 - Verification and verification metadata across the wire protocol
+- Commit-level visibility tiers: per-state `StateVisibility` records and `heddle visibility set/promote` verbs (with oplog tier records) are shipped client-side; the bridge export/checkout gate that withholds non-served commits from a Git mirror is landing; hosted serve-side enforcement is in progress
 
 ### Planned
 


### PR DESCRIPTION
Closes #541. Doc-only: refresh the README `## Capability status` section to reflect recently-shipped work. No code changes.

Additions (each verified against merged code/tests):
- **Semantic merge** → Shipped, honestly scoped: AST-item-level within a file; first-class Rust/Python/JS/TS (`crates/semantic/Cargo.toml` default `common-languages`), Go/C/C++/Java opt-in (`extended-languages`); container-as-node merge driver (`crates/semantic/src/merge_driver/`, #490); does NOT auto-rewrite cross-file imports/call-sites.
- **Automatic state signing** → Shipped: device-local ed25519 identity, automatic signing on capture/commit/merge, no manual key setup (#482, commit 71463585).
- **Commit-level visibility tiers** → Foundation in place (honestly hedged): `StateVisibility` object + sidecar (#315, in main) and `heddle visibility set/promote` verbs + oplog tier records (#317, in main) shipped client-side; bridge export gate (#316) landing on a task branch (not yet in main); hosted serve-side enforcement (#318) in progress — NOT claimed as done.
- **Byte-identical Git round-trip, CI-enforced** → Shipped: `crates/cli/tests/roundtrip_fidelity.rs` (#533, in main) — 10 deterministic fixtures asserting identical commit/tree/blob/tag SHAs + `git fsck`-clean, gated per-PR in `.github/workflows/rust-tests.yml`.

Existing true entries preserved. Prose-only change, so the docs-drift gate (`heddle doctor docs`) covers command docs not README prose — skipped the disproportionate CLI build for a prose edit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783292228&installation_id=132405951&pr_number=542&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F542&signature=cc4bd8ee3e7f5f5b76f7dca2810f45e8dcb4a863666f99675939151697879702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->