### PR TITLE
chore(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,4 +27,9 @@ ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraint accepted
     "RUSTSEC-2026-0099", # rustls-webpki: wildcard SAN constraint bypass
     "RUSTSEC-2026-0104", # rustls-webpki: reachable panic on malformed CRL
+
+    # proc-macro-error2 unmaintained — transitive build-time proc-macro via
+    # biscuit-quote → biscuit-auth 6.0 (heddle-client). No runtime exposure,
+    # no CVE. Remove when biscuit-auth drops it. (Mirrors deny.toml.)
+    "RUSTSEC-2026-0173",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,14 @@ ignore = [
     { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101: wildcard SAN constraint bypass. Transitive via aws-sdk-s3 → smithy-http-client → old rustls 0.21. Heddle doesn't validate certificates with wildcard name constraints on attacker-supplied trust anchors; mitigation is the aws-sdk-s3 bump tracked as a follow-up." },
     { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101: URI name constraint accepted. Same transitive chain as RUSTSEC-2026-0099; same mitigation path." },
     { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101: reachable panic parsing malformed CRL. Heddle does not consume attacker-supplied CRLs over the aws-sdk-s3 path (S3 endpoint TLS uses a small fixed root set); same mitigation path." },
+
+    # proc-macro-error2 2.0.1: unmaintained (RUSTSEC-2026-0173). Pulled
+    # transitively via biscuit-quote → biscuit-auth 6.0 (heddle-client's auth
+    # lib). It is a BUILD-TIME proc-macro helper, not a runtime dependency, and
+    # "unmaintained" is a maintenance-status warning, not a vulnerability — no
+    # CVE, no runtime attack surface. Remove this ignore when biscuit-auth drops
+    # proc-macro-error2 upstream.
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive build-time proc-macro via biscuit-quote → biscuit-auth 6.0; no runtime exposure, no CVE. Remove when biscuit-auth drops it." },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Unblocks `cargo-audit` / `cargo-deny` on every heddle PR.

**Advisory:** [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173) — `proc-macro-error2` is unmaintained.

**Why ignore (not bump):** it's a *build-time* proc-macro pulled transitively via `biscuit-quote → biscuit-auth 6.0` (heddle-client). No runtime exposure, no CVE — "unmaintained" is a maintenance-status warning. Bumping it requires biscuit-auth to drop it upstream, out of scope here. Ignored in `deny.toml` + mirrored in `.cargo/audit.toml` per the repo convention; reason notes the removal condition.

Was failing `cargo audit --deny warnings` on **main and every open PR** (e.g. #626/#627/#628), masking real signal across the board.

_Staged; **hold merge until the Codex gate is back** (no @codex ping per current cap-mode)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783649865&installation_id=132405951&pr_number=629&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F629&signature=1d42eadf568ff0784bfcd66d72159d795b3e09b98d8b3a852c9caa8fa62075eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->