### PR TITLE
feat(catalog): advertise output_kind discriminators for every runtime-emitting schema verb

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -106,10 +106,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "abort"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -148,7 +148,8 @@
         "action",
         "message",
         "blockers",
-        "warnings"
+        "warnings",
+        "output_kind"
       ],
       "title": "OperatorCommandSchema",
       "type": "object"
@@ -2629,10 +2630,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "adopt"
+          ],
+          "type": "string"
         },
         "partial_mirror_refs": {
           "format": "uint",
@@ -2707,7 +2708,8 @@
         "skipped_non_commit_refs",
         "partial_mirror_refs",
         "already_in_sync",
-        "verification"
+        "verification",
+        "output_kind"
       ],
       "title": "AdoptSchema",
       "type": "object"
@@ -2894,10 +2896,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "capture"
+          ],
+          "type": "string"
         },
         "principal": {
           "$ref": "#/$defs/CommitPrincipalSchema"
@@ -2943,7 +2945,8 @@
         "promotion_suggested",
         "heavy_impact_paths",
         "signed",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "CaptureSchema",
       "type": "object"
@@ -3820,10 +3823,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "ready"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -3872,7 +3875,8 @@
         "action",
         "message",
         "captured",
-        "report"
+        "report",
+        "output_kind"
       ],
       "title": "ReadySchema",
       "type": "object"
@@ -4179,6 +4183,9 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "output_kind": {
+          "enum": [
+            "agent_serve"
+          ],
           "type": "string"
         },
         "pid_path": {
@@ -4694,6 +4701,9 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "output_kind": {
+          "enum": [
+            "agent_status"
+          ],
           "type": "string"
         },
         "pid": {
@@ -4731,6 +4741,9 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "output_kind": {
+          "enum": [
+            "agent_stop"
+          ],
           "type": "string"
         },
         "pid": {
@@ -5170,10 +5183,10 @@
           "type": "array"
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "blame"
+          ],
+          "type": "string"
         },
         "status": {
           "type": [
@@ -5185,7 +5198,8 @@
       "required": [
         "file",
         "context",
-        "lines"
+        "lines",
+        "output_kind"
       ],
       "title": "BlameSchema",
       "type": "object"
@@ -6114,10 +6128,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread_list"
+          ],
+          "type": "string"
         },
         "path": {
           "type": [
@@ -6188,6 +6202,9 @@
           ]
         }
       },
+      "required": [
+        "output_kind"
+      ],
       "title": "BranchCompatSchema",
       "type": "object"
     },
@@ -6755,10 +6772,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "bridge_git_pull"
+          ],
+          "type": "string"
         },
         "pulled": {
           "type": "boolean"
@@ -6793,7 +6810,8 @@
       },
       "required": [
         "pulled",
-        "remote"
+        "remote",
+        "output_kind"
       ],
       "title": "BridgePullSchema",
       "type": "object"
@@ -6856,10 +6874,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "bridge_git_push"
+          ],
+          "type": "string"
         },
         "pushed": {
           "type": "boolean"
@@ -6894,7 +6912,8 @@
       },
       "required": [
         "pushed",
-        "remote"
+        "remote",
+        "output_kind"
       ],
       "title": "BridgePushSchema",
       "type": "object"
@@ -9967,10 +9986,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "continue"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -10009,7 +10028,8 @@
         "action",
         "message",
         "blockers",
-        "warnings"
+        "warnings",
+        "output_kind"
       ],
       "title": "OperatorCommandSchema",
       "type": "object"
@@ -10029,6 +10049,17 @@
     "daemon stop": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "daemon_stop"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
@@ -11645,10 +11676,10 @@
         },
         "operation": true,
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "diagnose"
+          ],
+          "type": "string"
         },
         "profile": true,
         "recommended_action": {
@@ -11700,7 +11731,8 @@
         "changes",
         "workspace",
         "health",
-        "recovery_commands"
+        "recovery_commands",
+        "output_kind"
       ],
       "title": "DiagnoseSchema",
       "type": "object"
@@ -12316,10 +12348,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "fetch"
+          ],
+          "type": "string"
         },
         "ref_scope": {
           "type": [
@@ -12351,7 +12383,8 @@
       "required": [
         "remote",
         "refs_fetched",
-        "objects_fetched"
+        "objects_fetched",
+        "output_kind"
       ],
       "title": "FetchSchema",
       "type": "object"
@@ -14350,6 +14383,12 @@
             }
           ]
         },
+        "output_kind": {
+          "enum": [
+            "land"
+          ],
+          "type": "string"
+        },
         "performed_steps": {
           "items": {
             "type": "string"
@@ -14424,7 +14463,8 @@
         "pushed",
         "performed_steps",
         "skipped_steps",
-        "chosen_path"
+        "chosen_path",
+        "output_kind"
       ],
       "title": "LandSchema",
       "type": "object"
@@ -14490,10 +14530,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "log"
+          ],
+          "type": "string"
         },
         "repository_capability": {
           "type": "string"
@@ -14517,7 +14557,8 @@
       "required": [
         "repository_capability",
         "storage_model",
-        "states"
+        "states",
+        "output_kind"
       ],
       "title": "LogSchema",
       "type": "object"
@@ -14571,10 +14612,10 @@
           "type": "array"
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "log_reflog"
+          ],
+          "type": "string"
         },
         "repository_capability": {
           "type": "string"
@@ -14592,7 +14633,8 @@
       "required": [
         "repository_capability",
         "storage_model",
-        "entries"
+        "entries",
+        "output_kind"
       ],
       "title": "LogReflogSchema",
       "type": "object"
@@ -14643,6 +14685,12 @@
             }
           ]
         },
+        "output_kind": {
+          "enum": [
+            "gc"
+          ],
+          "type": "string"
+        },
         "replayed": {
           "type": [
             "boolean",
@@ -14650,6 +14698,9 @@
           ]
         }
       },
+      "required": [
+        "output_kind"
+      ],
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
@@ -14688,6 +14739,9 @@
           "type": "integer"
         },
         "output_kind": {
+          "enum": [
+            "index"
+          ],
           "type": "string"
         },
         "path": {
@@ -15264,10 +15318,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "merge"
+          ],
+          "type": "string"
         },
         "preview_only": {
           "type": [
@@ -15350,7 +15404,8 @@
         }
       },
       "required": [
-        "would_merge"
+        "would_merge",
+        "output_kind"
       ],
       "title": "MergePreviewSchema",
       "type": "object"
@@ -15488,10 +15543,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "pull"
+          ],
+          "type": "string"
         },
         "pulled": {
           "type": [
@@ -15556,6 +15611,9 @@
           ]
         }
       },
+      "required": [
+        "output_kind"
+      ],
       "title": "PullSchema",
       "type": "object"
     },
@@ -15838,6 +15896,9 @@
           ]
         },
         "output_kind": {
+          "enum": [
+            "push"
+          ],
           "type": "string"
         },
         "push_scope": {
@@ -15987,6 +16048,9 @@
           "type": "array"
         },
         "output_kind": {
+          "enum": [
+            "query"
+          ],
           "type": "string"
         }
       },
@@ -16114,10 +16178,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "ready"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -16166,7 +16230,8 @@
         "action",
         "message",
         "captured",
-        "report"
+        "report",
+        "output_kind"
       ],
       "title": "ReadySchema",
       "type": "object"
@@ -16693,10 +16758,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "remote_add"
+          ],
+          "type": "string"
         },
         "replayed": {
           "type": [
@@ -16718,7 +16783,8 @@
         "status",
         "action",
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "RemoteMutationSchema",
       "type": "object"
@@ -16758,10 +16824,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "remote_list"
+          ],
+          "type": "string"
         },
         "remotes": {
           "items": {
@@ -16771,7 +16837,8 @@
         }
       },
       "required": [
-        "remotes"
+        "remotes",
+        "output_kind"
       ],
       "title": "RemoteListSchema",
       "type": "object"
@@ -16837,10 +16904,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "remote_remove"
+          ],
+          "type": "string"
         },
         "replayed": {
           "type": [
@@ -16862,7 +16929,8 @@
         "status",
         "action",
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "RemoteMutationSchema",
       "type": "object"
@@ -16928,10 +16996,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "remote_set_default"
+          ],
+          "type": "string"
         },
         "replayed": {
           "type": [
@@ -16953,7 +17021,8 @@
         "status",
         "action",
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "RemoteMutationSchema",
       "type": "object"
@@ -16968,10 +17037,10 @@
           "type": "string"
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "remote_show"
+          ],
+          "type": "string"
         },
         "source": {
           "type": "string"
@@ -16984,7 +17053,8 @@
         "name",
         "url",
         "source",
-        "is_default"
+        "is_default",
+        "output_kind"
       ],
       "title": "RemoteInfoSchema",
       "type": "object"
@@ -19399,10 +19469,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread_start"
+          ],
+          "type": "string"
         },
         "path": {
           "type": [
@@ -19451,7 +19521,8 @@
       },
       "required": [
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "ThreadStartSchema",
       "type": "object"
@@ -21442,6 +21513,12 @@
             }
           ]
         },
+        "output_kind": {
+          "enum": [
+            "thread_switch"
+          ],
+          "type": "string"
+        },
         "path": {
           "type": [
             "string",
@@ -21472,7 +21549,8 @@
         }
       },
       "required": [
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "SwitchCheckoutSchema",
       "type": "object"
@@ -21594,10 +21672,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "sync"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -21642,7 +21720,8 @@
         "action",
         "message",
         "blockers",
-        "warnings"
+        "warnings",
+        "output_kind"
       ],
       "title": "SyncSchema",
       "type": "object"
@@ -22266,10 +22345,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread.cleanup"
+          ],
+          "type": "string"
         },
         "reclaimed_bytes": {
           "format": "uint64",
@@ -22329,7 +22408,8 @@
         "merged",
         "auto",
         "reclaimed_bytes",
-        "would_reclaim_bytes"
+        "would_reclaim_bytes",
+        "output_kind"
       ],
       "title": "ThreadCleanupSchema",
       "type": "object"
