### PR TITLE
ci(release): replace retired macos-13 runner; park win-arm64 until cosign supports it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,11 @@ jobs:
             runner: macos-14
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            # macos-13 was retired 2025-12-04 (jobs queue for hours, then a
+            # brownout cancels the whole run — observed on the v0.3.0-rc.1
+            # dry-run). macos-15-intel is the LAST x86_64 macOS image and
+            # lives until August 2027; plan the Intel-mac sunset before then.
+            runner: macos-15-intel
             archive: tar.gz
           - target: aarch64-unknown-linux-gnu
             # glibc floor: ubuntu-22.04 ships glibc 2.35, so the -gnu
@@ -203,9 +207,12 @@ jobs:
           - target: x86_64-pc-windows-msvc
             runner: windows-2022
             archive: zip
-          - target: aarch64-pc-windows-msvc
-            runner: windows-11-arm
-            archive: zip
+          # aarch64-pc-windows-msvc is parked: the binary builds fine, but
+          # sigstore/cosign-installer@v3 ships no Windows-arm64 asset, so the
+          # signing step hard-fails (observed on the v0.3.0-rc.1 dry-run).
+          # Unsigned artifacts in an otherwise-signed release are worse than
+          # absence. Re-add when cosign ships win-arm64 binaries — tracked in
+          # the "re-enable aarch64-pc-windows-msvc" issue.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -84,7 +84,7 @@ else
   err "validate-tag must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
 fi
 
-# All six target triples.
+# All five active target triples (win-arm64 parked, see below).
 targets=(
   "aarch64-apple-darwin"
   "x86_64-apple-darwin"

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -91,7 +91,9 @@ targets=(
   "aarch64-unknown-linux-gnu"
   "x86_64-unknown-linux-gnu"
   "x86_64-pc-windows-msvc"
-  "aarch64-pc-windows-msvc"
+  # aarch64-pc-windows-msvc parked until cosign ships win-arm64 binaries
+  # (cosign-installer@v3 has no asset; signing hard-fails). See the
+  # re-enable tracking issue before adding it back here AND in release.yml.
 )
 for t in "${targets[@]}"; do
   if grep -F "$t" "$WF" >/dev/null; then


### PR DESCRIPTION
Two pipeline gaps surfaced by the v0.3.0-rc.1 dry-run (run 27371923487):

1. **macos-13 is retired** (GitHub, 2025-12-04): the x86_64-apple-darwin job queued for 3h40m, then a brownout cancelled the entire run (taking the publish step with it). → `macos-15-intel`, the last x86_64 macOS image, supported to Aug 2027.
2. **aarch64-pc-windows-msvc builds but cannot sign**: sigstore/cosign-installer@v3 ships no Windows-arm64 asset. Unsigned artifacts in an otherwise-signed release are worse than absence → parked with comments in both release.yml and the pipeline asserter; re-enable tracked in a follow-up issue.

Validated: YAML parses; `scripts/check-release-pipeline.sh` passes with the five-target expectation (asserter updated honestly rather than letting the comment string satisfy the grep).

Part of the v0.3.0 release prep (#25 in the orchestrator plan).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783811333&installation_id=132405951&pr_number=639&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F639&signature=b21995b516eba4583f6780182c2b3916341ab377a372b19e6d996f7cee6cac39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->