### PR TITLE
perf(adopt): write the git mirror as one pack, not N loose objects (#561)

### DIFF
--- a/crates/cli/src/bridge/git_bridge_tests.rs
+++ b/crates/cli/src/bridge/git_bridge_tests.rs
@@ -2787,6 +2787,95 @@ fn import_isolates_per_ref_mirror_failures() {
         );
     }
 }
+
+/// #561 — the mirror copy writes reachable objects as a single packfile
+/// (pack + index), not as N loose objects. The packed mirror must still
+/// contain *exactly* the object set the loose path produced (same OIDs,
+/// byte-identical), so SHA-stable export and annotated-tag preservation
+/// are unaffected by the storage form.
+#[test]
+fn import_writes_mirror_as_pack_with_identical_object_set() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_src_temp, source_repo) = init_git_repo();
+
+    // A real (non-empty) tree so every reachable object is physically
+    // stored — the empty tree is a gix synthetic and would skew a
+    // store-vs-store object-set comparison.
+    let blob = source_repo.write_blob(b"hello\n").expect("blob").detach();
+    let mut editor = source_repo
+        .edit_tree(gix::hash::ObjectId::empty_tree(source_repo.object_hash()))
+        .expect("tree editor");
+    editor
+        .upsert("file.txt", gix::object::tree::EntryKind::Blob, blob)
+        .expect("upsert blob");
+    let tree = editor.write().expect("tree").detach();
+
+    let first = commit_with_tree(&source_repo, Some("refs/heads/main"), tree, "first", &[]);
+    let second = commit_with_tree(&source_repo, Some("refs/heads/main"), tree, "second", &[first]);
+    let tag_oid = create_annotated_tag(&source_repo, "v1.0", second, "release");
+
+    let mut bridge = GitBridge::new(&repo);
+    bridge
+        .import(Some(source_repo.workdir().expect("workdir")))
+        .expect("import");
+
+    let mirror = bridge.open_git_repo().expect("open mirror");
+
+    // (1) Objects are stored packed, not loose.
+    let pack_dir = mirror.git_dir().join("objects").join("pack");
+    let pack_count = std::fs::read_dir(&pack_dir)
+        .expect("read pack dir")
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|x| x == "pack"))
+        .count();
+    assert!(
+        pack_count >= 1,
+        "mirror should store reachable objects in at least one packfile"
+    );
+
+    // No loose objects: `objects/` should hold only `pack`/`info`, never a
+    // 2-hex fanout dir (the loose-object layout the old path produced).
+    let loose: Vec<_> = std::fs::read_dir(mirror.git_dir().join("objects"))
+        .expect("read objects dir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.len() == 2 && name.chars().all(|c| c.is_ascii_hexdigit())
+        })
+        .collect();
+    assert!(
+        loose.is_empty(),
+        "mirror must not contain loose object dirs, found {loose:?}"
+    );
+
+    // (2) The packed set equals the source's stored (== reachable) set.
+    let source_set: std::collections::HashSet<_> = source_repo
+        .objects
+        .iter()
+        .expect("source object iter")
+        .map(|r| r.expect("source oid"))
+        .collect();
+    let mirror_set: std::collections::HashSet<_> = mirror
+        .objects
+        .iter()
+        .expect("mirror object iter")
+        .map(|r| r.expect("mirror oid"))
+        .collect();
+    assert_eq!(
+        mirror_set, source_set,
+        "packed mirror object set must equal the source reachable set"
+    );
+
+    // The annotated tag object survives in the pack, byte-identical.
+    let src = source_repo.find_object(tag_oid).expect("source tag present");
+    let mir = mirror.find_object(tag_oid).expect("mirror tag present");
+    assert_eq!(src.kind, gix::objs::Kind::Tag);
+    assert_eq!(mir.kind, src.kind, "tag object kind must match");
+    assert_eq!(mir.data, src.data, "annotated tag bytes must be identical");
+}
+
 #[test]
 fn import_honors_legacy_heddle_change_id_trailer() {
     let heddle_temp = TempDir::new().expect("heddle temp");

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -3462,42 +3462,56 @@ pub(crate) fn copy_reachable_objects(
         )));
     }
 
-    for oid in collect_reachable_object_ids(source, roots)? {
-        let object = source.find_object(oid).map_err(git_err)?;
-        let object_ref =
-            gix::objs::ObjectRef::from_bytes(&object.data, object.kind, source.object_hash())
-                .map_err(git_err)?;
-        target.write_object(object_ref).map_err(git_err)?;
-    }
-
-    Ok(())
+    let entries = collect_reachable_entries(source, roots)?;
+    install_objects_pack(target, entries)
 }
 
