### PR TITLE
perf(push): drop the redundant second to_proto_object_info encode (#401)

### DIFF
--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -174,6 +174,17 @@ pub(super) fn descriptor_id(descriptor: &ObjectDescriptor) -> (String, String) {
     (descriptor.id.clone(), descriptor.object_type.clone())
 }
 
+/// Compute the same `(id, object_type)` key as
+/// `descriptor_id(&to_proto_object_info(info))` without the throwaway full
+/// proto encode. Must stay byte-identical to the descriptor the server keys on.
+pub(super) fn descriptor_id_from_info(info: &ObjectInfo) -> (String, String) {
+    let id = match &info.id {
+        ObjectId::Hash(hash) => hash.to_hex(),
+        ObjectId::ChangeId(change_id) => change_id.to_string_full(),
+    };
+    (id, object_type_name(info.obj_type).to_string())
+}
+
 pub(super) fn status_to_protocol_error(status: Status) -> ProtocolError {
     match status.code() {
         tonic::Code::Unauthenticated | tonic::Code::PermissionDenied => {

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -24,8 +24,9 @@ use tonic::Request;
 use super::{
     HostedGrpcClient, PullMaterialization,
     helpers::{
-        descriptor_id, object_descriptor_with_status, parse_descriptor_to_info,
-        status_to_protocol_error, to_proto_object_info, transport_mode_name,
+        descriptor_id, descriptor_id_from_info, object_descriptor_with_status,
+        parse_descriptor_to_info, status_to_protocol_error, to_proto_object_info,
+        transport_mode_name,
     },
 };
 
@@ -229,7 +230,7 @@ impl HostedGrpcClient {
 
         let object_index = objects
             .into_iter()
-            .map(|info| (descriptor_id(&to_proto_object_info(&info)), info))
+            .map(|info| (descriptor_id_from_info(&info), info))
             .collect::<HashMap<_, _>>();
 
         let ready_transport_mode = ready
@@ -1511,6 +1512,22 @@ mod tests {
 
     fn sample_blob() -> ContentHash {
         ContentHash::from_bytes([7u8; 32])
+    }
+
+    #[test]
+    fn descriptor_id_from_info_matches_proto_encode_path() {
+        let infos = [
+            redaction_info(sample_blob()),
+            state_info(ChangeId::from_bytes([3u8; 16])),
+            state_visibility_info(ChangeId::from_bytes([9u8; 16])),
+        ];
+        for info in infos {
+            assert_eq!(
+                descriptor_id_from_info(&info),
+                descriptor_id(&to_proto_object_info(&info)),
+                "keying path must stay byte-identical to the throwaway-encode path",
+            );
+        }
     }
 
     fn loose_tree_path(repo: &Repository, hash: &ContentHash) -> std::path::PathBuf {


### PR DESCRIPTION
Closes #401.

## The redundancy
On the push path in `crates/client/src/grpc_hosted/sync.rs`, `to_proto_object_info` ran over the whole state closure **twice**:
- `objects.iter().map(to_proto_object_info)` builds the wire manifest (unchanged).
- The `object_index` map then keyed each entry via `descriptor_id(&to_proto_object_info(&info))` — a second full proto encode per object whose result was immediately discarded (`descriptor_id` reads only id + type).

## The fix
Added `descriptor_id_from_info(&info)` in `helpers.rs`, which derives the exact same `(id, object_type)` key directly from `&ObjectInfo` (same `ObjectId::Hash`/`ChangeId` → string + `object_type_name` mapping the descriptor uses), with no throwaway encode. The `object_index` map now keys on it.

The wire manifest at the request site and the `want`-subset lookup protocol are untouched — only the wasteful second encode is gone.

## Proof
- `descriptor_id_from_info_matches_proto_encode_path` asserts byte-identical keys vs `descriptor_id(&to_proto_object_info(&info))` across Hash + ChangeId (state/state_visibility) id forms.
- The push round-trip / sync integration tests in `grpc_hosted::sync::tests` pass — the want-subset lookup still resolves (15 passed).
- Default-features build, all-features build, no-silent-default check, and clippy all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783296684&installation_id=132405951&pr_number=544&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F544&signature=8b4271eb5833a4288fba0f09d4922c132ae422d5b97e78f470b28e1bcb49b3d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->