### PR TITLE
feat(npm): transport-agnostic TS Heddle API over the CLI (#583)

### DIFF
--- a/clients/npm/.gitignore
+++ b/clients/npm/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/clients/npm/README.md
+++ b/clients/npm/README.md
@@ -18,6 +18,61 @@ Import from the package (#584) like:
 import type { CommitSchema, HeddleVerbOutputs } from "./generated/heddle-schemas";
 ```
 
+## The `Heddle` API (#583)
+
+`src/` is a transport-agnostic TypeScript wrapper that drives the CLI over
+this JSON contract. It spawns `heddle <verb> --output json [...]`, parses the
+stdout envelope, and returns the `HeddleVerbOutputs`-typed payload.
+
+```ts
+import { Heddle, HeddleError } from "@heddle/cli";
+
+// binaryPath is caller-supplied (binary bundling is #584); falls back to
+// "heddle" on PATH.
+const heddle = new Heddle({ binaryPath: "./bin/heddle", repoPath: "/repo" });
+
+const status = await heddle.status();        // typed StatusSchema
+console.log(status.output_kind);
+
+// Mutating verbs thread --op-id for idempotent retries.
+await heddle.commit(["-m", "msg"], { opId: crypto.randomUUID() });
+
+try {
+  await heddle.push();
+} catch (err) {
+  if (err instanceof HeddleError) {
+    // Error envelope is parsed off stderr; retryable is true ONLY for exit 75.
+    if (err.retryable) {/* safe to retry with the same op-id */}
+    else console.error(err.code, err.message); // e.g. "no_remote"
+  }
+}
+```
+
+Covered harness ops have convenience methods (`adopt`, `init`, `status`,
+`start`, `commit`, `log`, `diff`, `fetch`, `push`, `export` →
+`bridge git export`); any schema-backed verb is reachable via
+`heddle.run(verb, args, opts)`.
+
+### Transport seam (#586)
+
+Dispatch goes through an `Executor` interface; the default `SpawnExecutor`
+shells out to the binary. A future napi/daemon backend (#586) implements the
+same interface and swaps in via `new Heddle({ executor })` — call sites don't
+change.
+
+### Build / test
+
+```sh
+npm run typecheck          # tsc --noEmit, strict
+npm test                   # tsc + node --test (deterministic fake-executor)
+HEDDLE_BIN=./bin/heddle npm test   # also runs the real-binary smoke test
+```
+
+> **CI:** heddle's CI has no TypeScript gate yet — wiring the npm typecheck/
+> test/publish matrix is owned by **#584**. Binary bundling
+> (`optionalDependencies`, asar) is also #584; this package takes a
+> caller-supplied `binaryPath` and otherwise relies on PATH.
+
 ## Regenerating
 
 The types come straight from `crates/cli/src/cli/commands/schemas.rs` via the

--- a/clients/npm/examples/smoke.ts
+++ b/clients/npm/examples/smoke.ts
@@ -1,0 +1,34 @@
+/**
+ * Runnable example: drive a real heddle binary and print a typed payload.
+ *
+ *   HEDDLE_BIN=./path/to/heddle node dist/examples/smoke.js
+ *   # or, with heddle on PATH:
+ *   npm run example
+ */
+import { Heddle, HeddleError } from "../src/index.js";
+
+async function main(): Promise<void> {
+  const heddle = new Heddle({
+    binaryPath: process.env["HEDDLE_BIN"] ?? "heddle",
+    repoPath: process.argv[2],
+  });
+
+  try {
+    // `status` is read-only; its payload is `StatusSchema`-typed.
+    const status = await heddle.status();
+    console.log("status output_kind:", status.output_kind);
+    console.log(JSON.stringify(status, null, 2));
+  } catch (err) {
+    if (err instanceof HeddleError) {
+      console.error(
+        `heddle ${err.verb} failed (exit ${err.exitCode}, code=${err.code}, retryable=${err.retryable})`,
+      );
+      console.error(err.message);
+      process.exitCode = err.exitCode;
+      return;
+    }
+    throw err;
+  }
+}
+
+void main();

--- a/clients/npm/package-lock.json
+++ b/clients/npm/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@heddle/cli",
+  "version": "0.2.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@heddle/cli",
+      "version": "0.2.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/clients/npm/package.json
+++ b/clients/npm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@heddle/cli",
+  "version": "0.2.4",
+  "description": "Transport-agnostic TypeScript API that drives the heddle CLI over its JSON contract.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "generated",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsc -p tsconfig.json && node --test dist/test/",
+    "example": "tsc -p tsconfig.json && node dist/examples/smoke.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/clients/npm/package.json
+++ b/clients/npm/package.json
@@ -4,12 +4,12 @@
   "description": "Transport-agnostic TypeScript API that drives the heddle CLI over its JSON contract.",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
     }
   },
   "files": [
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "tsc -p tsconfig.json && node --test dist/test/",
+    "test": "tsc -p tsconfig.json && node --test dist/test/*.test.js",
     "example": "tsc -p tsconfig.json && node dist/examples/smoke.js"
   },
   "engines": {

--- a/clients/npm/src/errors.ts
+++ b/clients/npm/src/errors.ts
@@ -23,6 +23,26 @@ export type HeddleExitCodeName = keyof typeof HeddleExitCode;
 export const RETRYABLE_EXIT_CODE = HeddleExitCode.TempFail;
 
 /**
+ * Thrown when {@link Heddle.run} is called with a streaming (JSONL) verb.
+ * Such verbs emit one JSON object per line, which a single `JSON.parse`
+ * cannot consume; the caller should use {@link Heddle.stream} instead.
+ */
+export class HeddleStreamingVerbError extends Error {
+  /** The streaming verb that was (incorrectly) passed to `run()`. */
+  readonly verb: string;
+
+  constructor(verb: string) {
+    super(
+      `\`${verb}\` emits JSONL (one JSON object per line); run() parses a ` +
+        `single JSON payload and would mis-parse it. Use ` +
+        `heddle.stream(${JSON.stringify(verb)}) to iterate the lines.`,
+    );
+    this.name = "HeddleStreamingVerbError";
+    this.verb = verb;
+  }
+}
+
+/**
  * Thrown when a heddle invocation exits non-zero. Carries the parsed JSON
  * error envelope (when the CLI emitted one), the raw streams, and a
  * `retryable` flag derived from the sysexits contract (only exit 75).

--- a/clients/npm/src/errors.ts
+++ b/clients/npm/src/errors.ts
@@ -1,0 +1,68 @@
+import type { ErrorEnvelopeSchema } from "../generated/heddle-schemas.js";
+
+/**
+ * BSD sysexits codes the heddle CLI emits. The canonical table lives in
+ * `docs/exit-codes.md`; mirrored here so callers can branch without magic
+ * numbers. `TempFail` (75) is the ONLY safe-to-retry code.
+ */
+export const HeddleExitCode = {
+  Ok: 0,
+  Usage: 64,
+  DataErr: 65,
+  CantCreat: 73,
+  IoErr: 74,
+  TempFail: 75,
+  Protocol: 76,
+  NoPerm: 77,
+  Config: 78,
+} as const;
+
+export type HeddleExitCodeName = keyof typeof HeddleExitCode;
+
+/** The one exit code for which retrying with identical args is safe. */
+export const RETRYABLE_EXIT_CODE = HeddleExitCode.TempFail;
+
+/**
+ * Thrown when a heddle invocation exits non-zero. Carries the parsed JSON
+ * error envelope (when the CLI emitted one), the raw streams, and a
+ * `retryable` flag derived from the sysexits contract (only exit 75).
+ */
+export class HeddleError extends Error {
+  /** Process exit code (sysexits). */
+  readonly exitCode: number;
+  /** Stable error `kind`/`code` from the envelope, if present. */
+  readonly code: string | undefined;
+  /** Safe to retry with the same args? True only for exit 75 (TempFail). */
+  readonly retryable: boolean;
+  /** Parsed `--output json` error envelope, if the CLI emitted one. */
+  readonly envelope: ErrorEnvelopeSchema | undefined;
+  /** Raw stderr (the envelope is emitted here in JSON mode). */
+  readonly stderr: string;
+  /** Raw stdout (usually empty on failure). */
+  readonly stdout: string;
+  /** The verb that was invoked, e.g. "bridge git export". */
+  readonly verb: string;
+
+  constructor(args: {
+    verb: string;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    envelope?: ErrorEnvelopeSchema | undefined;
+  }) {
+    const { verb, exitCode, stdout, stderr, envelope } = args;
+    const message =
+      envelope?.error ??
+      stderr.trim() ??
+      `heddle ${verb} exited with code ${exitCode}`;
+    super(message || `heddle ${verb} exited with code ${exitCode}`);
+    this.name = "HeddleError";
+    this.verb = verb;
+    this.exitCode = exitCode;
+    this.stdout = stdout;
+    this.stderr = stderr;
+    this.envelope = envelope;
+    this.code = envelope?.code ?? envelope?.kind;
+    this.retryable = exitCode === RETRYABLE_EXIT_CODE;
+  }
+}

