### PR TITLE
perf(status): dedup redundant git-overlay passes + index stat fast-path (#559)

### DIFF
--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -897,6 +897,7 @@ fn worktree_entry_changed(root: &Path, path: &str, entry: &IndexEntryIntent) -> 
         path,
         entry.id,
         entry.mode.bits(),
+        None,
     )
     .with_context(|| format!("failed to inspect worktree path before commit: {path}"))?;
     Ok(state != GitWorktreeEntryState::Clean)

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -1938,9 +1938,10 @@ fn plain_git_worktree_status(
     }) {
         head_entries.insert(path, entry);
     }
+    let index_timestamp_secs = index.timestamp().unix_seconds();
     let mut index_entries = BTreeMap::new();
     for (_, (path, entry)) in index.entries_with_paths_by_filter_map(|path, entry| {
-        Some((plain_git_path(path), (entry.id, entry.mode.bits())))
+        Some((plain_git_path(path), (entry.id, entry.mode.bits(), entry.stat)))
     }) {
         index_entries.insert(path, entry);
     }
@@ -1949,12 +1950,12 @@ fn plain_git_worktree_status(
     let mut modified = BTreeSet::new();
     let mut deleted = BTreeSet::new();
 
-    for (path, entry) in &index_entries {
+    for (path, (oid, mode, _stat)) in &index_entries {
         match head_entries.get(path) {
             None => {
                 added.insert(PathBuf::from(path));
             }
-            Some(head_entry) if head_entry != entry => {
+            Some((head_oid, head_mode)) if (head_oid, head_mode) != (oid, mode) => {
                 modified.insert(PathBuf::from(path));
             }
             Some(_) => {}
@@ -1966,8 +1967,18 @@ fn plain_git_worktree_status(
         }
     }
 
-    for (path, (oid, mode)) in &index_entries {
-        match repo::git_worktree_status::git_worktree_entry_state(root, path, *oid, *mode)? {
+    for (path, (oid, mode, stat)) in &index_entries {
+        let probe = repo::git_worktree_status::IndexStatProbe {
+            stat: *stat,
+            index_timestamp_secs,
+        };
+        match repo::git_worktree_status::git_worktree_entry_state(
+            root,
+            path,
+            *oid,
+            *mode,
+            Some(probe),
+        )? {
             GitWorktreeEntryState::Clean => {}
             GitWorktreeEntryState::Deleted => {
                 deleted.insert(PathBuf::from(path));
@@ -2535,6 +2546,26 @@ fn git_default_remote_name_from_repo(repo: &gix::Repository) -> Option<String> {
 }
 
 pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
+    build_git_overlay_health_inner(repo, None)
+}
+
+/// `status` hot-path variant: reuse the caller's already-computed git-overlay
+/// worktree status instead of recomputing it. `git_overlay_worktree_status`
+/// re-reads + SHA-1s every tracked file (~950ms on a 10k-file worktree); the
+/// `status` command otherwise pays it twice (here and in `build_status_output`).
+/// `worktree_status` is the exact `Result` from `git_overlay_worktree_status()`,
+/// so the clean/dirty/degraded classification stays byte-identical.
+pub(crate) fn build_git_overlay_health_with_worktree_status(
+    repo: &Repository,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> GitOverlayHealth {
+    build_git_overlay_health_inner(repo, Some(worktree_status))
+}
+
+fn build_git_overlay_health_inner(
+    repo: &Repository,
+    precomputed_worktree_status: Option<&repo::Result<Option<WorktreeStatus>>>,
+) -> GitOverlayHealth {
     if repo.capability() != repo::RepositoryCapability::GitOverlay {
         return build_native_heddle_health(repo);
     }
@@ -2721,7 +2752,17 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
         }),
     }
 
-    match repo.git_overlay_worktree_status() {
+    // Reuse the caller's computation on the `status` path; fall back to a fresh
+    // probe (only reached here, after the early returns above) otherwise.
+    let computed_worktree_status;
+    let worktree_status = match precomputed_worktree_status {
+        Some(status) => status,
+        None => {
+            computed_worktree_status = repo.git_overlay_worktree_status();
+            &computed_worktree_status
+        }
+    };
+    match worktree_status {
         Ok(Some(status)) if !status.is_clean() => {
             let changed = status.modified.len() + status.added.len() + status.deleted.len();
             if heddle_worktree_is_clean(repo) {
@@ -2731,7 +2772,7 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
                     summary: format!(
                         "{changed} Git worktree path(s) are captured in Heddle but not checkpointed to Git"
                     ),
-                    details: dirty_details(&status),
+                    details: dirty_details(status),
                 });
                 return GitOverlayHealth {
                     status: "needs_checkpoint".to_string(),
@@ -2747,7 +2788,7 @@ pub(crate) fn build_git_overlay_health(repo: &Repository) -> GitOverlayHealth {
                 name: "worktree".to_string(),
                 status: "dirty_worktree".to_string(),
                 summary: format!("{changed} Git worktree path(s) have uncommitted changes"),
-                details: dirty_details(&status),
+                details: dirty_details(status),
             });
             return GitOverlayHealth {
                 status: "dirty_worktree".to_string(),

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -32,8 +32,9 @@ use super::{
     command_catalog::ActionFields,
     git_compat::{GitIndexPlan, git_index_plan_for_repo, git_index_plan_for_root},
     git_overlay_health::{
-        GitOverlayHealth, RepositoryVerificationState, build_git_overlay_health,
-        build_plain_git_verification_probe, override_trust_recommended_action,
+        GitOverlayHealth, RepositoryVerificationState,
+        build_git_overlay_health_with_worktree_status, build_plain_git_verification_probe,
+        override_trust_recommended_action,
         remote_tracking_with_verification_action, repository_setup_guidance,
         serialize_empty_action_as_null,
     },
@@ -463,12 +464,18 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         repo.git_overlay_import_hint().unwrap_or(None)
     };
     let import_hint_ms = import_hint_start.elapsed().as_millis();
-    let git_overlay_health = build_git_overlay_health(&repo);
+    // Compute the git-overlay worktree status ONCE and thread it through both
+    // consumers (the health build below + the changes computation here). It
+    // re-reads + SHA-1s every tracked file (~950ms on a 10k-file worktree);
+    // previously `status` paid that twice.
+    let git_worktree_status_result = repo.git_overlay_worktree_status();
+    let git_overlay_health =
+        build_git_overlay_health_with_worktree_status(&repo, &git_worktree_status_result);
     let trust = RepositoryVerificationState::from_health(&repo, git_overlay_health.clone());
     let remote_tracking =
         remote_tracking.map(|remote| remote_tracking_with_verification_action(remote, &trust));
     let status_options = worktree_status_options(Some(repo.config()));
-    let git_worktree_status = repo.git_overlay_worktree_status().unwrap_or(None);
+    let git_worktree_status = git_worktree_status_result.unwrap_or(None);
     let git_index = git_index_plan_for_repo(&repo)?;
     let identity_notice = first_capture_identity_notice(&repo, current_state.as_ref())?;
     let git_clean_mapping_blocker = matches!(

--- a/crates/repo/src/git_worktree_status.rs
+++ b/crates/repo/src/git_worktree_status.rs
@@ -54,6 +54,50 @@ pub enum GitWorktreeEntryState {
     Deleted,
 }
 
+/// The index-recorded stat for a tracked path plus the index's own write
+/// timestamp (the `.git/index` file mtime, in whole seconds since epoch).
+///
+/// Passed into [`git_worktree_entry_state`] to enable git's stat fast-path:
+/// when the worktree file's stat still matches the index's cached stat — and
+/// the entry isn't inside the racy window — the content is provably unchanged
+/// and the (10k-file) read+SHA-1 is skipped entirely, exactly like
+/// `git status`. Anything uncertain falls back to hashing.
+#[derive(Debug, Clone, Copy)]
+pub struct IndexStatProbe {
+    /// The stat git cached for this entry the last time it refreshed the index.
+    pub stat: gix::index::entry::Stat,
+    /// The index file's own mtime, in whole seconds since the unix epoch.
+    pub index_timestamp_secs: i64,
+}
+
+impl IndexStatProbe {
+    /// Whether the worktree file at `absolute` is *provably* unchanged versus
+    /// the index — i.e. its stat matches the cached stat and it predates the
+    /// index's write time (so it's outside the racy-clean window). Returns
+    /// `false` on any uncertainty (stat mismatch, racy window, stat
+    /// unavailable), leaving the caller to read + hash.
+    fn proves_clean(&self, absolute: &Path) -> bool {
+        let Ok(metadata) = gix::index::fs::Metadata::from_path_no_follow(absolute) else {
+            return false;
+        };
+        let Ok(worktree_stat) = gix::index::entry::Stat::from_fs(&metadata) else {
+            return false;
+        };
+        if !self
+            .stat
+            .matches(&worktree_stat, gix::index::entry::stat::Options::default())
+        {
+            return false;
+        }
+        // Racy-clean guard, mirroring `gix::index::entry::Stat::is_racy` with
+        // `use_nsec = false` (git's Linux default): an entry whose mtime is at
+        // or after the index's own write time could have been modified within
+        // the same second without the stat changing, so it must be hashed.
+        // `is_racy` is true when `index_timestamp <= mtime_secs`.
+        self.index_timestamp_secs > i64::from(self.stat.mtime.secs)
+    }
+}
+
 /// Compare the worktree file at `root/path` to its indexed
 /// `expected_oid` + `mode` (a raw Git file mode such as `0o100644`).
 /// See the module-level docs for the rules.
@@ -62,6 +106,7 @@ pub fn git_worktree_entry_state(
     path: &str,
     expected_oid: gix::ObjectId,
     mode: u32,
+    index_probe: Option<IndexStatProbe>,
 ) -> Result<GitWorktreeEntryState> {
     let absolute = root.join(path);
     let metadata = match fs::symlink_metadata(&absolute) {
@@ -122,6 +167,17 @@ pub fn git_worktree_entry_state(
     #[cfg(not(unix))]
     let _ = (GIT_MODE_REGULAR, GIT_MODE_EXECUTABLE);
 
+    // Stat fast-path: if the index's cached stat still matches the worktree
+    // (and we're outside the racy window), the blob is unchanged — skip the
+    // read + SHA-1. The exec-bit divergence above is already ruled out, and a
+    // chmod bumps ctime, which `matches` (trust_ctime) catches, so this never
+    // masks a mode flip.
+    if let Some(probe) = index_probe
+        && probe.proves_clean(&absolute)
+    {
+        return Ok(GitWorktreeEntryState::Clean);
+    }
+
     let bytes = fs::read(&absolute)?;
     hash_and_compare(expected_oid, &bytes)
 }
@@ -153,7 +209,7 @@ mod tests {
     fn missing_path_is_deleted() {
         let temp = tempfile::TempDir::new().unwrap();
         let oid = write_blob_hash(b"anything");
-        let state = git_worktree_entry_state(temp.path(), "nope.txt", oid, GIT_MODE_REGULAR)
+        let state = git_worktree_entry_state(temp.path(), "nope.txt", oid, GIT_MODE_REGULAR, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Deleted);
     }
@@ -169,7 +225,7 @@ mod tests {
         // ancestor and cannot be statted.
         fs::write(temp.path().join("data"), b"now a file").unwrap();
         let oid = write_blob_hash(b"x\ny\n");
-        let state = git_worktree_entry_state(temp.path(), "data/item.txt", oid, GIT_MODE_REGULAR)
+        let state = git_worktree_entry_state(temp.path(), "data/item.txt", oid, GIT_MODE_REGULAR, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Deleted);
     }
@@ -180,7 +236,7 @@ mod tests {
         fs::write(temp.path().join("a.txt"), b"hello").unwrap();
         let oid = write_blob_hash(b"hello");
         let state =
-            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR).expect("call");
+            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR, None).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Clean);
     }
 
@@ -190,7 +246,7 @@ mod tests {
         fs::write(temp.path().join("a.txt"), b"new content").unwrap();
         let oid = write_blob_hash(b"old content");
         let state =
-            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR).expect("call");
+            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR, None).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Modified);
     }
 
@@ -207,19 +263,19 @@ mod tests {
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
         let oid = write_blob_hash(b"#!/bin/sh\necho hi\n");
         // Indexed as regular (no exec bit) but worktree has it → Modified.
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_REGULAR)
+        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_REGULAR, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Modified);
 
         // Symmetric: indexed as executable but worktree is plain → Modified.
         fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE)
+        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Modified);
 
         // Same exec bit on both sides → Clean.
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE)
+        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Clean);
     }
@@ -236,7 +292,7 @@ mod tests {
         // Index says it's a regular file, but worktree is a symlink.
         let oid = write_blob_hash(b"anything");
         let state =
-            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_REGULAR).expect("call");
+            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_REGULAR, None).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Modified);
     }
 
