### PR TITLE
fix(cli)!: error/exit/envelope contract core for v0.3.0 (#640 #642 #645 #647 #648)

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -5859,7 +5859,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -5970,7 +5973,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -7701,7 +7703,10 @@
           "type": "string"
         },
         "recommended_action": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recommended_action_template": {
           "anyOf": [
@@ -7734,7 +7739,6 @@
         "storage_model",
         "mirror_initialized",
         "git_overlay_health",
-        "recommended_action",
         "recovery_commands",
         "verification",
         "output_kind"
@@ -11648,7 +11652,10 @@
         },
         "profile": true,
         "recommended_action": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recommended_action_template": {
           "anyOf": [
@@ -11693,7 +11700,6 @@
         "changes",
         "workspace",
         "health",
-        "recommended_action",
         "recovery_commands"
       ],
       "title": "DiagnoseSchema",
@@ -12182,9 +12188,6 @@
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
-        "code": {
-          "type": "string"
-        },
         "error": {
           "type": "string"
         },
@@ -12247,7 +12250,6 @@
         }
       },
       "required": [
-        "code",
         "error",
         "exit_code",
         "hint",
@@ -13890,7 +13892,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto",
             "verification",
@@ -15642,6 +15643,35 @@
     },
     "push": {
       "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
         "GitRemoteConfiguredSchema": {
           "properties": {
             "name": {
@@ -15671,6 +15701,26 @@
             "remote"
           ],
           "type": "object"
+        },
+        "NullableActionTemplateSchema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActionTemplateSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "NullableStringSchema": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -15738,36 +15788,10 @@
           ]
         },
         "next_action": {
-          "type": "string"
+          "$ref": "#/$defs/NullableStringSchema"
         },
         "next_action_template": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
+          "$ref": "#/$defs/NullableActionTemplateSchema"
         },
         "objects": {
           "format": "uint",
@@ -15826,36 +15850,10 @@
           "type": "boolean"
         },
         "recommended_action": {
-          "type": "string"
+          "$ref": "#/$defs/NullableStringSchema"
         },
         "recommended_action_template": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
+          "$ref": "#/$defs/NullableActionTemplateSchema"
         },
         "ref_scope": {
           "type": [
@@ -19202,7 +19200,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -19313,7 +19314,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -21257,7 +21257,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -21368,7 +21371,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -22602,7 +22604,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -22713,7 +22718,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -23139,7 +23143,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -23250,7 +23257,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -23444,7 +23450,10 @@
               "type": "string"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -23459,8 +23468,7 @@
           },
           "required": [
             "name",
-            "git_commit",
-            "recommended_action"
+            "git_commit"
           ],
           "type": "object"
         },
@@ -24114,7 +24122,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -24225,7 +24236,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -24316,7 +24326,10 @@
           "type": "string"
         },
         "recommended_action": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recommended_action_template": {
           "anyOf": [
@@ -24377,7 +24390,6 @@
         "threads",
         "available_git_refs",
         "verification",
-        "recommended_action",
         "recovery_commands",
         "recovery_action_templates",
         "output_kind"
@@ -24741,7 +24753,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -24852,7 +24867,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -25259,7 +25273,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -25370,7 +25387,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -25777,7 +25793,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -25888,7 +25907,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -27170,7 +27188,6 @@
         "is_isolated",
         "thread_health",
         "blockers",
-        "recommended_action",
         "history_imported",
         "auto",
         "verification",
@@ -27450,7 +27467,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -27561,7 +27581,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -29147,7 +29166,10 @@
               "type": "string"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -29162,8 +29184,7 @@
           },
           "required": [
             "name",
-            "git_commit",
-            "recommended_action"
+            "git_commit"
           ],
           "type": "object"
         },
