### PR TITLE
fix(release): pin Linux build to glibc 2.35 floor (runs on Debian 12 / Ubuntu 22.04) (#549)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,10 +191,14 @@ jobs:
             runner: macos-13
             archive: tar.gz
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            # glibc floor: ubuntu-22.04 ships glibc 2.35, so the -gnu
+            # binaries run on Debian 12 (2.36) and Ubuntu 22.04+ forward.
+            # Building on ubuntu-24.04 (glibc 2.39) crashed at runtime on
+            # those targets with GLIBC_2.3x-not-found (#549).
+            runner: ubuntu-22.04-arm
             archive: tar.gz
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             archive: tar.gz
           - target: x86_64-pc-windows-msvc
             runner: windows-2022

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -144,6 +144,29 @@ The asset filenames and the `SHA256SUMS` layout are part of this
 contract. Changing them is a breaking change for downstream packaging
 channels and requires a coordinated update.
 
+### Linux glibc floor
+
+The two `-unknown-linux-gnu` legs target **glibc ≥ 2.35**. They are
+built on `ubuntu-22.04` / `ubuntu-22.04-arm` runners (glibc 2.35), so
+the binaries dynamically link against no symbol newer than `GLIBC_2.35`
+and run on Debian 12 (glibc 2.36), Ubuntu 22.04, and every newer glibc
+distro forward.
+
+This is a declared contract, not an accident of the runner image.
+Building these legs on a newer runner (e.g. `ubuntu-24.04`, glibc 2.39)
+raises the symbol floor and crashes the binary at first run on the
+supported targets with `GLIBC_2.3x not found` (#549) — it `apt
+install`s / extracts fine and only fails on exec, so it is not caught
+by packaging tests. The runner pins are asserted by
+`scripts/check-release-pipeline.sh`; a bump back to a newer runner
+fails that check. To verify a built binary's floor:
+
+```bash
+objdump -T heddle | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1   # must be <= GLIBC_2.35
+# end-to-end smoke on the oldest supported target:
+docker run --rm -v "$PWD:/h" debian:12 /h/heddle --version
+```
+
 ## Verifying a release
 
 ```bash
@@ -178,7 +201,7 @@ cross-compiling from a single host. Trade-off:
 - **Native matrix (chosen)**: five parallel runners (~5–10 min each
   with `Swatinem/rust-cache`). No `cross`, no sysroot juggling, no
   Apple-codesign-on-Linux contortions later if/when we add notarization.
-  ARM is free on GitHub-hosted runners (`ubuntu-24.04-arm`, `macos-14`).
+  ARM is free on GitHub-hosted runners (`ubuntu-22.04-arm`, `macos-14`).
 - **Cross-compilation**: one runner, more setup. Wins on cost only if
   we hit a parallelism cap, which we won't at our release cadence.
 

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -101,6 +101,23 @@ for t in "${targets[@]}"; do
   fi
 done
 
+# Linux glibc floor (#549). The two -unknown-linux-gnu legs MUST build on
+# ubuntu-22.04 runners (glibc 2.35) so the binaries run on Debian 12 /
+# Ubuntu 22.04 forward. Building on a newer runner (ubuntu-24.04, glibc
+# 2.39) raises the symbol floor and crashes at runtime on those targets.
+# We assert the runner pin per-leg via the parsed-YAML pass below; this
+# grep is the cheap smoke screen that flags a wholesale bump.
+if grep -E "runner:\s*ubuntu-24\.04(-arm)?\b" "$WF" >/dev/null; then
+  err "a job pins runner: ubuntu-24.04 — the linux-gnu legs must stay on ubuntu-22.04 for the glibc 2.35 floor (#549)"
+else
+  ok "no ubuntu-24.04 runner pin (glibc floor preserved)"
+fi
+if grep -F "glibc floor" RELEASING.md >/dev/null; then
+  ok "RELEASING.md documents the Linux glibc floor"
+else
+  err "RELEASING.md must document the Linux glibc floor (see #549)"
+fi
+
 # Packaging: tarball for unix, zip for windows.
 grep -E "\.tar\.gz" "$WF" >/dev/null && ok "tar.gz packaging" || err "no tar.gz packaging in $WF"
 grep -E "\.zip"    "$WF" >/dev/null && ok "zip packaging"    || err "no zip packaging in $WF"
@@ -261,6 +278,28 @@ for name in downstream:
             )
         else:
             oks.append(f"{name} job pins checkout to validated tag_sha")
+
+# Linux glibc floor (#549): the two -unknown-linux-gnu build legs must
+# pin an ubuntu-22.04 runner (glibc 2.35). Read the runner per matrix
+# entry rather than grepping, so a per-leg regression (one leg bumped)
+# is caught even if the other stays correct.
+build_job = jobs.get("build")
+if isinstance(build_job, dict):
+    matrix = ((build_job.get("strategy") or {}).get("matrix") or {})
+    include = matrix.get("include", []) or []
+    gnu_legs = [e for e in include if isinstance(e, dict)
+                and str(e.get("target", "")).endswith("-unknown-linux-gnu")]
+    if not gnu_legs:
+        errors.append("build matrix has no *-unknown-linux-gnu legs to floor")
+    for e in gnu_legs:
+        runner = str(e.get("runner", ""))
+        target = e.get("target")
+        if runner.startswith("ubuntu-22.04"):
+            oks.append(f"{target} pinned to {runner} (glibc 2.35 floor)")
+        else:
+            errors.append(
+                f"{target} builds on '{runner}', not ubuntu-22.04 — raises the glibc floor above 2.35 (#549)"
+            )
 
 print("OKS:")
 for o in oks:


### PR DESCRIPTION
Closes #549.

## Problem
The two `-unknown-linux-gnu` release legs built on `ubuntu-24.04` /
`ubuntu-24.04-arm` (glibc 2.39). A 2.39-linked binary references glibc
symbols newer than the target floor and **crashes at first run** on
Debian 12 (glibc 2.36) and Ubuntu 22.04 (2.35) with `GLIBC_2.3x not
found`. The archive `apt install`s / extracts fine and only fails on
exec, so packaging tests don't catch it. Affects raw tarballs today and
the future apt (#234) / brew-Linux (#232) channels.

## Fix
Pin both gnu legs to `ubuntu-22.04` / `ubuntu-22.04-arm` (glibc 2.35).
Target triples unchanged. A 2.35-linked binary runs on Debian 12 (2.36),
Ubuntu 22.04, and every newer glibc distro forward. Smallest-diff,
lowest-risk option per the issue (no cargo-zigbuild / musl needed —
no build-dep blocker on 22.04). amd64 + arm64 both covered.

## Verification — objdump symbol floor
This orchestrator host is glibc 2.39 (same as ubuntu-24.04, the buggy
config). `objdump -T` on a binary built here shows the exact crash
cause:

```
$ objdump -T heddle | grep -E 'GLIBC_2\.3[6-9]'
__isoc23_sscanf   (GLIBC_2.38)
__isoc23_strtol   (GLIBC_2.38)
pidfd_getpid      (GLIBC_2.39)
pidfd_spawnp      (GLIBC_2.39)
```

These symbols don't exist in the ubuntu-22.04 toolchain's libc, so a
binary built there cannot reference them (highest floor becomes
`GLIBC_2.35`). The per-binary check (and a `docker run --rm debian:12
/h/heddle --version` smoke) is documented in RELEASING.md as the
CI/manual verification step — no container available in this build env
to run it here.

## Regression guard
- `RELEASING.md` declares the **glibc ≥ 2.35** floor as a contract
  (Artifact-contract section) with the objdump/container verification
  recipe.
- `scripts/check-release-pipeline.sh` now asserts the runner pin two
  ways: a grep that fails on any `ubuntu-24.04` pin, and a parsed-YAML
  per-leg check that each `*-unknown-linux-gnu` matrix entry pins
  `ubuntu-22.04`. A bump back to a newer runner fails the check.

`bash scripts/check-release-pipeline.sh` passes (no Rust source change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783311927&installation_id=132405951&pr_number=554&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F554&signature=ac0f4fd90ed506b6c0240d72674cf3d33b0538e6e7778fac0d9a1205533fee90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->