### PR TITLE
perf(test): in-process help rendering for the parallel-safe CLI help assertions (#381)

### DIFF
--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -85,62 +85,71 @@ fn catalog_summary(catalog: &crate::cli::commands::CommandCatalogOutput, verb: &
 /// `Ok(())` even for unknown topics; the printer surfaces the
 /// suggestion text rather than erroring.
 pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> {
-    use std::io::Write;
-    let stdout = std::io::stdout();
-    let mut out = stdout.lock();
+    crate::cli::render::write_stdout(&render_help(cmd, topic))
+        .map_err(|err| std::io::Error::other(err.to_string()))
+}
+
+/// Render the curated help surface to a `String` instead of stdout.
+///
+/// [`print_help`] is a thin `write_stdout(&render_help(..))` wrapper over
+/// this, so the bytes are identical. Extracted so in-process tests can
+/// assert on help prose without spawning the binary (HeddleCo/heddle#381).
+pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
     match topic {
         [] => {
             let catalog = crate::cli::commands::build_command_catalog();
-            writeln!(out, "Heddle — AI-native version control")?;
-            writeln!(out)?;
-            writeln!(out, "Common loop:")?;
+            let _ = writeln!(out, "Heddle — AI-native version control");
+            let _ = writeln!(out);
+            let _ = writeln!(out, "Common loop:");
             for name in primary_loop_verbs(&catalog) {
                 let blurb = catalog_summary(&catalog, name);
                 if blurb.is_empty() {
                     continue;
                 }
-                writeln!(out, "  {:<10}  {}", name, blurb)?;
+                let _ = writeln!(out, "  {:<10}  {}", name, blurb);
             }
-            writeln!(out)?;
-            writeln!(
+            let _ = writeln!(out);
+            let _ = writeln!(
                 out,
                 "Existing Git: heddle status -> heddle adopt -> heddle verify -> heddle commit -m \"...\" -> heddle push"
-            )?;
-            writeln!(
+            );
+            let _ = writeln!(
                 out,
                 "Isolated work: heddle start <name> --path ../<name> -> heddle commit -m \"...\" -> heddle ready -> heddle land"
-            )?;
-            writeln!(out)?;
-            writeln!(
+            );
+            let _ = writeln!(out);
+            let _ = writeln!(
                 out,
                 "Nearby: `heddle undo`, `heddle verify`, `heddle push`, `heddle pull`."
-            )?;
-            writeln!(
+            );
+            let _ = writeln!(
                 out,
                 "Start here: `heddle init`, `heddle adopt`, or `heddle clone`."
-            )?;
-            writeln!(out)?;
-            writeln!(
+            );
+            let _ = writeln!(out);
+            let _ = writeln!(
                 out,
                 "Output: text is the default; pass `--output json` for the \
                  full machine contract (stable `output_kind`, exit codes, recovery \
                  templates), or `--output json-compact` for the decision surface \
                  only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection."
-            )?;
-            writeln!(out)?;
-            writeln!(
+            );
+            let _ = writeln!(out);
+            let _ = writeln!(
                 out,
                 "Run `heddle help model` for the short mental model, \
                  `heddle help advanced` for power surfaces, automation, and Git interop, \
                  or `heddle help <topic>` for a topic page (e.g. `git-overlay`, \
                  `threads`, `daemon`, `signals`, `bridge`, `operation-ids`, \
                  `remotes`, `git-dependencies`)."
-            )?;
+            );
         }
         [name] if name == "advanced" => {
             let catalog = crate::cli::commands::build_command_catalog();
-            writeln!(out, "{}", ADVANCED_HELP)?;
-            writeln!(out, "Advanced commands:")?;
+            let _ = writeln!(out, "{}", ADVANCED_HELP);
+            let _ = writeln!(out, "Advanced commands:");
             for name in advanced_verbs() {
                 let blurb = catalog_summary(&catalog, name);
                 if blurb.is_empty() {
@@ -156,41 +165,52 @@ pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> 
                 let canonical = crate::cli::commands::command_canonical_command(name)
                     .map(|canonical| format!("; use `{canonical}`"))
                     .unwrap_or_default();
-                writeln!(out, "  {:<14}  {} [{}{}]", name, blurb, label, canonical)?;
+                let _ = writeln!(out, "  {:<14}  {} [{}{}]", name, blurb, label, canonical);
             }
         }
         [name] if topic_text(name).is_some() => {
-            writeln!(out, "{}", topic_text(name).expect("checked above"))?;
+            let _ = writeln!(out, "{}", topic_text(name).expect("checked above"));
         }
         path => {
             if let Some(mut subcommand) = help_command_for_path(cmd, path) {
                 // `heddle help <command path>` falls through to that
                 // command's clap-derived help so the contract on
                 // `Commands::Help` holds for nested public paths too.
-                drop(out);
-                subcommand.print_help()?;
+                let _ = write!(out, "{}", subcommand.render_help());
             } else {
                 let name = path.join(" ");
-                writeln!(
+                let _ = writeln!(
                     out,
                     "no topic or command '{name}'. Run `heddle help advanced` for \
                      the full advanced list, or `heddle help` for the \
                      curated everyday surface."
-                )?;
+                );
             }
         }
     }
-    Ok(())
+    out
 }
 
 pub fn print_direct_help_for_raw(
     cmd: &clap::Command,
     raw: &[String],
 ) -> Option<std::io::Result<()>> {
+    let rendered = render_direct_help_for_raw(cmd, raw)?;
+    Some(
+        crate::cli::render::write_stdout(&rendered)
+            .map_err(|err| std::io::Error::other(err.to_string())),
+    )
+}
+
+/// Render the `heddle <path> --help` pre-parse help to a `String`.
+///
+/// In-process sibling of [`print_direct_help_for_raw`]; the printer is a
+/// `write_stdout` wrapper over this so the bytes match (HeddleCo/heddle#381).
+pub fn render_direct_help_for_raw(cmd: &clap::Command, raw: &[String]) -> Option<String> {
     let path = command_path_from_raw_help_request(cmd, raw)?;
     Some(match help_command_for_path(cmd, &path) {
-        Some(mut subcommand) => subcommand.print_long_help(),
-        None => print_help(cmd, &path),
+        Some(mut subcommand) => subcommand.render_long_help().to_string(),
+        None => render_help(cmd, &path),
     })
 }
 
@@ -233,11 +253,20 @@ fn reveal_capture_agent_flags(command: clap::Command) -> clap::Command {
 /// any legal position — is handled natively; there is no hand-rolled
 /// pre-parse token scan to keep in sync with clap's grammar.
 pub fn print_capture_agent_help(cmd: &clap::Command) -> std::io::Result<()> {
+    crate::cli::render::write_stdout(&render_capture_agent_help(cmd))
+        .map_err(|err| std::io::Error::other(err.to_string()))
+}
+
+/// Render `capture --help-agent` to a `String` (the reveal-help variant).
+///
+/// In-process sibling of [`print_capture_agent_help`]; the printer is a
+/// `write_stdout` wrapper over this so the bytes match (HeddleCo/heddle#381).
+pub fn render_capture_agent_help(cmd: &clap::Command) -> String {
     let capture = find_subcommand_or_alias(cmd, "capture")
         .expect("capture subcommand exists in the clap command tree");
     let bin_name = format!("{} {}", cmd.get_name(), capture.get_name());
     let mut help = reveal_capture_agent_flags(capture.clone()).bin_name(bin_name);
-    help.print_long_help()
+    help.render_long_help().to_string()
 }
 
 fn help_command_for_path(cmd: &clap::Command, path: &[String]) -> Option<clap::Command> {
@@ -346,6 +375,60 @@ fn command_path_from_raw_help_request(cmd: &clap::Command, raw: &[String]) -> Op
     }
 
     (!path.is_empty()).then_some(path)
+}
+
+/// Render the help that `heddle <args>` would print, **in-process**, for the
+/// help-shaped argv forms — without spawning the binary.
+///
+/// `args` is the argv *after* the program name (e.g. `["clone", "--help"]`,
+/// `["help", "threads"]`, `["capture", "--help-agent"]`). Returns `Some(text)`
+/// with the exact bytes the binary writes to stdout for that request, or
+/// `None` when the argv is not a pure help request this renderer serves (the
+/// caller should fall back to spawning the binary).
+///
+/// This mirrors `main.rs`'s help-dispatch routing precisely: the bare-help
+/// intercept, the `heddle <path> --help` pre-parse, the `capture --help-agent`
+/// reveal, and the `heddle help <topics>` arm. Because the underlying printers
+/// are now `write_stdout(&render_*(..))` wrappers, the in-process text is
+/// byte-identical to the spawned binary's stdout — only the execution
+/// mechanism differs (HeddleCo/heddle#381). Help is repo-, cwd-, and
+/// env-independent, so this is safe to call from parallel tests.
+pub fn render_for_args(args: &[&str]) -> Option<String> {
+    use crate::cli::cli_args::{Cli, Commands};
+    use clap::{CommandFactory, Parser};
+
+    let command = Cli::command();
+    let raw: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
+
+    // Bare-help shapes: `heddle`, `heddle help`. (`--help`/`-h` alone are
+    // clap-driven help that exits during parse; serve them too since they
+    // render the curated everyday surface.)
+    if raw.is_empty() || raw == ["--help"] || raw == ["-h"] || raw == ["help"] {
+        return Some(render_help(&command, &[]));
+    }
+
+    // `heddle <path> --help` pre-parse direct help (e.g. `clone --help`,
+    // `bridge git import --help`).
+    if let Some(rendered) = render_direct_help_for_raw(&command, &raw) {
+        return Some(rendered);
+    }
+
+    // `capture --help-agent` reveal: clap owns the parse, so every global
+    // spelling it accepts is handled natively.
+    if let Ok(cli) = Cli::try_parse_from(std::iter::once("heddle".to_string()).chain(raw.clone()))
+        && let Commands::Help { topics } = &cli.command
+    {
+        // `heddle help <topics>` — curated topic / advanced / command-path help.
+        return Some(render_help(&command, topics));
+    }
+    if let Ok(cli) = Cli::try_parse_from(std::iter::once("heddle".to_string()).chain(raw.clone()))
+        && let Commands::Capture(args) = &cli.command
+        && args.help_agent
+    {
+        return Some(render_capture_agent_help(&command));
+    }
+
+    None
 }
 
 /// Static per-topic help. Topics are addressed via `heddle help <topic>`.

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -199,6 +199,26 @@ fn heddle(args: &[&str], cwd: Option<&std::path::Path>) -> Result<String, String
     }
 }
 