@@ -248,7 +304,7 @@ mod tests {
         // Index says it's a symlink, but worktree is a regular file.
         let oid = write_blob_hash(b"old target");
         let state =
-            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK).expect("call");
+            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK, None).expect("call");
         assert_eq!(state, GitWorktreeEntryState::Modified);
     }
 
@@ -265,8 +321,83 @@ mod tests {
         let link = temp.path().join("link");
         symlink(target_os, &link).unwrap();
         let oid = write_blob_hash(raw_target);
-        let state = git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK)
+        let state = git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK, None)
             .expect("call");
         assert_eq!(state, GitWorktreeEntryState::Clean);
+    }
+
+    fn probe_for(path: &Path, index_timestamp_secs: i64) -> IndexStatProbe {
+        let metadata = gix::index::fs::Metadata::from_path_no_follow(path).expect("lstat");
+        let stat = gix::index::entry::Stat::from_fs(&metadata).expect("stat");
+        IndexStatProbe {
+            stat,
+            index_timestamp_secs,
+        }
+    }
+
+    /// When the worktree stat matches the index's cached stat and the entry is
+    /// outside the racy window, the read + hash is skipped — proven here by
+    /// passing a deliberately WRONG oid that would force `Modified` if it were
+    /// ever consulted, yet the entry reads `Clean`.
+    #[cfg(unix)]
+    #[test]
+    fn stat_fastpath_skips_hash_when_unchanged() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("a.txt");
+        fs::write(&path, b"hello").unwrap();
+        let stat = probe_for(&path, 0).stat;
+        // index written strictly after the file's mtime → not racy.
+        let probe = IndexStatProbe {
+            stat,
+            index_timestamp_secs: i64::from(stat.mtime.secs) + 5,
+        };
+        let wrong_oid = write_blob_hash(b"totally different bytes");
+        let state =
+            git_worktree_entry_state(temp.path(), "a.txt", wrong_oid, GIT_MODE_REGULAR, Some(probe))
+                .expect("call");
+        assert_eq!(state, GitWorktreeEntryState::Clean);
+    }
+
+    /// The racy-clean window: when the index's own write time is at or before
+    /// the file's mtime, a same-second modification could leave the stat
+    /// unchanged, so the fast-path MUST fall back to hashing. Same setup as the
+    /// test above (stat matches), but a racy timestamp — now the wrong oid is
+    /// consulted and the change is caught as `Modified`.
+    #[cfg(unix)]
+    #[test]
+    fn racy_window_falls_back_to_hashing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("a.txt");
+        fs::write(&path, b"hello").unwrap();
+        let stat = probe_for(&path, 0).stat;
+        // index timestamp == file mtime → racy: stat is untrustworthy.
+        let probe = IndexStatProbe {
+            stat,
+            index_timestamp_secs: i64::from(stat.mtime.secs),
+        };
+        let stale_oid = write_blob_hash(b"totally different bytes");
+        let state =
+            git_worktree_entry_state(temp.path(), "a.txt", stale_oid, GIT_MODE_REGULAR, Some(probe))
+                .expect("call");
+        assert_eq!(state, GitWorktreeEntryState::Modified);
+    }
+
+    /// A stat mismatch (here, a different size) bypasses the fast-path and
+    /// hashes, so a genuine change is reported even when the index isn't racy.
+    #[cfg(unix)]
+    #[test]
+    fn stat_mismatch_falls_back_to_hashing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("a.txt");
+        fs::write(&path, b"hello").unwrap();
+        let mut probe = probe_for(&path, 0);
+        probe.index_timestamp_secs = i64::from(probe.stat.mtime.secs) + 5;
+        // Pretend the index cached a different size → stat can't match.
+        probe.stat.size = probe.stat.size.wrapping_add(1);
+        let old_oid = write_blob_hash(b"world");
+        let state =
+            git_worktree_entry_state(temp.path(), "a.txt", old_oid, GIT_MODE_REGULAR, Some(probe))
+                .expect("call");
+        assert_eq!(state, GitWorktreeEntryState::Modified);
     }
 }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1318,9 +1318,10 @@ impl Repository {
         }) {
             head_entries.insert(path, entry);
         }
