### PR TITLE
harden(proto): namespace scope grants downward access only (#519)

### DIFF
--- a/crates/proto/src/auth_context.rs
+++ b/crates/proto/src/auth_context.rs
@@ -40,14 +40,18 @@ impl AuthContext {
         }
     }
 
+    /// Whether this context may access `namespace`.
+    ///
+    /// `NamespaceTree(scope)` grants access **downward only**: the scope
+    /// namespace itself and any descendant (`scope/...`). It deliberately does
+    /// NOT grant upward access — a token scoped to a child namespace cannot
+    /// reach its parent or ancestors. This mirrors [`Self::can_access_repo`].
     pub fn can_access_namespace(&self, namespace: &str) -> bool {
         match &self.scope {
             TokenScope::Global => true,
             TokenScope::Repositories(_) => false,
             TokenScope::NamespaceTree(scope) => {
-                namespace == scope
-                    || namespace.starts_with(&format!("{}/", scope))
-                    || scope.starts_with(&format!("{}/", namespace))
+                namespace == scope || namespace.starts_with(&format!("{}/", scope))
             }
         }
     }

--- a/crates/proto/src/auth_tests.rs
+++ b/crates/proto/src/auth_tests.rs
@@ -61,3 +61,52 @@ fn test_auth_context() {
     assert!(!ctx.can_write());
     assert!(!ctx.is_admin());
 }
+
+fn namespace_ctx(scope: &str) -> AuthContext {
+    AuthContext {
+        user: "alice".to_string(),
+        permissions: vec![Permission::Read],
+        token_id: "token123".to_string(),
+        scope: TokenScope::NamespaceTree(scope.to_string()),
+    }
+}
+
+#[test]
+fn test_namespace_tree_exact_match() {
+    let ctx = namespace_ctx("team");
+    assert!(ctx.can_access_namespace("team"));
+}
+
+#[test]
+fn test_namespace_tree_downward_access() {
+    // A token scoped to a namespace can reach the namespace itself and its descendants.
+    let ctx = namespace_ctx("team");
+    assert!(ctx.can_access_namespace("team/project"));
+    assert!(ctx.can_access_namespace("team/project/sub"));
+}
+
+#[test]
+fn test_namespace_tree_no_upward_access() {
+    // A token scoped to a child namespace must NOT reach its parent or ancestors.
+    let ctx = namespace_ctx("team/project");
+    assert!(ctx.can_access_namespace("team/project")); // exact still allowed
+    assert!(!ctx.can_access_namespace("team")); // parent — DENIED
+    assert!(!ctx.can_access_namespace("")); // root — DENIED
+}
+
+#[test]
+fn test_namespace_tree_no_sibling_access() {
+    // Siblings under a shared ancestor must not reach one another.
+    let ctx = namespace_ctx("team/project");
+    assert!(!ctx.can_access_namespace("team/other"));
+}
+
+#[test]
+fn test_namespace_tree_no_prefix_false_positive() {
+    // A non-boundary prefix match must not grant access in either direction.
+    let ctx = namespace_ctx("team");
+    assert!(!ctx.can_access_namespace("teamwork"));
+
+    let child = namespace_ctx("teamwork");
+    assert!(!child.can_access_namespace("team"));
+}


### PR DESCRIPTION
Closes #519.

**What:** removes the surprising upward `NamespaceTree` access (a `starts_with` that let a scope reach parent namespaces); scope grants now resolve downward-only.

**Test evidence (TDD):**
- Red: `9239e81c` — directionality tests for namespace scope (failing: upward access was permitted)
- Green: `e98ce550` — fix; downward-only resolution

_Staged for review; **do not merge until the Codex gate is back** (orchestrator dispatched in cap-mode, no @codex ping)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783649524&installation_id=132405951&pr_number=628&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F628&signature=308772882f5ce52b39840f26f1242bd52eb629f9667f50bb0b580097df43e97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->