### PR TITLE
harden(proto): segment-aware scope checks close ..-traversal bypass

### DIFF
--- a/crates/proto/src/auth_context.rs
+++ b/crates/proto/src/auth_context.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-use crate::{Permission, TokenScope};
+use crate::{Permission, TokenScope, scope_contains};
 
 #[derive(Debug, Clone)]
 pub struct AuthContext {
@@ -34,9 +34,7 @@ impl AuthContext {
         match &self.scope {
             TokenScope::Global => true,
             TokenScope::Repositories(repos) => repos.iter().any(|candidate| candidate == repo),
-            TokenScope::NamespaceTree(namespace) => {
-                repo == namespace || repo.starts_with(&format!("{}/", namespace))
-            }
+            TokenScope::NamespaceTree(namespace) => scope_contains(namespace, repo),
         }
     }
 
@@ -46,13 +44,15 @@ impl AuthContext {
     /// namespace itself and any descendant (`scope/...`). It deliberately does
     /// NOT grant upward access — a token scoped to a child namespace cannot
     /// reach its parent or ancestors. This mirrors [`Self::can_access_repo`].
+    ///
+    /// Containment is segment-aware via [`scope_contains`]: candidates with
+    /// `.`/`..`/empty segments are denied outright (no check-then-normalize
+    /// bypass).
     pub fn can_access_namespace(&self, namespace: &str) -> bool {
         match &self.scope {
             TokenScope::Global => true,
             TokenScope::Repositories(_) => false,
-            TokenScope::NamespaceTree(scope) => {
-                namespace == scope || namespace.starts_with(&format!("{}/", scope))
-            }
+            TokenScope::NamespaceTree(scope) => scope_contains(scope, namespace),
         }
     }
 }

--- a/crates/proto/src/auth_tests.rs
+++ b/crates/proto/src/auth_tests.rs
@@ -110,3 +110,60 @@ fn test_namespace_tree_no_prefix_false_positive() {
     let child = namespace_ctx("teamwork");
     assert!(!child.can_access_namespace("team"));
 }
+
+fn namespace_token(scope: &str) -> AuthToken {
+    AuthToken::new("token123", "alice").with_scope(TokenScope::NamespaceTree(scope.to_string()))
+}
+
+#[test]
+fn test_namespace_tree_traversal_denied_context_namespace() {
+    // heddle#631: "a/b/../c" matched the old prefix check against scope "a/b"
+    // but normalizes to the sibling "a/c" — must be denied.
+    let ctx = namespace_ctx("a/b");
+    assert!(!ctx.can_access_namespace("a/b/../c"));
+    assert!(!ctx.can_access_namespace("a/b/./c")); // deny, never normalize
+    assert!(!ctx.can_access_namespace("a//b")); // empty segment
+    assert!(!ctx.can_access_namespace("a/c")); // sibling
+    assert!(!ctx.can_access_namespace("a/bc")); // non-boundary prefix
+    assert!(ctx.can_access_namespace("a/b")); // exact still allowed
+    assert!(ctx.can_access_namespace("a/b/c")); // legitimate child still allowed
+}
+
+#[test]
+fn test_namespace_tree_traversal_denied_context_repo() {
+    let ctx = namespace_ctx("a/b");
+    assert!(!ctx.can_access_repo("a/b/../c"));
+    assert!(!ctx.can_access_repo("a/b/./c"));
+    assert!(!ctx.can_access_repo("a//b"));
+    assert!(!ctx.can_access_repo("a/c"));
+    assert!(!ctx.can_access_repo("a/bc"));
+    assert!(ctx.can_access_repo("a/b"));
+    assert!(ctx.can_access_repo("a/b/c"));
+}
+
+#[test]
+fn test_namespace_tree_traversal_denied_token_repo() {
+    // AuthToken::can_access_repo is the leg with live production consumers
+    // (weft); it must share the segment-aware primitive.
+    let token = namespace_token("a/b");
+    assert!(!token.can_access_repo("a/b/../c"));
+    assert!(!token.can_access_repo("a/b/./c"));
+    assert!(!token.can_access_repo("a//b"));
+    assert!(!token.can_access_repo("a/c"));
+    assert!(!token.can_access_repo("a/bc"));
+    assert!(token.can_access_repo("a/b"));
+    assert!(token.can_access_repo("a/b/c"));
+}
+
+#[test]
+fn test_namespace_tree_malformed_scope_denies_all() {
+    // A scope containing traversal or empty segments is misconfigured —
+    // deny everything rather than guess at intent.
+    let ctx = namespace_ctx("a/../b");
+    assert!(!ctx.can_access_namespace("a/../b"));
+    assert!(!ctx.can_access_namespace("b"));
+
+    let token = namespace_token("a//b");
+    assert!(!token.can_access_repo("a//b"));
+    assert!(!token.can_access_repo("a/b"));
+}

--- a/crates/proto/src/auth_token.rs
+++ b/crates/proto/src/auth_token.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use serde::{Deserialize, Serialize};
 
-use crate::Permission;
+use crate::{Permission, scope_contains};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthToken {
@@ -64,9 +64,7 @@ impl AuthToken {
         match &self.scope {
             TokenScope::Global => true,
             TokenScope::Repositories(repos) => repos.contains(&repo.to_string()),
-            TokenScope::NamespaceTree(namespace) => {
-                repo == namespace || repo.starts_with(&format!("{}/", namespace))
-            }
+            TokenScope::NamespaceTree(namespace) => scope_contains(namespace, repo),
         }
     }
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -17,6 +17,7 @@ mod native_pack;
 mod object_availability;
 mod object_graph;
 mod object_transfer;
+mod scope_match;
 
 pub use auth_context::AuthContext;
 pub use auth_token::{AuthToken, TokenScope};
@@ -60,6 +61,7 @@ pub use object_transfer::{
     check_received_transfer_blob_size, load_object_data, load_requested_object,
     store_received_object,
 };
+pub use scope_match::scope_contains;
 
 /// Default port for Heddle protocol.
 pub const DEFAULT_PORT: u16 = 8421;

--- a/crates/proto/src/scope_match.rs
+++ b/crates/proto/src/scope_match.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Segment-aware scope containment for namespace-tree access checks.
+//!
+//! This is the single authorization primitive for "is `candidate` inside the
+//! namespace tree rooted at `scope`?". Callers MUST NOT reimplement this with
+//! string prefix matching: `candidate.starts_with(&format!("{}/", scope))`
+//! treats `..` segments literally, so `a/b/../c` passes a check against scope
+//! `a/b` and then normalizes to the *sibling* `a/c` — a check-then-normalize
+//! bypass (see heddle#631).
+
+/// Whether `candidate` is the scope namespace itself or a descendant of it,
+/// compared whole-segment by whole-segment.
+///
+/// Hardening rules (deny-by-default):
+/// - Any `.` or `..` segment in either string is rejected outright. We never
+///   normalize traversal segments — a path that needs normalizing is denied.
+/// - Empty segments (`a//b`, leading/trailing `/`, or the empty string) are
+///   rejected outright, so `/`-boundary tricks cannot smuggle segments past
+///   the comparison.
+/// - Comparison is per-segment, so scope `a/b` does NOT match `a/bc` (the
+///   classic non-boundary prefix bug) and never grants upward access (scope
+///   `a/b` does not match `a`).
+pub fn scope_contains(scope: &str, candidate: &str) -> bool {
+    let Some(scope_segments) = well_formed_segments(scope) else {
+        return false;
+    };
+    let Some(candidate_segments) = well_formed_segments(candidate) else {
+        return false;
+    };
+
+    candidate_segments.len() >= scope_segments.len()
+        && scope_segments == candidate_segments[..scope_segments.len()]
+}
+
+/// Splits `path` on `/`, returning `None` if any segment is empty, `.`,
+/// or `..` (including the empty string itself).
+fn well_formed_segments(path: &str) -> Option<Vec<&str>> {
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments
+        .iter()
+        .any(|segment| segment.is_empty() || *segment == "." || *segment == "..")
+    {
+        return None;
+    }
+    Some(segments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scope_contains;
+
+    #[test]
+    fn exact_match_allowed() {
+        assert!(scope_contains("a/b", "a/b"));
+    }
+
+    #[test]
+    fn descendant_allowed() {
+        assert!(scope_contains("a/b", "a/b/c"));
+        assert!(scope_contains("a/b", "a/b/c/d"));
+    }
+
+    #[test]
+    fn dotdot_traversal_denied() {
+        // The heddle#631 bypass: matches the old prefix check, normalizes to
+        // the sibling a/c after it.
+        assert!(!scope_contains("a/b", "a/b/../c"));
+        assert!(!scope_contains("a/b", "a/b/.."));
+        assert!(!scope_contains("a/b", "a/b/c/../../b/c"));
+    }
+
+    #[test]
+    fn single_dot_denied() {
+        // We deny rather than normalize: no traversal-ish input is trusted.
+        assert!(!scope_contains("a/b", "a/b/./c"));
+        assert!(!scope_contains("a/b", "a/b/."));
+    }
+
+    #[test]
+    fn empty_segments_denied() {
+        assert!(!scope_contains("a/b", "a//b"));
+        assert!(!scope_contains("a/b", "a/b//c"));
+        assert!(!scope_contains("a/b", "a/b/"));
+        assert!(!scope_contains("a/b", "/a/b"));
+        assert!(!scope_contains("a/b", ""));
+    }
+
+    #[test]
+    fn sibling_denied() {
+        assert!(!scope_contains("a/b", "a/c"));
+    }
+
+    #[test]
+    fn upward_access_denied() {
+        assert!(!scope_contains("a/b", "a"));
+        assert!(!scope_contains("a/b/c", "a/b"));
+    }
+
+    #[test]
+    fn non_boundary_prefix_denied() {
+        // scope "a/b" must not match "a/bc" in either direction.
+        assert!(!scope_contains("a/b", "a/bc"));
+        assert!(!scope_contains("a/bc", "a/b"));
+    }
+
+    #[test]
+    fn malformed_scope_denies_everything() {
+        // A scope containing traversal/empty segments is misconfigured;
+        // deny rather than guess.
+        assert!(!scope_contains("a/..", "a"));
+        assert!(!scope_contains("a/../b", "a/../b"));
+        assert!(!scope_contains("a//b", "a/b/c"));
+        assert!(!scope_contains("", "a"));
+        assert!(!scope_contains("", ""));
+    }
+}


### PR DESCRIPTION
Fixes #631.

Both `can_access_namespace` (auth_context) and the two `can_access_repo` legs (auth_context + auth_token, the latter consumed in production by weft) checked scope containment via a literal string prefix match — a candidate like `a/b/../c` passed against scope `a/b`, then normalized post-check to the sibling `a/c` (check-then-normalize bypass).

This lifts the check into one shared segment-aware primitive (`scope_contains`): splits on `/`, denies any candidate containing `.`, `..`, or empty segments outright, and compares whole segments (also immune to the `a/b` ⊄ `a/bc` prefix-bug class). All three call sites route through it; the inline prefix logic is deleted.

Tests assert `a/b/../c` and `a//b` are denied for scope `a/b` at every call site, and that legitimate children (`a/b/c`) and dot-containing *names* (`a/b..c`) still pass.

Threat model note: candidates are denied (not normalized) — normalization belongs to the storage layer; the authz boundary refuses ambiguous input.

Agent-authored under the interim review gate (Codex offline); adversarial Claude review to follow on this PR before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783808768&installation_id=132405951&pr_number=638&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F638&signature=fd28e6892bb2ddd3cd33a0514b29f1bf3f7fd43a9b23a60b864c6cac3a05a85c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->