### PR TITLE
feat(push): document written refs in --help and report refs_written in JSON output

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -15861,6 +15861,16 @@
             "null"
           ]
         },
+        "refs_written": {
+          "description": "Full ref names this push wrote at the destination (sorted; empty\nfor a no-op push). Present on the Git-overlay refs path; omitted\non the native Heddle transport. Verify with `git ls-remote`.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "remote": {
           "type": [
             "string",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1648,6 +1648,8 @@ export interface PushSchema {
   recommended_action: NullableStringSchema;
   recommended_action_template: NullableActionTemplateSchema;
   ref_scope?: string | null;
+  /** Full ref names this push wrote at the destination (sorted; empty for a no-op push). Present on the Git-overlay refs path; omitted on the native Heddle transport. Verify with `git ls-remote`. */
+  refs_written?: string[] | null;
   remote?: string | null;
   replayed?: boolean | null;
   state?: string | null;

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -759,24 +759,36 @@ impl<'a> GitBridge<'a> {
         import_all(self, git_path)
     }
 
-    /// Push to a Git remote.
-    pub fn push(&mut self, remote_name: &str) -> GitResult<()> {
+    /// Push to a Git remote. Returns the full names of the refs written
+    /// at the destination this invocation (see [`Self::push_with_scope_force`]).
+    pub fn push(&mut self, remote_name: &str) -> GitResult<Vec<String>> {
         self.push_with_scope(remote_name, GitPushScope::AllThreads)
     }
 
-    /// Push to a Git remote with an explicit ref scope.
-    pub fn push_with_scope(&mut self, remote_name: &str, scope: GitPushScope) -> GitResult<()> {
+    /// Push to a Git remote with an explicit ref scope. Returns the full
+    /// names of the refs written at the destination this invocation.
+    pub fn push_with_scope(
+        &mut self,
+        remote_name: &str,
+        scope: GitPushScope,
+    ) -> GitResult<Vec<String>> {
         self.push_with_scope_force(remote_name, scope, false)
     }
 
     /// Push to a Git remote with an explicit ref scope and optional
     /// non-fast-forward ref movement.
+    ///
+    /// Returns the full names (e.g. `refs/heads/<thread>`,
+    /// `refs/notes/heddle`, `refs/tags/<tag>`) of the refs WRITTEN at the
+    /// destination this invocation — creations, fast-forwards, and forced
+    /// rewinds — sorted for deterministic output. A no-op push returns an
+    /// empty list. Retraction deletes are not included.
     pub fn push_with_scope_force(
         &mut self,
         remote_name: &str,
         scope: GitPushScope,
         force: bool,
-    ) -> GitResult<()> {
+    ) -> GitResult<Vec<String>> {
         self.init_mirror()?;
         let current_branch = match scope {
             GitPushScope::CurrentThread => Some(self.current_attached_thread_for_push()?),
@@ -864,6 +876,8 @@ impl<'a> GitBridge<'a> {
     /// as a bare repo when it does not exist. `scope`/`current_branch` gate only
     /// MATERIALIZATION (a scoped push never publishes a brand-new sibling); `force`
     /// authorizes retracting an out-of-band destination tip and forcing a true fork.
+    ///
+    /// Returns the sorted full names of the refs written at the destination.
     fn copy_mirror_to_path(
         &mut self,
         target_path: &Path,
@@ -872,7 +886,7 @@ impl<'a> GitBridge<'a> {
         scope: GitPushScope,
         current_branch: Option<&str>,
         force: bool,
-    ) -> GitResult<()> {
+    ) -> GitResult<Vec<String>> {
         let mirror_repo = self.open_git_repo()?;
         let target_repo = if target_path.exists() {
             open_repo(target_path)?
@@ -942,7 +956,7 @@ impl<'a> GitBridge<'a> {
             delete_reference_if_present(&target_repo, &delete.full_name)?;
         }
         write_exported_refs(&target_repo, &plan.new_manifest)?;
-        Ok(())
+        Ok(planned_write_names(&plan))
     }
 
     /// Fetch Git refs and objects into the internal mirror without moving
@@ -2999,6 +3013,22 @@ pub(crate) struct DestinationReconcilePlan {
     pub(crate) new_manifest: HashMap<String, ObjectId>,
 }
 
+/// The sorted full names of the refs a destination reconcile plan WRITES —
+/// creations, fast-forwards, and forced embargo rewinds. This is the
+/// `refs_written` surface `heddle push` reports so a git veteran (or agent)
+/// can verify the round-trip with `git ls-remote`. Retraction deletes are
+/// not included. Sorted because the plan's write order derives from hash-map
+/// iteration and the reported list must be deterministic.
+pub(crate) fn planned_write_names(plan: &DestinationReconcilePlan) -> Vec<String> {
+    let mut names: Vec<String> = plan
+        .writes
+        .iter()
+        .map(|write| write.full_name.clone())
+        .collect();
+    names.sort_unstable();
+    names
+}
+
 /// The full ref names a push may MATERIALIZE (create fresh) at a destination — the
 /// `creatable_names` gate for [`plan_destination_reconcile`]. `None` for an
 /// all-thread push (every served ref is creatable, so the gate never fires);
@@ -3597,6 +3627,8 @@ fn fetch_network_remote(
     Ok(())
 }
 
+/// Push the served frontier to a URL/network remote. Returns the sorted
+/// full names of the refs written on the wire (see [`planned_write_names`]).
 fn push_network_remote(
     mirror_repo: &gix::Repository,
     heddle_dir: &Path,
@@ -3604,7 +3636,7 @@ fn push_network_remote(
     scope: GitPushScope,
     current_branch: Option<&str>,
     force: bool,
-) -> GitResult<()> {
+) -> GitResult<Vec<String>> {
     // The network destination's exported-refs record lives in heddle's own dir,
     // keyed by the remote URL (the remote has no local git dir to host the
     // sidecar). Read it BEFORE the empty-frontier fast-path: a retraction lands
@@ -3624,7 +3656,7 @@ fn push_network_remote(
     let managed_record = read_mirror_managed_refs(mirror_repo)?;
     let served_frontier = collect_managed_ref_updates(mirror_repo, &managed_record)?;
     if served_frontier.is_empty() && previously_exported.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let mut transport = gix_transport::client::blocking_io::connect::connect(
@@ -3680,7 +3712,7 @@ fn push_network_remote(
         // Nothing to move on the wire, but the record may still need to drop a
         // ref that was already absent at the remote.
         write_exported_refs_at(&manifest_path, &plan.new_manifest)?;
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     // Pack only the SURVIVORS' new objects — a delete carries no new object.
@@ -3711,7 +3743,7 @@ fn push_network_remote(
     // Only persist the record once the remote has acknowledged every command, so
     // a failed push never leaves a ref recorded as exported that did not land.
     write_exported_refs_at(&manifest_path, &plan.new_manifest)?;
-    Ok(())
+    Ok(planned_write_names(&plan))
 }
 
 fn remote_refs_from_receive_pack_handshake(

--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -488,6 +488,13 @@ Examples:
     },
 
     /// Push to a remote repository.
+    ///
+    /// In Git-overlay mode, push writes plain Git refs the remote's users can
+    /// inspect with `git ls-remote`: each Heddle thread's state goes to
+    /// `refs/heads/<thread>`, Heddle metadata (state identity carried as Git
+    /// notes) goes to `refs/notes/heddle`, and with `--all-threads` Git tags go
+    /// to `refs/tags/<tag>`. JSON output lists the refs actually written this
+    /// invocation in `refs_written`.
     Push(PushArgs),
 
     /// Pull from a remote repository.

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -53,6 +53,7 @@ pub(crate) fn push_git_overlay_refs(
     GitPushScope,
     Option<String>,
     Option<GitOverlayTrackingRefresh>,
+    Vec<String>,
     super::git_overlay_health::RepositoryVerificationState,
 )> {
     let remote_name = resolve_default_remote_name(repo, remote)?;
@@ -70,10 +71,17 @@ pub(crate) fn push_git_overlay_refs(
         None
     };
     let mut bridge = GitBridge::new(repo);
-    bridge.push_with_scope_force(&remote_name, scope, force)?;
+    let refs_written = bridge.push_with_scope_force(&remote_name, scope, force)?;
     let tracking_refresh = refresh_git_tracking_after_overlay_push(repo, &remote_name)?;
     let trust = build_repository_verification_state(repo);
-    Ok((remote_name, scope, current_thread, tracking_refresh, trust))
+    Ok((
+        remote_name,
+        scope,
+        current_thread,
+        tracking_refresh,
+        refs_written,
+        trust,
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +114,14 @@ struct PushOutput {
     ref_scope: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     git_notes_ref: Option<&'static str>,
+    /// The full ref names this push actually wrote at the destination —
+    /// `refs/heads/<thread>`, `refs/notes/heddle`, `refs/tags/<tag>` —
+    /// sorted, empty for a no-op push. Present on the Git-overlay refs
+    /// path (`transport: "git"`); omitted on the native Heddle transport,
+    /// which writes Heddle thread refs, not Git refs. Verifiable with
+    /// `git ls-remote <remote>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refs_written: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     git_notes_visibility_warning: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -252,7 +268,7 @@ pub async fn cmd_push(
                 ));
             }
         }
-        let (remote_name, scope, current_thread, tracking_refresh, trust) =
+        let (remote_name, scope, current_thread, tracking_refresh, refs_written, trust) =
             push_git_overlay_refs(&repo, remote.as_deref(), all_threads, force)?;
         if should_output_json(cli, Some(repo.config())) {
             let output = git_overlay_push_output(
@@ -260,6 +276,7 @@ pub async fn cmd_push(
                 scope,
                 current_thread,
                 tracking_refresh,
+                refs_written,
                 force,
                 trust,
             );
@@ -452,11 +469,11 @@ fn render_mirror_outcome(
     cli: &Cli,
     repo: &Repository,
     mirror_remote: &str,
-    outcome: crate::bridge::GitResult<()>,
+    outcome: crate::bridge::GitResult<Vec<String>>,
 ) {
     let json = should_output_json(cli, Some(repo.config()));
     match outcome {
-        Ok(()) => {
+        Ok(_) => {
             if json {
                 // Stderr (not stdout): the primary push already wrote
                 // the documented single JSON object to stdout. Emitting
@@ -501,6 +518,7 @@ fn git_overlay_push_output(
     scope: GitPushScope,
     current_thread: Option<String>,
     tracking_refresh: Option<GitOverlayTrackingRefresh>,
+    refs_written: Vec<String>,
     force: bool,
     trust: RepositoryVerificationState,
 ) -> PushOutput {
@@ -542,6 +560,7 @@ fn git_overlay_push_output(
             GitPushScope::AllThreads => "all_threads_tags_and_heddle_notes",
         }),
         git_notes_ref: Some("refs/notes/heddle"),
+        refs_written: Some(refs_written),
         git_notes_visibility_warning: Some(
             "ordinary `git log --all` may show Heddle metadata commits from refs/notes/heddle",
         ),
@@ -582,6 +601,7 @@ fn heddle_push_output(
         push_scope: None,
         ref_scope: None,
         git_notes_ref: None,
+        refs_written: None,
         git_notes_visibility_warning: None,
         git_tracking_remote: None,
         git_remote_configured: None,

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1826,6 +1826,11 @@ pub struct PushSchema {
     pub ref_scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_notes_ref: Option<String>,
+    /// Full ref names this push wrote at the destination (sorted; empty
+    /// for a no-op push). Present on the Git-overlay refs path; omitted
+    /// on the native Heddle transport. Verify with `git ls-remote`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refs_written: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_notes_visibility_warning: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -741,7 +741,7 @@ async fn push_after_land(
     state: Option<String>,
 ) -> Result<String> {
     if repo.capability() == repo::RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
-        let (remote_name, _, _, _, _) =
+        let (remote_name, _, _, _, _, _) =
             super::remote::push_git_overlay_refs(repo, remote.as_deref(), false, false)?;
         Ok(remote_name)
     } else {

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -655,6 +655,104 @@ fn git_overlay_push_help_names_git_tag_scope_explicitly() {
 }
 
 #[test]
+fn push_help_documents_written_refs_namespace() {
+    let help = heddle_help(&["push", "--help"]);
+    assert!(
+        help.contains("refs/heads/<thread>")
+            && help.contains("refs/notes/heddle")
+            && help.contains("refs/tags/<tag>")
+            && help.contains("git ls-remote")
+            && help.contains("refs_written"),
+        "push help should document exactly which Git refs a push writes and how to verify them: {help}"
+    );
+}
+
+/// Every full ref name under `refs/` at the remote, sorted — the
+/// `git ls-remote` view (minus HEAD) the `refs_written` round-trip
+/// contract is asserted against.
+fn remote_ref_names(remote_repo: &gix::Repository) -> Vec<String> {
+    let mut names: Vec<String> = remote_repo
+        .references()
+        .expect("remote refs platform")
+        .all()
+        .expect("iterate remote refs")
+        .filter_map(Result::ok)
+        .map(|reference| reference.name().as_bstr().to_string())
+        .filter(|name| name.starts_with("refs/"))
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+#[test]
+fn git_overlay_push_reports_refs_written_matching_ls_remote() {
+    let (work, _remote, remote_repo) = setup_git_overlay_push_fixture();
+
+    let output = heddle(&["--output", "json", "push", "origin"], Some(work.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&output).expect("push JSON should parse");
+    assert_eq!(
+        parsed["refs_written"],
+        serde_json::json!(["refs/heads/main", "refs/notes/heddle"]),
+        "current-thread push should report exactly the branch + notes refs it wrote: {parsed}"
+    );
+
+    // Round-trip: the destination's refs are exactly the refs the push
+    // reported — a git veteran running `git ls-remote` sees the same set.
+    let reported: Vec<String> = parsed["refs_written"]
+        .as_array()
+        .expect("refs_written should be an array")
+        .iter()
+        .map(|name| name.as_str().expect("ref name is a string").to_string())
+        .collect();
+    assert_eq!(
+        remote_ref_names(&remote_repo),
+        reported,
+        "refs at the remote should be exactly the refs the push output reported"
+    );
+
+    // A no-op repeat push writes nothing and says so.
+    let output = heddle(&["--output", "json", "push", "origin"], Some(work.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&output).expect("no-op push JSON should parse");
+    assert_eq!(
+        parsed["refs_written"],
+        serde_json::json!([]),
+        "a no-op push should report an empty refs_written array: {parsed}"
+    );
+}
+
+#[test]
+fn git_overlay_push_all_threads_reports_tag_and_sibling_refs_written() {
+    let (work, _remote, remote_repo) = setup_git_overlay_push_fixture();
+
+    let output = heddle(
+        &["--output", "json", "push", "origin", "--all-threads"],
+        Some(work.path()),
+    )
+    .unwrap();
+    let parsed: Value = serde_json::from_str(&output).expect("push JSON should parse");
+    assert_eq!(
+        parsed["refs_written"],
+        serde_json::json!([
+            "refs/heads/main",
+            "refs/heads/side",
+            "refs/notes/heddle",
+            "refs/tags/v1.0"
+        ]),
+        "all-threads push should report every branch, tag, and notes ref it wrote: {parsed}"
+    );
+    assert_eq!(
+        remote_ref_names(&remote_repo),
+        vec![
+            "refs/heads/main".to_string(),
+            "refs/heads/side".to_string(),
+            "refs/notes/heddle".to_string(),
+            "refs/tags/v1.0".to_string(),
+        ],
+        "refs at the remote should be exactly the refs the push output reported"
+    );
+}
+
+#[test]
 fn git_overlay_push_defaults_to_current_thread_branch() {
     let (work, _remote, remote_repo) = setup_git_overlay_push_fixture();
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1561,6 +1561,7 @@ the same ready envelope.
   "push_scope": "current_thread",
   "ref_scope": "branch_and_heddle_notes",
   "git_notes_ref": "refs/notes/heddle",
+  "refs_written": ["refs/heads/main", "refs/notes/heddle"],
   "git_notes_visibility_warning": "ordinary `git log --all` may show Heddle metadata commits from refs/notes/heddle",
   "git_tracking_remote": "origin",
   "git_remote_configured": {
@@ -1599,6 +1600,7 @@ the same ready envelope.
 | `push_scope`, `ref_scope`, `tags_included`, `thread` | string/bool \| null | Git-overlay push only | Whether the push published only the current thread or all threads, the concrete Git ref scope, whether tags were included, and the thread whose branch was pushed. |
 | `force`, `force_discard_warning` | bool/string \| null | Git-overlay push only | Present for Git-overlay push. `force_discard_warning` is non-null when `--force` may move remote refs backward or discard remote-only commits. |
 | `git_notes_ref`, `git_notes_visibility_warning` | string \| null | Git-overlay push only | Heddle metadata notes ref carried with the push and the human-visible Git disclosure for that ref. |
+| `refs_written` | array<string> \| null | push | The fully-qualified Git refs this invocation actually wrote (e.g. `refs/heads/<thread>`, `refs/notes/heddle`); empty when the push was a no-op. Lets callers verify the round-trip with `git ls-remote`. |
 | `git_tracking_remote`, `git_remote_configured`, `git_upstream_configured` | mixed | Git-overlay push only | Git config side effects when Heddle configures a remote or branch upstream during push. |
 | `next_action`, `recommended_action`, `next_action_template`, `recommended_action_template` | mixed | required for push | Post-push action metadata promoted from verification; all are `null` when the push closes the remote loop. |
 | `verification` | object | required for pull/push | Post-transfer verification proof. |


### PR DESCRIPTION
## Summary

Fixes #643

`heddle push` wrote `refs/heads/<thread>`, `refs/notes/heddle`, and (with `--all-threads`) `refs/tags/<tag>` into the remote without ever saying so: `--help` said only "Push to a remote repository", and a git veteran running `git ls-remote` afterwards saw an unexplained refs layout.

### Changes

- **Help** (`crates/cli/src/cli/cli_args/commands_main.rs`): `heddle push --help` long-about now documents the exact ref mapping (thread state → `refs/heads/<thread>`, metadata notes → `refs/notes/heddle`, `--all-threads` tags → `refs/tags/<tag>`) and points at `git ls-remote` for verification.
- **JSON output** (`crates/cli/src/cli/commands/remote/mod.rs`, `crates/cli/src/bridge/git_core.rs`): the bridge push paths (local-path `copy_mirror_to_path` and URL/network `push_network_remote`) now return the sorted full names of the refs the shared destination-reconcile plan wrote; `GitBridge::push{,_with_scope,_with_scope_force}` return `GitResult<Vec<String>>` (pre-1.0 delete+replace, no compat shim). Push's JSON gains `refs_written`: present on the Git-overlay refs path, `[]` for a no-op push, omitted (`Option::is_none` convention) on the native Heddle transport which writes Heddle thread refs, not Git refs. Retraction deletes are not included.
- **Schema** (`crates/cli/src/cli/commands/schemas.rs`): `PushSchema` gains the matching optional `refs_written` field, keeping the runtime⊆schema parity gate green.

### Test evidence

New tests in `crates/cli/tests/cli_integration/remotes.rs`:
- `push_help_documents_written_refs_namespace` — help names `refs/heads/<thread>`, `refs/notes/heddle`, `refs/tags/<tag>`, `git ls-remote`, `refs_written`.
- `git_overlay_push_reports_refs_written_matching_ls_remote` — current-thread push reports exactly `["refs/heads/main", "refs/notes/heddle"]`, the destination's refs equal the reported set (round-trip), and a repeat no-op push reports `[]`.
- `git_overlay_push_all_threads_reports_tag_and_sibling_refs_written` — all-threads push reports branches + tag + notes, matching the remote exactly.

Round-trip also verified manually with the built binary: `heddle push` JSON `refs_written` == `git ls-remote` output (minus HEAD); no-op repeat push → `[]`.

Gates run locally: `cargo build --locked --workspace` (default features) and `--all-features`; `scripts/check-no-silent-default-tree-load.sh` clean; `cargo clippy --locked --workspace --all-targets -- -D warnings` clean; `cargo test -p heddle-cli` (924 passed + 692 lib; only failures are the 3 known pre-existing `oss_cli_polish` harness-detection tests that fail on this box's exported CLAUDE*/CODEX* env, on clean main too); `cargo test --workspace --no-fail-fast` and `cargo test -p heddle-mount` green.

Note for the catalog agent: no `command_catalog.rs` change was needed — the catalog entry for `push` does not enumerate output fields; the schema registration lives entirely in `PushSchema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783815328&installation_id=132405951&pr_number=657&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F657&signature=783f275bea7964b8f332adb9403f87344c6eaae5cff82a401298195214fff9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->