-fn collect_reachable_object_ids(
+/// Walk every object reachable from `roots` in `source`, reading each
+/// object exactly once, and serialize it into a base pack entry.
+///
+/// The walk decodes a commit/tree/tag's children from the bytes it has
+/// already loaded rather than issuing a second ODB lookup, so the whole
+/// reachable set is read in a single pass (the loose-copy path used to
+/// read every object twice: once to enumerate, once to re-serialize).
+fn collect_reachable_entries(
     source: &gix::Repository,
     roots: impl IntoIterator<Item = ObjectId>,
-) -> GitResult<Vec<ObjectId>> {
+) -> GitResult<Vec<gix_pack::data::output::Entry>> {
+    let object_hash = source.object_hash();
     let mut stack: Vec<ObjectId> = roots.into_iter().collect();
     let mut seen = HashSet::new();
-    let mut ordered = Vec::new();
+    let mut entries = Vec::new();
 
     while let Some(oid) = stack.pop() {
         if !seen.insert(oid) {
             continue;
         }
-        ordered.push(oid);
 
         let object = source.find_object(oid).map_err(git_err)?;
-        match object.kind {
+        let kind = object.kind;
+
+        // Serialize from the bytes we already hold — no second lookup.
+        let entry = {
+            let count = gix_pack::data::output::Count::from_data(oid, None);
+            let data = gix::objs::Data {
+                kind,
+                data: &object.data,
+                object_hash,
+            };
+            gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?
+        };
+        entries.push(entry);
+
+        match kind {
             gix::objs::Kind::Commit => {
-                let commit = source.find_commit(oid).map_err(git_err)?;
+                let commit = object.into_commit();
                 stack.push(commit.tree_id().map_err(git_err)?.detach());
                 for parent in commit.parent_ids() {
                     stack.push(parent.detach());
                 }
             }
             gix::objs::Kind::Tree => {
-                let tree = source.find_tree(oid).map_err(git_err)?;
+                let tree = object.into_tree();
                 for entry in tree.iter() {
                     let entry = entry.map_err(git_err)?;
                     // Gitlink (mode 160000) entries point at a commit
@@ -3522,14 +3536,79 @@ fn collect_reachable_object_ids(
                 }
             }
             gix::objs::Kind::Tag => {
-                let tag = source.find_tag(oid).map_err(git_err)?;
+                let tag = object.into_tag();
                 stack.push(tag.target_id().map_err(git_err)?.detach());
             }
             gix::objs::Kind::Blob => {}
         }
     }
 
-    Ok(ordered)
+    Ok(entries)
+}
+
+/// Install `entries` into `target`'s ODB as a single packfile (pack +
+/// generated index) under `objects/pack/`.
+///
+/// This replaces what used to be N individual loose-object writes (one
+/// temp-write + `rename(2)` per object), which dominated `adopt` wall
+/// time. A packed object is byte-identical to its loose form — same git
+/// OID, read transparently — so SHA-stable export and annotated-tag
+/// preservation are unaffected by the storage form.
+fn install_objects_pack(
+    target: &gix::Repository,
+    entries: Vec<gix_pack::data::output::Entry>,
+) -> GitResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let object_hash = target.object_hash();
+    let num_entries: u32 = entries.len().try_into().map_err(|_| {
+        GitBridgeError::Git(format!(
+            "mirror pack has too many objects to encode: {}",
+            entries.len()
+        ))
+    })?;
+
+    // Encode the objects into an in-memory pack stream...
+    let mut pack = Vec::new();
+    {
+        let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
+        let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
+            input,
+            &mut pack,
+            num_entries,
+            gix_pack::data::Version::V2,
+            object_hash,
+        );
+        for result in writer.by_ref() {
+            result.map_err(git_err)?;
+        }
+    }
+
+    // ...then write it out with a freshly generated index.
+    let pack_dir = target.git_dir().join("objects").join("pack");
+    fs::create_dir_all(&pack_dir)?;
+    let outcome = gix_pack::Bundle::write_to_directory(
+        &mut std::io::Cursor::new(pack.as_slice()),
+        Some(&pack_dir),
+        &mut gix::progress::Discard,
+        &AtomicBool::new(false),
+        None::<gix::objs::find::Never>,
+        gix_pack::bundle::write::Options {
+            object_hash,
+            ..Default::default()
+        },
+    )
+    .map_err(git_err)?;
+
+    // The `.keep` marker suppresses repacks; the mirror manages its own
+    // packs, so don't leave one lying around for every imported ref.
+    if let Some(keep) = outcome.keep_path {
+        let _ = fs::remove_file(keep);
+    }
+
+    Ok(())
 }
 
 fn fetch_network_remote(
@@ -3723,33 +3802,22 @@ fn pack_reachable_objects(
     repo: &gix::Repository,
     roots: impl IntoIterator<Item = ObjectId>,
 ) -> GitResult<Vec<u8>> {
-    let oids = collect_reachable_object_ids(repo, roots)?;
-    let mut entries = Vec::with_capacity(oids.len());
-    for oid in &oids {
-        let object = repo.find_object(*oid).map_err(git_err)?;
-        let data = gix::objs::Data {
-            kind: object.kind,
-            data: &object.data,
-            object_hash: repo.object_hash(),
-        };
-        let count = gix_pack::data::output::Count::from_data(*oid, None);
-        let entry = gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?;
-        entries.push(entry);
-    }
+    let entries = collect_reachable_entries(repo, roots)?;
+    let num_entries: u32 = entries.len().try_into().map_err(|_| {
+        GitBridgeError::Git(format!(
+            "push pack has too many objects to encode: {}",
+            entries.len()
+        ))
+    })?;
 
     let mut pack = Vec::new();
     let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
     let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
         input,
         &mut pack,
-        oids.len().try_into().map_err(|_| {
-            GitBridgeError::Git(format!(
-                "push pack has too many objects to encode: {}",
-                oids.len()
-            ))
-        })?,
+        num_entries,
         gix_pack::data::Version::V2,
-        ObjectHashKind::Sha1,
+        repo.object_hash(),
     );
     for result in writer.by_ref() {
         result.map_err(git_err)?;


### PR DESCRIPTION
Closes #561.

## What
`adopt` populates the internal git mirror (`.heddle/git/objects/`) by copying every reachable object out of the source repo. Previously `copy_reachable_objects` (`crates/cli/src/bridge/git_core.rs`) wrote each object as a **loose git object** — one temp-write + `rename(2)` apiece (~30k objects for a 2.5k-commit repo) — which dominated adopt wall time.

This rewrites the copy to build **one packfile + generated index** in-process (gix's `data::output` encoder + `Bundle::write_to_directory`) and install it under `objects/pack/`, instead of N loose writes.

- **Lever 1 (big win):** loose-write loop → single pack install (`install_objects_pack`, git_core.rs).
- **Lever 3 (free):** dropped the double read — the reachable walk (`collect_reachable_entries`) now serializes each object from the bytes it already loaded during traversal, decoding children from those same bytes (`into_commit`/`into_tree`/`into_tag`) rather than re-`find_object`-ing each. `pack_reachable_objects` (push path) shares the same walk, so it loses its double read too.

Lever 2 (copy an already-packed source pack directly) is intentionally **left as a follow-up** — higher risk (loose/dangling/multi-pack sources).

## Correctness (#533-gated)
A packed object is byte-identical to its loose form (same git OID, read transparently by git), so the mirror is unchanged in content:
- per-ref isolation / `partial_mirror_refs` degradation preserved (the call is still per-ref; a failing ref still records partial without poisoning the rest);
- `roundtrip_fidelity` (#533, adopt→export reproduces identical SHAs) green;
- annotated-tag + partial-mirror + bridge tests green (100/100 in `bridge::`);
- new test `import_writes_mirror_as_pack_with_identical_object_set` asserts the post-adopt mirror is stored **packed** (≥1 `*.pack`, zero loose fanout dirs) and contains the **exact same object set** as the source reachable set, with the annotated-tag object byte-identical.

## Perf
A/B on this box, 2500-commit / 30k-object fixture, release build, `heddle adopt`:

| build | median wall |
|---|---|
| loose (main) | ~6.2s (6.12 / 6.31 / 6.23) |
| pack (this PR) | ~1.69s (1.86 / 1.69 / 1.65) |

**~3.7× faster** total adopt; the mirror loose-write phase collapses (clean-room A/B had loose 11.4s vs one pack 0.31s on the same objects).

## Gates
- `cargo build --locked --workspace` (default features) ✓
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd` ✓
- `cargo test --locked -p heddle-cli --test roundtrip_fidelity` ✓
- `bash scripts/check-no-silent-default-tree-load.sh` ✓
- `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings` ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783357504&installation_id=132405951&pr_number=563&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F563&signature=bd05e1d46905b703874fc3af5ca399f44d03b8fbbf4406c21d937150f532be5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->