### PR TITLE
harden(daemon): wire SO_PEERCRED peer-identity enforcement into serve (#517)

### DIFF
--- a/crates/daemon/src/local_daemon.rs
+++ b/crates/daemon/src/local_daemon.rs
@@ -495,4 +495,53 @@ mod tests {
         // can't verify the file is ours.
         assert!(PidFileContents::parse("12345").is_none());
     }
+
+    #[test]
+    fn enforce_peer_uid_admits_matching_uid() {
+        // The everyday case: the CLI and the daemon run as the same user,
+        // so the peer's uid equals the daemon's. The gate must admit it.
+        assert!(enforce_peer_uid(1000, 1000).is_ok());
+    }
+
+    #[test]
+    fn enforce_peer_uid_rejects_mismatched_uid() {
+        // A connection from a different uid (only reachable if the socket's
+        // mode 0600 were somehow widened) must be refused with a Conflict.
+        let err = enforce_peer_uid(1001, 1000).unwrap_err();
+        assert!(
+            matches!(err, HeddleError::Conflict(_)),
+            "mismatched peer uid must be a Conflict, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn guard_propagates_listener_io_errors() {
+        // Listener-level accept() errors must reach tonic unchanged — the
+        // peer-cred gate only drops mismatched peers, it never swallows
+        // I/O errors that tonic's own error handling should see.
+        let io_err = std::io::Error::other("accept failed");
+        let out = guard_peer_connection(Err(io_err));
+        assert!(matches!(out, Some(Err(_))), "io errors must propagate");
+    }
+
+    #[tokio::test]
+    async fn guard_admits_same_process_peer() {
+        // Both ends of a socketpair share this process's uid, so the gate
+        // must admit the connection — proving the serve-path filter does
+        // not reject the everyday same-user CLI connection.
+        let (peer, _local) = tokio::net::UnixStream::pair().expect("socketpair");
+        let out = guard_peer_connection(Ok(peer));
+        assert!(
+            matches!(out, Some(Ok(_))),
+            "a same-uid peer must be admitted by the gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_peer_uid_matches_self_admits_socketpair() {
+        // Direct check on a real UnixStream: same-process socketpair ends
+        // share our uid, so the SO_PEERCRED / getpeereid comparison passes.
+        let (peer, _local) = tokio::net::UnixStream::pair().expect("socketpair");
+        assert!(check_peer_uid_matches_self(&peer).is_ok());
+    }
 }

--- a/crates/daemon/src/local_daemon.rs
+++ b/crates/daemon/src/local_daemon.rs
@@ -41,7 +41,7 @@ use grpc::{
 use objects::error::{HeddleError, Result};
 use repo::{Repository, operation_dedup::OperationDedupStore};
 use tokio::net::UnixListener;
-use tokio_stream::wrappers::UnixListenerStream;
+use tokio_stream::{StreamExt, wrappers::UnixListenerStream};
 use tonic::transport::Server;
 
 use crate::grpc_local_impl::{
@@ -337,7 +337,12 @@ pub async fn serve(
     let transaction = TransactionServiceServer::new(LocalTransactionService::new(inner.clone()));
     let hook = HookServiceServer::new(LocalHookService::new(inner));
 
-    let incoming = UnixListenerStream::new(listener);
+    // Per-connection SO_PEERCRED gate. Mode 0600 already keeps other users
+    // from opening the socket; this filter is the defense-in-depth layer
+    // the module docs promise — every accepted connection is checked
+    // against the daemon's uid (and dropped on mismatch) before tonic ever
+    // sees it.
+    let incoming = UnixListenerStream::new(listener).filter_map(guard_peer_connection);
 
     Server::builder()
         .add_service(state_review)
@@ -360,25 +365,56 @@ fn set_socket_mode_0600(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Verify that a connecting peer's UID matches our own. Called by tonic's
-/// connection acceptor *if* the local-impl decides to enforce per-connection
-/// peer credentials. For first ship we rely on the socket file's mode 0600
-/// to keep other users out, which is the standard Unix posture for a
-/// single-user daemon. This helper is exported so a future hardening pass
-/// can wire it into a tonic interceptor without rewriting the daemon.
+/// Verify that a connecting peer's UID matches the daemon's own. Wired
+/// into the [`serve`] accept path via [`guard_peer_connection`]: every UDS
+/// connection passes through this check before tonic handles it. The
+/// socket's mode 0600 already keeps other users from opening it; this
+/// SO_PEERCRED check (`getpeereid` on macOS) is the defense-in-depth layer
+/// that enforces the same-user boundary per-connection even if the socket
+/// permissions were somehow widened.
 pub fn check_peer_uid_matches_self(stream: &tokio::net::UnixStream) -> Result<()> {
     let creds = stream
         .peer_cred()
         .map_err(|e| HeddleError::InvalidObject(format!("peer_cred failed: {e}")))?;
-    // SAFETY: getuid() never fails.
+    // SAFETY: geteuid() never fails.
     let our_uid = unsafe { libc::geteuid() };
-    if creds.uid() != our_uid {
+    enforce_peer_uid(creds.uid(), our_uid)
+}
+
+/// Compare a peer's UID against the daemon's effective UID, erroring when
+/// they differ. Split out from [`check_peer_uid_matches_self`] so the
+/// accept/reject decision is unit-testable without a real cross-UID
+/// connection (which would need root or a second user).
+fn enforce_peer_uid(peer_uid: u32, our_uid: u32) -> Result<()> {
+    if peer_uid != our_uid {
         return Err(HeddleError::Conflict(format!(
-            "peer uid {} does not match daemon uid {our_uid}",
-            creds.uid()
+            "peer uid {peer_uid} does not match daemon uid {our_uid}"
         )));
     }
     Ok(())
+}
+
+/// Per-connection gate applied to the [`serve`] accept stream. Each
+/// accepted UDS connection is checked with [`check_peer_uid_matches_self`];
+/// a peer whose UID doesn't match the daemon's is dropped here (its
+/// `UnixStream` is closed) and never handed to tonic. Listener-level I/O
+/// errors pass through unchanged so tonic's own error handling still runs.
+fn guard_peer_connection(
+    conn: std::io::Result<tokio::net::UnixStream>,
+) -> Option<std::io::Result<tokio::net::UnixStream>> {
+    match conn {
+        Ok(stream) => match check_peer_uid_matches_self(&stream) {
+            Ok(()) => Some(Ok(stream)),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "local-daemon: rejecting connection from peer with mismatched uid"
+                );
+                None
+            }
+        },
+        Err(e) => Some(Err(e)),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- The local gRPC daemon's module/lib docs and `heddle agent serve --help` claimed `SO_PEERCRED` (`getpeereid` on macOS) peer-identity enforcement, but `check_peer_uid_matches_self` was **dead code** — `serve` fed the raw `UnixListenerStream` straight to tonic, so the only real protection was the socket's mode `0600`. The documented same-user guarantee and the user-facing "peer-credential checks are enforced" help line were therefore **false**.
- Wires the check in as defense-in-depth on top of mode `0600`: a single per-connection chokepoint (`guard_peer_connection`) that the serve stream routes every accepted connection through via `filter_map`. Mismatched-uid peers are dropped (connection closed, never handed to tonic) with a warn log; listener-level I/O errors pass through unchanged.
- Splits the accept/reject decision into a pure `enforce_peer_uid(peer_uid, our_uid)` so the reject path is unit-testable without root or a second user; `check_peer_uid_matches_self` now delegates to it, and its stale "exported for a future hardening pass" doc is corrected.
- Scope: one file, `crates/daemon/src/local_daemon.rs`. The previously-false `--help`/module docs are now true, so no doc-weakening was needed.

Closes HeddleCo/heddle#517

## Red commit
`98e64a52`

## Test evidence
```
$ cargo test --locked -p heddle-daemon --lib
test local_daemon::tests::check_peer_uid_matches_self_admits_socketpair ... ok
test local_daemon::tests::enforce_peer_uid_admits_matching_uid ... ok
test local_daemon::tests::enforce_peer_uid_rejects_mismatched_uid ... ok
test local_daemon::tests::guard_admits_same_process_peer ... ok
test local_daemon::tests::guard_propagates_listener_io_errors ... ok
...
test result: ok. 74 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.34s
```
Local CI-parity gates (all clean):
```
cargo build --locked --workspace --tests          # BUILD_EXIT=0 (default features)
cargo clippy --locked --workspace --all-targets -- -D warnings   # CLIPPY_EXIT=0
```

The mismatched-uid **reject** path is covered at the unit level (`enforce_peer_uid_rejects_mismatched_uid`) because a real cross-UID UDS connection needs root or a second user, which CI has neither; the same-uid **admit** path is covered with a real `UnixStream::pair()` socketpair through both the helper and the `guard_peer_connection` gate.

## Manual verification
N/A — covered by tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783649397&installation_id=132405951&pr_number=626&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F626&signature=9a20e712f240fe1b8290be148d4ba544ce5e7ee62c60886b69ed98105c99c34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->