+/// Render the help that `heddle <args>` would print, **in-process**, without
+/// spawning the binary.
+///
+/// `heddle <verb> --help`, `heddle help <topic>`, and `heddle capture
+/// --help-agent` are pure presentation: they render text from the clap command
+/// tree + curated topic strings with no repo, cwd, or env dependence, and exit
+/// before any command body runs. So they don't need a real subprocess — calling
+/// `cli::cli::help::render_for_args` gives the byte-identical stdout the binary
+/// produces (the binary's `print_*` helpers are `write_stdout(&render_*(..))`
+/// wrappers; see `help_render_matches_spawned_binary` for the equivalence
+/// guard). This skips one process spawn per help assertion (HeddleCo/heddle#381).
+///
+/// Help output carries no ANSI styling here (matching the non-TTY piped
+/// subprocess the spawn helper used), so substring assertions transfer
+/// unchanged.
+fn heddle_help(args: &[&str]) -> String {
+    cli::cli::help::render_for_args(args)
+        .unwrap_or_else(|| panic!("`heddle {}` is not an in-process help request", args.join(" ")))
+}
+
 fn heddle_output(args: &[&str], cwd: Option<&std::path::Path>) -> Result<Output, String> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_heddle"));
     cmd.args(translate_legacy_args(args));

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -144,7 +144,7 @@ fn bridge_git_import_refuses_gitlink_by_default_and_lossy_summarizes() {
 
 #[test]
 fn bridge_git_import_help_documents_lossy_flag() {
-    let output = heddle(&["bridge", "git", "import", "--help"], None).expect("help");
+    let output = heddle_help(&["bridge", "git", "import", "--help"]);
 
     assert!(output.contains("--lossy"), "help should document --lossy");
 }

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -5,12 +5,55 @@
 
 use super::*;
 
+/// Equivalence guard for the in-process help renderer (HeddleCo/heddle#381).
+///
+/// The help assertions in this suite call `heddle_help(..)` (in-process)
+/// instead of spawning the binary, on the premise that the two produce
+/// byte-identical stdout. This test pins that premise: for a representative
+/// spread of help-shaped argv — per-verb `--help`, nested-path `--help`, the
+/// `capture --help-agent` reveal, the curated bare/advanced surfaces, and a
+/// topic page — the in-process render must equal the spawned binary's stdout
+/// exactly. If a future change makes a `print_*` helper diverge from its
+/// `render_*` core, this fails before the substring assertions silently drift.
+#[test]
+fn help_render_matches_spawned_binary() {
+    for args in [
+        vec!["clone", "--help"],
+        vec!["capture", "--help"],
+        vec!["capture", "--help-agent"],
+        vec!["push", "--help"],
+        vec!["log", "--help"],
+        vec!["bridge", "git", "import", "--help"],
+        // Alias resolution: `import` is an alias that resolves to `adopt`.
+        vec!["import", "--help"],
+        // Curated topic page + `heddle help <verb>` clap fall-through.
+        vec!["help"],
+        vec!["help", "advanced"],
+        vec!["help", "threads"],
+        vec!["help", "git-overlay"],
+        vec!["help", "status"],
+        // Global-flag-prefixed capture reveal forms.
+        vec!["-vC", ".", "capture", "--help-agent"],
+        vec!["--output", "text", "capture", "--help-agent"],
+    ] {
+        let spawned = heddle(&args, None)
+            .unwrap_or_else(|err| panic!("spawned `heddle {}`: {err}", args.join(" ")));
+        let in_process = heddle_help(&args);
+        assert_eq!(
+            in_process,
+            spawned,
+            "in-process render of `heddle {}` must match the spawned binary's stdout byte-for-byte",
+            args.join(" ")
+        );
+    }
+}
+
 /// `heddle clone --help` must keep its Behavior stanza: the prose that
 /// answers Priya's "wait, where am I?" — default-thread resolution and
 /// what `--depth` actually materializes (heddle#257).
 #[test]
 fn clone_help_pins_behavior_stanza() {
-    let help = heddle(&["clone", "--help"], None).expect("clone help should render");
+    let help = heddle_help(&["clone", "--help"]);
 
     assert!(
         help.contains("Behavior:"),
@@ -97,18 +140,16 @@ fn capture_help_agent_reveals_hidden_flags_through_clap() {
         }
     };
 
-    let plain = heddle(&["capture", "--help-agent"], None).expect("capture --help-agent renders");
+    let plain = heddle_help(&["capture", "--help-agent"]);
     expect_revealed(&plain, "capture --help-agent");
 
     // Clustered short globals before the verb: `-v` then valued `-C <path>`.
     // clap parses the path natively; the verb is still `capture`.
-    let clustered = heddle(&["-vC", ".", "capture", "--help-agent"], None)
-        .expect("-vC <path> capture --help-agent renders");
+    let clustered = heddle_help(&["-vC", ".", "capture", "--help-agent"]);
     expect_revealed(&clustered, "-vC <path> capture --help-agent");
 
     // Long valued global before the verb.
-    let long_global = heddle(&["--output", "text", "capture", "--help-agent"], None)
-        .expect("--output text capture --help-agent renders");
+    let long_global = heddle_help(&["--output", "text", "capture", "--help-agent"]);
     expect_revealed(&long_global, "--output text capture --help-agent");
 }
 
@@ -119,7 +160,7 @@ fn capture_help_agent_reveals_hidden_flags_through_clap() {
 /// by seeing the flag in the human help.
 #[test]
 fn capture_help_keeps_help_agent_hidden_but_keeps_the_pointer() {
-    let help = heddle(&["capture", "--help"], None).expect("capture --help renders");
+    let help = heddle_help(&["capture", "--help"]);
     // The discovery pointer in after-help stays so agents can still find it.
     assert!(
         help.contains("heddle capture --help-agent"),

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn git_overlay_guide_is_concise_and_actionable() {
-    let help = heddle(&["help", "git-overlay"], None).unwrap();
+    let help = heddle_help(&["help", "git-overlay"]);
     assert!(
         help.contains("Git-overlay quick start")
             && help.contains("heddle adopt")
@@ -52,7 +52,7 @@ fn git_overlay_guide_is_concise_and_actionable() {
 
 #[test]
 fn model_help_topic_gives_short_first_time_mental_model() {
-    let help = heddle(&["help", "model"], None).expect("model help topic should render");
+    let help = heddle_help(&["help", "model"]);
     assert!(
         help.contains("Heddle mental model")
             && help.contains("State:")
@@ -72,7 +72,7 @@ fn model_help_topic_gives_short_first_time_mental_model() {
 
 #[test]
 fn bridge_help_topic_teaches_adoption_before_export_notes() {
-    let help = heddle(&["help", "bridge"], None).expect("bridge help topic should render");
+    let help = heddle_help(&["help", "bridge"]);
     assert!(
         help.starts_with("Git bridge"),
         "bridge topic should open with the workflow, not advanced notes metadata: {help}"
@@ -106,7 +106,7 @@ fn bridge_help_topic_teaches_adoption_before_export_notes() {
 
 #[test]
 fn import_alias_leads_to_adopt_instead_of_clap_guesswork() {
-    let help = heddle(&["import", "--help"], None).expect("import alias help should render");
+    let help = heddle_help(&["import", "--help"]);
     assert!(
         help.contains("Adopt the current Git repository into Heddle")
             && help.contains("heddle adopt"),
@@ -116,7 +116,7 @@ fn import_alias_leads_to_adopt_instead_of_clap_guesswork() {
 
 #[test]
 fn adopt_help_does_not_claim_dirty_git_worktree_becomes_clean() {
-    let help = heddle(&["adopt", "--help"], None).expect("adopt help should render");
+    let help = heddle_help(&["adopt", "--help"]);
     assert!(
         help.contains("without modifying existing Git worktree changes"),
         "adopt help should say adoption leaves existing dirty work untouched: {help}"
@@ -246,7 +246,7 @@ fn switch_print_cd_path_alias_matches_thread_switch() {
 
 #[test]
 fn log_help_examples_use_singular_path_flag() {
-    let help = heddle(&["log", "--help"], None).expect("log help should render");
+    let help = heddle_help(&["log", "--help"]);
     assert!(
         help.contains("heddle log --path src/auth.rs"),
         "log help should document the implemented --path flag: {help}"
@@ -259,7 +259,7 @@ fn log_help_examples_use_singular_path_flag() {
 
 #[test]
 fn verify_help_names_checks_and_core_examples() {
-    let help = heddle(&["verify", "--help"], None).expect("verify help should render");
+    let help = heddle_help(&["verify", "--help"]);
     assert!(
         help.contains(
             "Checks: Git mapping, worktree, remote, operation, clone verification, machine contract."
@@ -281,7 +281,7 @@ fn verify_help_names_checks_and_core_examples() {
 #[test]
 fn thread_cleanup_help_renders_modes_as_bullets() {
     let help =
-        heddle(&["thread", "cleanup", "--help"], None).expect("thread cleanup help should render");
+        heddle_help(&["thread", "cleanup", "--help"]);
     assert!(
         help.contains("Modes:")
             && help.contains("  - --merged: clean up threads recorded as merged.")
@@ -2651,7 +2651,7 @@ fn git_overlay_commit_without_no_all_checkpoints_pending_capture() {
 
 #[test]
 fn commit_help_surfaces_index_vs_worktree_auto_switch() {
-    let commit = heddle(&["commit", "--help"], None).expect("heddle commit --help should render");
+    let commit = heddle_help(&["commit", "--help"]);
     assert!(
         commit.contains("auto-switches on the Git index")
             && commit.contains("with nothing staged it commits all worktree paths")
@@ -8079,7 +8079,7 @@ fn global_flags_only_json_renders_command_catalog_for_agents() {
 
 #[test]
 fn advanced_help_does_not_repeat_everyday_human_path() {
-    let advanced = heddle(&["help", "advanced"], None).expect("advanced help should render");
+    let advanced = heddle_help(&["help", "advanced"]);
     assert!(
         advanced.contains(
             "Advanced commands for power users, agents, automation, Git interop, and recovery."
@@ -8101,19 +8101,19 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         );
     }
 
-    let push_help = heddle(&["push", "--help"], None).expect("push help should render");
+    let push_help = heddle_help(&["push", "--help"]);
     assert!(
         push_help.contains("Remote name, local path, URL, or hosted address"),
         "push help should match Git-overlay and hosted reality, not only host:port remotes: {push_help}"
     );
-    let pull_help = heddle(&["pull", "--help"], None).expect("pull help should render");
+    let pull_help = heddle_help(&["pull", "--help"]);
     assert!(
         pull_help.contains("Remote name, local path, URL, or hosted address"),
         "pull help should match Git-overlay and hosted reality, not only host:port remotes: {pull_help}"
     );
 
     let operation_ids =
-        heddle(&["help", "operation-ids"], None).expect("operation ids help should render");
+        heddle_help(&["help", "operation-ids"]);
     assert!(
         operation_ids.contains("supports_op_id: true")
             && operation_ids.contains("op_id_behavior: explicit_replay")
@@ -8123,7 +8123,7 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         "operation-id help should defer to the command contract table: {operation_ids}"
     );
 
-    let capture_help = heddle(&["capture", "--help"], None).expect("capture help should render");
+    let capture_help = heddle_help(&["capture", "--help"]);
     assert!(
         !capture_help.contains("HEDDLE_SESSION_ID")
             && !capture_help.contains("HEDDLE_SESSION_SEGMENT"),
@@ -8145,7 +8145,7 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         );
     }
 
-    let start_help = heddle(&["start", "--help"], None).expect("start help should render");
+    let start_help = heddle_help(&["start", "--help"]);
     for hidden in [
         "--agent-provider",
         "--agent-model",
@@ -8167,7 +8167,7 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         "start help should describe workspace modes in human language: {start_help}"
     );
 
-    let clone_help = heddle(&["clone", "--help"], None).expect("clone help should render");
+    let clone_help = heddle_help(&["clone", "--help"]);
     for hidden in ["--lazy", "--filter", "v0.3.1", "blob:none"] {
         assert!(
             !clone_help.contains(hidden),
@@ -8176,13 +8176,13 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
     }
 
     let promote_help =
-        heddle(&["thread", "promote", "--help"], None).expect("thread promote help should render");
+        heddle_help(&["thread", "promote", "--help"]);
     assert!(
         !promote_help.contains("heavy checkout"),
         "thread promote help should use product-facing workspace language: {promote_help}"
     );
 
-    let try_help = heddle(&["try", "--help"], None).expect("try help should render");
+    let try_help = heddle_help(&["try", "--help"]);
     assert!(
         try_help.contains("Defaults to `materialized`")
             && try_help.contains("auto")
@@ -8192,7 +8192,7 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         "try help should use current workspace mode terms: {try_help}"
     );
 
-    let attempt_help = heddle(&["attempt", "--help"], None).expect("attempt help should render");
+    let attempt_help = heddle_help(&["attempt", "--help"]);
     assert!(
         attempt_help.contains("Defaults to `materialized`")
             && attempt_help.contains("auto")
@@ -9081,8 +9081,7 @@ fn command_catalog_filters_bound_agent_queries() {
 
 #[test]
 fn git_dependencies_help_topic_explains_no_git_contract() {
-    let help = heddle(&["help", "git-dependencies"], None)
-        .expect("git-dependencies help topic should render");
+    let help = heddle_help(&["help", "git-dependencies"]);
     assert!(
         help.contains("without `git` on PATH")
             && help.contains("Git-compatible, not Git-binary-dependent")
@@ -9097,7 +9096,7 @@ fn git_dependencies_help_topic_explains_no_git_contract() {
 
 #[test]
 fn remotes_help_topic_is_available_from_default_topic_list() {
-    let help = heddle(&["help", "remotes"], None).expect("remotes help topic should render");
+    let help = heddle_help(&["help", "remotes"]);
     assert!(
         help.contains("heddle remote add origin <url-or-path>")
             && help.contains("heddle push")
@@ -9429,7 +9428,7 @@ fn help_for_verb_prefixes_usage_with_heddle() {
     // `Usage: status` would suggest the user can run `status` standalone.
     for verb in ["status", "capture", "log", "merge", "undo", "start", "init"] {
         let output =
-            heddle(&["help", verb], None).unwrap_or_else(|err| panic!("heddle help {verb}: {err}"));
+            heddle_help(&["help", verb]);
         assert!(
             output.contains(&format!("Usage: heddle {verb}")),
             "`heddle help {verb}` must prefix the Usage line with `heddle`: {output}"
@@ -9439,8 +9438,8 @@ fn help_for_verb_prefixes_usage_with_heddle() {
 
 #[test]
 fn help_for_verb_includes_visible_global_flags() {
-    let topic = heddle(&["help", "status"], None).expect("heddle help status should render");
-    let direct = heddle(&["status", "--help"], None).expect("heddle status --help should render");
+    let topic = heddle_help(&["help", "status"]);
+    let direct = heddle_help(&["status", "--help"]);
     for flag in ["--output <OUTPUT>", "--repo <PATH>", "--quiet", "--verbose"] {
         assert!(
             topic.contains(flag),
@@ -9455,7 +9454,7 @@ fn help_for_verb_includes_visible_global_flags() {
 
 #[test]
 fn op_id_help_is_visible_only_for_supported_commands() {
-    let commit = heddle(&["commit", "--help"], None).expect("heddle commit --help should render");
+    let commit = heddle_help(&["commit", "--help"]);
     assert!(
         commit.contains("--op-id <UUID>"),
         "op-id capable command help should expose --op-id: {commit}"
@@ -9467,13 +9466,13 @@ fn op_id_help_is_visible_only_for_supported_commands() {
         "commit help should explain all-worktree and staged-index semantics for Git users: {commit}"
     );
 
-    let init = heddle(&["help", "init"], None).expect("heddle help init should render");
+    let init = heddle_help(&["help", "init"]);
     assert!(
         init.contains("--op-id <UUID>"),
         "first-contact mutator help should expose --op-id: {init}"
     );
 
-    let status = heddle(&["status", "--help"], None).expect("heddle status --help should render");
+    let status = heddle_help(&["status", "--help"]);
     assert!(
         !status.contains("--op-id"),
         "observe-only command help should not advertise --op-id: {status}"
@@ -9482,6 +9481,9 @@ fn op_id_help_is_visible_only_for_supported_commands() {
 
 #[test]
 fn public_command_paths_have_all_required_help_entrypoints() {
+    // Stays on the spawned binary (not the in-process `heddle_help`): this
+    // asserts the *process* contract — exit code 0 and an empty stderr stream —
+    // for every help entrypoint, which only a real subprocess can model.
     let paths = public_command_paths();
     assert!(
         paths.len() > 40,
@@ -9590,16 +9592,14 @@ fn everyday_commands_have_all_required_help_entrypoints() {
     }
 
     for verb in everyday {
-        let topic = heddle(&["help", verb], None)
-            .unwrap_or_else(|err| panic!("heddle help {verb} should succeed: {err}"));
+        let topic = heddle_help(&["help", verb]);
         assert!(
             !topic.trim().is_empty() && !topic.contains("no topic"),
             "heddle help {verb} should render useful help: {topic}"
         );
 
         for flag in ["--help", "-h"] {
-            let output = heddle(&[verb, flag], None)
-                .unwrap_or_else(|err| panic!("heddle {verb} {flag} should succeed: {err}"));
+            let output = heddle_help(&[verb, flag]);
             assert!(
                 output.contains("Usage:") && output.contains("heddle") && output.contains(verb),
                 "heddle {verb} {flag} should render command help with usage: {output}"

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -464,7 +464,7 @@ fn test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged() {
 
 #[test]
 fn test_cli_clone_help_hides_planned_lazy_flag() {
-    let output = heddle(&["clone", "--help"], None).unwrap();
+    let output = heddle_help(&["clone", "--help"]);
     assert!(
         !output.contains("--lazy") && !output.contains("--filter"),
         "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
@@ -636,7 +636,7 @@ fn test_cli_pull_local_detached_head_materializes_then_publishes_thread() {
 
 #[test]
 fn test_cli_pull_help_hides_planned_lazy_flag() {
-    let output = heddle(&["pull", "--help"], None).unwrap();
+    let output = heddle_help(&["pull", "--help"]);
     assert!(
         !output.contains("--lazy"),
         "pull help should keep planned lazy pull out of first-run help: {output}"
@@ -645,7 +645,7 @@ fn test_cli_pull_help_hides_planned_lazy_flag() {
 
 #[test]
 fn git_overlay_push_help_names_git_tag_scope_explicitly() {
-    let help = heddle(&["push", "--help"], None).expect("push help should render");
+    let help = heddle_help(&["push", "--help"]);
     assert!(
         help.contains("Git tag visible to this checkout")
             && help.contains("skips Git tags")


### PR DESCRIPTION
Refs #381 — the parallel-safe subset.

## What
Extracts string-returning `render_*` cores in `crates/cli/src/cli/help.rs` (the `print_*` fns become thin `write_stdout(&render_*(..))` wrappers — **byte-identical** stdout) plus a `render_for_args` router, then converts the ~33 **pure help-rendering** test assertions (cwd/env/exit-code-independent) from subprocess-spawn to in-process calls. ~5x faster on those tests. A `help_render_matches_spawned_binary` guard pins byte-equality across 12+ argv forms.

## Why only the help subset (the finding)
A blanket subprocess→in-process conversion is **unsound**: dispatch is process-global (`main.rs` reads `env::args()`, writes the real stdout fd, calls `process::exit`; 51 command impls read `std::env::current_dir()`), and the cli_integration harness runs **multi-threaded** — converting cwd/env/exit-code-dependent tests in-process would corrupt sibling tests under parallel execution. Those tests are correctly **left on the subprocess**. Converting the rest would require a production refactor (thread cwd + an injectable writer through dispatch) — filed as a follow-up.

## Behavior
Pure refactor of `help.rs` (byte-identical output, pinned by `help_render_matches_spawned_binary`); test changes are mechanism-only (same assertions/coverage). No command semantics, exit codes, or output content changed. No backcompat shims (`print_*` delegate, not duplicated).

## Gates (local)
`cargo build --locked --workspace` ✅ · `--all-features` ✅ · `check-no-silent-default-tree-load.sh` ✅ (547 files) · `clippy --workspace --all-targets -D warnings` ✅ clean · `heddle-mount` 4/4 ✅ · `heddle-cli cli_integration` 921 pass (the 3 `oss_cli_polish` actor-harness failures are **pre-existing on main**, identical there, env-dependent — not introduced here).

Reviewed via the interim adversarial Claude-review gate (Codex out): APPROVE, behavior-preserving confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783750849&installation_id=132405951&pr_number=636&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F636&signature=e63b084060758f7e88c5d81b34cbe51294ed3138f9fc0b27233660511bfaa561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->