### PR TITLE
feat(start): place thread checkouts under .heddle/threads/ (sandbox-friendly) (#572)

### DIFF
--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -576,8 +576,36 @@ impl GitIndexPlan {
     }
 }
 
+/// True when `root` is itself the top of a Git worktree, not merely
+/// nested inside one. A Heddle thread checkout now lives under the parent
+/// repo's `.heddle/threads/` (heddle#572); it's a *native* isolated
+/// checkout that shares the parent's object store but is NOT a Git
+/// worktree of its own. Bare `gix::discover` walks up the directory tree,
+/// so from inside such a checkout it would find the PARENT repo's `.git`
+/// and read its index/HEAD as though they belonged to the checkout.
+/// Requiring the discovered worktree to equal `root` keeps git-index
+/// inspection scoped to genuine git-overlay roots — and matches the
+/// pre-#572 behaviour where a sibling checkout had no git above it at all.
+fn git_worktree_rooted_at(root: &Path) -> bool {
+    match gix::discover(root) {
+        Ok(git) => git
+            .workdir()
+            .is_some_and(|workdir| paths_equal(workdir, root)),
+        Err(_) => false,
+    }
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    let left = left.canonicalize();
+    let right = right.canonicalize();
+    match (left, right) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
 pub(crate) fn git_index_plan_for_root(root: &Path) -> Result<Option<GitIndexPlan>> {
-    if gix::discover(root).is_err() {
+    if !git_worktree_rooted_at(root) {
         return Ok(None);
     }
     Ok(Some(GitIndexPlan::from_intent(
@@ -587,7 +615,7 @@ pub(crate) fn git_index_plan_for_root(root: &Path) -> Result<Option<GitIndexPlan
 }
 
 pub(crate) fn git_index_plan_for_repo(repo: &Repository) -> Result<Option<GitIndexPlan>> {
-    if gix::discover(repo.root()).is_err() {
+    if !git_worktree_rooted_at(repo.root()) {
         return Ok(None);
     }
     Ok(Some(GitIndexPlan::from_intent(

--- a/crates/cli/src/cli/commands/mount_lifecycle.rs
+++ b/crates/cli/src/cli/commands/mount_lifecycle.rs
@@ -6,8 +6,6 @@
 //! The mount itself lives in [`crates/mount`]; this module is the
 //! thin CLI-side adapter that:
 //!
-//! * builds the conventional mount-point path
-//!   (`.{repo_name}-heddle-mounts/{name}/`),
 //! * spawns a background mount session when the thread starts,
 //! * unmounts cleanly when the thread is dropped.
 //!
@@ -17,28 +15,9 @@
 //! [`virtualized_unsupported_error`] runtime check so the rest of
 //! the CLI keeps building everywhere.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::anyhow;
-
-/// Compute the conventional mount point for a virtualized thread.
-///
-/// Mirrors [`default_lightweight_thread_path`] / [`default_private_thread_path`]
-/// (which produce `.{repo_name}-heddle-threads/{name}/root/`) but
-/// uses a sibling parent directory so a single repo can host both
-/// lightweight checkouts and virtual mounts side-by-side without
-/// path collisions.
-///
-/// Resolved template: `<repo_parent>/.<repo_name>-heddle-mounts/<sanitized_name>/`
-pub(crate) fn default_virtualized_mount_path(
-    workspace_parent: &Path,
-    repo_name: &str,
-    sanitized_thread: &str,
-) -> PathBuf {
-    workspace_parent
-        .join(format!(".{repo_name}-heddle-mounts"))
-        .join(sanitized_thread)
-}
 
 /// Anchored error for any build that has no native mount adapter
 /// active. Surfaced when none of (linux+fuse, macos+fskit,

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -1514,7 +1514,7 @@ mod tests {
     fn plan_worktree_target_defers_dir_creation() {
         let (temp, repo, _state) = repo_with_state(&[]);
         let target = temp.path().join("iso-deferred");
-        let prepared = plan_worktree_target(&repo, &target).unwrap();
+        let prepared = plan_worktree_target(&repo, &target, None).unwrap();
         assert!(
             prepared.target_dir_created,
             "a non-existent target is flagged as one this start will create"

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -3410,18 +3410,22 @@ pub(crate) fn default_threads_root(repo: &Repository) -> PathBuf {
 /// Default checkout directory for a thread, for every workspace mode:
 /// `<repo>/.heddle/threads/<name>/root`.
 ///
-/// The `root/` leaf is load-bearing, not cosmetic:
-/// `thread_manifest::manifest_path` already owns
-/// `.heddle/threads/<name>/manifest.toml` as the per-thread stat-cache
-/// sidecar. Nesting the worktree bytes one level down at `<name>/root`
-/// keeps that `manifest.toml` a *sibling* of the checkout rather than a
-/// stray file inside it, and the manifest walk
-/// (`thread_manifest::walk_thread_manifests`) stops at the first
-/// `manifest.toml` it finds, so it never descends into `root/`.
+/// Keyed off the SAME `thread_manifest::thread_dir` derivation the
+/// per-thread `manifest.toml` sidecar uses — the raw (already
+/// `validate_thread_id`-checked) thread name, NOT a re-sanitised copy.
+/// Sanitising here would diverge from the manifest (a slashed id
+/// `foo/bar` nests as `threads/foo/bar/` for the manifest but collapsed
+/// to `threads/foo-bar/` for the checkout) and could collide two
+/// distinct ids onto one directory. Sharing `thread_dir` guarantees the
+/// checkout root and the manifest sit in the same per-thread directory.
+///
+/// The `root/` leaf is load-bearing, not cosmetic: nesting the worktree
+/// bytes one level down at `<name>/root` keeps `manifest.toml` a
+/// *sibling* of the checkout rather than a stray file inside it, and the
+/// manifest walk (`thread_manifest::walk_thread_manifests`) stops at the
+/// first `manifest.toml` it finds, so it never descends into `root/`.
 fn default_thread_checkout_path(repo: &Repository, name: &str) -> PathBuf {
-    default_threads_root(repo)
-        .join(sanitize_name(name))
-        .join("root")
+    repo::thread_manifest::thread_dir(repo.heddle_dir(), name).join("root")
 }
 
 fn default_thread_path(repo: &Repository, name: &str) -> PathBuf {
@@ -3531,22 +3535,6 @@ fn default_virtualized_thread_path(repo: &Repository, name: &str) -> PathBuf {
     default_thread_checkout_path(repo, name)
 }
 
-fn sanitize_name(name: &str) -> String {
-    let mut out = String::new();
-    let mut last_dash = false;
-    for ch in name.chars() {
-        let keep = ch.is_ascii_alphanumeric();
-        if keep {
-            out.push(ch.to_ascii_lowercase());
-            last_dash = false;
-        } else if !last_dash {
-            out.push('-');
-            last_dash = true;
-        }
-    }
-    out.trim_matches('-').to_string()
-}
-
 fn absolute_path(path: &std::path::Path) -> Result<PathBuf> {
     if path.is_absolute() {
         Ok(path.to_path_buf())
@@ -3596,5 +3584,36 @@ mod tests {
             "heddle bridge git reconcile --prefer heddle --ref feature/git --preview"
         );
         assert!(advice.preserved.contains("Git checkout was left unchanged"));
+    }
+
+    /// A slashed thread id must map the default checkout root and the
+    /// per-thread manifest to the SAME `.heddle/threads/<name>` directory
+    /// (the checkout's `root/` a sibling of `manifest.toml`), and neither
+    /// may escape `.heddle/threads/`. Before the unified `thread_dir`
+    /// derivation the checkout sanitised `foo/bar` to `foo-bar` while the
+    /// manifest nested it as `foo/bar`, so the two diverged and distinct
+    /// ids could collide onto one directory.
+    #[test]
+    fn slashed_thread_id_checkout_and_manifest_agree() {
+        let repo_dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+
+        let checkout = default_thread_checkout_path(&repo, "foo/bar");
+        let manifest = repo::thread_manifest::manifest_path(repo.heddle_dir(), "foo/bar");
+        let threads_root = repo.heddle_dir().join("threads");
+
+        // Both live in the same per-thread directory: checkout at
+        // `<dir>/root`, manifest at `<dir>/manifest.toml`.
+        assert_eq!(checkout.parent().unwrap(), manifest.parent().unwrap());
+        assert_eq!(checkout.parent().unwrap(), threads_root.join("foo").join("bar"));
+        assert_eq!(checkout.file_name().unwrap(), "root");
+
+        // Neither escapes `.heddle/threads/`.
+        assert!(checkout.starts_with(&threads_root));
+        assert!(manifest.starts_with(&threads_root));
+
+        // Distinct slashed/dashed ids no longer collide.
+        let other = default_thread_checkout_path(&repo, "foo-bar");
+        assert_ne!(checkout, other);
     }
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1761,7 +1761,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
         ThreadMode::Virtualized => default_virtualized_thread_path(repo, &args.name),
     };
     if args.path.is_some() {
-        ensure_explicit_start_path_outside_repo(repo, &args.name, &path)?;
+        ensure_explicit_start_path_outside_tracked_tree(repo, &args.name, &path)?;
     }
     // The retry-stable idempotency key, resolved BEFORE the fresh-start preflight
     // so a committed retry is recognized before any precondition can reject it
@@ -2646,7 +2646,7 @@ pub(crate) fn cmd_thread_switch(
 
     // "Invisible thread directories" rule: switching to a thread that has
     // its *own* dedicated worktree (the one `heddle start --workspace
-    // private|virtualized` recorded under `.run-heddle-threads/<name>/`)
+    // private|virtualized` recorded under `.heddle/threads/<name>/root/`)
     // is a metadata-only operation. The on-disk worktree at the
     // recorded path is already X's worktree — it was set up by `start`
     // and is kept in sync by the metadata-driven merge/rebase/goto/land
@@ -3390,21 +3390,51 @@ fn non_empty_action(action: &str) -> Option<String> {
     (!action.trim().is_empty()).then(|| action.to_string())
 }
 
-fn default_thread_path(repo: &Repository, name: &str) -> PathBuf {
-    let workspace_root = shared_workspace_root(repo);
-    let repo_name = workspace_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("heddle");
-    let parent = workspace_root
-        .parent()
-        .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| workspace_root.to_path_buf());
-    parent.join(format!("{repo_name}-{}", sanitize_name(name)))
+/// Root for all default thread checkouts: `<repo>/.heddle/threads`.
+///
+/// Living under `.heddle/` (heddle's reserved, never-tracked metadata
+/// dir) keeps the checkout *inside* the repository directory — so a
+/// sandbox scoped to the repo can still reach it — while staying out of
+/// the parent repo's overlay/status traversal. `.heddle/` is excluded
+/// everywhere it matters: the git-overlay status path carries `.heddle/`
+/// in `.git/info/exclude` (`repository::ensure_git_overlay_exclude`), and
+/// the native worktree walk / untracked scan / materialize walk root
+/// their ignore at `/.heddle` (`repo_config::default_ignore` +
+/// `worktree_ignore::canonical_line`). A checkout under
+/// `.heddle/threads/<name>` therefore never pollutes or recurses into the
+/// parent repo's status.
+pub(crate) fn default_threads_root(repo: &Repository) -> PathBuf {
+    repo.heddle_dir().join("threads")
 }
 
-fn ensure_explicit_start_path_outside_repo(
+/// Default checkout directory for a thread, for every workspace mode:
+/// `<repo>/.heddle/threads/<name>/root`.
+///
+/// The `root/` leaf is load-bearing, not cosmetic:
+/// `thread_manifest::manifest_path` already owns
+/// `.heddle/threads/<name>/manifest.toml` as the per-thread stat-cache
+/// sidecar. Nesting the worktree bytes one level down at `<name>/root`
+/// keeps that `manifest.toml` a *sibling* of the checkout rather than a
+/// stray file inside it, and the manifest walk
+/// (`thread_manifest::walk_thread_manifests`) stops at the first
+/// `manifest.toml` it finds, so it never descends into `root/`.
+fn default_thread_checkout_path(repo: &Repository, name: &str) -> PathBuf {
+    default_threads_root(repo)
+        .join(sanitize_name(name))
+        .join("root")
+}
+
+fn default_thread_path(repo: &Repository, name: &str) -> PathBuf {
+    default_thread_checkout_path(repo, name)
+}
+
+/// Guard an explicit `--path`. A checkout may live either OUTSIDE the
+/// repository (the classic sibling-directory escape hatch) or under the
+/// repo's reserved `.heddle/` metadata dir (where the new defaults live,
+/// and which is excluded from overlay/status traversal). What it must NOT
+/// do is land in the repo's *tracked* working tree — a checkout there
+/// would surface as nested unsaved work in the parent repo's status.
+fn ensure_explicit_start_path_outside_tracked_tree(
     repo: &Repository,
     name: &str,
     path: &Path,
@@ -3418,6 +3448,15 @@ fn ensure_explicit_start_path_outside_repo(
         std::env::current_dir()?.join(path)
     };
     let requested_for_check = normalize_path_for_containment(&requested)?;
+    let heddle_dir = normalize_path_for_containment(repo.heddle_dir())?;
+    // Under `.heddle/` is allowed — that's where managed checkouts live.
+    // (`validate_worktree_target` further restricts this to the
+    // `.heddle/threads` subtree so a checkout can't target the store.)
+    // Check this BEFORE the repo-root test, since `.heddle` is itself a
+    // child of the repo root.
+    if requested_for_check == heddle_dir || requested_for_check.starts_with(&heddle_dir) {
+        return Ok(());
+    }
     let repo_root = normalize_path_for_containment(repo.root())?;
     if requested_for_check == repo_root || requested_for_check.starts_with(&repo_root) {
         let suggested = default_thread_path(repo, name);
@@ -3429,10 +3468,10 @@ fn ensure_explicit_start_path_outside_repo(
                 requested_for_check.display()
             ),
             format!(
-                "Choose a sibling checkout outside the repository, for example `{suggested_command}`."
+                "Choose a checkout under `.heddle/threads` (the default) or a sibling outside the repository, for example `{suggested_command}`."
             ),
             format!(
-                "requested checkout path '{}' is inside repository '{}'",
+                "requested checkout path '{}' is inside the tracked working tree of repository '{}'",
                 requested_for_check.display(),
                 repo_root.display()
             ),
@@ -3476,44 +3515,20 @@ fn normalize_path_for_containment(path: &Path) -> Result<PathBuf> {
     Ok(normalized)
 }
 
+/// Lightweight (materialized) checkout path:
+/// `<repo>/.heddle/threads/<name>/root`.
 fn default_lightweight_thread_path(repo: &Repository, name: &str) -> PathBuf {
-    let workspace_root = shared_workspace_root(repo);
-    let repo_name = workspace_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("heddle");
-    let parent = workspace_root
-        .parent()
-        .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| workspace_root.to_path_buf());
-    parent
-        .join(format!(".{repo_name}-heddle-threads"))
-        .join(sanitize_name(name))
-        .join("root")
+    default_thread_checkout_path(repo, name)
 }
 
-/// Mount-point path for a virtualized thread. Sibling to the
-/// lightweight checkout path so a single repo can host both kinds
-/// of threads side-by-side without colliding.
-///
-/// Template: `<repo_parent>/.<repo_name>-heddle-mounts/<sanitized_name>/`
+/// Mount-point path for a virtualized thread:
+/// `<repo>/.heddle/threads/<name>/root`. Shares the same managed
+/// `.heddle/threads/<name>/root` layout as solid/lightweight checkouts
+/// (thread names are unique per repo), keeping the per-thread
+/// `manifest.toml` sidecar a sibling of the mount point rather than a
+/// stray entry inside it.
 fn default_virtualized_thread_path(repo: &Repository, name: &str) -> PathBuf {
-    let workspace_root = shared_workspace_root(repo);
-    let repo_name = workspace_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("heddle");
-    let parent = workspace_root
-        .parent()
-        .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| workspace_root.to_path_buf());
-    mount_lifecycle::default_virtualized_mount_path(&parent, repo_name, &sanitize_name(name))
-}
-
-fn shared_workspace_root(repo: &Repository) -> &std::path::Path {
-    repo.heddle_dir().parent().unwrap_or_else(|| repo.root())
+    default_thread_checkout_path(repo, name)
 }
 
 fn sanitize_name(name: &str) -> String {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1797,7 +1797,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     // creation is the transaction's first step, so a failure in the remaining
     // pre-transaction work below can't orphan a dir we made before `execute`
     // had a rewind ledger (heddle#356 cid 3333881552).
-    let prepared_target = plan_worktree_target(repo, &path)?;
+    let prepared_target = plan_worktree_target(repo, &path, Some(&args.name))?;
     let target_dir_created = prepared_target.target_dir_created;
     let abs_path = normalize_path_for_containment(&prepared_target.path)?;
 

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -3390,40 +3390,20 @@ fn non_empty_action(action: &str) -> Option<String> {
     (!action.trim().is_empty()).then(|| action.to_string())
 }
 
-/// Root for all default thread checkouts: `<repo>/.heddle/threads`.
-///
-/// Living under `.heddle/` (heddle's reserved, never-tracked metadata
-/// dir) keeps the checkout *inside* the repository directory — so a
-/// sandbox scoped to the repo can still reach it — while staying out of
-/// the parent repo's overlay/status traversal. `.heddle/` is excluded
-/// everywhere it matters: the git-overlay status path carries `.heddle/`
-/// in `.git/info/exclude` (`repository::ensure_git_overlay_exclude`), and
-/// the native worktree walk / untracked scan / materialize walk root
-/// their ignore at `/.heddle` (`repo_config::default_ignore` +
-/// `worktree_ignore::canonical_line`). A checkout under
-/// `.heddle/threads/<name>` therefore never pollutes or recurses into the
-/// parent repo's status.
-pub(crate) fn default_threads_root(repo: &Repository) -> PathBuf {
-    repo.heddle_dir().join("threads")
-}
-
 /// Default checkout directory for a thread, for every workspace mode:
-/// `<repo>/.heddle/threads/<name>/root`.
+/// `<repo>/.heddle/threads/<encoded>/root`.
 ///
 /// Keyed off the SAME `thread_manifest::thread_dir` derivation the
-/// per-thread `manifest.toml` sidecar uses — the raw (already
-/// `validate_thread_id`-checked) thread name, NOT a re-sanitised copy.
-/// Sanitising here would diverge from the manifest (a slashed id
-/// `foo/bar` nests as `threads/foo/bar/` for the manifest but collapsed
-/// to `threads/foo-bar/` for the checkout) and could collide two
-/// distinct ids onto one directory. Sharing `thread_dir` guarantees the
-/// checkout root and the manifest sit in the same per-thread directory.
+/// per-thread `manifest.toml` sidecar uses — the prefix-safe single-segment
+/// encoding of the thread name, NOT a re-sanitised copy. A local
+/// sanitisation would diverge from the manifest and could collide two
+/// distinct ids onto one directory; sharing `thread_dir` guarantees the
+/// checkout root and the manifest sit in the same per-thread directory and
+/// that no id can ever be a directory prefix of another (heddle#572 r2).
 ///
 /// The `root/` leaf is load-bearing, not cosmetic: nesting the worktree
-/// bytes one level down at `<name>/root` keeps `manifest.toml` a
-/// *sibling* of the checkout rather than a stray file inside it, and the
-/// manifest walk (`thread_manifest::walk_thread_manifests`) stops at the
-/// first `manifest.toml` it finds, so it never descends into `root/`.
+/// bytes one level down at `<encoded>/root` keeps `manifest.toml` a
+/// *sibling* of the checkout rather than a stray file inside it.
 fn default_thread_checkout_path(repo: &Repository, name: &str) -> PathBuf {
     repo::thread_manifest::thread_dir(repo.heddle_dir(), name).join("root")
 }
@@ -3587,12 +3567,11 @@ mod tests {
     }
 
     /// A slashed thread id must map the default checkout root and the
-    /// per-thread manifest to the SAME `.heddle/threads/<name>` directory
-    /// (the checkout's `root/` a sibling of `manifest.toml`), and neither
-    /// may escape `.heddle/threads/`. Before the unified `thread_dir`
-    /// derivation the checkout sanitised `foo/bar` to `foo-bar` while the
-    /// manifest nested it as `foo/bar`, so the two diverged and distinct
-    /// ids could collide onto one directory.
+    /// per-thread manifest to the SAME `.heddle/threads/<encoded>` directory
+    /// (the checkout's `root/` a sibling of `manifest.toml`), neither may
+    /// escape `.heddle/threads/`, and the encoded segment must be a single,
+    /// prefix-safe path component so a slashed id can never nest under
+    /// another thread's directory (heddle#572 r2).
     #[test]
     fn slashed_thread_id_checkout_and_manifest_agree() {
         let repo_dir = tempfile::TempDir::new().unwrap();
@@ -3605,12 +3584,21 @@ mod tests {
         // Both live in the same per-thread directory: checkout at
         // `<dir>/root`, manifest at `<dir>/manifest.toml`.
         assert_eq!(checkout.parent().unwrap(), manifest.parent().unwrap());
-        assert_eq!(checkout.parent().unwrap(), threads_root.join("foo").join("bar"));
+        // The slash is encoded into ONE segment directly under `threads/`.
+        assert_eq!(checkout.parent().unwrap(), threads_root.join("foo%2Fbar"));
         assert_eq!(checkout.file_name().unwrap(), "root");
 
         // Neither escapes `.heddle/threads/`.
         assert!(checkout.starts_with(&threads_root));
         assert!(manifest.starts_with(&threads_root));
+
+        // The bare `foo` thread's directory is NOT an ancestor of `foo/bar`'s
+        // (the prefix-nesting class): `foo` → `threads/foo`, `foo/bar` →
+        // `threads/foo%2Fbar`, which are disjoint siblings.
+        let foo = default_thread_checkout_path(&repo, "foo");
+        let foo_dir = foo.parent().unwrap();
+        let bar_dir = checkout.parent().unwrap();
+        assert!(!bar_dir.starts_with(foo_dir) && !foo_dir.starts_with(bar_dir));
 
         // Distinct slashed/dashed ids no longer collide.
         let other = default_thread_checkout_path(&repo, "foo-bar");

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1333,18 +1333,15 @@ fn print_thread_output(
 }
 
 fn default_materialized_thread_path(repo: &Repository, thread_id: &str) -> PathBuf {
-    let repo_name = repo
-        .root()
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("heddle");
-    let parent = repo
-        .root()
-        .parent()
-        .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| repo.root().to_path_buf());
-    parent.join(format!("{repo_name}-{}", thread_id.replace('/', "-")))
+    // Promote to a solid checkout under the same Heddle-managed
+    // `.heddle/threads/<name>/root` layout the `start` defaults use, so a
+    // promoted thread stays reachable from a repo-scoped sandbox and out
+    // of the parent repo's status. The `root/` leaf keeps the per-thread
+    // `manifest.toml` sidecar a sibling of the checkout, not inside it.
+    // See `thread::default_threads_root`.
+    super::thread::default_threads_root(repo)
+        .join(thread_id.replace('/', "-"))
+        .join("root")
 }
 
 // --- thread cleanup -------------------------------------------------

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1136,8 +1136,34 @@ fn cmd_thread_promote(
             );
         }
     }
-    let path = path.unwrap_or_else(|| default_materialized_thread_path(repo, thread_id));
-    let abs_path = prepare_worktree_target(repo, &path)?.path;
+    let using_default = path.is_none();
+    let target = path.unwrap_or_else(|| default_materialized_thread_path(repo, thread_id));
+
+    // Conversion-in-place (heddle#572 r3 Finding #3): an already-materialized
+    // (or solid) thread is ALREADY checked out at its canonical
+    // `.heddle/threads/<name>/root` — which is exactly the promote default. A
+    // fresh solid materialize there would hit the non-empty / existing-`.heddle`
+    // refusal, so promote of a default-located thread would never succeed. Tear
+    // down THIS thread's own existing checkout first so the conversion can write
+    // fresh (un-shared) bytes into the same canonical slot. Guarded narrowly to
+    // the default target AND this thread's own recorded checkout, so we never
+    // remove another thread's (or a user-supplied) directory; the clean-worktree
+    // gate above already ran against it.
+    if using_default && matches!(thread.mode, ThreadMode::Materialized | ThreadMode::Solid) {
+        let existing = thread
+            .materialized_path
+            .clone()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| thread.execution_path.clone());
+        if !existing.as_os_str().is_empty()
+            && existing.join(".heddle").exists()
+            && same_existing_dir(&existing, &target)
+        {
+            remove_path_recursively(&existing)?;
+        }
+    }
+
+    let abs_path = prepare_worktree_target(repo, &target, Some(thread_id))?.path;
     write_isolated_checkout(repo, &abs_path, &state_id, Some(&thread.thread))?;
 
     thread.mode = ThreadMode::Solid;
@@ -1330,6 +1356,17 @@ fn print_thread_output(
         }
     }
     Ok(())
+}
+
+/// Whether two paths denote the same directory. Canonicalizes both when they
+/// exist on disk (so a recorded-canonical path and a freshly-derived default
+/// that resolve to the same inode compare equal), falling back to a structural
+/// comparison otherwise.
+fn same_existing_dir(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => a == b,
+    }
 }
 
 fn default_materialized_thread_path(repo: &Repository, thread_id: &str) -> PathBuf {

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1333,15 +1333,15 @@ fn print_thread_output(
 }
 
 fn default_materialized_thread_path(repo: &Repository, thread_id: &str) -> PathBuf {
-    // Promote to a solid checkout under the same Heddle-managed
-    // `.heddle/threads/<name>/root` layout the `start` defaults use, so a
-    // promoted thread stays reachable from a repo-scoped sandbox and out
-    // of the parent repo's status. The `root/` leaf keeps the per-thread
-    // `manifest.toml` sidecar a sibling of the checkout, not inside it.
-    // See `thread::default_threads_root`.
-    super::thread::default_threads_root(repo)
-        .join(thread_id.replace('/', "-"))
-        .join("root")
+    // Promote to a solid checkout under the SAME canonical
+    // `thread_manifest::thread_dir` derivation `start` and the per-thread
+    // `manifest.toml` sidecar use. A local `replace('/', "-")` flattened
+    // slashed ids differently from the manifest layout, so `foo/bar`'s
+    // checkout landed at `.heddle/threads/foo-bar/root` while its manifest
+    // keyed `foo/bar` — diverging, and able to collide with a real `foo-bar`
+    // thread (heddle#572 r2). The `root/` leaf keeps the sidecar a sibling
+    // of the checkout, not inside it.
+    repo::thread_manifest::thread_dir(repo.heddle_dir(), thread_id).join("root")
 }
 
 // --- thread cleanup -------------------------------------------------
@@ -1794,6 +1794,27 @@ fn apply_thread_drop(repo: &Repository, manager: &ThreadManager, thread: &Thread
 #[cfg(test)]
 mod cleanup_tests {
     use super::*;
+
+    /// `promote`'s default checkout path must be byte-identical to the
+    /// canonical `thread_manifest::thread_dir(...).join("root")` derivation
+    /// `start` and the per-thread manifest use — for slashed ids too. Before
+    /// this, promote flattened `foo/bar` with `replace('/', "-")`, diverging
+    /// from the manifest layout and able to collide with a real `foo-bar`
+    /// thread (heddle#572 r2).
+    #[test]
+    fn promote_default_path_matches_canonical_thread_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        for id in ["foo", "foo/bar", "team@scope", "feature/foo"] {
+            let promote = default_materialized_thread_path(&repo, id);
+            let canonical =
+                repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
+            assert_eq!(
+                promote, canonical,
+                "promote default must match the canonical thread_dir for {id:?}"
+            );
+        }
+    }
 
     #[test]
     fn parse_duration_handles_supported_units() {

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -100,7 +100,14 @@ fn canonicalize_existing_ancestor(path: &Path) -> Result<PathBuf> {
 }
 
 fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
-    if path == repo.heddle_dir() || path.starts_with(repo.heddle_dir()) {
+    // `.heddle/threads/` is the managed home for thread checkouts (the
+    // default for `heddle start`), so it's explicitly allowed even though
+    // it sits under `.heddle/`. Everything else under `.heddle/` is repo
+    // metadata storage and stays off-limits — a checkout there could
+    // corrupt the store/refs/oplog.
+    let threads_root = repo.heddle_dir().join("threads");
+    let in_threads_root = path == threads_root || path.starts_with(&threads_root);
+    if !in_threads_root && (path == repo.heddle_dir() || path.starts_with(repo.heddle_dir())) {
         return Err(anyhow::anyhow!(worktree_target_storage_advice(path)));
     }
 

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -22,13 +22,14 @@ pub(crate) struct PreparedWorktreeTarget {
 pub(crate) fn prepare_worktree_target(
     repo: &Repository,
     path: &Path,
+    self_thread: Option<&str>,
 ) -> Result<PreparedWorktreeTarget> {
-    let prepared = plan_worktree_target(repo, path)?;
+    let prepared = plan_worktree_target(repo, path, self_thread)?;
     let requested = absolute_path(path)?;
     std::fs::create_dir_all(&prepared.path).map_err(|error| {
         anyhow::anyhow!(worktree_target_prepare_failed_advice(&requested, error))
     })?;
-    validate_worktree_target(repo, &prepared.path)?;
+    validate_worktree_target(repo, &prepared.path, self_thread)?;
     Ok(prepared)
 }
 
@@ -43,6 +44,7 @@ pub(crate) fn prepare_worktree_target(
 pub(crate) fn plan_worktree_target(
     repo: &Repository,
     path: &Path,
+    self_thread: Option<&str>,
 ) -> Result<PreparedWorktreeTarget> {
     let requested = absolute_path(path)?;
     if let Ok(metadata) = std::fs::symlink_metadata(&requested)
@@ -51,7 +53,7 @@ pub(crate) fn plan_worktree_target(
         return Err(anyhow::anyhow!(worktree_target_symlink_advice(&requested)));
     }
     let resolved = canonicalize_existing_ancestor(&requested)?;
-    validate_worktree_target(repo, &resolved)?;
+    validate_worktree_target(repo, &resolved, self_thread)?;
     // Capture pre-existence: this is the only point where "the user gave us an
     // existing empty dir" vs "we will create it" is still distinguishable. The
     // creation itself is deferred to the caller (the transaction) so a failure
@@ -99,7 +101,11 @@ fn canonicalize_existing_ancestor(path: &Path) -> Result<PathBuf> {
     Ok(resolved)
 }
 
-fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
+fn validate_worktree_target(
+    repo: &Repository,
+    path: &Path,
+    self_thread: Option<&str>,
+) -> Result<()> {
     // `.heddle/threads/` is the managed home for thread checkouts (the
     // default for `heddle start`), so it's explicitly allowed even though
     // it sits under `.heddle/`. Everything else under `.heddle/` is repo
@@ -116,16 +122,33 @@ fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
         if path == threads_root {
             return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
         }
+        // A managed checkout must be a per-thread *leaf* (`threads/<seg>/root`),
+        // never the bare per-thread directory `threads/<seg>` itself. The
+        // per-thread `manifest.toml` sidecar lives AT `threads/<encoded>/`
+        // (a sibling of `root/`); a checkout placed on the per-thread dir
+        // itself would make the sidecar a CHILD of the worktree — git keeps
+        // its worktree metadata at the worktree root, outside tracked content,
+        // and so must we. So `start foo --path .heddle/threads/foo` (no `root`
+        // leaf) would write `manifest.toml` inside foo's own checkout, starting
+        // it dirty and able to capture the sidecar as user content. Require the
+        // leaf so the sidecar stays OUTSIDE the checkout (heddle#572 r3).
+        if path.parent() == Some(threads_root.as_path()) {
+            return Err(anyhow::anyhow!(worktree_target_managed_needs_leaf_advice(
+                path
+            )));
+        }
         // Under `.heddle/threads` is allowed for managed checkouts, but the
         // target must be a fresh per-thread slot — never nested inside an
-        // EXISTING thread's reserved subtree (`.heddle/threads/<name>/`,
-        // which holds its `root/` worktree/mount). `is_inside_existing_thread`
-        // enumerates EVERY existing thread (solid, materialized, AND
-        // virtualized) via its record + the shared `thread_dir` derivation,
-        // not just manifest-bearing materialized roots — so an explicit
-        // `--path .heddle/threads/<existing>/root/nested` is rejected for any
-        // workspace mode (heddle#572 r2).
-        if is_inside_existing_thread(repo, &threads_root, path)? {
+        // EXISTING thread's reserved subtree (its canonical
+        // `.heddle/threads/<name>/` dir OR its durable recorded checkout/mount
+        // path). `is_inside_existing_thread` enumerates EVERY existing thread
+        // (solid, materialized, AND virtualized) via its record + the shared
+        // `thread_dir` derivation, so an explicit `--path` nested inside
+        // another thread's checkout is rejected for any workspace mode. The
+        // thread's OWN reserved root is exempt only for `self_thread` (a
+        // promote/re-materialize of that same thread), so one thread can never
+        // reuse another's reserved root (heddle#572 r2/r3).
+        if is_inside_existing_thread(repo, &threads_root, path, self_thread)? {
             return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
         }
     } else if path == repo.heddle_dir() || path.starts_with(repo.heddle_dir()) {
@@ -150,42 +173,66 @@ fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
 }
 
 /// True if `candidate` (already known to live under `threads_root`) falls
-/// inside an EXISTING thread's reserved per-thread directory
-/// `.heddle/threads/<encoded>/` — for ANY workspace mode.
+/// inside an EXISTING thread's reserved space — for ANY workspace mode.
 ///
 /// Existing threads are enumerated from the durable thread RECORDS (not the
-/// filesystem), and each record's reserved directory is recomputed with the
-/// shared [`repo::thread_manifest::thread_dir`] derivation. This is the
-/// mode-agnostic source of truth:
-///   * a `manifest.toml` sidecar exists only for *materialized* threads —
-///     `solid` and `virtualized` starts write a record but no manifest, so a
-///     manifest-only check (the heddle#572 r1 guard) silently missed them;
-///   * the record is written strictly AFTER target validation for a *new*
-///     thread (the atomic `start` stages it inside `execute`; the harness
-///     `save`s it after `prepare_worktree_target`), so a brand-new thread is
-///     never in this set — its fresh `.heddle/threads/<new>/root` slot is
-///     correctly allowed without self-exclusion.
+/// filesystem). For each we check two reserved regions:
+///   * the canonical per-thread directory `.heddle/threads/<encoded>/`,
+///     recomputed with the shared [`repo::thread_manifest::thread_dir`]
+///     derivation (the mode-agnostic source of truth: `solid`/`virtualized`
+///     starts write a record but no `manifest.toml`, so a manifest-only check
+///     silently missed them — heddle#572 r1/r2);
+///   * the thread's DURABLE recorded `execution_path` / `materialized_path`
+///     (filtered to ones under `threads_root`). A thread started with a custom
+///     `--path .heddle/threads/<custom>/root` checks out OUTSIDE its canonical
+///     `thread_dir`, so a canonical-only check would let a later `--path` nest
+///     under that custom checkout. Consulting the recorded paths closes that
+///     gap (heddle#572 r3).
 ///
-/// A thread's OWN canonical checkout root `.heddle/threads/<encoded>/root`
-/// is exempted, because `promote` re-materializes an EXISTING thread into
-/// exactly that slot (the record is already present at validation time). A
-/// reuse of a populated slot is still caught downstream by the
-/// emptiness/`.heddle`-already-present checks; only a target nested STRICTLY
-/// deeper than a thread's `root` (or anywhere else inside its reserved dir)
-/// is a nesting violation.
+/// The record is written strictly AFTER target validation for a *new* thread
+/// (the atomic `start` stages it inside `execute`; the harness `save`s it after
+/// `prepare_worktree_target`), so a brand-new thread is never in this set — its
+/// fresh `.heddle/threads/<new>/root` slot is correctly allowed.
+///
+/// A thread's OWN reserved root (canonical `<encoded>/root`, or its recorded
+/// checkout path) is exempt ONLY for `self_thread` — the same thread being
+/// promoted/re-materialized, whose record is already present at validation
+/// time. For every OTHER caller the exemption does NOT apply, so a fresh
+/// `start other --path .heddle/threads/<existing>/root` can never reuse another
+/// thread's reserved root (heddle#572 r3 Finding #2).
 fn is_inside_existing_thread(
     repo: &Repository,
     threads_root: &Path,
     candidate: &Path,
+    self_thread: Option<&str>,
 ) -> Result<bool> {
     // Cheap guard: only paths under `threads_root` can be inside a thread dir.
     if !candidate.starts_with(threads_root) {
         return Ok(false);
     }
     for thread in repo::ThreadManager::new(repo.heddle_dir()).list()? {
+        let is_self = self_thread == Some(thread.thread.as_str());
+
+        // Canonical per-thread directory.
         let dir = repo::thread_manifest::thread_dir(repo.heddle_dir(), &thread.thread);
-        if candidate.starts_with(&dir) && candidate != dir.join("root") {
+        if candidate.starts_with(&dir) && !(is_self && candidate == dir.join("root")) {
             return Ok(true);
+        }
+
+        // Durable recorded checkout/mount paths under `threads_root`. A path
+        // outside `threads_root` (a sibling-dir checkout, or the repo root for
+        // a non-isolated thread) can never be an ancestor of a `threads_root`
+        // candidate, so filtering both avoids false positives.
+        for recorded in [Some(&thread.execution_path), thread.materialized_path.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            if recorded.as_os_str().is_empty() || !recorded.starts_with(threads_root) {
+                continue;
+            }
+            if candidate.starts_with(recorded) && !(is_self && candidate == recorded.as_path()) {
+                return Ok(true);
+            }
         }
     }
     Ok(false)
@@ -298,6 +345,28 @@ fn worktree_target_nested_thread_advice(path: &Path) -> RecoveryAdvice {
         vec![
             "heddle start <name> --workspace materialized".to_string(),
             "heddle start <name> --path ../<name>".to_string(),
+        ],
+    )
+}
+
+fn worktree_target_managed_needs_leaf_advice(path: &Path) -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "worktree_target_managed_needs_leaf",
+        format!(
+            "managed worktree target '{}' must be a per-thread checkout leaf, not the per-thread directory itself",
+            path.display()
+        ),
+        "Append a `root` leaf, e.g. `<path>/root`, or let Heddle pick the default `.heddle/threads/<name>/root`.",
+        format!(
+            "target path '{}' is the bare `.heddle/threads/<name>` directory, where the per-thread manifest sidecar lives",
+            path.display()
+        ),
+        "checking out onto the per-thread directory would write Heddle's `manifest.toml` sidecar inside the worktree, starting it dirty",
+        "no thread, checkout, repository object, ref, or worktree file was changed",
+        "heddle start <name> --workspace materialized",
+        vec![
+            "heddle start <name> --workspace materialized".to_string(),
+            "heddle start <name> --path <path>/root".to_string(),
         ],
     )
 }
@@ -488,6 +557,28 @@ mod gate_tests {
     /// threads also write a `manifest.toml`; solid and virtualized threads do
     /// NOT — the guard must recognise them all from the record alone.
     fn register_thread(repo: &Repository, name: &str, mode: repo::ThreadMode) {
+        register_thread_at(repo, name, mode, PathBuf::new());
+    }
+
+    /// Like [`register_thread`], but with an explicit durable
+    /// `execution_path`/`materialized_path` — used to exercise the
+    /// recorded-path branch of the nesting guard for threads checked out at a
+    /// CUSTOM `--path` (outside their canonical `thread_dir`).
+    fn register_thread_at(
+        repo: &Repository,
+        name: &str,
+        mode: repo::ThreadMode,
+        execution_path: PathBuf,
+    ) {
+        register_thread_inner(repo, name, mode, execution_path)
+    }
+
+    fn register_thread_inner(
+        repo: &Repository,
+        name: &str,
+        mode: repo::ThreadMode,
+        execution_path: PathBuf,
+    ) {
         let now = Utc::now();
         let thread = repo::Thread {
             id: name.to_string(),
@@ -501,8 +592,9 @@ mod gate_tests {
             current_state: None,
             merged_state: None,
             task: None,
-            execution_path: PathBuf::new(),
-            materialized_path: None,
+            materialized_path: (!execution_path.as_os_str().is_empty())
+                .then(|| execution_path.clone()),
+            execution_path,
             changed_paths: Vec::new(),
             impact_categories: Vec::new(),
             heavy_impact_paths: Vec::new(),
@@ -528,7 +620,8 @@ mod gate_tests {
     /// another thread's `root/` worktree or mount. The guard enumerates
     /// threads from their records, so it covers EVERY workspace mode —
     /// including `virtualized`, which writes no `manifest.toml` (heddle#572
-    /// r2). A fresh slot, and the threads-root itself, are also exercised.
+    /// r2). A fresh leaf, the threads-root, the bare per-thread dir, custom
+    /// recorded checkouts, and the same-thread promote exemption are exercised.
     #[test]
     fn validate_rejects_path_nested_in_existing_thread_checkout() {
         let repo_dir = TempDir::new().unwrap();
@@ -542,7 +635,7 @@ mod gate_tests {
         register_thread(&repo, "virt", repo::ThreadMode::Virtualized);
         for name in ["foo", "virt"] {
             let nested = threads_root.join(name).join("root").join("nested");
-            let err = validate_worktree_target(&repo, &nested).unwrap_err();
+            let err = validate_worktree_target(&repo, &nested, None).unwrap_err();
             assert!(
                 err.to_string().contains("nested inside an existing thread"),
                 "path nested in existing {name} thread must be rejected: {err}"
@@ -550,24 +643,50 @@ mod gate_tests {
         }
 
         // The threads metadata root itself is rejected (never a checkout slot).
-        let err = validate_worktree_target(&repo, &threads_root)
+        validate_worktree_target(&repo, &threads_root, None)
             .expect_err("the .heddle/threads metadata root must be rejected");
+
+        // The bare per-thread directory (no `root` leaf) is rejected: the
+        // manifest sidecar lives there, so a checkout would swallow it
+        // (heddle#572 r3 Finding #4).
+        let err = validate_worktree_target(&repo, &threads_root.join("brandnew"), None)
+            .expect_err("a bare .heddle/threads/<name> dir (no leaf) must be rejected");
         assert!(
-            err.to_string().contains("nested inside an existing thread"),
-            "unexpected error for threads-root target: {err}"
+            err.to_string().contains("per-thread checkout leaf"),
+            "unexpected error for the no-leaf target: {err}"
         );
 
-        // A fresh per-thread slot (and its `root/` leaf) is still accepted.
-        validate_worktree_target(&repo, &threads_root.join("brandnew"))
-            .expect("a fresh .heddle/threads/<name> slot is allowed");
-        validate_worktree_target(&repo, &threads_root.join("brandnew").join("root"))
+        // A fresh per-thread checkout LEAF is accepted.
+        validate_worktree_target(&repo, &threads_root.join("brandnew").join("root"), None)
             .expect("a fresh .heddle/threads/<name>/root checkout is allowed");
 
-        // An EXISTING thread's OWN canonical `root` slot is allowed — this is
-        // exactly what `promote` re-materializes (the record already exists at
-        // validation time). Empty here, so the emptiness check passes too.
-        validate_worktree_target(&repo, &threads_root.join("foo").join("root"))
-            .expect("re-materializing a thread's own canonical root slot is allowed");
+        // Finding #2: an EXISTING thread's OWN canonical `root` is reserved.
+        // A *different* caller (e.g. a fresh `start other`) must NOT reuse it,
+        // but a same-thread promote/re-materialize of `foo` may.
+        validate_worktree_target(&repo, &threads_root.join("foo").join("root"), None)
+            .expect_err("another thread must not reuse foo's reserved root");
+        validate_worktree_target(&repo, &threads_root.join("foo").join("root"), Some("foo"))
+            .expect("re-materializing foo's own canonical root slot is allowed");
+
+        // Finding #1: a thread checked out at a CUSTOM `--path` reserves that
+        // recorded location too — a later `--path` nested under it is rejected
+        // even though it lies outside the thread's canonical `thread_dir`.
+        let custom_root = threads_root.join("custom-slot").join("root");
+        register_thread_at(
+            &repo,
+            "custom",
+            repo::ThreadMode::Solid,
+            custom_root.clone(),
+        );
+        let nested_in_custom = custom_root.join("nested");
+        validate_worktree_target(&repo, &nested_in_custom, None)
+            .expect_err("a path nested in a thread's recorded custom checkout must be rejected");
+        // The custom thread itself may re-materialize at its own recorded root.
+        validate_worktree_target(&repo, &custom_root, Some("custom"))
+            .expect("the same thread may re-use its own recorded checkout root");
+        // But another caller may not reuse it.
+        validate_worktree_target(&repo, &custom_root, None)
+            .expect_err("another thread must not reuse a recorded custom checkout root");
     }
 
     /// The same chokepoint still materializes the real bytes for a state that

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -107,7 +107,16 @@ fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
     // corrupt the store/refs/oplog.
     let threads_root = repo.heddle_dir().join("threads");
     let in_threads_root = path == threads_root || path.starts_with(&threads_root);
-    if !in_threads_root && (path == repo.heddle_dir() || path.starts_with(repo.heddle_dir())) {
+    if in_threads_root {
+        // Under `.heddle/threads` is allowed for managed checkouts, but the
+        // target must be a fresh per-thread slot — never nested inside an
+        // EXISTING thread's reserved subtree (its `root/` worktree). Allowing
+        // any descendant would land the new checkout inside thread `foo` when
+        // `--path .heddle/threads/foo/root/nested` is passed after `foo` exists.
+        if repo::thread_manifest::is_inside_existing_thread_dir(&threads_root, path) {
+            return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
+        }
+    } else if path == repo.heddle_dir() || path.starts_with(repo.heddle_dir()) {
         return Err(anyhow::anyhow!(worktree_target_storage_advice(path)));
     }
 
@@ -214,6 +223,28 @@ fn worktree_target_storage_advice(path: &Path) -> RecoveryAdvice {
         "no thread, checkout, repository object, ref, or worktree file was changed",
         "heddle start <name> --path ../<name>",
         vec!["heddle start <name> --path ../<name>".to_string()],
+    )
+}
+
+fn worktree_target_nested_thread_advice(path: &Path) -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "worktree_target_nested_thread",
+        format!(
+            "worktree target '{}' is nested inside an existing thread's checkout",
+            path.display()
+        ),
+        "Choose a fresh `.heddle/threads/<name>` slot or a sibling directory outside the repository.",
+        format!(
+            "target path '{}' falls under another thread's reserved `.heddle/threads/<name>` subtree",
+            path.display()
+        ),
+        "writing a checkout there would land it inside another thread's worktree",
+        "no thread, checkout, repository object, ref, or worktree file was changed",
+        "heddle start <name> --workspace materialized",
+        vec![
+            "heddle start <name> --workspace materialized".to_string(),
+            "heddle start <name> --path ../<name>".to_string(),
+        ],
     )
 }
 
@@ -396,6 +427,38 @@ mod gate_tests {
             !dest.join("secret.rs").exists(),
             "embargoed bytes must NOT be materialized via write_isolated_checkout"
         );
+    }
+
+    /// An explicit `--path` may live under `.heddle/threads/<newname>` (the
+    /// managed home for checkouts) but must NOT nest inside an EXISTING
+    /// thread's reserved subtree — that would land the new checkout inside
+    /// another thread's `root/` worktree. A fresh slot is still accepted.
+    #[test]
+    fn validate_rejects_path_nested_in_existing_thread_checkout() {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+        let threads_root = repo.heddle_dir().join("threads");
+
+        // Simulate an existing thread `foo`: its manifest sidecar marks the
+        // reserved subtree, and `root/` holds its worktree bytes.
+        let foo_dir = threads_root.join("foo");
+        std::fs::create_dir_all(foo_dir.join("root")).unwrap();
+        std::fs::write(foo_dir.join("manifest.toml"), b"# stub\n").unwrap();
+
+        // Nested inside foo's checkout → rejected with a clear error.
+        let nested = foo_dir.join("root").join("nested");
+        let err = validate_worktree_target(&repo, &nested)
+            .expect_err("path nested in an existing thread must be rejected");
+        assert!(
+            err.to_string().contains("nested inside an existing thread"),
+            "unexpected error: {err}"
+        );
+
+        // A fresh per-thread slot (and its `root/` leaf) is still accepted.
+        validate_worktree_target(&repo, &threads_root.join("brandnew"))
+            .expect("a fresh .heddle/threads/<name> slot is allowed");
+        validate_worktree_target(&repo, &threads_root.join("brandnew").join("root"))
+            .expect("a fresh .heddle/threads/<name>/root checkout is allowed");
     }
 
     /// The same chokepoint still materializes the real bytes for a state that

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -108,12 +108,24 @@ fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
     let threads_root = repo.heddle_dir().join("threads");
     let in_threads_root = path == threads_root || path.starts_with(&threads_root);
     if in_threads_root {
+        // The threads metadata root ITSELF is off-limits: checking out at
+        // `.heddle/threads` would write the worktree's `.heddle/` and the
+        // per-thread `manifest.toml` on top of the thread-metadata root,
+        // breaking the layout invariant (heddle#572 r2). A descendant
+        // per-thread slot is what's allowed, not the root.
+        if path == threads_root {
+            return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
+        }
         // Under `.heddle/threads` is allowed for managed checkouts, but the
         // target must be a fresh per-thread slot — never nested inside an
-        // EXISTING thread's reserved subtree (its `root/` worktree). Allowing
-        // any descendant would land the new checkout inside thread `foo` when
-        // `--path .heddle/threads/foo/root/nested` is passed after `foo` exists.
-        if repo::thread_manifest::is_inside_existing_thread_dir(&threads_root, path) {
+        // EXISTING thread's reserved subtree (`.heddle/threads/<name>/`,
+        // which holds its `root/` worktree/mount). `is_inside_existing_thread`
+        // enumerates EVERY existing thread (solid, materialized, AND
+        // virtualized) via its record + the shared `thread_dir` derivation,
+        // not just manifest-bearing materialized roots — so an explicit
+        // `--path .heddle/threads/<existing>/root/nested` is rejected for any
+        // workspace mode (heddle#572 r2).
+        if is_inside_existing_thread(repo, &threads_root, path)? {
             return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
         }
     } else if path == repo.heddle_dir() || path.starts_with(repo.heddle_dir()) {
@@ -135,6 +147,48 @@ fn validate_worktree_target(repo: &Repository, path: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// True if `candidate` (already known to live under `threads_root`) falls
+/// inside an EXISTING thread's reserved per-thread directory
+/// `.heddle/threads/<encoded>/` — for ANY workspace mode.
+///
+/// Existing threads are enumerated from the durable thread RECORDS (not the
+/// filesystem), and each record's reserved directory is recomputed with the
+/// shared [`repo::thread_manifest::thread_dir`] derivation. This is the
+/// mode-agnostic source of truth:
+///   * a `manifest.toml` sidecar exists only for *materialized* threads —
+///     `solid` and `virtualized` starts write a record but no manifest, so a
+///     manifest-only check (the heddle#572 r1 guard) silently missed them;
+///   * the record is written strictly AFTER target validation for a *new*
+///     thread (the atomic `start` stages it inside `execute`; the harness
+///     `save`s it after `prepare_worktree_target`), so a brand-new thread is
+///     never in this set — its fresh `.heddle/threads/<new>/root` slot is
+///     correctly allowed without self-exclusion.
+///
+/// A thread's OWN canonical checkout root `.heddle/threads/<encoded>/root`
+/// is exempted, because `promote` re-materializes an EXISTING thread into
+/// exactly that slot (the record is already present at validation time). A
+/// reuse of a populated slot is still caught downstream by the
+/// emptiness/`.heddle`-already-present checks; only a target nested STRICTLY
+/// deeper than a thread's `root` (or anywhere else inside its reserved dir)
+/// is a nesting violation.
+fn is_inside_existing_thread(
+    repo: &Repository,
+    threads_root: &Path,
+    candidate: &Path,
+) -> Result<bool> {
+    // Cheap guard: only paths under `threads_root` can be inside a thread dir.
+    if !candidate.starts_with(threads_root) {
+        return Ok(false);
+    }
+    for thread in repo::ThreadManager::new(repo.heddle_dir()).list()? {
+        let dir = repo::thread_manifest::thread_dir(repo.heddle_dir(), &thread.thread);
+        if candidate.starts_with(&dir) && candidate != dir.join("root") {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn worktree_target_symlink_advice(path: &Path) -> RecoveryAdvice {
@@ -429,29 +483,78 @@ mod gate_tests {
         );
     }
 
+    /// Register a thread record (any mode) the way a completed `start`
+    /// would, so the registry-based nesting guard can see it. Materialized
+    /// threads also write a `manifest.toml`; solid and virtualized threads do
+    /// NOT — the guard must recognise them all from the record alone.
+    fn register_thread(repo: &Repository, name: &str, mode: repo::ThreadMode) {
+        let now = Utc::now();
+        let thread = repo::Thread {
+            id: name.to_string(),
+            thread: name.to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode,
+            state: repo::ThreadState::Active,
+            base_state: "deadbeef".to_string(),
+            base_root: "deadbeef".to_string(),
+            current_state: None,
+            merged_state: None,
+            task: None,
+            execution_path: PathBuf::new(),
+            materialized_path: None,
+            changed_paths: Vec::new(),
+            impact_categories: Vec::new(),
+            heavy_impact_paths: Vec::new(),
+            promotion_suggested: false,
+            freshness: repo::ThreadFreshness::Unknown,
+            verification_summary: Default::default(),
+            confidence_summary: Default::default(),
+            integration_policy_result: Default::default(),
+            created_at: now,
+            updated_at: now,
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        };
+        repo::ThreadManager::new(repo.heddle_dir())
+            .save(&thread)
+            .expect("save thread record");
+    }
+
     /// An explicit `--path` may live under `.heddle/threads/<newname>` (the
     /// managed home for checkouts) but must NOT nest inside an EXISTING
     /// thread's reserved subtree — that would land the new checkout inside
-    /// another thread's `root/` worktree. A fresh slot is still accepted.
+    /// another thread's `root/` worktree or mount. The guard enumerates
+    /// threads from their records, so it covers EVERY workspace mode —
+    /// including `virtualized`, which writes no `manifest.toml` (heddle#572
+    /// r2). A fresh slot, and the threads-root itself, are also exercised.
     #[test]
     fn validate_rejects_path_nested_in_existing_thread_checkout() {
         let repo_dir = TempDir::new().unwrap();
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         let threads_root = repo.heddle_dir().join("threads");
 
-        // Simulate an existing thread `foo`: its manifest sidecar marks the
-        // reserved subtree, and `root/` holds its worktree bytes.
-        let foo_dir = threads_root.join("foo");
-        std::fs::create_dir_all(foo_dir.join("root")).unwrap();
-        std::fs::write(foo_dir.join("manifest.toml"), b"# stub\n").unwrap();
+        // An existing MATERIALIZED thread `foo` and an existing VIRTUALIZED
+        // thread `virt`. Both occupy `.heddle/threads/<name>/` with a `root/`
+        // worktree/mount; only `foo` has a `manifest.toml`.
+        register_thread(&repo, "foo", repo::ThreadMode::Materialized);
+        register_thread(&repo, "virt", repo::ThreadMode::Virtualized);
+        for name in ["foo", "virt"] {
+            let nested = threads_root.join(name).join("root").join("nested");
+            let err = validate_worktree_target(&repo, &nested).unwrap_err();
+            assert!(
+                err.to_string().contains("nested inside an existing thread"),
+                "path nested in existing {name} thread must be rejected: {err}"
+            );
+        }
 
-        // Nested inside foo's checkout → rejected with a clear error.
-        let nested = foo_dir.join("root").join("nested");
-        let err = validate_worktree_target(&repo, &nested)
-            .expect_err("path nested in an existing thread must be rejected");
+        // The threads metadata root itself is rejected (never a checkout slot).
+        let err = validate_worktree_target(&repo, &threads_root)
+            .expect_err("the .heddle/threads metadata root must be rejected");
         assert!(
             err.to_string().contains("nested inside an existing thread"),
-            "unexpected error: {err}"
+            "unexpected error for threads-root target: {err}"
         );
 
         // A fresh per-thread slot (and its `root/` leaf) is still accepted.
@@ -459,6 +562,12 @@ mod gate_tests {
             .expect("a fresh .heddle/threads/<name> slot is allowed");
         validate_worktree_target(&repo, &threads_root.join("brandnew").join("root"))
             .expect("a fresh .heddle/threads/<name>/root checkout is allowed");
+
+        // An EXISTING thread's OWN canonical `root` slot is allowed — this is
+        // exactly what `promote` re-materializes (the record already exists at
+        // validation time). Empty here, so the emptiness check passes too.
+        validate_worktree_target(&repo, &threads_root.join("foo").join("root"))
+            .expect("re-materializing a thread's own canonical root slot is allowed");
     }
 
     /// The same chokepoint still materializes the real bytes for a state that

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2154,24 +2154,13 @@ fn allocate_thread_name(repo: &Repository, base: &str) -> Result<String> {
 }
 
 fn default_private_thread_path(repo: &Repository, name: &str) -> PathBuf {
-    let workspace_root = shared_workspace_root(repo);
-    let repo_name = workspace_root
-        .file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .unwrap_or("heddle");
-    let parent = workspace_root
-        .parent()
-        .map(|path| path.to_path_buf())
-        .unwrap_or_else(|| workspace_root.to_path_buf());
-    parent
-        .join(format!(".{repo_name}-heddle-threads"))
+    // Mirror `thread::default_threads_root`: managed checkouts live under
+    // the repo's reserved `.heddle/threads/` dir (excluded from the
+    // parent's overlay/status traversal, reachable from a repo sandbox).
+    repo.heddle_dir()
+        .join("threads")
         .join(sanitize_name(name))
         .join("root")
-}
-
-fn shared_workspace_root(repo: &Repository) -> &Path {
-    repo.heddle_dir().parent().unwrap_or_else(|| repo.root())
 }
 
 fn sanitize_name(name: &str) -> String {

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2154,13 +2154,14 @@ fn allocate_thread_name(repo: &Repository, base: &str) -> Result<String> {
 }
 
 fn default_private_thread_path(repo: &Repository, name: &str) -> PathBuf {
-    // Mirror `thread::default_threads_root`: managed checkouts live under
-    // the repo's reserved `.heddle/threads/` dir (excluded from the
-    // parent's overlay/status traversal, reachable from a repo sandbox).
-    repo.heddle_dir()
-        .join("threads")
-        .join(sanitize_name(name))
-        .join("root")
+    // Route through the ONE canonical `thread_manifest::thread_dir`
+    // derivation `heddle start` and the per-thread `manifest.toml` sidecar
+    // use — NOT a harness-local re-sanitisation. Harness subagent/root-actor
+    // names are commonly slash-namespaced (`parent/task`); a local
+    // `sanitize_name` flattened `parent/task` and `parent-task` onto the same
+    // `.heddle/threads/parent-task/root`, colliding two distinct threads and
+    // diverging from the manifest/checkout layout (heddle#572 r2).
+    repo::thread_manifest::thread_dir(repo.heddle_dir(), name).join("root")
 }
 
 fn sanitize_name(name: &str) -> String {
@@ -2807,6 +2808,27 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         (temp, repo)
+    }
+
+    /// Harness subagent/root-actor checkout paths must use the SAME canonical
+    /// `thread_manifest::thread_dir(...).join("root")` derivation `start` and
+    /// the per-thread manifest use — for the slash-namespaced names the
+    /// harness commonly mints (`parent/task`). Before this, a harness-local
+    /// `sanitize_name` flattened `parent/task` and `parent-task` onto the same
+    /// `.heddle/threads/parent-task/root`, colliding distinct threads
+    /// (heddle#572 r2).
+    #[test]
+    fn harness_default_path_matches_canonical_thread_dir() {
+        let (_temp, repo) = init_repo();
+        for id in ["foo", "parent/task", "feature/foo", "team@scope"] {
+            let harness_path = default_private_thread_path(&repo, id);
+            let canonical =
+                repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
+            assert_eq!(
+                harness_path, canonical,
+                "harness default must match the canonical thread_dir for {id:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -1029,7 +1029,7 @@ impl HarnessBridgeRuntime {
             // wiring before they can become the default execution root.
             ThreadMode::Virtualized => default_private_thread_path(&self.repo, name),
         };
-        let abs_path = prepare_worktree_target(&self.repo, &path)?.path;
+        let abs_path = prepare_worktree_target(&self.repo, &path, Some(name))?.path;
         write_isolated_checkout(&self.repo, &abs_path, &base_state, Some(name))?;
 
         let base_state_obj = self

--- a/crates/cli/tests/cli_integration/attempt.rs
+++ b/crates/cli/tests/cli_integration/attempt.rs
@@ -227,7 +227,7 @@ fn attempt_mixed_success_and_failure_ranks_success_first() {
 
     // Build a script that flips behaviour based on which thread's
     // checkout it's running in. Each attempt's checkout sits at
-    // `<...>-heddle-threads/<thread-name>/root`, so the parent
+    // `.heddle/threads/<thread-name>/root`, so the parent
     // directory's basename is the thread name (`mixed-1`, `mixed-2`,
     // …). We succeed on threads whose name ends in `-1` and fail on
     // the rest. With N=3 that yields exactly one success and two
@@ -410,16 +410,10 @@ fn attempt_shared_target_default_on_for_rust_workspace() {
     // The thread checkouts should each contain a `.cargo/config.toml`
     // that redirects to the shared target dir. The thread path layout
     // for `--workspace materialized` is
-    // `<repo_parent>/.<repo_name>-heddle-threads/<thread>/root/`; we
-    // assert the cargo config exists there.
+    // `<repo>/.heddle/threads/<thread>/root/`; we assert the cargo
+    // config exists there.
     let attempts = value["attempts"].as_array().unwrap();
-    let repo_parent = temp.path().parent().expect("temp dir has a parent");
-    let repo_basename = temp
-        .path()
-        .file_name()
-        .and_then(|n| n.to_str())
-        .expect("temp dir has a basename");
-    let threads_dir = repo_parent.join(format!(".{repo_basename}-heddle-threads"));
+    let threads_dir = temp.path().join(".heddle").join("threads");
     for attempt in attempts {
         let name = attempt["thread"].as_str().unwrap();
         let cargo_config = threads_dir

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1873,9 +1873,14 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
     // thread's confidence, so the recovery must scope the recapture to the
     // thread via the global `--repo` flag. (Contrast the in-thread `ready`
     // recovery above, which stays unscoped.)
+    // The thread's checkout lives under `.heddle/threads/<encoded>/root`, and
+    // the slash in `feature/land-low-confidence` is percent-encoded into one
+    // path segment (`feature%2Fland-low-confidence`, heddle#572 r2). The `%`
+    // is outside `shell_quote`'s bare set, so the breadcrumb single-quotes the
+    // `--repo` path — apply the same quoting here rather than hard-coding it.
     let expected_scoped_recapture = format!(
         "heddle --repo {} commit -m \"...\" --confidence <confidence>",
-        thread_path.display()
+        repo::shell_quote(&thread_path.display().to_string())
     );
     assert_eq!(
         land["recommended_action"], expected_scoped_recapture,

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -5612,6 +5612,115 @@ fn start_normalized_nested_path_inside_repo_is_refused() {
 }
 
 #[test]
+fn start_default_path_lands_under_heddle_threads() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    for (mode, name) in [("solid", "solid-thread"), ("materialized", "mat-thread")] {
+        let started = json_value(
+            temp.path(),
+            &["--output", "json", "start", name, "--workspace", mode],
+        );
+        let path = started["execution_path"]
+            .as_str()
+            .or_else(|| started["materialized_path"].as_str())
+            .unwrap_or_else(|| panic!("{mode} start output should carry a checkout path: {started}"));
+        let needle = format!("/.heddle/threads/{name}");
+        assert!(
+            path.contains(&needle),
+            "{mode} thread should default under .heddle/threads/<name> (got {path})"
+        );
+        assert!(
+            std::path::Path::new(path).join(".heddle").exists(),
+            "{mode} checkout should be materialized at {path}"
+        );
+    }
+}
+
+#[test]
+fn parent_status_ignores_default_thread_checkout_under_heddle() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    // A default `start` drops a full checkout under `.heddle/threads/<name>`.
+    json_value(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "start",
+            "pollution-check",
+            "--workspace",
+            "materialized",
+        ],
+    );
+    assert!(
+        temp.path()
+            .join(".heddle/threads/pollution-check/root/.heddle")
+            .exists(),
+        "thread checkout should materialize under .heddle/threads/"
+    );
+
+    // Git itself must not see the checkout — `.heddle/` lives in
+    // `.git/info/exclude`, so the parent working tree stays clean.
+    let porcelain = git_stdout_for_json_contract(temp.path(), &["status", "--porcelain"]);
+    assert!(
+        porcelain.trim().is_empty(),
+        "parent git status should stay clean; the .heddle/ checkout leaked: {porcelain:?}"
+    );
+
+    // Heddle's overlay verify/status must report the parent as clean too:
+    // the worktree walk roots its ignore at `/.heddle`, so the checkout
+    // never registers as untracked/uncaptured work.
+    let verify = json_value(temp.path(), &["verify", "--output", "json"]);
+    assert_eq!(
+        verify["verified"], true,
+        "parent overlay status should ignore the .heddle/threads checkout: {verify}"
+    );
+    assert_eq!(verify["status"], "clean", "{verify}");
+}
+
+#[test]
+fn start_explicit_path_under_heddle_threads_is_accepted() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    // The inverted guard allows an explicit `--path` under `.heddle/`
+    // (heddle's reserved dir) even though it's inside the repo directory.
+    let custom = temp
+        .path()
+        .join(".heddle")
+        .join("threads")
+        .join("explicit-custom");
+    let custom_arg = custom.to_str().unwrap();
+    let started = json_value(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "start",
+            "explicit-under-heddle",
+            "--path",
+            custom_arg,
+        ],
+    );
+    assert_eq!(started["thread"]["name"], "explicit-under-heddle");
+    assert!(
+        custom.join(".heddle").exists(),
+        "explicit .heddle/threads path should be accepted and materialized: {started}"
+    );
+}
+
+#[test]
 fn revert_refuses_dirty_worktree_with_shared_advice() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -5695,12 +5695,15 @@ fn start_explicit_path_under_heddle_threads_is_accepted() {
     heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
 
     // The inverted guard allows an explicit `--path` under `.heddle/`
-    // (heddle's reserved dir) even though it's inside the repo directory.
+    // (heddle's reserved dir) even though it's inside the repo directory — as
+    // long as it is a per-thread checkout LEAF (`<slot>/root`), so the manifest
+    // sidecar stays OUTSIDE the checkout.
     let custom = temp
         .path()
         .join(".heddle")
         .join("threads")
-        .join("explicit-custom");
+        .join("explicit-custom")
+        .join("root");
     let custom_arg = custom.to_str().unwrap();
     let started = json_value(
         temp.path(),
@@ -5716,8 +5719,159 @@ fn start_explicit_path_under_heddle_threads_is_accepted() {
     assert_eq!(started["thread"]["name"], "explicit-under-heddle");
     assert!(
         custom.join(".heddle").exists(),
-        "explicit .heddle/threads path should be accepted and materialized: {started}"
+        "explicit .heddle/threads/<slot>/root path should be accepted and materialized: {started}"
     );
+}
+
+/// heddle#572 r3 Finding #4: a managed `--path` that is the bare per-thread
+/// directory `.heddle/threads/<slot>` (no `root` leaf) is refused — the
+/// per-thread `manifest.toml` sidecar lives there, so a checkout would swallow
+/// it. The sidecar must stay a SIBLING of the checkout, never a child.
+#[test]
+fn start_managed_path_without_leaf_is_refused() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    let bare = temp.path().join(".heddle").join("threads").join("no-leaf");
+    let err = heddle(
+        &["start", "no-leaf-thread", "--path", bare.to_str().unwrap()],
+        Some(temp.path()),
+    )
+    .expect_err("a bare per-thread dir (no leaf) must be refused");
+    assert!(
+        err.contains("per-thread checkout leaf"),
+        "unexpected error for no-leaf managed target: {err}"
+    );
+}
+
+/// heddle#572 r3 Finding #2: a fresh `start` must NOT reuse another thread's
+/// reserved canonical root. Two threads sharing one execution path is a
+/// corruption hazard; only a same-thread promote may re-occupy it.
+#[test]
+fn start_cannot_reuse_another_threads_reserved_root() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    json_value(
+        temp.path(),
+        &["--output", "json", "start", "owner", "--workspace", "solid"],
+    );
+    // `owner`'s reserved root is `.heddle/threads/owner/root`. A different
+    // thread aiming there must be refused.
+    let owner_root = temp.path().join(".heddle/threads/owner/root");
+    let err = heddle(
+        &["start", "intruder", "--path", owner_root.to_str().unwrap()],
+        Some(temp.path()),
+    )
+    .expect_err("reusing another thread's reserved root must be refused");
+    assert!(
+        err.contains("nested inside an existing thread"),
+        "unexpected error reusing another thread's root: {err}"
+    );
+}
+
+/// heddle#572 r3 Finding #3: a materialized thread is already checked out at
+/// its canonical `.heddle/threads/<name>/root` — the promote default. Promotion
+/// must succeed by converting that checkout in place to a solid one, not refuse
+/// because the slot is occupied.
+#[test]
+fn promote_materialized_thread_converts_in_place() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    json_value(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "start",
+            "promo",
+            "--workspace",
+            "materialized",
+        ],
+    );
+    let checkout = temp.path().join(".heddle/threads/promo/root");
+    assert!(checkout.join(".heddle").exists(), "materialized checkout present");
+
+    let promoted = json_value(temp.path(), &["thread", "promote", "promo"]);
+    assert_eq!(promoted["thread"]["mode"], "solid", "{promoted}");
+    assert!(
+        checkout.join(".heddle").exists(),
+        "the in-place converted solid checkout must still exist at the canonical root: {promoted}"
+    );
+    // The sidecar stayed OUTSIDE the checkout (a sibling of `root`).
+    assert!(
+        temp.path()
+            .join(".heddle/threads/promo/manifest.toml")
+            .exists(),
+        "manifest sidecar must remain a sibling of the checkout, not inside it"
+    );
+}
+
+/// heddle#572 r3 Finding #5 (the isolation guard): a thread checkout under
+/// `.heddle/threads/<t>/root` is a boundary-delimited worktree. A command run
+/// INSIDE it must resolve the THREAD's own HEAD/branch — never climb to the
+/// git-overlay parent and adopt the parent branch. The checkout's own `.heddle`
+/// pointer is that boundary (git's analogue is the linked-worktree `.git`
+/// file); capability detection roots at the checkout, so the parent's
+/// `git-overlay` capability and `main` branch never leak in.
+#[test]
+fn inside_thread_checkout_resolves_thread_not_parent_branch() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_for_json_contract(temp.path(), "main");
+    std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
+    git_commit_all_for_json_contract(temp.path(), "seed");
+    heddle(&["adopt"], Some(temp.path())).expect("adopt Git overlay repo");
+
+    for mode in ["solid", "materialized"] {
+        let name = format!("{mode}-iso");
+        json_value(
+            temp.path(),
+            &["--output", "json", "start", &name, "--workspace", mode],
+        );
+        let checkout = temp.path().join(format!(".heddle/threads/{name}/root"));
+        assert!(
+            checkout.join(".heddle").exists(),
+            "{mode} checkout should materialize at {}",
+            checkout.display()
+        );
+
+        let status = json_value(&checkout, &["status"]);
+        // Capability roots at the checkout boundary, not the git-overlay parent.
+        assert_eq!(
+            status["repository_capability"], "native-heddle",
+            "inside a {mode} checkout the capability must root at the checkout, not the parent: {status}"
+        );
+        // HEAD resolves to the THREAD, never the parent's `main` branch.
+        assert_eq!(
+            status["thread"], name.as_str(),
+            "inside a {mode} checkout HEAD must be the thread, not the parent: {status}"
+        );
+        assert_eq!(
+            status["verification"]["heddle_thread"], name.as_str(),
+            "the overlay verification must also see the thread, not the parent: {status}"
+        );
+        // The parent's git branch (`main`) must NOT leak in.
+        assert!(
+            status["verification"]["git_branch"].is_null(),
+            "inside a {mode} checkout the parent git branch must NOT leak in: {status}"
+        );
+        // The checkout still knows it lives under a git-overlay parent, but as
+        // an isolated checkout — not as the parent repo itself.
+        assert_eq!(
+            status["repository_context"]["kind"], "git-overlay-isolated-checkout",
+            "{status}"
+        );
+    }
 }
 
 #[test]

--- a/crates/cli/tests/multi_agent_worktrees/materialized_threads_e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/materialized_threads_e2e.rs
@@ -73,11 +73,11 @@ fn materialized_thread_full_lifecycle() {
     // Manifest sidecar must be written under the *main* repo's
     // heddle_dir (the worktree's `.heddle/objectstore` pointer keeps
     // everyone agreeing on a single store).
-    let manifest_dir = main
-        .path()
-        .join(".heddle")
-        .join("threads")
-        .join("feature/m-thread");
+    // Use the canonical prefix-safe `thread_dir` derivation: a slashed id
+    // lives at `.heddle/threads/<encoded>/` (e.g. `feature%2Fm-thread`), NOT
+    // a nested `feature/m-thread/` (heddle#572 r2).
+    let manifest_dir =
+        repo::thread_manifest::thread_dir(&main.path().join(".heddle"), "feature/m-thread");
     let manifest_path = manifest_dir.join("manifest.toml");
     assert!(
         manifest_path.is_file(),
@@ -216,12 +216,11 @@ fn short_status_surfaces_stale_materialized_thread_advisory() {
     // This is the same observable condition produced when the head
     // advances past a manifest without the manifest being refreshed
     // (the unit test in status.rs exercises that path directly).
-    let manifest_path = main
-        .path()
-        .join(".heddle")
-        .join("threads")
-        .join("feature/short-stale")
-        .join("manifest.toml");
+    // Canonical prefix-safe layout: `.heddle/threads/<encoded>/manifest.toml`
+    // (`feature%2Fshort-stale`), not a nested `feature/short-stale/`
+    // (heddle#572 r2).
+    let manifest_path =
+        repo::thread_manifest::manifest_path(&main.path().join(".heddle"), "feature/short-stale");
     assert!(
         manifest_path.is_file(),
         "manifest expected at {} after start --workspace materialized",

--- a/crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs
+++ b/crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs
@@ -37,10 +37,10 @@ use super::{heddle, setup_repo};
 fn virtualized_thread_round_trip() {
     let main = setup_repo("greet.txt", "hello from heddle");
 
-    // Start a virtualized thread. The mount point lives outside
-    // the repo (sibling `.{name}-heddle-mounts/...` directory),
-    // and `heddle --output json` prints the resolved path under
-    // `thread.path`.
+    // Start a virtualized thread. The mount point lives under the
+    // repo's reserved `.heddle/threads/<name>` dir (excluded from the
+    // parent repo's overlay/status traversal), and `heddle --output
+    // json` prints the resolved path under `thread.path`.
     let raw = heddle(
         &[
             "--output", "json",
@@ -67,8 +67,8 @@ fn virtualized_thread_round_trip() {
         .expect("virtualized thread output should include the mount path under thread.path")
         .to_string();
     assert!(
-        mount_path.contains("-heddle-mounts/"),
-        "mount path should sit under the conventional .<repo>-heddle-mounts/ sibling \
+        mount_path.contains("/.heddle/threads/"),
+        "mount path should sit under the managed .heddle/threads/ root \
          (got {mount_path:?})"
     );
 

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -506,7 +506,7 @@ fn test_merge_fast_forward_advances_current_thread() {
 /// directory the operator happened to invoke `heddle` from.
 ///
 /// This is the YC-demo workflow: operator stays at the project root
-/// and never `cd`s into `.run-heddle-threads/<thread>/root/`. The fix
+/// and never `cd`s into `.heddle/threads/<thread>/root/`. The fix
 /// lives in `Repository::active_worktree_path` + the merge entry point.
 #[test]
 fn test_merge_from_main_worktree_targets_active_thread_lightweight_worktree() {

--- a/crates/devtools/src/fuse_dispatch_bench.rs
+++ b/crates/devtools/src/fuse_dispatch_bench.rs
@@ -783,7 +783,7 @@ fn branch_name_for(mode: Mode, args: &Args, idx: usize) -> Option<String> {
 /// Create a workdir for `mode` and return the *actual* on-disk path
 /// where cargo should be invoked. For git and solid modes that matches
 /// `desired_path`; for virtualized mode the heddle CLI ignores `--path`
-/// and mounts under `<parent>/.<repo-name>-heddle-mounts/<thread>` —
+/// and mounts under `<repo>/.heddle/threads/<thread>` —
 /// we parse the JSON `path` field from stdout to discover it.
 fn create_workdir(
     mode: Mode,

--- a/crates/mount/src/projfs.rs
+++ b/crates/mount/src/projfs.rs
@@ -512,7 +512,7 @@ fn load_or_create_instance_id(root: &Path) -> Result<GUID> {
     let bytes = encode_guid(&guid);
 
     // Best-effort: ensure the primary's parent exists. The CLI
-    // usually creates `<repo_parent>/.<repo_name>-heddle-mounts/`
+    // usually creates `<repo>/.heddle/threads/<thread>/`
     // before calling us, so this is a no-op in the common path.
     if let Some(parent) = primary.parent() {
         let _ = std::fs::create_dir_all(parent);

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -635,6 +635,23 @@ impl Repository {
     ///   (per-checkout cached state).
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let start_path = path.as_ref().canonicalize()?;
+        // A virtualized thread mounts at `.heddle/threads/<encoded>/root` and
+        // writes no checkout metadata of its own. Without this guard, the
+        // upward walk below would sail past the metadata-less mount and open
+        // the PARENT repo, so status/capture/thread operations would silently
+        // hit the wrong checkout. Refuse rather than resolve to the parent
+        // (heddle#572 r2). Solid/materialized checkouts have their own
+        // `.heddle` pointer and are handled by the worktree branch below, so
+        // this only fires for a virtualized (or torn-down) mount root.
+        if let Some(mount_root) = metadataless_managed_thread_root(&start_path) {
+            return Err(HeddleError::Config(format!(
+                "'{}' is a Heddle-managed virtualized thread mount with no checkout \
+                 metadata of its own; refusing to operate on the parent repository from \
+                 inside it. Run heddle from the repository root, or use a solid/materialized \
+                 thread checkout.",
+                mount_root.display()
+            )));
+        }
         let mut discovered_git_root = None;
 
         let mut current = Some(start_path.as_path());
@@ -2344,6 +2361,38 @@ fn has_git_metadata(path: &Path) -> bool {
     }
 
     gix::discover(path).is_ok()
+}
+
+/// If `start_path` lies inside a *managed virtualized thread root*
+/// (`<repo>/.heddle/threads/<encoded>/root`) that carries NO checkout
+/// metadata of its own, return that mount root.
+///
+/// Solid and materialized thread checkouts write their own `.heddle`
+/// objectstore pointer at the checkout root, so [`Repository::open`]
+/// resolves them as a worktree before it climbs to the parent. A
+/// *virtualized* thread mounts a content-addressed projection there and
+/// writes no such pointer, so a bare upward walk would sail past the
+/// metadata-less mount and open the PARENT repo. The flat
+/// `thread_manifest::thread_dir` encoding guarantees `<encoded>` is exactly
+/// one path component, so the `root → <encoded> → threads → .heddle`
+/// shape is unambiguous (heddle#572 r2).
+fn metadataless_managed_thread_root(start_path: &Path) -> Option<PathBuf> {
+    let mut cur: Option<&Path> = Some(start_path);
+    while let Some(dir) = cur {
+        if dir.file_name().and_then(|n| n.to_str()) == Some("root")
+            && let Some(thread_dir) = dir.parent()
+            && let Some(threads) = thread_dir.parent()
+            && threads.file_name().and_then(|n| n.to_str()) == Some("threads")
+            && let Some(heddle) = threads.parent()
+            && heddle.file_name().and_then(|n| n.to_str()) == Some(".heddle")
+            && heddle.join("objects").is_dir()
+            && !dir.join(".heddle").exists()
+        {
+            return Some(dir.to_path_buf());
+        }
+        cur = dir.parent();
+    }
+    None
 }
 
 fn git_config_principal(root: &Path) -> Option<Principal> {

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -2021,3 +2021,58 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
         after.added,
     );
 }
+
+/// heddle#572 r2: a virtualized thread mounts at
+/// `.heddle/threads/<encoded>/root` with no checkout metadata of its own.
+/// `Repository::open` from inside such a mount must REFUSE rather than climb
+/// past the metadata-less mount and open the PARENT repo (which would apply
+/// status/capture/thread operations to the wrong checkout). Solid/materialized
+/// checkout roots carry their own `.heddle` pointer and are unaffected.
+#[test]
+fn open_refuses_metadataless_virtualized_thread_mount() {
+    let (_temp, repo) = create_test_repo();
+    let heddle = repo.heddle_dir().to_path_buf();
+
+    // Simulate a virtualized thread `virt`: its mount root exists but has no
+    // `.heddle` checkout metadata of its own.
+    let mount_root = crate::thread_manifest::thread_dir(&heddle, "virt").join("root");
+    fs::create_dir_all(&mount_root).unwrap();
+
+    // `Repository` isn't `Debug`, so match rather than `expect_err`.
+    let err = match Repository::open(&mount_root) {
+        Ok(_) => panic!("opening from a metadata-less virtualized mount must refuse the parent climb"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("virtualized thread mount"),
+        "unexpected error opening the virtualized mount root: {err}"
+    );
+
+    // A path deeper inside the mount is refused too (the upward walk catches
+    // the mount root as an ancestor).
+    let deeper = mount_root.join("src");
+    fs::create_dir_all(&deeper).unwrap();
+    assert!(
+        Repository::open(&deeper).is_err(),
+        "a path inside the virtualized mount must also refuse"
+    );
+
+    // The detection is narrow: a solid/materialized checkout root carries its
+    // own `.heddle`, so it is NOT treated as a metadata-less mount.
+    let solid_root = crate::thread_manifest::thread_dir(&heddle, "solid").join("root");
+    fs::create_dir_all(solid_root.join(".heddle")).unwrap();
+    assert!(
+        super::metadataless_managed_thread_root(&solid_root).is_none(),
+        "a checkout root with its own .heddle must not be flagged"
+    );
+    assert!(
+        super::metadataless_managed_thread_root(&mount_root).is_some(),
+        "a metadata-less mount root must be flagged"
+    );
+
+    // Normal open from the repository root still works — the guard is narrow.
+    assert!(
+        Repository::open(repo.root()).is_ok(),
+        "opening the repository root must still succeed"
+    );
+}

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -2076,3 +2076,60 @@ fn open_refuses_metadataless_virtualized_thread_mount() {
         "opening the repository root must still succeed"
     );
 }
+
+/// heddle#572 r3 Finding #5: a solid/materialized thread checkout under
+/// `.heddle/threads/<encoded>/root` is a boundary-delimited worktree. Its own
+/// `.heddle` pointer is the discovery boundary (git's analogue is the
+/// linked-worktree `.git` file): `Repository::open` from inside it must root at
+/// the checkout — capability derived from the checkout's OWN `.git` (absent →
+/// NativeHeddle), HEAD resolved to the THREAD — and must NEVER climb to the
+/// git-overlay parent and adopt the parent's `GitOverlay` capability or branch.
+#[test]
+fn open_solid_checkout_roots_at_boundary_not_git_overlay_parent() {
+    let temp_dir = TempDir::new().unwrap();
+    gix::init(temp_dir.path()).expect("init real git repository");
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    assert_eq!(
+        repo.capability(),
+        RepositoryCapability::GitOverlay,
+        "the parent repo is a git-overlay repo"
+    );
+    let heddle = repo.heddle_dir().to_path_buf();
+
+    // Mimic write_isolated_checkout for a solid thread `feature`: a checkout
+    // root under `.heddle/threads/feature/root` carrying its OWN `.heddle`
+    // pointer + per-checkout HEAD (`ref: feature`), but no `.git` of its own.
+    let checkout = crate::thread_manifest::thread_dir(&heddle, "feature").join("root");
+    let co_heddle = checkout.join(".heddle");
+    fs::create_dir_all(&co_heddle).unwrap();
+    fs::write(
+        co_heddle.join("objectstore"),
+        format!("objectstore: {}\n", heddle.display()),
+    )
+    .unwrap();
+    fs::create_dir_all(co_heddle.join("state")).unwrap();
+    fs::write(co_heddle.join("HEAD"), "ref: feature\n").unwrap();
+
+    let opened = Repository::open(&checkout).expect("open solid checkout");
+
+    // Capability roots at the checkout's own boundary (no `.git` AT the
+    // checkout → NativeHeddle), NOT the ancestor git-overlay parent.
+    assert_eq!(
+        opened.capability(),
+        RepositoryCapability::NativeHeddle,
+        "capability must root at the checkout boundary, not the parent .git"
+    );
+    assert!(
+        opened.root().ends_with("threads/feature/root"),
+        "open must root AT the checkout, got {}",
+        opened.root().display()
+    );
+    // HEAD is the thread's own, never the parent branch.
+    assert!(
+        matches!(opened.head_ref().unwrap(), Head::Attached { thread } if thread.as_str() == "feature"),
+        "HEAD must resolve to the thread, not the parent branch"
+    );
+    // The git-overlay branch probe stays inert — the parent branch never leaks.
+    assert_eq!(opened.git_overlay_current_branch().unwrap(), None);
+    assert_eq!(opened.current_lane().unwrap().as_deref(), Some("feature"));
+}

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -573,8 +573,7 @@ impl Repository {
     ///      name*, which is what auto-capture-on-switch needs.
     ///   2. `snapshot` walks `self.root`. Capture-from-disk walks
     ///      whatever directory the materializer put the thread at —
-    ///      sibling directories under
-    ///      `<workspace_parent>/.<repo>-heddle-mounts/<thread>/`,
+    ///      managed checkouts under `<repo>/.heddle/threads/<thread>/`,
     ///      which are NOT `self.root`.
     ///
     /// Walks `Repository::build_tree` for the slow path so the

--- a/crates/repo/src/thread_manifest.rs
+++ b/crates/repo/src/thread_manifest.rs
@@ -163,63 +163,94 @@ impl ManifestFile {
 }
 
 /// The single per-thread directory under `<heddle_dir>/threads/`, keyed
-/// off the raw thread name. Slashed ids nest (`feature/x` →
-/// `threads/feature/x/`), matching the manifest walk's name
-/// reconstruction. Thread ids are `validate_thread_id`-checked (no `..`,
-/// no leading `/`) before they ever reach here, so the join stays inside
-/// `threads/`. This is the ONE derivation both the manifest sidecar and
-/// the worktree checkout root key off, so the two never diverge or
-/// collide for a given thread.
+/// off the thread name through a **prefix-safe single-segment encoding**
+/// ([`encode_thread_segment`]). A slashed id never becomes a directory
+/// prefix of another: `feature/foo` maps to `threads/feature%2Ffoo`, NOT
+/// `threads/feature/foo`, so it can neither nest under nor swallow a
+/// `feature` (or `feature/f`) thread. Because the encoding is injective
+/// and yields exactly one path component, two distinct ids always land in
+/// disjoint sibling directories, and none can ever be an ancestor of
+/// another (closing the prefix-nesting + recursive-drop class, heddle#572
+/// r2).
+///
+/// This is the ONE derivation every thread-path consumer keys off — the
+/// `manifest.toml` sidecar, the worktree checkout root (`<dir>/root`) for
+/// all three workspace modes, the harness subagent/root-actor paths, and
+/// the promote default — so the manifest and the checkout can never
+/// diverge or collide for a given thread.
 pub fn thread_dir(heddle_dir: &Path, thread: &str) -> PathBuf {
-    heddle_dir.join("threads").join(thread)
+    heddle_dir
+        .join("threads")
+        .join(encode_thread_segment(thread))
+}
+
+/// Encode a thread id into a single, filesystem-safe, prefix-free path
+/// segment. Percent-encodes every byte that is unsafe as a lone path
+/// component — the separators `/` and `\`, the Windows-hostile `:`, the
+/// `%` escape itself, and anything outside the safe slug set — so the
+/// mapping is injective and reversible ([`decode_thread_segment`]) and
+/// each id occupies one disjoint leaf under `threads/`. The common safe
+/// slug characters (alphanumerics and `_ - . @ + =`) pass through for
+/// readability, so `v1.2`, `team@scope`, and `wip+1=2` stay legible while
+/// `feature/foo` becomes `feature%2Ffoo`.
+///
+/// The whole-segment `.` / `..` results are escaped specially: a thread
+/// id of exactly `.` (which [`crate::validate_thread_id`] permits) or `..`
+/// (which it rejects, but unchecked/deserialized ids could still carry)
+/// would otherwise be a current-/parent-dir component that escapes or
+/// aliases `threads/`.
+pub fn encode_thread_segment(thread: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(thread.len());
+    for &b in thread.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'@' | b'+' | b'=') {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0f) as usize] as char);
+        }
+    }
+    match out.as_str() {
+        "." => "%2E".to_string(),
+        ".." => "%2E%2E".to_string(),
+        _ => out,
+    }
+}
+
+/// Inverse of [`encode_thread_segment`]: recover the thread id from its
+/// on-disk directory segment. Returns `None` for a malformed segment (a
+/// truncated/`%`-escape with non-hex digits, or bytes that don't form
+/// valid UTF-8) so the manifest walk skips foreign directories rather than
+/// inventing a bogus thread name.
+pub fn decode_thread_segment(segment: &str) -> Option<String> {
+    let bytes = segment.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = (bytes[i + 1] as char).to_digit(16)?;
+            let lo = (bytes[i + 2] as char).to_digit(16)?;
+            out.push((hi * 16 + lo) as u8);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 /// Where this thread's manifest lives on disk, given the repo's
-/// `heddle_dir` and a thread name: `<heddle_dir>/threads/<thread>/manifest.toml`.
+/// `heddle_dir` and a thread name:
+/// `<heddle_dir>/threads/<encoded>/manifest.toml`, a sibling of the
+/// checkout root `<encoded>/root`. Derives from [`thread_dir`] so it
+/// shares the one prefix-safe encoding.
 pub fn manifest_path(heddle_dir: &Path, thread: &str) -> PathBuf {
     thread_dir(heddle_dir, thread).join("manifest.toml")
-}
-
-/// True if `candidate` would land *inside* an already-existing thread's
-/// reserved subtree under `threads_root` (`<heddle_dir>/threads`). A
-/// thread occupies `threads/<name>/`, marked by its `manifest.toml`
-/// sidecar; a new explicit `--path` checkout must not nest below one, or
-/// it would land inside another thread's `root/` worktree. A fresh
-/// `threads/<newname>` or `threads/<newname>/root` (no manifest-bearing
-/// ancestor) returns false.
-///
-/// The marker is the `manifest.toml` sidecar — NOT the presence of a
-/// `root/` subdir: callers that create the target directory *before*
-/// re-validating (e.g. `prepare_worktree_target`) would otherwise see the
-/// just-created `root/` and falsely reject a legitimate fresh checkout.
-/// The manifest is written by the materialize transaction, strictly after
-/// target preparation, so a thread being created right now has none yet.
-///
-/// `threads_root` must be the same `<heddle_dir>/threads` base the caller
-/// tested `candidate`'s containment against, so the prefix strips cleanly.
-pub fn is_inside_existing_thread_dir(threads_root: &Path, candidate: &Path) -> bool {
-    let Ok(rel) = candidate.strip_prefix(threads_root) else {
-        return false;
-    };
-    let comps: Vec<_> = rel
-        .components()
-        .filter_map(|c| match c {
-            std::path::Component::Normal(s) => Some(s.to_owned()),
-            _ => None,
-        })
-        .collect();
-    // Walk every PROPER ancestor directory of `candidate` under
-    // `threads_root` (i.e. drop the candidate leaf itself). If any such
-    // ancestor carries a `manifest.toml`, it is an existing thread root
-    // and `candidate` sits nested inside it.
-    let mut dir = threads_root.to_path_buf();
-    for seg in comps.iter().take(comps.len().saturating_sub(1)) {
-        dir.push(seg);
-        if dir.join("manifest.toml").is_file() {
-            return true;
-        }
-    }
-    false
 }
 
 /// Summary of a single materialized thread, gathered by walking
@@ -245,76 +276,36 @@ pub struct MaterializedThreadSummary {
 /// manifests are silently skipped — callers that care can re-read
 /// individual manifests via [`read_manifest`].
 ///
-/// Walks recursively. Thread names conventionally contain slashes
-/// (`feature/m-thread`, `bugfix/issue-123`) which `manifest_path`
-/// passes through to `Path::join`, so the on-disk layout mirrors
-/// the conceptual hierarchy. A single-level read_dir would miss
-/// every nested thread; recursing reconstructs the thread name from
-/// the relative path of each `manifest.toml`'s parent directory.
+/// A single-level scan: every thread occupies exactly one directory
+/// `threads/<encoded>/` (the prefix-safe [`thread_dir`] encoding), so the
+/// thread name is the *decoded* directory segment and there is nothing to
+/// recurse into. Directories whose segment doesn't decode (foreign / hand-
+/// placed) are skipped. This also keeps the scan out of each thread's
+/// `root/` worktree, which has no thread `manifest.toml` of its own.
 pub fn list_thread_manifests(heddle_dir: &Path) -> io::Result<Vec<MaterializedThreadSummary>> {
     let threads_dir = heddle_dir.join("threads");
-    let mut summaries = Vec::new();
-    walk_thread_manifests(&threads_dir, &threads_dir, &mut summaries)?;
-    summaries.sort_by(|a, b| a.thread.cmp(&b.thread));
-    Ok(summaries)
-}
-
-/// Depth-first walk under `threads_dir`. For every directory found
-/// to contain a `manifest.toml`, parse it and collect a summary; the
-/// thread name is the relative path of that directory from the root
-/// (`feature/m-thread` for a manifest at `threads/feature/m-thread/`).
-/// Subdirectories of a manifest-bearing directory are *not* recursed
-/// into — a thread directory shouldn't contain another thread.
-fn walk_thread_manifests(
-    threads_dir: &Path,
-    cur: &Path,
-    out: &mut Vec<MaterializedThreadSummary>,
-) -> io::Result<()> {
-    let entries = match fs::read_dir(cur) {
+    let entries = match fs::read_dir(&threads_dir) {
         Ok(e) => e,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(enrich_fs_error(cur, "listing", e)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(enrich_fs_error(&threads_dir, "listing", e)),
     };
-    // Two-pass: first look for `manifest.toml` (treat this dir as a
-    // thread root and stop), otherwise recurse into subdirectories.
-    // Collected so we can short-circuit cheaply without re-stating.
-    let mut subdirs = Vec::new();
-    let mut has_manifest = false;
+    let mut summaries = Vec::new();
     for entry in entries {
         let entry = entry?;
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            subdirs.push(entry.path());
-        } else if ft.is_file() && entry.file_name() == "manifest.toml" {
-            has_manifest = true;
+        if !entry.file_type()?.is_dir() {
+            continue;
         }
-    }
-    if has_manifest {
-        // Reconstruct the thread name from the path relative to
-        // `threads_dir`. On Windows the separator is `\`; the on-
-        // disk schema is always `/`-joined per `manifest_path`'s use
-        // of `Path::join` plus the convention that thread names use
-        // forward slashes. Normalise here so the returned summary's
-        // `thread` field round-trips through `read_manifest` and
-        // `manifest_path` cleanly.
-        let rel = cur.strip_prefix(threads_dir).unwrap_or(cur);
-        let mut name_parts: Vec<String> = Vec::new();
-        for component in rel.components() {
-            if let std::path::Component::Normal(s) = component
-                && let Some(s) = s.to_str()
-            {
-                name_parts.push(s.to_string());
-            } else {
-                // Non-utf8 or weird path component → skip silently.
-                return Ok(());
-            }
-        }
-        if name_parts.is_empty() {
-            return Ok(());
-        }
-        let name = name_parts.join("/");
-        if let Ok(Some(m)) = read_manifest(threads_dir.parent().unwrap_or(threads_dir), &name) {
-            out.push(MaterializedThreadSummary {
+        let Some(segment) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Some(name) = decode_thread_segment(&segment) else {
+            continue;
+        };
+        // Read the manifest directly from this dir rather than re-deriving
+        // its path from `name` — robust to any segment whose decode→encode
+        // isn't byte-identical (e.g. a hand-placed lowercase escape).
+        if let Ok(Some(m)) = read_manifest_at(&entry.path().join("manifest.toml")) {
+            summaries.push(MaterializedThreadSummary {
                 thread: name,
                 state_id: m.state_id,
                 tree_hash: m.tree_hash,
@@ -322,12 +313,9 @@ fn walk_thread_manifests(
                 file_count: m.files.len(),
             });
         }
-        return Ok(());
     }
-    for sub in subdirs {
-        walk_thread_manifests(threads_dir, &sub, out)?;
-    }
-    Ok(())
+    summaries.sort_by(|a, b| a.thread.cmp(&b.thread));
+    Ok(summaries)
 }
 
 /// Read the on-disk manifest for `thread`. Returns `Ok(None)` when no
@@ -336,11 +324,18 @@ fn walk_thread_manifests(
 /// schema-version mismatch — callers should treat that as "rebuild
 /// the manifest from scratch", not as a corruption hazard.
 pub fn read_manifest(heddle_dir: &Path, thread: &str) -> io::Result<Option<ThreadManifest>> {
-    let path = manifest_path(heddle_dir, thread);
-    let text = match fs::read_to_string(&path) {
+    read_manifest_at(&manifest_path(heddle_dir, thread))
+}
+
+/// Read + validate a `manifest.toml` at an explicit `path`. Shared by the
+/// name-keyed [`read_manifest`] and the directory-scanning
+/// [`list_thread_manifests`] so both apply the same not-found / malformed /
+/// schema-mismatch handling.
+pub fn read_manifest_at(path: &Path) -> io::Result<Option<ThreadManifest>> {
+    let text = match fs::read_to_string(path) {
         Ok(t) => t,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(enrich_fs_error(&path, "reading", e)),
+        Err(e) => return Err(enrich_fs_error(path, "reading", e)),
     };
     let manifest: ThreadManifest = toml::from_str(&text).map_err(|e| {
         io::Error::new(
@@ -379,57 +374,31 @@ pub fn manifest_for_worktree_root(
     canonical_worktree_root: &Path,
 ) -> io::Result<Option<ThreadManifest>> {
     let threads_dir = heddle_dir.join("threads");
-    let mut found = None;
-    find_manifest_for_root(&threads_dir, canonical_worktree_root, &mut found)?;
-    Ok(found)
-}
-
-/// Depth-first walk under `cur` looking for a `manifest.toml` whose
-/// `worktree_path` matches `root_match`. Stops at the first match. Mirrors
-/// [`walk_thread_manifests`]'s structure but parses the full manifest (not a
-/// summary) and short-circuits on the path predicate.
-fn find_manifest_for_root(
-    cur: &Path,
-    root_match: &Path,
-    out: &mut Option<ThreadManifest>,
-) -> io::Result<()> {
-    if out.is_some() {
-        return Ok(());
-    }
-    let entries = match fs::read_dir(cur) {
+    let entries = match fs::read_dir(&threads_dir) {
         Ok(e) => e,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(enrich_fs_error(cur, "listing", e)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(enrich_fs_error(&threads_dir, "listing", e)),
     };
-    let mut subdirs = Vec::new();
+    // Single-level scan: every thread's `manifest.toml` lives exactly one
+    // level deep at `threads/<encoded>/manifest.toml` (flat [`thread_dir`]
+    // layout). Match on the recorded `worktree_path`, so the thread name is
+    // irrelevant; skip anything unparseable or schema-stale — the reconcile
+    // caller is conservative by design.
     for entry in entries {
         let entry = entry?;
-        let ft = entry.file_type()?;
-        let path = entry.path();
-        if ft.is_dir() {
-            subdirs.push(path);
-        } else if ft.is_file() && entry.file_name() == "manifest.toml" {
-            // Parse directly rather than reconstructing the thread name and
-            // routing through `read_manifest`: we match on `worktree_path`, so
-            // the thread name is irrelevant here. Skip anything unparseable or
-            // schema-stale — the reconcile caller is conservative by design.
-            if let Ok(text) = fs::read_to_string(&path)
-                && let Ok(manifest) = toml::from_str::<ThreadManifest>(&text)
-                && manifest.schema_version == SCHEMA_VERSION
-                && manifest.worktree_path == root_match
-            {
-                *out = Some(manifest);
-                return Ok(());
-            }
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let path = entry.path().join("manifest.toml");
+        if let Ok(text) = fs::read_to_string(&path)
+            && let Ok(manifest) = toml::from_str::<ThreadManifest>(&text)
+            && manifest.schema_version == SCHEMA_VERSION
+            && manifest.worktree_path == canonical_worktree_root
+        {
+            return Ok(Some(manifest));
         }
     }
-    for sub in subdirs {
-        find_manifest_for_root(&sub, root_match, out)?;
-        if out.is_some() {
-            return Ok(());
-        }
-    }
-    Ok(())
+    Ok(None)
 }
 
 /// Delete the on-disk manifest directory for `thread`. Used by
@@ -438,47 +407,23 @@ fn find_manifest_for_root(
 /// thread set. Idempotent: a missing directory is reported as
 /// "deleted = false" rather than an error.
 ///
-/// Removes the whole `<heddle_dir>/threads/<thread>/` directory —
+/// Removes the whole `<heddle_dir>/threads/<encoded>/` directory —
 /// not just `manifest.toml` — so future per-thread sidecars
 /// (verification artefacts, capture journals, etc.) clean up with
 /// the same call.
+///
+/// The flat [`thread_dir`] encoding gives every thread its own
+/// single-segment leaf with no shared parent namespace, so dropping one
+/// thread can never recursively delete a *different* slash-namespaced
+/// thread's checkout, and there are no empty intermediate parents left to
+/// reap (the heddle#572 r2 recursive-drop hazard).
 pub fn remove_thread_manifest_dir(heddle_dir: &Path, thread: &str) -> io::Result<bool> {
-    let threads_root = heddle_dir.join("threads");
-    let dir = threads_root.join(thread);
-    let removed = match fs::remove_dir_all(&dir) {
-        Ok(()) => true,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => false,
-        Err(e) => return Err(enrich_fs_error(&dir, "removing", e)),
-    };
-    // Sweep empty parent directories left over by slash-namespaced
-    // threads. Dropping `feature/m-thread` removes
-    // `threads/feature/m-thread/` but `threads/feature/` would
-    // otherwise linger — purely cosmetic, but after many dropped
-    // threads the on-disk tree grows visually messy and the user
-    // ends up with a `ls .heddle/threads/` full of empty husks.
-    // Walk upward stopping at the first non-empty parent (another
-    // thread might still live there) or at `threads/` itself
-    // (we don't reap the root, that's heddle-managed).
-    if removed && let Some(mut parent) = dir.parent() {
-        while parent != threads_root {
-            match fs::read_dir(parent).map(|mut it| it.next().is_some()) {
-                Ok(true) => break, // sibling thread present
-                Ok(false) => match fs::remove_dir(parent) {
-                    Ok(()) => {}
-                    // Race: another process refilled the dir
-                    // between the read_dir check and the remove —
-                    // treat as "stop, that's their problem now".
-                    Err(_) => break,
-                },
-                Err(_) => break,
-            }
-            match parent.parent() {
-                Some(next) => parent = next,
-                None => break,
-            }
-        }
+    let dir = thread_dir(heddle_dir, thread);
+    match fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(enrich_fs_error(&dir, "removing", e)),
     }
-    Ok(removed)
 }
 
 /// On-disk location of the *withheld-checkout* marker for the worktree
@@ -786,51 +731,73 @@ mod tests {
     fn thread_dir_and_manifest_share_one_derivation_for_slashed_ids() {
         let heddle = Path::new("/repo/.heddle");
         let dir = thread_dir(heddle, "feature/foo");
-        assert_eq!(dir, Path::new("/repo/.heddle/threads/feature/foo"));
+        // The slash is percent-encoded into ONE path segment, so the id can
+        // never nest under (or swallow) another thread's directory.
+        assert_eq!(dir, Path::new("/repo/.heddle/threads/feature%2Ffoo"));
         // The manifest is a child of the shared per-thread dir, so a checkout
         // root at `<dir>/root` is its sibling.
         assert_eq!(manifest_path(heddle, "feature/foo"), dir.join("manifest.toml"));
         assert!(manifest_path(heddle, "feature/foo").starts_with(heddle.join("threads")));
     }
 
+    /// The close-the-class proof for the prefix-nesting bug: a thread id that
+    /// is a path-component prefix of another (`feature/f` vs `feature/foo`, and
+    /// the bare `feature` vs `feature/foo`) must map to DISJOINT directories
+    /// where neither is an ancestor of the other. Before the flat encoding,
+    /// `feature` lived at `threads/feature/` and `feature/foo` nested inside it
+    /// at `threads/feature/foo/`, so `thread drop feature` recursively deleted
+    /// `feature/foo`'s checkout (heddle#572 r2).
     #[test]
-    fn nested_inside_existing_thread_detected_for_slashed_ids() {
-        let dir = TempDir::new().unwrap();
-        let threads_root = dir.path().join("threads");
+    fn prefix_thread_ids_get_disjoint_non_nested_dirs() {
+        let heddle = Path::new("/repo/.heddle");
+        let pairs = [
+            ("feature/f", "feature/foo"),
+            ("feature", "feature/foo"),
+            ("foo", "foo/root"),
+        ];
+        for (a, b) in pairs {
+            let da = thread_dir(heddle, a);
+            let db = thread_dir(heddle, b);
+            assert_ne!(da, db, "distinct ids {a:?}/{b:?} must map to distinct dirs");
+            assert!(
+                !da.starts_with(&db) && !db.starts_with(&da),
+                "neither {a:?}→{} nor {b:?}→{} may be a path prefix of the other",
+                da.display(),
+                db.display(),
+            );
+        }
+    }
 
-        // An existing slashed thread `feature/foo` carries its manifest.
-        let foo = threads_root.join("feature").join("foo");
-        std::fs::create_dir_all(foo.join("root")).unwrap();
-        std::fs::write(foo.join("manifest.toml"), b"# stub\n").unwrap();
-
-        // Nested inside the existing thread's checkout → true.
-        assert!(is_inside_existing_thread_dir(
-            &threads_root,
-            &foo.join("root").join("nested")
-        ));
-        // The checkout root itself sits below the manifest-bearing dir → true.
-        assert!(is_inside_existing_thread_dir(&threads_root, &foo.join("root")));
-
-        // A fresh thread under the SAME `feature/` namespace is fine — the
-        // intermediate `feature/` dir carries no manifest of its own.
-        assert!(!is_inside_existing_thread_dir(
-            &threads_root,
-            &threads_root.join("feature").join("bar")
-        ));
-        assert!(!is_inside_existing_thread_dir(
-            &threads_root,
-            &threads_root.join("feature").join("bar").join("root")
-        ));
-        // A brand-new top-level slot is fine.
-        assert!(!is_inside_existing_thread_dir(
-            &threads_root,
-            &threads_root.join("brandnew")
-        ));
-        // A path outside threads_root is never "inside a thread".
-        assert!(!is_inside_existing_thread_dir(
-            &threads_root,
-            Path::new("/elsewhere/foo")
-        ));
+    /// `encode`/`decode` round-trips every thread id `validate_thread_id`
+    /// accepts (plus the dangerous `.`/`..` whole-segment cases), and never
+    /// emits a `/` or a path-traversal component.
+    #[test]
+    fn encode_decode_round_trips_and_stays_single_segment() {
+        for id in [
+            "feature/foo",
+            "feature/f",
+            "feature",
+            "v1.2",
+            "team@scope",
+            "wip+1=2",
+            "a_b-c.d",
+            "main",
+            ".",
+            "..",
+            "weird name with spaces",
+            "team:scope",
+            "100%done",
+        ] {
+            let seg = encode_thread_segment(id);
+            assert!(!seg.contains('/'), "{id:?} → {seg:?} must be one segment");
+            assert_ne!(seg, ".", "{id:?} must not encode to a current-dir component");
+            assert_ne!(seg, "..", "{id:?} must not encode to a parent-dir component");
+            assert_eq!(
+                decode_thread_segment(&seg).as_deref(),
+                Some(id),
+                "{id:?} must round-trip through encode/decode"
+            );
+        }
     }
 
     #[test]
@@ -892,41 +859,35 @@ mod tests {
         assert!(!a.matches(&e), "size change must invalidate the cache");
     }
 
-    /// `remove_thread_manifest_dir` must reap empty parent directories
-    /// left behind by slash-namespaced thread names so the on-disk
-    /// inventory doesn't grow visually messy after many drops. Stop
-    /// reaping when a sibling thread is still around, and never reap
-    /// the `threads/` root itself.
+    /// Close-the-class proof for the recursive-drop hazard: dropping a
+    /// slash-namespaced thread must remove ONLY its own flat directory and
+    /// never touch a sibling that shares a conceptual namespace. Under the
+    /// old slash-nesting layout `feature/keeper` and `feature/dropme` shared a
+    /// `threads/feature/` parent, so dropping one could recursively delete the
+    /// other; the flat encoding gives each a disjoint leaf (heddle#572 r2).
     #[test]
-    fn remove_thread_manifest_dir_reaps_empty_parents() {
+    fn remove_thread_manifest_dir_isolates_slash_namespaced_siblings() {
         let dir = TempDir::new().unwrap();
-        // Two threads under the same `feature/` parent. Drop one;
-        // `feature/` must survive because the other is still there.
         let m = ThreadManifest::new(cid(), h(1), PathBuf::from("/tmp/test-worktree"));
         write_manifest(dir.path(), "feature/keeper", &m).unwrap();
         write_manifest(dir.path(), "feature/dropme", &m).unwrap();
 
         assert!(remove_thread_manifest_dir(dir.path(), "feature/dropme").unwrap());
         assert!(
-            dir.path().join("threads").join("feature").is_dir(),
-            "sibling thread must keep the `feature/` parent alive"
+            !thread_dir(dir.path(), "feature/dropme").exists(),
+            "the dropped thread's directory must be gone"
         );
         assert!(
-            dir.path()
-                .join("threads")
-                .join("feature")
-                .join("keeper")
-                .is_dir(),
-            "keeper's directory must be untouched"
+            thread_dir(dir.path(), "feature/keeper").exists(),
+            "a slash-namespaced sibling must be completely untouched by the drop"
+        );
+        assert!(
+            read_manifest(dir.path(), "feature/keeper").unwrap().is_some(),
+            "the sibling's manifest must survive"
         );
 
-        // Now drop the second one. `feature/` should be reaped, and
-        // `threads/` itself must stay (heddle-managed root).
+        // The `threads/` root is heddle-managed and must never be removed.
         assert!(remove_thread_manifest_dir(dir.path(), "feature/keeper").unwrap());
-        assert!(
-            !dir.path().join("threads").join("feature").exists(),
-            "empty `feature/` parent must be reaped"
-        );
         assert!(
             dir.path().join("threads").is_dir(),
             "the `threads/` root is heddle-managed and must never be reaped"

--- a/crates/repo/src/thread_manifest.rs
+++ b/crates/repo/src/thread_manifest.rs
@@ -162,13 +162,64 @@ impl ManifestFile {
     }
 }
 
+/// The single per-thread directory under `<heddle_dir>/threads/`, keyed
+/// off the raw thread name. Slashed ids nest (`feature/x` →
+/// `threads/feature/x/`), matching the manifest walk's name
+/// reconstruction. Thread ids are `validate_thread_id`-checked (no `..`,
+/// no leading `/`) before they ever reach here, so the join stays inside
+/// `threads/`. This is the ONE derivation both the manifest sidecar and
+/// the worktree checkout root key off, so the two never diverge or
+/// collide for a given thread.
+pub fn thread_dir(heddle_dir: &Path, thread: &str) -> PathBuf {
+    heddle_dir.join("threads").join(thread)
+}
+
 /// Where this thread's manifest lives on disk, given the repo's
-/// `heddle_dir` and a sanitised thread name.
+/// `heddle_dir` and a thread name: `<heddle_dir>/threads/<thread>/manifest.toml`.
 pub fn manifest_path(heddle_dir: &Path, thread: &str) -> PathBuf {
-    heddle_dir
-        .join("threads")
-        .join(thread)
-        .join("manifest.toml")
+    thread_dir(heddle_dir, thread).join("manifest.toml")
+}
+
+/// True if `candidate` would land *inside* an already-existing thread's
+/// reserved subtree under `threads_root` (`<heddle_dir>/threads`). A
+/// thread occupies `threads/<name>/`, marked by its `manifest.toml`
+/// sidecar; a new explicit `--path` checkout must not nest below one, or
+/// it would land inside another thread's `root/` worktree. A fresh
+/// `threads/<newname>` or `threads/<newname>/root` (no manifest-bearing
+/// ancestor) returns false.
+///
+/// The marker is the `manifest.toml` sidecar — NOT the presence of a
+/// `root/` subdir: callers that create the target directory *before*
+/// re-validating (e.g. `prepare_worktree_target`) would otherwise see the
+/// just-created `root/` and falsely reject a legitimate fresh checkout.
+/// The manifest is written by the materialize transaction, strictly after
+/// target preparation, so a thread being created right now has none yet.
+///
+/// `threads_root` must be the same `<heddle_dir>/threads` base the caller
+/// tested `candidate`'s containment against, so the prefix strips cleanly.
+pub fn is_inside_existing_thread_dir(threads_root: &Path, candidate: &Path) -> bool {
+    let Ok(rel) = candidate.strip_prefix(threads_root) else {
+        return false;
+    };
+    let comps: Vec<_> = rel
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_owned()),
+            _ => None,
+        })
+        .collect();
+    // Walk every PROPER ancestor directory of `candidate` under
+    // `threads_root` (i.e. drop the candidate leaf itself). If any such
+    // ancestor carries a `manifest.toml`, it is an existing thread root
+    // and `candidate` sits nested inside it.
+    let mut dir = threads_root.to_path_buf();
+    for seg in comps.iter().take(comps.len().saturating_sub(1)) {
+        dir.push(seg);
+        if dir.join("manifest.toml").is_file() {
+            return true;
+        }
+    }
+    false
 }
 
 /// Summary of a single materialized thread, gathered by walking
@@ -729,6 +780,57 @@ mod tests {
     fn read_missing_returns_none() {
         let dir = TempDir::new().unwrap();
         assert!(read_manifest(dir.path(), "no-such").unwrap().is_none());
+    }
+
+    #[test]
+    fn thread_dir_and_manifest_share_one_derivation_for_slashed_ids() {
+        let heddle = Path::new("/repo/.heddle");
+        let dir = thread_dir(heddle, "feature/foo");
+        assert_eq!(dir, Path::new("/repo/.heddle/threads/feature/foo"));
+        // The manifest is a child of the shared per-thread dir, so a checkout
+        // root at `<dir>/root` is its sibling.
+        assert_eq!(manifest_path(heddle, "feature/foo"), dir.join("manifest.toml"));
+        assert!(manifest_path(heddle, "feature/foo").starts_with(heddle.join("threads")));
+    }
+
+    #[test]
+    fn nested_inside_existing_thread_detected_for_slashed_ids() {
+        let dir = TempDir::new().unwrap();
+        let threads_root = dir.path().join("threads");
+
+        // An existing slashed thread `feature/foo` carries its manifest.
+        let foo = threads_root.join("feature").join("foo");
+        std::fs::create_dir_all(foo.join("root")).unwrap();
+        std::fs::write(foo.join("manifest.toml"), b"# stub\n").unwrap();
+
+        // Nested inside the existing thread's checkout → true.
+        assert!(is_inside_existing_thread_dir(
+            &threads_root,
+            &foo.join("root").join("nested")
+        ));
+        // The checkout root itself sits below the manifest-bearing dir → true.
+        assert!(is_inside_existing_thread_dir(&threads_root, &foo.join("root")));
+
+        // A fresh thread under the SAME `feature/` namespace is fine — the
+        // intermediate `feature/` dir carries no manifest of its own.
+        assert!(!is_inside_existing_thread_dir(
+            &threads_root,
+            &threads_root.join("feature").join("bar")
+        ));
+        assert!(!is_inside_existing_thread_dir(
+            &threads_root,
+            &threads_root.join("feature").join("bar").join("root")
+        ));
+        // A brand-new top-level slot is fine.
+        assert!(!is_inside_existing_thread_dir(
+            &threads_root,
+            &threads_root.join("brandnew")
+        ));
+        // A path outside threads_root is never "inside a thread".
+        assert!(!is_inside_existing_thread_dir(
+            &threads_root,
+            Path::new("/elsewhere/foo")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #572.

## What changed
- **Default thread paths relocated** — solid, materialized, and virtualized `heddle start` defaults (plus the `thread promote` default) now resolve under the repo's reserved `.heddle/threads/<name>/root` instead of a sibling directory outside the repo. This keeps checkouts *inside* the repo dir so a sandbox scoped to the repo can still reach them. (`crates/cli/src/cli/commands/thread.rs` `default_threads_root` / `default_thread_checkout_path`; `thread_cmd.rs`; `harness/mod.rs`.)
  - The `root/` leaf is load-bearing: `thread_manifest::manifest_path` already owns `.heddle/threads/<name>/manifest.toml` as the per-thread stat-cache sidecar. Nesting the worktree at `<name>/root` keeps that manifest a *sibling* of the checkout, not a stray file inside it.
- **Outside-repo guard inverted** — `ensure_explicit_start_path_outside_tracked_tree` (was `...outside_repo`) now ALLOWS an explicit `--path` under `.heddle/` while still rejecting placement in the repo's tracked working tree. `validate_worktree_target` (`worktree_cmd/helpers.rs`) is relaxed to permit the `.heddle/threads` subtree while keeping the rest of `.heddle/` (store/refs/oplog) off-limits. The explicit `--path <outside-repo>` escape hatch is retained.
- **`.heddle/` confirmed excluded from overlay/status traversal** — git-overlay status carries `.heddle/` in `.git/info/exclude` (`repository::ensure_git_overlay_exclude`, repository.rs:108/2260) and the native worktree walk / untracked scan / materialize walk root their ignore at `/.heddle` (`repo_config::default_ignore` repo_config.rs:278 + `worktree_ignore::canonical_line` worktree_ignore.rs:136). No new exclusion needed.
- **Git-index inspection gated to the real git root** — `git_compat::git_index_plan_for_root`/`_for_repo` now require the discovered Git worktree to equal the queried root (`git_worktree_rooted_at`). Without this, a checkout nested under the parent's worktree would make `gix::discover` walk up and read the PARENT repo's HEAD/index as its own (manifested as a malformed-ref error in `heddle status` from inside a thread checkout).

## Test evidence
New tests in `oss_cli_polish.rs`:
- `start_default_path_lands_under_heddle_threads` — solid + materialized defaults land under `.heddle/threads/<name>`.
- `parent_status_ignores_default_thread_checkout_under_heddle` — parent `git status --porcelain` stays empty and `heddle verify` reports clean after a default start.
- `start_explicit_path_under_heddle_threads_is_accepted` — explicit `--path` under `.heddle/threads` is allowed.

Existing rejection tests (`start_path_inside_repo_refuses...`, `start_normalized_nested_path_inside_repo_is_refused`) still pass; `start_relative_sibling_path_outside_repo_is_accepted` confirms the escape hatch.

## Gates (all green)
- `cargo build --locked --workspace` (default features) + `--all-features`
- `cargo test --locked --workspace --features git-overlay,native,semantic,zstd`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo clippy --locked --workspace --all-targets --features git-overlay,native,semantic -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783396624&installation_id=132405951&pr_number=576&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F576&signature=efbc77301604a37ebd6817f84517b75acf56d6ea50aeb6838cb1dcf7425789f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->