### PR TITLE
fix(start): surface real io errors (not 'conflict') + fix clonefile ENOENT on macOS (#571)

### DIFF
--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -73,15 +73,26 @@ use super::worktree_cmd::{
 ///     propagate through the helpers' `anyhow::Result` via `?`) keeps its
 ///     variant, so an `Io`/`NotFound`/etc. stays itself and only a genuine
 ///     merge/visibility `Conflict` stays a `Conflict`;
-///   * a bare `std::io::Error` surfaces as `HeddleError::Io` (preserving the
-///     path/os-error its source carries);
+///   * an error whose chain bottoms out in a `std::io::Error` surfaces as
+///     `HeddleError::Io`, preserving BOTH the original `ErrorKind` (so
+///     `exit::from_error`'s kind-keyed classification stays correct) AND the
+///     `anyhow` context (the exact path/action that helpers like
+///     `write_cargo_config` attach via `.with_context`) — we must not downcast
+///     the bare `io::Error` out of the chain, which would throw every context
+///     layer away and leave the user with a contextless `No such file or
+///     directory`;
 ///   * only a genuinely-unclassifiable error falls back to `Conflict`.
 fn apply_error(err: anyhow::Error) -> HeddleError {
     match err.downcast::<HeddleError>() {
         Ok(heddle) => heddle,
-        Err(err) => match err.downcast::<std::io::Error>() {
-            Ok(io) => HeddleError::Io(io),
-            Err(err) => HeddleError::Conflict(format!("{err:#}")),
+        // Not already a structured `HeddleError`. If an `io::Error` sits
+        // anywhere in the chain, keep the variant as `Io` with its kind, but
+        // carry the full context chain (`{err:#}`) as the message so the
+        // path/action survives. Extract the kind first so the `downcast_ref`
+        // borrow is dropped before we format `err`.
+        Err(err) => match err.downcast_ref::<std::io::Error>().map(std::io::Error::kind) {
+            Some(kind) => HeddleError::Io(std::io::Error::new(kind, format!("{err:#}"))),
+            None => HeddleError::Conflict(format!("{err:#}")),
         },
     }
 }
@@ -1133,6 +1144,38 @@ mod tests {
         assert!(
             matches!(apply_error(conflict), HeddleError::Conflict(_)),
             "a genuine conflict must remain a conflict"
+        );
+    }
+
+    /// heddle#571 (round 2, finding 1): reclassifying an io failure must NOT
+    /// drop the `anyhow` context. The real shape is `write_cargo_config` doing
+    /// `fs::write(..).with_context(|| "writing .cargo/config.toml to {path}")?` —
+    /// the chain's outer layer is the context string, its source the io::Error.
+    /// `apply_error` must surface it as `Io` (kind preserved) WHILE keeping the
+    /// path/action in the message, so `heddle start --shared-target` failing to
+    /// write the cargo config still tells the user which file/action failed.
+    #[test]
+    fn apply_error_preserves_context_when_reclassifying_io() {
+        use anyhow::Context as _;
+
+        let with_ctx = Err::<(), _>(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "os error 13",
+        ))
+        .context("writing .cargo/config.toml to /work/.cargo/config.toml")
+        .unwrap_err();
+
+        let mapped = apply_error(with_ctx);
+        // Kind preserved so `exit::from_error` still classifies it correctly.
+        assert!(
+            matches!(&mapped, HeddleError::Io(io) if io.kind() == std::io::ErrorKind::PermissionDenied),
+            "io kind must survive reclassification, got {mapped:?}"
+        );
+        // The path/action context must NOT be flattened away.
+        let msg = format!("{mapped}");
+        assert!(
+            msg.contains(".cargo/config.toml") && msg.contains("writing"),
+            "reclassified io error must retain the path/action context: {msg}"
         );
     }
 

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -59,13 +59,31 @@ use super::worktree_cmd::{
     helpers::write_isolated_checkout, hydrate, shared_target::write_cargo_config,
 };
 
-/// Wrap an `anyhow` error from a materialize/hydrate helper into the
+/// Classify an `anyhow` error from a materialize/hydrate helper into the
 /// `HeddleError` the primitive's `Result` requires (mirrors undo/redo's
 /// `apply_error`). The command-level preflights produce the structured
-/// refusals; a message wrapped here only ever surfaces a genuinely
+/// refusals; a message reaching here only ever surfaces a genuinely
 /// unexpected mid-apply failure whose rewind has already run.
+///
+/// This must NOT blanket-wrap every failure as a `Conflict`: a plain I/O
+/// failure mid-materialize (e.g. a `clonefile`/`FICLONE` ENOENT, heddle#571)
+/// would then be reported to the user as `conflict: No such file or directory`,
+/// which is both wrong and blocks diagnosis. So we recover the real variant:
+///   * an already-structured `HeddleError` (the common case — repo-layer errors
+///     propagate through the helpers' `anyhow::Result` via `?`) keeps its
+///     variant, so an `Io`/`NotFound`/etc. stays itself and only a genuine
+///     merge/visibility `Conflict` stays a `Conflict`;
+///   * a bare `std::io::Error` surfaces as `HeddleError::Io` (preserving the
+///     path/os-error its source carries);
+///   * only a genuinely-unclassifiable error falls back to `Conflict`.
 fn apply_error(err: anyhow::Error) -> HeddleError {
-    HeddleError::Conflict(format!("{err:#}"))
+    match err.downcast::<HeddleError>() {
+        Ok(heddle) => heddle,
+        Err(err) => match err.downcast::<std::io::Error>() {
+            Ok(io) => HeddleError::Io(io),
+            Err(err) => HeddleError::Conflict(format!("{err:#}")),
+        },
+    }
 }
 
 // ---- In-process fault seam (unit tests only) ----
@@ -1073,6 +1091,50 @@ mod tests {
     use crate::cli::{ThreadStartArgs, WorkspaceModeArg};
     use repo::Repository;
     use tempfile::TempDir;
+
+    /// heddle#571 (Bug 1): a non-conflict failure on the start path must NOT be
+    /// reported as `conflict:`. The macOS regression was a `clonefile` ENOENT
+    /// (an `io::Error`) bubbling through the materialize helper's
+    /// `anyhow::Result` and getting blanket-wrapped as `HeddleError::Conflict`,
+    /// surfacing to the user as `conflict: No such file or directory (os error
+    /// 2)` — wrong, and it blocked diagnosis. `apply_error` is the classifier on
+    /// that path; assert it preserves the real variant.
+    #[test]
+    fn apply_error_preserves_io_and_does_not_mislabel_as_conflict() {
+        // A bare io::Error (what `clonefile`/`FICLONE` produce on ENOENT).
+        let bare_io = anyhow::Error::new(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory (os error 2)",
+        ));
+        let mapped = apply_error(bare_io);
+        assert!(
+            matches!(mapped, HeddleError::Io(_)),
+            "a bare io error must surface as Io, got {mapped:?}"
+        );
+        assert!(
+            !format!("{mapped}").starts_with("conflict:"),
+            "io error must not be reported as a conflict: {mapped}"
+        );
+
+        // The real shape from the materialize path: an io error already
+        // converted to `HeddleError::Io`, then propagated through the helper's
+        // `anyhow::Result` via `?`. `apply_error` must recover the Io variant.
+        let structured_io = anyhow::Error::new(HeddleError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory (os error 2)",
+        )));
+        assert!(
+            matches!(apply_error(structured_io), HeddleError::Io(_)),
+            "a propagated HeddleError::Io must keep its variant"
+        );
+
+        // A genuine merge/visibility conflict still maps to Conflict.
+        let conflict = anyhow::Error::new(HeddleError::Conflict("real merge conflict".to_string()));
+        assert!(
+            matches!(apply_error(conflict), HeddleError::Conflict(_)),
+            "a genuine conflict must remain a conflict"
+        );
+    }
 
     /// A `--path` solid-thread start that pins its base on `from` (no current-
     /// state bootstrap) and never spawns a daemon — minimal machinery for the