--- a/clients/npm/src/executor.ts
+++ b/clients/npm/src/executor.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+
+/**
+ * One CLI invocation, transport-neutral. The `verb` is the canonical
+ * space-joined verb (e.g. `"bridge git export"`); the executor is
+ * responsible for splitting it into argv tokens for a subprocess, or
+ * routing it however a daemon/napi backend prefers.
+ */
+export interface ExecRequest {
+  /** Canonical verb, space-joined (e.g. "bridge git export"). */
+  verb: string;
+  /** Verb-specific arguments appended after the global flags. */
+  args: readonly string[];
+  /** Threaded as `--op-id` for idempotent retries on mutating verbs. */
+  opId?: string | undefined;
+  /** Repo path, threaded as `-C <path>` (default: process cwd). */
+  repoPath?: string | undefined;
+  /** Abort signal to cancel an in-flight invocation. */
+  signal?: AbortSignal | undefined;
+}
+
+/** Raw, unparsed result of an invocation. Parsing lives in `Heddle`. */
+export interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * The transport seam. The default {@link SpawnExecutor} shells out to the
+ * `heddle` binary, but a future napi or daemon backend (#586) can implement
+ * this same interface and swap in with no change to `Heddle` call sites —
+ * it just has to return the JSON contract on stdout and a sysexits code.
+ */
+export interface Executor {
+  exec(req: ExecRequest): Promise<ExecResult>;
+}
+
+export interface SpawnExecutorOptions {
+  /** Path to the heddle binary. Defaults to "heddle" (resolved on PATH). */
+  binaryPath?: string | undefined;
+  /** Default repo path applied when a request omits `repoPath`. */
+  repoPath?: string | undefined;
+  /** Working directory for the spawned process. */
+  cwd?: string | undefined;
+  /** Extra environment overlaid on `process.env`. */
+  env?: Record<string, string> | undefined;
+}
+
+/**
+ * Default executor: spawns `heddle <verb> --output json [...]` as a
+ * subprocess and captures stdout/stderr. Binary-bundling/resolution is
+ * out of scope (#584) — the caller supplies `binaryPath` or relies on PATH.
+ */
+export class SpawnExecutor implements Executor {
+  private readonly binaryPath: string;
+  private readonly repoPath: string | undefined;
+  private readonly cwd: string | undefined;
+  private readonly env: Record<string, string> | undefined;
+
+  constructor(options: SpawnExecutorOptions = {}) {
+    this.binaryPath = options.binaryPath ?? "heddle";
+    this.repoPath = options.repoPath;
+    this.cwd = options.cwd;
+    this.env = options.env;
+  }
+
+  exec(req: ExecRequest): Promise<ExecResult> {
+    const argv = this.buildArgv(req);
+    const spawnOptions: Parameters<typeof spawn>[2] = {
+      env: this.env ? { ...process.env, ...this.env } : process.env,
+    };
+    if (this.cwd !== undefined) spawnOptions.cwd = this.cwd;
+    if (req.signal !== undefined) spawnOptions.signal = req.signal;
+
+    return new Promise<ExecResult>((resolve, reject) => {
+      const child = spawn(this.binaryPath, argv, spawnOptions);
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
+      child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+      child.on("error", reject);
+      child.on("close", (code, signal) => {
+        resolve({
+          // A signal kill reports `code === null`; surface 128+signal-ish
+          // as a generic IO failure so callers still get a non-zero code.
+          exitCode: code ?? (signal ? 128 : 1),
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+        });
+      });
+    });
+  }
+
+  /** `[...verb tokens, --output json, -C <repo>?, --op-id <id>?, ...args]`. */
+  private buildArgv(req: ExecRequest): string[] {
+    const argv: string[] = [...req.verb.split(" "), "--output", "json"];
+    const repoPath = req.repoPath ?? this.repoPath;
+    if (repoPath !== undefined) argv.push("-C", repoPath);
+    if (req.opId !== undefined) argv.push("--op-id", req.opId);
+    argv.push(...req.args);
+    return argv;
+  }
+}

--- a/clients/npm/src/executor.ts
+++ b/clients/npm/src/executor.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
 
 /**
  * One CLI invocation, transport-neutral. The `verb` is the canonical
@@ -27,6 +28,21 @@ export interface ExecResult {
 }
 
 /**
+ * Thrown by {@link Executor.execStream} when a streaming invocation exits
+ * non-zero. Carries the same {@link ExecResult} shape (the accumulated
+ * stdout lines + stderr + code) so {@link Heddle.stream} can rebuild the
+ * usual {@link HeddleError}.
+ */
+export class ExecStreamError extends Error {
+  readonly result: ExecResult;
+  constructor(result: ExecResult) {
+    super(`heddle stream exited with code ${result.exitCode}`);
+    this.name = "ExecStreamError";
+    this.result = result;
+  }
+}
+
+/**
  * The transport seam. The default {@link SpawnExecutor} shells out to the
  * `heddle` binary, but a future napi or daemon backend (#586) can implement
  * this same interface and swap in with no change to `Heddle` call sites —
@@ -34,6 +50,17 @@ export interface ExecResult {
  */
 export interface Executor {
   exec(req: ExecRequest): Promise<ExecResult>;
+  /**
+   * Optional streaming transport for JSONL verbs. Yields each stdout line
+   * (newline stripped) as it arrives — without waiting for the process to
+   * exit — so {@link Heddle.stream} can drive indefinite verbs like
+   * `heddle watch` / `status --watch`. The iterator completes when the
+   * child's stdout closes; on a non-zero exit it throws
+   * {@link ExecStreamError}. Executors that can't stream (e.g. a buffered
+   * daemon backend) omit this; {@link Heddle.stream} falls back to
+   * {@link Executor.exec} and splits the buffered output.
+   */
+  execStream?(req: ExecRequest): AsyncIterable<string>;
 }
 
 export interface SpawnExecutorOptions {
@@ -90,6 +117,53 @@ export class SpawnExecutor implements Executor {
         });
       });
     });
