### PR TITLE
fix/UX(adopt): repo-relative output paths + commit-import progress (#551, #550)

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -250,7 +250,7 @@ pub fn import_commit(
 
 /// Import Git commits into Heddle states.
 pub fn import_all(bridge: &mut GitBridge, git_path: Option<&Path>) -> GitResult<ImportStats> {
-    import_with_ref_filter(bridge, git_path, None, GitImportOptions::default())
+    import_with_ref_filter(bridge, git_path, None, GitImportOptions::default(), None)
 }
 
 pub fn import_all_with_options(
@@ -258,7 +258,17 @@ pub fn import_all_with_options(
     git_path: Option<&Path>,
     options: GitImportOptions,
 ) -> GitResult<ImportStats> {
-    import_with_ref_filter(bridge, git_path, None, options)
+    import_with_ref_filter(bridge, git_path, None, options, None)
+}
+
+/// Like [`import_all`], reporting the running commit count to `progress`
+/// after each commit is walked (drives the adopt progress indicator).
+pub fn import_all_with_progress(
+    bridge: &mut GitBridge,
+    git_path: Option<&Path>,
+    progress: Option<&mut dyn FnMut(usize)>,
+) -> GitResult<ImportStats> {
+    import_with_ref_filter(bridge, git_path, None, GitImportOptions::default(), progress)
 }
 
 pub fn import_selected_refs(
@@ -267,7 +277,13 @@ pub fn import_selected_refs(
     refs: &[String],
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(bridge, git_path, Some(&wanted), GitImportOptions::default())
+    import_with_ref_filter(
+        bridge,
+        git_path,
+        Some(&wanted),
+        GitImportOptions::default(),
+        None,
+    )
 }
 
 pub fn import_selected_refs_with_options(
@@ -277,7 +293,25 @@ pub fn import_selected_refs_with_options(
     options: GitImportOptions,
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(bridge, git_path, Some(&wanted), options)
+    import_with_ref_filter(bridge, git_path, Some(&wanted), options, None)
+}
+
+/// Like [`import_selected_refs`], reporting the running commit count to
+/// `progress` after each commit is walked.
+pub fn import_selected_refs_with_progress(
+    bridge: &mut GitBridge,
+    git_path: Option<&Path>,
+    refs: &[String],
+    progress: Option<&mut dyn FnMut(usize)>,
+) -> GitResult<ImportStats> {
+    let wanted = refs.iter().cloned().collect::<HashSet<_>>();
+    import_with_ref_filter(
+        bridge,
+        git_path,
+        Some(&wanted),
+        GitImportOptions::default(),
+        progress,
+    )
 }
 
 fn import_with_ref_filter(
@@ -285,6 +319,7 @@ fn import_with_ref_filter(
     git_path: Option<&Path>,
     wanted_refs: Option<&HashSet<String>>,
     options: GitImportOptions,
+    progress: Option<&mut dyn FnMut(usize)>,
 ) -> GitResult<ImportStats> {
     let repo = if let Some(path) = git_path {
         open_repo(path)?
@@ -537,23 +572,13 @@ fn import_with_ref_filter(
     let mut tree_importer =
         GitTreeImporter::with_options(bridge.heddle_repo, &repo, options.clone());
     bridge.heddle_repo.store().begin_snapshot_write_batch()?;
-    let import_result = (|| -> GitResult<()> {
-        let mut visiting = HashSet::new();
-        let mut imported = HashSet::new();
-        for plan in &plans {
-            let tip = plan.peeled_commit_oid;
-            import_commit_ancestry(
-                bridge,
-                &repo,
-                &mut tree_importer,
-                tip,
-                &mut visiting,
-                &mut imported,
-                &mut stats,
-            )?;
-        }
-        Ok(())
-    })();
+    let mut noop_progress = |_: usize| {};
+    let progress_cb: &mut dyn FnMut(usize) = match progress {
+        Some(callback) => callback,
+        None => &mut noop_progress,
+    };
+    let import_result =
+        walk_plans_into_states(bridge, &repo, &mut tree_importer, &plans, &mut stats, progress_cb);
     match import_result {
         Ok(()) => {
             stats
@@ -795,6 +820,37 @@ enum WalkPhase {
 /// children, already-imported nodes are skipped, and re-entering a node
 /// that's still in flight (a merge with two paths to the same ancestor)
 /// is a no-op.
+/// Walk each ref plan's ancestry into Heddle states, threading the optional
+/// per-commit progress callback through. Extracted from the import flow so the
+/// `progress` borrow is scoped to this call (an inline closure would force the
+/// borrow to outlive the surrounding function).
+#[allow(clippy::too_many_arguments)]
+fn walk_plans_into_states(
+    bridge: &mut GitBridge<'_>,
+    repo: &gix::Repository,
+    tree_importer: &mut GitTreeImporter<'_>,
+    plans: &[RefPlan],
+    stats: &mut ImportStats,
+    progress: &mut dyn FnMut(usize),
+) -> GitResult<()> {
+    let mut visiting = HashSet::new();
+    let mut imported = HashSet::new();
+    for plan in plans {
+        import_commit_ancestry(
+            bridge,
+            repo,
+            tree_importer,
+            plan.peeled_commit_oid,
+            &mut visiting,
+            &mut imported,
+            stats,
+            &mut *progress,
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 fn import_commit_ancestry(
     bridge: &mut GitBridge<'_>,
     repo: &gix::Repository,
@@ -803,6 +859,7 @@ fn import_commit_ancestry(
     visiting: &mut HashSet<gix::hash::ObjectId>,
     imported: &mut HashSet<gix::hash::ObjectId>,
     stats: &mut ImportStats,
+    progress: &mut dyn FnMut(usize),
 ) -> GitResult<()> {
     let mut stack: Vec<WalkPhase> = vec![WalkPhase::Enter(git_oid)];
 
@@ -883,6 +940,7 @@ fn import_commit_ancestry(
                 // failure next to `ingest`. `states_created` retains
                 // the "new heddle states written" meaning.
                 stats.commits_imported += 1;
+                progress(stats.commits_imported);
                 visiting.remove(&oid);
                 imported.insert(oid);
             }

--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{
     bridge::{
         GitBridge,
-        git_import::{import_all, import_selected_refs},
+        git_import::{import_all_with_progress, import_selected_refs_with_progress},
     },
     cli::{AdoptArgs, Cli, should_output_json, style},
 };
@@ -78,23 +78,39 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
     progress.advance("importing commits");
     let mut bridge = GitBridge::new(&repo);
     let _ = bridge.hydrate_checkout_heddle_notes_from_configured_remotes();
-    let stats = if args.refs.is_empty() {
-        import_all(&mut bridge, Some(repo.root()))?
-    } else {
-        import_selected_refs(&mut bridge, Some(repo.root()), &args.refs)?
+    let stats = {
+        let mut on_commit = |count: usize| progress.commit_tick(count);
+        if args.refs.is_empty() {
+            import_all_with_progress(&mut bridge, Some(repo.root()), Some(&mut on_commit))?
+        } else {
+            import_selected_refs_with_progress(
+                &mut bridge,
+                Some(repo.root()),
+                &args.refs,
+                Some(&mut on_commit),
+            )?
+        }
     };
     progress.advance("writing refs");
     progress.finish();
     let trust = build_repository_verification_state(&repo);
     let already_in_sync = stats.states_created == 0 && stats.commits_imported > 0;
     let recommended_action = action_value(&trust);
+    // The .heddle data dir lives inside the repo; render it relative to the
+    // repo root so adopt output stays repo-relative and doesn't leak the
+    // user's absolute home path (#551).
+    let heddle_dir = repo.heddle_dir();
+    let heddle_data_path = heddle_dir
+        .strip_prefix(repo.root())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| heddle_dir.to_path_buf());
     let output = AdoptOutput {
         output_kind: "adopt",
         status: "completed",
         action: "adopt",
         adopted: true,
         initialized,
-        path: repo.heddle_dir().to_path_buf(),
+        path: heddle_data_path,
         refs: args.refs,
         commits_imported: stats.commits_imported,
         states_created: stats.states_created,

--- a/crates/cli/src/cli/commands/import_progress.rs
+++ b/crates/cli/src/cli/commands/import_progress.rs
@@ -7,6 +7,10 @@ use repo::Repository;
 
 use crate::cli::{Cli, should_output_json, style};
 
+/// Redraw the live commit counter at most once per this many commits, so a
+/// large import doesn't spend its time flushing the terminal.
+const COMMIT_TICK_INTERVAL: usize = 64;
+
 pub(crate) struct ImportProgress {
     enabled: bool,
     current: usize,
@@ -38,13 +42,34 @@ impl ImportProgress {
         self.step(label);
     }
 
+    /// Live per-commit counter for the import phase. Renders only to a TTY
+    /// (throttled); under `--json`/agent output or a piped stdout it is a
+    /// no-op so no control codes leak into machine-readable output (#550).
+    pub(crate) fn commit_tick(&mut self, count: usize) {
+        if !self.enabled || !io::stdout().is_terminal() {
+            return;
+        }
+        if !count.is_multiple_of(COMMIT_TICK_INTERVAL) {
+            return;
+        }
+        print!(
+            "\r{}\x1b[K",
+            style::dim(&format!(
+                "[{}/{}] importing commits… {count}",
+                self.current + 1,
+                self.total
+            ))
+        );
+        io::stdout().flush().ok();
+    }
+
     pub(crate) fn finish(&mut self) {
         if !self.enabled {
             return;
         }
         self.current = self.total;
         if io::stdout().is_terminal() {
-            print!("\r{}\n", style::accent("[done] imported Git history"));
+            print!("\r\x1b[K{}\n", style::accent("[done] imported Git history"));
             io::stdout().flush().ok();
         } else {
             println!("{}", style::accent("[done] imported Git history"));
@@ -58,7 +83,7 @@ impl ImportProgress {
         let next = self.current + 1;
         if io::stdout().is_terminal() {
             print!(
-                "\r{}",
+                "\r\x1b[K{}",
                 style::dim(&format!("[{next}/{}] {label}...", self.total))
             );
             io::stdout().flush().ok();

--- a/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
@@ -119,3 +119,60 @@ fn git_overlay_sync_adopts_fast_forward_upstream_tip() {
         after["recommended_action"]
     );
 }
+
+#[test]
+fn adopt_renders_in_repo_paths_relative_to_repo_root() {
+    let temp = TempDir::new().unwrap();
+    let work = temp.path().join("work");
+    std::fs::create_dir(&work).unwrap();
+    git(&work, &["init", "-b", "main"]);
+    configure_git_identity(&work);
+    commit_file(&work, "story.txt", "one\n", "seed");
+
+    // The .heddle data path lives inside the repo and must render relative
+    // to the repo root, not as an absolute path that leaks the user's home
+    // directory (#551).
+    let json = heddle(&["adopt", "--output", "json"], Some(&work)).unwrap();
+    let value: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(value["path"], ".heddle");
+    let abs = work.to_str().unwrap();
+    assert!(
+        !json.contains(&format!("{abs}/.heddle")),
+        "adopt JSON should not contain an absolute in-repo path: {json}"
+    );
+}
+
+#[test]
+fn adopt_emits_no_terminal_control_codes_in_piped_output() {
+    let temp = TempDir::new().unwrap();
+
+    // Human output, piped (non-TTY): no spinner carriage returns or ANSI
+    // escapes should reach a non-terminal stdout (#550 progress AC).
+    let work = temp.path().join("work");
+    std::fs::create_dir(&work).unwrap();
+    git(&work, &["init", "-b", "main"]);
+    configure_git_identity(&work);
+    commit_file(&work, "story.txt", "one\n", "seed");
+    let human = heddle(&["adopt"], Some(&work)).unwrap();
+    assert!(
+        !human.contains('\r'),
+        "human adopt output leaked a carriage return: {human:?}"
+    );
+    assert!(
+        !human.contains('\u{1b}'),
+        "human adopt output leaked an ANSI escape: {human:?}"
+    );
+
+    // JSON output: likewise free of live-progress control codes.
+    let work2 = temp.path().join("work2");
+    std::fs::create_dir(&work2).unwrap();
+    git(&work2, &["init", "-b", "main"]);
+    configure_git_identity(&work2);
+    commit_file(&work2, "story.txt", "one\n", "seed");
+    let json = heddle(&["adopt", "--output", "json"], Some(&work2)).unwrap();
+    assert!(!json.contains('\r'), "adopt JSON leaked a carriage return: {json:?}");
+    assert!(
+        !json.contains('\u{1b}'),
+        "adopt JSON leaked an ANSI escape: {json:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- **#551 (Closes):** adopt output rendered the in-repo `.heddle` data path as an absolute path (e.g. `/home/you/proj/.heddle`), leaking the user's home dir. Now it renders repo-relative (`.heddle`) in both human and `--json` output. The top-level repo-root anchor ("from …") stays absolute by design.
- **#550 (progress AC only):** adopt looked hung while importing commits. A per-commit progress callback is now threaded through the import walk (`git_import.rs`) and drives a live `importing commits… N` counter via the existing `ImportProgress` helper.
- **TTY-gated:** the live counter renders only to a TTY (throttled to every 64 commits); under `--json`, agent output, or a piped/non-TTY stdout it emits nothing — no spinner control codes leak into machine-readable output.
- **Out of scope:** #550's import *perf* investigation is intentionally NOT in this PR — it stays open as a separate follow-up. Import correctness / round-trip fidelity (#533) is unchanged.

## Emit sites changed
- `adopt.rs`: `.heddle` path now `strip_prefix(repo.root())`; import calls switched to `import_*_with_progress`.
- `git_import.rs`: new `import_all_with_progress` / `import_selected_refs_with_progress`; `import_with_ref_filter` + `import_commit_ancestry` thread a `&mut dyn FnMut(usize)` callback (no-op fallback when absent).
- `import_progress.rs`: `commit_tick(count)` + line-clear (`\x1b[K`) on redraws.

## Tests
- `adopt_renders_in_repo_paths_relative_to_repo_root` — JSON `path == ".heddle"`, no absolute in-repo path.
- `adopt_emits_no_terminal_control_codes_in_piped_output` — human + JSON piped output contain no `\r` / ANSI escapes.
- Manual: live counter verified under a pseudo-TTY (`importing commits… 64/128/192` on a 200-commit repo).

## Gates
- `cargo build --locked --workspace` (default features) ✅
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` ✅
- `scripts/check-no-silent-default-tree-load.sh` ✅
- `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` ✅
- Note: `cargo build --all-features` fails on pre-existing, unrelated errors (`visibility.rs`, `cherry_pick.rs`, `materialize_tree` privacy) — reproduced on clean `main` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783305956&installation_id=132405951&pr_number=552&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F552&signature=db007d532e3761812c88f38ab5208feb4be93f4a832e0d342acc4a7b240f3ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->