### PR TITLE
feat(cli): onboarding + help-wording QoL cluster (init next-step, hidden-flag discovery, push/diff/commit help)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -285,7 +285,9 @@ Examples:
   heddle commit --all -m 'save everything'  # include unstaged/untracked paths even when the Git index is staged
 ")]
 pub struct CommitArgs {
-    /// Commit/capture message.
+    /// Commit/capture message. `--intent` is a deliberate alias: agents
+    /// (and humans) may prefer it to record WHY the change was made, not
+    /// just what changed — intent is first-class in Heddle's state model.
     #[arg(short = 'm', long = "message", visible_alias = "intent")]
     pub message: Option<String>,
 
@@ -448,6 +450,10 @@ pub struct RetroArgs {
 
 /// Arguments for the `diff` command.
 #[derive(Clone, Debug, clap::Args)]
+#[command(after_help = "\
+Patch compatibility:
+  --patch output targets a clean `git apply` round-trip; patch(1) support is best-effort — use `git apply` for git extended headers (type changes, mode bits, empty add/delete hunks).
+")]
 pub struct DiffArgs {
     /// Base state (default: HEAD).
     pub from: Option<String>,
@@ -606,6 +612,9 @@ Examples:
   heddle start fix-flake --task 'fix CI flake'    # attach a task description
 
 Isolated checkouts are Heddle-managed working directories. They do not contain a .git directory; use Heddle commands inside them, and run raw Git commands from the parent Git-overlay repo when needed.
+
+Advanced (hidden) flags:
+  --agent-provider/--agent-model (agent attribution for the registered thread), --parent-thread (delegated child work), --print-cd-path (print only the checkout path for shell wrappers), --daemon/--no-daemon (virtualized-mount ownership), --shared-target (workspace-shared cargo target dir). All are accepted here; they stay out of the flag list to keep everyday help terse.
 ")]
 pub struct ThreadStartArgs {
     /// Thread name to create or resume.
@@ -1300,6 +1309,10 @@ impl PushArgs {
 
 /// Arguments for the `pull` command.
 #[derive(Clone, Debug, clap::Args)]
+#[command(after_help = "\
+Advanced (hidden) flags:
+  --lazy leaves blob content absent by design and hydrates it explicitly later. Hosted/network Heddle remotes only; Git-overlay pulls reject it today — lazy hydration over the Git transport is planned for v0.3.1.
+")]
 pub struct PullArgs {
     #[command(flatten)]
     pub remote_op: RemoteOperationArgs,
@@ -1322,6 +1335,9 @@ Behavior:
   Depth controls history extent only — how many states the clone fetches — and says nothing about object contents. Whether a state's blobs are present locally or fetched lazily is a separate, independent concern that --depth never governs.
 
   See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.
+
+Advanced (hidden) flags:
+  --lazy and --filter blob:none skip blob content and hydrate it on demand. Hosted/network Heddle remotes only; Git-overlay clones (plain `https://…/repo.git` URLs and local-path clones) reject them today — lazy hydration over the Git transport is planned for v0.3.1.
 
 Examples:
   heddle clone https://example.com/repo.git ./clone   # Git repo: lands on the remote's default branch

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -1029,7 +1029,9 @@ impl RecoveryAdvice {
         Self::safety_refusal(
             "remote_not_configured",
             format!("No default remote is configured for {action}"),
-            "Add a remote with `heddle remote add <name> <url>`, inspect remotes with `heddle remote list`, or choose one with `heddle remote set-default <name>`.",
+            format!(
+                "Add a remote with `heddle remote add <name> <url>`, inspect remotes with `heddle remote list`, or choose one with `heddle remote set-default <name>`. Ad-hoc targets are supported without configuration: `heddle {action} <remote>` accepts a remote name, URL, local path, or hosted address positionally."
+            ),
             "the command did not receive a remote argument and no default remote is configured",
             format!(
                 "{action} needs a concrete remote target before it can move remote refs or transfer objects"

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -398,10 +398,20 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     let trust = build_repository_verification_state(&repo);
     // After a quickstart the user has a captured state to inspect, so
     // point them at `heddle log` regardless of the trust-derived action.
+    //
+    // A non-quickstart init must never end without a next step
+    // (heddle#644). When the repo has existing Git history the trust
+    // state already recommends the exact adopt/import command; when it
+    // doesn't (fresh native repo, or a Git checkout with no commits),
+    // trust has nothing to flag, so point at the first save — `heddle
+    // commit` records the first state (and, in Git-overlay repos, the
+    // matching Git checkpoint).
     let next_action = if quickstart.is_some() {
         Some("heddle log".to_string())
+    } else if !trust.recommended_action.is_empty() {
+        Some(trust.recommended_action.clone())
     } else {
-        (!trust.recommended_action.is_empty()).then(|| trust.recommended_action.clone())
+        Some("heddle commit -m \"...\"".to_string())
     };
     let principal_status = init_principal_status(&repo, &user_config)?;
     let output = InitOutput {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -232,13 +232,16 @@ struct PlainGitStatusOutput {
     git_index: Option<GitIndexPlan>,
 }
 
-/// Recommend the one-command first run when a native Heddle repository
-/// has been initialized but has no user-visible history yet (the log
-/// shows only the filtered synthetic root) and the worktree is clean —
-/// i.e. there is genuinely nothing to act on yet. A dirty worktree
-/// already has its own advice (`heddle commit`), and Git-overlay repos
-/// have their own onboarding (import/adopt), so both are left alone.
-fn quickstart_init_recommendation(
+/// Recommend the first save when a native Heddle repository has been
+/// initialized but has no user-visible history yet (the log shows only
+/// the filtered synthetic root) and the worktree is clean — i.e. there
+/// is genuinely nothing to act on yet. The repo is already initialized,
+/// so recommending `heddle init --quickstart` here read as "you
+/// initialized wrong" (heddle#644); point at the first commit instead.
+/// A dirty worktree already has its own advice (`heddle commit`), and
+/// Git-overlay repos have their own onboarding (import/adopt), so both
+/// are left alone.
+fn first_save_recommendation(
     repo: &Repository,
     current_state: Option<&objects::object::State>,
     worktree_clean: bool,
@@ -247,11 +250,7 @@ fn quickstart_init_recommendation(
         return None;
     }
     let empty_log = current_state.map(is_synthetic_root).unwrap_or(true);
-    // The repo already has `.heddle/` (it has been init'd to reach this
-    // branch), so a bare `heddle init --quickstart` hits the confirmation
-    // gate and is refused non-interactively. Recommend the runnable form —
-    // `--yes` clears the gate — so an agent/script can run it verbatim.
-    empty_log.then(|| "heddle init --quickstart --yes".to_string())
+    empty_log.then(|| "heddle commit -m \"...\"".to_string())
 }
 
 fn changes_from_status(status: &WorktreeStatus) -> ChangesInfo {
@@ -528,7 +527,7 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
             && changes.added.is_empty()
             && changes.deleted.is_empty();
         let recommended_action =
-            quickstart_init_recommendation(&repo, current_state.as_ref(), worktree_clean)
+            first_save_recommendation(&repo, current_state.as_ref(), worktree_clean)
                 .unwrap_or(recommended_action);
         debug!(
             repo_open_ms,
@@ -979,10 +978,9 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
     }
     // A freshly-`init`'d native repo whose log is still empty (only the
     // synthetic root) and whose worktree is clean has nothing to act on
-    // yet — point the user at the one-command first run.
-    let recommended_action =
-        quickstart_init_recommendation(&repo, current_state.as_ref(), !has_changes)
-            .unwrap_or(recommended_action);
+    // yet — point the user at the first save.
+    let recommended_action = first_save_recommendation(&repo, current_state.as_ref(), !has_changes)
+        .unwrap_or(recommended_action);
     let recommended_action_fields = ActionFields::from_action(&recommended_action);
     let thread_health = if trust.verified {
         advice

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -1168,8 +1168,8 @@ mod tests {
     ///     points at a reveal surface (`heddle help <topic>` /
     ///     `--help-agent`).
     ///
-    /// Hidden commands (debug surfaces like `heddle index`/`monitor`)
-    /// are skipped wholesale — their entire surface is intentionally
+    /// Hidden commands (debug surfaces like `index`/`monitor`) are
+    /// skipped wholesale — their entire surface is intentionally
     /// unadvertised. Global args are skipped (`--op-id` has its own
     /// contract-driven reveal in `help_command_for_path` plus the
     /// `operation-ids` topic).

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -1153,4 +1153,88 @@ mod tests {
             );
         }
     }
+
+    /// heddle#646. Close-the-class: every `hide = true` flag on a visible
+    /// command must carry a discovery affordance, so no flag is learnable
+    /// only by reading the source (the clone `--lazy`/`--filter` gap).
+    /// Two affordances are recognized:
+    ///
+    /// (a) internal plumbing — the flag's own help text starts with
+    ///     "Internal", declaring it not-for-users (test helpers, hints
+    ///     automation sets on the user's behalf); or
+    /// (b) a help breadcrumb — the command's after-help carries an
+    ///     advanced/hidden-flags note (mentions "hidden" or "advanced
+    ///     flag") that either names the flag (`--<long>`) inline or
+    ///     points at a reveal surface (`heddle help <topic>` /
+    ///     `--help-agent`).
+    ///
+    /// Hidden commands (debug surfaces like `heddle index`/`monitor`)
+    /// are skipped wholesale — their entire surface is intentionally
+    /// unadvertised. Global args are skipped (`--op-id` has its own
+    /// contract-driven reveal in `help_command_for_path` plus the
+    /// `operation-ids` topic).
+    #[test]
+    fn hidden_flags_carry_discovery_affordances() {
+        use clap::CommandFactory;
+
+        fn walk(cmd: &clap::Command, path: &str, violations: &mut Vec<String>) {
+            let after_help = [
+                cmd.get_after_help().map(ToString::to_string),
+                cmd.get_after_long_help().map(ToString::to_string),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("\n");
+            let after_lower = after_help.to_lowercase();
+            let breadcrumb_marker =
+                after_lower.contains("hidden") || after_lower.contains("advanced flag");
+            let points_at_reveal =
+                after_help.contains("heddle help ") || after_help.contains("--help-agent");
+
+            for arg in cmd.get_arguments() {
+                if !arg.is_hide_set() || arg.is_global_set() {
+                    continue;
+                }
+                let flag_help = arg
+                    .get_long_help()
+                    .or_else(|| arg.get_help())
+                    .map(ToString::to_string)
+                    .unwrap_or_default();
+                if flag_help.starts_with("Internal") {
+                    continue;
+                }
+                let named_inline = arg
+                    .get_long()
+                    .is_some_and(|long| after_help.contains(&format!("--{long}")));
+                if breadcrumb_marker && (points_at_reveal || named_inline) {
+                    continue;
+                }
+                let name = arg
+                    .get_long()
+                    .map(|long| format!("--{long}"))
+                    .unwrap_or_else(|| arg.get_id().to_string());
+                violations.push(format!("`{path}` hides `{name}`"));
+            }
+
+            for sub in cmd.get_subcommands() {
+                if sub.is_hide_set() {
+                    continue;
+                }
+                walk(sub, &format!("{path} {}", sub.get_name()), violations);
+            }
+        }
+
+        let cmd = crate::cli::cli_args::Cli::command();
+        let mut violations = Vec::new();
+        walk(&cmd, cmd.get_name(), &mut violations);
+        assert!(
+            violations.is_empty(),
+            "hidden flags without a discovery affordance (heddle#646): either \
+             prefix the flag's help with `Internal` (plumbing, not for users) \
+             or add an after-help breadcrumb that mentions the hidden/advanced \
+             flags and names the flag or a reveal surface:\n  {}",
+            violations.join("\n  ")
+        );
+    }
 }

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -434,6 +434,47 @@ fn test_cli_init_in_git_repo_bootstraps_sidecar() {
     assert_eq!(parsed["storage_model"], "git+heddle-sidecar");
 }
 
+/// heddle#644: a successful non-quickstart init on an empty directory
+/// must end with a next step in both text and JSON — the first save —
+/// instead of a null `recommended_action`.
+#[test]
+fn test_cli_init_empty_dir_recommends_first_save() {
+    let temp = TempDir::new().unwrap();
+    let text = heddle(&["init"], Some(temp.path())).unwrap();
+    assert!(
+        text.contains("heddle commit -m"),
+        "text init output should point at the first save: {text}"
+    );
+
+    let temp = TempDir::new().unwrap();
+    let json = heddle(&["--output", "json", "init"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        parsed["recommended_action"], "heddle commit -m \"...\"",
+        "JSON init output carries the first-save recommendation: {parsed}"
+    );
+    assert_eq!(parsed["next_action"], parsed["recommended_action"]);
+}
+
+/// heddle#644: a non-quickstart init over existing Git history must
+/// recommend the adopt/import path (text + JSON), mirroring the
+/// workflow-choice pathways in the main help.
+#[test]
+fn test_cli_init_with_git_history_recommends_adopt() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo(temp.path());
+    std::fs::write(temp.path().join("seed.txt"), "history").unwrap();
+    git_commit_all(temp.path(), "seed commit");
+
+    let json = heddle(&["--output", "json", "init"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    let action = parsed["recommended_action"].as_str().unwrap_or_default();
+    assert!(
+        action.contains("adopt") || action.contains("import"),
+        "init over existing Git history recommends adopting it, got {action:?}: {parsed}"
+    );
+}
+
 #[test]
 fn test_cli_status_bootstraps_plain_git_repo_and_adopts_current_branch() {
     let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -174,3 +174,81 @@ fn capture_help_keeps_help_agent_hidden_but_keeps_the_pointer() {
         "`capture --help` must not list the hidden `--help-agent` flag (only the after-help pointer): {help}"
     );
 }
+
+/// heddle#646. The hidden `--lazy`/`--filter` clone flags need a discovery
+/// affordance: a git veteran who knows `git clone --filter` must be able to
+/// learn from `clone --help` that the flags exist, where they work today
+/// (hosted/network remotes), and the Git-transport timeline (v0.3.1) —
+/// before a failure teaches them.
+#[test]
+fn clone_help_carries_hidden_flag_breadcrumb() {
+    let help = heddle_help(&["clone", "--help"]);
+    assert!(
+        help.contains("--lazy") && help.contains("--filter blob:none"),
+        "clone help should name the hidden lazy/filter flags: {help}"
+    );
+    assert!(
+        help.contains("planned for v0.3.1"),
+        "clone help should state the Git-transport timeline for lazy clones: {help}"
+    );
+}
+
+/// heddle#646 (same class, pull surface). `pull --lazy` is hidden too; the
+/// breadcrumb keeps it discoverable.
+#[test]
+fn pull_help_carries_hidden_flag_breadcrumb() {
+    let help = heddle_help(&["pull", "--help"]);
+    assert!(
+        help.contains("--lazy") && help.contains("planned for v0.3.1"),
+        "pull help should name the hidden --lazy flag and its timeline: {help}"
+    );
+}
+
+/// heddle#646 (same class, start surface). The hidden automation/power
+/// flags on `start` are named in an advanced-flags stanza so agents and
+/// power users can discover them without reading the source.
+#[test]
+fn start_help_carries_hidden_flag_breadcrumb() {
+    let help = heddle_help(&["start", "--help"]);
+    for flag in [
+        "--agent-provider",
+        "--agent-model",
+        "--parent-thread",
+        "--print-cd-path",
+        "--daemon",
+        "--no-daemon",
+        "--shared-target",
+    ] {
+        assert!(
+            help.contains(flag),
+            "start help should name the hidden `{flag}` flag in its advanced stanza: {help}"
+        );
+    }
+}
+
+/// heddle#654. A user piping `heddle diff --patch | patch -p1` must learn
+/// from `--help` — not from a silent failure — that patch(1) compatibility
+/// is best-effort and `git apply` is the canonical consumer.
+#[test]
+fn diff_help_warns_patch_compat_is_best_effort() {
+    let help = heddle_help(&["diff", "--help"]);
+    assert!(
+        help.contains("git apply") && help.contains("patch(1)") && help.contains("best-effort"),
+        "diff help should state that patch(1) support is best-effort and git apply is canonical: {help}"
+    );
+    assert!(
+        help.contains("type changes") && help.contains("mode bits"),
+        "diff help should name the git-extended-header cases that need git apply: {help}"
+    );
+}
+
+/// heddle#655. `[aliases: --intent]` on commit's `-m` reads as a typo
+/// without an explanation; the help text must say why the alias exists.
+#[test]
+fn commit_help_explains_intent_alias() {
+    let help = heddle_help(&["commit", "--help"]);
+    assert!(
+        help.contains("--intent") && help.contains("WHY"),
+        "commit help should explain the deliberate --intent alias: {help}"
+    );
+}

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8145,7 +8145,14 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         );
     }
 
+    // heddle#646: hidden flags stay out of the options list, but a single
+    // after-help "Advanced (hidden) flags" breadcrumb names them so they
+    // remain discoverable. The first-run surface (everything before the
+    // breadcrumb) stays free of the advanced machinery.
     let start_help = heddle_help(&["start", "--help"]);
+    let (start_first_run, start_breadcrumb) = start_help
+        .split_once("Advanced (hidden) flags:")
+        .expect("start help carries the advanced-flags breadcrumb (heddle#646)");
     for hidden in [
         "--agent-provider",
         "--agent-model",
@@ -8153,12 +8160,20 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
         "--daemon",
         "--no-daemon",
         "--shared-target",
-        "FUSE",
-        "heddled",
     ] {
         assert!(
-            !start_help.contains(hidden),
+            !start_first_run.contains(hidden),
             "start help should keep advanced checkout machinery out of the first-run surface: {start_help}"
+        );
+        assert!(
+            start_breadcrumb.contains(hidden),
+            "start help's advanced-flags breadcrumb should name `{hidden}`: {start_help}"
+        );
+    }
+    for jargon in ["FUSE", "heddled"] {
+        assert!(
+            !start_help.contains(jargon),
+            "start help should avoid mount-internals jargon everywhere: {start_help}"
         );
     }
     assert!(
@@ -8168,10 +8183,17 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
     );
 
     let clone_help = heddle_help(&["clone", "--help"]);
+    let (clone_first_run, clone_breadcrumb) = clone_help
+        .split_once("Advanced (hidden) flags:")
+        .expect("clone help carries the advanced-flags breadcrumb (heddle#646)");
     for hidden in ["--lazy", "--filter", "v0.3.1", "blob:none"] {
         assert!(
-            !clone_help.contains(hidden),
+            !clone_first_run.contains(hidden),
             "clone help should not lead with planned partial-clone machinery: {clone_help}"
+        );
+        assert!(
+            clone_breadcrumb.contains(hidden),
+            "clone help's advanced-flags breadcrumb should name `{hidden}`: {clone_help}"
         );
     }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -11381,6 +11381,15 @@ fn push_without_default_remote_uses_typed_json_recovery() {
                 && hint.contains("heddle remote set-default <name>")),
         "push remote setup hint should be specific and actionable: {envelope}"
     );
+    // heddle#653: the hint must say whether ad-hoc (git `push <url>`
+    // style) targets work, not leave veterans to discover it by trial.
+    assert!(
+        envelope["hint"]
+            .as_str()
+            .is_some_and(|hint| hint.contains("heddle push <remote>")
+                && hint.contains("positionally")),
+        "push no-remote hint should state that ad-hoc positional targets are supported: {envelope}"
+    );
     assert_eq!(
         envelope["primary_command"],
         "heddle remote add <name> <url>"

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -98,10 +98,12 @@ fn quickstart_writes_placeholder_when_directory_is_empty() {
     );
 }
 
-/// `heddle status` on a freshly-`init`'d native repo whose log is empty
-/// surfaces `heddle init --quickstart` in `recommended_action`.
+/// heddle#644: `heddle status` on a freshly-`init`'d native repo whose
+/// log is empty points at the first save — never back at `heddle init
+/// --quickstart`, which read as "you initialized wrong" on a repo that
+/// is already initialized.
 #[test]
-fn status_recommends_quickstart_on_empty_native_repo() {
+fn status_recommends_first_save_not_reinit_on_empty_native_repo() {
     let temp = TempDir::new().unwrap();
     let dir = temp.path();
 
@@ -110,8 +112,15 @@ fn status_recommends_quickstart_on_empty_native_repo() {
     let status = status_json(dir);
     assert_eq!(
         status["recommended_action"].as_str(),
-        Some("heddle init --quickstart --yes"),
-        "fresh native repo recommends the runnable quickstart command: {status}"
+        Some("heddle commit -m \"...\""),
+        "fresh native repo recommends the first save: {status}"
+    );
+    assert!(
+        !status["recommended_action"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("init --quickstart"),
+        "status must not suggest re-init on an already-initialized repo: {status}"
     );
 
     // Once quickstart has produced a capture, the log is no longer empty
@@ -133,8 +142,8 @@ fn status_recommends_quickstart_on_empty_native_repo() {
     let status = status_json(dir);
     assert_ne!(
         status["recommended_action"].as_str(),
-        Some("heddle init --quickstart"),
-        "after quickstart the recommendation no longer fires: {status}"
+        Some("heddle commit -m \"...\""),
+        "after the first capture the first-save recommendation no longer fires: {status}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -462,12 +462,22 @@ fn test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged() {
     );
 }
 
+/// heddle#646: the planned lazy/partial-clone flags stay `hide = true`
+/// (out of the options list) but are named once in the after-help
+/// "Advanced (hidden) flags" breadcrumb so they're discoverable.
 #[test]
-fn test_cli_clone_help_hides_planned_lazy_flag() {
+fn test_cli_clone_help_keeps_planned_lazy_flag_to_breadcrumb() {
     let output = heddle_help(&["clone", "--help"]);
+    let (first_run, breadcrumb) = output
+        .split_once("Advanced (hidden) flags:")
+        .expect("clone help carries the advanced-flags breadcrumb (heddle#646)");
     assert!(
-        !output.contains("--lazy") && !output.contains("--filter"),
+        !first_run.contains("--lazy") && !first_run.contains("--filter"),
         "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
+    );
+    assert!(
+        breadcrumb.contains("--lazy") && breadcrumb.contains("--filter"),
+        "clone help's breadcrumb should name the hidden lazy/filter flags: {output}"
     );
 }
 
@@ -634,12 +644,22 @@ fn test_cli_pull_local_detached_head_materializes_then_publishes_thread() {
     );
 }
 
+/// heddle#646: `pull --lazy` stays `hide = true` (out of the options
+/// list) but is named once in the after-help "Advanced (hidden) flags"
+/// breadcrumb so it's discoverable.
 #[test]
-fn test_cli_pull_help_hides_planned_lazy_flag() {
+fn test_cli_pull_help_keeps_planned_lazy_flag_to_breadcrumb() {
     let output = heddle_help(&["pull", "--help"]);
+    let (first_run, breadcrumb) = output
+        .split_once("Advanced (hidden) flags:")
+        .expect("pull help carries the advanced-flags breadcrumb (heddle#646)");
     assert!(
-        !output.contains("--lazy"),
+        !first_run.contains("--lazy"),
         "pull help should keep planned lazy pull out of first-run help: {output}"
+    );
+    assert!(
+        breadcrumb.contains("--lazy"),
+        "pull help's breadcrumb should name the hidden --lazy flag: {output}"
     );
 }
 


### PR DESCRIPTION
Pre-v0.3.0 QoL cluster: onboarding + help wording, from the 2026-06-11 persona-eval.

## #644 — init ends with a next step; status stops suggesting re-init
Fixes #644
- Non-quickstart `heddle init` now always sets `recommended_action` (text `Next:` line + JSON, `next_action` mirrored): existing Git history keeps the trust-derived adopt/import command (e.g. `heddle adopt --ref main`); a fresh/empty repo (native, or a Git checkout with no commits) gets `heddle commit -m "..."` — the registered display-only placeholder, never an empty string (`crates/cli/src/cli/commands/init.rs`).
- `heddle status` on an already-initialized empty native repo no longer recommends `heddle init --quickstart --yes` (which read as "you initialized wrong"); it points at the first save instead (`first_save_recommendation` in `crates/cli/src/cli/commands/status.rs`).
- Tests: `test_cli_init_empty_dir_recommends_first_save` (text + JSON), `test_cli_init_with_git_history_recommends_adopt`, and `status_recommends_first_save_not_reinit_on_empty_native_repo` (rewritten from the old quickstart pin — the old assertion pinned exactly the behavior this issue removes).

## #646 — hidden flags get discovery affordances (class closed)
Part of #646 (catalog half — hidden-flag marker in commands --output json — delivered by the catalog cluster)
- `clone --help` and `pull --help` carry an "Advanced (hidden) flags" breadcrumb naming `--lazy` / `--filter blob:none`, where they work today (hosted/network remotes), and the v0.3.1 Git-transport timeline.
- `start --help` names its hidden automation/power flags (`--agent-provider`, `--agent-model`, `--parent-thread`, `--print-cd-path`, `--daemon`/`--no-daemon`, `--shared-target`) in the same breadcrumb shape. `capture --help` already had its breadcrumb (`heddle help agent-flags` / `--help-agent`).
- **Conformance test** (`hidden_flags_carry_discovery_affordances`, `crates/cli/src/cli/help.rs`): walks the full clap tree; every `hide = true` flag on a visible command must either declare itself `Internal` in its own help text (plumbing/test helpers) or be covered by an after-help breadcrumb that names the flag inline or points at a reveal surface (`heddle help <topic>` / `--help-agent`). Red evidence: run against pre-fix args it fails on `clone --lazy/--filter`, `pull --lazy`, and the six `start` flags.
- Policy pins updated to match (`remotes.rs`, `oss_cli_polish.rs::advanced_help_does_not_repeat_everyday_human_path`): hidden flags stay out of the options list / first-run surface, named once in the breadcrumb.
- NOT in this PR (sibling owns `command_catalog.rs`): exposing hidden flags in `heddle commands --output json` with a `hidden: true` marker — that half of the #646 DoD belongs to the catalog work.

## #653 — push no-remote error states ad-hoc URL push support
Fixes #653
- `remote_not_configured` hint (push and pull) now states explicitly: ad-hoc targets are supported without configuration — `heddle push <remote>` accepts a remote name, URL, local path, or hosted address positionally. Text-only change; kind/schema untouched.
- Test: extended `push_without_default_remote_uses_typed_json_recovery` to pin the new sentence.

## #654 — diff --help warns patch(1) is best-effort
Fixes #654
- `diff --help` after-help: `--patch` output targets a clean `git apply` round-trip; patch(1) support is best-effort — use `git apply` for git extended headers (type changes, mode bits, empty add/delete hunks).
- Test: `diff_help_warns_patch_compat_is_best_effort`.

## #655 — commit's --intent alias explained
Fixes #655
- `-m/--message` help now says the `--intent` alias is deliberate: record WHY, not just what — intent is first-class in Heddle's state model.
- Test: `commit_help_explains_intent_alias`.

## Test evidence
- `cargo build --locked --workspace` (default features) and `--all-features`: green (one pre-existing all-features-only dead-code warning on `network_feature_unavailable`, untouched here; CI clippy runs default/postgres features and is clean).
- `bash scripts/check-no-silent-default-tree-load.sh`: clean (548 files).
- `cargo clippy --locked --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p heddle-cli` / `cargo test --workspace --no-fail-fast`: all green except 5 pre-existing harness-detection failures on this box (3 in `oss_cli_polish`, 2 in `multi_agent_worktrees`) — the host exports CLAUDE*/CODEX* env, so the harness probe resolves the Claude identity instead of the expected `gpt-5.3-codex`; fails identically on clean main, not chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783816708&installation_id=132405951&pr_number=658&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F658&signature=d1884da919ec63446219fb2ce0c10cb5adc6e5beaf3f5b7a43812e5f5911aa7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->