+  }
+
+  async *execStream(req: ExecRequest): AsyncGenerator<string, void, unknown> {
+    const argv = this.buildArgv(req);
+    const spawnOptions: Parameters<typeof spawn>[2] = {
+      env: this.env ? { ...process.env, ...this.env } : process.env,
+    };
+    if (this.cwd !== undefined) spawnOptions.cwd = this.cwd;
+    if (req.signal !== undefined) spawnOptions.signal = req.signal;
+
+    const child = spawn(this.binaryPath, argv, spawnOptions);
+    const stderr: Buffer[] = [];
+    child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+    let spawnError: Error | undefined;
+    child.on("error", (err: Error) => {
+      spawnError = err;
+    });
+
+    const stdoutLines: string[] = [];
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+      // readline yields each line as it arrives on stdout — the loop
+      // produces values during the child's lifetime, not after exit.
+      for await (const line of rl) {
+        stdoutLines.push(line);
+        yield line;
+      }
+    }
+
+    const exitCode = await new Promise<number>((resolve) => {
+      const settle = (code: number | null, signal: NodeJS.Signals | null) =>
+        resolve(code ?? (signal ? 128 : 1));
+      if (child.exitCode !== null || child.signalCode !== null) {
+        settle(child.exitCode, child.signalCode);
+      } else {
+        child.once("close", settle);
+      }
+    });
+
+    if (spawnError) throw spawnError;
+    if (exitCode !== 0) {
+      throw new ExecStreamError({
+        exitCode,
+        stdout: stdoutLines.join("\n"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    }
   }
 
   /** `[...verb tokens, --output json, -C <repo>?, --op-id <id>?, ...args]`. */

--- a/clients/npm/src/heddle.ts
+++ b/clients/npm/src/heddle.ts
@@ -49,8 +49,11 @@ export interface RunOptions {
  */
 export class Heddle {
   private readonly executor: Executor;
+  /** Instance default repo path (`-C`), applied regardless of transport. */
+  private readonly repoPath: string | undefined;
 
   constructor(options: HeddleOptions = {}) {
+    this.repoPath = options.repoPath;
     if (options.executor) {
       this.executor = options.executor;
     } else {
@@ -77,7 +80,7 @@ export class Heddle {
       verb,
       args,
       opId: options.opId,
-      repoPath: options.repoPath,
+      repoPath: options.repoPath ?? this.repoPath,
       signal: options.signal,
     });
 

--- a/clients/npm/src/heddle.ts
+++ b/clients/npm/src/heddle.ts
@@ -8,7 +8,32 @@ import {
   type Executor,
   type ExecResult,
 } from "./executor.js";
-import { HeddleError } from "./errors.js";
+import { HeddleError, HeddleStreamingVerbError } from "./errors.js";
+
+/**
+ * Verbs that emit JSONL — one JSON object per line — instead of a single
+ * JSON payload. These carry `json_kind: "jsonl"` in the CLI command catalog
+ * (`heddle watch` streams live oplog activity; `harness-bridge` relays an
+ * event stream). A single `JSON.parse` of their stdout is always wrong, so
+ * {@link Heddle.run} refuses them — callers iterate {@link Heddle.stream}.
+ */
+export type HeddleStreamingVerb = Extract<
+  HeddleSchemaVerb,
+  "watch" | "harness-bridge"
+>;
+
+/** Runtime mirror of {@link HeddleStreamingVerb} for value-level checks. */
+export const HEDDLE_STREAMING_VERBS: readonly HeddleStreamingVerb[] = [
+  "watch",
+  "harness-bridge",
+];
+
+/** Any schema-backed verb that returns a single JSON payload via `run()`. */
+export type HeddleRunVerb = Exclude<HeddleSchemaVerb, HeddleStreamingVerb>;
+
+function isStreamingVerb(verb: string): verb is HeddleStreamingVerb {
+  return (HEDDLE_STREAMING_VERBS as readonly string[]).includes(verb);
+}
 
 export interface HeddleOptions {
   /** Path to the heddle binary. Defaults to "heddle" on PATH. Ignored if
@@ -67,15 +92,21 @@ export class Heddle {
   }
 
   /**
-   * Run any schema-backed verb and return its typed payload. Throws
-   * {@link HeddleError} on a non-zero exit, {@link HeddleError} on
-   * unparseable stdout.
+   * Run a single-payload schema-backed verb and return its typed payload.
+   * Throws {@link HeddleError} on a non-zero exit or unparseable stdout, and
+   * {@link HeddleStreamingVerbError} if given a JSONL/streaming verb (use
+   * {@link Heddle.stream} for those — the type already excludes them, but the
+   * runtime guard catches untyped JS callers).
    */
-  async run<V extends HeddleSchemaVerb>(
+  async run<V extends HeddleRunVerb>(
     verb: V,
     args: readonly string[] = [],
     options: RunOptions = {},
   ): Promise<HeddleVerbOutputs[V]> {
+    if (isStreamingVerb(verb)) {
+      throw new HeddleStreamingVerbError(verb);
+    }
+
     const result = await this.executor.exec({
       verb,
       args,
@@ -95,6 +126,55 @@ export class Heddle {
     }
 
     return parsePayload<V>(verb, result);
+  }
+
+  /**
+   * Drive a streaming (JSONL) verb and yield each line's typed payload. The
+   * default {@link SpawnExecutor} buffers the process output and resolves on
+   * exit, so this iterates the collected lines once the verb terminates (a
+   * snapshot `heddle watch`, `harness-bridge` relay, etc.); incremental
+   * line-by-line delivery awaits a streaming transport (#586). Throws
+   * {@link HeddleError} on a non-zero exit or an unparseable line.
+   */
+  async *stream<V extends HeddleStreamingVerb>(
+    verb: V,
+    args: readonly string[] = [],
+    options: RunOptions = {},
+  ): AsyncGenerator<HeddleVerbOutputs[V], void, unknown> {
+    const result = await this.executor.exec({
+      verb,
+      args,
+      opId: options.opId,
+      repoPath: options.repoPath ?? this.repoPath,
+      signal: options.signal,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new HeddleError({
+        verb,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        envelope: parseErrorEnvelope(result),
+      });
+    }
+
+    for (const line of result.stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let parsed: HeddleVerbOutputs[V];
+      try {
+        parsed = JSON.parse(trimmed) as HeddleVerbOutputs[V];
+      } catch {
+        throw new HeddleError({
+          verb,
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        });
+      }
+      yield parsed;
+    }
   }
 
   // ---- Harness ops (documented schemas, #581) ----------------------------
@@ -147,6 +227,11 @@ export class Heddle {
   /** `heddle bridge git export` — export to a git repo. Mutating. */
   export(args: readonly string[] = [], options: RunOptions = {}) {
     return this.run("bridge git export", args, options);
+  }
+
+  /** `heddle watch` — stream live oplog activity (JSONL). Read-only. */
+  watch(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.stream("watch", args, options);
   }
 }
 

--- a/clients/npm/src/heddle.ts
+++ b/clients/npm/src/heddle.ts
@@ -5,17 +5,19 @@ import type {
 } from "../generated/heddle-schemas.js";
 import {
   SpawnExecutor,
+  ExecStreamError,
   type Executor,
   type ExecResult,
 } from "./executor.js";
 import { HeddleError, HeddleStreamingVerbError } from "./errors.js";
 
 /**
- * Verbs that emit JSONL — one JSON object per line — instead of a single
- * JSON payload. These carry `json_kind: "jsonl"` in the CLI command catalog
- * (`heddle watch` streams live oplog activity; `harness-bridge` relays an
- * event stream). A single `JSON.parse` of their stdout is always wrong, so
- * {@link Heddle.run} refuses them — callers iterate {@link Heddle.stream}.
+ * Verbs that ALWAYS emit JSONL — one JSON object per line — instead of a
+ * single JSON payload. These carry `json_kind: "jsonl"` in the CLI command
+ * catalog (`heddle watch` streams live oplog activity; `harness-bridge`
+ * relays an event stream). A single `JSON.parse` of their stdout is always
+ * wrong, so {@link Heddle.run} refuses them outright — callers iterate
+ * {@link Heddle.stream}.
  */
 export type HeddleStreamingVerb = Extract<
   HeddleSchemaVerb,
@@ -28,11 +30,46 @@ export const HEDDLE_STREAMING_VERBS: readonly HeddleStreamingVerb[] = [
   "harness-bridge",
 ];
 
+/**
+ * Verbs that emit a single JSON payload by default but switch to a JSONL
+ * stream under a `--watch`-style flag. These carry `json_kind:
+ * "json_or_jsonl"` in the CLI command catalog (`status`, `thread show`,
+ * `workspace show` all gain a `--watch` live-refresh mode that prints one
+ * JSON snapshot per tick). {@link Heddle.run} accepts them in their default
+ * single-payload mode but refuses them when a watch flag is present, since
+ * the output then streams; {@link Heddle.stream} iterates the snapshots.
+ */
+export type HeddleWatchModeVerb = Extract<
+  HeddleSchemaVerb,
+  "status" | "thread show" | "workspace show"
+>;
+
+/** Runtime mirror of {@link HeddleWatchModeVerb} for value-level checks. */
+export const HEDDLE_WATCH_MODE_VERBS: readonly HeddleWatchModeVerb[] = [
+  "status",
+  "thread show",
+  "workspace show",
+];
+
+/** Flags that flip a {@link HeddleWatchModeVerb} into a JSONL stream. */
+export const HEDDLE_WATCH_FLAGS: readonly string[] = ["--watch"];
+
+/** Every JSONL-capable verb: always-streaming plus watch-mode streaming. */
+export type HeddleJsonlVerb = HeddleStreamingVerb | HeddleWatchModeVerb;
+
 /** Any schema-backed verb that returns a single JSON payload via `run()`. */
 export type HeddleRunVerb = Exclude<HeddleSchemaVerb, HeddleStreamingVerb>;
 
 function isStreamingVerb(verb: string): verb is HeddleStreamingVerb {
   return (HEDDLE_STREAMING_VERBS as readonly string[]).includes(verb);
+}
+
+function isWatchModeVerb(verb: string): verb is HeddleWatchModeVerb {
+  return (HEDDLE_WATCH_MODE_VERBS as readonly string[]).includes(verb);
+}
+
+function requestsWatchMode(args: readonly string[]): boolean {
+  return args.some((arg) => HEDDLE_WATCH_FLAGS.includes(arg));
 }
 
 export interface HeddleOptions {
@@ -94,9 +131,11 @@ export class Heddle {
   /**
    * Run a single-payload schema-backed verb and return its typed payload.
    * Throws {@link HeddleError} on a non-zero exit or unparseable stdout, and
-   * {@link HeddleStreamingVerbError} if given a JSONL/streaming verb (use
-   * {@link Heddle.stream} for those — the type already excludes them, but the
-   * runtime guard catches untyped JS callers).
+   * {@link HeddleStreamingVerbError} if given a JSONL/streaming verb — both
+   * the always-streaming verbs (the type already excludes them; the runtime
+   * guard catches untyped JS callers) and a {@link HeddleWatchModeVerb}
+   * invoked with a `--watch`-style flag, which makes its output stream. Use
+   * {@link Heddle.stream} for those.
    */
   async run<V extends HeddleRunVerb>(
     verb: V,
@@ -104,6 +143,9 @@ export class Heddle {
     options: RunOptions = {},
   ): Promise<HeddleVerbOutputs[V]> {
     if (isStreamingVerb(verb)) {
+      throw new HeddleStreamingVerbError(verb);
+    }
+    if (isWatchModeVerb(verb) && requestsWatchMode(args)) {
       throw new HeddleStreamingVerbError(verb);
     }
 
@@ -129,25 +171,53 @@ export class Heddle {
   }
 
   /**
-   * Drive a streaming (JSONL) verb and yield each line's typed payload. The
-   * default {@link SpawnExecutor} buffers the process output and resolves on
-   * exit, so this iterates the collected lines once the verb terminates (a
-   * snapshot `heddle watch`, `harness-bridge` relay, etc.); incremental
-   * line-by-line delivery awaits a streaming transport (#586). Throws
+   * Drive a JSONL verb and yield each line's typed payload AS IT ARRIVES.
+   * Streaming verbs like `heddle watch` or `status --watch` run
+   * indefinitely, so this must not wait for the process to exit before
+   * producing values. When the {@link Executor} supports streaming
+   * ({@link Executor.execStream}, as the default {@link SpawnExecutor}
+   * does), each stdout line is parsed and yielded the moment it lands; the
+   * iterator ends when the child's stdout closes. A buffered-only executor
+   * (e.g. a daemon backend that implements just {@link Executor.exec}) falls
+   * back to splitting the collected output once the verb terminates. Throws
    * {@link HeddleError} on a non-zero exit or an unparseable line.
    */
-  async *stream<V extends HeddleStreamingVerb>(
+  async *stream<V extends HeddleJsonlVerb>(
     verb: V,
     args: readonly string[] = [],
     options: RunOptions = {},
   ): AsyncGenerator<HeddleVerbOutputs[V], void, unknown> {
-    const result = await this.executor.exec({
+    const req = {
       verb,
       args,
       opId: options.opId,
       repoPath: options.repoPath ?? this.repoPath,
       signal: options.signal,
-    });
+    };
+
+    if (this.executor.execStream) {
+      try {
+        for await (const line of this.executor.execStream(req)) {
+          const trimmed = line.trim();
+          if (trimmed.length === 0) continue;
+          yield parseStreamLine<V>(verb, trimmed);
+        }
+      } catch (err) {
+        if (err instanceof ExecStreamError) {
+          throw new HeddleError({
+            verb,
+            exitCode: err.result.exitCode,
+            stdout: err.result.stdout,
+            stderr: err.result.stderr,
+            envelope: parseErrorEnvelope(err.result),
+          });
+        }
+        throw err;
+      }
+      return;
+    }
+
+    const result = await this.executor.exec(req);
 
     if (result.exitCode !== 0) {
       throw new HeddleError({
@@ -162,18 +232,7 @@ export class Heddle {
     for (const line of result.stdout.split("\n")) {
       const trimmed = line.trim();
       if (trimmed.length === 0) continue;
-      let parsed: HeddleVerbOutputs[V];
-      try {
-        parsed = JSON.parse(trimmed) as HeddleVerbOutputs[V];
-      } catch {
-        throw new HeddleError({
-          verb,
-          exitCode: result.exitCode,
-          stdout: result.stdout,
-          stderr: result.stderr,
-        });
-      }
-      yield parsed;
+      yield parseStreamLine<V>(verb, trimmed);
     }
   }
 
@@ -232,6 +291,23 @@ export class Heddle {
   /** `heddle watch` — stream live oplog activity (JSONL). Read-only. */
   watch(args: readonly string[] = [], options: RunOptions = {}) {
     return this.stream("watch", args, options);
+  }
+}
+
+/** Parse one JSONL line, wrapping a JSON error as a HeddleError. */
+function parseStreamLine<V extends HeddleSchemaVerb>(
+  verb: V,
+  trimmed: string,
+): HeddleVerbOutputs[V] {
+  try {
+    return JSON.parse(trimmed) as HeddleVerbOutputs[V];
+  } catch {
+    throw new HeddleError({
+      verb,
+      exitCode: 0,
+      stdout: trimmed,
+      stderr: "",
+    });
   }
 }
 

--- a/clients/npm/src/heddle.ts
+++ b/clients/npm/src/heddle.ts
@@ -1,0 +1,183 @@
+import type {
+  HeddleSchemaVerb,
+  HeddleVerbOutputs,
+  ErrorEnvelopeSchema,
+} from "../generated/heddle-schemas.js";
+import {
+  SpawnExecutor,
+  type Executor,
+  type ExecResult,
+} from "./executor.js";
+import { HeddleError } from "./errors.js";
+
+export interface HeddleOptions {
+  /** Path to the heddle binary. Defaults to "heddle" on PATH. Ignored if
+   *  a custom `executor` is supplied. */
+  binaryPath?: string | undefined;
+  /** Default repo path (`-C`) for every call; overridable per-call. */
+  repoPath?: string | undefined;
+  /** Working directory for spawned processes. */
+  cwd?: string | undefined;
+  /** Extra environment for spawned processes. */
+  env?: Record<string, string> | undefined;
+  /**
+   * Override the transport. Defaults to a {@link SpawnExecutor}. Supply a
+   * custom {@link Executor} (e.g. a napi/daemon backend, #586) to change
+   * how invocations are dispatched without touching call sites.
+   */
+  executor?: Executor;
+}
+
+/** Per-call options applied on top of the instance defaults. */
+export interface RunOptions {
+  /** `--op-id` for idempotent retries. Honored by mutating verbs. */
+  opId?: string | undefined;
+  /** Repo path (`-C`) for this call, overriding the instance default. */
+  repoPath?: string | undefined;
+  /** Cancel an in-flight invocation. */
+  signal?: AbortSignal | undefined;
+}
+
+/**
+ * Transport-agnostic TypeScript API over the heddle CLI's JSON contract.
+ *
+ * Each call drives `heddle <verb> --output json [...]` through an
+ * {@link Executor}, parses the stdout envelope, and returns the
+ * `HeddleVerbOutputs`-typed payload. Non-zero exits become a
+ * {@link HeddleError} carrying the parsed error envelope and a `retryable`
+ * flag (true only for sysexits 75 / TempFail).
+ */
+export class Heddle {
+  private readonly executor: Executor;
+
+  constructor(options: HeddleOptions = {}) {
+    if (options.executor) {
+      this.executor = options.executor;
+    } else {
+      this.executor = new SpawnExecutor({
+        binaryPath: options.binaryPath,
+        repoPath: options.repoPath,
+        cwd: options.cwd,
+        env: options.env,
+      });
+    }
+  }
+
+  /**
+   * Run any schema-backed verb and return its typed payload. Throws
+   * {@link HeddleError} on a non-zero exit, {@link HeddleError} on
+   * unparseable stdout.
+   */
+  async run<V extends HeddleSchemaVerb>(
+    verb: V,
+    args: readonly string[] = [],
+    options: RunOptions = {},
+  ): Promise<HeddleVerbOutputs[V]> {
+    const result = await this.executor.exec({
+      verb,
+      args,
+      opId: options.opId,
+      repoPath: options.repoPath,
+      signal: options.signal,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new HeddleError({
+        verb,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        envelope: parseErrorEnvelope(result),
+      });
+    }
+
+    return parsePayload<V>(verb, result);
+  }
+
+  // ---- Harness ops (documented schemas, #581) ----------------------------
+
+  /** `heddle adopt` — bring an existing repo under heddle. Mutating. */
+  adopt(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("adopt", args, options);
+  }
+
+  /** `heddle init` — initialize a new heddle repo. Mutating. */
+  init(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("init", args, options);
+  }
+
+  /** `heddle status` — working-state snapshot. Read-only. */
+  status(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("status", args, options);
+  }
+
+  /** `heddle start` — start a thread/attempt. Mutating. */
+  start(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("start", args, options);
+  }
+
+  /** `heddle commit` — capture working changes. Mutating. */
+  commit(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("commit", args, options);
+  }
+
+  /** `heddle log` — history. Read-only. */
+  log(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("log", args, options);
+  }
+
+  /** `heddle diff` — working/range diff. Read-only. */
+  diff(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("diff", args, options);
+  }
+
+  /** `heddle fetch` — fetch objects/refs from a remote. Mutating. */
+  fetch(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("fetch", args, options);
+  }
+
+  /** `heddle push` — push to a remote. Mutating. */
+  push(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("push", args, options);
+  }
+
+  /** `heddle bridge git export` — export to a git repo. Mutating. */
+  export(args: readonly string[] = [], options: RunOptions = {}) {
+    return this.run("bridge git export", args, options);
+  }
+}
+
+/** Parse a success payload, wrapping JSON errors as a HeddleError. */
+function parsePayload<V extends HeddleSchemaVerb>(
+  verb: V,
+  result: ExecResult,
+): HeddleVerbOutputs[V] {
+  try {
+    return JSON.parse(result.stdout) as HeddleVerbOutputs[V];
+  } catch {
+    throw new HeddleError({
+      verb,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  }
+}
+
+/**
+ * The CLI emits its JSON error envelope on STDERR in `--output json` mode
+ * (success payloads go to stdout). Best-effort parse; undefined if the
+ * stderr wasn't a JSON envelope (e.g. a panic or clap usage error).
+ */
+function parseErrorEnvelope(result: ExecResult): ErrorEnvelopeSchema | undefined {
+  const text = result.stderr.trim();
+  if (!text) return undefined;
+  try {
+    const parsed = JSON.parse(text) as ErrorEnvelopeSchema;
+    return typeof parsed === "object" && parsed !== null && "exit_code" in parsed
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/clients/npm/src/index.ts
+++ b/clients/npm/src/index.ts
@@ -1,5 +1,10 @@
-export { Heddle } from "./heddle.js";
-export type { HeddleOptions, RunOptions } from "./heddle.js";
+export { Heddle, HEDDLE_STREAMING_VERBS } from "./heddle.js";
+export type {
+  HeddleOptions,
+  RunOptions,
+  HeddleStreamingVerb,
+  HeddleRunVerb,
+} from "./heddle.js";
 export {
   SpawnExecutor,
   type Executor,
@@ -9,6 +14,7 @@ export {
 } from "./executor.js";
 export {
   HeddleError,
+  HeddleStreamingVerbError,
   HeddleExitCode,
   RETRYABLE_EXIT_CODE,
   type HeddleExitCodeName,

--- a/clients/npm/src/index.ts
+++ b/clients/npm/src/index.ts
@@ -1,0 +1,19 @@
+export { Heddle } from "./heddle.js";
+export type { HeddleOptions, RunOptions } from "./heddle.js";
+export {
+  SpawnExecutor,
+  type Executor,
+  type ExecRequest,
+  type ExecResult,
+  type SpawnExecutorOptions,
+} from "./executor.js";
+export {
+  HeddleError,
+  HeddleExitCode,
+  RETRYABLE_EXIT_CODE,
+  type HeddleExitCodeName,
+} from "./errors.js";
+
+// Re-export the generated contract so callers can `import { Heddle, type
+// StatusSchema } from "@heddle/cli"` without reaching into generated/.
+export * from "../generated/heddle-schemas.js";

--- a/clients/npm/src/index.ts
+++ b/clients/npm/src/index.ts
@@ -1,12 +1,20 @@
-export { Heddle, HEDDLE_STREAMING_VERBS } from "./heddle.js";
+export {
+  Heddle,
+  HEDDLE_STREAMING_VERBS,
+  HEDDLE_WATCH_MODE_VERBS,
+  HEDDLE_WATCH_FLAGS,
+} from "./heddle.js";
 export type {
   HeddleOptions,
   RunOptions,
   HeddleStreamingVerb,
+  HeddleWatchModeVerb,
+  HeddleJsonlVerb,
   HeddleRunVerb,
 } from "./heddle.js";
 export {
   SpawnExecutor,
+  ExecStreamError,
   type Executor,
   type ExecRequest,
   type ExecResult,

--- a/clients/npm/test/heddle.test.ts
+++ b/clients/npm/test/heddle.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { Heddle, HeddleError, HeddleStreamingVerbError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
+import { Heddle, HeddleError, HeddleStreamingVerbError, ExecStreamError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
 import type { StatusSchema, WatchLineSchema } from "../generated/heddle-schemas.js";
 
 /** A deterministic in-memory executor — proves the parsing/error seam works
@@ -146,6 +146,108 @@ test("stream() maps a non-zero exit to a HeddleError", async () => {
       return true;
     },
   );
+});
+
+test("stream() yields lines incrementally before the process exits", async () => {
+  // A streaming executor that emits the first line, then BLOCKS — modelling
+  // a still-running `watch` / `status --watch` that has not exited. If
+  // stream() awaited process exit (the old P1 bug) the first `next()` would
+  // never resolve. We assert line 1 arrives while the source is still open,
+  // then release it for the rest.
+  let releaseSecond!: () => void;
+  const secondGate = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+  class StreamingExecutor implements Executor {
+    lastRequest: ExecRequest | undefined;
+    exec(): Promise<ExecResult> {
+      return Promise.reject(new Error("streaming verb must use execStream"));
+    }
+    async *execStream(req: ExecRequest): AsyncGenerator<string> {
+      this.lastRequest = req;
+      yield JSON.stringify({ id: 1, kind: "capture", ts: "t1" });
+      await secondGate; // process stays open — no exit yet
+      yield JSON.stringify({ id: 2, kind: "commit", ts: "t2" });
+    }
+  }
+  const fake = new StreamingExecutor();
+  const heddle = new Heddle({ executor: fake });
+  const iter = heddle.watch()[Symbol.asyncIterator]();
+
+  const first = await iter.next();
+  assert.equal(first.done, false);
+  assert.equal((first.value as WatchLineSchema).id, 1);
+
+  releaseSecond();
+  const second = await iter.next();
+  assert.equal((second.value as WatchLineSchema).id, 2);
+
+  const end = await iter.next();
+  assert.equal(end.done, true);
+  assert.equal(fake.lastRequest?.verb, "watch");
+});
+
+test("stream() over a watch-mode verb maps a non-zero exit via ExecStreamError", async () => {
+  class FailingStreamExecutor implements Executor {
+    exec(): Promise<ExecResult> {
+      return Promise.reject(new Error("should use execStream"));
+    }
+    async *execStream(): AsyncGenerator<string> {
+      yield JSON.stringify({ output_kind: "status" });
+      throw new ExecStreamError({
+        exitCode: 74,
+        stdout: "",
+        stderr: JSON.stringify({ code: "io", error: "watch failed", exit_code: 74, hint: "", kind: "io" }),
+      });
+    }
+  }
+  const heddle = new Heddle({ executor: new FailingStreamExecutor() });
+  await assert.rejects(
+    async () => {
+      for await (const _ of heddle.stream("status", ["--watch"])) void _;
+    },
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.exitCode, 74);
+      assert.equal(err.code, "io");
+      return true;
+    },
+  );
+});
+
+test("run() rejects every jsonl-capable verb", async () => {
+  const heddle = new Heddle({
+    executor: new FakeExecutor({ exitCode: 0, stdout: "{}", stderr: "" }),
+  });
+  const call = heddle.run as (verb: string, args?: readonly string[]) => Promise<unknown>;
+
+  // Always-streaming verbs (json_kind "jsonl") are refused unconditionally.
+  for (const verb of ["watch", "harness-bridge"]) {
+    await assert.rejects(() => call(verb), (err: unknown) => {
+      assert.ok(err instanceof HeddleStreamingVerbError);
+      assert.equal(err.verb, verb);
+      return true;
+    });
+  }
+
+  // Watch-mode verbs (json_kind "json_or_jsonl") are refused ONLY when a
+  // watch flag flips them into a stream.
+  for (const verb of ["status", "thread show", "workspace show"]) {
+    await assert.rejects(() => call(verb, ["--watch"]), (err: unknown) => {
+      assert.ok(err instanceof HeddleStreamingVerbError);
+      assert.equal(err.verb, verb);
+      return true;
+    });
+  }
+});
+
+test("run() still accepts a watch-mode verb in single-payload mode", async () => {
+  const fake = new FakeExecutor({ exitCode: 0, stdout: JSON.stringify(STATUS_JSON), stderr: "" });
+  const heddle = new Heddle({ executor: fake });
+  // No --watch → a single JSON payload, parsed normally.
+  const status = await heddle.run("status");
+  assert.equal((status as StatusSchema).output_kind, "status");
+  assert.equal(fake.lastRequest?.verb, "status");
 });
 
 test("real-binary smoke test", { skip: !process.env["HEDDLE_BIN"] }, async () => {

--- a/clients/npm/test/heddle.test.ts
+++ b/clients/npm/test/heddle.test.ts
@@ -39,6 +39,16 @@ test("threads --op-id through the executor for mutating verbs", async () => {
   assert.deepEqual(fake.lastRequest?.args, ["-m", "msg"]);
 });
 
+test("applies the instance default repoPath through a custom executor", async () => {
+  const fake = new FakeExecutor({ exitCode: 0, stdout: JSON.stringify(STATUS_JSON), stderr: "" });
+  const heddle = new Heddle({ executor: fake, repoPath: "/repos/demo" });
+  await heddle.status();
+  assert.equal(fake.lastRequest?.repoPath, "/repos/demo");
+  // A per-call repoPath still overrides the instance default.
+  await heddle.status([], { repoPath: "/repos/other" });
+  assert.equal(fake.lastRequest?.repoPath, "/repos/other");
+});
+
 test("maps a non-zero exit to a HeddleError with parsed envelope", async () => {
   const envelope = {
     code: "no_remote",

--- a/clients/npm/test/heddle.test.ts
+++ b/clients/npm/test/heddle.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Heddle, HeddleError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
+import type { StatusSchema } from "../generated/heddle-schemas.js";
+
+/** A deterministic in-memory executor — proves the parsing/error seam works
+ *  without building or spawning the real binary. The real-binary smoke test
+ *  is gated below on HEDDLE_BIN and the npm CI matrix lands in #584. */
+class FakeExecutor implements Executor {
+  lastRequest: ExecRequest | undefined;
+  constructor(private readonly canned: ExecResult) {}
+  exec(req: ExecRequest): Promise<ExecResult> {
+    this.lastRequest = req;
+    return Promise.resolve(this.canned);
+  }
+}
+
+const STATUS_JSON: StatusSchema = {
+  branch: "main",
+  output_kind: "status",
+} as unknown as StatusSchema;
+
+test("parses a success payload into the typed shape", async () => {
+  const fake = new FakeExecutor({ exitCode: 0, stdout: JSON.stringify(STATUS_JSON), stderr: "" });
+  const heddle = new Heddle({ executor: fake });
+  const status = await heddle.status();
+  assert.equal((status as StatusSchema).output_kind, "status");
+  assert.equal(fake.lastRequest?.verb, "status");
+  // The executor receives the canonical verb; SpawnExecutor injects
+  // `--output json`. Here we just assert the seam carried the verb through.
+  assert.deepEqual(fake.lastRequest?.args, []);
+});
+
+test("threads --op-id through the executor for mutating verbs", async () => {
+  const fake = new FakeExecutor({ exitCode: 0, stdout: "{}", stderr: "" });
+  const heddle = new Heddle({ executor: fake });
+  await heddle.commit(["-m", "msg"], { opId: "op-123" });
+  assert.equal(fake.lastRequest?.opId, "op-123");
+  assert.deepEqual(fake.lastRequest?.args, ["-m", "msg"]);
+});
+
+test("maps a non-zero exit to a HeddleError with parsed envelope", async () => {
+  const envelope = {
+    code: "no_remote",
+    error: "no default remote configured",
+    exit_code: 78,
+    hint: "set a remote",
+    kind: "no_remote",
+  };
+  const fake = new FakeExecutor({ exitCode: 78, stdout: "", stderr: JSON.stringify(envelope) });
+  const heddle = new Heddle({ executor: fake });
+  await assert.rejects(
+    () => heddle.push(),
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.exitCode, 78);
+      assert.equal(err.code, "no_remote");
+      assert.equal(err.retryable, false);
+      assert.equal(err.message, "no default remote configured");
+      return true;
+    },
+  );
+});
+
+test("flags exit 75 (TempFail) as retryable", async () => {
+  const fake = new FakeExecutor({
+    exitCode: 75,
+    stdout: "",
+    stderr: JSON.stringify({ code: "transient", error: "try again", exit_code: 75, hint: "", kind: "transient" }),
+  });
+  const heddle = new Heddle({ executor: fake });
+  await assert.rejects(
+    () => heddle.fetch(),
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.retryable, true);
+      return true;
+    },
+  );
+});
+
+test("real-binary smoke test", { skip: !process.env["HEDDLE_BIN"] }, async () => {
+  const heddle = new Heddle({ binaryPath: process.env["HEDDLE_BIN"] });
+  // `schemas` is read-only and works outside a repo: a stable known verb.
+  const schemas = await heddle.run("schemas");
+  assert.ok(schemas, "schemas payload should parse");
+});

--- a/clients/npm/test/heddle.test.ts
+++ b/clients/npm/test/heddle.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { Heddle, HeddleError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
-import type { StatusSchema } from "../generated/heddle-schemas.js";
+import { Heddle, HeddleError, HeddleStreamingVerbError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
+import type { StatusSchema, WatchLineSchema } from "../generated/heddle-schemas.js";
 
 /** A deterministic in-memory executor — proves the parsing/error seam works
  *  without building or spawning the real binary. The real-binary smoke test
@@ -84,6 +84,65 @@ test("flags exit 75 (TempFail) as retryable", async () => {
     (err: unknown) => {
       assert.ok(err instanceof HeddleError);
       assert.equal(err.retryable, true);
+      return true;
+    },
+  );
+});
+
+test("run() refuses a streaming (JSONL) verb instead of mis-parsing it", async () => {
+  // `watch` emits JSONL — multiple objects, one per line. A single
+  // JSON.parse of this would throw or silently keep only the first object.
+  const jsonl = [
+    JSON.stringify({ id: 1, kind: "capture", ts: "t1" }),
+    JSON.stringify({ id: 2, kind: "commit", ts: "t2" }),
+  ].join("\n");
+  const fake = new FakeExecutor({ exitCode: 0, stdout: jsonl, stderr: "" });
+  const heddle = new Heddle({ executor: fake });
+  await assert.rejects(
+    // A typed caller is blocked at compile time; the cast exercises the
+    // runtime guard that protects untyped JS callers.
+    () => (heddle.run as (verb: string) => Promise<unknown>)("watch"),
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleStreamingVerbError);
+      assert.equal(err.verb, "watch");
+      // The executor must not even be invoked for a streaming verb on run().
+      assert.equal(fake.lastRequest, undefined);
+      return true;
+    },
+  );
+});
+
+test("stream() parses a JSONL verb line by line", async () => {
+  const lines: WatchLineSchema[] = [
+    { id: 1, kind: "capture", ts: "t1" },
+    { id: 2, kind: "commit", ts: "t2" },
+  ];
+  const fake = new FakeExecutor({
+    exitCode: 0,
+    stdout: lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    stderr: "",
+  });
+  const heddle = new Heddle({ executor: fake });
+  const collected: WatchLineSchema[] = [];
+  for await (const line of heddle.watch()) collected.push(line);
+  assert.deepEqual(collected, lines);
+  assert.equal(fake.lastRequest?.verb, "watch");
+});
+
+test("stream() maps a non-zero exit to a HeddleError", async () => {
+  const fake = new FakeExecutor({
+    exitCode: 74,
+    stdout: "",
+    stderr: JSON.stringify({ code: "io", error: "stream failed", exit_code: 74, hint: "", kind: "io" }),
+  });
+  const heddle = new Heddle({ executor: fake });
+  await assert.rejects(
+    async () => {
+      for await (const _ of heddle.watch()) void _;
+    },
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.exitCode, 74);
       return true;
     },
   );

--- a/clients/npm/tsconfig.json
+++ b/clients/npm/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "test", "examples", "generated"]
+}


### PR DESCRIPTION
From spike #580. Adds a transport-agnostic TypeScript `Heddle` class in `clients/npm/` that drives the heddle CLI over its JSON contract. **TS-only — no Rust changes.** Reuses the generated types from #581.

## What it does
- **`Heddle` class** spawns `heddle <verb> --output json [...]`, captures stdout, `JSON.parse`s it, and returns the `HeddleVerbOutputs[verb]`-typed payload. Generic `run(verb, args, opts)` + convenience methods for the harness ops (`adopt`, `init`, `status`, `start`, `commit`, `log`, `diff`, `fetch`, `push`, `export` → `bridge git export`).
- **Exit-code handling** per the sysexits contract: non-zero exit → typed `HeddleError` carrying the parsed error envelope (parsed off **stderr**, where the CLI emits it in JSON mode), `code`, `exitCode`, raw streams, and a `retryable` flag that is true **only** for exit 75 (TempFail).
- **`--op-id` threading**: per-call `opId` option → `--op-id` for idempotent retries on mutating verbs.
- **Transport-agnostic `Executor` seam**: dispatch goes through an `Executor` interface; default `SpawnExecutor` shells out to the binary. A future napi/daemon backend (#586) implements the same interface and swaps in via `new Heddle({ executor })` with no call-site changes.
- `binaryPath` is caller-supplied (binary bundling is #584); falls back to `"heddle"` on PATH.
- README usage section.

## Gates / tests
- `npm run typecheck` (`tsc --noEmit`, strict + `exactOptionalPropertyTypes`) — clean against the generated types.
- `npm test` — `node --test` smoke suite with a deterministic fake `Executor` (payload parse, `--op-id` threading, exit→`HeddleError` mapping, 75=retryable). A real-binary test runs when `HEDDLE_BIN` is set — exercised locally against a debug `heddle` build: `schemas` parses, 5/5 pass.

## Deferred (not this PR)
- **heddle CI has no TypeScript gate yet** — wiring the npm typecheck/test/publish matrix is owned by **#584**. No CI workflow added here.
- Binary bundling / `optionalDependencies` / asar (#584); napi backend (#586); sandbox alignment (#585).

Closes #583.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783444519&installation_id=132405951&pr_number=592&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F592&signature=7ea9bdb7a160146529de0c102689bbf801abeb3d83430b4ee0510475ae78ac86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->