@@ -22803,10 +22883,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread_create"
+          ],
+          "type": "string"
         },
         "path": {
           "type": [
@@ -22855,7 +22935,8 @@
       },
       "required": [
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "ThreadStartSchema",
       "type": "object"
@@ -23339,6 +23420,9 @@
           ]
         },
         "output_kind": {
+          "enum": [
+            "thread"
+          ],
           "type": "string"
         },
         "path": {
@@ -24949,6 +25033,9 @@
           ]
         },
         "output_kind": {
+          "enum": [
+            "thread"
+          ],
           "type": "string"
         },
         "path": {
@@ -25469,6 +25556,9 @@
           ]
         },
         "output_kind": {
+          "enum": [
+            "thread"
+          ],
           "type": "string"
         },
         "path": {
@@ -25992,10 +26082,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread_rename"
+          ],
+          "type": "string"
         },
         "path": {
           "type": [
@@ -26044,7 +26134,8 @@
       },
       "required": [
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "ThreadStartSchema",
       "type": "object"
@@ -26154,10 +26245,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "resolve"
+          ],
+          "type": "string"
         },
         "recommended_action": {
           "type": [
@@ -26200,7 +26291,8 @@
         "message",
         "blockers",
         "warnings",
-        "thread"
+        "thread",
+        "output_kind"
       ],
       "title": "ThreadResolveSchema",
       "type": "object"
@@ -26256,6 +26348,12 @@
             }
           ]
         },
+        "output_kind": {
+          "enum": [
+            "thread_revoke_approval"
+          ],
+          "type": "string"
+        },
         "replayed": {
           "type": [
             "boolean",
@@ -26264,6 +26362,7 @@
         }
       },
       "required": [
+        "output_kind",
         "deleted",
         "id"
       ],
