### PR TITLE
perf(adopt): speed up commit import (#550)

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -584,8 +584,17 @@ fn import_with_ref_filter(
             stats
                 .lossy_entries
                 .extend(tree_importer.lossy_entries().iter().cloned());
-            bridge.write_mapping_tmp_to_disk()?;
+            // Durability ordering (heddle#550): the syncfs barrier that
+            // makes the imported objects durable MUST run before the
+            // recoverable mapping that references them is written. The
+            // mapping tmp is recoverable on the next load (a leftover
+            // `.tmp` is renamed into place), so writing it first would
+            // let a crash leave a recoverable mapping pointing at objects
+            // whose data was never flushed. Flush (syncfs + promote)
+            // first, then persist the referencing artifact.
             bridge.heddle_repo.store().flush_snapshot_write_batch()?;
+            objects::fault_inject::maybe_panic_at("import_after_flush_before_mapping");
+            bridge.write_mapping_tmp_to_disk()?;
             bridge.commit_mapping_tmp_to_disk()?;
         }
         Err(error) => {

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -154,6 +154,127 @@ fn bridge_recovers_from_crash_after_tmp_before_commit() {
     );
 }
 
+/// heddle#550 Finding 1: object durability must be ordered BEFORE the
+/// recoverable mapping that references those objects.
+///
+/// `import_all` writes imported objects into a snapshot batch, runs the
+/// `flush_snapshot_write_batch` durability barrier (`syncfs` + promote),
+/// and only then writes the heddle↔git mapping sidecar
+/// (`bridge-mapping.json.tmp` → `bridge-mapping.json`). The sidecar is
+/// recoverable on the next load (a leftover `.tmp` is renamed into
+/// place), so if it were written BEFORE the flush, a crash in the gap
+/// would leave a recoverable mapping pointing at objects whose data was
+/// never flushed.
+///
+/// The `import_after_flush_before_mapping` checkpoint sits in exactly
+/// that gap — after the flush, before the mapping tmp write. Crashing
+/// there must leave NO mapping tmp on disk and must NOT have advanced the
+/// committed mapping: proof that the flush ran first. A clean re-run then
+/// recovers and records the new commit.
+#[test]
+#[ignore = "fault-injection: spawns child processes with HEDDLE_FAULT_INJECT"]
+fn import_flushes_objects_before_writing_referencing_mapping() {
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin.git");
+    let work = temp.path().join("work");
+
+    // Seed origin with commit A and clone it (the clone imports A and
+    // writes the initial mapping sidecar).
+    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let blob_a = origin_repo.write_blob(b"fn a() {}\n").unwrap().detach();
+    let mut tree_a = origin_repo
+        .edit_tree(origin_repo.empty_tree().id)
+        .expect("tree editor");
+    tree_a
+        .upsert("core.rs", gix::object::tree::EntryKind::Blob, blob_a)
+        .unwrap();
+    let tree_a_oid = tree_a.write().unwrap().detach();
+    let commit_a =
+        git_commit_with_tree(&origin_repo, Some("refs/heads/main"), tree_a_oid, "seed", &[]);
+
+    heddle_output_with_env(
+        &["clone", origin.to_str().unwrap(), work.to_str().unwrap()],
+        Some(temp.path()),
+        &[],
+    )
+    .expect("initial clone succeeds");
+
+    let mapping_dir = work.join(".heddle").join("git-bridge");
+    let canonical = mapping_dir.join("bridge-mapping.json");
+    let tmp = mapping_dir.join("bridge-mapping.json.tmp");
+    let mapping_after_clone =
+        std::fs::read_to_string(&canonical).expect("clone writes the initial mapping");
+
+    // Add a NEW commit B to origin so the next import does real object
+    // work (a fresh state + tree + blob flow through the batch flush).
+    let blob_b = origin_repo.write_blob(b"fn b() {}\n").unwrap().detach();
+    let mut tree_b = origin_repo
+        .edit_tree(origin_repo.empty_tree().id)
+        .expect("tree editor");
+    tree_b
+        .upsert("core.rs", gix::object::tree::EntryKind::Blob, blob_b)
+        .unwrap();
+    let tree_b_oid = tree_b.write().unwrap().detach();
+    let commit_b = git_commit_with_tree(
+        &origin_repo,
+        Some("refs/heads/main"),
+        tree_b_oid,
+        "second",
+        &[commit_a],
+    );
+
+    // ── Phase 1: import B, crashing in the post-flush / pre-mapping gap ──
+    let crashed = Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(["bridge", "git", "import", "--path", origin.to_str().unwrap()])
+        .current_dir(&work)
+        .env("HEDDLE_FAULT_INJECT", "import_after_flush_before_mapping")
+        .env("HEDDLE_CONFIG", work.join(".heddle-user/config.toml"))
+        .output()
+        .expect("spawn child");
+    assert_intentional_snapshot_crash(crashed, "import_after_flush_before_mapping");
+
+    // ── Phase 2: the flush ran, but the mapping was NOT touched ──
+    //
+    // No mapping tmp may exist (write_mapping_tmp_to_disk never ran), and
+    // the committed mapping must still be exactly what the clone left —
+    // it must NOT yet reference commit B. Either failure means the
+    // referencing artifact was made durable before the object flush.
+    assert!(
+        !tmp.exists(),
+        "no mapping tmp may exist after a crash before the mapping write — \
+         its presence means write_mapping_tmp ran before flush",
+    );
+    let mapping_after_crash =
+        std::fs::read_to_string(&canonical).expect("committed mapping survives the crash");
+    assert_eq!(
+        mapping_after_crash, mapping_after_clone,
+        "the post-flush crash must not have advanced the committed mapping",
+    );
+    assert!(
+        !mapping_after_crash.contains(&commit_b.to_string()),
+        "committed mapping must not reference commit B before the mapping write",
+    );
+
+    // ── Phase 3: a clean re-run recovers and records commit B ──
+    let recovered = heddle_output_with_env(
+        &["bridge", "git", "import", "--path", origin.to_str().unwrap()],
+        Some(&work),
+        &[],
+    )
+    .expect("recovery import succeeds");
+    assert!(
+        recovered.status.success(),
+        "post-crash import should succeed cleanly: stderr={}",
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+    assert!(!tmp.exists(), "recovery leaves no leftover mapping tmp");
+    let recovered_mapping = std::fs::read_to_string(&canonical).expect("read recovered mapping");
+    assert!(
+        recovered_mapping.contains(&commit_b.to_string()),
+        "recovered mapping must now reference commit B",
+    );
+}
+
 fn current_main_tip(repo: &std::path::Path) -> String {
     let log: Value = serde_json::from_str(
         &heddle(&["--output", "json", "log", "main", "-n", "5"], Some(repo)).expect("log"),

--- a/crates/cli/tests/import_perf_harness.rs
+++ b/crates/cli/tests/import_perf_harness.rs
@@ -1,0 +1,113 @@
+//! Ad-hoc timed harness for `heddle adopt` commit import (#550).
+//! Run with: `cargo test -p heddle-cli --test import_perf_harness \
+//!   --features git-overlay,native,semantic,zstd -- --ignored --nocapture`
+
+use std::time::Instant;
+
+use cli::Repository;
+use cli::bridge::{GitBridge, git_import::import_all};
+use gix::refs::transaction::PreviousValue;
+use tempfile::TempDir;
+
+fn sig() -> gix::actor::Signature {
+    gix::actor::Signature {
+        name: "Bench".into(),
+        email: "bench@test".into(),
+        time: gix::date::Time {
+            seconds: 0,
+            offset: 0,
+        },
+    }
+}
+
+/// Build an N-commit linear history where each commit rewrites one file
+/// (so every commit yields a fresh blob + fresh root tree — the realistic
+/// adopt shape, not a degenerate all-trees-cached chain).
+fn build_history(repo: &gix::Repository, n: usize) {
+    let mut parents: Vec<gix::hash::ObjectId> = Vec::new();
+    for i in 0..n {
+        let blob = repo
+            .write_blob(format!("content for commit {i}\n").as_bytes())
+            .expect("write blob")
+            .detach();
+        let mut editor = repo
+            .edit_tree(gix::hash::ObjectId::empty_tree(repo.object_hash()))
+            .expect("tree editor");
+        editor
+            .upsert("file.txt", gix::object::tree::EntryKind::Blob, blob)
+            .expect("upsert");
+        // A second file that stays constant — exercises the tree-cache miss
+        // on the changing entry while keeping trees non-trivial.
+        let stable = repo
+            .write_blob(b"stable\n".as_ref())
+            .expect("write stable blob")
+            .detach();
+        editor
+            .upsert("README", gix::object::tree::EntryKind::Blob, stable)
+            .expect("upsert stable");
+        let tree = editor.write().expect("write tree").detach();
+
+        let mut cbuf = gix::date::parse::TimeBuf::default();
+        let mut abuf = gix::date::parse::TimeBuf::default();
+        let commit = repo
+            .new_commit_as(
+                sig().to_ref(&mut cbuf),
+                sig().to_ref(&mut abuf),
+                format!("commit {i}"),
+                tree,
+                parents.clone(),
+            )
+            .expect("commit");
+        parents = vec![commit.id];
+    }
+    // Point main at the tip.
+    if let Some(tip) = parents.first() {
+        gix::Repository::edit_reference(
+            repo,
+            gix::refs::transaction::RefEdit {
+                change: gix::refs::transaction::Change::Update {
+                    log: gix::refs::transaction::LogChange::default(),
+                    expected: PreviousValue::Any,
+                    new: gix::refs::Target::Object(*tip),
+                },
+                name: "refs/heads/main".try_into().unwrap(),
+                deref: false,
+            },
+        )
+        .expect("set main");
+    }
+}
+
+#[test]
+#[ignore = "perf harness; run explicitly with --ignored --nocapture"]
+fn time_commit_import() {
+    let n: usize = std::env::var("IMPORT_N")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3000);
+
+    let git_temp = TempDir::new().expect("git temp");
+    let git_repo = gix::init(git_temp.path()).expect("init git");
+    let build_start = Instant::now();
+    build_history(&git_repo, n);
+    eprintln!(
+        "built {n}-commit fixture in {:?}",
+        build_start.elapsed()
+    );
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut bridge = GitBridge::new(&repo);
+
+    let git_path = git_repo.workdir().expect("workdir").to_path_buf();
+    let start = Instant::now();
+    let stats = import_all(&mut bridge, Some(&git_path)).expect("import");
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "IMPORT {n} commits ({} states) in {:?} => {:.0} commits/s",
+        stats.states_created,
+        elapsed,
+        n as f64 / elapsed.as_secs_f64()
+    );
+}

--- a/crates/objects/src/fs_atomic.rs
+++ b/crates/objects/src/fs_atomic.rs
@@ -181,7 +181,17 @@ pub fn is_cross_device_link(err: &io::Error) -> bool {
     err.raw_os_error() == Some(EXDEV)
 }
 
-pub fn temp_path(path: &Path) -> PathBuf {
+/// Filename infix that marks a snapshot-batch *staging* temp, kept
+/// distinct from the `.tmp-` infix [`temp_path`] uses for ordinary
+/// `write_atomic` temps. The abandoned-staging sweep (heddle#550
+/// Finding 3) keys off this marker so it only ever removes un-promoted
+/// batch garbage — never a concurrent durable write's short-lived
+/// `.tmp-` temp, and never a canonical object (canonical names are
+/// hex hashes or `<id>.state`/`<id>.action`, none of which start with
+/// `.` or contain this marker).
+pub(crate) const STAGED_TEMP_MARKER: &str = ".stage-";
+
+fn temp_path_with_infix(path: &Path, infix: &str) -> PathBuf {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let file_name = path
         .file_name()
@@ -194,7 +204,26 @@ pub fn temp_path(path: &Path) -> PathBuf {
         .unwrap_or(0);
     let counter = TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
-    parent.join(format!(".{file_name}.tmp-{pid}-{unique}-{counter}"))
+    parent.join(format!(".{file_name}{infix}{pid}-{unique}-{counter}"))
+}
+
+pub fn temp_path(path: &Path) -> PathBuf {
+    temp_path_with_infix(path, ".tmp-")
+}
+
+/// Temp path for a snapshot-batch staged object. Uses
+/// [`STAGED_TEMP_MARKER`] so the abandoned-staging sweep can recognise
+/// and reclaim it without touching ordinary `.tmp-` temps.
+pub(crate) fn stage_temp_path(path: &Path) -> PathBuf {
+    temp_path_with_infix(path, STAGED_TEMP_MARKER)
+}
+
+/// True for the filename of a snapshot-batch staging temp produced by
+/// [`stage_temp_path`]. Canonical object files never start with `.`,
+/// so the leading-dot + marker test cannot false-positive on a real
+/// object.
+pub(crate) fn is_staged_temp_name(file_name: &str) -> bool {
+    file_name.starts_with('.') && file_name.contains(STAGED_TEMP_MARKER)
 }
 
 /// fsync the directory inode so a preceding `rename` is durable across

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -15,6 +15,7 @@ use super::{
         action_path, actions_dir, blobs_dir, hash_path, redaction_path, redactions_dir, state_path,
         state_visibility_dir, state_visibility_path, states_dir, trees_dir,
     },
+    fs_store::LooseObjectKind,
 };
 use crate::{
     object::{Action, ActionId, Blob, ChangeId, ContentHash, State, Tree},
@@ -428,7 +429,7 @@ impl ObjectStore for FsStore {
             let content = blob.content();
             let data = compress(content, &self.compression)?.unwrap_or_else(|| content.to_vec());
             trace!(compressed_size = data.len(), "Writing blob");
-            self.write_loose_object_atomic(&path, &data)?;
+            self.write_loose_object_atomic(&path, &data, LooseObjectKind::ContentAddressed)?;
         } else {
             trace!("Blob already exists, skipping write");
         }
@@ -457,7 +458,7 @@ impl ObjectStore for FsStore {
                 compressed_size = data.len(),
                 "Writing blob with precomputed hash"
             );
-            self.write_loose_object_atomic(&path, &data)?;
+            self.write_loose_object_atomic(&path, &data, LooseObjectKind::ContentAddressed)?;
         }
         if let Ok(mut cache) = self.recent_blobs.write() {
             cache.insert(hash, blob.clone());
@@ -476,7 +477,7 @@ impl ObjectStore for FsStore {
                 size = data.len(),
                 "Writing raw blob bytes with precomputed hash"
             );
-            self.write_loose_object_atomic(&path, data)?;
+            self.write_loose_object_atomic(&path, data, LooseObjectKind::ContentAddressed)?;
         }
         if let Ok(mut cache) = self.recent_blobs.write() {
             cache.insert(hash, Blob::from_slice(data));
@@ -651,7 +652,7 @@ impl ObjectStore for FsStore {
             let serialized = rmp_serde::to_vec(tree)?;
             let data = compress(&serialized, &self.compression)?.unwrap_or(serialized);
             trace!(compressed_size = data.len(), "Writing tree");
-            self.write_loose_object_atomic(&path, &data)?;
+            self.write_loose_object_atomic(&path, &data, LooseObjectKind::ContentAddressed)?;
         } else {
             trace!("Tree already exists, skipping write");
         }
@@ -669,7 +670,7 @@ impl ObjectStore for FsStore {
         let path = hash_path(&trees_dir(&self.root), &hash);
         if !path.exists() {
             trace!(size = data.len(), "Writing raw serialized tree");
-            self.write_loose_object_atomic(&path, data)?;
+            self.write_loose_object_atomic(&path, data, LooseObjectKind::ContentAddressed)?;
         }
         if let Ok(mut cache) = self.recent_trees.write() {
             cache.insert(hash, tree);
@@ -709,7 +710,7 @@ impl ObjectStore for FsStore {
         let serialized = rmp_serde::to_vec(state)?;
         let data = compress(&serialized, &self.compression)?.unwrap_or(serialized);
         trace!(compressed_size = data.len(), "Writing state");
-        self.write_loose_object_atomic(&path, &data)?;
+        self.write_loose_object_atomic(&path, &data, LooseObjectKind::Mutable)?;
         if let Ok(mut cache) = self.recent_states.write() {
             cache.insert(state.change_id, state.clone());
         }
@@ -721,7 +722,7 @@ impl ObjectStore for FsStore {
         let state = validate_state_serialized(data, id)?;
         let path = state_path(&self.root, &id);
         trace!(size = data.len(), "Writing raw serialized state");
-        self.write_loose_object_atomic(&path, data)?;
+        self.write_loose_object_atomic(&path, data, LooseObjectKind::Mutable)?;
         if let Ok(mut cache) = self.recent_states.write() {
             cache.insert(id, state);
         }
@@ -809,7 +810,7 @@ impl ObjectStore for FsStore {
             let serialized = rmp_serde::to_vec(action)?;
             let data = compress(&serialized, &self.compression)?.unwrap_or(serialized);
             trace!(id = %id, compressed_size = data.len(), "Writing action");
-            self.write_loose_object_atomic(&path, &data)?;
+            self.write_loose_object_atomic(&path, &data, LooseObjectKind::ContentAddressed)?;
         }
 
         Ok(id)

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -2,11 +2,9 @@
 //! IO helpers for FsStore.
 
 use std::{
-    collections::BTreeSet,
     fs::File,
     io::Read,
     path::{Path, PathBuf},
-    sync::Mutex,
 };
 
 use bytes::Bytes;
@@ -43,7 +41,6 @@ impl FileBytes {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum AtomicWriteMode {
     Durable,
-    BatchDirectorySync,
     /// No fsync at all. Caller asserts the file is a recoverable
     /// cache mirror — the authoritative copy lives elsewhere
     /// (typically a pack) and re-derivation on read is correct.
@@ -56,37 +53,98 @@ pub(super) enum AtomicWriteMode {
     NoSync,
 }
 
-/// Whether a `BatchDirectorySync` write must issue its own per-file
+/// Whether a snapshot-batch staged object must issue its own per-file
 /// `sync_data` for content durability, rather than deferring to the
-/// snapshot batch's single `syncfs()` barrier.
+/// batch's single `syncfs()` barrier at flush.
 ///
-/// The deferral (skip the per-file fsync, let `flush_snapshot_write_batch`
-/// run one `syncfs`) is sound ONLY on Linux AND ONLY inside an active
-/// snapshot batch — that's the only state in which a `syncfs` is
-/// guaranteed to follow. `BatchDirectorySync` can also be configured
-/// standalone via the public `set_loose_object_write_mode` setter with
-/// no active batch (depth 0); in that case no `syncfs` is ever issued,
-/// so the write must sync itself. Non-Linux has no `syncfs` and always
-/// syncs per file.
-fn batch_directory_sync_needs_per_file_sync(in_snapshot_batch: bool) -> bool {
-    if cfg!(target_os = "linux") {
-        !in_snapshot_batch
-    } else {
-        true
-    }
+/// On Linux the staged temp's data sync is deferred to one `syncfs()`
+/// in `flush_snapshot_write_batch` (git's `core.fsyncMethod=batch`):
+/// one filesystem-wide flush replaces the N per-object fsyncs that
+/// dominate large commit-history import (heddle#550). Non-Linux has no
+/// `syncfs`, so each staged temp must sync its own data before the
+/// flush promotes (renames) it into place.
+fn batch_staged_object_needs_per_file_sync() -> bool {
+    !cfg!(target_os = "linux")
 }
 
-/// `in_snapshot_batch` is true only when this write happens inside an
-/// active `begin_snapshot_write_batch` (depth > 0), which guarantees a
-/// later `flush_snapshot_write_batch` will run the `syncfs()` barrier —
-/// see [`batch_directory_sync_needs_per_file_sync`].
-pub(super) fn write_atomic(
-    path: &Path,
-    data: &[u8],
-    mode: AtomicWriteMode,
-    pending_directory_syncs: Option<&Mutex<BTreeSet<PathBuf>>>,
-    in_snapshot_batch: bool,
-) -> Result<()> {
+/// Write `data` to a temp file beside `path` but DON'T rename it into
+/// place. Used to *stage* a snapshot-batch object (heddle#550
+/// quarantine-then-promote): the canonical content-addressed path never
+/// holds bytes until [`promote_staged_object`] renames the temp in
+/// AFTER the durability barrier, so a crash before flush can only leave
+/// an orphan temp (ignored by reads) — never a present-but-torn object
+/// that the exists-skip would refuse to rewrite.
+///
+/// On Linux the temp is left un-synced (the batch's `syncfs()` flushes
+/// it); elsewhere it is `sync_data`'d so the bytes are durable before
+/// the promote rename. Returns the temp path to record for promotion.
+pub(super) fn stage_loose_object(path: &Path, data: &[u8]) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("invalid atomic write path"))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| HeddleError::Io(enrich_fs_error(parent, "creating", e)))?;
+
+    let temp_path = temp_path(path);
+    let write_result: std::io::Result<()> = (|| {
+        let mut file = open_temp_0o644(&temp_path)?;
+        use std::io::Write as _;
+        file.write_all(data)?;
+        if batch_staged_object_needs_per_file_sync() {
+            file.sync_data()?;
+        }
+        Ok(())
+    })();
+
+    if let Err(err) = write_result {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(HeddleError::Io(enrich_fs_error(path, "writing", err)));
+    }
+    Ok(temp_path)
+}
+
+/// Promote a temp staged by [`stage_loose_object`] into its canonical
+/// path. The caller MUST have run the batch durability barrier (Linux
+/// `syncfs`, else the per-file `sync_data` in `stage_loose_object`)
+/// BEFORE calling this, so the renamed bytes are already durable; the
+/// only remaining durability step is making the new directory entry
+/// itself durable, which the caller does once for the whole batch
+/// (a second `syncfs` on Linux, per-directory fsyncs elsewhere).
+///
+/// A `rename` over an existing canonical file atomically replaces it
+/// (a sibling writer may have installed the same content-addressed
+/// object meanwhile — identical bytes, so the replace is a no-op in
+/// effect). The temp is cleaned up on failure.
+pub(super) fn promote_staged_object(temp_path: &Path, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| HeddleError::Io(enrich_fs_error(parent, "creating", e)))?;
+    }
+    if let Err(err) = std::fs::rename(temp_path, path) {
+        let _ = std::fs::remove_file(temp_path);
+        return Err(HeddleError::Io(enrich_rename_error(temp_path, path, err)));
+    }
+    Ok(())
+}
+
+fn open_temp_0o644(temp_path: &Path) -> std::io::Result<File> {
+    // Open with explicit mode 0o644 instead of relying on the process
+    // umask. This makes loose objects byte-and-mode deterministic:
+    // clonefile on macOS preserves source mode, so a worktree
+    // materialised from a loose blob inherits 0o644 *without* an extra
+    // chmod. `repository_materialization` skips `set_file_mode` on
+    // non-executable files because of this contract.
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o644);
+    }
+    opts.open(temp_path)
+}
+
+pub(super) fn write_atomic(path: &Path, data: &[u8], mode: AtomicWriteMode) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| std::io::Error::other("invalid atomic write path"))?;
@@ -95,12 +153,8 @@ pub(super) fn write_atomic(
 
     let temp_path = temp_path(path);
     // Tag each fallible op with the verb that should appear in the
-    // user-facing message if it trips. We compute the wrapped error at
-    // the boundary so an EXDEV from `rename` gets the src+dst-aware
-    // message via `enrich_rename_error`, while a write into the temp
-    // file gets the "writing" verb against the destination path. The
-    // deferred-directory-sync lock-poison case is non-IO and gets a
-    // synthetic `io::Error::other`.
+    // user-facing message if it trips, so an EXDEV from `rename` gets
+    // the src+dst-aware message via `enrich_rename_error`.
     enum Op {
         Write,
         Rename,
@@ -108,22 +162,7 @@ pub(super) fn write_atomic(
     }
     let mut failing_op = Op::Write;
     let write_result: std::io::Result<()> = (|| {
-        // Open with explicit mode 0o644 instead of relying on the
-        // process umask. This makes loose objects byte-and-mode
-        // deterministic: clonefile on macOS preserves source mode,
-        // so a worktree materialised from a loose blob inherits
-        // 0o644 *without* an extra chmod. `repository_materialization`
-        // skips `set_file_mode` on non-executable files because of
-        // this contract — see `materialize_blob`'s comment near the
-        // `set_file_mode(dest, true)` call.
-        let mut opts = std::fs::OpenOptions::new();
-        opts.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            opts.mode(0o644);
-        }
-        let mut file = opts.open(&temp_path)?;
+        let mut file = open_temp_0o644(&temp_path)?;
         use std::io::Write as _;
         file.write_all(data)?;
         match mode {
@@ -132,41 +171,6 @@ pub(super) fn write_atomic(
             // is fully on disk and discoverable through the parent
             // directory before this returns.
             AtomicWriteMode::Durable => file.sync_all()?,
-            // `BatchDirectorySync` keeps per-file content durability
-            // (so a crash mid-batch can't leave a renamed-but-empty
-            // file behind) but defers parent-directory fsyncs to
-            // `flush_snapshot_write_batch`. The trees + state file
-            // written during a snapshot rely on this mode for
-            // durability of their *contents*; the deferred dir fsync
-            // is what makes the rename observable to a fresh process.
-            // Without `sync_data` here, a crash after rename + before
-            // flush could leave a file that "exists" in the directory
-            // but whose data blocks weren't flushed — exactly the
-            // ACID violation we want to avoid for state/tree writes.
-            //
-            // On Linux the per-file `sync_data` is deferred to a single
-            // `syncfs()` barrier in `flush_snapshot_write_batch` (git's
-            // `core.fsyncMethod=batch`): one filesystem-wide flush
-            // replaces the N per-object fsyncs that dominate large
-            // commit-history import (heddle#550 — measured ~65% of
-            // `heddle adopt` import time). Objects written mid-batch are
-            // unreferenced until the post-flush oplog/ref/mapping
-            // commit, so a crash before flush leaves only harmless,
-            // content-addressed orphans that the next run re-creates
-            // identically.
-            //
-            // That deferral is sound ONLY when a `syncfs` is guaranteed
-            // to follow — i.e. inside an active snapshot batch on Linux.
-            // When `BatchDirectorySync` is configured standalone via the
-            // public `set_loose_object_write_mode` setter with no active
-            // batch, no `syncfs` is ever issued, so the write must sync
-            // itself. Non-Linux platforms (no `syncfs`) always keep the
-            // per-file fsync. See `batch_directory_sync_needs_per_file_sync`.
-            AtomicWriteMode::BatchDirectorySync => {
-                if batch_directory_sync_needs_per_file_sync(in_snapshot_batch) {
-                    file.sync_data()?;
-                }
-            }
             // Cache-mirror writes: no fsync. Caller guards reads
             // with a hash check, so torn-write corruption is
             // recoverable (re-promote from the authoritative copy).
@@ -177,14 +181,6 @@ pub(super) fn write_atomic(
         failing_op = Op::SyncDir;
         match mode {
             AtomicWriteMode::Durable => sync_directory(parent)?,
-            AtomicWriteMode::BatchDirectorySync => {
-                if let Some(pending) = pending_directory_syncs {
-                    let mut dirs = pending.lock().map_err(|_| {
-                        std::io::Error::other("failed to acquire pending directory sync lock")
-                    })?;
-                    dirs.insert(parent.to_path_buf());
-                }
-            }
             AtomicWriteMode::NoSync => {}
         }
         Ok(())
@@ -322,32 +318,25 @@ pub(super) fn list_hashes_from_dir(
 
 #[cfg(test)]
 mod tests {
-    use super::batch_directory_sync_needs_per_file_sync;
+    use super::batch_staged_object_needs_per_file_sync;
 
     #[test]
-    fn batch_directory_sync_defers_per_file_fsync_only_in_active_batch() {
-        // Standalone (mode set via the public setter, no active batch):
-        // no `syncfs` barrier is coming, so the write must always sync
-        // itself — on every platform. This is the heddle#550 durability
-        // fix: the Linux skip must not apply outside a snapshot batch.
-        assert!(
-            batch_directory_sync_needs_per_file_sync(false),
-            "standalone BatchDirectorySync must issue its own per-file sync_data",
-        );
-
-        // Inside an active snapshot batch, Linux may defer to the single
-        // `syncfs()` in flush_snapshot_write_batch (the #550 perf win);
-        // other platforms still sync per file.
-        let needs_sync_in_batch = batch_directory_sync_needs_per_file_sync(true);
+    fn staged_object_defers_per_file_fsync_to_syncfs_only_on_linux() {
+        // A snapshot-batch staged object defers its data sync to the
+        // batch's single `syncfs()` barrier ONLY on Linux (the #550
+        // perf win — N per-object fsyncs collapse to one syncfs). Every
+        // other platform has no `syncfs`, so each staged temp must
+        // `sync_data` itself before the flush promotes it into place.
+        let needs_sync = batch_staged_object_needs_per_file_sync();
         if cfg!(target_os = "linux") {
             assert!(
-                !needs_sync_in_batch,
-                "Linux must defer the per-file sync to the batch syncfs barrier",
+                !needs_sync,
+                "Linux must defer the staged-object data sync to the batch syncfs barrier",
             );
         } else {
             assert!(
-                needs_sync_in_batch,
-                "non-Linux has no syncfs and must always sync per file",
+                needs_sync,
+                "non-Linux has no syncfs and must sync each staged object per file",
             );
         }
     }

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! IO helpers for FsStore.
 
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-};
+use std::{fs::File, io::Read, path::Path};
 
 use bytes::Bytes;
 
@@ -67,27 +63,30 @@ fn batch_staged_object_needs_per_file_sync() -> bool {
     !cfg!(target_os = "linux")
 }
 
-/// Write `data` to a temp file beside `path` but DON'T rename it into
-/// place. Used to *stage* a snapshot-batch object (heddle#550
-/// quarantine-then-promote): the canonical content-addressed path never
-/// holds bytes until [`promote_staged_object`] renames the temp in
-/// AFTER the durability barrier, so a crash before flush can only leave
-/// an orphan temp (ignored by reads) — never a present-but-torn object
-/// that the exists-skip would refuse to rewrite.
+/// Write `data` to the pre-computed staging temp `temp_path` (beside the
+/// canonical `path`) but DON'T rename it into place. Used to *stage* a
+/// snapshot-batch object (heddle#550 quarantine-then-promote): the
+/// canonical path never holds bytes until [`promote_staged_object`]
+/// renames the temp in AFTER the durability barrier, so a crash before
+/// flush can only leave an orphan temp (reclaimed by the staging sweep)
+/// — never a present-but-torn object that the exists-skip would refuse
+/// to rewrite.
 ///
-/// On Linux the temp is left un-synced (the batch's `syncfs()` flushes
-/// it); elsewhere it is `sync_data`'d so the bytes are durable before
-/// the promote rename. Returns the temp path to record for promotion.
-pub(super) fn stage_loose_object(path: &Path, data: &[u8]) -> Result<PathBuf> {
+/// The caller computes `temp_path` (via `stage_temp_path`) and records
+/// it for promotion BEFORE this call, so a concurrent staging sweep can
+/// never observe the temp on disk without also seeing it tracked. On
+/// Linux the temp is left un-synced (the batch's `syncfs()` flushes it);
+/// elsewhere it is `sync_data`'d so the bytes are durable before the
+/// promote rename.
+pub(super) fn stage_loose_object(path: &Path, temp_path: &Path, data: &[u8]) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| std::io::Error::other("invalid atomic write path"))?;
     std::fs::create_dir_all(parent)
         .map_err(|e| HeddleError::Io(enrich_fs_error(parent, "creating", e)))?;
 
-    let temp_path = temp_path(path);
     let write_result: std::io::Result<()> = (|| {
-        let mut file = open_temp_0o644(&temp_path)?;
+        let mut file = open_temp_0o644(temp_path)?;
         use std::io::Write as _;
         file.write_all(data)?;
         if batch_staged_object_needs_per_file_sync() {
@@ -97,10 +96,10 @@ pub(super) fn stage_loose_object(path: &Path, data: &[u8]) -> Result<PathBuf> {
     })();
 
     if let Err(err) = write_result {
-        let _ = std::fs::remove_file(&temp_path);
+        let _ = std::fs::remove_file(temp_path);
         return Err(HeddleError::Io(enrich_fs_error(path, "writing", err)));
     }
-    Ok(temp_path)
+    Ok(())
 }
 
 /// Promote a temp staged by [`stage_loose_object`] into its canonical

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -56,11 +56,36 @@ pub(super) enum AtomicWriteMode {
     NoSync,
 }
 
+/// Whether a `BatchDirectorySync` write must issue its own per-file
+/// `sync_data` for content durability, rather than deferring to the
+/// snapshot batch's single `syncfs()` barrier.
+///
+/// The deferral (skip the per-file fsync, let `flush_snapshot_write_batch`
+/// run one `syncfs`) is sound ONLY on Linux AND ONLY inside an active
+/// snapshot batch — that's the only state in which a `syncfs` is
+/// guaranteed to follow. `BatchDirectorySync` can also be configured
+/// standalone via the public `set_loose_object_write_mode` setter with
+/// no active batch (depth 0); in that case no `syncfs` is ever issued,
+/// so the write must sync itself. Non-Linux has no `syncfs` and always
+/// syncs per file.
+fn batch_directory_sync_needs_per_file_sync(in_snapshot_batch: bool) -> bool {
+    if cfg!(target_os = "linux") {
+        !in_snapshot_batch
+    } else {
+        true
+    }
+}
+
+/// `in_snapshot_batch` is true only when this write happens inside an
+/// active `begin_snapshot_write_batch` (depth > 0), which guarantees a
+/// later `flush_snapshot_write_batch` will run the `syncfs()` barrier —
+/// see [`batch_directory_sync_needs_per_file_sync`].
 pub(super) fn write_atomic(
     path: &Path,
     data: &[u8],
     mode: AtomicWriteMode,
     pending_directory_syncs: Option<&Mutex<BTreeSet<PathBuf>>>,
+    in_snapshot_batch: bool,
 ) -> Result<()> {
     let parent = path
         .parent()
@@ -128,12 +153,20 @@ pub(super) fn write_atomic(
             // unreferenced until the post-flush oplog/ref/mapping
             // commit, so a crash before flush leaves only harmless,
             // content-addressed orphans that the next run re-creates
-            // identically. Non-Linux platforms (no `syncfs`) keep the
-            // per-file fsync and the deferred per-directory sync below.
-            #[cfg(not(target_os = "linux"))]
-            AtomicWriteMode::BatchDirectorySync => file.sync_data()?,
-            #[cfg(target_os = "linux")]
-            AtomicWriteMode::BatchDirectorySync => {}
+            // identically.
+            //
+            // That deferral is sound ONLY when a `syncfs` is guaranteed
+            // to follow — i.e. inside an active snapshot batch on Linux.
+            // When `BatchDirectorySync` is configured standalone via the
+            // public `set_loose_object_write_mode` setter with no active
+            // batch, no `syncfs` is ever issued, so the write must sync
+            // itself. Non-Linux platforms (no `syncfs`) always keep the
+            // per-file fsync. See `batch_directory_sync_needs_per_file_sync`.
+            AtomicWriteMode::BatchDirectorySync => {
+                if batch_directory_sync_needs_per_file_sync(in_snapshot_batch) {
+                    file.sync_data()?;
+                }
+            }
             // Cache-mirror writes: no fsync. Caller guards reads
             // with a hash check, so torn-write corruption is
             // recoverable (re-promote from the authoritative copy).
@@ -285,4 +318,37 @@ pub(super) fn list_hashes_from_dir(
     }
     debug!(count = hashes.len(), "Listed hashes");
     Ok(hashes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::batch_directory_sync_needs_per_file_sync;
+
+    #[test]
+    fn batch_directory_sync_defers_per_file_fsync_only_in_active_batch() {
+        // Standalone (mode set via the public setter, no active batch):
+        // no `syncfs` barrier is coming, so the write must always sync
+        // itself — on every platform. This is the heddle#550 durability
+        // fix: the Linux skip must not apply outside a snapshot batch.
+        assert!(
+            batch_directory_sync_needs_per_file_sync(false),
+            "standalone BatchDirectorySync must issue its own per-file sync_data",
+        );
+
+        // Inside an active snapshot batch, Linux may defer to the single
+        // `syncfs()` in flush_snapshot_write_batch (the #550 perf win);
+        // other platforms still sync per file.
+        let needs_sync_in_batch = batch_directory_sync_needs_per_file_sync(true);
+        if cfg!(target_os = "linux") {
+            assert!(
+                !needs_sync_in_batch,
+                "Linux must defer the per-file sync to the batch syncfs barrier",
+            );
+        } else {
+            assert!(
+                needs_sync_in_batch,
+                "non-Linux has no syncfs and must always sync per file",
+            );
+        }
+    }
 }

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -118,7 +118,22 @@ pub(super) fn write_atomic(
             // flush could leave a file that "exists" in the directory
             // but whose data blocks weren't flushed — exactly the
             // ACID violation we want to avoid for state/tree writes.
+            //
+            // On Linux the per-file `sync_data` is deferred to a single
+            // `syncfs()` barrier in `flush_snapshot_write_batch` (git's
+            // `core.fsyncMethod=batch`): one filesystem-wide flush
+            // replaces the N per-object fsyncs that dominate large
+            // commit-history import (heddle#550 — measured ~65% of
+            // `heddle adopt` import time). Objects written mid-batch are
+            // unreferenced until the post-flush oplog/ref/mapping
+            // commit, so a crash before flush leaves only harmless,
+            // content-addressed orphans that the next run re-creates
+            // identically. Non-Linux platforms (no `syncfs`) keep the
+            // per-file fsync and the deferred per-directory sync below.
+            #[cfg(not(target_os = "linux"))]
             AtomicWriteMode::BatchDirectorySync => file.sync_data()?,
+            #[cfg(target_os = "linux")]
+            AtomicWriteMode::BatchDirectorySync => {}
             // Cache-mirror writes: no fsync. Caller guards reads
             // with a hash check, so torn-write corruption is
             // recoverable (re-promote from the authoritative copy).

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -2,14 +2,15 @@
 //! Core FsStore structure.
 
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{HashMap, VecDeque},
     hash::Hash,
     path::{Path, PathBuf},
     sync::{Mutex, RwLock},
+    thread::ThreadId,
 };
 
 use super::{
-    fs_io::{AtomicWriteMode, write_atomic},
+    fs_io::{AtomicWriteMode, promote_staged_object, stage_loose_object, write_atomic},
     fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, trees_dir},
 };
 use crate::{
@@ -33,7 +34,39 @@ const VERIFIED_LOOSE_BLOB_CACHE_CAPACITY: usize = 65_536;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LooseObjectWriteMode {
     Durable,
+    /// Legacy alias for [`LooseObjectWriteMode::Durable`]. Snapshot-batch
+    /// deferral is no longer driven by this store-wide mode field — it is
+    /// scoped per-batch via `begin_snapshot_write_batch` (heddle#550
+    /// Finding 3). Configured standalone via `set_loose_object_write_mode`
+    /// with no active batch, a write must still be fully durable on its
+    /// own (no `syncfs` is ever coming), so this is treated exactly like
+    /// `Durable`. Retained so the public setter keeps its r1 durability
+    /// guarantee without a behavioural surprise.
     BatchDirectorySync,
+}
+
+/// Per-thread snapshot write-batch state.
+///
+/// Scoping the batch to the thread that opened it (heddle#550 Finding 3)
+/// is what keeps a concurrent unrelated write on the same `FsStore` —
+/// e.g. a daemon servicing a second operation — out of this batch's
+/// deferred `syncfs` barrier. Only writes issued by the batch-opening
+/// thread are staged; every other caller gets normal per-write
+/// durability even while this batch is open.
+///
+/// Each batch is single-threaded by construction (the import/snapshot
+/// operation that opens it issues all its object writes from the opening
+/// thread), so this entry is only ever touched by its owning thread.
+#[derive(Debug, Default)]
+struct SnapshotBatch {
+    /// begin/flush nesting depth; the `syncfs` barrier + promotion run
+    /// when a flush brings this back to 0.
+    depth: usize,
+    /// Objects staged during this batch: canonical destination -> the
+    /// temp file holding the not-yet-promoted bytes. Keyed by canonical
+    /// path so a repeated put of the same content-addressed object
+    /// dedups instead of staging the bytes twice.
+    staged: HashMap<PathBuf, PathBuf>,
 }
 
 #[derive(Debug)]
@@ -102,8 +135,11 @@ pub struct FsStore {
     pub(super) recent_trees: RwLock<RecentObjectCache<ContentHash, Tree>>,
     pub(super) recent_states: RwLock<RecentObjectCache<ChangeId, State>>,
     loose_object_write_mode: LooseObjectWriteMode,
-    snapshot_write_batch_depth: Mutex<usize>,
-    pending_directory_syncs: Mutex<BTreeSet<PathBuf>>,
+    /// Active snapshot write batches, keyed by the thread that opened
+    /// each. See [`SnapshotBatch`] — per-thread scoping is the
+    /// heddle#550 Finding 3 fix (a process-wide depth counter swept
+    /// every concurrent caller's writes into one operation's batch).
+    snapshot_batches: Mutex<HashMap<ThreadId, SnapshotBatch>>,
     /// In-process trust cache for loose-blob cache mirrors. A hash
     /// enters this LRU when this process either (a) wrote the blob
     /// itself via `promote_to_loose_uncompressed` or (b) successfully
@@ -144,8 +180,7 @@ impl FsStore {
                 RECENT_TREE_CACHE_CAPACITY,
             )),
             loose_object_write_mode: LooseObjectWriteMode::Durable,
-            snapshot_write_batch_depth: Mutex::new(0),
-            pending_directory_syncs: Mutex::new(BTreeSet::new()),
+            snapshot_batches: Mutex::new(HashMap::new()),
             verified_loose_blobs: RwLock::new(RecentObjectCache::with_capacity(
                 VERIFIED_LOOSE_BLOB_CACHE_CAPACITY,
             )),
@@ -166,8 +201,7 @@ impl FsStore {
                 RECENT_TREE_CACHE_CAPACITY,
             )),
             loose_object_write_mode: LooseObjectWriteMode::Durable,
-            snapshot_write_batch_depth: Mutex::new(0),
-            pending_directory_syncs: Mutex::new(BTreeSet::new()),
+            snapshot_batches: Mutex::new(HashMap::new()),
             verified_loose_blobs: RwLock::new(RecentObjectCache::with_capacity(
                 VERIFIED_LOOSE_BLOB_CACHE_CAPACITY,
             )),
@@ -205,35 +239,6 @@ impl FsStore {
 
     pub fn set_loose_object_write_mode(&mut self, mode: LooseObjectWriteMode) {
         self.loose_object_write_mode = mode;
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    fn flush_pending_directory_syncs(&self) -> Result<usize> {
-        use crate::fs_atomic::sync_directory;
-        let pending_dirs = {
-            let mut guard = self.pending_directory_syncs.lock().map_err(|_| {
-                crate::store::HeddleError::Config(
-                    "Failed to acquire pending directory sync lock".to_string(),
-                )
-            })?;
-            if guard.is_empty() {
-                return Ok(0);
-            }
-            let dirs = guard.iter().cloned().collect::<Vec<_>>();
-            guard.clear();
-            dirs
-        };
-
-        for (index, dir) in pending_dirs.iter().enumerate() {
-            if let Err(error) = sync_directory(dir) {
-                if let Ok(mut guard) = self.pending_directory_syncs.lock() {
-                    guard.extend(pending_dirs[index..].iter().cloned());
-                }
-                return Err(error.into());
-            }
-        }
-
-        Ok(pending_dirs.len())
     }
 
     /// Reload pack files from disk.
@@ -302,32 +307,82 @@ impl FsStore {
     }
 
     pub(super) fn write_loose_object_atomic(&self, path: &Path, data: &[u8]) -> Result<()> {
-        let batch_active = self.snapshot_write_batch_depth.lock().map_err(|_| {
-            crate::store::HeddleError::Config("Failed to acquire snapshot batch lock".to_string())
-        })?;
-        let in_snapshot_batch = *batch_active > 0;
-        let configured_mode = if in_snapshot_batch {
-            LooseObjectWriteMode::BatchDirectorySync
-        } else {
-            self.loose_object_write_mode
+        // Is THIS thread inside an active snapshot batch? Only the
+        // batch-opening thread's writes are staged for deferred-flush
+        // promotion (heddle#550 Finding 3); a concurrent write from any
+        // other thread — or any non-batch caller — falls through to a
+        // normal fully-durable write below.
+        let tid = std::thread::current().id();
+        let in_batch_this_thread = {
+            let batches = self.lock_snapshot_batches()?;
+            batches.get(&tid).is_some_and(|batch| batch.depth > 0)
         };
-        drop(batch_active);
 
-        let mode = match configured_mode {
-            LooseObjectWriteMode::Durable => AtomicWriteMode::Durable,
-            LooseObjectWriteMode::BatchDirectorySync => AtomicWriteMode::BatchDirectorySync,
-        };
-        write_atomic(
-            path,
-            data,
-            mode,
-            Some(&self.pending_directory_syncs),
-            in_snapshot_batch,
-        )
+        if in_batch_this_thread {
+            // Quarantine-then-promote (heddle#550 Finding 2): stage the
+            // bytes in a temp file beside the canonical path but DON'T
+            // rename into place yet. The canonical content-addressed
+            // path therefore never holds bytes that aren't durably
+            // flushed, so a crash before flush can only leave an orphan
+            // temp (ignored by reads) — never a present-but-torn object
+            // that `put_blob`/`put_tree`/`put_state`'s exists-skip would
+            // refuse to rewrite. Promotion (the rename) happens in
+            // `flush_snapshot_write_batch`, after the `syncfs` barrier.
+            //
+            // Dedup: a repeated put of the same content-addressed object
+            // within the batch is identical bytes, so skip re-staging.
+            // Safe to check unlocked-then-locked because the batch is
+            // single-threaded (only its owning thread, this one, mutates
+            // the `staged` map).
+            {
+                let batches = self.lock_snapshot_batches()?;
+                if batches
+                    .get(&tid)
+                    .is_some_and(|batch| batch.staged.contains_key(path))
+                {
+                    return Ok(());
+                }
+            }
+            let temp = stage_loose_object(path, data)?;
+            let mut batches = self.lock_snapshot_batches()?;
+            match batches.get_mut(&tid) {
+                Some(batch) if batch.depth > 0 => {
+                    if let Some(prev) = batch.staged.insert(path.to_path_buf(), temp) {
+                        // Lost a dedup race with ourselves (unreachable in
+                        // the single-threaded-per-batch model); drop the
+                        // superseded temp so it doesn't leak.
+                        let _ = std::fs::remove_file(prev);
+                    }
+                    Ok(())
+                }
+                // The batch closed out from under us between the staging
+                // write and re-acquiring the lock. Can't happen on the
+                // owning thread, but if it did the bytes would be lost —
+                // promote immediately so the write still lands durably.
+                _ => {
+                    promote_staged_object(&temp, path)?;
+                    crate::fs_atomic::sync_directory(path.parent().unwrap_or(Path::new(".")))?;
+                    Ok(())
+                }
+            }
+        } else {
+            // No active batch on this thread. `BatchDirectorySync` set
+            // standalone via the public setter still means "fully
+            // durable" — no `syncfs` is ever coming to back a deferral.
+            write_atomic(path, data, AtomicWriteMode::Durable)
+        }
+    }
+
+    fn lock_snapshot_batches(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<ThreadId, SnapshotBatch>>> {
+        self.snapshot_batches.lock().map_err(|_| {
+            crate::store::HeddleError::Config("Failed to acquire snapshot batch lock".to_string())
+        })
     }
 
     pub(super) fn write_pack_atomic(&self, path: &Path, data: &[u8]) -> Result<()> {
-        write_atomic(path, data, AtomicWriteMode::Durable, None, false)
+        write_atomic(path, data, AtomicWriteMode::Durable)
     }
 
     /// Atomic write tuned for *cache-mirror* loose objects: no fsync
@@ -351,49 +406,89 @@ impl FsStore {
     /// / `put_state` — those are the authoritative copy and must
     /// survive a crash.
     pub(super) fn write_loose_object_cache(&self, path: &Path, data: &[u8]) -> Result<()> {
-        write_atomic(path, data, AtomicWriteMode::NoSync, None, false)
+        write_atomic(path, data, AtomicWriteMode::NoSync)
     }
 
     pub(super) fn begin_snapshot_write_batch_impl(&self) -> Result<()> {
-        let mut depth = self.snapshot_write_batch_depth.lock().map_err(|_| {
-            crate::store::HeddleError::Config("Failed to acquire snapshot batch lock".to_string())
-        })?;
-        *depth += 1;
+        let tid = std::thread::current().id();
+        let mut batches = self.lock_snapshot_batches()?;
+        batches.entry(tid).or_default().depth += 1;
         Ok(())
     }
 
     pub(super) fn flush_snapshot_write_batch_impl(&self) -> Result<()> {
-        let should_flush = {
-            let mut depth = self.snapshot_write_batch_depth.lock().map_err(|_| {
-                crate::store::HeddleError::Config(
-                    "Failed to acquire snapshot batch lock".to_string(),
-                )
-            })?;
-            if *depth == 0 {
+        let tid = std::thread::current().id();
+        // Pop the staged set iff this flush closes the (nested) batch.
+        let staged = {
+            let mut batches = self.lock_snapshot_batches()?;
+            let Some(batch) = batches.get_mut(&tid) else {
+                return Ok(());
+            };
+            if batch.depth == 0 {
                 return Ok(());
             }
-            *depth -= 1;
-            *depth == 0
+            batch.depth -= 1;
+            if batch.depth > 0 {
+                return Ok(());
+            }
+            let staged = std::mem::take(&mut batch.staged);
+            batches.remove(&tid);
+            staged
         };
 
-        if should_flush {
-            // On Linux, one `syncfs()` makes every object written during
-            // the batch durable in a single filesystem-wide barrier (git's
-            // `core.fsyncMethod=batch`), replacing the per-file `sync_data`
-            // skipped in `write_atomic`. It also flushes the directory
-            // metadata, so the deferred per-directory fsync queue is then
-            // redundant and just cleared. Other platforms fall back to the
-            // per-directory fsyncs that pair with their per-file `sync_data`.
-            #[cfg(target_os = "linux")]
-            {
-                self.syncfs_root()?;
-                if let Ok(mut pending) = self.pending_directory_syncs.lock() {
-                    pending.clear();
+        self.promote_staged_batch(staged)
+    }
+
+    /// Make every object staged during a snapshot batch durable, then
+    /// promote (rename) it into its canonical content-addressed path.
+    ///
+    /// The ordering is what holds the heddle#550 durability invariant:
+    /// the data barrier runs while the objects are still in their temp
+    /// staging files, so after the promote a canonical path can only
+    /// ever reference *durable* bytes. A crash at any point leaves either
+    /// orphan temps (pre-barrier) or canonical objects whose data is
+    /// already on disk (post-barrier) — never a present-but-torn object.
+    /// A second barrier makes the new directory entries themselves
+    /// durable before the caller writes any referencing artifact.
+    fn promote_staged_batch(&self, staged: HashMap<PathBuf, PathBuf>) -> Result<()> {
+        if staged.is_empty() {
+            return Ok(());
+        }
+
+        // Step 1: durability barrier for the staged temp *data*. On Linux
+        // one `syncfs()` flushes every staged temp in a single
+        // filesystem-wide barrier (git's `core.fsyncMethod=batch`) —
+        // replacing the N per-object fsyncs that dominate large-history
+        // import (heddle#550). Elsewhere each temp was already
+        // `sync_data`'d in `stage_loose_object`.
+        #[cfg(target_os = "linux")]
+        self.syncfs_root()?;
+
+        // Step 2: promote each temp into its canonical path. The bytes are
+        // already durable, so a renamed-into-place object is never torn.
+        for (canonical, temp) in &staged {
+            promote_staged_object(temp, canonical)?;
+        }
+
+        // Step 3: make the new directory entries durable before any
+        // referencing artifact (mapping/oplog/refs) is written. On Linux
+        // a second `syncfs()` covers every touched directory; elsewhere
+        // fsync each distinct canonical parent directory.
+        #[cfg(target_os = "linux")]
+        self.syncfs_root()?;
+        #[cfg(not(target_os = "linux"))]
+        {
+            use std::collections::BTreeSet;
+
+            use crate::fs_atomic::sync_directory;
+            let mut dirs: BTreeSet<&Path> = BTreeSet::new();
+            for canonical in staged.keys() {
+                if let Some(parent) = canonical.parent() {
+                    dirs.insert(parent);
                 }
             }
-            #[cfg(not(target_os = "linux"))]
-            {
-                let _ = self.flush_pending_directory_syncs()?;
+            for dir in dirs {
+                sync_directory(dir)?;
             }
         }
 
@@ -420,19 +515,31 @@ impl FsStore {
     }
 
     pub(super) fn abort_snapshot_write_batch_impl(&self) {
-        if let Ok(mut depth) = self.snapshot_write_batch_depth.lock() {
-            *depth = 0;
-        }
-        if let Ok(mut pending) = self.pending_directory_syncs.lock() {
-            pending.clear();
+        let tid = std::thread::current().id();
+        let staged = {
+            let Ok(mut batches) = self.snapshot_batches.lock() else {
+                return;
+            };
+            batches.remove(&tid).map(|batch| batch.staged)
+        };
+        // Discard the staged temps. They were never promoted to a
+        // canonical path, so there are no torn objects to clean up —
+        // just orphan temp files the next run would ignore anyway.
+        if let Some(staged) = staged {
+            for temp in staged.into_values() {
+                let _ = std::fs::remove_file(temp);
+            }
         }
     }
 
+    /// Number of objects currently staged (written but not yet promoted)
+    /// in the calling thread's active snapshot batch.
     #[cfg(test)]
-    pub(super) fn pending_directory_sync_count(&self) -> usize {
-        self.pending_directory_syncs
+    pub(super) fn staged_object_count(&self) -> usize {
+        let tid = std::thread::current().id();
+        self.snapshot_batches
             .lock()
-            .map(|pending| pending.len())
+            .map(|batches| batches.get(&tid).map(|b| b.staged.len()).unwrap_or(0))
             .unwrap_or(0)
     }
 }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -305,7 +305,8 @@ impl FsStore {
         let batch_active = self.snapshot_write_batch_depth.lock().map_err(|_| {
             crate::store::HeddleError::Config("Failed to acquire snapshot batch lock".to_string())
         })?;
-        let configured_mode = if *batch_active > 0 {
+        let in_snapshot_batch = *batch_active > 0;
+        let configured_mode = if in_snapshot_batch {
             LooseObjectWriteMode::BatchDirectorySync
         } else {
             self.loose_object_write_mode
@@ -316,11 +317,17 @@ impl FsStore {
             LooseObjectWriteMode::Durable => AtomicWriteMode::Durable,
             LooseObjectWriteMode::BatchDirectorySync => AtomicWriteMode::BatchDirectorySync,
         };
-        write_atomic(path, data, mode, Some(&self.pending_directory_syncs))
+        write_atomic(
+            path,
+            data,
+            mode,
+            Some(&self.pending_directory_syncs),
+            in_snapshot_batch,
+        )
     }
 
     pub(super) fn write_pack_atomic(&self, path: &Path, data: &[u8]) -> Result<()> {
-        write_atomic(path, data, AtomicWriteMode::Durable, None)
+        write_atomic(path, data, AtomicWriteMode::Durable, None, false)
     }
 
     /// Atomic write tuned for *cache-mirror* loose objects: no fsync
@@ -344,7 +351,7 @@ impl FsStore {
     /// / `put_state` — those are the authoritative copy and must
     /// survive a crash.
     pub(super) fn write_loose_object_cache(&self, path: &Path, data: &[u8]) -> Result<()> {
-        write_atomic(path, data, AtomicWriteMode::NoSync, None)
+        write_atomic(path, data, AtomicWriteMode::NoSync, None, false)
     }
 
     pub(super) fn begin_snapshot_write_batch_impl(&self) -> Result<()> {

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -2,7 +2,7 @@
 //! Core FsStore structure.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
     path::{Path, PathBuf},
     sync::{Mutex, RwLock},
@@ -14,12 +14,31 @@ use super::{
     fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, trees_dir},
 };
 use crate::{
+    fs_atomic::{is_staged_temp_name, stage_temp_path},
     object::{Blob, ChangeId, ContentHash, State, Tree},
     store::{
         CompressionConfig, Result,
         pack::{PackManager, PackObjectId},
     },
 };
+
+/// Whether a loose-object write is content-addressed (its path is a
+/// content hash, so a re-stage at the same path is byte-identical and
+/// dedups safely) or mutable (keyed by an external id, so the same path
+/// can be legitimately re-staged with DIFFERENT bytes within one batch
+/// and the LATEST must win — heddle#550 Finding 1).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum LooseObjectKind {
+    /// Blobs, trees, actions: path derived from the object's content
+    /// hash. A repeated stage of the same path carries identical bytes,
+    /// so it is safe to dedup-skip.
+    ContentAddressed,
+    /// State objects keyed by `ChangeId`. `put_state` intentionally
+    /// overwrites the same path as a change mutates, so a later staged
+    /// write at the same path must SUPERSEDE the earlier one rather than
+    /// dedup-skip it; otherwise the promoted state would be stale.
+    Mutable,
+}
 
 const RECENT_BLOB_CACHE_CAPACITY: usize = 2_048;
 const RECENT_TREE_CACHE_CAPACITY: usize = 1_024;
@@ -306,7 +325,12 @@ impl FsStore {
         manager.list_all_ids()
     }
 
-    pub(super) fn write_loose_object_atomic(&self, path: &Path, data: &[u8]) -> Result<()> {
+    pub(super) fn write_loose_object_atomic(
+        &self,
+        path: &Path,
+        data: &[u8],
+        kind: LooseObjectKind,
+    ) -> Result<()> {
         // Is THIS thread inside an active snapshot batch? Only the
         // batch-opening thread's writes are staged for deferred-flush
         // promotion (heddle#550 Finding 3); a concurrent write from any
@@ -318,59 +342,83 @@ impl FsStore {
             batches.get(&tid).is_some_and(|batch| batch.depth > 0)
         };
 
-        if in_batch_this_thread {
-            // Quarantine-then-promote (heddle#550 Finding 2): stage the
-            // bytes in a temp file beside the canonical path but DON'T
-            // rename into place yet. The canonical content-addressed
-            // path therefore never holds bytes that aren't durably
-            // flushed, so a crash before flush can only leave an orphan
-            // temp (ignored by reads) — never a present-but-torn object
-            // that `put_blob`/`put_tree`/`put_state`'s exists-skip would
-            // refuse to rewrite. Promotion (the rename) happens in
-            // `flush_snapshot_write_batch`, after the `syncfs` barrier.
-            //
-            // Dedup: a repeated put of the same content-addressed object
-            // within the batch is identical bytes, so skip re-staging.
-            // Safe to check unlocked-then-locked because the batch is
-            // single-threaded (only its owning thread, this one, mutates
-            // the `staged` map).
-            {
-                let batches = self.lock_snapshot_batches()?;
-                if batches
-                    .get(&tid)
-                    .is_some_and(|batch| batch.staged.contains_key(path))
-                {
-                    return Ok(());
-                }
-            }
-            let temp = stage_loose_object(path, data)?;
-            let mut batches = self.lock_snapshot_batches()?;
-            match batches.get_mut(&tid) {
-                Some(batch) if batch.depth > 0 => {
-                    if let Some(prev) = batch.staged.insert(path.to_path_buf(), temp) {
-                        // Lost a dedup race with ourselves (unreachable in
-                        // the single-threaded-per-batch model); drop the
-                        // superseded temp so it doesn't leak.
-                        let _ = std::fs::remove_file(prev);
-                    }
-                    Ok(())
-                }
-                // The batch closed out from under us between the staging
-                // write and re-acquiring the lock. Can't happen on the
-                // owning thread, but if it did the bytes would be lost —
-                // promote immediately so the write still lands durably.
-                _ => {
-                    promote_staged_object(&temp, path)?;
-                    crate::fs_atomic::sync_directory(path.parent().unwrap_or(Path::new(".")))?;
-                    Ok(())
-                }
-            }
-        } else {
+        if !in_batch_this_thread {
             // No active batch on this thread. `BatchDirectorySync` set
             // standalone via the public setter still means "fully
             // durable" — no `syncfs` is ever coming to back a deferral.
-            write_atomic(path, data, AtomicWriteMode::Durable)
+            return write_atomic(path, data, AtomicWriteMode::Durable);
         }
+
+        // Quarantine-then-promote (heddle#550): stage the bytes in a temp
+        // file beside the canonical path but DON'T rename into place yet.
+        // The canonical path therefore never holds bytes that aren't
+        // durably flushed, so a crash before flush can only leave an
+        // orphan staging temp (ignored by reads, reclaimed by the
+        // abandoned-staging sweep) — never a present-but-torn object that
+        // an exists-skip would refuse to rewrite. Promotion (the rename)
+        // happens in `flush_snapshot_write_batch`, after the `syncfs`
+        // barrier.
+        //
+        // Reserve the staging slot in `staged` UNDER THE LOCK before the
+        // temp file is written, so a concurrent staging sweep (another
+        // thread opening a batch on the same store) can never see this
+        // temp on disk without also seeing it tracked as in-flight.
+        let temp = stage_temp_path(path);
+        let superseded = {
+            let mut batches = self.lock_snapshot_batches()?;
+            match batches.get_mut(&tid) {
+                Some(batch) if batch.depth > 0 => {
+                    // Dedup applies ONLY to content-addressed objects: a
+                    // re-stage at the same path is byte-identical, so skip
+                    // it. Mutable (`ChangeId`-keyed) state writes are
+                    // exempt and fall through to stage + supersede so the
+                    // LATEST version wins (heddle#550 Finding 1).
+                    if kind == LooseObjectKind::ContentAddressed
+                        && batch.staged.contains_key(path)
+                    {
+                        return Ok(());
+                    }
+                    batch.staged.insert(path.to_path_buf(), temp.clone())
+                }
+                // The batch closed out from under us between the depth
+                // probe and re-acquiring the lock. Can't happen on the
+                // owning thread, but if it did the bytes would be lost —
+                // write durably so the object still lands.
+                _ => return write_atomic(path, data, AtomicWriteMode::Durable),
+            }
+        };
+
+        // Write the reserved temp with the lock released (keep file I/O
+        // off the snapshot-batch mutex).
+        if let Err(err) = stage_loose_object(path, &temp, data) {
+            // The staged write failed (`stage_loose_object` already
+            // removed its own partial temp). Roll the reservation back so
+            // a later flush never tries to promote a temp that does not
+            // exist: restore the version we superseded, or drop the slot
+            // if there was none.
+            let mut batches = self.lock_snapshot_batches()?;
+            if let Some(batch) = batches.get_mut(&tid)
+                && batch.staged.get(path) == Some(&temp)
+            {
+                match superseded {
+                    Some(prev) => {
+                        batch.staged.insert(path.to_path_buf(), prev);
+                    }
+                    None => {
+                        batch.staged.remove(path);
+                    }
+                }
+            }
+            return Err(err);
+        }
+
+        // The new bytes are durably staged; the superseded temp (a
+        // mutable re-stage, or an unreachable content-addressed dedup
+        // race) is now garbage.
+        if let Some(prev) = superseded {
+            let _ = std::fs::remove_file(prev);
+        }
+        Ok(())
     }
 
     fn lock_snapshot_batches(
@@ -411,14 +459,29 @@ impl FsStore {
 
     pub(super) fn begin_snapshot_write_batch_impl(&self) -> Result<()> {
         let tid = std::thread::current().id();
-        let mut batches = self.lock_snapshot_batches()?;
-        batches.entry(tid).or_default().depth += 1;
+        let opened_fresh = {
+            let mut batches = self.lock_snapshot_batches()?;
+            let batch = batches.entry(tid).or_default();
+            batch.depth += 1;
+            batch.depth == 1
+        };
+        // When this opens a fresh (not nested) batch, reclaim any staging
+        // temps abandoned by a previously crashed import (heddle#550
+        // Finding 3). Runs with the lock released — the sweep takes the
+        // lock itself to read the live-batch tracked set it must skip.
+        if opened_fresh {
+            self.sweep_abandoned_staged_temps();
+        }
         Ok(())
     }
 
     pub(super) fn flush_snapshot_write_batch_impl(&self) -> Result<()> {
         let tid = std::thread::current().id();
-        // Pop the staged set iff this flush closes the (nested) batch.
+        // Snapshot the staged set iff this flush closes the (nested)
+        // batch. The batch entry is LEFT in the map (at depth 0) while we
+        // promote, so a concurrent staging sweep still sees these temps as
+        // in-flight and won't reclaim them mid-promotion. It is removed
+        // once promotion finishes.
         let staged = {
             let mut batches = self.lock_snapshot_batches()?;
             let Some(batch) = batches.get_mut(&tid) else {
@@ -431,12 +494,23 @@ impl FsStore {
             if batch.depth > 0 {
                 return Ok(());
             }
-            let staged = std::mem::take(&mut batch.staged);
-            batches.remove(&tid);
-            staged
+            batch.staged.clone()
         };
 
-        self.promote_staged_batch(staged)
+        let result = self.promote_staged_batch(&staged);
+
+        // Promotion done (or failed): drop the now-quiescent batch entry.
+        // A failed promote leaves un-promoted temps behind, but they are
+        // no longer tracked once the entry is gone — the next import's
+        // begin-time sweep reclaims them.
+        {
+            let mut batches = self.lock_snapshot_batches()?;
+            if batches.get(&tid).is_some_and(|batch| batch.depth == 0) {
+                batches.remove(&tid);
+            }
+        }
+
+        result
     }
 
     /// Make every object staged during a snapshot batch durable, then
@@ -450,7 +524,7 @@ impl FsStore {
     /// already on disk (post-barrier) — never a present-but-torn object.
     /// A second barrier makes the new directory entries themselves
     /// durable before the caller writes any referencing artifact.
-    fn promote_staged_batch(&self, staged: HashMap<PathBuf, PathBuf>) -> Result<()> {
+    fn promote_staged_batch(&self, staged: &HashMap<PathBuf, PathBuf>) -> Result<()> {
         if staged.is_empty() {
             return Ok(());
         }
@@ -466,7 +540,7 @@ impl FsStore {
 
         // Step 2: promote each temp into its canonical path. The bytes are
         // already durable, so a renamed-into-place object is never torn.
-        for (canonical, temp) in &staged {
+        for (canonical, temp) in staged {
             promote_staged_object(temp, canonical)?;
         }
 
@@ -530,6 +604,53 @@ impl FsStore {
                 let _ = std::fs::remove_file(temp);
             }
         }
+        // Invalidate the in-memory object caches (heddle#550 Finding 2).
+        // `put_blob`/`put_tree`/`put_state` populate `recent_blobs` /
+        // `recent_trees` / `recent_states` eagerly, BEFORE the staged temp
+        // is promoted. On abort the temp is discarded and the canonical
+        // path is never written, so those cache entries now describe
+        // objects that do not exist on disk. The existence-gated read
+        // paths already refuse to serve them, but the cache-first
+        // `blob_size` fast path would report a never-written object as
+        // present — so purge the caches to force post-abort reads to
+        // re-resolve from disk.
+        self.clear_recent_object_caches();
+    }
+
+    /// Reclaim staging temp files abandoned by a crashed or killed import
+    /// (heddle#550 Finding 3). A crash before `flush_snapshot_write_batch`
+    /// leaves a `.stage-` temp beside every staged object; with no sweep
+    /// they accumulate across repeated crashes.
+    ///
+    /// Safety: only files whose names carry [`STAGED_TEMP_MARKER`] are
+    /// touched, so this never removes a canonical object or a concurrent
+    /// `write_atomic`'s short-lived `.tmp-` temp. Temps still tracked by a
+    /// live batch (in this store's `snapshot_batches`, including one
+    /// mid-promotion in `flush`) are skipped, so a concurrent import's
+    /// in-flight staging is never reclaimed out from under it.
+    ///
+    /// Cost: one `read_dir` pass over the loose-object directories,
+    /// metadata-only, run once per fresh batch (i.e. once per import) —
+    /// negligible beside the import it precedes.
+    fn sweep_abandoned_staged_temps(&self) {
+        let in_flight: HashSet<PathBuf> = match self.snapshot_batches.lock() {
+            Ok(batches) => batches
+                .values()
+                .flat_map(|batch| batch.staged.values().cloned())
+                .collect(),
+            // Poisoned lock: skip the opportunistic sweep rather than risk
+            // reclaiming a temp we can't prove is abandoned.
+            Err(_) => return,
+        };
+
+        for dir in [
+            blobs_dir(&self.root),
+            trees_dir(&self.root),
+            states_dir(&self.root),
+            actions_dir(&self.root),
+        ] {
+            sweep_staged_temps_under(&dir, &in_flight);
+        }
     }
 
     /// Number of objects currently staged (written but not yet promoted)
@@ -541,5 +662,33 @@ impl FsStore {
             .lock()
             .map(|batches| batches.get(&tid).map(|b| b.staged.len()).unwrap_or(0))
             .unwrap_or(0)
+    }
+}
+
+/// Remove abandoned `.stage-` temps under `dir`, recursing into the
+/// sharded sub-directories blobs/trees use. A temp in `in_flight` (still
+/// tracked by a live batch) is left alone; every other staged temp is
+/// crash garbage and is reclaimed. Best-effort: any I/O error (missing
+/// dir on a fresh store, permission) simply leaves the temp for a later
+/// sweep rather than failing the batch.
+fn sweep_staged_temps_under(dir: &Path, in_flight: &HashSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            sweep_staged_temps_under(&path, in_flight);
+        } else if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(is_staged_temp_name)
+            && !in_flight.contains(&path)
+        {
+            let _ = std::fs::remove_file(&path);
+        }
     }
 }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -13,7 +13,6 @@ use super::{
     fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, trees_dir},
 };
 use crate::{
-    fs_atomic::sync_directory,
     object::{Blob, ChangeId, ContentHash, State, Tree},
     store::{
         CompressionConfig, Result,
@@ -208,7 +207,9 @@ impl FsStore {
         self.loose_object_write_mode = mode;
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn flush_pending_directory_syncs(&self) -> Result<usize> {
+        use crate::fs_atomic::sync_directory;
         let pending_dirs = {
             let mut guard = self.pending_directory_syncs.lock().map_err(|_| {
                 crate::store::HeddleError::Config(
@@ -369,9 +370,45 @@ impl FsStore {
         };
 
         if should_flush {
-            let _ = self.flush_pending_directory_syncs()?;
+            // On Linux, one `syncfs()` makes every object written during
+            // the batch durable in a single filesystem-wide barrier (git's
+            // `core.fsyncMethod=batch`), replacing the per-file `sync_data`
+            // skipped in `write_atomic`. It also flushes the directory
+            // metadata, so the deferred per-directory fsync queue is then
+            // redundant and just cleared. Other platforms fall back to the
+            // per-directory fsyncs that pair with their per-file `sync_data`.
+            #[cfg(target_os = "linux")]
+            {
+                self.syncfs_root()?;
+                if let Ok(mut pending) = self.pending_directory_syncs.lock() {
+                    pending.clear();
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = self.flush_pending_directory_syncs()?;
+            }
         }
 
+        Ok(())
+    }
+
+    /// Single filesystem-wide durability barrier for a snapshot write
+    /// batch on Linux (git's `core.fsyncMethod=batch`). `syncfs` flushes
+    /// every dirty page on the filesystem backing the object store in one
+    /// barrier, making all objects written during the batch durable
+    /// without the per-file `sync_data` that dominated large-history
+    /// import (heddle#550).
+    #[cfg(target_os = "linux")]
+    fn syncfs_root(&self) -> Result<()> {
+        use std::os::fd::AsRawFd;
+        let dir = std::fs::File::open(&self.root).map_err(crate::store::HeddleError::Io)?;
+        // SAFETY: `dir` owns a valid open fd for the duration of the call;
+        // `syncfs` only reads it to locate the filesystem to flush.
+        let rc = unsafe { libc::syncfs(dir.as_raw_fd()) };
+        if rc != 0 {
+            return Err(crate::store::HeddleError::Io(std::io::Error::last_os_error()));
+        }
         Ok(())
     }
 

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -68,6 +68,41 @@ fn test_durable_loose_object_write_mode_does_not_queue_directory_syncs() {
 }
 
 #[test]
+fn standalone_batch_directory_sync_mode_writes_durably_without_a_batch() {
+    // Durability guard for heddle#550: `BatchDirectorySync` can be
+    // configured standalone via the public `set_loose_object_write_mode`
+    // setter, with no `begin_snapshot_write_batch` ever called. In that
+    // state the deferred `syncfs()` barrier never runs, so on Linux the
+    // write must NOT skip its per-file `sync_data` (that skip is only
+    // sound inside an active batch). Here we exercise that path
+    // end-to-end: set the mode standalone, write a loose object with no
+    // batch active, and confirm it is committed + round-trips with no
+    // flush call. The per-file-sync decision itself is unit-tested in
+    // `fs_io::tests::batch_directory_sync_defers_per_file_fsync_only_in_active_batch`.
+    let temp_dir = TempDir::new().unwrap();
+    let heddle_dir = temp_dir.path().join(".heddle");
+    let mut store = FsStore::new(&heddle_dir);
+    store.set_loose_object_write_mode(LooseObjectWriteMode::BatchDirectorySync);
+    store.init().unwrap();
+
+    assert_eq!(
+        store.loose_object_write_mode(),
+        LooseObjectWriteMode::BatchDirectorySync
+    );
+
+    let blob = Blob::from("standalone batch-mode durable bytes");
+    let hash = store.put_blob(&blob).unwrap();
+
+    // The object is committed and readable without any
+    // begin/flush_snapshot_write_batch call — its durability came from
+    // the per-file sync, not a syncfs that never runs.
+    let path = hash_path(&blobs_dir(store.root()), &hash);
+    assert!(path.exists(), "standalone-mode write must be committed on disk");
+    let retrieved = store.get_blob(&hash).unwrap().unwrap();
+    assert_eq!(retrieved.content(), blob.content());
+}
+
+#[test]
 fn test_snapshot_write_batch_defers_directory_sync_until_flush() {
     let (_temp, store) = create_test_store();
 

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -48,13 +48,16 @@ fn test_default_loose_object_write_mode_is_durable_outside_snapshot_batch() {
     );
 
     let blob = Blob::from("durable default");
-    store.put_blob(&blob).unwrap();
+    let hash = store.put_blob(&blob).unwrap();
 
-    assert_eq!(store.pending_directory_sync_count(), 0);
+    // No batch open: the write lands at its canonical path immediately
+    // (fully durable), nothing is left staged.
+    assert_eq!(store.staged_object_count(), 0);
+    assert!(hash_path(&blobs_dir(store.root()), &hash).exists());
 }
 
 #[test]
-fn test_durable_loose_object_write_mode_does_not_queue_directory_syncs() {
+fn test_durable_loose_object_write_mode_does_not_stage_objects() {
     let temp_dir = TempDir::new().unwrap();
     let heddle_dir = temp_dir.path().join(".heddle");
     let mut store = FsStore::new(&heddle_dir);
@@ -64,7 +67,7 @@ fn test_durable_loose_object_write_mode_does_not_queue_directory_syncs() {
     let blob = Blob::from("durable sync");
     store.put_blob(&blob).unwrap();
 
-    assert_eq!(store.pending_directory_sync_count(), 0);
+    assert_eq!(store.staged_object_count(), 0);
 }
 
 #[test]
@@ -103,31 +106,180 @@ fn standalone_batch_directory_sync_mode_writes_durably_without_a_batch() {
 }
 
 #[test]
-fn test_snapshot_write_batch_defers_directory_sync_until_flush() {
+fn test_snapshot_write_batch_stages_until_flush_then_promotes() {
     let (_temp, store) = create_test_store();
 
     store.begin_snapshot_write_batch().unwrap();
 
     let blob = Blob::from("batched sync");
     let hash = store.put_blob(&blob).unwrap();
+    let canonical = hash_path(&blobs_dir(store.root()), &hash);
 
-    assert_eq!(store.pending_directory_sync_count(), 1);
-    assert!(store.get_blob(&hash).unwrap().is_some());
+    // Quarantine (heddle#550 Finding 2): mid-batch the object is staged
+    // in a temp beside its canonical path, NOT renamed into place — so
+    // the canonical content-addressed path never holds bytes that aren't
+    // yet durably flushed. A crash here can only leave an orphan temp.
+    assert_eq!(store.staged_object_count(), 1);
+    assert!(
+        !canonical.exists(),
+        "staged object must not occupy its canonical path before flush",
+    );
 
     store.flush_snapshot_write_batch().unwrap();
-    assert_eq!(store.pending_directory_sync_count(), 0);
+
+    // After the flush barrier + promote, the object is at its canonical
+    // path and reads back correctly.
+    assert_eq!(store.staged_object_count(), 0);
+    assert!(canonical.exists(), "flush must promote the staged object");
+    assert_eq!(
+        store.get_blob(&hash).unwrap().unwrap().content(),
+        blob.content(),
+    );
 }
 
 #[test]
-fn test_abort_snapshot_write_batch_clears_pending_directory_syncs() {
+fn test_abort_snapshot_write_batch_discards_staged_objects() {
     let (_temp, store) = create_test_store();
 
     store.begin_snapshot_write_batch().unwrap();
-    store.put_blob(&Blob::from("aborted batch")).unwrap();
-    assert_eq!(store.pending_directory_sync_count(), 1);
+    let hash = store.put_blob(&Blob::from("aborted batch")).unwrap();
+    let canonical = hash_path(&blobs_dir(store.root()), &hash);
+    assert_eq!(store.staged_object_count(), 1);
+    assert!(!canonical.exists());
 
     store.abort_snapshot_write_batch();
-    assert_eq!(store.pending_directory_sync_count(), 0);
+
+    // Abort drops the staged temps and never promotes them: the canonical
+    // path stays empty (no torn object the next run could exists-skip).
+    assert_eq!(store.staged_object_count(), 0);
+    assert!(
+        !canonical.exists(),
+        "aborted batch must not leave a canonical object behind",
+    );
+}
+
+#[test]
+fn incomplete_batch_leaves_no_canonical_object_so_rerun_rewrites() {
+    // heddle#550 Finding 2: a batch that writes objects but never flushes
+    // (process crashed mid-import, before the mapping/oplog commit) must
+    // not leave a present-but-torn object at a canonical content-addressed
+    // path. If it did, the next run's content-addressed exists-skip would
+    // refuse to rewrite it and the torn bytes would survive forever.
+    //
+    // Quarantine-then-promote guarantees the opposite: in-batch writes are
+    // staged in temp files and only renamed into canonical AFTER the
+    // durability barrier, so an unflushed batch leaves canonical empty and
+    // the re-run rewrites cleanly + byte-identically.
+    let temp_dir = TempDir::new().unwrap();
+    let heddle_dir = temp_dir.path().join(".heddle");
+    let blob = Blob::from("content recreated identically after a torn batch");
+
+    let hash = {
+        let store = FsStore::new(&heddle_dir);
+        store.init().unwrap();
+        store.begin_snapshot_write_batch().unwrap();
+        let hash = store.put_blob(&blob).unwrap();
+        let canonical = hash_path(&blobs_dir(store.root()), &hash);
+
+        // Incomplete batch: no flush, no abort. The object is staged but
+        // never promoted, so its canonical path is empty and it is
+        // invisible to reads.
+        assert_eq!(store.staged_object_count(), 1);
+        assert!(
+            !canonical.exists(),
+            "an unflushed batch must not occupy the canonical path",
+        );
+        assert!(store.get_blob(&hash).unwrap().is_none());
+
+        hash
+        // `store` dropped here with the batch still open == crash. No Drop
+        // promotes the staged temps; the canonical path stays empty.
+    };
+
+    // Fresh store over the same root re-imports the same content. Because
+    // the canonical path is empty (no torn object to exists-skip), the put
+    // actually rewrites; after flush the object is durable + byte-identical.
+    let store = FsStore::new(&heddle_dir);
+    let canonical = hash_path(&blobs_dir(store.root()), &hash);
+    assert!(
+        !canonical.exists(),
+        "the crashed batch must have left no canonical object behind",
+    );
+    store.begin_snapshot_write_batch().unwrap();
+    let rehash = store.put_blob(&blob).unwrap();
+    assert_eq!(rehash, hash, "content-addressed hash must be stable");
+    store.flush_snapshot_write_batch().unwrap();
+
+    assert!(
+        canonical.exists(),
+        "the re-run must rewrite + promote the object (not exists-skip a torn one)",
+    );
+    assert_eq!(
+        store.get_blob(&hash).unwrap().unwrap().content(),
+        blob.content(),
+    );
+}
+
+#[test]
+fn concurrent_non_batch_write_is_durable_while_another_thread_holds_a_batch() {
+    use std::sync::{Arc, mpsc};
+
+    // heddle#550 Finding 3: the snapshot batch is scoped to the thread
+    // that opened it. A concurrent unrelated write on a *different* thread
+    // (e.g. a daemon servicing a second operation on the same store) must
+    // get normal per-write durability — it must NOT be swept into the
+    // batch-owner's deferred `syncfs` barrier.
+    let (_temp, store) = create_test_store();
+    let store = Arc::new(store);
+
+    let (staged_tx, staged_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+
+    let store_a = Arc::clone(&store);
+    let batch_owner = std::thread::spawn(move || {
+        store_a.begin_snapshot_write_batch().unwrap();
+        let hash = store_a
+            .put_blob(&Blob::from("batch-owner staged object"))
+            .unwrap();
+        staged_tx.send(hash).unwrap();
+        // Hold the batch open until the main thread has done its write.
+        release_rx.recv().unwrap();
+        store_a.flush_snapshot_write_batch().unwrap();
+    });
+
+    let owner_hash = staged_rx.recv().unwrap();
+    let owner_canonical = hash_path(&blobs_dir(store.root()), &owner_hash);
+    assert!(
+        !owner_canonical.exists(),
+        "the batch owner's object is staged, not yet promoted",
+    );
+
+    // This (main) thread holds no batch. Its write must land durably at
+    // its canonical path immediately, independent of the other thread's
+    // open batch.
+    let unrelated = Blob::from("main-thread unrelated durable write");
+    let unrelated_hash = store.put_blob(&unrelated).unwrap();
+    let unrelated_canonical = hash_path(&blobs_dir(store.root()), &unrelated_hash);
+    assert!(
+        unrelated_canonical.exists(),
+        "a concurrent non-batch write must be durable immediately, not deferred \
+         to the other thread's batch",
+    );
+    assert_eq!(
+        store.staged_object_count(),
+        0,
+        "the main thread opened no batch, so it stages nothing",
+    );
+    assert_eq!(
+        store.get_blob(&unrelated_hash).unwrap().unwrap().content(),
+        unrelated.content(),
+    );
+
+    release_tx.send(()).unwrap();
+    batch_owner.join().unwrap();
+
+    // The owner's flush promotes only its own object.
+    assert!(owner_canonical.exists());
 }
 
 #[test]

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -4,9 +4,10 @@ use tempfile::TempDir;
 
 use super::{
     FsStore, LooseObjectWriteMode,
-    fs_paths::{blobs_dir, hash_path, packs_dir},
+    fs_paths::{blobs_dir, hash_path, packs_dir, state_path, states_dir},
 };
 use crate::{
+    fs_atomic::{is_staged_temp_name, stage_temp_path},
     object::{
         Action, Attribution, Blob, ChangeId, ContentHash, Operation, Principal, State, Tree,
         TreeEntry,
@@ -18,6 +19,29 @@ use crate::{
         pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
     },
 };
+
+/// Count `.stage-` staging temps anywhere under `dir` (recursing into
+/// the sharded sub-dirs blobs/trees use). Used by the Finding 3 sweep
+/// tests to assert what was reclaimed vs. preserved.
+fn count_staged_temps(dir: &std::path::Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            count += count_staged_temps(&path);
+        } else if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(is_staged_temp_name)
+        {
+            count += 1;
+        }
+    }
+    count
+}
 
 fn create_test_store() -> (TempDir, FsStore) {
     let temp_dir = TempDir::new().unwrap();
@@ -829,5 +853,222 @@ fn loose_blob_path_rejects_torn_cache_mirror() {
     assert!(
         probed.is_none(),
         "corrupted loose blob must not be served as canonical bytes"
+    );
+}
+
+#[test]
+fn batch_restage_of_same_state_promotes_latest_version() {
+    // heddle#550 Finding 1: the staging dedup keys by canonical path, but
+    // `put_state` is keyed by `ChangeId` and *intentionally overwrites*
+    // the same path as a change mutates. A later staged write to the same
+    // state path must SUPERSEDE the earlier one (the latest is
+    // authoritative) — content-addressed blobs/trees still dedup-skip,
+    // but a mutable state that drops its newest version would promote a
+    // stale snapshot.
+    let (_temp, store) = create_test_store();
+
+    let tree_v1 = ContentHash::compute(b"tree-v1");
+    let tree_v2 = ContentHash::compute(b"tree-v2");
+    let attribution = Attribution::human(Principal::new("Test", "test@example.com"));
+    let state_v1 = State::new(tree_v1, vec![], attribution.clone()).with_intent("first");
+    let change_id = state_v1.change_id;
+    // Same ChangeId, different content (newer intent + tree).
+    let state_v2 = State::new(tree_v2, vec![], attribution)
+        .with_change_id(change_id)
+        .with_intent("second");
+
+    store.begin_snapshot_write_batch().unwrap();
+    store.put_state(&state_v1).unwrap();
+    store.put_state(&state_v2).unwrap();
+
+    // Both writes target the one ChangeId-keyed path, so the batch holds
+    // exactly one staged object — the supersede replaced the temp rather
+    // than stacking a second one.
+    assert_eq!(
+        store.staged_object_count(),
+        1,
+        "re-staging the same state path must supersede, not accumulate",
+    );
+
+    store.flush_snapshot_write_batch().unwrap();
+    store.clear_recent_object_caches();
+
+    let promoted = store.get_state(&change_id).unwrap().unwrap();
+    assert_eq!(
+        promoted.intent,
+        Some("second".to_string()),
+        "the LATEST staged state must be the one promoted",
+    );
+    assert_eq!(promoted.tree, tree_v2);
+}
+
+#[test]
+fn batch_restage_of_same_blob_still_dedups() {
+    // Counterpart to the Finding 1 supersede: a content-addressed object
+    // re-put within a batch carries identical bytes, so it must still
+    // dedup-skip (one staged temp), not stage a redundant second copy.
+    let (_temp, store) = create_test_store();
+
+    store.begin_snapshot_write_batch().unwrap();
+    let blob = Blob::from("identical content addressed bytes");
+    let h1 = store.put_blob(&blob).unwrap();
+    let h2 = store.put_blob(&blob).unwrap();
+    assert_eq!(h1, h2);
+    assert_eq!(
+        store.staged_object_count(),
+        1,
+        "an identical content-addressed re-put must dedup, not double-stage",
+    );
+    store.flush_snapshot_write_batch().unwrap();
+    assert_eq!(store.get_blob(&h1).unwrap().unwrap().content(), blob.content());
+}
+
+#[test]
+fn batch_abort_purges_in_memory_caches_so_reads_miss() {
+    // heddle#550 Finding 2: `put_blob` populates `recent_blobs` eagerly,
+    // BEFORE its staged temp is promoted. On abort the temp is discarded
+    // and the canonical path is never written, so that cache entry now
+    // points at an object that does not exist. The existence-gated
+    // `get_blob` already refuses to serve it, but the cache-first
+    // `blob_size` fast path would report the never-written object as
+    // present unless the abort purges the cache.
+    let (_temp, store) = create_test_store();
+
+    store.begin_snapshot_write_batch().unwrap();
+    let blob = Blob::from("aborted-and-must-not-leak-via-cache");
+    let hash = store.put_blob(&blob).unwrap();
+    // Cache-first size path sees the staged-but-unpromoted blob mid-batch.
+    assert_eq!(store.blob_size(&hash).unwrap(), Some(blob.content().len() as u64));
+
+    store.abort_snapshot_write_batch();
+
+    // After abort the object exists nowhere on disk. Every read path —
+    // including the cache-first size path — must re-resolve from disk and
+    // miss; none may serve a stale cache hit.
+    let canonical = hash_path(&blobs_dir(store.root()), &hash);
+    assert!(!canonical.exists(), "aborted blob must not occupy its canonical path");
+    assert!(
+        store.get_blob(&hash).unwrap().is_none(),
+        "get_blob must miss after abort",
+    );
+    assert!(
+        store.blob_size(&hash).unwrap().is_none(),
+        "blob_size must not serve a stale cache hit for an aborted (never-written) blob",
+    );
+    assert!(!store.has_blob(&hash).unwrap(), "has_blob must miss after abort");
+}
+
+#[test]
+fn begin_batch_sweeps_abandoned_staging_temps_but_spares_other_files() {
+    // heddle#550 Finding 3: a crash before flush leaves `.stage-` temps
+    // beside every staged object. The next import's fresh batch-begin must
+    // reclaim them — but ONLY them: ordinary `.tmp-` temps (from a
+    // concurrent durable `write_atomic`) and canonical objects must be
+    // left untouched.
+    let (_temp, store) = create_test_store();
+
+    // A real committed blob: canonical decoy that must survive the sweep.
+    let kept_blob = Blob::from("canonical object that must survive the sweep");
+    let kept_hash = store.put_blob(&kept_blob).unwrap();
+    let kept_canonical = hash_path(&blobs_dir(store.root()), &kept_hash);
+    assert!(kept_canonical.exists());
+
+    // Abandoned staging temps left by a "crashed" prior batch: one in a
+    // blobs shard, one in the flat states dir.
+    let orphan_blob_hash = Blob::from("orphaned staged blob").hash();
+    let orphan_blob_canonical = hash_path(&blobs_dir(store.root()), &orphan_blob_hash);
+    std::fs::create_dir_all(orphan_blob_canonical.parent().unwrap()).unwrap();
+    let orphan_blob_temp = stage_temp_path(&orphan_blob_canonical);
+    std::fs::write(&orphan_blob_temp, b"abandoned staged blob bytes").unwrap();
+
+    let orphan_state_canonical = state_path(store.root(), &ChangeId::generate());
+    std::fs::create_dir_all(orphan_state_canonical.parent().unwrap()).unwrap();
+    let orphan_state_temp = stage_temp_path(&orphan_state_canonical);
+    std::fs::write(&orphan_state_temp, b"abandoned staged state bytes").unwrap();
+
+    // A non-staging `.tmp-` temp (the shape `write_atomic` leaves): the
+    // sweep keys off the `.stage-` marker, so this must be spared.
+    let tmp_decoy = temp_path(&hash_path(&blobs_dir(store.root()), &Blob::from("decoy").hash()));
+    std::fs::create_dir_all(tmp_decoy.parent().unwrap()).unwrap();
+    std::fs::write(&tmp_decoy, b"ordinary write_atomic temp").unwrap();
+
+    assert_eq!(count_staged_temps(&blobs_dir(store.root())), 1);
+    assert_eq!(count_staged_temps(&states_dir(store.root())), 1);
+
+    // A fresh batch-begin runs the sweep.
+    store.begin_snapshot_write_batch().unwrap();
+
+    assert!(!orphan_blob_temp.exists(), "abandoned blob staging temp must be swept");
+    assert!(!orphan_state_temp.exists(), "abandoned state staging temp must be swept");
+    assert_eq!(count_staged_temps(&blobs_dir(store.root())), 0);
+    assert_eq!(count_staged_temps(&states_dir(store.root())), 0);
+
+    // Untouched: the `.tmp-` temp and the canonical blob.
+    assert!(tmp_decoy.exists(), "ordinary .tmp- temp must NOT be swept");
+    assert!(kept_canonical.exists(), "canonical object must NOT be swept");
+    assert_eq!(
+        store.get_blob(&kept_hash).unwrap().unwrap().content(),
+        kept_blob.content(),
+    );
+
+    store.abort_snapshot_write_batch();
+}
+
+#[test]
+fn staging_sweep_spares_a_concurrent_batchs_in_flight_temps() {
+    use std::sync::{Arc, mpsc};
+
+    // heddle#550 Finding 3: the sweep must reclaim ONLY abandoned temps.
+    // A concurrent batch on another thread has live, tracked staging temps
+    // mid-import; a fresh batch-begin on this thread must not delete them
+    // out from under it.
+    let (_temp, store) = create_test_store();
+    let store = Arc::new(store);
+
+    let (staged_tx, staged_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+
+    let store_a = Arc::clone(&store);
+    let batch_owner = std::thread::spawn(move || {
+        store_a.begin_snapshot_write_batch().unwrap();
+        let hash = store_a
+            .put_blob(&Blob::from("live in-flight staged blob"))
+            .unwrap();
+        staged_tx.send(hash).unwrap();
+        release_rx.recv().unwrap();
+        store_a.flush_snapshot_write_batch().unwrap();
+    });
+
+    let owner_hash = staged_rx.recv().unwrap();
+    let owner_canonical = hash_path(&blobs_dir(store.root()), &owner_hash);
+    assert!(!owner_canonical.exists(), "owner's blob is staged, not yet promoted");
+    // The owner's live staging temp is on disk and tracked.
+    assert_eq!(count_staged_temps(&blobs_dir(store.root())), 1);
+
+    // Plant an abandoned staging temp the sweep SHOULD reclaim.
+    let orphan_hash = Blob::from("orphan vs live").hash();
+    let orphan_canonical = hash_path(&blobs_dir(store.root()), &orphan_hash);
+    std::fs::create_dir_all(orphan_canonical.parent().unwrap()).unwrap();
+    let orphan_temp = stage_temp_path(&orphan_canonical);
+    std::fs::write(&orphan_temp, b"abandoned").unwrap();
+
+    // A fresh batch-begin on THIS thread sweeps. The owner's temp is
+    // tracked (in-flight) and must survive; the orphan must be reclaimed.
+    store.begin_snapshot_write_batch().unwrap();
+    assert!(!orphan_temp.exists(), "abandoned temp must be reclaimed by the sweep");
+    assert_eq!(
+        count_staged_temps(&blobs_dir(store.root())),
+        1,
+        "the concurrent batch's live staging temp must be spared",
+    );
+    store.abort_snapshot_write_batch();
+
+    // The owner can still flush: its temp survived to be promoted.
+    release_tx.send(()).unwrap();
+    batch_owner.join().unwrap();
+    assert!(owner_canonical.exists(), "owner's staged blob must promote after a concurrent sweep");
+    assert_eq!(
+        store.get_blob(&owner_hash).unwrap().unwrap().content(),
+        b"live in-flight staged blob",
     );
 }


### PR DESCRIPTION
Closes #550.

## Dominant cost
Profiled `heddle adopt`'s commit import with a timed harness (`crates/cli/tests/import_perf_harness.rs`, `#[ignore]`) that builds an N-commit fixture and times `import_all`. Each imported commit writes a blob + tree + state through `FsStore`, and during the import snapshot batch every loose-object write does a per-file `file.sync_data()` at **`crates/objects/src/store/fs/fs_io.rs:121`** (the `AtomicWriteMode::BatchDirectorySync` arm).

Neutralizing that one fsync took a 3000-commit import from **95 → 269 commits/s** — i.e. the per-object fsync was **~65%** of import wall time. fsync, not CPU/serialization, is the bottleneck.

## The reduction
Adopt git's `core.fsyncMethod=batch` strategy. On Linux, skip the per-file `sync_data` during a snapshot write batch and issue **one `syncfs()`** filesystem-wide durability barrier at `flush_snapshot_write_batch` (new `FsStore::syncfs_root`). N per-object fsync barriers collapse into one.

Durability is preserved: objects written mid-batch are unreferenced until the **post-flush** oplog/ref/mapping commit (both batch callers — `git_import` and `repository_snapshot` — commit their referencing record after `flush_snapshot_write_batch` returns), so the single barrier runs before anything durable points at the objects. A crash before flush leaves only harmless, content-addressed orphans that the next run re-creates identically. Non-Linux platforms (no `syncfs`) keep the per-file fsync + deferred per-directory sync unchanged.

## Before/after (same 3000-commit fixture, same box)
| variant | commits/s | per-commit |
|---|---|---|
| baseline (`Durable` per-file `sync_data`) | 95 | ~10.5 ms |
| **this PR (`syncfs` batch)** | **202–236** | **~4.2–5.0 ms** |
| upper bound (no fsync at all) | 269 | ~3.7 ms |

~**2.2–2.5×** throughput. Numbers are debug builds on a box at ~99% disk (a single large filesystem), which is *pessimistic* for `syncfs` since it flushes the whole busy FS; a typical adopt flushes a quieter filesystem and the relative win holds (fsync dominance is OS-level, independent of opt level).

**Latency target:** ≤ ~5 ms/commit on Linux for a representative adopt (down from ~10.5 ms), recovering most of the gap to the no-fsync ceiling.

## Correctness
Imported history is byte-identical before/after: round-trip fidelity gate #533 (`roundtrip_fidelity`, 10 tests) green, plus objects store suite (324, incl. batch-durability `pending_directory_sync_count` tests), bridge import suite (71, incl. deep-history), and the workspace adopt/import/status tests (100+, 0 failures). Default-features build, no-silent-default check, and `clippy --workspace --all-targets -- -D warnings` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783311789&installation_id=132405951&pr_number=553&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F553&signature=ddc639e0f0336317d475a71932b6e74532c78055fa6d477203c0f4b28047c940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->