--- a/crates/objects/src/fs_clone.rs
+++ b/crates/objects/src/fs_clone.rs
@@ -50,6 +50,21 @@ use std::{fs, io, path::Path};
 /// be opened for writing on a regular file, which we create with
 /// `O_CREAT | O_WRONLY | O_TRUNC`.
 pub fn try_reflink(source: &Path, dest: &Path) -> io::Result<bool> {
+    // Never hand `clonefile`/`FICLONE` a source that isn't there: a missing
+    // source is reported as ENOENT, which `reflink_unsupported` deliberately
+    // does NOT swallow (ENOENT is a genuinely-missing file, not "reflink
+    // unsupported"), so it would hard-error. Reflink is only an optimization —
+    // a vanished loose mirror (concurrent prune / torn promote) must degrade to
+    // the caller's copy/bytes-write fallback, not crash. We treat
+    // "source not a usable file right now" exactly like "filesystem can't
+    // reflink": `Ok(false)`. This guard is what stopped `heddle start` from
+    // failing on macOS/APFS with `conflict: No such file or directory`
+    // (heddle#571). A genuinely-missing blob still errors loudly downstream —
+    // `get_blob` returns `NotFound` with the hash when the copy fallback also
+    // can't find the bytes.
+    if !source.exists() {
+        return Ok(false);
+    }
     #[cfg(target_os = "macos")]
     {
         try_clonefile_macos(source, dest)
@@ -223,6 +238,29 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    /// heddle#571 (Bug 2): reflink must be gated on the source existing. A
+    /// vanished loose mirror (concurrent prune / torn promote) must degrade to
+    /// the caller's copy/bytes-write fallback (`Ok(false)`), NOT hard-error with
+    /// the ENOENT that `clonefile` raises on macOS (and that `reflink_unsupported`
+    /// correctly refuses to swallow). Verifiable on Linux: no syscall is issued.
+    #[test]
+    fn try_reflink_missing_source_falls_back_not_errors() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("does-not-exist.txt");
+        let dst = temp.path().join("dst.txt");
+        assert!(!src.exists());
+
+        let result = try_reflink(&src, &dst);
+        assert!(
+            matches!(result, Ok(false)),
+            "a missing reflink source must return Ok(false) (fall back), got {result:?}"
+        );
+        assert!(
+            !dst.exists(),
+            "no destination should be created when the source is missing"
+        );
+    }
 
     #[test]
     fn clonefile_or_copy_creates_destination_with_source_bytes() {

--- a/crates/objects/src/fs_clone.rs
+++ b/crates/objects/src/fs_clone.rs
@@ -21,27 +21,61 @@
 //! - **Anywhere else** (or when reflink isn't supported by the
 //!   underlying filesystem): caller falls back to a real copy.
 //!
-//! The functions here return `Ok(true)` on a successful clone,
-//! `Ok(false)` when the kernel reported the operation isn't supported
-//! on this filesystem (so the caller should fall back to a real copy
-//! and remember to skip future reflink attempts in this batch), and an
-//! `Err` for genuine I/O errors that the caller should surface.
+//! The core [`try_reflink`] returns a [`ReflinkOutcome`] so the caller
+//! can tell three genuinely-different situations apart: a successful
+//! clone, a "this filesystem can't reflink" verdict (batch-wide signal
+//! to stop trying), and a "the source vanished from under us" race
+//! (a per-blob fallback that must NOT poison the batch). Overloading the
+//! last two — as a bare `Ok(false)` did — makes one concurrently-pruned
+//! loose mirror needlessly disable reflinks for every remaining blob.
 
 use std::{fs, io, path::Path};
+
+/// The three outcomes of a reflink attempt, kept distinct so callers
+/// don't conflate "filesystem can't reflink" (a batch-wide property)
+/// with "this one source vanished mid-flight" (a per-blob race).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflinkOutcome {
+    /// CoW clone succeeded; `dest` now exists, sharing physical blocks
+    /// with `source` until either side is written.
+    Cloned,
+    /// The kernel reported reflinks aren't supported for this
+    /// filesystem / src+dst pair (`EXDEV`/`EOPNOTSUPP`/`ENOTSUP`/
+    /// `ENOSYS`/`EINVAL`). This is a property of the destination
+    /// filesystem, so a caller materializing a batch MAY disable
+    /// reflinks for the rest of it and fall straight to copy/write.
+    Unsupported,
+    /// The `source` was gone by the time we looked (concurrent prune /
+    /// torn NoSync promote). Reflink is only an optimization, so the
+    /// caller should degrade to a real copy / bytes-write for THIS blob
+    /// only — and crucially keep reflinks enabled for the rest of the
+    /// batch, since the filesystem itself is perfectly capable. A blob
+    /// that is genuinely absent (not just unreflinkable) still surfaces
+    /// downstream when the copy/write fallback can't find its bytes.
+    SourceVanished,
+}
 
 /// Try a filesystem-level reflink (copy-on-write clone) from `source`
 /// to `dest`. On success the destination has its own inode and shares
 /// physical blocks with the source until either side is modified.
 ///
-/// On a successful reflink: returns `Ok(true)`. The destination file
-/// has been created with the kernel's choice of permissions (typically
-/// the source's). Callers should `set_permissions` afterwards if they
-/// need a specific mode.
+/// On a successful reflink: returns `Ok(ReflinkOutcome::Cloned)`. The
+/// destination file has been created with the kernel's choice of
+/// permissions (typically the source's). Callers should
+/// `set_permissions` afterwards if they need a specific mode.
 ///
 /// On a "filesystem doesn't support reflinks" verdict (`EXDEV`,
 /// `EOPNOTSUPP`, `ENOTSUP`, `ENOSYS`, `EINVAL` from the ioctl form):
-/// returns `Ok(false)`. The caller should fall back to `fs::copy` and
-/// remember to skip future reflink attempts on this filesystem.
+/// returns `Ok(ReflinkOutcome::Unsupported)`. The caller should fall
+/// back to `fs::copy` and may skip future reflink attempts on this
+/// filesystem.
+///
+/// When the `source` is gone (missing at the pre-check, or `ENOENT`
+/// from the syscall in the TOCTOU window after it): returns
+/// `Ok(ReflinkOutcome::SourceVanished)`. The caller should fall back
+/// to a copy/bytes-write for this blob only and keep reflinks enabled
+/// for the rest of the batch — a vanished mirror says nothing about
+/// the filesystem's reflink capability.
 ///
 /// On any other I/O error: returns `Err`.
 ///
@@ -49,21 +83,21 @@ use std::{fs, io, path::Path};
 /// nonexistent destination). On Linux `FICLONE` requires the dest fd
 /// be opened for writing on a regular file, which we create with
 /// `O_CREAT | O_WRONLY | O_TRUNC`.
-pub fn try_reflink(source: &Path, dest: &Path) -> io::Result<bool> {
+pub fn try_reflink(source: &Path, dest: &Path) -> io::Result<ReflinkOutcome> {
     // Never hand `clonefile`/`FICLONE` a source that isn't there: a missing
     // source is reported as ENOENT, which `reflink_unsupported` deliberately
     // does NOT swallow (ENOENT is a genuinely-missing file, not "reflink
     // unsupported"), so it would hard-error. Reflink is only an optimization —
     // a vanished loose mirror (concurrent prune / torn promote) must degrade to
-    // the caller's copy/bytes-write fallback, not crash. We treat
-    // "source not a usable file right now" exactly like "filesystem can't
-    // reflink": `Ok(false)`. This guard is what stopped `heddle start` from
-    // failing on macOS/APFS with `conflict: No such file or directory`
-    // (heddle#571). A genuinely-missing blob still errors loudly downstream —
-    // `get_blob` returns `NotFound` with the hash when the copy fallback also
-    // can't find the bytes.
+    // the caller's copy/bytes-write fallback, not crash. This is reported as
+    // `SourceVanished` (NOT `Unsupported`) so a single pruned blob doesn't
+    // disable reflinks for the whole batch. This guard is what stopped `heddle
+    // start` from failing on macOS/APFS with `conflict: No such file or
+    // directory` (heddle#571). A genuinely-missing blob still errors loudly
+    // downstream — `get_blob` returns `NotFound` with the hash when the copy
+    // fallback also can't find the bytes.
     if !source.exists() {
-        return Ok(false);
+        return Ok(ReflinkOutcome::SourceVanished);
     }
     #[cfg(target_os = "macos")]
     {
@@ -76,7 +110,7 @@ pub fn try_reflink(source: &Path, dest: &Path) -> io::Result<bool> {
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         let _ = (source, dest);
-        Ok(false)
+        Ok(ReflinkOutcome::Unsupported)
     }
 }
 
@@ -93,7 +127,7 @@ pub fn clonefile_or_copy(source: &Path, dest: &Path) -> io::Result<bool> {
     // `clonefile`/FICLONE require dest not to exist; remove any stale
     // entry first. Ignored if dest doesn't exist.
     let _ = fs::remove_file(dest);
-    if try_reflink(source, dest)? {
+    if matches!(try_reflink(source, dest)?, ReflinkOutcome::Cloned) {
         return Ok(true);
     }
     fs::copy(source, dest)?;
@@ -101,7 +135,7 @@ pub fn clonefile_or_copy(source: &Path, dest: &Path) -> io::Result<bool> {
 }
 
 #[cfg(target_os = "macos")]
-fn try_clonefile_macos(source: &Path, dest: &Path) -> io::Result<bool> {
+fn try_clonefile_macos(source: &Path, dest: &Path) -> io::Result<ReflinkOutcome> {
     use std::{ffi::CString, os::unix::ffi::OsStrExt};
 
     // SAFETY: linking the system `clonefile(2)` symbol. Signature
@@ -130,19 +164,15 @@ fn try_clonefile_macos(source: &Path, dest: &Path) -> io::Result<bool> {
     // (clone metadata + data, follow no symlinks on the source).
     let rc = unsafe { clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
     if rc == 0 {
-        return Ok(true);
+        return Ok(ReflinkOutcome::Cloned);
     }
 
     let err = io::Error::last_os_error();
-    if reflink_unsupported(&err) {
-        Ok(false)
-    } else {
-        Err(err)
-    }
+    classify_clone_err(source, err)
 }
 
 #[cfg(target_os = "linux")]
-fn try_ficlone_linux(source: &Path, dest: &Path) -> io::Result<bool> {
+fn try_ficlone_linux(source: &Path, dest: &Path) -> io::Result<ReflinkOutcome> {
     use std::{fs::OpenOptions, os::unix::io::AsRawFd};
 
     // FICLONE = _IOW(0x94, 9, int) on Linux. The kernel header
@@ -151,7 +181,14 @@ fn try_ficlone_linux(source: &Path, dest: &Path) -> io::Result<bool> {
     // i.e. _IOC_WRITE | sizeof(int) | type=0x94 | nr=9.
     const FICLONE: libc::c_ulong = 0x4004_9409;
 
-    let src = OpenOptions::new().read(true).open(source)?;
+    // Opening the source can race a concurrent prune: the pre-check in
+    // `try_reflink` saw it, but it can vanish before this open. Map that
+    // to `SourceVanished` so the caller degrades per-blob rather than
+    // disabling reflinks for the batch (or hard-erroring).
+    let src = match OpenOptions::new().read(true).open(source) {
+        Ok(f) => f,
+        Err(err) => return classify_clone_err(source, err),
+    };
     let dst = OpenOptions::new()
         .write(true)
         .create(true)
@@ -162,7 +199,7 @@ fn try_ficlone_linux(source: &Path, dest: &Path) -> io::Result<bool> {
     // as the third arg.
     let rc = unsafe { libc::ioctl(dst.as_raw_fd(), FICLONE, src.as_raw_fd()) };
     if rc == 0 {
-        return Ok(true);
+        return Ok(ReflinkOutcome::Cloned);
     }
 
     let err = io::Error::last_os_error();
@@ -170,8 +207,27 @@ fn try_ficlone_linux(source: &Path, dest: &Path) -> io::Result<bool> {
     // `fs::copy` fallback starts from a known state.
     drop(dst);
     let _ = fs::remove_file(dest);
+    classify_clone_err(source, err)
+}
+
+/// Classify a clonefile/FICLONE (or source-open) failure into the
+/// caller-meaningful [`ReflinkOutcome`] or a genuine error.
+///
+/// * `Unsupported` — the filesystem (or src/dst pair) can't reflink
+///   (`reflink_unsupported`). A batch-wide property.
+/// * `SourceVanished` — the failure is `ENOENT` and the source is in
+///   fact gone now (concurrent prune / torn promote in the TOCTOU
+///   window after the pre-check). A per-blob race; reflinks stay viable
+///   for the rest of the batch. An `ENOENT` whose source still exists
+///   (e.g. a missing dest parent) is NOT swallowed here — it surfaces
+///   as an `Err` for the caller to attribute correctly.
+/// * `Err` — anything else; the caller should surface it.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn classify_clone_err(source: &Path, err: io::Error) -> io::Result<ReflinkOutcome> {
     if reflink_unsupported(&err) {
-        Ok(false)
+        Ok(ReflinkOutcome::Unsupported)
+    } else if err.kind() == io::ErrorKind::NotFound && !source.exists() {
+        Ok(ReflinkOutcome::SourceVanished)
     } else {
         Err(err)
     }
@@ -227,7 +283,7 @@ pub fn filesystem_supports_reflink(parent_dir: &Path) -> bool {
     }
     drop(f);
 
-    let supported = matches!(try_reflink(&src, &dst), Ok(true));
+    let supported = matches!(try_reflink(&src, &dst), Ok(ReflinkOutcome::Cloned));
     let _ = fs::remove_file(&src);
     let _ = fs::remove_file(&dst);
     supported
@@ -241,11 +297,14 @@ mod tests {
 
     /// heddle#571 (Bug 2): reflink must be gated on the source existing. A
     /// vanished loose mirror (concurrent prune / torn promote) must degrade to
-    /// the caller's copy/bytes-write fallback (`Ok(false)`), NOT hard-error with
-    /// the ENOENT that `clonefile` raises on macOS (and that `reflink_unsupported`
-    /// correctly refuses to swallow). Verifiable on Linux: no syscall is issued.
+    /// the caller's copy/bytes-write fallback, NOT hard-error with the ENOENT
+    /// that `clonefile` raises on macOS (and that `reflink_unsupported`
+    /// correctly refuses to swallow). It must report `SourceVanished` —
+    /// distinct from `Unsupported` — so one pruned blob doesn't disable
+    /// reflinks for the whole batch (heddle#571 r3). Verifiable on Linux: no
+    /// syscall is issued.
     #[test]
-    fn try_reflink_missing_source_falls_back_not_errors() {
+    fn try_reflink_missing_source_reports_vanished_not_unsupported() {
         let temp = TempDir::new().unwrap();
         let src = temp.path().join("does-not-exist.txt");
         let dst = temp.path().join("dst.txt");
@@ -253,8 +312,9 @@ mod tests {
 
         let result = try_reflink(&src, &dst);
         assert!(
-            matches!(result, Ok(false)),
-            "a missing reflink source must return Ok(false) (fall back), got {result:?}"
+            matches!(result, Ok(ReflinkOutcome::SourceVanished)),
+            "a missing reflink source must report SourceVanished (per-blob fallback, \
+             NOT the batch-wide Unsupported), got {result:?}"
         );
         assert!(
             !dst.exists(),
@@ -326,8 +386,12 @@ mod tests {
         let dst = temp.path().join("dst.txt");
         fs::write(&src, b"reflink inode test").unwrap();
 
-        let did_reflink = try_reflink(&src, &dst).unwrap();
-        assert!(did_reflink, "filesystem advertised reflink support");
+        let outcome = try_reflink(&src, &dst).unwrap();
+        assert_eq!(
+            outcome,
+            ReflinkOutcome::Cloned,
+            "filesystem advertised reflink support"
+        );
 
         let src_inode = fs::metadata(&src).unwrap().ino();
         let dst_inode = fs::metadata(&dst).unwrap().ino();

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -706,6 +706,27 @@ impl Repository {
         // make sure we're starting from a clean slate. A previous
         // `goto` could have left a regular file or a stale link here.
         let _ = fs::remove_file(dest);
+        // Reflink is a pure optimization; correctness must never depend on the
+        // loose source still being present at the syscall. `loose_blob_path`
+        // verified it existed, but a concurrent prune or a torn NoSync promote
+        // can remove it before we get here. On macOS, handing `clonefile(2)` a
+        // missing source surfaces as ENOENT — which `reflink_unsupported`
+        // deliberately does NOT swallow (ENOENT means a genuinely missing file,
+        // not "reflink unsupported") — so without this guard the whole
+        // `heddle start` hard-fails (heddle#571). Fall back to the bytes-write
+        // path for THIS blob only by returning `Ok(false)`; do NOT
+        // `disable_reflinks`, so sibling blobs whose mirrors are intact still
+        // clone. The caller (`materialize_blob`) then writes the blob from its
+        // decompressed bytes via `get_blob` — the same path Linux's
+        // ext4-EOPNOTSUPP short-circuit already takes.
+        if !source.exists() {
+            debug!(
+                source = %source.display(),
+                dest = %dest.display(),
+                "loose reflink source missing before clone; falling back to bytes-write for this blob"
+            );
+            return Ok(false);
+        }
         match objects::fs_clone::try_reflink(source, dest) {
             Ok(true) => {
                 set_file_mode(dest, executable)?;
@@ -732,7 +753,12 @@ impl Repository {
                     dest = %dest.display(),
                     "reflink failed with I/O error"
                 );
-                Err(err.into())
+                // Surface the offending loose source path so a
+                // clonefile/FICLONE failure is diagnosable instead of a bare
+                // `No such file or directory (os error 2)` with no context
+                // (heddle#571). `enrich_fs_error` also classifies common
+                // failures (out-of-space, read-only, permission) by ErrorKind.
+                Err(HeddleError::Io(enrich_fs_error(source, "reflinking", err)))
             }
         }
     }

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -753,14 +753,57 @@ impl Repository {
                     dest = %dest.display(),
                     "reflink failed with I/O error"
                 );
-                // Surface the offending loose source path so a
-                // clonefile/FICLONE failure is diagnosable instead of a bare
-                // `No such file or directory (os error 2)` with no context
-                // (heddle#571). `enrich_fs_error` also classifies common
-                // failures (out-of-space, read-only, permission) by ErrorKind.
-                Err(HeddleError::Io(enrich_fs_error(source, "reflinking", err)))
+                match classify_clone_failure(source, dest, &err) {
+                    // [heddle#571 r2, finding 2] Source vanished mid-flight
+                    // (TOCTOU): degrade to the bytes-write fallback for this
+                    // blob rather than hard-erroring. See `classify_clone_failure`.
+                    None => {
+                        debug!(
+                            source = %source.display(),
+                            dest = %dest.display(),
+                            "loose reflink source vanished between pre-check and clone syscall; falling back to bytes-write for this blob"
+                        );
+                        Ok(false)
+                    }
+                    // [heddle#571 r2, finding 3] Attribute to the offending side.
+                    Some((offender, action)) => {
+                        Err(HeddleError::Io(enrich_fs_error(offender, action, err)))
+                    }
+                }
             }
         }
+    }
+}
+
+/// Classify a clone-syscall (`clonefile`/`FICLONE`) I/O failure into either a
+/// bytes-write fallback or an enriched, correctly-attributed error.
+///
+/// * `None` — the loose source vanished between the `!source.exists()`
+///   pre-check and the syscall (concurrent prune / torn NoSync promote), so the
+///   syscall raised `ENOENT`. The caller should degrade to the bytes-write
+///   fallback (`Ok(false)`), which re-reads the authoritative bytes from the
+///   store; a blob genuinely absent from the store still errors there with its
+///   hash. This closes the TOCTOU race rather than blindly masking `ENOENT`
+///   (heddle#571 r2, finding 2).
+/// * `Some((path, action))` — a real failure to surface, attributed to the side
+///   that actually failed. The source survived (the vanished case returned
+///   `None`), so a create/permission/read-only/no-space failure is the
+///   DESTINATION's (read-only checkout dir, unwritable target). We blame the
+///   source only when it is the unreadable party (probed directly). Reporting a
+///   dest-side failure against the blob path would point the user at the wrong
+///   file (heddle#571 r2, finding 3).
+fn classify_clone_failure<'a>(
+    source: &'a Path,
+    dest: &'a Path,
+    err: &std::io::Error,
+) -> Option<(&'a Path, &'static str)> {
+    if err.kind() == std::io::ErrorKind::NotFound && !source.exists() {
+        return None;
+    }
+    if fs::File::open(source).is_ok() {
+        Some((dest, "reflinking into"))
+    } else {
+        Some((source, "reflinking"))
     }
 }
 
@@ -870,8 +913,65 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Repository, WorktreeWriteOp, materialization_worker_count, remove_materialized_leaf,
+        Repository, WorktreeWriteOp, classify_clone_failure, materialization_worker_count,
+        remove_materialized_leaf,
     };
+
+    /// heddle#571 (round 2, finding 2): a clone syscall that raises ENOENT
+    /// because the loose source vanished AFTER the pre-check (TOCTOU) must
+    /// degrade to the bytes-write fallback (`None`), not hard-error.
+    #[test]
+    fn classify_clone_failure_vanished_source_falls_back() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("gone.blob");
+        let dest = temp.path().join("checkout/file");
+        assert!(!source.exists());
+
+        let enoent = std::io::Error::from(std::io::ErrorKind::NotFound);
+        assert!(
+            classify_clone_failure(&source, &dest, &enoent).is_none(),
+            "a vanished-source ENOENT must signal the bytes-write fallback"
+        );
+    }
+
+    /// heddle#571 (round 2, finding 3): when the source is still present and
+    /// readable, the clone failed on the DESTINATION side — attribute the error
+    /// to the dest (checkout) path, not the blob.
+    #[test]
+    fn classify_clone_failure_present_source_blames_dest() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("present.blob");
+        std::fs::write(&source, b"bytes").unwrap();
+        let dest = temp.path().join("readonly-checkout/file");
+
+        // A dest-side failure shape (e.g. read-only checkout dir).
+        let erofs = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let attributed = classify_clone_failure(&source, &dest, &erofs);
+        assert_eq!(
+            attributed,
+            Some((dest.as_path(), "reflinking into")),
+            "a failure with the source still readable must be attributed to dest"
+        );
+    }
+
+    /// heddle#571 (round 2, finding 3): a non-ENOENT failure whose source is no
+    /// longer openable is attributed to the SOURCE path (it is the unreadable
+    /// party), not the destination.
+    #[test]
+    fn classify_clone_failure_unreadable_source_blames_source() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("missing.blob"); // not created → unopenable
+        let dest = temp.path().join("file");
+
+        // Not ENOENT (so the vanished-source fast path doesn't fire), but the
+        // source can't be opened → blame the source.
+        let other = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            classify_clone_failure(&source, &dest, &other),
+            Some((source.as_path(), "reflinking")),
+            "an unreadable source must be attributed to the source path"
+        );
+    }
 
     /// Regression: `remove_materialized_leaf` must tolerate `ENOTEMPTY` on
     /// the directory branch, mirroring `remove_existing_path` in the

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -688,13 +688,22 @@ impl Repository {
         Ok(())
     }
 
-    /// One clone attempt: returns `Ok(true)` on a successful reflink
-    /// or fallback `fs::copy`, `Ok(false)` only when the
-    /// filesystem-level helper reports the operation isn't supported
-    /// (`EXDEV`/`EOPNOTSUPP`/`ENOSYS`/`EINVAL`). On the unsupported
-    /// verdict the context is flipped so the rest of the batch skips
-    /// straight to the in-memory `fs::write` path without paying the
-    /// failed-syscall tax. Genuine I/O errors bubble up.
+    /// One clone attempt: returns `Ok(true)` on a successful reflink,
+    /// `Ok(false)` when the caller should fall back to the in-memory
+    /// `fs::write` path. The two `Ok(false)` causes are deliberately
+    /// handled differently:
+    ///
+    /// * `ReflinkOutcome::Unsupported` (`EXDEV`/`EOPNOTSUPP`/`ENOSYS`/
+    ///   `EINVAL`) — a filesystem-capability verdict, so the context is
+    ///   flipped (`disable_reflinks`) and the rest of the batch skips
+    ///   straight to `fs::write` without paying the failed-syscall tax.
+    /// * `ReflinkOutcome::SourceVanished` — the loose mirror was pruned
+    ///   mid-flight. A per-blob race, so we fall back for this blob only
+    ///   and leave reflinks ENABLED for the rest of the batch
+    ///   (heddle#571 r3).
+    ///
+    /// Genuine I/O errors bubble up (attributed to the offending side by
+    /// `classify_clone_failure`).
     fn try_clone(
         &self,
         source: &Path,
@@ -727,13 +736,14 @@ impl Repository {
             );
             return Ok(false);
         }
+        use objects::fs_clone::ReflinkOutcome;
         match objects::fs_clone::try_reflink(source, dest) {
-            Ok(true) => {
+            Ok(ReflinkOutcome::Cloned) => {
                 set_file_mode(dest, executable)?;
                 context.record_reflink();
                 Ok(true)
             }
-            Ok(false) => {
+            Ok(ReflinkOutcome::Unsupported) => {
                 // Filesystem doesn't support reflinks. Disable for
                 // the rest of the batch and let the caller fall
                 // through to `fs::write` (which decompresses from
@@ -744,6 +754,22 @@ impl Repository {
                     "reflink not supported on this filesystem; switching batch to fs::write fallback"
                 );
                 context.disable_reflinks();
+                Ok(false)
+            }
+            Ok(ReflinkOutcome::SourceVanished) => {
+                // [heddle#571 r3] The loose mirror was pruned out from under
+                // us between the pre-check and the clone. That's a per-blob
+                // race, NOT a filesystem-capability verdict — so degrade to
+                // the bytes-write fallback for THIS blob only and DO NOT
+                // `disable_reflinks`. Sibling blobs whose mirrors are intact
+                // still get the CoW win. A blob genuinely absent from the
+                // store still errors loudly when the bytes-write fallback's
+                // `get_blob` can't find it.
+                debug!(
+                    source = %source.display(),
+                    dest = %dest.display(),
+                    "loose reflink source vanished before clone; falling back to bytes-write for this blob (reflinks stay enabled batch-wide)"
+                );
                 Ok(false)
             }
             Err(err) => {
@@ -913,8 +939,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        Repository, WorktreeWriteOp, classify_clone_failure, materialization_worker_count,
-        remove_materialized_leaf,
+        MaterializationContext, Repository, WorktreeWriteOp, classify_clone_failure,
+        materialization_worker_count, remove_materialized_leaf,
     };
 
     /// heddle#571 (round 2, finding 2): a clone syscall that raises ENOENT
@@ -970,6 +996,34 @@ mod tests {
             classify_clone_failure(&source, &dest, &other),
             Some((source.as_path(), "reflinking")),
             "an unreadable source must be attributed to the source path"
+        );
+    }
+
+    /// heddle#571 (round 3): a vanished loose source is a per-blob race, not a
+    /// filesystem-capability verdict — `try_clone` must degrade to the
+    /// bytes-write fallback for that blob WITHOUT flipping the batch-wide
+    /// `reflink_supported` flag. Previously the helper's pre-check returned a
+    /// bare `Ok(false)`, indistinguishable from "filesystem can't reflink", so
+    /// one concurrently-pruned mirror needlessly disabled reflinks (forcing
+    /// copy-writes) for every remaining blob in the batch.
+    #[test]
+    fn try_clone_vanished_source_keeps_batch_reflinks_enabled() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let context = MaterializationContext::new();
+        assert!(context.reflinks_enabled(), "context starts optimistic");
+
+        let missing = temp.path().join("pruned.blob");
+        let dest = temp.path().join("wt/out.txt");
+        assert!(!missing.exists());
+
+        let cloned = repo
+            .try_clone(&missing, &dest, false, &context)
+            .expect("a vanished source must fall back, not error");
+        assert!(!cloned, "a vanished source cannot have been reflinked");
+        assert!(
+            context.reflinks_enabled(),
+            "a vanished source must NOT disable reflinks for the rest of the batch"
         );
     }
 


### PR DESCRIPTION
Closes #571.

`heddle start` failed on macOS/APFS with `Error: conflict: No such file or directory (os error 2)` (did not reproduce on Linux). Two distinct bugs.

## Bug 1 — error mislabeling (Linux-verified)
`apply_error` (`crates/cli/src/cli/commands/start_atomic.rs`) blanket-wrapped **any** anyhow error from materialize/hydrate into `HeddleError::Conflict(...)` (`#[error("conflict: {0}")]`). A plain `io::Error` (ENOENT) therefore surfaced as a "conflict", which is wrong and blocks diagnosis.

Fix: classify instead of blanket-wrap —
- a structured `HeddleError` (the common case; repo-layer errors propagate through the helpers' `anyhow::Result` via `?`) keeps its real variant, so `Io`/`NotFound`/etc. stay themselves and only a genuine merge/visibility `Conflict` stays a `Conflict`;
- a bare `std::io::Error` surfaces as `HeddleError::Io` (preserving path + os-error);
- only a genuinely-unclassifiable error falls back to `Conflict`.

Test: `apply_error_preserves_io_and_does_not_mislabel_as_conflict` asserts an io error (bare and propagated-through-HeddleError) is **not** reported as `conflict:`, and a genuine conflict still maps to `Conflict`.

## Bug 2 — clonefile ENOENT on macOS (reasoned on Linux; **clonefile syscall behavior is MAC-UNVERIFIED**)
Root cause (traced in code): `materialize_blob` → `try_clone` → `try_reflink` clones from a **loose blob path**. `loose_blob_path` verifies the loose file exists, but a TOCTOU window (concurrent prune / torn NoSync promote) can remove it before the syscall. macOS `clonefile(2)` reports a missing source as **ENOENT**, which `reflink_unsupported` deliberately does **not** swallow → hard error. Linux hides it: ext4 returns EOPNOTSUPP→`Ok(false)` first, disabling reflinks before the source is read.

Fix (correctness must not depend on the reflink optimization):
- **`crates/objects/src/fs_clone.rs`** `try_reflink`: gate on `source.exists()` → `Ok(false)` so the syscall is never handed a missing source. Linux-verifiable; unit test `try_reflink_missing_source_falls_back_not_errors` (no syscall issued, no dest created).
- **`crates/repo/src/repository_materialization.rs`** `try_clone`: per-blob source-existence gate returning `Ok(false)` **without** disabling reflinks batch-wide, so the blob is written from its decompressed bytes via `get_blob` (the same path Linux's EOPNOTSUPP short-circuit already takes); sibling blobs with intact mirrors still clone. The reflink `Err` branch now enriches the io error with the offending **source path** via `enrich_fs_error`.
- ENOENT is **not** masked in `reflink_unsupported`; a genuinely-missing blob still errors loudly (`get_blob` → `NotFound` with the hash).

### Verified on Linux
- Bug-1 classification (mislabel fix) + its test.
- Bug-2 path-existence/fallback logic + its test; default-features build, all-features build, no-silent-default check, clippy `-D warnings`, full workspace suite — all green.

### MAC-UNVERIFIED (needs Mac confirmation)
- The actual `clonefile(2)` ENOENT→fallback behavior on APFS. The path-existence reasoning and the bytes-write fallback are Linux-verified, but the macOS syscall outcome itself can only be confirmed on a Mac.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783382567&installation_id=132405951&pr_number=574&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F574&signature=d3363f85542ea7788442534b2e49710d317599acc61697084cbc70d7157c1103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->