@@ -29817,7 +29838,10 @@
               "type": "boolean"
             },
             "recommended_action": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "recommended_action_template": {
               "anyOf": [
@@ -29928,7 +29952,6 @@
             "is_isolated",
             "thread_health",
             "blockers",
-            "recommended_action",
             "history_imported",
             "auto"
           ],
@@ -30048,7 +30071,10 @@
           "type": "string"
         },
         "recommended_action": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recommended_action_template": {
           "anyOf": [
@@ -30099,7 +30125,6 @@
         "storage_model",
         "hosted_enabled",
         "verification",
-        "recommended_action",
         "groups",
         "available_git_refs",
         "thread_count",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -318,7 +318,7 @@ export interface AttemptSchema {
 export interface AvailableGitRefSchema {
   git_commit: string;
   name: string;
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
 }
 
@@ -449,7 +449,7 @@ export interface BridgeGitStatusSchema {
   mirror_initialized: boolean;
   mirror_path?: string | null;
   output_kind: "bridge_git_status";
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_commands: string[];
   repository_capability: string;
@@ -944,7 +944,7 @@ export interface DiagnoseSchema {
   operation?: unknown;
   output_kind?: string | null;
   profile?: unknown;
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_commands: string[];
   remote_tracking?: unknown;
@@ -1142,7 +1142,6 @@ export interface DoctorSchemasSchema {
 }
 
 export interface ErrorEnvelopeSchema {
-  code: string;
   error: string;
   exit_code: number;
   hint: string;
@@ -1638,16 +1637,16 @@ export interface PushSchema {
   git_tracking_remote?: string | null;
   git_upstream_configured?: GitUpstreamConfiguredSchema | null;
   idempotency_status?: string | null;
-  next_action: string;
-  next_action_template: { action: string; agent_may_fill: boolean; argv_template: string[]; required_inputs: string[]; };
+  next_action: NullableStringSchema;
+  next_action_template: NullableActionTemplateSchema;
   objects?: number | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: string;
   push_scope?: string | null;
   pushed: boolean;
-  recommended_action: string;
-  recommended_action_template: { action: string; agent_may_fill: boolean; argv_template: string[]; required_inputs: string[]; };
+  recommended_action: NullableStringSchema;
+  recommended_action_template: NullableActionTemplateSchema;
   ref_scope?: string | null;
   remote?: string | null;
   replayed?: boolean | null;
@@ -2447,7 +2446,7 @@ export interface ThreadListSchema {
   current?: string | null;
   hosted_enabled: boolean;
   output_kind: "thread_list";
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_action_templates: ActionTemplateSchema[];
   recovery_commands: string[];
@@ -2610,7 +2609,7 @@ export interface ThreadShowSchema {
   probe_confidence?: number | null;
   probe_source?: string | null;
   promotion_suggested: boolean;
-  recommended_action: string | null;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_commands: string[];
   remote_tracking?: unknown;
@@ -2671,7 +2670,7 @@ export interface ThreadShowSchema2 {
   probe_confidence?: number | null;
   probe_source?: string | null;
   promotion_suggested: boolean;
-  recommended_action: string | null;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_commands: string[];
   remote_tracking?: unknown;
@@ -2731,7 +2730,7 @@ export interface ThreadSummarySchema {
   probe_confidence?: number | null;
   probe_source?: string | null;
   promotion_suggested: boolean;
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   remote_tracking?: unknown;
   report_flush_state?: string | null;
@@ -2944,7 +2943,7 @@ export interface WorkspaceShowSchema {
   hosted_enabled: boolean;
   operation?: unknown;
   output_kind: "workspace_summary";
-  recommended_action: string;
+  recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   remote_tracking?: unknown;
   repository: string;

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -1322,6 +1322,31 @@ impl RecoveryAdvice {
         )
     }
 
+    /// Stored repository state failed msgpack/serde decoding. Without
+    /// this mapping the user sees the raw decoder internals ("wrong
+    /// msgpack marker FixArray(0)") with no recovery path — and every
+    /// subsequent command, including `heddle status` (the natural
+    /// recovery probe), dead-ends on the same opaque error
+    /// (HeddleCo/heddle#642). The decoder detail is preserved in
+    /// `unsafe_condition` for diagnosis; the user-facing error names the
+    /// condition and the recovery tooling.
+    pub(crate) fn serialization_error(detail: impl fmt::Display) -> Self {
+        Self::safety_refusal(
+            "state_corrupted",
+            "Repository state is corrupted or unreadable",
+            "Diagnose with `heddle verify`, inspect store integrity with `heddle fsck --full`, then repair with `heddle fsck --repair`.",
+            format!("a stored repository object failed to decode: {detail}"),
+            "continuing would read or write through repository state Heddle cannot decode",
+            "the command stopped before mutating repository state; intact objects were left unchanged",
+            "heddle verify",
+            vec![
+                "heddle verify".to_string(),
+                "heddle fsck --full".to_string(),
+                "heddle fsck --repair".to_string(),
+            ],
+        )
+    }
+
     /// A thread command resolved a state spec or anchor and the
     /// referenced state was not in the object store. Distinct from
     /// `state_not_found` because the lookup happens inside thread

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -422,6 +422,15 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
                 };
             }
             match heddle_err {
+                // Corrupted stored state (HeddleCo/heddle#642): decode
+                // failures must surface as a recovery path, not raw msgpack
+                // internals — `heddle status` is the natural recovery probe
+                // and would otherwise dead-end on the same opaque error.
+                HeddleError::Serialization(detail) => {
+                    return ErrorClassification::from_advice(
+                        &RecoveryAdvice::serialization_error(detail),
+                    );
+                }
                 HeddleError::RepositoryNotFound(path) => {
                     let command =
                         format!("heddle init {}", shell_quote(&path.display().to_string()));

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -35,7 +35,6 @@ pub fn print_error_with_hint(cli: &Cli, err: &anyhow::Error) {
         let primary_command_template = command_template(&classification.primary_command);
         let recovery_action_templates = command_templates(&classification.recovery_commands);
         let mut body = serde_json::json!({
-            "code": kind,
             "error": envelope_error,
             "exit_code": HeddleExitCode::from_error(err).as_u8(),
             "hint": hint,
@@ -144,7 +143,6 @@ pub fn print_parse_error_json_envelope(err: &ClapError) {
     ];
     let recovery_action_templates = command_templates(&recovery_commands);
     let body = serde_json::json!({
-        "code": "parse_error",
         "error": err.to_string(),
         "exit_code": HeddleExitCode::from_clap(err).as_u8(),
         "hint": "Run `heddle commands --output json` to inspect the command surface.",

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -25,7 +25,7 @@ use super::{
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
         override_trust_recommended_action,
-        repository_verification_blocked_advice,
+        repository_verification_blocked_advice, serialize_empty_action_as_null,
     },
     next_action::{NextActionValidationContext, write_command_json},
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
@@ -76,6 +76,9 @@ pub struct ThreadPreviewReport {
     pub conflicts: Vec<String>,
     pub conflict_count: usize,
     pub blockers: Vec<String>,
+    // "" means "no action selected" internally; the wire contract is null
+    // (HeddleCo/heddle#645) — the boundary walker rejects raw empties.
+    #[serde(serialize_with = "serialize_empty_action_as_null")]
     pub recommended_action: String,
     pub recommended_action_template: Option<ActionTemplate>,
     pub thread_health: String,

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -124,6 +124,18 @@ fn validate_next_actions_at_path(
                 if matches!(key.as_str(), "next_action" | "recommended_action")
                     && let Some(action) = child.as_str()
                 {
+                    // Action-field contract (HeddleCo/heddle#645): "no
+                    // action needed" is `null` and "not applicable" is an
+                    // absent field — the empty string is never a valid
+                    // serialized action. Route emitters through
+                    // `normalized_action` so empties become `None` before
+                    // they reach this boundary.
+                    if action.trim().is_empty() {
+                        return Err(next_action_validation_error(format!(
+                            "empty {key} at {child_path}: serialize no-action as null (or omit \
+                             the field), never \"\" — see normalized_action"
+                        )));
+                    }
                     validate_next_action(action, context)
                         .with_context(|| format!("invalid {key} at {child_path}"))?;
                 }
@@ -406,7 +418,27 @@ pub(crate) fn thread_recovery_action_is_primary(
         || thread_action.starts_with("heddle thread promote ")
 }
 
-fn non_empty_action(action: Option<&str>) -> Option<&str> {
+/// The single normalizer for serialized action fields
+/// (HeddleCo/heddle#645). The internal selection helpers above use
+/// `String` with "empty means no action"; this collapses that convention
+/// at the boundary — empty/whitespace-only becomes `None`, so JSON output
+/// serializes `null` (or omits the field) and `""` can never leak into a
+/// `next_action`/`recommended_action`. Route every output-struct
+/// assignment through here instead of ad-hoc `.is_empty()` checks; the
+/// serialization walker in `validate_next_actions_at_path` rejects any
+/// empty string that slips past.
+pub(crate) fn normalized_action(action: impl Into<String>) -> Option<String> {
+    let action = action.into();
+    if action.trim().is_empty() {
+        None
+    } else {
+        Some(action)
+    }
+}
+
+/// Borrowed sibling of [`normalized_action`] for render paths that only
+/// need to know whether an action exists.
+pub(crate) fn non_empty_action(action: Option<&str>) -> Option<&str> {
     action.filter(|action| !action.trim().is_empty())
 }
 
@@ -468,6 +500,45 @@ mod tests {
         )
         .expect_err("ready must not point back to ready");
         assert!(err.to_string().contains("self-loop"));
+    }
+
+    #[test]
+    fn normalized_action_maps_empty_and_whitespace_to_none() {
+        assert_eq!(normalized_action(""), None);
+        assert_eq!(normalized_action("   "), None);
+        assert_eq!(
+            normalized_action("heddle status"),
+            Some("heddle status".to_string())
+        );
+    }
+
+    #[test]
+    fn boundary_rejects_empty_string_actions() {
+        // HeddleCo/heddle#645: `""` is not a valid serialized action —
+        // no-action is `null`, not-applicable is an absent field.
+        for payload in [
+            json!({"recommended_action": ""}),
+            json!({"next_action": "  "}),
+            json!({"nested": {"checks": [{"recommended_action": ""}]}}),
+        ] {
+            let err = validate_next_actions_in_value(&payload, ctx(&["status"]))
+                .expect_err("empty-string action must fail the serialization boundary");
+            assert!(
+                err.to_string().contains("empty"),
+                "rejection should name the empty-action contract: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn boundary_accepts_null_and_absent_actions() {
+        for payload in [
+            json!({"recommended_action": null, "next_action": null}),
+            json!({"output_kind": "status"}),
+        ] {
+            validate_next_actions_in_value(&payload, ctx(&["status"]))
+                .expect("null/absent actions are the documented no-action encodings");
+        }
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -19,7 +19,8 @@ use super::{
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},
     next_action::{
-        NextActionInput, NextActionValidationContext, effective_next_action, write_command_json,
+        NextActionInput, NextActionValidationContext, effective_next_action, non_empty_action,
+        normalized_action, write_command_json,
     },
     operator_core::{
         OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
@@ -288,8 +289,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         report.recommended_action = recommended_action.clone();
         report.refresh_recommended_action_metadata();
     }
-    let recommended_action_value =
-        (!recommended_action.is_empty()).then(|| recommended_action.clone());
+    let recommended_action_value = normalized_action(recommended_action.clone());
 
     let status = if thread.state == ThreadState::Ready || !has_integration_target {
         "completed"
@@ -439,7 +439,7 @@ fn write_trust_blocked_setup(recommended_action: Option<&str>) {
         style::field("status", &style::thread_state("blocked"))
     );
     println!("  {}", style::field("checks", "not run"));
-    if let Some(recommended_action) = recommended_action.filter(|action| !action.is_empty()) {
+    if let Some(recommended_action) = non_empty_action(recommended_action) {
         println!();
         print_next(recommended_action);
     }
@@ -647,7 +647,7 @@ fn write_preview_report(report: &ThreadPreviewReport, recommended_action: Option
             println!("  {} {}", style::warn("-"), style::warn(blocker));
         }
     }
-    if let Some(recommended_action) = recommended_action.filter(|action| !action.is_empty()) {
+    if let Some(recommended_action) = non_empty_action(recommended_action) {
         println!();
         print_next(recommended_action);
     }
@@ -666,11 +666,7 @@ fn ready_report_recommended_action(report: &ThreadPreviewReport) -> Option<Strin
     if report.semantic_result == "no_target" {
         return None;
     }
-    if report.recommended_action.trim().is_empty() {
-        None
-    } else {
-        Some(report.recommended_action.clone())
-    }
+    normalized_action(report.recommended_action.clone())
 }
 
 fn trust_blocked_report_for(

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1453,7 +1453,10 @@ pub struct ThreadSummarySchema {
     pub is_isolated: bool,
     pub thread_health: String,
     pub blockers: Vec<String>,
-    pub recommended_action: String,
+    // Runtime `ThreadSummary.recommended_action` is a `String` serialized
+    // through `serialize_empty_action_as_null`, so the wire value is
+    // `string | null` (HeddleCo/heddle#645 presence contract).
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub git_branch_tip: Option<String>,
     pub history_imported: bool,
@@ -1844,14 +1847,14 @@ pub struct PushSchema {
     pub thread: Option<String>,
     pub state: Option<String>,
     pub objects: Option<usize>,
-    #[schemars(required)]
-    pub next_action: Option<String>,
-    #[schemars(required)]
-    pub next_action_template: Option<ActionTemplateSchema>,
-    #[schemars(required)]
-    pub recommended_action: Option<String>,
-    #[schemars(required)]
-    pub recommended_action_template: Option<ActionTemplateSchema>,
+    // Required AND nullable (the `#[schemars(required)]` shorthand strips
+    // the null variant from `Option<T>`, mis-declaring the wire contract —
+    // HeddleCo/heddle#645 conformance): push always emits these fields,
+    // serializing null for the no-action case.
+    pub next_action: NullableStringSchema,
+    pub next_action_template: NullableActionTemplateSchema,
+    pub recommended_action: NullableStringSchema,
+    pub recommended_action_template: NullableActionTemplateSchema,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -2078,7 +2081,7 @@ pub struct BridgeGitStatusSchema {
     pub mirror_initialized: bool,
     pub git_overlay_import_hint: Option<GitOverlayImportHintSchema>,
     pub git_overlay_health: GitOverlayHealthSchema,
-    pub recommended_action: String,
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub recovery_commands: Vec<String>,
     #[serde(rename = "verification")]
@@ -2232,7 +2235,7 @@ pub struct ThreadListSchema {
     pub current: Option<String>,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationStateSchema,
-    pub recommended_action: String,
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub recovery_commands: Vec<String>,
     pub recovery_action_templates: Vec<ActionTemplateSchema>,
@@ -2242,7 +2245,7 @@ pub struct ThreadListSchema {
 pub struct AvailableGitRefSchema {
     pub name: String,
     pub git_commit: String,
-    pub recommended_action: String,
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
 }
 
@@ -2261,7 +2264,7 @@ pub struct WorkspaceShowSchema {
     pub remote_tracking: OpaqueObject,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationStateSchema,
-    pub recommended_action: String,
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub current_thread: Option<String>,
     pub groups: Vec<WorkspaceGroupSchema>,
@@ -2681,7 +2684,7 @@ pub struct DiagnoseSchema {
     pub changes: Value,
     pub workspace: Value,
     pub health: Value,
-    pub recommended_action: String,
+    pub recommended_action: Option<String>,
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub recovery_commands: Vec<String>,
     pub profile: Option<Value>,
@@ -2722,7 +2725,6 @@ pub struct DiagnoseSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ErrorEnvelopeSchema {
-    pub code: String,
     pub error: String,
     pub exit_code: u8,
     pub hint: String,
@@ -3055,6 +3057,66 @@ mod tests {
                 properties.contains_key(*required),
                 "status schema missing property '{required}'"
             );
+        }
+    }
+
+    /// HeddleCo/heddle#645 conformance: the action-field presence contract.
+    ///
+    /// `next_action` / `recommended_action` encode "no action needed" as
+    /// `null` and "not applicable to this output shape" as an absent
+    /// field — never as `""` (the runtime maps empty selections to `None`
+    /// via `next_action::normalized_action` /
+    /// `serialize_empty_action_as_null`, and the serialization walker in
+    /// `validate_next_actions_at_path` rejects any empty string that
+    /// slips past). At the schema level that means: wherever one of these
+    /// properties is *required*, its schema must allow `null` — a
+    /// non-nullable required action field would force emitters to leak
+    /// `""` for the no-action case.
+    #[test]
+    fn action_fields_follow_presence_contract_in_every_schema() {
+        fn walk(root: &Value, schema: &Value, verb: &str, path: &str) {
+            match schema {
+                Value::Object(object) => {
+                    if let Some(properties) =
+                        object.get("properties").and_then(|p| p.as_object())
+                    {
+                        let required: Vec<&str> = object
+                            .get("required")
+                            .and_then(|value| value.as_array())
+                            .map(|fields| {
+                                fields.iter().filter_map(|field| field.as_str()).collect()
+                            })
+                            .unwrap_or_default();
+                        for (name, child) in properties {
+                            if matches!(name.as_str(), "next_action" | "recommended_action")
+                                && required.contains(&name.as_str())
+                            {
+                                assert!(
+                                    schema_allows_null(root, child),
+                                    "`{verb}` schema requires `{path}.{name}` without allowing \
+                                     null; the action contract is null = no action, absent = \
+                                     not applicable, never \"\": {child}"
+                                );
+                            }
+                        }
+                    }
+                    for (key, child) in object {
+                        walk(root, child, verb, &format!("{path}.{key}"));
+                    }
+                }
+                Value::Array(items) => {
+                    for (index, child) in items.iter().enumerate() {
+                        walk(root, child, verb, &format!("{path}[{index}]"));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for verb in schema_verbs() {
+            let schema =
+                schema_for_verb(verb).unwrap_or_else(|| panic!("schema registered for `{verb}`"));
+            walk(&schema, &schema, verb, "$");
         }
     }
 

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -24,6 +24,7 @@ use super::{
     git_overlay_health::{PlainGitVerificationProbe, build_plain_git_verification_probe},
     mount_lifecycle,
     operator_core::OperatorCommandOutput,
+    next_action::normalized_action,
     operator_loop::primary_next_action,
     thread::{
         cmd_thread_cd, cmd_thread_create, cmd_thread_current, cmd_thread_delete, cmd_thread_list,
@@ -1325,7 +1326,7 @@ fn print_thread_output(
         import_hint.as_ref(),
         Some(&advice.recommended_action),
     );
-    let recommended_action = (!recommended_action.trim().is_empty()).then_some(recommended_action);
+    let recommended_action = normalized_action(recommended_action);
     if should_output_json(cli, Some(repo.config())) {
         println!(
             "{}",

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -51,6 +51,34 @@ impl HeddleExitCode {
         }
     }
 
+    /// Exit code for a typed `RecoveryAdvice` kind whose documented code
+    /// differs from the `IoErr` catch-all. This table — not the
+    /// user-visible message — is the classification contract: rewording
+    /// advice copy can never regress an exit code, and every entry here is
+    /// pinned by a per-kind regression test below.
+    fn for_advice_kind(kind: &str) -> Option<Self> {
+        match kind {
+            // Missing precondition (no default remote for push/pull), not
+            // an IO failure.
+            "remote_not_configured" => Some(Self::Config),
+            // Well-formed input the command semantically rejects:
+            // - nothing staged / no changes to capture
+            // - a reconcile that needs a `--prefer` side
+            // - unsaved worktree changes blocking a tree write
+            // - repository state that fails msgpack/serde decoding
+            // - `--output json`/`json-compact` against a command without
+            //   that output contract (the invocation parses fine; the
+            //   command rejects the requested projection)
+            "nothing_to_commit"
+            | "reconcile_direction_required"
+            | "dirty_worktree"
+            | "state_corrupted"
+            | "json_unsupported"
+            | "json_compact_unsupported" => Some(Self::DataErr),
+            _ => None,
+        }
+    }
+
     /// Map an anyhow error chain to an exit code. Walks the chain and uses
     /// the first downcast match; falls back to `IoErr` so callers always
     /// get a code more informative than the bare `1` shell convention.
@@ -60,15 +88,20 @@ impl HeddleExitCode {
             // ones whose documented code differs from the `IoErr` catch-all.
             // Keyed on `kind` (not the user-visible message) so rewording the
             // error text can't silently regress the contract.
-            if let Some(advice) = cause.downcast_ref::<crate::cli::commands::RecoveryAdvice>() {
-                match advice.kind {
-                    // No default remote configured (push/pull): a missing
-                    // precondition, not an IO failure.
-                    "remote_not_configured" => return Self::Config,
-                    // Nothing staged / no changes to capture, and a reconcile
-                    // that needs a `--prefer` side: well-formed input the
-                    // command semantically rejects.
-                    "nothing_to_commit" | "reconcile_direction_required" => return Self::DataErr,
+            if let Some(advice) = cause.downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+                && let Some(code) = Self::for_advice_kind(advice.kind)
+            {
+                return code;
+            }
+            if let Some(heddle_err) = cause.downcast_ref::<objects::error::HeddleError>() {
+                match heddle_err {
+                    // A missing repository is a missing precondition
+                    // (initialize/point at one), not an IO failure.
+                    objects::error::HeddleError::RepositoryNotFound(_) => return Self::Config,
+                    // Stored state that fails msgpack decoding is corrupted
+                    // data, not a transient IO problem — same class as the
+                    // serde_json/toml parse failures below.
+                    objects::error::HeddleError::Serialization(_) => return Self::DataErr,
                     _ => {}
                 }
             }
@@ -103,10 +136,14 @@ impl HeddleExitCode {
             }
         }
 
-        // Heddle-specific string sentinels — match the user-visible phrasing
-        // produced by RecoveryAdvice. Cheap to scan; only runs on the error
-        // path. Keep these short and exact so they don't false-positive on
-        // unrelated messages that happen to mention "no upstream".
+        // Legacy string sentinels — LAST RESORT for raw-string error paths
+        // that carry no typed `RecoveryAdvice` or `HeddleError` (e.g. the
+        // stringified `RemoteError::NotFound` display from `resolve_remote`,
+        // or upstream messages flattened through `anyhow::Error::msg`).
+        // Any error that has a typed kind MUST be classified above via
+        // `for_advice_kind` / the `HeddleError` match — never add a sentinel
+        // here for a message a typed constructor produces. Keep these short
+        // and exact so they don't false-positive on unrelated messages.
         let msg = format!("{err:#}");
         if msg.contains("no upstream configured")
             || msg.contains("no remote configured")
@@ -241,6 +278,124 @@ mod tests {
     fn missing_repo_string_sentinel_is_config() {
         let err = anyhow::anyhow!("repository not found at /tmp/whatever");
         assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn repository_not_found_typed_variant_is_config() {
+        // The typed `HeddleError::RepositoryNotFound` must classify without
+        // relying on its Display text surviving a rewording.
+        let err: anyhow::Error = objects::error::HeddleError::RepositoryNotFound(
+            std::path::PathBuf::from("/tmp/whatever"),
+        )
+        .into();
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::Config);
+    }
+
+    #[test]
+    fn serialization_error_typed_variant_is_data_err() {
+        // Corrupted msgpack state (HeddleCo/heddle#642): decode failures
+        // are data corruption, not the IoErr catch-all.
+        let err: anyhow::Error = objects::error::HeddleError::Serialization(
+            "wrong msgpack marker FixArray(0)".to_string(),
+        )
+        .into();
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    /// Build a `RecoveryAdvice` with the given kind and deliberately
+    /// unrelated copy, proving classification reads `kind`, never the
+    /// user-visible message (HeddleCo/heddle#640).
+    fn advice_with_kind(kind: &'static str) -> anyhow::Error {
+        anyhow::anyhow!(crate::cli::commands::RecoveryAdvice::safety_refusal(
+            kind,
+            "reworded copy that matches no sentinel",
+            "hint",
+            "unsafe",
+            "would change",
+            "preserved",
+            "heddle status",
+            vec!["heddle status".to_string()],
+        ))
+    }
+
+    #[test]
+    fn every_classified_advice_kind_maps_to_its_documented_exit_code() {
+        // Per-kind regression matrix: copy edits that orphan a string
+        // sentinel can no longer regress these to the IoErr catch-all.
+        for (kind, expected) in [
+            ("remote_not_configured", HeddleExitCode::Config),
+            ("nothing_to_commit", HeddleExitCode::DataErr),
+            ("reconcile_direction_required", HeddleExitCode::DataErr),
+            ("dirty_worktree", HeddleExitCode::DataErr),
+            ("state_corrupted", HeddleExitCode::DataErr),
+            ("json_unsupported", HeddleExitCode::DataErr),
+            ("json_compact_unsupported", HeddleExitCode::DataErr),
+        ] {
+            assert_eq!(
+                HeddleExitCode::from_error(&advice_with_kind(kind)),
+                expected,
+                "advice kind `{kind}` must classify by kind, not message text"
+            );
+        }
+    }
+
+    #[test]
+    fn dirty_worktree_advice_constructor_is_data_err() {
+        // The real constructor's Display does not contain the legacy
+        // "dirty worktree" sentinel, so only the typed kind can classify it.
+        let err = anyhow::anyhow!(crate::cli::commands::RecoveryAdvice::dirty_worktree(
+            "merge",
+            vec!["src/lib.rs".to_string()],
+            "repository state was left unchanged",
+        ));
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
+    fn dirty_worktree_string_sentinel_is_data_err() {
+        // Raw-string path (e.g. repository_worktree_apply's refusal) that
+        // carries no typed advice still classifies via the legacy sentinel.
+        let err = anyhow::anyhow!(
+            "dirty worktree would be overwritten by full rematerialize (switch)"
+        );
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
+    fn unsupported_output_advice_is_data_err() {
+        // HeddleCo/heddle#648: `--output json[-compact]` against a command
+        // without that contract is semantic rejection of well-formed input
+        // (DataErr 65), not a malformed invocation (Usage 64).
+        let json = anyhow::anyhow!(crate::cli::commands::RecoveryAdvice::json_unsupported(
+            "shell completion"
+        ));
+        assert_eq!(HeddleExitCode::from_error(&json), HeddleExitCode::DataErr);
+
+        let compact = anyhow::anyhow!(
+            crate::cli::commands::RecoveryAdvice::json_compact_unsupported("log")
+        );
+        assert_eq!(
+            HeddleExitCode::from_error(&compact),
+            HeddleExitCode::DataErr
+        );
+    }
+
+    #[test]
+    fn state_corrupted_advice_is_data_err() {
+        let err = anyhow::anyhow!(crate::cli::commands::RecoveryAdvice::serialization_error(
+            "wrong msgpack marker FixArray(0)"
+        ));
+        assert_eq!(HeddleExitCode::from_error(&err), HeddleExitCode::DataErr);
+    }
+
+    #[test]
+    fn unclassified_advice_kind_falls_back_to_io_err() {
+        // Kinds without a documented divergent code keep the catch-all, so
+        // adding a new advice kind never silently changes an exit code.
+        assert_eq!(
+            HeddleExitCode::from_error(&advice_with_kind("hook_veto")),
+            HeddleExitCode::IoErr
+        );
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -236,21 +236,29 @@ async fn async_main() -> Result<()> {
         "CLI startup complete"
     );
 
+    // Unsupported-output gates exit through `from_error` so the process
+    // exit code and the envelope's `exit_code` field agree: DataErr (65),
+    // because `--output json[-compact]` here is well-formed syntax the
+    // command semantically rejects — not a malformed invocation (Usage 64).
+    // Agents treat 64 as "fix your argv" and retry-with-mutation; 65 tells
+    // them to fall back to a supported output mode (HeddleCo/heddle#648).
     if explicit_json_requested(&cli) && !command_contract.supports_json {
         telemetry.shutdown();
         let err = anyhow::anyhow!(cli::cli::commands::RecoveryAdvice::json_unsupported(
             &command_name
         ));
+        let code = HeddleExitCode::from_error(&err);
         print_error_with_hint(&cli, &err);
-        std::process::exit(HeddleExitCode::Usage.into());
+        std::process::exit(code.into());
     }
     if cli::cli::output_is_compact(&cli) && !command_contract.supports_json_compact {
         telemetry.shutdown();
         let err = anyhow::anyhow!(
             cli::cli::commands::RecoveryAdvice::json_compact_unsupported(&command_name)
         );
+        let code = HeddleExitCode::from_error(&err);
         print_error_with_hint(&cli, &err);
-        std::process::exit(HeddleExitCode::Usage.into());
+        std::process::exit(code.into());
     }
 
     match run_local_idempotency_if_requested(&cli, &command_name, command_supports_op_id) {

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -183,7 +183,11 @@ fn test_cli_capture_blocks_large_git_overlay_deletion_without_force() {
     let stderr = str::from_utf8(&json_refusal.stderr).expect("stderr should be utf8");
     let envelope: Value = serde_json::from_str(stderr.trim()).expect("stderr should be JSON");
     assert_eq!(envelope["kind"], "large_capture_requires_force");
-    assert_eq!(envelope["code"], "large_capture_requires_force");
+    assert!(
+        envelope.get("code").is_none(),
+        "`kind` is the envelope's only discriminator; the redundant `code` \
+         duplicate was dropped pre-1.0 (HeddleCo/heddle#647): {envelope}"
+    );
     assert!(
         envelope["error"]
             .as_str()

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -93,7 +93,9 @@ fn assert_compact_op_id_error_envelope(args: &[&str], temp: &TempDir, context: &
     let stderr = str::from_utf8(&out.stderr).expect("stderr utf8");
     let envelope: Value = serde_json::from_str(stderr.trim())
         .unwrap_or_else(|err| panic!("{context}: stderr not JSON: {err}\n  stderr: {stderr}"));
-    for key in ["code", "error", "exit_code", "hint"] {
+    // `kind` (not the dropped `code` duplicate) is the envelope's
+    // discriminator (HeddleCo/heddle#647).
+    for key in ["kind", "error", "exit_code", "hint"] {
         assert!(
             envelope.get(key).is_some(),
             "{context}: compact op-id failure stripped `{key}` from error envelope: {envelope}"

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -171,6 +171,108 @@ fn bridge_git_reconcile_without_side_is_data_err() {
 }
 
 #[test]
+fn unsupported_output_json_is_data_err() {
+    // HeddleCo/heddle#648: `--output json` against a text-only command is
+    // well-formed syntax the command semantically rejects — DataErr (65),
+    // not Usage (64). Agents treat 64 as "fix your argv" and may
+    // retry-with-mutation instead of falling back to `--output text`.
+    let repo = init_repo();
+    assert_exit(
+        &["--output", "json", "shell", "completion", "bash"],
+        repo.path(),
+        65,
+    );
+}
+
+#[test]
+fn unsupported_output_json_compact_is_data_err() {
+    // Sibling gate: `--output json-compact` against a command without a
+    // compact projection. Same semantics, same code (HeddleCo/heddle#648).
+    // The envelope's `exit_code` field must agree with the process exit.
+    let repo = init_repo();
+    let output = heddle_output(&["--output", "json-compact", "log"], Some(repo.path()))
+        .expect("spawn log --output json-compact");
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "json-compact rejection should exit 65 (DataErr); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let envelope: serde_json::Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|err| panic!("rejection envelope not JSON: {err}\n  stderr: {stderr}"));
+    assert_eq!(envelope["kind"], "json_compact_unsupported");
+    assert_eq!(
+        envelope["exit_code"], 65,
+        "envelope exit_code must agree with the process exit: {envelope}"
+    );
+}
+
+#[test]
+fn status_on_corrupted_state_is_data_err_with_recovery_path() {
+    // HeddleCo/heddle#642: corrupted msgpack state must not dead-end on
+    // raw decoder internals. `heddle status` is the natural recovery
+    // probe, so it must name the condition, exit DataErr (65), and hand
+    // back executable recovery commands in both output modes.
+    let repo = init_repo();
+    std::fs::write(repo.path().join("f.txt"), "base\n").expect("write f.txt");
+    assert_exit(&["commit", "-m", "base"], repo.path(), 0);
+
+    // Corrupt every stored state object: 0x90 is msgpack FixArray(0),
+    // the exact marker from the persona report's dead-end.
+    let states_dir = repo.path().join(".heddle/objects/states");
+    let mut corrupted = 0usize;
+    for entry in std::fs::read_dir(&states_dir).expect("read states dir") {
+        let path = entry.expect("dir entry").path();
+        std::fs::write(&path, [0x90u8]).expect("corrupt state file");
+        corrupted += 1;
+    }
+    assert!(corrupted > 0, "fixture should have stored state objects");
+
+    let json = heddle_output(&["--output", "json", "status"], Some(repo.path()))
+        .expect("spawn status on corrupted repo");
+    assert_eq!(
+        json.status.code(),
+        Some(65),
+        "corrupted state should exit 65 (DataErr); stderr: {}",
+        String::from_utf8_lossy(&json.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&json.stderr);
+    let envelope: serde_json::Value = serde_json::from_str(stderr.trim()).unwrap_or_else(|err| {
+        panic!("corrupted-state envelope not JSON: {err}\n  stderr: {stderr}")
+    });
+    assert_eq!(envelope["kind"], "state_corrupted");
+    assert_eq!(envelope["exit_code"], 65);
+    assert_eq!(
+        envelope["error"], "Repository state is corrupted or unreadable",
+        "user-facing error must name the condition, not echo decoder internals: {envelope}"
+    );
+    let recovery_commands = envelope["recovery_commands"]
+        .as_array()
+        .unwrap_or_else(|| panic!("recovery_commands should be an array: {envelope}"));
+    assert!(
+        !recovery_commands.is_empty(),
+        "corrupted state must hand back recovery commands: {envelope}"
+    );
+    assert!(
+        recovery_commands
+            .iter()
+            .any(|command| command.as_str().is_some_and(|c| c.contains("fsck"))),
+        "recovery should point at the integrity tooling: {envelope}"
+    );
+
+    let text = heddle_output(&["status"], Some(repo.path()))
+        .expect("spawn text status on corrupted repo");
+    assert_eq!(text.status.code(), Some(65));
+    let text_stderr = String::from_utf8_lossy(&text.stderr);
+    assert!(
+        text_stderr.contains("Repository state is corrupted or unreadable")
+            && text_stderr.contains("Next: heddle verify"),
+        "text mode should name the condition and the recovery probe: {text_stderr}"
+    );
+}
+
+#[test]
 fn unconfigured_remote_keeps_no_default_remote_phrasing() {
     // Regression guard for the string sentinel `from_error` relies on for
     // the raw `resolve_remote` path (HeddleCo/heddle#252). If the

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -6261,7 +6261,7 @@ fn git_overlay_matrix_ship_undo_restores_git_and_heddle_together() {
     let stderr = String::from_utf8_lossy(&redo_refusal.stderr);
     let envelope: Value = serde_json::from_str(stderr.trim())
         .unwrap_or_else(|err| panic!("dirty redo should emit JSON envelope: {err}: {stderr}"));
-    assert_eq!(envelope["code"], "dirty_worktree");
+    assert_eq!(envelope["kind"], "dirty_worktree");
     assert!(
         !temp.path().join("feature.txt").exists(),
         "redo refusal must not partially re-apply Heddle/worktree state"

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -943,7 +943,6 @@ fn json_mode_parse_errors_emit_error_envelope() {
     let parsed: Value = serde_json::from_str(stderr)
         .unwrap_or_else(|err| panic!("stderr should be JSON: {err}: {stderr}"));
     assert_eq!(parsed["kind"], "parse_error");
-    assert_eq!(parsed["code"], "parse_error");
     // EX_USAGE (sysexits) — unknown subcommand. The taxonomy in
     // `crates/cli/src/exit.rs` reserves `2` for unhandled errors /
     // panics, never intentional emission.
@@ -993,7 +992,6 @@ fn confidence_parse_errors_fail_loudly_in_json_mode() {
         let parsed: Value = serde_json::from_str(stderr)
             .unwrap_or_else(|err| panic!("stderr should be JSON: {err}: {stderr}"));
         assert_eq!(parsed["kind"], "parse_error");
-        assert_eq!(parsed["code"], "parse_error");
         assert_eq!(
             parsed["primary_command_template"]["argv_template"],
             heddle_argv_json(["commands", "--output", "json"])
@@ -10948,7 +10946,6 @@ fn error_envelope_schema_is_registered_and_matches_runtime_shape() {
         .as_object()
         .expect("schema has properties");
     for field in [
-        "code",
         "error",
         "exit_code",
         "hint",
@@ -10976,7 +10973,6 @@ fn error_envelope_schema_is_registered_and_matches_runtime_shape() {
         .filter_map(|v| v.as_str())
         .collect();
     for field in [
-        "code",
         "error",
         "exit_code",
         "hint",
@@ -11005,7 +11001,6 @@ fn error_envelope_schema_is_registered_and_matches_runtime_shape() {
     let envelope: serde_json::Value =
         serde_json::from_str(stderr.trim()).expect("stderr is a JSON object");
     for field in [
-        "code",
         "error",
         "exit_code",
         "hint",
@@ -11024,7 +11019,13 @@ fn error_envelope_schema_is_registered_and_matches_runtime_shape() {
         );
     }
     assert_eq!(envelope["kind"], "repository_not_found");
-    assert_eq!(envelope["code"], "repository_not_found");
+    // `kind` is the envelope's single discriminator. The redundant `code`
+    // duplicate (always identical) was dropped pre-1.0 so consumers can't
+    // pick the wrong field (HeddleCo/heddle#647).
+    assert!(
+        envelope.get("code").is_none(),
+        "envelope must not re-grow the dropped `code` duplicate: {stderr}"
+    );
     // EX_CONFIG (sysexits) — repository config missing. Matches the
     // taxonomy in `crates/cli/src/exit.rs`.
     assert_eq!(envelope["exit_code"], 78);
@@ -11489,7 +11490,6 @@ fn doctor_schemas_json_failure_uses_recovery_envelope() {
         panic!("schema failure should emit one JSON envelope: {err}: {stderr}")
     });
     assert_eq!(envelope["kind"], "machine_contract_drift");
-    assert_eq!(envelope["code"], "machine_contract_drift");
     assert_eq!(
         envelope["primary_command"],
         "heddle doctor schemas --output json"
@@ -12147,7 +12147,6 @@ fn bridge_git_divergence_error_uses_structured_recovery_envelope() {
         .unwrap_or_else(|err| panic!("stderr should be one JSON envelope: {err}: {stderr}"));
     assert_json_recovery_advice_fields(&envelope, stderr);
     assert_eq!(envelope["kind"], "git_heddle_thread_diverged");
-    assert_eq!(envelope["code"], "git_heddle_thread_diverged");
     assert_eq!(
         envelope["primary_command"],
         "heddle bridge git reconcile --ref main --preview"

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -1058,10 +1058,9 @@ fn ready_blocks_stale_or_heavy_impact_threads_and_status_reports_next_step() {
     );
     let ready: Value = serde_json::from_slice(&ready_output.stdout).unwrap();
     assert_eq!(ready["thread_state"], "blocked");
-    assert_eq!(
-        ready["report"]["recommended_action"].as_str(),
-        Some("")
-    );
+    // No selected action serializes as null, never "" (HeddleCo/heddle#645
+    // action-field contract).
+    assert!(ready["report"]["recommended_action"].is_null());
     assert!(ready["recommended_action"].is_null());
 
     let reviewed: Value = serde_json::from_str(

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -9,19 +9,26 @@ The canonical mapping lives in
 command's catalogued codes live on its `CommandContract.exit_codes` entry in
 [`crates/cli/src/cli/commands/command_catalog.rs`](../crates/cli/src/cli/commands/command_catalog.rs).
 
+Classification is keyed on typed error kinds — the `RecoveryAdvice.kind`
+discriminator and `HeddleError` variants — never on user-visible message
+text, so rewording an error can't silently change its exit code. A small
+set of legacy string sentinels remains only for raw-string error paths
+that carry no typed kind; each typed kind→code pair is pinned by a
+regression test in `exit.rs`.
+
 ## Codes
 
 | Code | Symbol      | Meaning                                                                 |
 | ---: | ---         | ---                                                                     |
 |   0  | `Ok`        | Success.                                                                |
 |  64  | `Usage`     | Invalid CLI args, unknown subcommand, malformed flag (`EX_USAGE`).      |
-|  65  | `DataErr`   | Well-formed input, semantically rejected (`EX_DATAERR`).                |
+|  65  | `DataErr`   | Well-formed input, semantically rejected (`EX_DATAERR`). Includes corrupted/undecodable repository state and `--output json`/`json-compact` against a command without that output contract. |
 |  73  | `CantCreat` | Output file refused — exists, unwritable, or state dir uncreatable.     |
 |  74  | `IoErr`     | Generic IO failure during read/write (`EX_IOERR`). Default fallback.    |
 |  75  | `TempFail`  | Transient failure; safe to retry with the same args (`EX_TEMPFAIL`).    |
 |  76  | `Protocol`  | Remote rejected the payload; retrying without changing inputs will fail the same way (`EX_PROTOCOL`). |
 |  77  | `NoPerm`    | Operation refused for permission reasons (`EX_NOPERM`).                 |
-|  78  | `Config`    | Configuration missing, ambiguous, or invalid (no upstream, no remote, conflicting identity). |
+|  78  | `Config`    | Configuration or a required precondition is missing, ambiguous, or invalid — not just config-*file* errors. Covers unconfigured remotes/upstreams, a missing repository, and conflicting identity. |
 
 `2` is reserved for `set -e` / unhandled panic and is never emitted
 intentionally — let it surface naturally.
@@ -36,12 +43,17 @@ intentionally — let it surface naturally.
   Don't loop. Surface to the human or change strategy.
 - **`78` (Config) is the right code when a precondition is missing**
   (no upstream, no remote configured, no default remote for `push`/`pull`,
-  ambiguous identity). Agents should print the missing setting rather than
-  retry.
+  no repository at the requested path, ambiguous identity) — it is not
+  limited to config-file parse errors. Agents should print the missing
+  setting rather than retry.
 - **`65` (DataErr) covers semantic rejection of well-formed input**
   (e.g. `commit` with nothing to capture, `merge` with unresolvable
-  conflict, `bridge git reconcile` that needs a `--prefer` side chosen).
-  Agents must surface the condition; no retry will help.
+  conflict, `bridge git reconcile` that needs a `--prefer` side chosen,
+  repository state that fails decoding — `state_corrupted` — and
+  `--output json`/`json-compact` requested from a command without that
+  output contract). Agents must surface the condition (for unsupported
+  output, fall back to a supported `--output` mode); no retry with the
+  same inputs will help.
 - **`74` (IoErr) is the catch-all.** When a command's contract does not
   declare a more specific code, treat a non-zero exit as `IoErr` and surface
   the stderr envelope.

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -58,6 +58,17 @@ and assume the discipline holds.
 5. **Pretty printing is reserved for `heddle show`.** Every other verb
    emits compact, single-line JSON suitable for line-oriented streaming
    (one document per line for `heddle watch`, etc.).
+6. **Action fields (`next_action`, `recommended_action`) follow one
+   presence contract.** `null` means "this output carries the field and
+   no action is needed right now"; an *absent* field means "not
+   applicable to this output shape"; the empty string is **never**
+   emitted. Agents can branch on `action == null` for "nothing to do"
+   without an emptiness guard. Enforced at the serialization boundary
+   (`validate_next_actions_at_path` rejects `""`) and by the
+   `action_fields_follow_presence_contract_in_every_schema` conformance
+   test over the schema registry; emitters normalize empty selections
+   through `next_action::normalized_action` /
+   `serialize_empty_action_as_null` (HeddleCo/heddle#645).
 
 The schemas below are hand-curated rather than auto-generated. We
 chose this over `schemars`-based introspection because the surface is
@@ -408,7 +419,6 @@ standard recovery fields plus nested verification proof:
 
 ```text
 {
-  "code": "verify_failed",
   "error": "Repository is not verified: dirty_worktree",
   "exit_code": 1,
   "hint": "Run `heddle commit -m <message>` to clear the primary verification blocker.",
@@ -3153,7 +3163,6 @@ without scraping freeform text.
 
 ```json
 {
-  "code": "repository_not_found",
   "error": "repository not found at /tmp/scratch",
   "exit_code": 1,
   "hint": "Run `heddle init` to initialize a repository here.",
@@ -3172,7 +3181,7 @@ without scraping freeform text.
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
-| `code`, `kind` | string | required | Stable predicate name keying the hint class. `code` mirrors `kind` for callers that prefer error-code naming. |
+| `kind` | string | required | Stable predicate name keying the hint class. The envelope's single discriminator — the redundant `code` mirror was dropped pre-1.0 (HeddleCo/heddle#647). |
 | `error` | string | required | Human-readable failure message (the anyhow chain rendered via `{:#}`). Never empty. |
 | `exit_code` | integer | required | Process exit code for this failure; currently `1`. |
 | `hint` | string | required | One-line actionable next step. JSON-mode runtime errors use a non-empty fallback hint. |

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -46,7 +46,7 @@ The three personas are NOT the only people who use heddle. They're chosen becaus
 - Exit codes — every documented exit value is correct + every error path maps to one.
 - `output_kind` / dispatch discriminators — agents route on field, not output text.
 - Dedup / op-id — agents retry; safety depends on heddle's cross-process correctness.
-- Error envelopes — `kind` / `code` / `recommended_action` are machine-readable.
+- Error envelopes — `kind` / `recommended_action` are machine-readable.
 - Token economy — JSON payloads should not bloat. Agents pay per token.
 - ContentService RPC surface — for FS-less invocation (see [#267](https://github.com/HeddleCo/heddle/issues/267)).
 


### PR DESCRIPTION
Pre-release QoL cluster: the error/exit/envelope contract core, landed as one coherent change before the v0.3.0 binary release.

## Per-issue summary

### Typed exit-code classification (Fixes #640)
- `HeddleExitCode::from_error` now classifies via a single `for_advice_kind` table keyed on `RecoveryAdvice.kind`, plus typed `HeddleError` matches (`RepositoryNotFound` → Config 78, `Serialization` → DataErr 65). String sentinels remain only as a last resort for raw-string paths with no typed kind, with a comment forbidding new sentinels for typed errors.
- Per-kind regression matrix in `exit.rs` pins every mapped kind→code pair, including a reworded-copy test proving classification never reads message text, and a fallback test pinning that unmapped kinds keep IoErr.
- `docs/exit-codes.md`: Config (78) explicitly covers missing preconditions (unconfigured remotes, missing repository), not just config-file errors; documented the typed-kind classification substrate.

**Test evidence:** `exit::tests::every_classified_advice_kind_maps_to_its_documented_exit_code`, `dirty_worktree_advice_constructor_is_data_err` (the real constructor's Display never matched the legacy sentinel — it was silently hitting the IoErr catch-all), `repository_not_found_typed_variant_is_config`, plus the retained legacy-string sentinel tests.

### Unsupported-output gates exit DataErr (Fixes #648)
- Both `main.rs` gates (`json_unsupported`, `json_compact_unsupported`) now exit through `from_error` → DataErr (65) instead of hard-coded Usage (64), so the process exit and the envelope's `exit_code` field agree (previously the envelope said 74 while the process exited 64).

**Test evidence:** `exit_codes::unsupported_output_json_is_data_err`, `exit_codes::unsupported_output_json_compact_is_data_err` (asserts envelope/process exit-code agreement), `exit::tests::unsupported_output_advice_is_data_err`.

### state_corrupted recovery path (Fixes #642)
- New `RecoveryAdvice::serialization_error()` (kind `state_corrupted`): msgpack/serde decode failures surface "Repository state is corrupted or unreadable" with `heddle verify` / `heddle fsck --full` / `heddle fsck --repair` recovery commands, exit DataErr (65). The decoder detail is preserved in `unsafe_condition` for diagnosis instead of being the headline.
- Wired from `HeddleError::Serialization` in the envelope classifier, so `heddle status` on a corrupted repo points at recovery tooling in both text and JSON modes instead of echoing `wrong msgpack marker FixArray(0)`.

**Test evidence:** `exit_codes::status_on_corrupted_state_is_data_err_with_recovery_path` — injects msgpack `FixArray(0)` (the exact persona dead-end marker) into `.heddle/objects/states/*.state`, asserts envelope kind, exit 65, non-empty recovery_commands containing fsck, and the text-mode `Next: heddle verify`.

### Envelope has one discriminator (Fixes #647)
- Dropped the redundant `"code"` duplicate from the stderr error envelope (pre-1.0 breaking schema change); `kind` is canonical. Updated `ErrorEnvelopeSchema`, both envelope emitters, docs samples + field table, and every in-repo consumer; the runtime-shape test now asserts `code` stays absent.
- Grep of tapestry found no consumers of the envelope `code` field (hits were CSS classes and gRPC ConnectError codes).

### Action-field presence contract (Fixes #645)
- Pinned the contract: `null` = no action needed, absent = not applicable, `""` never emitted. Documented as Discipline rule 6 in `docs/json-schemas.md`.
- Lifted the invariant to primitives: `next_action::normalized_action` (empty → `None` at the type level) replaces the per-command `.is_empty()` checks in `ready_cmd.rs`/`thread_cmd.rs`; the serialization-boundary walker (`validate_next_actions_at_path`) now rejects any empty-string action outright.
- New conformance test walks every registered schema asserting required action fields allow null. It caught real drift: six schema mirrors declared non-nullable strings while runtime serializes empty→null, and `PushSchema`'s `#[schemars(required)]` silently stripped the null variant from `Option<T>`.
- The boundary walker caught a live leak: `ThreadPreviewReport.recommended_action` serialized `""` into `ready`/`merge` JSON — now routed through `serialize_empty_action_as_null`.
- Regenerated `clients/npm/generated/` TS types for the schema changes.

**Test evidence:** `schemas::tests::action_fields_follow_presence_contract_in_every_schema`, `next_action::tests::boundary_rejects_empty_string_actions` / `boundary_accepts_null_and_absent_actions` / `normalized_action_maps_empty_and_whitespace_to_none`, updated `multi_agent_worktrees::e2e` assertion (`Some("")` → null).

## Gates run locally
- `cargo build --locked --workspace` (default features) and `--all-features` — green (one pre-existing dead-code warning under all-features only, untouched code)
- `bash scripts/check-no-silent-default-tree-load.sh` — clean
- `cargo test -p heddle-cli --lib` (704 passed), `cargo test -p heddle-mount`, full `cli_integration` + every other heddle-cli test binary, `cargo test --workspace --exclude heddle-cli` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Known pre-existing failures on this box only (verified failing on clean main, host harness leaks into detection): 3 oss_cli_polish harness-detection tests + 2 multi_agent_worktrees codex-probe tests (`agent_registry::start_path_inherits_codex_probe_identity_into_actor_metadata`, `e2e::agent_api_capture_and_ready_require_active_session`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783817249&installation_id=132405951&pr_number=659&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F659&signature=36853badfdcf56018ace9cf08a6c2dd4f7550935250f8b0a915302cb74f645b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->