### PR TITLE
perf(status): cut compare_worktree get_tree overhead (#535)

### DIFF
--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -263,17 +263,13 @@ impl FsStore {
     }
 
     fn try_get_tree_once(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        let path = hash_path(&trees_dir(&self.root), hash);
-        let loose_exists = path.exists();
-        let pack_has = if loose_exists {
-            false
-        } else if let Ok(manager) = self.pack_manager().read() {
-            manager.has_object(hash)
-        } else {
-            false
-        };
-        if (loose_exists || pack_has)
-            && let Ok(cache) = self.recent_trees.read()
+        // Cache first. The recent-object cache only ever holds trees we
+        // wrote or read this process, so a hit is authoritative for a
+        // read — no need to confirm on-disk existence first. Skipping
+        // that probe removes a `stat` (and a pack-index lookup) per
+        // call, which dominates `heddle status` on directory-heavy
+        // trees (the walker loads one subtree per directory).
+        if let Ok(cache) = self.recent_trees.read()
             && let Some(tree) = cache.get(hash)
         {
             trace!("Found tree in recent object cache");
@@ -295,6 +291,7 @@ impl FsStore {
             return Ok(Some(tree));
         }
 
+        let path = hash_path(&trees_dir(&self.root), hash);
         match read_file_bytes(&path)? {
             Some(data) => {
                 trace!(size = data.as_slice().len(), "Tree data read");

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -126,21 +126,9 @@ fn refresh_tracked_file(
         return Ok(false);
     }
 
-    let hash = if ctx.index.is_fresh(key, &metadata) {
+    let hash = if let Some(cached_hash) = ctx.index.fresh_entry(key, &metadata).map(|c| c.hash) {
         ctx.stats.cache_hits += 1;
-        ctx.index.get(key).map(|cached| cached.hash).map_or_else(
-            || {
-                compute_and_cache_file(
-                    &path,
-                    key,
-                    &metadata,
-                    tree_entry.is_executable(),
-                    ctx.index,
-                    ctx.stats,
-                )
-            },
-            Ok,
-        )?
+        cached_hash
     } else {
         compute_and_cache_file(
             &path,
@@ -185,12 +173,9 @@ fn refresh_tracked_symlink(
         return Ok(false);
     }
 
-    let hash = if ctx.index.is_fresh(key, &metadata) {
+    let hash = if let Some(cached_hash) = ctx.index.fresh_entry(key, &metadata).map(|c| c.hash) {
         ctx.stats.cache_hits += 1;
-        ctx.index.get(key).map(|cached| cached.hash).map_or_else(
-            || compute_and_cache_symlink(&path, key, &metadata, ctx.index),
-            Ok,
-        )?
+        cached_hash
     } else {
         compute_and_cache_symlink(&path, key, &metadata, ctx.index)?
     };

--- a/crates/repo/src/worktree_index.rs
+++ b/crates/repo/src/worktree_index.rs
@@ -383,27 +383,20 @@ impl WorktreeIndex {
 
     /// Check if a cached entry is still fresh compared to filesystem metadata.
     pub fn is_fresh(&self, path: &str, metadata: &fs::Metadata) -> bool {
-        let entry = match self.entries.get(path) {
-            Some(e) => e,
-            None => return false,
-        };
+        self.fresh_entry(path, metadata).is_some()
+    }
 
-        let modified = match metadata.modified() {
-            Ok(m) => m,
-            Err(_) => return false,
-        };
+    /// Return the cached entry for `path` iff it is still fresh compared to
+    /// filesystem metadata. Combines the lookup and freshness check into a
+    /// single map traversal — the tracked-refresh hot path calls this once
+    /// per file, so the second redundant `get` it replaces was pure overhead.
+    pub fn fresh_entry(&self, path: &str, metadata: &fs::Metadata) -> Option<&IndexEntry> {
+        let entry = self.entries.get(path)?;
 
-        let duration = match modified.duration_since(std::time::UNIX_EPOCH) {
-            Ok(d) => d,
-            Err(_) => return false,
-        };
-
-        let modified_sec = match i64::try_from(duration.as_secs()) {
-            Ok(s) => s,
-            Err(_) => return false,
-        };
+        let modified = metadata.modified().ok()?;
+        let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+        let modified_sec = i64::try_from(duration.as_secs()).ok()?;
         let modified_nsec = duration.subsec_nanos();
-
         let size = metadata.len();
 
         let kind = if metadata.is_symlink() {
@@ -427,11 +420,13 @@ impl WorktreeIndex {
             IndexEntryKind::Symlink => !entry.executable,
         };
 
-        entry.size == size
+        let fresh = entry.size == size
             && entry.modified_sec == modified_sec
             && entry.modified_nsec == modified_nsec
             && executable_matches
-            && entry.kind == kind
+            && entry.kind == kind;
+
+        fresh.then_some(entry)
     }
 
     /// Get a directory entry by path.


### PR DESCRIPTION
Closes #535.

## Dominant cost
`heddle status` runs the worktree comparison pass (`compare_worktree`), which walks the committed tree and loads **one subtree per directory** via `FsStore::get_tree`. Measured with a tiny foreground timed harness (1K-untracked-dir fixture, `std::time::Instant`, `timeout`-wrapped — **NOT** the heavy `compare_worktree_untracked_dirs` criterion bench that wedged prior attempts), the comparison breaks down as:

- `tracked_refresh` dominates the pass; `untracked_scan` is negligible (~5% of it).
- Within tracked-refresh, ~70% is `FsStore::get_tree` (`crates/objects/src/store/fs/fs_impl.rs:265 try_get_tree_once`). The bare `stat` floor over all files is only ~8% of the cost.

## The reduction
1. **`try_get_tree_once`** (`crates/objects/src/store/fs/fs_impl.rs:265`): it did a `path.exists()` stat **plus** a pack-index probe purely to gate the recent-object cache lookup. The cache is authoritative for a read, so check it first and only touch the filesystem on a miss (`read_file_bytes` already returns `None` for an absent object). Removes **one stat syscall + one pack-index probe per directory**, scaling linearly with directory count. Loose-vs-pack data precedence and the per-read corruption check are preserved.
2. **`refresh_tracked_file` / `refresh_tracked_symlink`** (`crates/repo/src/status_tracked_refresh.rs`): the per-file hot path did `is_fresh()` (a `BTreeMap::get`) immediately followed by another `get()` for the same key. Folded into a single `WorktreeIndex::fresh_entry` traversal.

## Before / after (release, tiny foreground harness, 1K-dir fixture)
`get_tree` measured in isolation over 1150 subtrees (cold cache — the path a fresh `heddle status` process actually hits):

- before: **27.3 ms**
- after: **22.0 ms**  (**−19%**, and it scales with directory count)

## Correctness
`status` output is byte-identical (no change to what is reported). Full status/worktree suite green.

## Verification
- `cargo build --locked --workspace` (default features) — green
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` — green
- `bash scripts/check-no-silent-default-tree-load.sh` — clean
- `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` — clean

NOTE: all timings were taken with a small foreground timed harness, **not** the heavy criterion bench.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783338230&installation_id=132405951&pr_number=556&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F556&signature=4058fb68dd3839d4a98ce263d7d081bcedff29ebef9c272c5ae2852c5286c1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->