### PR TITLE
harden(review): validate host/scheme/port on GitHub Link-header pagination (#521)

### DIFF
--- a/crates/review/src/github/auth.rs
+++ b/crates/review/src/github/auth.rs
@@ -53,6 +53,10 @@ impl GitHubAuthClient {
         Ok(Self {
             http: reqwest::Client::builder()
                 .user_agent("heddle-review")
+                // Mirror the REST client: never follow redirects, so a
+                // server-controlled `Location` can't steer auth traffic
+                // off-origin (SSRF, #521).
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .map_err(|err| ReviewError::Github(err.to_string()))?,
             app_id,

--- a/crates/review/src/github/rest.rs
+++ b/crates/review/src/github/rest.rs
@@ -404,7 +404,11 @@ impl GitHubRestClient {
                 .await
                 .map_err(|err| ReviewError::Serialization(err.to_string()))?;
             items.extend(page);
-            url = next_page_url(link_header.as_deref())?;
+            let next = next_page_url(link_header.as_deref())?;
+            if let Some(candidate) = next.as_deref() {
+                validate_pagination_origin(&self.api_base_url, candidate)?;
+            }
+            url = next;
         }
 
         Ok(items)
@@ -445,6 +449,14 @@ fn parse_next_link(link: &str) -> Result<Option<String>> {
         }
     }
     Ok(next)
+}
+
+/// Reject a server-provided pagination URL whose origin (scheme + host + port)
+/// differs from the configured API base. GitHub's `Link` header is
+/// server-controlled; without this check a spoofed or compromised endpoint
+/// could point pagination at an internal address (SSRF-adjacent, #521).
+fn validate_pagination_origin(_base: &str, _candidate: &str) -> Result<()> {
+    Ok(())
 }
 
 fn is_agent_author(name: &str, email: &str) -> bool {
@@ -698,6 +710,61 @@ mod tests {
         assert!(err.to_string().contains("malformed Link header"));
     }
 
+    #[test]
+    fn validate_pagination_origin_accepts_same_origin() {
+        validate_pagination_origin(
+            "https://api.github.com",
+            "https://api.github.com/repositories/1/pulls?per_page=100&page=2",
+        )
+        .expect("same-origin pagination URL must be accepted");
+    }
+
+    #[test]
+    fn validate_pagination_origin_accepts_explicit_default_port() {
+        validate_pagination_origin(
+            "https://api.github.com",
+            "https://api.github.com:443/resource?page=2",
+        )
+        .expect("an explicit default port is the same origin as the implicit one");
+    }
+
+    #[test]
+    fn validate_pagination_origin_rejects_foreign_host() {
+        let err = validate_pagination_origin(
+            "https://api.github.com",
+            "https://169.254.169.254/resource?page=2",
+        )
+        .expect_err("a foreign host must be rejected");
+        assert!(err.to_string().contains("unexpected origin"));
+    }
+
+    #[test]
+    fn validate_pagination_origin_rejects_scheme_downgrade() {
+        let err = validate_pagination_origin(
+            "https://api.github.com",
+            "http://api.github.com/resource?page=2",
+        )
+        .expect_err("a scheme downgrade must be rejected");
+        assert!(err.to_string().contains("unexpected origin"));
+    }
+
+    #[test]
+    fn validate_pagination_origin_rejects_foreign_port() {
+        let err = validate_pagination_origin(
+            "https://api.github.com",
+            "https://api.github.com:8443/resource?page=2",
+        )
+        .expect_err("a foreign port must be rejected");
+        assert!(err.to_string().contains("unexpected origin"));
+    }
+
+    #[test]
+    fn validate_pagination_origin_rejects_unparseable_candidate() {
+        let err = validate_pagination_origin("https://api.github.com", "not a url")
+            .expect_err("an unparseable pagination URL must be rejected");
+        assert!(err.to_string().contains("malformed pagination URL"));
+    }
+
     #[tokio::test]
     async fn fetch_pull_request_accepts_complete_data() {
         let base_url = spawn_server(|_| {
@@ -848,6 +915,30 @@ mod tests {
             .await
             .expect_err("malformed Link header must not return a partial file list");
         assert!(err.to_string().contains("malformed Link header"));
+    }
+
+    #[tokio::test]
+    async fn fetch_files_rejects_cross_origin_pagination_url() {
+        let base_url = spawn_server(|_| {
+            // Same host, but a port nothing answers on — a stand-in for an
+            // attacker-controlled `next` redirecting pagination off-origin
+            // (e.g. at a cloud metadata endpoint). Validation must refuse it
+            // before any request is issued, so the error is an origin
+            // rejection rather than a connection failure.
+            vec![MockResponse::json(200, file_page(0, GITHUB_PER_PAGE)).with_header(
+                "Link",
+                "<http://127.0.0.1:1/repos/heddle/repo/pulls/439/files?per_page=100&page=2>; rel=\"next\"",
+            )]
+        })
+        .await;
+        let err = client_for(&base_url)
+            .fetch_files(&review_key(), None)
+            .await
+            .expect_err("cross-origin pagination URL must be rejected");
+        assert!(
+            err.to_string().contains("unexpected origin"),
+            "expected an origin-rejection error, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/review/src/github/rest.rs
+++ b/crates/review/src/github/rest.rs
@@ -455,7 +455,21 @@ fn parse_next_link(link: &str) -> Result<Option<String>> {
 /// differs from the configured API base. GitHub's `Link` header is
 /// server-controlled; without this check a spoofed or compromised endpoint
 /// could point pagination at an internal address (SSRF-adjacent, #521).
-fn validate_pagination_origin(_base: &str, _candidate: &str) -> Result<()> {
+fn validate_pagination_origin(base: &str, candidate: &str) -> Result<()> {
+    let base_url = reqwest::Url::parse(base)
+        .map_err(|err| ReviewError::Github(format!("invalid API base URL `{base}`: {err}")))?;
+    let next_url = reqwest::Url::parse(candidate).map_err(|err| {
+        ReviewError::Github(format!("malformed pagination URL `{candidate}`: {err}"))
+    })?;
+    let same_origin = next_url.scheme() == base_url.scheme()
+        && next_url.host_str() == base_url.host_str()
+        && next_url.port_or_known_default() == base_url.port_or_known_default();
+    if !same_origin {
+        return Err(ReviewError::Github(format!(
+            "refusing to follow pagination URL to unexpected origin `{candidate}` \
+             (expected the origin of `{base}`)"
+        )));
+    }
     Ok(())
 }
 

--- a/crates/review/src/github/rest.rs
+++ b/crates/review/src/github/rest.rs
@@ -126,6 +126,11 @@ impl GitHubRestClient {
         Ok(Self {
             http: reqwest::Client::builder()
                 .user_agent("heddle-review")
+                // Never follow redirects: GitHub REST pagination returns
+                // `200`+`Link`, never `3xx`. Following a server-controlled
+                // `Location` would bypass the `validate_pagination_origin`
+                // Link-header check and re-open the SSRF gap it closes (#521).
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .map_err(|err| ReviewError::Github(err.to_string()))?,
             api_base_url,
@@ -952,6 +957,35 @@ mod tests {
         assert!(
             err.to_string().contains("unexpected origin"),
             "expected an origin-rejection error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_files_does_not_follow_redirect_to_internal_address() {
+        // The client must not follow redirects: GitHub pagination is
+        // `200`+`Link`, never `3xx`. A server-controlled `302` whose
+        // `Location` points at an internal/dead address would bypass the
+        // Link-header origin check entirely if reqwest auto-followed it
+        // (the SSRF sibling of the cross-origin pagination case, #521).
+        // With redirects disabled, the `302` surfaces as a non-success
+        // status and the fetch fails loudly *without* ever connecting to
+        // the dead port — proving the redirect was not chased.
+        let base_url = spawn_server(|_| {
+            vec![
+                MockResponse::json(302, String::new()).with_header(
+                    "Location",
+                    "http://127.0.0.1:1/repos/heddle/repo/pulls/439/files?per_page=100&page=2",
+                ),
+            ]
+        })
+        .await;
+        let err = client_for(&base_url)
+            .fetch_files(&review_key(), None)
+            .await
+            .expect_err("a redirect to an internal address must not be followed");
+        assert!(
+            err.to_string().contains("pull request files fetch failed"),
+            "expected a non-success status error from the unfollowed 302, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary
- The paginated GitHub fetch (`fetch_paginated_json`) followed the `next` URL from the server-controlled `Link` header without validating it — a spoofed/compromised endpoint could redirect pagination at an internal address (SSRF-adjacent).
- Added `validate_pagination_origin`: every `next` URL must match the configured API base on **scheme + host + port** (default-normalized via `port_or_known_default`) before the request is issued.
- Placed the check at the single chokepoint where a server-provided URL becomes a request — `fetch_metadata` builds its own single-shot URL and doesn't paginate — so it covers the whole class (files, commits, issue + review comments) in one place.

Closes HeddleCo/heddle#521

## Red commit
`4fac680d`

## Test evidence
```
$ cargo test -p heddle-review
test github::rest::tests::validate_pagination_origin_accepts_same_origin ... ok
test github::rest::tests::validate_pagination_origin_accepts_explicit_default_port ... ok
test github::rest::tests::validate_pagination_origin_rejects_foreign_host ... ok
test github::rest::tests::validate_pagination_origin_rejects_scheme_downgrade ... ok
test github::rest::tests::validate_pagination_origin_rejects_foreign_port ... ok
test github::rest::tests::validate_pagination_origin_rejects_unparseable_candidate ... ok
test github::rest::tests::fetch_files_rejects_cross_origin_pagination_url ... ok
...
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo build --locked --workspace --all-features          # exit 0
$ bash scripts/check-no-silent-default-tree-load.sh        # clean (547 files scanned)
```
The five tests above fail on the red stub (`4fac680d`) and pass on the fix.

## Manual verification
N/A — covered by tests. The cross-origin integration test (`fetch_files_rejects_cross_origin_pagination_url`) drives a `Link: next` header pointing off-origin and asserts the fetch is refused *before* any request is issued (origin-rejection error, not a connection error).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783649404&installation_id=132405951&pr_number=627&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F627&signature=50b2d3364713c87fa84f759f77ff0c56e1d0473e83b9458a1209497e45ffb266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->