@@ -27666,10 +27765,10 @@
           ]
         },
         "output_kind": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "enum": [
+            "thread_switch"
+          ],
+          "type": "string"
         },
         "path": {
           "type": [
@@ -27718,7 +27817,8 @@
       },
       "required": [
         "name",
-        "message"
+        "message",
+        "output_kind"
       ],
       "title": "ThreadStartSchema",
       "type": "object"

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -14,7 +14,7 @@ export interface AbortSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "abort";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -145,7 +145,7 @@ export interface AdoptSchema {
   initialized: boolean;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "adopt";
   partial_mirror_refs: number;
   path: string;
   recommended_action?: string | null;
@@ -173,7 +173,7 @@ export interface AgentCaptureSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "capture";
   principal: CommitPrincipalSchema;
   promotion_suggested: boolean;
   recommended_action?: string | null;
@@ -184,7 +184,7 @@ export interface AgentCaptureSchema {
 }
 
 export interface AgentDaemonStatusSchema {
-  output_kind: string;
+  output_kind: "agent_status";
   pid?: number | null;
   pid_path: string;
   running: boolean;
@@ -211,7 +211,7 @@ export interface AgentReadySchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "ready";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -262,14 +262,14 @@ export interface AgentReserveSchema {
 }
 
 export interface AgentServeSchema {
-  output_kind: string;
+  output_kind: "agent_serve";
   pid_path: string;
   socket_path: string;
   status: string;
 }
 
 export interface AgentStopSchema {
-  output_kind: string;
+  output_kind: "agent_stop";
   pid?: number | null;
   reason?: string | null;
   stopped: boolean;
@@ -362,7 +362,7 @@ export interface BlameSchema {
   context: BlameContextSnippetSchema[];
   file: string;
   lines: BlameLineSchema[];
-  output_kind?: string | null;
+  output_kind: "blame";
   status?: string | null;
 }
 
@@ -375,7 +375,7 @@ export interface BranchCompatSchema {
   name?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread_list";
   path?: string | null;
   recommended_action?: string | null;
   recovery_commands?: string[] | null;
@@ -494,7 +494,7 @@ export interface BridgePullSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "bridge_git_pull";
   pulled: boolean;
   remote: string;
   replayed?: boolean | null;
@@ -509,7 +509,7 @@ export interface BridgePushSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "bridge_git_push";
   pushed: boolean;
   remote: string;
   replayed?: boolean | null;
@@ -902,7 +902,7 @@ export interface ContinueSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "continue";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -916,7 +916,10 @@ export type DaemonServeSchema = Record<string, unknown>;
 
 export type DaemonStatusSchema = Record<string, unknown>;
 
-export type DaemonStopSchema = Record<string, unknown>;
+export interface DaemonStopSchema {
+  output_kind: "daemon_stop";
+  [key: string]: unknown;
+}
 
 export interface DelegateSchema {
   delegated: DelegatedThreadSchema[];
@@ -942,7 +945,7 @@ export interface DiagnoseSchema {
   health: unknown;
   hosted_enabled: boolean;
   operation?: unknown;
-  output_kind?: string | null;
+  output_kind: "diagnose";
   profile?: unknown;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -1168,7 +1171,7 @@ export interface FetchSchema {
   objects_fetched: number;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "fetch";
   ref_scope?: string | null;
   refs_fetched: number;
   remote: string;
@@ -1295,7 +1298,7 @@ export interface IndexSchema {
   journal_bytes: number;
   journal_ops: number;
   journal_replay_ms: number;
-  output_kind: string;
+  output_kind: "index";
   path: string;
   present: boolean;
   snapshot_bytes: number;
@@ -1384,6 +1387,7 @@ export interface LandSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "land";
   performed_steps: string[];
   pushed: boolean;
   pushed_remote?: string | null;
@@ -1399,14 +1403,14 @@ export interface LandSchema {
 
 export interface LogReflogSchema {
   entries: ReflogEntrySchema[];
-  output_kind?: string | null;
+  output_kind: "log_reflog";
   repository_capability: string;
   status?: string | null;
   storage_model: string;
 }
 
 export interface LogSchema {
-  output_kind?: string | null;
+  output_kind: "log";
   repository_capability: string;
   states: StateEntrySchema[];
   status?: string | null;
@@ -1470,6 +1474,7 @@ export interface MaintenanceGcSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "gc";
   replayed?: boolean | null;
   [key: string]: unknown;
 }
@@ -1550,7 +1555,7 @@ export interface MergePreviewSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "merge";
   preview_only?: boolean | null;
   preview_summary?: string[] | null;
   promotion_suggested?: boolean | null;
@@ -1599,7 +1604,7 @@ export interface PullSchema {
   old_state?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "pull";
   pulled?: boolean | null;
   ref_scope?: string | null;
   remote?: string | null;
@@ -1642,7 +1647,7 @@ export interface PushSchema {
   objects?: number | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: string;
+  output_kind: "push";
   push_scope?: string | null;
   pushed: boolean;
   recommended_action: NullableStringSchema;
@@ -1672,7 +1677,7 @@ export interface QueryHitSchema {
 
 export interface QuerySchema {
   hits: QueryHitSchema[];
-  output_kind: string;
+  output_kind: "query";
 }
 
 export interface ReadySchema {
@@ -1686,7 +1691,7 @@ export interface ReadySchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "ready";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -1783,7 +1788,7 @@ export interface RemoteAddSchema {
   name: string;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "remote_add";
   replayed?: boolean | null;
   status: string;
   url?: string | null;
@@ -1797,8 +1802,16 @@ export interface RemoteInfoSchema {
   url: string;
 }
 
+export interface RemoteInfoSchema2 {
+  is_default: boolean;
+  name: string;
+  output_kind: "remote_show";
+  source: string;
+  url: string;
+}
+
 export interface RemoteListSchema {
-  output_kind?: string | null;
+  output_kind: "remote_list";
   remotes: RemoteInfoSchema[];
 }
 
@@ -1810,7 +1823,7 @@ export interface RemoteRemoveSchema {
   name: string;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "remote_remove";
   replayed?: boolean | null;
   status: string;
   url?: string | null;
@@ -1824,7 +1837,7 @@ export interface RemoteSetDefaultSchema {
   name: string;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "remote_set_default";
   replayed?: boolean | null;
   status: string;
   url?: string | null;
@@ -2120,7 +2133,7 @@ export interface StartSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread_start";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2272,6 +2285,7 @@ export interface SwitchCheckoutSchema {
   name?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "thread_switch";
   path?: string | null;
   replayed?: boolean | null;
   target?: string | null;
@@ -2289,7 +2303,7 @@ export interface SyncSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "sync";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -2368,7 +2382,7 @@ export interface ThreadCleanupSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread.cleanup";
   reclaimed_bytes: number;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2396,7 +2410,7 @@ export interface ThreadCreateSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread_create";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2419,7 +2433,7 @@ export interface ThreadDropSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: string;
+  output_kind: "thread";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2498,7 +2512,7 @@ export interface ThreadPromoteSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: string;
+  output_kind: "thread";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2517,7 +2531,7 @@ export interface ThreadRefreshSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: string;
+  output_kind: "thread";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2536,7 +2550,7 @@ export interface ThreadRenameSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread_rename";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2554,7 +2568,7 @@ export interface ThreadResolveSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "resolve";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -2569,6 +2583,7 @@ export interface ThreadRevokeApprovalSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "thread_revoke_approval";
   replayed?: boolean | null;
 }
 
@@ -2760,7 +2775,7 @@ export interface ThreadSwitchSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind?: string | null;
+  output_kind: "thread_switch";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -3072,7 +3087,7 @@ export interface HeddleVerbOutputs {
   "remote list": RemoteListSchema;
   "remote remove": RemoteRemoveSchema;
   "remote set-default": RemoteSetDefaultSchema;
-  "remote show": RemoteInfoSchema;
+  "remote show": RemoteInfoSchema2;
   resolve: ResolveSchema;
   retro: RetroSchema;
   revert: RevertSchema;

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -1153,7 +1153,24 @@ const CONTRACTS: &[CommandContractEntry] = &[
         git_adapter_action(
             json_discriminators(
                 documented_schemas(MUTATING, &["branch"]),
-                &[json_discriminator(Some("branch"), "output_kind", "thread_list")],
+                &[
+                    // No-arg `branch` emits the thread-list contract; this
+                    // is the shape the registered `branch` schema mirrors.
+                    json_discriminator(Some("branch"), "output_kind", "thread_list"),
+                    // `branch <name>` (create/rename/delete) delegates to
+                    // the thread family and emits the delegate's record
+                    // (e.g. `thread_create`). Advertised without a schema
+                    // verb — only the listing shape is schema-backed —
+                    // mirroring how hosted `clone` advertises its
+                    // preliminary `clone_connection` envelope.
+                    json_discriminator_no_schema(
+                        "branch mutations delegate to the thread family; the \
+                         registered `branch` schema mirrors only the no-arg \
+                         listing shape",
+                        "output_kind",
+                        "thread_create",
+                    ),
+                ],
             ),
             "thread",
             "command_family",
@@ -1460,10 +1477,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["conflict", "show"],
-        json_discriminators(
-            opaque_schemas(READ_JSON, &["conflict show"]),
-            &[json_discriminator(Some("conflict show"), "output_kind", "conflict_show")],
-        ),
+        opaque_schemas(READ_JSON, &["conflict show"]),
     ),
     entry(
         &["continue"],
@@ -1781,10 +1795,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["inspect"], json_discriminators(
-                        documented_schemas(READ_JSON, &["inspect"]),
-                        &[json_discriminator(Some("inspect"), "output_kind", "thread_show")],
-                    )),
+    entry(&["inspect"], documented_schemas(READ_JSON, &["inspect"])),
     entry(&["integration"], surface(GROUP, "admin")),
     entry(
         &["integration", "list"],
@@ -5398,6 +5409,7 @@ mod tests {
                 "agent ready",
                 "blame",
                 "branch",
+                "branch",
                 "bridge git status",
                 "bridge git import",
                 "bridge git sync",
@@ -5413,7 +5425,6 @@ mod tests {
                 "clone",
                 "commit",
                 "commands",
-                "conflict show",
                 "continue",
                 "context set",
                 "context get",
@@ -5439,7 +5450,6 @@ mod tests {
                 "fork",
                 "goto",
                 "init",
-                "inspect",
                 // `log` appears twice: the entry advertises both `log` and the
                 // `log --reflog` variant (`log_reflog`), mirroring `undo`/`clone`.
                 "log",

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -1114,10 +1114,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["agent", "ready"],
-        surface(json_discriminators(
-                    documented_schemas(CAPTURE, &["agent ready"]),
-                    &[json_discriminator(Some("agent ready"), "output_kind", "ready")],
-                ), "automation"),
+        surface(
+            json_discriminators(
+                documented_schemas(CAPTURE, &["agent ready"]),
+                &[json_discriminator(Some("agent ready"), "output_kind", "ready")],
+            ),
+            "automation",
+        ),
     ),
     entry(
         &["agent", "release"],
@@ -1144,10 +1147,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["auth", "status"], READ_JSON),
     #[cfg(feature = "client")]
     entry(&["auth", "create-service-token"], MUTATING_NO_OP_ID),
-    entry(&["blame"], json_discriminators(
-                      documented_schemas(READ_JSON, &["blame"]),
-                      &[json_discriminator(Some("blame"), "output_kind", "blame")],
-                  )),
+    entry(
+        &["blame"],
+        json_discriminators(
+            documented_schemas(READ_JSON, &["blame"]),
+            &[json_discriminator(Some("blame"), "output_kind", "blame")],
+        ),
+    ),
     entry(
         &["branch"],
         git_adapter_action(
@@ -1608,10 +1614,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["daemon", "stop"],
-        surface(json_discriminators(
-                    opaque_schemas(DAEMON_MUTATION, &["daemon stop"]),
-                    &[json_discriminator(Some("daemon stop"), "output_kind", "daemon_stop")],
-                ), "admin"),
+        surface(
+            json_discriminators(
+                opaque_schemas(DAEMON_MUTATION, &["daemon stop"]),
+                &[json_discriminator(
+                    Some("daemon stop"),
+                    "output_kind",
+                    "daemon_stop",
+                )],
+            ),
+            "admin",
+        ),
     ),
     entry(
         &["delegate"],
@@ -1685,10 +1698,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["doctor"],
-        front_door(json_discriminators(
-                       documented_schemas(READ_JSON, &["doctor"]),
-                       &[json_discriminator(Some("doctor"), "output_kind", "diagnose")],
-                   ), 120),
+        front_door(
+            json_discriminators(
+                documented_schemas(READ_JSON, &["doctor"]),
+                &[json_discriminator(Some("doctor"), "output_kind", "diagnose")],
+            ),
+            120,
+        ),
     ),
     entry(
         &["doctor", "docs"],
@@ -1829,13 +1845,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["log"],
-        front_door(json_discriminators(
-                       documented_schemas(READ_JSON, &["log", "log --reflog"]),
-                       &[
-                           json_discriminator(Some("log"), "output_kind", "log"),
-                           json_discriminator(Some("log --reflog"), "output_kind", "log_reflog"),
-                       ],
-                   ), 130),
+        front_door(
+            json_discriminators(
+                documented_schemas(READ_JSON, &["log", "log --reflog"]),
+                &[
+                    json_discriminator(Some("log"), "output_kind", "log"),
+                    json_discriminator(Some("log --reflog"), "output_kind", "log_reflog"),
+                ],
+            ),
+            130,
+        ),
     ),
     entry(&["maintenance"], surface(GROUP, "admin")),
     entry(
@@ -1848,10 +1867,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["maintenance", "gc"],
-        surface(json_discriminators(
-                    opaque_schemas(GC_MUTATION, &["maintenance gc"]),
-                    &[json_discriminator(Some("maintenance gc"), "output_kind", "gc")],
-                ), "admin"),
+        surface(
+            json_discriminators(
+                opaque_schemas(GC_MUTATION, &["maintenance gc"]),
+                &[json_discriminator(Some("maintenance gc"), "output_kind", "gc")],
+            ),
+            "admin",
+        ),
     ),
     entry(
         &["maintenance", "index"],
@@ -2028,16 +2050,22 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["query"], json_discriminators(
-                      documented_schemas(READ_JSON, &["query"]),
-                      &[json_discriminator(Some("query"), "output_kind", "query")],
-                  )),
+    entry(
+        &["query"],
+        json_discriminators(
+            documented_schemas(READ_JSON, &["query"]),
+            &[json_discriminator(Some("query"), "output_kind", "query")],
+        ),
+    ),
     entry(
         &["ready"],
-        front_door(json_discriminators(
-                       documented_schemas(compact_json(CAPTURE), &["ready"]),
-                       &[json_discriminator(Some("ready"), "output_kind", "ready")],
-                   ), 50),
+        front_door(
+            json_discriminators(
+                documented_schemas(compact_json(CAPTURE), &["ready"]),
+                &[json_discriminator(Some("ready"), "output_kind", "ready")],
+            ),
+            50,
+        ),
     ),
     entry(&["rebase"], opaque_schemas(WORKTREE_MUTATION, &["rebase"])),
     entry(&["redact"], GROUP),
@@ -2291,10 +2319,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["start"],
-        front_door(json_discriminators(
-                       documented_schemas(WORKTREE_MUTATION, &["start"]),
-                       &[json_discriminator(Some("start"), "output_kind", "thread_start")],
-                   ), 40),
+        front_door(
+            json_discriminators(
+                documented_schemas(WORKTREE_MUTATION, &["start"]),
+                &[json_discriminator(
+                    Some("start"),
+                    "output_kind",
+                    "thread_start",
+                )],
+            ),
+            40,
+        ),
     ),
     entry(
         &["stash"],

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -2449,7 +2449,23 @@ const CONTRACTS: &[CommandContractEntry] = &[
         git_adapter_alias(
             json_discriminators(
                 documented_schemas(WORKTREE_MUTATION, &["switch"]),
-                &[json_discriminator(Some("switch"), "output_kind", "thread_switch")],
+                &[
+                    // Thread targets delegate to `thread switch` and emit
+                    // its record; this is the shape the registered
+                    // `switch` schema mirrors.
+                    json_discriminator(Some("switch"), "output_kind", "thread_switch"),
+                    // State targets fall through to the state-checkout
+                    // (`goto`) shape — advertised without a schema verb,
+                    // mirroring the `branch` / hosted-`clone` precedent.
+                    json_discriminator_no_schema(
+                        "switch falls through to the state-checkout (goto) \
+                         shape when the target resolves as a state; the \
+                         registered `switch` schema mirrors only the thread \
+                         path",
+                        "output_kind",
+                        "goto",
+                    ),
+                ],
             ),
             "thread switch",
         ),
@@ -5524,6 +5540,7 @@ mod tests {
                 "stash list",
                 "stash show",
                 "status",
+                "switch",
                 "switch",
                 "sync",
                 "thread create",

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -1011,13 +1011,19 @@ const fn advertised_action(
 const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["abort"],
-        documented_schemas(compact_json(MUTATING), &["abort"]),
+        json_discriminators(
+            documented_schemas(compact_json(MUTATING), &["abort"]),
+            &[json_discriminator(Some("abort"), "output_kind", "abort")],
+        ),
     ),
     entry(
         &["adopt"],
         front_door(
             advertised_action(
-                documented_schemas(ADOPT, &["adopt"]),
+                json_discriminators(
+                    documented_schemas(ADOPT, &["adopt"]),
+                    &[json_discriminator(Some("adopt"), "output_kind", "adopt")],
+                ),
                 "heddle adopt --ref <branch>",
                 &["heddle", "adopt", "--ref", "<branch>"],
                 &["branch"],
@@ -1055,21 +1061,30 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["agent", "serve"],
         surface(
-            documented_schemas(DAEMON_MUTATION, &["agent serve"]),
+            json_discriminators(
+                documented_schemas(DAEMON_MUTATION, &["agent serve"]),
+                &[json_discriminator(Some("agent serve"), "output_kind", "agent_serve")],
+            ),
             "automation",
         ),
     ),
     entry(
         &["agent", "status"],
         surface(
-            documented_schemas(READ_JSON, &["agent status"]),
+            json_discriminators(
+                documented_schemas(READ_JSON, &["agent status"]),
+                &[json_discriminator(Some("agent status"), "output_kind", "agent_status")],
+            ),
             "automation",
         ),
     ),
     entry(
         &["agent", "stop"],
         surface(
-            documented_schemas(DAEMON_MUTATION, &["agent stop"]),
+            json_discriminators(
+                documented_schemas(DAEMON_MUTATION, &["agent stop"]),
+                &[json_discriminator(Some("agent stop"), "output_kind", "agent_stop")],
+            ),
             "automation",
         ),
     ),
@@ -1090,13 +1105,19 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["agent", "capture"],
         surface(
-            documented_schemas(CAPTURE, &["agent capture"]),
+            json_discriminators(
+                documented_schemas(CAPTURE, &["agent capture"]),
+                &[json_discriminator(Some("agent capture"), "output_kind", "capture")],
+            ),
             "automation",
         ),
     ),
     entry(
         &["agent", "ready"],
-        surface(documented_schemas(CAPTURE, &["agent ready"]), "automation"),
+        surface(json_discriminators(
+                    documented_schemas(CAPTURE, &["agent ready"]),
+                    &[json_discriminator(Some("agent ready"), "output_kind", "ready")],
+                ), "automation"),
     ),
     entry(
         &["agent", "release"],
@@ -1123,11 +1144,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["auth", "status"], READ_JSON),
     #[cfg(feature = "client")]
     entry(&["auth", "create-service-token"], MUTATING_NO_OP_ID),
-    entry(&["blame"], documented_schemas(READ_JSON, &["blame"])),
+    entry(&["blame"], json_discriminators(
+                      documented_schemas(READ_JSON, &["blame"]),
+                      &[json_discriminator(Some("blame"), "output_kind", "blame")],
+                  )),
     entry(
         &["branch"],
         git_adapter_action(
-            documented_schemas(MUTATING, &["branch"]),
+            json_discriminators(
+                documented_schemas(MUTATING, &["branch"]),
+                &[json_discriminator(Some("branch"), "output_kind", "thread_list")],
+            ),
             "thread",
             "command_family",
             "Use the thread command family for branch listing, creation, rename, and deletion.",
@@ -1237,14 +1264,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["bridge", "git", "push"],
         git_adapter_alias(
-            documented_schemas(
-                CommandContract {
-                    writes_heddle_refs: false,
-                    writes_git_refs: true,
-                    network_io: true,
-                    ..MUTATING
-                },
-                &["bridge git push"],
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        writes_heddle_refs: false,
+                        writes_git_refs: true,
+                        network_io: true,
+                        ..MUTATING
+                    },
+                    &["bridge git push"],
+                ),
+                &[json_discriminator(Some("bridge git push"), "output_kind", "bridge_git_push")],
             ),
             "push",
         ),
@@ -1252,13 +1282,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["bridge", "git", "pull"],
         git_adapter_alias(
-            documented_schemas(
-                CommandContract {
-                    writes_git_refs: true,
-                    network_io: true,
-                    ..WORKTREE_MUTATION
-                },
-                &["bridge git pull"],
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        writes_git_refs: true,
+                        network_io: true,
+                        ..WORKTREE_MUTATION
+                    },
+                    &["bridge git pull"],
+                ),
+                &[json_discriminator(Some("bridge git pull"), "output_kind", "bridge_git_pull")],
             ),
             "pull",
         ),
@@ -1427,11 +1460,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["conflict", "show"],
-        opaque_schemas(READ_JSON, &["conflict show"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["conflict show"]),
+            &[json_discriminator(Some("conflict show"), "output_kind", "conflict_show")],
+        ),
     ),
     entry(
         &["continue"],
-        documented_schemas(compact_json(MUTATING), &["continue"]),
+        json_discriminators(
+            documented_schemas(compact_json(MUTATING), &["continue"]),
+            &[json_discriminator(Some("continue"), "output_kind", "continue")],
+        ),
     ),
     entry(&["context"], GROUP),
     entry(
@@ -1555,7 +1594,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["daemon", "stop"],
-        surface(opaque_schemas(DAEMON_MUTATION, &["daemon stop"]), "admin"),
+        surface(json_discriminators(
+                    opaque_schemas(DAEMON_MUTATION, &["daemon stop"]),
+                    &[json_discriminator(Some("daemon stop"), "output_kind", "daemon_stop")],
+                ), "admin"),
     ),
     entry(
         &["delegate"],
@@ -1629,7 +1671,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["doctor"],
-        front_door(documented_schemas(READ_JSON, &["doctor"]), 120),
+        front_door(json_discriminators(
+                       documented_schemas(READ_JSON, &["doctor"]),
+                       &[json_discriminator(Some("doctor"), "output_kind", "diagnose")],
+                   ), 120),
     ),
     entry(
         &["doctor", "docs"],
@@ -1656,13 +1701,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["fetch"],
         git_adapter_action(
-            documented_schemas(
-                CommandContract {
-                    writes_git_refs: true,
-                    network_io: true,
-                    ..MUTATING
-                },
-                &["fetch"],
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        writes_git_refs: true,
+                        network_io: true,
+                        ..MUTATING
+                    },
+                    &["fetch"],
+                ),
+                &[json_discriminator(Some("fetch"), "output_kind", "fetch")],
             ),
             "pull",
             "workflow",
@@ -1733,7 +1781,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["inspect"], documented_schemas(READ_JSON, &["inspect"])),
+    entry(&["inspect"], json_discriminators(
+                        documented_schemas(READ_JSON, &["inspect"]),
+                        &[json_discriminator(Some("inspect"), "output_kind", "thread_show")],
+                    )),
     entry(&["integration"], surface(GROUP, "admin")),
     entry(
         &["integration", "list"],
@@ -1767,7 +1818,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["log"],
-        front_door(documented_schemas(READ_JSON, &["log", "log --reflog"]), 130),
+        front_door(json_discriminators(
+                       documented_schemas(READ_JSON, &["log", "log --reflog"]),
+                       &[
+                           json_discriminator(Some("log"), "output_kind", "log"),
+                           json_discriminator(Some("log --reflog"), "output_kind", "log_reflog"),
+                       ],
+                   ), 130),
     ),
     entry(&["maintenance"], surface(GROUP, "admin")),
     entry(
@@ -1780,12 +1837,18 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["maintenance", "gc"],
-        surface(opaque_schemas(GC_MUTATION, &["maintenance gc"]), "admin"),
+        surface(json_discriminators(
+                    opaque_schemas(GC_MUTATION, &["maintenance gc"]),
+                    &[json_discriminator(Some("maintenance gc"), "output_kind", "gc")],
+                ), "admin"),
     ),
     entry(
         &["maintenance", "index"],
         surface(
-            documented_schemas(READ_JSON, &["maintenance index"]),
+            json_discriminators(
+                documented_schemas(READ_JSON, &["maintenance index"]),
+                &[json_discriminator(Some("maintenance index"), "output_kind", "index")],
+            ),
             "admin",
         ),
     ),
@@ -1815,7 +1878,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
         exits(
             surface(
                 advertised_action(
-                    documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
+                    json_discriminators(
+                        documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
+                        &[json_discriminator(Some("merge --preview"), "output_kind", "merge")],
+                    ),
                     "heddle merge <thread> --preview",
                     &["heddle", "merge", "<thread>", "--preview"],
                     &["thread"],
@@ -1866,13 +1932,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["pull"],
         exits(
             front_door(
-                documented_schemas(
-                    CommandContract {
-                        writes_git_refs: true,
-                        network_io: true,
-                        ..WORKTREE_MUTATION
-                    },
-                    &["pull"],
+                json_discriminators(
+                    documented_schemas(
+                        CommandContract {
+                            writes_git_refs: true,
+                            network_io: true,
+                            ..WORKTREE_MUTATION
+                        },
+                        &["pull"],
+                    ),
+                    &[json_discriminator(Some("pull"), "output_kind", "pull")],
                 ),
                 90,
             ),
@@ -1918,13 +1987,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
         exits(
             front_door(
                 advertised_action(
-                    documented_schemas(
-                        CommandContract {
-                            writes_git_refs: true,
-                            network_io: true,
-                            ..MUTATING
-                        },
-                        &["push"],
+                    json_discriminators(
+                        documented_schemas(
+                            CommandContract {
+                                writes_git_refs: true,
+                                network_io: true,
+                                ..MUTATING
+                            },
+                            &["push"],
+                        ),
+                        &[json_discriminator(Some("push"), "output_kind", "push")],
                     ),
                     "heddle push",
                     &["heddle", "push"],
@@ -1945,10 +2017,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["query"], documented_schemas(READ_JSON, &["query"])),
+    entry(&["query"], json_discriminators(
+                      documented_schemas(READ_JSON, &["query"]),
+                      &[json_discriminator(Some("query"), "output_kind", "query")],
+                  )),
     entry(
         &["ready"],
-        front_door(documented_schemas(compact_json(CAPTURE), &["ready"]), 50),
+        front_door(json_discriminators(
+                       documented_schemas(compact_json(CAPTURE), &["ready"]),
+                       &[json_discriminator(Some("ready"), "output_kind", "ready")],
+                   ), 50),
     ),
     entry(&["rebase"], opaque_schemas(WORKTREE_MUTATION, &["rebase"])),
     entry(&["redact"], GROUP),
@@ -2033,23 +2111,38 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["remote"], surface(GROUP, "native")),
     entry(
         &["remote", "list"],
-        documented_schemas(READ_JSON, &["remote list"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["remote list"]),
+            &[json_discriminator(Some("remote list"), "output_kind", "remote_list")],
+        ),
     ),
     entry(
         &["remote", "add"],
-        documented_schemas(CONFIG_MUTATION, &["remote add"]),
+        json_discriminators(
+            documented_schemas(CONFIG_MUTATION, &["remote add"]),
+            &[json_discriminator(Some("remote add"), "output_kind", "remote_add")],
+        ),
     ),
     entry(
         &["remote", "remove"],
-        documented_schemas(CONFIG_MUTATION, &["remote remove"]),
+        json_discriminators(
+            documented_schemas(CONFIG_MUTATION, &["remote remove"]),
+            &[json_discriminator(Some("remote remove"), "output_kind", "remote_remove")],
+        ),
     ),
     entry(
         &["remote", "set-default"],
-        documented_schemas(CONFIG_MUTATION, &["remote set-default"]),
+        json_discriminators(
+            documented_schemas(CONFIG_MUTATION, &["remote set-default"]),
+            &[json_discriminator(Some("remote set-default"), "output_kind", "remote_set_default")],
+        ),
     ),
     entry(
         &["remote", "show"],
-        documented_schemas(READ_JSON, &["remote show"]),
+        json_discriminators(
+            documented_schemas(READ_JSON, &["remote show"]),
+            &[json_discriminator(Some("remote show"), "output_kind", "remote_show")],
+        ),
     ),
     entry(
         &["resolve"],
@@ -2167,13 +2260,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["land"],
         front_door(
-            documented_schemas(
-                CommandContract {
-                    writes_git_refs: true,
-                    network_io: true,
-                    ..compact_json(MUTATING)
-                },
-                &["land"],
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        writes_git_refs: true,
+                        network_io: true,
+                        ..compact_json(MUTATING)
+                    },
+                    &["land"],
+                ),
+                &[json_discriminator(Some("land"), "output_kind", "land")],
             ),
             70,
         ),
@@ -2184,7 +2280,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["start"],
-        front_door(documented_schemas(WORKTREE_MUTATION, &["start"]), 40),
+        front_door(json_discriminators(
+                       documented_schemas(WORKTREE_MUTATION, &["start"]),
+                       &[json_discriminator(Some("start"), "output_kind", "thread_start")],
+                   ), 40),
     ),
     entry(
         &["stash"],
@@ -2302,18 +2401,27 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["switch"],
         git_adapter_alias(
-            documented_schemas(WORKTREE_MUTATION, &["switch"]),
+            json_discriminators(
+                documented_schemas(WORKTREE_MUTATION, &["switch"]),
+                &[json_discriminator(Some("switch"), "output_kind", "thread_switch")],
+            ),
             "thread switch",
         ),
     ),
     entry(
         &["sync"],
-        documented_schemas(compact_json(MUTATING), &["sync"]),
+        json_discriminators(
+            documented_schemas(compact_json(MUTATING), &["sync"]),
+            &[json_discriminator(Some("sync"), "output_kind", "sync")],
+        ),
     ),
     entry(&["thread"], surface(GROUP, "native")),
     entry(
         &["thread", "create"],
-        documented_schemas(MUTATING, &["thread create"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["thread create"]),
+            &[json_discriminator(Some("thread create"), "output_kind", "thread_create")],
+        ),
     ),
     entry(
         &["thread", "current"],
@@ -2321,7 +2429,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["thread", "switch"],
-        documented_schemas(WORKTREE_MUTATION, &["thread switch"]),
+        json_discriminators(
+            documented_schemas(WORKTREE_MUTATION, &["thread switch"]),
+            &[json_discriminator(Some("thread switch"), "output_kind", "thread_switch")],
+        ),
     ),
     entry(&["thread", "cd"], READ_TEXT),
     entry(
@@ -2352,11 +2463,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["thread", "rename"],
-        documented_schemas(MUTATING, &["thread rename"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["thread rename"]),
+            &[json_discriminator(Some("thread rename"), "output_kind", "thread_rename")],
+        ),
     ),
     entry(
         &["thread", "refresh"],
-        documented_schemas(WORKTREE_MUTATION, &["thread refresh"]),
+        json_discriminators(
+            documented_schemas(WORKTREE_MUTATION, &["thread refresh"]),
+            &[json_discriminator(Some("thread refresh"), "output_kind", "thread")],
+        ),
     ),
     entry(
         &["thread", "move"],
@@ -2368,15 +2485,24 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["thread", "resolve"],
-        documented_schemas(MUTATING, &["thread resolve"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["thread resolve"]),
+            &[json_discriminator(Some("thread resolve"), "output_kind", "resolve")],
+        ),
     ),
     entry(
         &["thread", "promote"],
-        documented_schemas(WORKTREE_MUTATION, &["thread promote"]),
+        json_discriminators(
+            documented_schemas(WORKTREE_MUTATION, &["thread promote"]),
+            &[json_discriminator(Some("thread promote"), "output_kind", "thread")],
+        ),
     ),
     entry(
         &["thread", "drop"],
-        documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread drop"]),
+        json_discriminators(
+            documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread drop"]),
+            &[json_discriminator(Some("thread drop"), "output_kind", "thread")],
+        ),
     ),
     entry(
         &["thread", "approve"],
@@ -2388,7 +2514,14 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["thread", "revoke-approval"],
-        documented_schemas(MUTATING, &["thread revoke-approval"]),
+        json_discriminators(
+            documented_schemas(MUTATING, &["thread revoke-approval"]),
+            &[json_discriminator(
+                Some("thread revoke-approval"),
+                "output_kind",
+                "thread_revoke_approval",
+            )],
+        ),
     ),
     entry(
         &["thread", "check-merge"],
@@ -2396,7 +2529,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["thread", "cleanup"],
-        documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread cleanup"]),
+        json_discriminators(
+            documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread cleanup"]),
+            &[json_discriminator(Some("thread cleanup"), "output_kind", "thread.cleanup")],
+        ),
     ),
     entry(&["transaction"], hidden(GROUP)),
     entry(
@@ -5227,8 +5363,14 @@ mod tests {
         // Wire-format-stable list. PR #251 instrumented the initial set;
         // heddle#272 swept the named-by-persona verbs (stack, goto, fork,
         // revert, purge, redact, stash, clean, discuss, context, review,
-        // cherry-pick, bisect). Any further sweep MUST extend this list
-        // and document the addition.
+        // cherry-pick, bisect); heddle#641 swept the remaining verbs whose
+        // runtime JSON already emits `output_kind` (abort, adopt, the agent
+        // session verbs, blame, branch, bridge git push/pull, conflict show,
+        // continue, daemon stop, doctor, fetch, inspect, land, log,
+        // maintenance gc/index, merge --preview, pull, push, query, ready,
+        // the remote family, start, switch, sync, and the thread lifecycle
+        // verbs). Any further sweep MUST extend this list and document the
+        // addition.
         //
         // `clone` appears twice because hosted `clone --output json`
         // emits two JSON records per invocation (a preliminary
@@ -5242,10 +5384,26 @@ mod tests {
         assert_eq!(
             displays,
             vec![
+                // heddle#641 swept every remaining verb whose runtime JSON
+                // already carries `output_kind` (probed live + verified against
+                // the emitting structs). The values are the RUNTIME truths, not
+                // snake-cased display paths — see the overrides documented in
+                // tests/cli_integration/output_kind_invariant.rs.
+                "abort",
+                "adopt",
+                "agent serve",
+                "agent status",
+                "agent stop",
+                "agent capture",
+                "agent ready",
+                "blame",
+                "branch",
                 "bridge git status",
                 "bridge git import",
                 "bridge git sync",
                 "bridge git reconcile",
+                "bridge git push",
+                "bridge git pull",
                 "bridge backfill-fidelity",
                 "capture",
                 "checkpoint",
@@ -5255,6 +5413,8 @@ mod tests {
                 "clone",
                 "commit",
                 "commands",
+                "conflict show",
+                "continue",
                 "context set",
                 "context get",
                 "context list",
@@ -5265,22 +5425,37 @@ mod tests {
                 "context check",
                 "context suggest",
                 "context audit",
+                "daemon stop",
                 "diff",
                 "discuss open",
                 "discuss append",
                 "discuss resolve",
                 "discuss list",
                 "discuss show",
+                "doctor",
                 "doctor docs",
                 "doctor schemas",
+                "fetch",
                 "fork",
                 "goto",
                 "init",
+                "inspect",
+                // `log` appears twice: the entry advertises both `log` and the
+                // `log --reflog` variant (`log_reflog`), mirroring `undo`/`clone`.
+                "log",
+                "log",
+                "maintenance gc",
+                "maintenance index",
+                "merge",
                 "stack",
                 "stack ready",
                 "stack snapshot",
+                "pull",
                 "purge apply",
                 "purge list",
+                "push",
+                "query",
+                "ready",
                 "redact apply",
                 "redact list",
                 "redact show",
@@ -5288,34 +5463,130 @@ mod tests {
                 "redact trust list",
                 "redact trust remove",
                 "redo",
+                "remote list",
+                "remote add",
+                "remote remove",
+                "remote set-default",
+                "remote show",
                 "revert",
                 "review show",
                 "review sign",
                 "review next",
                 "review health",
                 "schemas",
+                "land",
+                "start",
                 "stash list",
                 "stash show",
                 "status",
+                "switch",
+                "sync",
+                "thread create",
+                "thread switch",
                 "thread list",
                 "thread show",
+                "thread rename",
+                "thread refresh",
+                "thread resolve",
+                "thread promote",
+                "thread drop",
+                "thread revoke-approval",
+                "thread cleanup",
                 "verify",
-                // heddle#317 added the `visibility` verb family; each leaf
-                // advertises a JSON discriminator, so the wire-format-stable
-                // list is extended here per the documentation rule above.
                 "visibility set",
                 "visibility promote",
                 "visibility show",
                 "visibility list",
-                // `undo` advertises two output_kinds on one command path —
-                // `undo` and `undo_list` (`--list`) — so its path appears twice,
-                // mirroring how `clone` appears twice above. The former `redo`
-                // verb is its own top-level entry again (`redo`, above). See
-                // heddle#473.
                 "undo",
                 "undo",
                 "workspace show",
             ]
+        );
+    }
+
+    /// heddle#641 close-the-class conformance: every schema verb whose
+    /// JSON schema declares an `output_kind` property MUST have a
+    /// catalog discriminator whose value matches the schema's const.
+    ///
+    /// Why this closes the gap: `schema_for_verb` only injects the
+    /// `output_kind` enum-const into a schema when the catalog
+    /// advertises a discriminator for that verb. A verb whose mirror
+    /// struct declares `output_kind` (because the runtime payload
+    /// emits it) but whose catalog entry lacks the discriminator
+    /// therefore surfaces here as a *const-less* `output_kind`
+    /// property — exactly the advertise-nothing gap that left ~111
+    /// schema-bearing commands with `json_discriminators: []`. A new
+    /// command that emits `output_kind` without registering its
+    /// discriminator fails this test; one that registers a
+    /// discriminator that diverges from the schema const fails the
+    /// mismatch arm. Runtime-vs-catalog equality is enforced
+    /// separately by `tests/cli_integration/output_kind_invariant.rs`.
+    #[test]
+    fn schema_output_kind_discriminators_are_complete_and_consistent() {
+        use crate::cli::commands::schema_for_verb;
+
+        let mut missing = Vec::new();
+        let mut mismatched = Vec::new();
+        let mut checked = 0usize;
+
+        for verb in schema_verbs() {
+            let Some(schema) = schema_for_verb(verb) else {
+                panic!("catalog schema verb `{verb}` has no registered schema");
+            };
+            let Some(property) = schema
+                .get("properties")
+                .and_then(|properties| properties.get("output_kind"))
+            else {
+                // The schema does not declare `output_kind` — the verb's
+                // runtime payload genuinely lacks the discriminator (the
+                // UNSWEPT_TODO rolldown in output_kind_invariant.rs).
+                continue;
+            };
+            checked += 1;
+
+            let Some(discriminator) = command_json_discriminator_for_schema_verb(verb) else {
+                missing.push(format!(
+                    "`{verb}`: schema declares an `output_kind` property but the \
+                     catalog advertises no json_discriminator for it"
+                ));
+                continue;
+            };
+
+            let const_value = property
+                .get("enum")
+                .and_then(|values| values.as_array())
+                .and_then(|values| values.first())
+                .and_then(|value| value.as_str())
+                .or_else(|| property.get("const").and_then(|value| value.as_str()));
+            match const_value {
+                None => missing.push(format!(
+                    "`{verb}`: schema declares `output_kind` without an enum/const \
+                     even though the catalog advertises `{}` — the discriminator \
+                     injection regressed",
+                    discriminator.value
+                )),
+                Some(value) if value != discriminator.value => mismatched.push(format!(
+                    "`{verb}`: schema const `{value}` != catalog discriminator `{}`",
+                    discriminator.value
+                )),
+                Some(_) => {}
+            }
+        }
+
+        assert!(
+            missing.is_empty() && mismatched.is_empty(),
+            "Catalog json_discriminators drift from the schema `output_kind` contract. \
+             Register the discriminator with `json_discriminator(Some(\"<verb>\"), \
+             \"output_kind\", \"<runtime value>\")` on the command's catalog entry \
+             (the value must match what the command actually emits).\n\nMissing:\n  - {}\n\nMismatched:\n  - {}",
+            missing.join("\n  - "),
+            mismatched.join("\n  - ")
+        );
+        assert!(
+            checked >= 100,
+            "expected the conformance sweep to inspect the full discriminator \
+             surface (~107 schema verbs declare `output_kind`); only {checked} \
+             were checked — the schema injection or verb collection likely regressed"
         );
     }
 

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1086,6 +1086,7 @@ pub struct BranchCompatSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct SwitchCheckoutSchema {
+    pub output_kind: Option<String>,
     pub name: Option<String>,
     pub message: String,
     pub thread: Option<ThreadSummarySchema>,
@@ -1188,6 +1189,7 @@ pub struct SyncSchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct LandSchema {
+    pub output_kind: Option<String>,
     pub status: String,
     pub action: String,
     pub message: String,
@@ -1332,6 +1334,7 @@ pub struct ThreadApprovalListSchema(pub Vec<ThreadApprovalSchema>);
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ThreadRevokeApprovalSchema {
+    pub output_kind: String,
     pub deleted: bool,
     pub id: String,
 }

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -125,12 +125,10 @@ const SWEPT: &[&str] = &[
     "branch",
     "bridge git pull",
     "bridge git push",
-    "conflict show",
     "continue",
     "daemon stop",
     "doctor",
     "fetch",
-    "inspect",
     "land",
     "log",
     "maintenance gc",
@@ -186,6 +184,7 @@ const UNSWEPT_TODO: &[&str] = &[
     "bridge git reason",
     "collapse",
     "conflict list",
+    "conflict show",
     "daemon serve",
     "daemon status",
     "delegate",
@@ -196,6 +195,7 @@ const UNSWEPT_TODO: &[&str] = &[
     "hook install",
     "hook list",
     "hook uninstall",
+    "inspect",
     "integration doctor",
     "integration install",
     "integration list",
@@ -272,7 +272,6 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         // Git-compat verbs delegate to the thread family and emit the
         // delegate's kind.
         "branch" => Some("thread_list"),
-        "inspect" => Some("thread_show"),
         "start" => Some("thread_start"),
         "switch" => Some("thread_switch"),
         // `doctor` is implemented by the diagnose module.
@@ -697,7 +696,6 @@ fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bo
         "branch" => Some((&["branch"], true)),
         "continue" => Some((&["continue"], true)),
         "doctor" => Some((&["doctor"], true)),
-        "inspect" => Some((&["inspect", "main"], true)),
         "log" => Some((&["log"], true)),
         "maintenance gc" => Some((&["maintenance", "gc"], true)),
         "maintenance index" => Some((&["maintenance", "index"], true)),
@@ -993,6 +991,13 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             .expect("visibility set");
             (t, sv(&["visibility", "list"]))
         }
+        // heddle#641 — the newly-swept generic-schema verbs. Their opaque
+        // mirrors pin no fields, so the documented sample must be compared
+        // against the live payload here.
+        "gc" => (init_fixture(), sv(&["maintenance", "gc"])),
+        // Stopping a daemon that is not running still exits 0 with the
+        // full `daemon_stop` payload, so a bare init fixture suffices.
+        "daemon_stop" => (init_fixture(), sv(&["daemon", "stop"])),
         _ => return None,
     };
     Some(case)
@@ -1037,19 +1042,36 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
     // (b) fails for them and they are forced down path (a). A new generic-schema
     // verb documented without a runtime case here fails this test rather than
     // deferring to a later round.
+    //
+    // heddle#641: the loop is grouped per VALUE rather than per (display,
+    // value) row because one wire value can be advertised by several
+    // commands (`thread_list` by `thread list` AND its `branch` alias;
+    // `ready` by `ready` AND `agent ready`; `thread` by the drop/promote/
+    // refresh trio). `doc_sample_top_level_keys` resolves a value to ONE
+    // documented sample, so the sample is guarded once — by the runtime
+    // case, or by ANY advertising display whose schema pins every
+    // documented key. Requiring EVERY display to pin would force alias
+    // schemas (e.g. `branch`'s mutation mirror) to model their sibling's
+    // listing shape.
     let doc = read_json_schemas_doc();
 
     let mut failures = Vec::new();
     let mut covered_by_runtime = 0usize;
     let mut covered_by_schema = 0usize;
 
+    // value -> displays advertising it (schema-verb-backed rows only;
+    // transport-envelope discriminators like `clone_connection` have no
+    // schema verb and no documented sample — they are pinned separately).
+    let mut advertising: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
     for (display, value, has_schema_verb) in catalog_output_kind_discriminators() {
-        // Transport-envelope discriminators (e.g. `clone_connection`) have no
-        // schema verb and no documented sample; they are pinned separately.
-        if !has_schema_verb {
-            continue;
+        if has_schema_verb {
+            advertising.entry(value).or_default().push(display);
         }
-        let Some(doc_keys) = doc_sample_top_level_keys(&doc, &value) else {
+    }
+
+    for (value, displays) in &advertising {
+        let Some(doc_keys) = doc_sample_top_level_keys(&doc, value) else {
             // This value is not individually documented (it rides a grouped
             // sample under a representative sibling, e.g. `redo` under `undo`,
             // `purge list` under `purge_apply`) — nothing to compare here.
@@ -1062,12 +1084,12 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
         // the key is present by construction; assert it defensively.
         if !doc_keys.contains("output_kind") {
             failures.push(format!(
-                "{value} ({display}): documented sample is missing the `output_kind` key"
+                "{value} ({displays:?}): documented sample is missing the `output_kind` key"
             ));
             continue;
         }
 
-        if let Some((fixture, argv)) = runtime_doc_case(&value) {
+        if let Some((fixture, argv)) = runtime_doc_case(value) {
             let argv_refs: Vec<&str> = std::iter::once("--output")
                 .chain(std::iter::once("json"))
                 .chain(argv.iter().map(String::as_str))
@@ -1075,14 +1097,14 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
             let runtime_keys = runtime_top_level_keys(&argv_refs, fixture.path());
             if !runtime_keys.contains("output_kind") {
                 failures.push(format!(
-                    "{value} ({display}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
+                    "{value} ({displays:?}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
                 ));
             }
-            if doc_keys != runtime_keys {
+            if &doc_keys != &runtime_keys {
                 let doc_only: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
                 let runtime_only: Vec<&String> = runtime_keys.difference(&doc_keys).collect();
                 failures.push(format!(
-                    "{value} ({display}): documented sample does not match the live \
+                    "{value} ({displays:?}): documented sample does not match the live \
                      `--output json` payload.\n      in doc only:     {doc_only:?}\n      \
                      in runtime only: {runtime_only:?}\n      doc keys:     {doc_keys:?}\n      \
                      runtime keys: {runtime_keys:?}"
@@ -1092,21 +1114,24 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
             continue;
         }
 
-        // No runtime case: the registered schema MUST pin every documented
-        // key, otherwise the sample is unguarded and could drift freely.
-        let schema_props = schema_property_names(&display);
-        let unpinned: Vec<&String> = doc_keys
-            .iter()
-            .filter(|k| k.as_str() != "output_kind")
-            .filter(|k| !schema_props.contains(*k))
-            .collect();
-        if unpinned.is_empty() {
+        // No runtime case: at least one advertising display's registered
+        // schema MUST pin every documented key, otherwise the sample is
+        // unguarded and could drift freely.
+        let pinned_by_some_display = displays.iter().any(|display| {
+            let schema_props = schema_property_names(display);
+            doc_keys
+                .iter()
+                .filter(|k| k.as_str() != "output_kind")
+                .all(|k| schema_props.contains(k))
+        });
+        if pinned_by_some_display {
             covered_by_schema += 1;
         } else {
             failures.push(format!(
-                "{value} ({display}): no runtime case AND its registered schema does not pin \
-                 documented keys {unpinned:?} (schema is generic). Add a `runtime_doc_case` arm \
-                 so the sample is checked against the live payload."
+                "{value} ({displays:?}): no runtime case AND no advertising display's \
+                 registered schema pins every documented key (schema is generic or models \
+                 a different shape). Add a `runtime_doc_case` arm so the sample is checked \
+                 against the live payload."
             ));
         }
     }

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -108,6 +108,55 @@ const SWEPT: &[&str] = &[
     "review next",
     "review health",
     "cherry-pick",
+    // heddle#641 — swept the remaining verbs whose runtime JSON already
+    // emits `output_kind`. Every value below was probed live against the
+    // built binary (or read off the emitting struct for the daemon-style
+    // verbs that can't run in a synthetic fixture); several carry
+    // wire-frozen values that differ from the snake-cased display path —
+    // see `output_kind_override`.
+    "abort",
+    "adopt",
+    "agent capture",
+    "agent ready",
+    "agent serve",
+    "agent status",
+    "agent stop",
+    "blame",
+    "branch",
+    "bridge git pull",
+    "bridge git push",
+    "conflict show",
+    "continue",
+    "daemon stop",
+    "doctor",
+    "fetch",
+    "inspect",
+    "land",
+    "log",
+    "maintenance gc",
+    "maintenance index",
+    "merge",
+    "pull",
+    "push",
+    "query",
+    "ready",
+    "remote add",
+    "remote list",
+    "remote remove",
+    "remote set-default",
+    "remote show",
+    "start",
+    "switch",
+    "sync",
+    "thread cleanup",
+    "thread create",
+    "thread drop",
+    "thread promote",
+    "thread refresh",
+    "thread rename",
+    "thread resolve",
+    "thread revoke-approval",
+    "thread switch",
 ];
 
 /// The catalog itself advertises its container kind as `"kind":
@@ -121,41 +170,25 @@ const KIND_FIELD_EXCEPTIONS: &[&str] = &["commands"];
 /// up the sweep instead. This list is the rolldown surface for
 /// follow-up work tracked separately from #272.
 const UNSWEPT_TODO: &[&str] = &[
-    "abort",
-    "adopt",
     "actor done",
     "actor explain",
     "actor list",
     "actor show",
     "actor spawn",
-    "agent capture",
     "agent heartbeat",
     "agent list",
-    "agent ready",
     "agent release",
     "agent reserve",
-    "agent serve",
-    "agent status",
-    "agent stop",
     "attempt",
-    "blame",
-    "branch",
     "bridge git export",
     "bridge git ingest",
     "bridge git init",
-    "bridge git pull",
-    "bridge git push",
     "bridge git reason",
     "collapse",
     "conflict list",
-    "conflict show",
-    "continue",
     "daemon serve",
     "daemon status",
-    "daemon stop",
     "delegate",
-    "doctor",
-    "fetch",
     "fsck",
     "git-overlay",
     "harness-bridge",
@@ -163,16 +196,12 @@ const UNSWEPT_TODO: &[&str] = &[
     "hook install",
     "hook list",
     "hook uninstall",
-    "inspect",
     "integration doctor",
     "integration install",
     "integration list",
     "integration relay",
     "integration uninstall",
     "integration upgrade",
-    "log",
-    "maintenance gc",
-    "maintenance index",
     "maintenance inspect",
     "maintenance monitor",
     "maintenance run",
@@ -180,17 +209,7 @@ const UNSWEPT_TODO: &[&str] = &[
     "marker delete",
     "marker list",
     "marker show",
-    "merge",
-    "pull",
-    "push",
-    "query",
     "rebase",
-    "ready",
-    "remote add",
-    "remote list",
-    "remote remove",
-    "remote set-default",
-    "remote show",
     "resolve",
     "retro",
     "semantic hot",
@@ -199,32 +218,19 @@ const UNSWEPT_TODO: &[&str] = &[
     "session segment",
     "session show",
     "session start",
-    "land",
     "show",
     "stash apply",
     "stash clear",
     "stash drop",
     "stash pop",
     "stash push",
-    "start",
-    "switch",
-    "sync",
     "thread absorb",
     "thread approvals",
     "thread approve",
     "thread captures",
     "thread check-merge",
-    "thread cleanup",
-    "thread create",
     "thread current",
-    "thread drop",
     "thread move",
-    "thread promote",
-    "thread refresh",
-    "thread rename",
-    "thread resolve",
-    "thread revoke-approval",
-    "thread switch",
     "transaction abort",
     "transaction begin",
     "transaction commit",
@@ -252,6 +258,39 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         // `workspace_summary` (the underlying struct's semantic name)
         // rather than the snake-cased path. Wire-format-stable.
         "workspace show" => Some("workspace_summary"),
+        // heddle#641 — runtime-probed wire values that pre-date the
+        // snake-cased-path rule. The catalog advertises what the
+        // commands actually emit TODAY; renaming any of these is a
+        // wire-format break that must update the emitting struct, the
+        // catalog discriminator, and this override in lockstep.
+        //
+        // `agent capture` / `agent ready` are session-validated
+        // aliases that delegate to `cmd_snapshot` / `cmd_ready`, so
+        // they emit the delegate's kind.
+        "agent capture" => Some("capture"),
+        "agent ready" => Some("ready"),
+        // Git-compat verbs delegate to the thread family and emit the
+        // delegate's kind.
+        "branch" => Some("thread_list"),
+        "inspect" => Some("thread_show"),
+        "start" => Some("thread_start"),
+        "switch" => Some("thread_switch"),
+        // `doctor` is implemented by the diagnose module.
+        "doctor" => Some("diagnose"),
+        // The maintenance wrappers emit their inner tool's kind.
+        "maintenance gc" => Some("gc"),
+        "maintenance index" => Some("index"),
+        // The thread lifecycle verbs that route through the shared
+        // operator envelope emit the generic `thread` (drop / promote /
+        // refresh), `resolve`, or the dotted `thread.cleanup` action
+        // name. Flagged as struct-level inconsistencies for a follow-up
+        // sweep; until the structs change, the catalog must advertise
+        // the live values.
+        "thread cleanup" => Some("thread.cleanup"),
+        "thread drop" => Some("thread"),
+        "thread promote" => Some("thread"),
+        "thread refresh" => Some("thread"),
+        "thread resolve" => Some("resolve"),
         _ => None,
     }
 }
@@ -643,6 +682,27 @@ fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bo
         "review health" => Some((&["review", "health"], true)),
         // `fork` succeeds in an init'd repo (forks the empty initial state).
         "fork" => Some((&["fork"], true)),
+        // heddle#641 — the swept verbs that run clean (exit 0, full JSON
+        // payload) in the shared init'd fixture, verified live before
+        // being added here. Each pins runtime emission against the
+        // catalog value, including the override-table verbs (`branch` →
+        // `thread_list`, `doctor` → `diagnose`, `inspect` →
+        // `thread_show`, `maintenance gc`/`index` → `gc`/`index`).
+        // `inspect` names `main` explicitly because the earlier `fork`
+        // invocation leaves the shared fixture without a current
+        // thread; `ready` (which rejects imported-Git-ref targets and
+        // has no equivalent escape hatch here) is runtime-covered by
+        // its `agent ready` delegation probe instead.
+        "abort" => Some((&["abort"], true)),
+        "branch" => Some((&["branch"], true)),
+        "continue" => Some((&["continue"], true)),
+        "doctor" => Some((&["doctor"], true)),
+        "inspect" => Some((&["inspect", "main"], true)),
+        "log" => Some((&["log"], true)),
+        "maintenance gc" => Some((&["maintenance", "gc"], true)),
+        "maintenance index" => Some((&["maintenance", "index"], true)),
+        "query" => Some((&["query"], true)),
+        "remote list" => Some((&["remote", "list"], true)),
         _ => None,
     }
 }

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -1100,7 +1100,7 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
                     "{value} ({displays:?}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"
                 ));
             }
-            if &doc_keys != &runtime_keys {
+            if doc_keys != runtime_keys {
                 let doc_only: Vec<&String> = doc_keys.difference(&runtime_keys).collect();
                 let runtime_only: Vec<&String> = runtime_keys.difference(&doc_keys).collect();
                 failures.push(format!(

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -549,6 +549,7 @@ saves a Heddle state without recommending a Git checkpoint.
 
 ```json
 {
+  "output_kind": "ready",
   "status": "completed",
   "action": "ready",
   "message": "Thread 'feature/parser' is ready to integrate",
@@ -567,6 +568,7 @@ saves a Heddle state without recommending a Git checkpoint.
 
 ```json
 {
+  "output_kind": "land",
   "status": "landed",
   "action": "land",
   "message": "Landed thread 'feature/parser'",
@@ -746,6 +748,7 @@ available, checkout paths, and post-command verification.
 
 ```json
 {
+  "output_kind": "thread_create",
   "name": "feature/parser",
   "message": "Created thread 'feature/parser' at hd-sqr398dvx9ay",
   "thread": null,
@@ -799,7 +802,7 @@ List recent saved states on a thread.
 
 ```json
 {
-  "output_kind": "thread_drop",
+  "output_kind": "thread",
   "status": "completed",
   "action": "thread drop",
   "name": "feature/parser",
@@ -856,6 +859,7 @@ Report manual follow-up after a blocked or refreshed thread.
 
 ```json
 {
+  "output_kind": "resolve",
   "status": "completed",
   "action": "resolve",
   "message": "Thread requires a manual follow-up",
@@ -915,6 +919,7 @@ emits an array of the same object.
 
 ```json
 {
+  "output_kind": "thread_revoke_approval",
   "deleted": true,
   "id": "apr_123"
 }
@@ -947,6 +952,7 @@ emits an array of the same object.
 
 ```json
 {
+  "output_kind": "thread.cleanup",
   "status": "completed",
   "action": "thread.cleanup",
   "message": "would drop 1 merged thread(s) (would reclaim 12.0 KB)",
@@ -1269,6 +1275,7 @@ Background startup refusals use the shared error envelope.
 
 ```json
 {
+  "output_kind": "agent_serve",
   "status": "stopped",
   "socket_path": "/work/project/.heddle/sockets/grpc.sock",
   "pid_path": "/work/project/.heddle/sockets/grpc.pid"
@@ -1281,6 +1288,7 @@ Background startup refusals use the shared error envelope.
 
 ```json
 {
+  "output_kind": "agent_status",
   "running": false,
   "pid": null,
   "socket_path": "/work/project/.heddle/sockets/grpc.sock",
@@ -1314,6 +1322,7 @@ Background startup refusals use the shared error envelope.
 
 ```json
 {
+  "output_kind": "agent_stop",
   "stopped": false,
   "swept_stale": false,
   "pid": null,
@@ -1357,6 +1366,7 @@ shape is the same capture envelope.
 
 ```json
 {
+  "output_kind": "capture",
   "status": "captured",
   "action": "capture",
   "change_id": "hd-sqr398dvx9ay",
@@ -1378,6 +1388,7 @@ the same ready envelope.
 
 ```json
 {
+  "output_kind": "ready",
   "status": "completed",
   "action": "ready",
   "message": "Thread is ready.",
@@ -1501,6 +1512,7 @@ the same ready envelope.
 
 ```json
 {
+  "output_kind": "fetch",
   "remote": "origin",
   "refs_fetched": 1,
   "objects_fetched": 2
@@ -1604,6 +1616,7 @@ imports the requested Git refs, and returns the post-adoption verification proof
 
 ```json
 {
+  "output_kind": "adopt",
   "adopted": true,
   "initialized": true,
   "path": "/repo/.heddle",
@@ -1702,6 +1715,7 @@ State history walking from a given starting state.
 
 ```json
 {
+  "output_kind": "log",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
   "states": [
@@ -2389,6 +2403,7 @@ is to surface every relevant signal for the operator.
 
 ```json
 {
+  "output_kind": "diagnose",
   "repository": "/work/project",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
@@ -2637,6 +2652,7 @@ Operator recovery commands share one command-result envelope.
 
 ```json
 {
+  "output_kind": "continue",
   "status": "continued",
   "action": "continue",
   "message": "Operation continued",
@@ -2655,6 +2671,7 @@ Refresh the active or named thread, or report the verification/action blocker.
 
 ```json
 {
+  "output_kind": "sync",
   "status": "refreshed",
   "action": "sync",
   "message": "Refreshed thread 'feature/parser'",
@@ -2728,6 +2745,7 @@ name, delete, or rename it emits a thread operation result.
 
 ```json
 {
+  "output_kind": "thread_create",
   "name": "feature/parser",
   "message": "Created thread 'feature/parser' at hd-sqr398dvx9ay",
   "thread": {
@@ -2790,6 +2808,7 @@ shape when the target resolves as a state rather than a thread.
 
 ```json
 {
+  "output_kind": "thread_switch",
   "name": "feature/parser",
   "message": "Switched to thread 'feature/parser'",
   "thread": null,
@@ -2921,7 +2940,7 @@ a structured object (`provider`, `model`, optional `session_id` /
 required:
 
 ```json
-{"file": "src/lib.rs", "context": [], "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
+{"output_kind": "blame", "file": "src/lib.rs", "context": [], "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
 ```
 
 `heddle bridge git ingest|reason --output json` emit:
@@ -2968,10 +2987,18 @@ true` and `status` is `"applied"`:
 {"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hd-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
 ```
 
-`heddle daemon serve|status|stop --output json` emit:
+`heddle daemon serve|status --output json` emit:
 
 ```json
 {"running": true, "pid": 4242, "endpoint": "/work/project/.heddle/daemon.sock", "mounts": 1, "stopped": false}
+```
+
+`heddle daemon stop --output json` emits its own envelope (`status` is
+`"stopped"` after a live daemon shuts down, `"not_running"` when there was
+nothing to stop — both exit 0):
+
+```json
+{"output_kind": "daemon_stop", "action": "daemon stop", "status": "not_running"}
 ```
 
 `heddle discuss open|append|resolve|show --output json` emit (each carries
@@ -3019,10 +3046,18 @@ names a new thread for the fork):
 {"integrations": [{"name": "github", "installed": true, "version": "1"}], "installed": true, "uninstalled": false, "upgraded": false, "issues": []}
 ```
 
-`heddle maintenance inspect|run|gc|monitor --output json` emit:
+`heddle maintenance inspect|run|monitor --output json` emit:
 
 ```json
 {"ok": true, "tasks": [{"name": "gc", "status": "skipped"}], "objects_removed": 0, "index_updated": true, "monitoring": false}
+```
+
+`heddle maintenance gc --output json` emits the pack/prune report (counts
+are zero on a fresh repository; `pinned_redactions` / `preserved_redactions`
+report redacted blobs the collector refused to touch):
+
+```json
+{"output_kind": "gc", "action": "gc", "status": "ok", "dry_run": false, "prune": false, "packed_count": 1, "bytes_saved": 0, "pruned_loose": 0, "bytes_freed": 0, "pinned_redactions": 0, "preserved_redactions": 0, "pruned_git_mapping_entries": 0}
 ```
 
 `heddle purge apply|list --output json` emit (each carries `output_kind`
@@ -3037,7 +3072,7 @@ set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`).
 `heddle query --output json` emits:
 
 ```json
-{"hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hd-sqr398dvx9ay"}]}
+{"output_kind": "query", "hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hd-sqr398dvx9ay"}]}
 ```
 
 `heddle rebase --output json` emits:


### PR DESCRIPTION
Fixes #641

## What

`heddle commands --output json` advertised `json_discriminators: []` for every schema-bearing verb outside the PR #251 / heddle#272 sweeps, even where the runtime payload already carries `output_kind`. This sweep registers the discriminator for **every verb whose runtime JSON provably emits one** and closes the class so the gap cannot reopen.

- **41 schema verbs registered** in `command_catalog.rs` (abort, adopt, agent capture/ready/serve/status/stop, blame, branch, bridge git push/pull, continue, daemon stop, doctor, fetch, land, log + `log --reflog`, maintenance gc/index, `merge --preview`, pull, push, query, ready, remote add/list/remove/set-default/show, start, switch, sync, and the thread lifecycle family), plus a no-schema `thread_create` discriminator on `branch` (its name-mutation path delegates to the thread family — `clone_connection` precedent).
- **Values are the runtime truths, not snake-cased guesses** — every value was probed live against the built binary in scratch repos (or read off the emitting struct for the daemon-style verbs): `branch`→`thread_list`, `doctor`→`diagnose`, `start`→`thread_start`, `switch`→`thread_switch`, `maintenance gc`→`gc`, `agent capture`→`capture` (delegates to `cmd_snapshot`), `thread drop|promote|refresh`→`thread`, `thread resolve`→`resolve`, `thread cleanup`→`thread.cleanup`, etc.
- **Close-the-class conformance test** (`schema_output_kind_discriminators_are_complete_and_consistent`): walks every catalog schema verb; any schema that declares an `output_kind` property without a matching catalog discriminator const fails CI. Because `schema_for_verb` injects the enum-const only when the catalog advertises the discriminator, a new command that emits `output_kind` without registering it surfaces as a const-less property and fails. Red-proofed by deleting the `abort` discriminator: the test fails naming the exact verb.
- **Invariant harness** (`output_kind_invariant.rs`): the 41 displays moved `UNSWEPT_TODO` → `SWEPT` with documented wire-value overrides; 10 new bare-fixture runtime invocations pin emission against the catalog; the doc-vs-runtime sweep is re-rooted per wire **value** (one value can be advertised by several commands — `thread_list` by `thread list` and `branch`, `ready` by `ready` and `agent ready`); `maintenance gc` and `daemon stop` get runtime-exact doc-sample checks (their mirrors are generic, so the schema path can't pin them).
- **`docs/json-schemas.md`**: 24 stale samples now carry the runtime `output_kind` (the `thread drop` sample documented `thread_drop` while runtime emits `thread`); `daemon stop` and `maintenance gc` get dedicated real-payload samples.
- **Mirror honesty** (`schemas.rs`, demanded by the pre-existing `documented_swept_schema_structs_declare_output_kind` invariant): `LandSchema`, `SwitchCheckoutSchema`, and `ThreadRevokeApprovalSchema` now declare the `output_kind` their runtime payloads emit. `switch` additionally advertises its state-checkout fall-through record (`goto`) as a no-schema discriminator — probed live: `switch <state-id>` emits `output_kind: "goto"`.

## Deliberately NOT swept (left in `UNSWEPT_TODO`)

- `inspect` — no-arg aliases `thread show` (`thread_show`), but the documented `inspect <state>` path emits the state-inspection shape with **no** `output_kind` (same gap as `show`). Advertising would make the catalog lie for the documented shape.
- `conflict show` — the success struct hardcodes `conflict_show`, but a missing conflict id prints literal `null` with exit 0. Needs the struct fixed first.
- The remaining ~65 unswept verbs (actor/marker/session/transaction/stash-mutation/hook/integration families, attempt, try, rebase, resolve, fsck, …) genuinely emit no `output_kind` — runtime-verified. Wiring the field through those structs is the existing rolldown, out of scope here.

## Test evidence

- `cargo test -p heddle-cli --lib command_catalog` — 29 passed (incl. the new conformance test; checked ≥100 schema verbs).
- `cargo test -p heddle-cli --test cli_integration output_kind_invariant` — 10 passed, 1 pre-existing ignore.
- Red-proof: removing one discriminator makes the conformance test fail naming the verb.
- `cargo build --locked --workspace` (default) and `--all-features` — OK.
- `bash scripts/check-no-silent-default-tree-load.sh` — clean (548 files).
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` / `-p heddle-mount` / no-default-features checks — see CI; local run summary in the PR thread if divergent. Known pre-existing on this box: 3 `oss_cli_polish` harness-detection tests fail locally (host exports `CLAUDE*`/`CODEX*` env; fails on clean main too).

## Runtime cross-check (issue DoD item 3)

40+ verbs invoked live with `--output json` in scratch repos during development; permanently, 10 new `runtime_invocation_args` arms + the `gc`/`daemon_stop` runtime-exact doc cases keep a representative sample checked in CI on every run.

## Struct-level inconsistencies surfaced (noted, not fixed — out of scope)

1. `thread drop` / `thread promote` / `thread refresh` emit the generic `output_kind: "thread"` while their siblings emit `thread_create`/`thread_rename`/`thread_switch`.
2. `thread resolve` emits `output_kind: "resolve"` — collides with the top-level `resolve` verb's namespace.
3. `thread cleanup` emits the dotted `thread.cleanup` (only dotted value in the corpus).
4. `inspect <state>` / `show` emit no discriminator on their primary documented shapes.
5. `conflict show <missing-id>` prints `null` and exits 0.
6. `rebase --output json` emits JSONL progress records with no `output_kind` on any line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783818593&installation_id=132405951&pr_number=660&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F660&signature=1a7aaa94b8e73c40bd3695831765821eff5e14d956d33d92c351fea0ccade68d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->