+        let index_timestamp_secs = index.timestamp().unix_seconds();
         let mut index_entries = BTreeMap::new();
         for (_, (path, entry)) in index.entries_with_paths_by_filter_map(|path, entry| {
-            Some((git_path(path), (entry.id, entry.mode.bits())))
+            Some((git_path(path), (entry.id, entry.mode.bits(), entry.stat)))
         }) {
             index_entries.insert(path, entry);
         }
@@ -1329,7 +1330,7 @@ impl Repository {
         let mut modified = BTreeSet::new();
         let mut deleted = BTreeSet::new();
 
-        for (path, entry) in &index_entries {
+        for (path, (oid, mode, _stat)) in &index_entries {
             if ignored_git_overlay_status_path(path) {
                 continue;
             }
@@ -1337,7 +1338,7 @@ impl Repository {
                 None => {
                     added.insert(PathBuf::from(path));
                 }
-                Some(head_entry) if head_entry != entry => {
+                Some((head_oid, head_mode)) if (head_oid, head_mode) != (oid, mode) => {
                     modified.insert(PathBuf::from(path));
                 }
                 Some(_) => {}
@@ -1349,15 +1350,20 @@ impl Repository {
             }
         }
 
-        for (path, (oid, mode)) in &index_entries {
+        for (path, (oid, mode, stat)) in &index_entries {
             if ignored_git_overlay_status_path(path) {
                 continue;
             }
+            let probe = crate::git_worktree_status::IndexStatProbe {
+                stat: *stat,
+                index_timestamp_secs,
+            };
             match crate::git_worktree_status::git_worktree_entry_state(
                 &self.root,
                 path,
                 *oid,
                 *mode,
+                Some(probe),
             )? {
                 GitWorktreeEntryState::Clean => {}
                 GitWorktreeEntryState::Deleted => {


### PR DESCRIPTION
Closes #559.

A dirty `heddle status` on a ~10k-file worktree measured ~1.05s (with larger files, ~2.7s) — dominated by `git_overlay_worktree_status` → `git_worktree_entry_state`, which `fs::read` + full SHA-1 hashes every tracked file, and ran that full pass redundantly per status.

## Levers

**Lever 1 — compute the overlay worktree status once.** `git_overlay_worktree_status` was recomputed on the status path (in `build_status_output` and again inside `build_git_overlay_health`). It's now computed once in `build_status_output` and threaded into `build_git_overlay_health_with_worktree_status` by reference, so the clean/dirty/degraded classification is byte-identical. Non-status callers (bridge, diagnose, the `git_overlay_health` command) keep the lazy path.

**Lever 2 — index stat/mtime fast-path.** `git_worktree_entry_state` now accepts an optional `IndexStatProbe` (the index entry's cached `Stat` + the `.git/index` mtime). For a regular file, if the worktree stat matches the index's cached stat (git's `Stat::matches`, `trust_ctime` on — so a chmod is still caught) **and** the entry is outside the racy-clean window, the blob is provably unchanged and the read+SHA-1 is skipped. Racy entries (mtime ≥ index write time) and any stat mismatch fall back to hashing, exactly like `git status`. Wired through both the overlay status path and the plain-git probe; the commit-preflight caller passes `None`.

## Before/after (tiny foreground timed harness, NOT criterion)

10k files across nested dirs, best-of-5 wall-clock:

| Scenario | Before | After |
|---|---|---|
| dirty (16KB files) | 2685ms | 1023ms (2.6×) |
| clean (16KB files) | 2676ms | 1050ms (2.5×) |
| dirty (1-line files) | 964ms | 597ms |
| clean (1-line files) | 940ms | 629ms |

(`git status` baseline on the same fixture: ~26ms. The residual cost is the heddle-native `compare_worktree` pass, which is a separate code path outside this issue's scope.)

## Correctness

- Added unit tests: stat fast-path skips hashing when unchanged; the racy window still detects a same-second change; a stat mismatch falls back to hashing. Existing chmod / type-change / symlink tests unchanged.
- Verified `status` output is **byte-identical** (text + JSON) before/after on a fixture exercising modified / added / deleted / chmod-exec-bit / untracked classification.
- Gates green: default `cargo build --locked --workspace`, full `cargo test` suite, `check-no-silent-default-tree-load.sh`, clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783347258&installation_id=132405951&pr_number=560&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F560&signature=b98eaffb8fde23138a2e932645653c115a97ea5a851e9135b84617363d70422f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->