### PR TITLE
perf(adopt): import via the streaming pack builder (#555)

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -13,7 +13,7 @@ use repo::{Repository as HeddleRepository, ThreadId};
 use tracing::warn;
 
 pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
-use super::git_import_tree::fail_lossy_entry;
+use super::git_import_tree::{PackImportSink, fail_lossy_entry};
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, RefNamespace, RefUpdate, SyncMapping,
@@ -148,7 +148,6 @@ fn resolve_identity(
 /// Import a single Git commit as a Heddle state.
 pub fn import_commit(
     mapping: &mut SyncMapping,
-    heddle_repo: &HeddleRepository,
     repo: &gix::Repository,
     tree_importer: &mut GitTreeImporter<'_>,
     git_oid: gix::hash::ObjectId,
@@ -243,7 +242,7 @@ pub fn import_commit(
         state
     };
 
-    heddle_repo.store().put_state(&state)?;
+    tree_importer.write_state(&state)?;
 
     Ok(change_id)
 }
@@ -569,9 +568,24 @@ fn import_with_ref_filter(
 
     bridge.build_existing_mapping(Some(repo.path()))?;
 
-    let mut tree_importer =
-        GitTreeImporter::with_options(bridge.heddle_repo, &repo, options.clone());
-    bridge.heddle_repo.store().begin_snapshot_write_batch()?;
+    // heddle#555: route the bulk import through a single streaming pack (one
+    // atomic install) instead of N loose objects + per-object fsync. Stage
+    // under the Heddle store dir so the final install is a same-filesystem
+    // rename(2). Only the write sink changes — every bridge import semantic
+    // (identity recovery, annotated-tag mirror, lossy handling, divergence
+    // checks, ref/tag/marker sync) is preserved by reusing the same walk.
+    let staging_dir = bridge
+        .heddle_repo
+        .heddle_dir()
+        .join("bridge-import")
+        .join("staging");
+    let pack_sink = PackImportSink::new(&staging_dir)?;
+    let mut tree_importer = GitTreeImporter::with_options_packed(
+        bridge.heddle_repo,
+        &repo,
+        options.clone(),
+        pack_sink,
+    );
     let mut noop_progress = |_: usize| {};
     let progress_cb: &mut dyn FnMut(usize) = match progress {
         Some(callback) => callback,
@@ -584,12 +598,16 @@ fn import_with_ref_filter(
             stats
                 .lossy_entries
                 .extend(tree_importer.lossy_entries().iter().cloned());
+            // Crash-safe sequencing (risk #3): the pack must be durably
+            // installed BEFORE the change_id↔git_oid mapping is committed or
+            // any ref/tag/marker is synced below, so a crash can never leave
+            // a ref or mapping entry pointing into a pack that didn't land.
+            tree_importer.finalize_pack_install()?;
             bridge.write_mapping_tmp_to_disk()?;
-            bridge.heddle_repo.store().flush_snapshot_write_batch()?;
             bridge.commit_mapping_tmp_to_disk()?;
         }
         Err(error) => {
-            bridge.heddle_repo.store().abort_snapshot_write_batch();
+            tree_importer.abort_pack();
             return Err(error);
         }
     }
@@ -906,18 +924,21 @@ fn import_commit_ancestry(
                 // with identical bytes.
                 let existing_change_id = bridge.mapping.get_heddle(oid);
                 let needs_state = match existing_change_id {
-                    Some(cid) => bridge.heddle_repo.store().get_state(&cid)?.is_none(),
+                    // heddle#555 risk #2: a state buffered in the un-finalized
+                    // pack isn't readable via the store yet, so check the
+                    // in-memory staged set first; fall back to the store for
+                    // states a prior import already installed (keeps re-import
+                    // idempotent — states_created stays 0 on a no-op re-adopt).
+                    Some(cid) => {
+                        !tree_importer.state_staged_in_pack(&cid)
+                            && bridge.heddle_repo.store().get_state(&cid)?.is_none()
+                    }
                     None => true,
                 };
                 if needs_state {
                     let before_lossy = tree_importer.lossy_entries().len();
-                    let change_id = import_commit(
-                        &mut bridge.mapping,
-                        bridge.heddle_repo,
-                        repo,
-                        tree_importer,
-                        oid,
-                    )?;
+                    let change_id =
+                        import_commit(&mut bridge.mapping, repo, tree_importer, oid)?;
                     bridge.mapping.insert(change_id, oid);
                     let commit_lossy_entries =
                         tree_importer.lossy_entries()[before_lossy..].to_vec();

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Import Git trees as Heddle trees.
 
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
 
-use objects::object::{Blob, ContentHash, FileMode, Tree, TreeEntry};
-use objects::store::ObjectStore;
+use objects::object::{Blob, ChangeId, ContentHash, FileMode, State, Tree, TreeEntry};
+use objects::store::{
+    CompressionConfig, ObjectStore,
+    pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
+};
 use objects::util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name};
 use repo::Repository as HeddleRepository;
 
@@ -21,6 +29,10 @@ pub struct GitTreeImporter<'a> {
     options: GitImportOptions,
     lossy_entries: Vec<LossyGitImportEntry>,
     lossy_by_tree: HashMap<gix::hash::ObjectId, Vec<LossyGitImportEntry>>,
+    /// When set, imported blobs/trees/states stream into a single native
+    /// pack instead of N loose objects (heddle#555). `None` keeps the
+    /// legacy loose-write path for callers like [`import_git_tree`].
+    pack: Option<PackImportSink>,
 }
 
 impl<'a> GitTreeImporter<'a> {
@@ -41,6 +53,95 @@ impl<'a> GitTreeImporter<'a> {
             options,
             lossy_entries: Vec::new(),
             lossy_by_tree: HashMap::new(),
+            pack: None,
+        }
+    }
+
+    /// Like [`Self::with_options`] but routes every imported blob/tree/state
+    /// into `sink`'s streaming pack rather than loose object writes. The
+    /// caller must call [`Self::finalize_pack_install`] after the walk (or
+    /// [`Self::abort_pack`] on failure) to durably install the pack.
+    pub(crate) fn with_options_packed(
+        heddle_repo: &'a HeddleRepository,
+        repo: &'a gix::Repository,
+        options: GitImportOptions,
+        sink: PackImportSink,
+    ) -> Self {
+        Self {
+            heddle_repo,
+            repo,
+            tree_cache: HashMap::new(),
+            blob_cache: HashMap::new(),
+            options,
+            lossy_entries: Vec::new(),
+            lossy_by_tree: HashMap::new(),
+            pack: Some(sink),
+        }
+    }
+
+    /// Persist a Heddle `State` produced by `import_commit` — into the pack
+    /// when packing, else loose. Centralizing the write here is what lets
+    /// the same walk/identity logic feed either sink.
+    pub(crate) fn write_state(&mut self, state: &State) -> GitResult<()> {
+        let repo = self.heddle_repo;
+        match self.pack.as_mut() {
+            Some(sink) => sink.add_state(repo.store(), state),
+            None => {
+                repo.store().put_state(state)?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Whether `change_id`'s state has already been buffered into this run's
+    /// in-flight pack. The pack isn't installed until the walk finishes, so
+    /// such a state isn't yet readable through the store — the walk's
+    /// idempotency check consults this first (heddle#555 risk #2).
+    pub(crate) fn state_staged_in_pack(&self, change_id: &ChangeId) -> bool {
+        self.pack
+            .as_ref()
+            .is_some_and(|sink| sink.staged_states.contains(change_id))
+    }
+
+    /// Finalize and durably install the pack (no-op for the loose path or an
+    /// empty import). Must run before refs/markers/mapping are committed so a
+    /// crash can't leave them pointing into a pack that never landed.
+    pub(crate) fn finalize_pack_install(&mut self) -> GitResult<()> {
+        let repo = self.heddle_repo;
+        if let Some(sink) = self.pack.take() {
+            sink.finalize_and_install(repo.store())?;
+        }
+        Ok(())
+    }
+
+    /// Discard the in-flight pack and its staging files (failure path).
+    pub(crate) fn abort_pack(&mut self) {
+        if let Some(sink) = self.pack.take() {
+            sink.abort();
+        }
+    }
+
+    /// Route a blob write to the pack sink or the loose store.
+    fn write_blob(&mut self, hash: ContentHash, blob: Blob) -> GitResult<()> {
+        let repo = self.heddle_repo;
+        match self.pack.as_mut() {
+            Some(sink) => sink.add_blob(repo.store(), hash, blob.into_content()),
+            None => {
+                repo.store().put_blob(&blob)?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Route a tree write to the pack sink or the loose store.
+    fn write_tree(&mut self, hash: ContentHash, tree: &Tree) -> GitResult<()> {
+        let repo = self.heddle_repo;
+        match self.pack.as_mut() {
+            Some(sink) => sink.add_tree(repo.store(), hash, tree),
+            None => {
+                repo.store().put_tree(tree)?;
+                Ok(())
+            }
         }
     }
 
@@ -157,7 +258,8 @@ impl<'a> GitTreeImporter<'a> {
             .collect::<Vec<_>>();
 
         let tree = Tree::from_entries(entries);
-        let hash = self.heddle_repo.store().put_tree(&tree)?;
+        let hash = tree.hash();
+        self.write_tree(hash, &tree)?;
         self.tree_cache.insert(tree_oid, hash);
         self.lossy_by_tree.insert(tree_oid, tree_lossy_entries);
         Ok(hash)
@@ -215,7 +317,8 @@ impl<'a> GitTreeImporter<'a> {
             .map_err(|err| GitBridgeError::Git(err.to_string()))?;
 
         let heddle_blob = Blob::new(blob.take_data());
-        let hash = self.heddle_repo.store().put_blob(&heddle_blob)?;
+        let hash = heddle_blob.hash();
+        self.write_blob(hash, heddle_blob)?;
         self.blob_cache.insert(blob_oid, hash);
         Ok(hash)
     }
@@ -226,7 +329,8 @@ impl<'a> GitTreeImporter<'a> {
         }
 
         let blob = Blob::new(format!("{} {}", SUBMODULE_PREFIX, oid).into_bytes());
-        let hash = self.heddle_repo.store().put_blob(&blob)?;
+        let hash = blob.hash();
+        self.write_blob(hash, blob)?;
         self.blob_cache.insert(oid, hash);
         Ok(hash)
     }
@@ -283,4 +387,166 @@ fn entry_relative_to_prefix(prefix: &str, entry: &LossyGitImportEntry) -> LossyG
         relative.path = stripped.trim_start_matches('/').to_string();
     }
     relative
+}
+
+/// Per-process counter so concurrent imports stage to distinct pack basenames.
+static PACK_SINK_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Write-sink that streams imported blobs/trees/states into a single native
+/// pack instead of writing N loose objects (one durable rename + index vs.
+/// N per-object writes). The pack stages under the Heddle store's own
+/// directory, then installs atomically via `install_pack_streaming`
+/// (rename(2) of pack + index) once the walk succeeds — see heddle#555.
+///
+/// Every bridge import semantic is preserved: this only changes the
+/// durability mechanism, not which objects get written or how their
+/// identity is computed.
+pub(crate) struct PackImportSink {
+    builder: StreamingPackBuilder<File>,
+    pack_path: PathBuf,
+    index_path: PathBuf,
+    bucket_dir: PathBuf,
+    object_count: usize,
+    /// Heddle hashes already buffered this run. Guards the rare case where a
+    /// lossy translation collapses two distinct git trees to one Heddle tree
+    /// (the in-flight pack object isn't yet readable via `has_tree`).
+    staged_trees: HashSet<ContentHash>,
+    /// Change-ids already buffered this run; the walk's idempotency check
+    /// reads this before falling back to the store (heddle#555 risk #2).
+    staged_states: HashSet<ChangeId>,
+}
+
+impl PackImportSink {
+    pub(crate) fn new(staging_dir: &Path) -> GitResult<Self> {
+        std::fs::create_dir_all(staging_dir)?;
+        let seq = PACK_SINK_SEQ.fetch_add(1, Ordering::Relaxed);
+        let run_id = format!("bridge-import-{}-{}", std::process::id(), seq);
+        let pack_path = staging_dir.join(format!("{run_id}.pack"));
+        let index_path = staging_dir.join(format!("{run_id}.idx"));
+        let bucket_dir = staging_dir.join(format!("{run_id}-buckets"));
+
+        let pack_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&pack_path)?;
+        // Delta search disabled: the streaming builder can't delta anyway and
+        // the cost/benefit is poor on real history (matches the ingest path).
+        let compression = CompressionConfig {
+            max_delta_size: 0,
+            ..CompressionConfig::default()
+        };
+        let builder =
+            StreamingPackBuilder::new(pack_file, index_path.clone(), compression, bucket_dir.clone())?;
+
+        Ok(Self {
+            builder,
+            pack_path,
+            index_path,
+            bucket_dir,
+            object_count: 0,
+            staged_trees: HashSet::new(),
+            staged_states: HashSet::new(),
+        })
+    }
+
+    fn add_blob(
+        &mut self,
+        store: &impl ObjectStore,
+        hash: ContentHash,
+        content: Vec<u8>,
+    ) -> GitResult<()> {
+        // Git blobs are content-addressed, so the caller's per-oid cache
+        // already dedups within a run; only the cross-run (re-import) case
+        // remains, which `has_blob` covers.
+        if store.has_blob(&hash)? {
+            return Ok(());
+        }
+        self.builder.add(hash, PackObjectType::Blob, content)?;
+        self.object_count += 1;
+        Ok(())
+    }
+
+    fn add_tree(
+        &mut self,
+        store: &impl ObjectStore,
+        hash: ContentHash,
+        tree: &Tree,
+    ) -> GitResult<()> {
+        if !self.staged_trees.insert(hash) {
+            return Ok(());
+        }
+        if store.has_tree(&hash)? {
+            return Ok(());
+        }
+        // `to_vec_named` (struct-as-map) is mandatory: every pack reader uses
+        // `rmp_serde::from_slice`, which defaults to struct-as-map. Plain
+        // `to_vec` would round-trip the bytes but fail deserialization.
+        let data = rmp_serde::to_vec_named(tree).map_err(|e| {
+            GitBridgeError::InvalidMapping(format!("serialize tree for import pack: {e}"))
+        })?;
+        self.builder.add(hash, PackObjectType::Tree, data)?;
+        self.object_count += 1;
+        Ok(())
+    }
+
+    fn add_state(&mut self, store: &impl ObjectStore, state: &State) -> GitResult<()> {
+        if !self.staged_states.insert(state.change_id) {
+            return Ok(());
+        }
+        if store.has_state(&state.change_id)? {
+            return Ok(());
+        }
+        let data = rmp_serde::to_vec_named(state).map_err(|e| {
+            GitBridgeError::InvalidMapping(format!("serialize state for import pack: {e}"))
+        })?;
+        self.builder
+            .add_id(PackObjectId::ChangeId(state.change_id), PackObjectType::State, data)?;
+        self.object_count += 1;
+        Ok(())
+    }
+
+    fn finalize_and_install(self, store: &impl ObjectStore) -> GitResult<()> {
+        let PackImportSink {
+            builder,
+            pack_path,
+            index_path,
+            bucket_dir,
+            object_count,
+            ..
+        } = self;
+
+        if object_count == 0 {
+            // Nothing new to install — drop the (header-only) staging pack.
+            // Dropping the builder cleans the bucket dir.
+            drop(builder);
+            let _ = std::fs::remove_file(&pack_path);
+            let _ = std::fs::remove_dir_all(&bucket_dir);
+            return Ok(());
+        }
+
+        // Finalize writes the count + trailer to the pack file and the sorted
+        // index to `index_path`, then cleans the bucket dir. Drop the file
+        // handle before the install renames it into the store.
+        let (file, _stats) = builder.finalize()?;
+        drop(file);
+        store.install_pack_streaming(&pack_path, &index_path)?;
+        Ok(())
+    }
+
+    fn abort(self) {
+        let PackImportSink {
+            builder,
+            pack_path,
+            index_path,
+            bucket_dir,
+            ..
+        } = self;
+        // Drop cleans the bucket dir; remove the staged pack/index too.
+        drop(builder);
+        let _ = std::fs::remove_file(&pack_path);
+        let _ = std::fs::remove_file(&index_path);
+        let _ = std::fs::remove_dir_all(&bucket_dir);
+    }
 }


### PR DESCRIPTION
Closes #555.

Route the bridge bulk import (used by `heddle adopt` and `heddle bridge git import`) through a **single streaming native pack + one atomic install** instead of N loose objects with per-object durability. This is a routing change — the import walk, identity resolution, and ref sync are unchanged.

## Parity audit — ingest (`crates/ingest/src/importer.rs`) vs bridge (`crates/cli/src/bridge/git_import.rs`)

| Bridge feature | `git_import.rs` (loose — adopt's current path) | `ingest/importer.rs` (pack) |
|---|---|---|
| **change_id derivation** | Deterministic: sidecar → `refs/notes/heddle` → `Heddle-Change-Id:` trailer → first-16-of-git-SHA (`resolve_identity`, git_import.rs:124-146) | **Random ULID** — `State::new` → `ChangeId::generate()` (state_core.rs:272); never `.with_change_id`. Breaks identity recovery + round-trip |
| **annotated-tag mirror / SHA-stable export** | `copy_reachable_objects` + `apply_ref_updates` into gix mirror (git_import.rs:509-567) | **Absent** (no mirror) |
| **refs/notes/heddle import** | `collect_note_ref_updates` (git_import.rs:724-748) | **Absent** |
| **partial-mirror degradation** | per-ref copy; records `partial_mirror_refs` (git_import.rs:514-544) | **Absent** |
| **confidence / status / agent** | from notes + trailers (git_import.rs:182-228) | Co-Authored-By agent only (state_writer.rs:130-185); no confidence/status |
| **thread-divergence checks** | `thread_can_adopt_change` + `GitHeddleThreadDiverged` (git_import.rs:618-656, 778-791) | RefEmitter sets threads; no divergence guard |
| **ThreadId validation** | rejects invalid branch→thread names (git_import.rs:612-617) | absent |
| **lossy-entry semantics** | `GitTreeImporter` + `fail_lossy_entry` (git_import_tree.rs) | present (importer.rs:425-490) |
| **change_id↔git_oid mapping commit** | `write/commit_mapping_tmp_to_disk` (git_import.rs:587-589) | `ShaMap` sqlite (different sidecar) |

## Shape chosen: **(B) pack write-sink inside `git_import.rs`**

Shape (A) — re-pointing adopt at `import_git_into_with_options` — was **rejected**: ingest mints random change_ids and lacks the entire mirror / notes / divergence / confidence layer, so it would regress identity recovery and #533 round-trip fidelity. Per the issue's default, (B) preserves every bridge semantic by reusing the same walk and only swapping the write sink.

`PackImportSink` streams blobs/trees/states into a `StreamingPackBuilder` (`to_vec_named`, delta search off — matches the proven ingest builder), then finalizes + `install_pack_streaming` (rename(2) of pack + index). The `GitTreeImporter` keeps a `None` loose path for other callers (`import_git_tree`).

## The 3 spike risks, handled

1. **Feature drift** — N/A for (B): the walk/identity/ref logic is reused verbatim; only `put_blob`/`put_tree`/`put_state` become `add`/`add_id` into the builder.
2. **Mid-walk read-back** — the `get_state` idempotency check now consults an in-memory `staged_states` set first (an un-finalized pack object isn't readable via the store), falling back to `get_state` only for states a prior import already installed → re-adopt stays idempotent (`states_created` = 0).
3. **Crash-safe sequencing** — `finalize_pack_install()` runs **before** the change_id↔git_oid mapping is committed and before any ref/tag/marker sync, so a crash can never leave a ref or mapping entry pointing into a pack that didn't land.

## Correctness

- All bridge import semantics preserved (audit list above).
- #533 round-trip byte-identical: `cargo test -p heddle-cli --test roundtrip_fidelity` — 10/10 green.
- Full feature-gated suite green (`--features git-overlay,native,semantic,zstd`); 71 bridge unit tests green (annotated-tag SHA, change-id-via-notes, symlinks, deep history); default-features build, no-silent-default check, and clippy `-D warnings` all green.

## Timing (tiny foreground harness, 2.5k-commit fixture, real ext4 — not `cargo bench`)

| path | commits | elapsed | rate |
|---|---|---|---|
| before (loose) | 2501 | 41,920 ms | 60 commits/s |
| after (pack)   | 2501 | 21,039 ms | 119 commits/s |

~2× faster (~50% wall-clock reduction); the gap widens on slower / fsync-heavy storage since the loose path pays N per-object durability vs. one pack install.

Note: this is a perf refactor guarded by the existing round-trip + bridge suites, so there is no TDD red-commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783341618&installation_id=132405951&pr_number=558&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F558&signature=bcc79b7fd26e5624726ab2b1e36c9a79fede3b888f440649b8662b9cf97d12da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->