### PR TITLE
docs(dx): explain dual hd-/git-sha ids and the [1m] agent suffix (#462)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ heddle blame path/to/file.rs
 | Concept | Description |
 |---------|-------------|
 | **State** | Immutable snapshot of a repository at a point in time |
-| **ChangeId** | Stable logical identifier that survives rewrites |
+| **ChangeId** | Per-state identifier. Each state carries a *logical* ChangeId (the same value is carried forward across rewrites) and a *physical* ChangeId minted fresh for that state. The `hd-…` shown in output is the **physical** id; the logical id is internal and not surfaced (see [Identifiers in output](#identifiers-in-output)) |
 | **ContentHash** | BLAKE3 hash of object contents for integrity and deduplication |
 | **Thread** | Mutable named reference to a state |
 | **Marker** | Immutable named reference to a state |
@@ -147,7 +147,7 @@ heddle blame path/to/file.rs
 
 History commands render up to three distinct identifiers. They are not interchangeable:
 
-- **`hd-…` change id** (e.g. `hd-wgqnj47xyh40`) — the **ChangeId**. This is the stable, canonical handle: it is assigned once and survives rewrites, amends, and rebases. Pass it to commands that take a change as an argument — `heddle show <id>`, `heddle blame` reports it per line, and `heddle log <id>` selects by it. Prefixes are accepted, so a short `hd-…` is enough as long as it is unambiguous.
+- **`hd-…` change id** (e.g. `hd-wgqnj47xyh40`) — the **physical ChangeId**, minted fresh for each state. It is the handle for *this specific state*: pass it to commands that take a change as an argument — `heddle show <id>`, `heddle blame` reports it per line, and `heddle log <id>` selects by it (resolution matches the physical id of a recorded state). Prefixes are accepted, so a short `hd-…` is enough as long as it is unambiguous. It is **not** a lineage handle that survives rewrites: amending or rebasing produces a *new* state with a *new* `hd-…`, so an `hd-…` captured before a rebase still resolves to the pre-rebase state, not the rewritten one. Heddle does track a separate stable *logical* ChangeId that is carried forward across a rewrite, but it is internal — it is not rendered in output and is not accepted as a command argument, so the displayed `hd-…` is the only id you can pass, and it identifies one state rather than a lineage.
 - **`(……)` content hash** (e.g. `(61408ef9)`, shown beside the change id by `heddle log --verbose` and `heddle show`) — the short form of the **ContentHash**, a BLAKE3 digest of the state's contents. It is *not* a Git commit sha. Because it is content-addressed, it changes whenever the state's content changes, so it pins an exact snapshot but is not a stable handle to "the change". Use it for integrity/equality checks, not as a command argument.
 - **Git checkpoint sha** (shown on the `Git checkpoint:` line under `heddle log --verbose` / `heddle show`) — the actual Git commit that binds the state into Git history. This is the handle for plain-Git tooling (`git show`, `git log`); heddle commands take the `hd-…` change id instead.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ heddle blame path/to/file.rs
 | **Principal** | Human identity accountable for a change |
 | **Agent** | Model identity associated with a change |
 
+### Identifiers in output
+
+History commands render up to three distinct identifiers. They are not interchangeable:
+
+- **`hd-…` change id** (e.g. `hd-wgqnj47xyh40`) — the **ChangeId**. This is the stable, canonical handle: it is assigned once and survives rewrites, amends, and rebases. Pass it to commands that take a change as an argument — `heddle show <id>`, `heddle blame` reports it per line, and `heddle log <id>` selects by it. Prefixes are accepted, so a short `hd-…` is enough as long as it is unambiguous.
+- **`(……)` content hash** (e.g. `(61408ef9)`, shown beside the change id by `heddle log --verbose` and `heddle show`) — the short form of the **ContentHash**, a BLAKE3 digest of the state's contents. It is *not* a Git commit sha. Because it is content-addressed, it changes whenever the state's content changes, so it pins an exact snapshot but is not a stable handle to "the change". Use it for integrity/equality checks, not as a command argument.
+- **Git checkpoint sha** (shown on the `Git checkpoint:` line under `heddle log --verbose` / `heddle show`) — the actual Git commit that binds the state into Git history. This is the handle for plain-Git tooling (`git show`, `git log`); heddle commands take the `hd-…` change id instead.
+
+Rule of thumb: hand `hd-…` change ids to heddle, and the checkpoint sha to Git.
+
 ## Agent-friendly output
 
 Heddle is designed for programmatic use by agents and automation. Most read-shaped commands take `--output json`; `--output auto` — the default — renders text on a TTY and JSON when stdout is piped:
@@ -188,6 +198,8 @@ export HEDDLE_PRINCIPAL_EMAIL="you@example.com"
 export RUST_LOG=heddle=debug
 export RUST_BACKTRACE=1
 ```
+
+Heddle records the agent model string verbatim and echoes it back in attribution output (for example the `Agent:` line of `heddle log --verbose`). If the coding agent reports a model id with a bracketed suffix — such as `claude-opus-4-8[1m]` — heddle preserves the suffix as-is; it does not add or interpret it. The suffix is supplied by the agent harness to distinguish a model variant (for Claude models the bracketed tag denotes the context-window variant), so set `HEDDLE_AGENT_MODEL` to whatever identifier you want recorded.
 
 ## Repository layout
 


### PR DESCRIPTION
Closes #462. Documents two output-legibility nits from a DX field report. **Doc-only** (README.md prose); no logic changes.

## What each identifier is — and which command takes which
A correction surfaced while verifying against the code: the parenthetical in `heddle log --verbose` / `heddle show` is **not** a Git sha (the field report assumed it was). History output carries up to three distinct ids:

- **`hd-…` change id** — the **ChangeId**, stable/canonical, survives rewrites/amends/rebases. Pass this to heddle commands (`show <id>`, `log <id>`; `blame` reports it). Verified: `crates/objects/src/object/hash.rs:101-153` (random 16-byte, Crockford base32, `hd-` prefix); `blame` uses `change_id.short()` at `crates/cli/src/cli/commands/blame.rs:237`.
- **`(……)` content hash** — short **ContentHash** (BLAKE3), shown beside the change id. Content-addressed, so it changes when content changes; not a command handle, not a Git sha. Verified: `crates/cli/src/cli/commands/log.rs:114` (`compute_hash().short()`), `crates/objects/src/object/hash.rs:75-77` (first 8 hex).
- **Git checkpoint sha** — the actual Git commit binding the state into Git history, shown on the `Git checkpoint:` line in verbose. Verified: `crates/cli/src/cli/commands/log.rs:209-210,638-642`; `crates/cli/src/cli/commands/show.rs:132-136` (`git_commit`).

Documented as a new **Identifiers in output** subsection under Core concepts.

## What `[1m]` means
Heddle records the agent model string **verbatim** and does not construct or interpret a `[1m]`-style suffix — it is supplied by the agent harness as a model-variant tag (for Claude models, the context-window variant). Verified: `crates/objects/src/object/state_attribution.rs:43-104` (model stored verbatim, sourced from `HEDDLE_AGENT_MODEL` at :88); harness reads payload `model` verbatim in `crates/cli/src/harness/mod.rs` (`value_string(payload, &["model"])`); no `[1m]` is built anywhere outside tests. Documented as a line near the `HEDDLE_AGENT_MODEL` env-var docs.

## Scope
- Items 1 & 2 only. Item 3 (`heddle ready` `checks: not run`) is split to #543 — untouched.
- Docs/help-text only; no logic changes; every claim cited to the code read.
- Gate: README prose only (no `--help`/catalog surface), so a `heddle doctor docs` build check is disproportionate — skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339835&installation_id=132405951&pr_number=557&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F557&signature=2dab26ce48ece8dd2585bae8a7de15b8632edd5a94a0f048bae9d10094ee171f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->