### PR TITLE
fix(cli): de-bloat help output — single-source --output blurb, one-screen clone help, grouped advanced list

### DIFF
--- a/crates/cli/src/cli/cli_args/cli_base.rs
+++ b/crates/cli/src/cli/cli_args/cli_base.rs
@@ -47,13 +47,13 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
 
-    /// Output format. Default is `text`. Pass `--output json` for the
-    /// full machine contract (stable `output_kind`, exit codes, recovery
-    /// templates), or `--output json-compact` for the decision surface
-    /// only (`output_kind`, `status`/`coordination_status`, `blockers`,
-    /// `next_action`, `changed_paths`, `conflicts`) — fewer tokens, same
-    /// `output_kind` so callers can still dispatch. No TTY/pipe
-    /// auto-detection — the default never switches under you.
+    // This is a `global = true` arg, so clap stamps its help onto every
+    // subcommand's --help. Keep it to ONE line; the full contract
+    // (json vs json-compact fields, no-TTY-autodetect guarantee) lives in
+    // `heddle help output-formats` (help.rs OUTPUT_FORMATS_TOPIC) and the
+    // top-level `heddle help` Output paragraph, stated exactly once each
+    // (heddle#652).
+    /// Output format: `text` (default), `json`, or `json-compact`. See `heddle help output-formats`
     #[arg(long, global = true, value_enum)]
     pub output: Option<OutputMode>,
 
@@ -73,15 +73,12 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub quiet: bool,
 
-    /// Client-supplied operation id (UUID v4) for idempotent retries.
-    ///
-    /// Commands that advertise `supports_op_id: true` in
-    /// `heddle commands --output json` return the original outcome on
-    /// replay. Unset by default; agents supply one explicitly. Also
-    /// reads `HEDDLE_OPERATION_ID` from the environment.
-    ///
-    /// Hidden from default `--help` to keep the human surface uncluttered;
-    /// see `heddle help operation-ids` for the full agent-facing contract.
+    // Global like --output, and revealed on every `supports_op_id`
+    // command's help — keep it to one line (heddle#652). Replay semantics
+    // (`supports_op_id` advertisement, same-body replay, typed conflicts)
+    // live in `heddle help operation-ids`. Hidden from default `--help` to
+    // keep the human surface uncluttered.
+    /// Operation id (UUID v4) for idempotent retries. See `heddle help operation-ids`
     #[arg(long, global = true, env = "HEDDLE_OPERATION_ID", hide = true)]
     pub op_id: Option<String>,
 }
@@ -107,8 +104,12 @@ impl Cli {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum OutputMode {
     Json,
-    /// JSON, but only the decision-surface fields (heddle#470). Renders
-    /// as `--output json-compact` on the CLI.
+    // JSON, but only the decision-surface fields (heddle#470). Renders as
+    // `--output json-compact` on the CLI. Deliberately NOT a doc comment:
+    // a per-value help string forces clap's spaced long-help layout onto
+    // every command (the value list is rendered with the global --output
+    // arg), re-bloating all 100+ helps; the format semantics live in
+    // `heddle help output-formats` instead (heddle#652).
     JsonCompact,
     Text,
 }

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1327,22 +1327,23 @@ pub struct PullArgs {
 }
 
 /// Arguments for the `clone` command.
+///
+/// Help style budget (heddle#652): `--help` carries the signature, flags,
+/// a one-screen Behavior summary, and the hidden-flag breadcrumb
+/// (heddle#646). The full default-thread fallback chain and --depth
+/// exposition moved to `heddle help clone` (help.rs CLONE_TOPIC); keep
+/// flag docs single-line so clap renders the compact help layout.
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Behavior:
-  Default thread (no --thread): Git-overlay clones (cloning a Git repository) land on the remote's advertised default branch (its Git HEAD); if the remote advertises none, they fall back to a thread named `main`, then to the alphabetically first imported thread. Native-local and hosted Heddle clones instead target `main` directly with no fallback chain; if the remote has no `main` thread, the clone fails — pass `--thread <name>` to select one. It never prompts.
-  Depth (Heddle remotes only): --depth 0 (the default) clones full history. --depth N fetches only the tip plus N generations of ancestry, so `heddle log` stops at the depth boundary; history older than that is not present locally — re-clone at a greater --depth (or --depth 0) to obtain it. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted and clones full history (the default).
-  Depth controls history extent only — how many states the clone fetches — and says nothing about object contents. Whether a state's blobs are present locally or fetched lazily is a separate, independent concern that --depth never governs.
-
-  See `heddle help threads` for the thread model and `heddle help advanced` for power surfaces.
+  Git-overlay clones land on the remote's default branch; Heddle remotes check out `main` (pass --thread to pick another). --depth N limits history on Heddle remotes only. Never prompts. Full details: `heddle help clone`.
 
 Advanced (hidden) flags:
   --lazy and --filter blob:none skip blob content and hydrate it on demand. Hosted/network Heddle remotes only; Git-overlay clones (plain `https://…/repo.git` URLs and local-path clones) reject them today — lazy hydration over the Git transport is planned for v0.3.1.
 
 Examples:
   heddle clone https://example.com/repo.git ./clone   # Git repo: lands on the remote's default branch
-  heddle clone ./repo ./clone --thread main           # check out a named thread after cloning
-  heddle clone heddle://host/repo ./clone --depth 1   # shallow Heddle clone: keep the tip plus its immediate parents
+  heddle clone heddle://host/repo ./clone --depth 1   # shallow Heddle clone: tip plus immediate parents
 ")]
 pub struct CloneArgs {
     /// Remote repository path.
@@ -1359,20 +1360,20 @@ pub struct CloneArgs {
     #[arg(long)]
     pub depth: Option<u32>,
 
+    // Hosted/network remotes only; Git-overlay clones reject it today —
+    // lazy hydration over the Git transport is planned for v0.3.1. The
+    // user-facing exposition lives in the after-help breadcrumb above and
+    // `heddle help clone`.
     /// Leave blob content absent by design and hydrate it explicitly later.
-    /// Supported for hosted/network remotes only; Git-overlay clones
-    /// (plain `https://…/repo.git` URLs and local-path clones) reject
-    /// this flag today and report a clear error — lazy hydration over
-    /// the Git transport is planned for v0.3.1.
     #[arg(long, hide = true)]
     pub lazy: bool,
 
-    /// Partial-clone filter spec. Only `blob:none` is accepted; other
-    /// git-style filters such as `tree:0` or `blob:limit=…` are
-    /// rejected at parse time. On hosted/network remotes `blob:none`
-    /// is a synonym for `--lazy` (skip blob content; hydrate on
-    /// demand). Git-overlay clones reject the flag at runtime; this
-    /// is planned for v0.3.1.
+    // Only `blob:none` is accepted (a synonym for --lazy on hosted
+    // remotes); git-style filters such as `tree:0` or `blob:limit=…` are
+    // rejected at parse time, and Git-overlay clones reject the flag at
+    // runtime until v0.3.1. See the after-help breadcrumb and
+    // `heddle help clone`.
+    /// Partial-clone filter spec (`blob:none` only).
     #[arg(long, hide = true, value_name = "SPEC", value_parser = parse_clone_filter_spec)]
     pub filter: Option<String>,
 }

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -292,6 +292,15 @@ struct CommandContract {
     surface: &'static str,
     help_visibility: &'static str,
     help_rank: u16,
+    /// Area grouping for the `heddle help advanced` listing (heddle#652).
+    /// Only meaningful on native-surface root commands with an advanced
+    /// help visibility; commands on the `automation` / `admin` /
+    /// `git_adapter` surfaces derive their group from the surface itself
+    /// (see [`advanced_help_groups`]). The
+    /// `advanced_help_groups_cover_every_advanced_verb` test forces
+    /// every advanced native root command to pick one, so the grouped
+    /// help can never silently grow an uncategorized verb.
+    help_category: Option<&'static str>,
     canonical_command: Option<&'static str>,
     canonical_kind: Option<&'static str>,
     canonical_note: Option<&'static str>,
@@ -696,6 +705,7 @@ const READ_JSON: CommandContract = CommandContract {
     surface: "native",
     help_visibility: "advanced",
     help_rank: 1000,
+    help_category: None,
     canonical_command: None,
     canonical_kind: None,
     canonical_note: None,
@@ -943,6 +953,16 @@ const fn surface(contract: CommandContract, surface: &'static str) -> CommandCon
     }
 }
 
+/// Assign the `heddle help advanced` area group for a native-surface
+/// advanced root command (heddle#652). See [`advanced_help_groups`] for
+/// the recognized ids and their display titles.
+const fn category(contract: CommandContract, help_category: &'static str) -> CommandContract {
+    CommandContract {
+        help_category: Some(help_category),
+        ..contract
+    }
+}
+
 const fn feature_gated(contract: CommandContract, feature_gate: &'static str) -> CommandContract {
     CommandContract {
         feature_gate: Some(feature_gate),
@@ -1011,7 +1031,10 @@ const fn advertised_action(
 const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["abort"],
-        documented_schemas(compact_json(MUTATING), &["abort"]),
+        category(
+            documented_schemas(compact_json(MUTATING), &["abort"]),
+            "recovery",
+        ),
     ),
     entry(
         &["adopt"],
@@ -1111,10 +1134,19 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["attempt"],
-        documented_schemas(EXTERNAL_WORKTREE_MUTATION, &["attempt"]),
+        category(
+            documented_schemas(EXTERNAL_WORKTREE_MUTATION, &["attempt"]),
+            "threads",
+        ),
     ),
     #[cfg(feature = "client")]
-    entry(&["auth"], GROUP),
+    entry(
+        &["auth"],
+        category(
+            GROUP,
+            "repo",
+        ),
+    ),
     #[cfg(feature = "client")]
     entry(&["auth", "login"], MUTATING_TEXT),
     #[cfg(feature = "client")]
@@ -1123,7 +1155,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["auth", "status"], READ_JSON),
     #[cfg(feature = "client")]
     entry(&["auth", "create-service-token"], MUTATING_NO_OP_ID),
-    entry(&["blame"], documented_schemas(READ_JSON, &["blame"])),
+    entry(
+        &["blame"],
+        category(
+            documented_schemas(READ_JSON, &["blame"]),
+            "states",
+        ),
+    ),
     entry(
         &["branch"],
         git_adapter_action(
@@ -1293,48 +1331,60 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["capture"],
-        json_discriminators(
-            documented_schemas(compact_json(CAPTURE), &["capture"]),
-            &[json_discriminator(
-                Some("capture"),
-                "output_kind",
-                "capture",
-            )],
+        category(
+            json_discriminators(
+                documented_schemas(compact_json(CAPTURE), &["capture"]),
+                &[json_discriminator(
+                    Some("capture"),
+                    "output_kind",
+                    "capture",
+                )],
+            ),
+            "states",
         ),
     ),
     entry(
         &["checkpoint"],
-        json_discriminators(
-            documented_schemas(
-                CommandContract {
-                    writes_git_refs: true,
-                    ..CAPTURE
-                },
-                &["checkpoint"],
+        category(
+            json_discriminators(
+                documented_schemas(
+                    CommandContract {
+                        writes_git_refs: true,
+                        ..CAPTURE
+                    },
+                    &["checkpoint"],
+                ),
+                &[json_discriminator(
+                    Some("checkpoint"),
+                    "output_kind",
+                    "checkpoint",
+                )],
             ),
-            &[json_discriminator(
-                Some("checkpoint"),
-                "output_kind",
-                "checkpoint",
-            )],
+            "states",
         ),
     ),
     entry(
         &["cherry-pick"],
-        json_discriminators(
-            opaque_schemas(WORKTREE_MUTATION, &["cherry-pick"]),
-            &[json_discriminator(
-                Some("cherry-pick"),
-                "output_kind",
-                "cherry_pick",
-            )],
+        category(
+            json_discriminators(
+                opaque_schemas(WORKTREE_MUTATION, &["cherry-pick"]),
+                &[json_discriminator(
+                    Some("cherry-pick"),
+                    "output_kind",
+                    "cherry_pick",
+                )],
+            ),
+            "states",
         ),
     ),
     entry(
         &["clean"],
-        json_discriminators(
-            documented_schemas(DESTRUCTIVE_WORKTREE_ONLY_MUTATION, &["clean"]),
-            &[json_discriminator(Some("clean"), "output_kind", "clean")],
+        category(
+            json_discriminators(
+                documented_schemas(DESTRUCTIVE_WORKTREE_ONLY_MUTATION, &["clean"]),
+                &[json_discriminator(Some("clean"), "output_kind", "clean")],
+            ),
+            "recovery",
         ),
     ),
     entry(
@@ -1375,7 +1425,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             220,
         ),
     ),
-    entry(&["collapse"], opaque_schemas(MUTATING, &["collapse"])),
+    entry(
+        &["collapse"],
+        category(
+            opaque_schemas(MUTATING, &["collapse"]),
+            "states",
+        ),
+    ),
     entry(
         &["commit"],
         exits(
@@ -1420,7 +1476,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(&["conflict"], GROUP),
+    entry(
+        &["conflict"],
+        category(
+            GROUP,
+            "recovery",
+        ),
+    ),
     entry(
         &["conflict", "list"],
         opaque_schemas(READ_JSON, &["conflict list"]),
@@ -1431,9 +1493,18 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["continue"],
-        documented_schemas(compact_json(MUTATING), &["continue"]),
+        category(
+            documented_schemas(compact_json(MUTATING), &["continue"]),
+            "recovery",
+        ),
     ),
-    entry(&["context"], GROUP),
+    entry(
+        &["context"],
+        category(
+            GROUP,
+            "collab",
+        ),
+    ),
     entry(
         &["context", "set"],
         json_discriminators(
@@ -1559,7 +1630,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["delegate"],
-        documented_schemas(WORKTREE_MUTATION, &["delegate"]),
+        category(
+            documented_schemas(WORKTREE_MUTATION, &["delegate"]),
+            "threads",
+        ),
     ),
     entry(
         &["diff"],
@@ -1571,7 +1645,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             20,
         ),
     ),
-    entry(&["discuss"], GROUP),
+    entry(
+        &["discuss"],
+        category(
+            GROUP,
+            "collab",
+        ),
+    ),
     entry(
         &["discuss", "open"],
         json_discriminators(
@@ -1671,28 +1751,49 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["fork"],
-        json_discriminators(
-            opaque_schemas(MUTATING, &["fork"]),
-            &[json_discriminator(Some("fork"), "output_kind", "fork")],
+        category(
+            json_discriminators(
+                opaque_schemas(MUTATING, &["fork"]),
+                &[json_discriminator(Some("fork"), "output_kind", "fork")],
+            ),
+            "threads",
         ),
     ),
-    entry(&["fsck"], documented_schemas(MUTATING, &["fsck"])),
+    entry(
+        &["fsck"],
+        category(
+            documented_schemas(MUTATING, &["fsck"]),
+            "recovery",
+        ),
+    ),
     entry(
         &["git-overlay"],
-        documented_schemas(READ_JSON, &["git-overlay"]),
+        category(
+            documented_schemas(READ_JSON, &["git-overlay"]),
+            "repo",
+        ),
     ),
     entry(
         &["goto"],
-        json_discriminators(
-            documented_schemas(WORKTREE_MUTATION, &["goto"]),
-            &[json_discriminator(Some("goto"), "output_kind", "goto")],
+        category(
+            json_discriminators(
+                documented_schemas(WORKTREE_MUTATION, &["goto"]),
+                &[json_discriminator(Some("goto"), "output_kind", "goto")],
+            ),
+            "threads",
         ),
     ),
     entry(
         &["harness-bridge"],
         hidden(opaque_schemas(READ_JSONL, &["harness-bridge"])),
     ),
-    entry(&["help"], READ_TEXT),
+    entry(
+        &["help"],
+        category(
+            READ_TEXT,
+            "repo",
+        ),
+    ),
     entry(&["hook"], surface(GROUP, "automation")),
     entry(
         &["hook", "list"],
@@ -1733,7 +1834,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["inspect"], documented_schemas(READ_JSON, &["inspect"])),
+    entry(
+        &["inspect"],
+        category(
+            documented_schemas(READ_JSON, &["inspect"]),
+            "states",
+        ),
+    ),
     entry(&["integration"], surface(GROUP, "admin")),
     entry(
         &["integration", "list"],
@@ -1793,7 +1900,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["maintenance", "monitor"],
         surface(opaque_schemas(READ_JSON, &["maintenance monitor"]), "admin"),
     ),
-    entry(&["marker"], GROUP),
+    entry(
+        &["marker"],
+        category(
+            GROUP,
+            "collab",
+        ),
+    ),
     entry(
         &["marker", "list"],
         documented_schemas(READ_JSON, &["marker list"]),
@@ -1812,30 +1925,36 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["merge"],
-        exits(
-            surface(
-                advertised_action(
-                    documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
-                    "heddle merge <thread> --preview",
-                    &["heddle", "merge", "<thread>", "--preview"],
-                    &["thread"],
-                    true,
-                    false,
+        category(
+            exits(
+                surface(
+                    advertised_action(
+                        documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
+                        "heddle merge <thread> --preview",
+                        &["heddle", "merge", "<thread>", "--preview"],
+                        &["thread"],
+                        true,
+                        false,
+                    ),
+                    "native",
                 ),
-                "native",
+                &[
+                    (0, "ok"),
+                    (65, "conflict requires manual resolution"),
+                    (74, "io while writing state"),
+                ],
             ),
-            &[
-                (0, "ok"),
-                (65, "conflict requires manual resolution"),
-                (74, "io while writing state"),
-            ],
+            "threads",
         ),
     ),
     entry(
         &["stack"],
-        json_discriminators(
-            opaque_schemas(READ_JSON, &["stack"]),
-            &[json_discriminator(Some("stack"), "output_kind", "stack")],
+        category(
+            json_discriminators(
+                opaque_schemas(READ_JSON, &["stack"]),
+                &[json_discriminator(Some("stack"), "output_kind", "stack")],
+            ),
+            "threads",
         ),
     ),
     entry(
@@ -1860,7 +1979,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             )],
         ),
     ),
-    entry(&["presence"], feature_gated(READ_JSON, "client")),
+    entry(
+        &["presence"],
+        category(
+            feature_gated(READ_JSON, "client"),
+            "collab",
+        ),
+    ),
     entry(&["presence", "publish"], feature_gated(READ_JSON, "client")),
     entry(
         &["pull"],
@@ -1884,7 +2009,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["purge"], GROUP),
+    entry(
+        &["purge"],
+        category(
+            GROUP,
+            "recovery",
+        ),
+    ),
     entry(
         &["purge", "apply"],
         json_discriminators(
@@ -1945,13 +2076,31 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["query"], documented_schemas(READ_JSON, &["query"])),
+    entry(
+        &["query"],
+        category(
+            documented_schemas(READ_JSON, &["query"]),
+            "states",
+        ),
+    ),
     entry(
         &["ready"],
         front_door(documented_schemas(compact_json(CAPTURE), &["ready"]), 50),
     ),
-    entry(&["rebase"], opaque_schemas(WORKTREE_MUTATION, &["rebase"])),
-    entry(&["redact"], GROUP),
+    entry(
+        &["rebase"],
+        category(
+            opaque_schemas(WORKTREE_MUTATION, &["rebase"]),
+            "threads",
+        ),
+    ),
+    entry(
+        &["redact"],
+        category(
+            GROUP,
+            "recovery",
+        ),
+    ),
     entry(
         &["redact", "apply"],
         json_discriminators(
@@ -2025,12 +2174,21 @@ const CONTRACTS: &[CommandContractEntry] = &[
         // output_kind — `redo` — schema-backed by `UndoSchema` (shared payload
         // shape with `undo`).
         &["redo"],
-        json_discriminators(
-            documented_schemas(WORKTREE_MUTATION, &["redo"]),
-            &[json_discriminator(Some("redo"), "output_kind", "redo")],
+        category(
+            json_discriminators(
+                documented_schemas(WORKTREE_MUTATION, &["redo"]),
+                &[json_discriminator(Some("redo"), "output_kind", "redo")],
+            ),
+            "recovery",
         ),
     ),
-    entry(&["remote"], surface(GROUP, "native")),
+    entry(
+        &["remote"],
+        category(
+            surface(GROUP, "native"),
+            "repo",
+        ),
+    ),
     entry(
         &["remote", "list"],
         documented_schemas(READ_JSON, &["remote list"]),
@@ -2055,15 +2213,30 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["resolve"],
         front_door(documented_schemas(MUTATING, &["resolve"]), 300),
     ),
-    entry(&["retro"], documented_schemas(READ_JSON, &["retro"])),
     entry(
-        &["revert"],
-        json_discriminators(
-            documented_schemas(WORKTREE_MUTATION, &["revert"]),
-            &[json_discriminator(Some("revert"), "output_kind", "revert")],
+        &["retro"],
+        category(
+            documented_schemas(READ_JSON, &["retro"]),
+            "states",
         ),
     ),
-    entry(&["review"], GROUP),
+    entry(
+        &["revert"],
+        category(
+            json_discriminators(
+                documented_schemas(WORKTREE_MUTATION, &["revert"]),
+                &[json_discriminator(Some("revert"), "output_kind", "revert")],
+            ),
+            "states",
+        ),
+    ),
+    entry(
+        &["review"],
+        category(
+            GROUP,
+            "collab",
+        ),
+    ),
     entry(
         &["review", "show"],
         json_discriminators(
@@ -2123,7 +2296,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(&["semantic"], GROUP),
+    entry(
+        &["semantic"],
+        category(
+            GROUP,
+            "states",
+        ),
+    ),
     entry(
         &["semantic", "hot"],
         opaque_schemas(READ_JSON, &["semantic hot"]),
@@ -2161,7 +2340,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(&["shell"], READ_TEXT),
+    entry(
+        &["shell"],
+        category(
+            READ_TEXT,
+            "repo",
+        ),
+    ),
     entry(&["shell", "init"], READ_TEXT),
     entry(&["shell", "completion"], READ_TEXT),
     entry(
@@ -2289,7 +2474,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             &[(0, "ok"), (74, "io reading workspace state")],
         ),
     ),
-    entry(&["support"], feature_gated(MUTATING, "client")),
+    entry(
+        &["support"],
+        category(
+            feature_gated(MUTATING, "client"),
+            "repo",
+        ),
+    ),
     entry(
         &["support", "grant"],
         feature_gated(MUTATING_NO_OP_ID, "client"),
@@ -2308,9 +2499,18 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["sync"],
-        documented_schemas(compact_json(MUTATING), &["sync"]),
+        category(
+            documented_schemas(compact_json(MUTATING), &["sync"]),
+            "threads",
+        ),
     ),
-    entry(&["thread"], surface(GROUP, "native")),
+    entry(
+        &["thread"],
+        category(
+            surface(GROUP, "native"),
+            "threads",
+        ),
+    ),
     entry(
         &["thread", "create"],
         documented_schemas(MUTATING, &["thread create"]),
@@ -2432,7 +2632,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["visibility"], GROUP),
+    entry(
+        &["visibility"],
+        category(
+            GROUP,
+            "collab",
+        ),
+    ),
     entry(
         &["visibility", "set"],
         json_discriminators(
@@ -2479,7 +2685,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["try"],
-        documented_schemas(EXTERNAL_WORKTREE_MUTATION, &["try"]),
+        category(
+            documented_schemas(EXTERNAL_WORKTREE_MUTATION, &["try"]),
+            "threads",
+        ),
     ),
     entry(
         &["undo"],
@@ -2509,7 +2718,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["workspace"],
-        documented_schemas(READ_JSON, &["workspace show"]),
+        category(
+            documented_schemas(READ_JSON, &["workspace show"]),
+            "threads",
+        ),
     ),
     entry(
         &["workspace", "show"],
@@ -3440,16 +3652,73 @@ pub fn root_commands_for_help_visibility(visibility: &str) -> Vec<&'static str> 
 }
 
 pub fn root_commands_for_advanced_help() -> Vec<&'static str> {
-    let mut entries = active_command_contract_entries()
+    let mut entries = advanced_help_root_entries();
+    entries.sort_by_key(|entry| (entry.contract.help_rank, entry.path[0]));
+    entries.into_iter().map(|entry| entry.path[0]).collect()
+}
+
+/// Root commands on the advanced help surface, unsorted.
+fn advanced_help_root_entries() -> Vec<&'static CommandContractEntry> {
+    active_command_contract_entries()
         .iter()
         .copied()
         .filter(|entry| {
             entry.path.len() == 1
                 && !matches!(entry.contract.help_visibility, "everyday" | "hidden")
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+/// Area groups for the `heddle help advanced` listing, in render order,
+/// as `(display title, verbs)` pairs (heddle#652). The grouping is
+/// contract-table data, not a hand-maintained help string: native
+/// advanced commands carry an explicit `help_category` on their
+/// registration, while `automation` / `admin` / `git_adapter` commands
+/// derive their group from the surface they already declare. Verbs keep
+/// contract order (help_rank, then name) within each group — the same
+/// ordering the flat list used. Feature-gated verbs absent from the
+/// current build simply don't appear; a group may come back empty.
+pub fn advanced_help_groups() -> Vec<(&'static str, Vec<&'static str>)> {
+    const GROUPS: &[(&str, &str)] = &[
+        ("threads", "Threads and integration"),
+        ("states", "States and history"),
+        ("collab", "Collaboration and review"),
+        ("recovery", "Recovery and integrity"),
+        ("repo", "Repo and environment"),
+        ("automation", "Agents and automation"),
+        ("git-interop", "Git interop"),
+        ("admin", "Admin and maintenance"),
+    ];
+    let mut entries = advanced_help_root_entries();
     entries.sort_by_key(|entry| (entry.contract.help_rank, entry.path[0]));
-    entries.into_iter().map(|entry| entry.path[0]).collect()
+    GROUPS
+        .iter()
+        .map(|(id, title)| {
+            (
+                *title,
+                entries
+                    .iter()
+                    .filter(|entry| advanced_help_group_id(&entry.contract) == *id)
+                    .map(|entry| entry.path[0])
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+/// Resolve which advanced-help group a root command belongs to. The
+/// non-native surfaces are themselves the grouping; native commands use
+/// the `help_category` set at registration. An unset category on a
+/// native advanced command maps to "" (member of no group) — the
+/// `advanced_help_groups_cover_every_advanced_verb` test turns that into
+/// a build failure rather than a silently missing help line.
+fn advanced_help_group_id(contract: &CommandContract) -> &'static str {
+    match contract.surface {
+        "automation" => "automation",
+        "admin" => "admin",
+        "git_adapter" => "git-interop",
+        _ => contract.help_category.unwrap_or(""),
+    }
 }
 
 pub(crate) fn recommended_action_template(action: &str) -> Option<ActionTemplate> {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -126,7 +126,8 @@ pub use clone::{
 };
 pub use collapse::cmd_collapse;
 pub use command_catalog::{
-    CommandCatalogOutput, build_command_catalog, cmd_commands, command_canonical_command,
+    CommandCatalogOutput, advanced_help_groups, build_command_catalog, cmd_commands,
+    command_canonical_command,
     command_contract_root_commands, command_help_tier, command_help_visibility, command_path,
     command_persists_op_id, command_runtime_contract, command_runtime_contract_for_command,
     command_supports_json_for_command, command_supports_op_id, command_supports_op_id_for_command,

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -515,63 +515,65 @@ need them.\n";
 // one-paragraph version on the top-level `heddle help`). The global
 // `--output` flag's own help is one line pointing here, so the contract
 // is not restated on every command's --help (heddle#652).
-const OUTPUT_FORMATS_TOPIC: &str = "Output formats — `--output text | json | json-compact`.\n\
-\n\
-`text` is the default, always. There is no TTY/pipe auto-detection — the\n\
-default never switches under you, so scripts and humans see the same thing\n\
-until a flag says otherwise.\n\
-\n\
-`--output json` emits the full machine contract: a stable `output_kind`\n\
-discriminator, exit codes, and recovery templates. Schemas per verb:\n\
-`heddle schemas <verb>`; the catalog of which commands emit what:\n\
-`heddle commands --output json`.\n\
-\n\
-`--output json-compact` emits only the decision-surface fields —\n\
-`output_kind`, `status`/`coordination_status`, `blockers`, `next_action`,\n\
-`changed_paths`, `conflicts` — fewer tokens, same `output_kind`, so callers\n\
-can still dispatch on it. Commands advertise `supports_json_compact` in the\n\
-command catalog.\n\
-\n\
-Related: `heddle help operation-ids` for idempotent retries, `heddle help\n\
-agent-flags` for capture attribution overrides.\n";
+const OUTPUT_FORMATS_TOPIC: &str = r#"Output formats — `--output text | json | json-compact`.
+
+`text` is the default, always. There is no TTY/pipe auto-detection — the
+default never switches under you, so scripts and humans see the same thing
+until a flag says otherwise.
+
+`--output json` emits the full machine contract: a stable `output_kind`
+discriminator, exit codes, and recovery templates. Schemas per verb:
+`heddle schemas <verb>`; the catalog of which commands emit what:
+`heddle commands --output json`.
+
+`--output json-compact` emits only the decision-surface fields —
+`output_kind`, `status`/`coordination_status`, `blockers`, `next_action`,
+`changed_paths`, `conflicts` — fewer tokens, same `output_kind`, so callers
+can still dispatch on it. Commands advertise `supports_json_compact` in the
+command catalog.
+
+Related: `heddle help operation-ids` for idempotent retries, `heddle help
+agent-flags` for capture attribution overrides.
+"#;
 
 // `heddle clone --help` keeps the signature + flags + a one-screen
 // summary; this topic carries the full default-thread fallback chain and
 // --depth exposition that used to bloat the after-help (heddle#652).
-const CLONE_TOPIC: &str = "Cloning — Git repositories and Heddle remotes.\n\
-\n\
-    heddle clone <remote> <dir> [--thread <name>] [--depth <n>]\n\
-\n\
-Run `heddle clone --help` for the flag list.\n\
-\n\
-# Which thread the clone lands on (no --thread)\n\
-\n\
-- Git-overlay clones (cloning a Git repository) land on the remote's\n\
-  advertised default branch (its Git HEAD); if the remote advertises\n\
-  none, they fall back to a thread named `main`, then to the\n\
-  alphabetically first imported thread.\n\
-- Native-local and hosted Heddle clones target `main` directly with no\n\
-  fallback chain; if the remote has no `main` thread the clone fails —\n\
-  pass `--thread <name>` to select one.\n\
-- Clone never prompts.\n\
-\n\
-# Shallow clones (--depth, Heddle remotes only)\n\
-\n\
-`--depth 0` (the default) clones full history. `--depth N` fetches only\n\
-the tip plus N generations of ancestry, so `heddle log` stops at the\n\
-depth boundary; history older than that is not present locally —\n\
-re-clone at a greater `--depth` (or `--depth 0`) to obtain it.\n\
-Git-overlay clones reject a nonzero `--depth`; `--depth 0` is accepted\n\
-and clones full history.\n\
-\n\
-Depth controls history extent only — how many states the clone fetches —\n\
-and says nothing about object contents. Whether a state's blobs are\n\
-present locally or fetched lazily is a separate concern that `--depth`\n\
-never governs (see the hidden `--lazy` / `--filter blob:none` flags in\n\
-`heddle clone --help`; hosted/network Heddle remotes only).\n\
-\n\
-See `heddle help threads` for the thread model and `heddle help remotes`\n\
-for remote management.\n";
+const CLONE_TOPIC: &str = r#"Cloning — Git repositories and Heddle remotes.
+
+    heddle clone <remote> <dir> [--thread <name>] [--depth <n>]
+
+Run `heddle clone --help` for the flag list.
+
+# Which thread the clone lands on (no --thread)
+
+- Git-overlay clones (cloning a Git repository) land on the remote's
+  advertised default branch (its Git HEAD); if the remote advertises
+  none, they fall back to a thread named `main`, then to the
+  alphabetically first imported thread.
+- Native-local and hosted Heddle clones target `main` directly with no
+  fallback chain; if the remote has no `main` thread the clone fails —
+  pass `--thread <name>` to select one.
+- Clone never prompts.
+
+# Shallow clones (--depth, Heddle remotes only)
+
+--depth 0 (the default) clones full history. --depth N fetches only the
+tip plus N generations of ancestry (--depth 1: the tip plus its immediate parents),
+so `heddle log` stops at the depth boundary; history older than that is
+not present locally — re-clone at a greater --depth (or --depth 0) to
+obtain it. Git-overlay clones reject a nonzero --depth; --depth 0 is accepted
+and clones full history.
+
+Depth controls history extent only — how many states the clone fetches —
+and says nothing about object contents. Whether a state's blobs are
+present locally or fetched lazily is a separate concern that `--depth`
+never governs (see the hidden `--lazy` / `--filter blob:none` flags in
+`heddle clone --help`; hosted/network Heddle remotes only).
+
+See `heddle help threads` for the thread model and `heddle help remotes`
+for remote management.
+"#;
 
 const AGENT_FLAGS_TOPIC: &str = r#"Agent automation flags for `heddle capture`.
 

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -129,12 +129,17 @@ pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
                 "Start here: `heddle init`, `heddle adopt`, or `heddle clone`."
             );
             let _ = writeln!(out);
+            // The ONE place the --output machine-contract blurb is stated
+            // in full on a help screen; per-command --help carries only the
+            // one-line global flag plus the `heddle help output-formats`
+            // breadcrumb (heddle#652).
             let _ = writeln!(
                 out,
                 "Output: text is the default; pass `--output json` for the \
                  full machine contract (stable `output_kind`, exit codes, recovery \
                  templates), or `--output json-compact` for the decision surface \
-                 only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection."
+                 only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection. \
+                 Details: `heddle help output-formats`."
             );
             let _ = writeln!(out);
             let _ = writeln!(
@@ -143,29 +148,38 @@ pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
                  `heddle help advanced` for power surfaces, automation, and Git interop, \
                  or `heddle help <topic>` for a topic page (e.g. `git-overlay`, \
                  `threads`, `daemon`, `signals`, `bridge`, `operation-ids`, \
-                 `remotes`, `git-dependencies`)."
+                 `remotes`, `output-formats`, `git-dependencies`)."
             );
         }
         [name] if name == "advanced" => {
             let catalog = crate::cli::commands::build_command_catalog();
             let _ = writeln!(out, "{}", ADVANCED_HELP);
-            let _ = writeln!(out, "Advanced commands:");
-            for name in advanced_verbs() {
-                let blurb = catalog_summary(&catalog, name);
-                if blurb.is_empty() {
+            // Grouped by area from the command contract table — the
+            // group is registration data (`help_category` / surface),
+            // not a hand-maintained help string (heddle#652). The group
+            // header replaces the old per-line `[advanced]`-style
+            // surface label; only the `use <canonical>` redirect for
+            // Git-shaped aliases stays on the line.
+            for (title, verbs) in crate::cli::commands::advanced_help_groups() {
+                let mut lines = Vec::new();
+                for name in verbs {
+                    let blurb = catalog_summary(&catalog, name);
+                    if blurb.is_empty() {
+                        continue;
+                    }
+                    let canonical = crate::cli::commands::command_canonical_command(name)
+                        .map(|canonical| format!(" [use `{canonical}`]"))
+                        .unwrap_or_default();
+                    lines.push(format!("  {name:<14}  {blurb}{canonical}"));
+                }
+                if lines.is_empty() {
                     continue;
                 }
-                let visibility = crate::cli::commands::command_help_visibility(name);
-                let surface = crate::cli::commands::command_surface(name);
-                let label = if visibility == "git_adapter" || surface != "native" {
-                    surface
-                } else {
-                    visibility
-                };
-                let canonical = crate::cli::commands::command_canonical_command(name)
-                    .map(|canonical| format!("; use `{canonical}`"))
-                    .unwrap_or_default();
-                let _ = writeln!(out, "  {:<14}  {} [{}{}]", name, blurb, label, canonical);
+                let _ = writeln!(out, "{title}:");
+                for line in lines {
+                    let _ = writeln!(out, "{line}");
+                }
+                let _ = writeln!(out);
             }
         }
         [name] if topic_text(name).is_some() => {
@@ -209,9 +223,40 @@ pub fn print_direct_help_for_raw(
 pub fn render_direct_help_for_raw(cmd: &clap::Command, raw: &[String]) -> Option<String> {
     let path = command_path_from_raw_help_request(cmd, raw)?;
     Some(match help_command_for_path(cmd, &path) {
-        Some(mut subcommand) => subcommand.render_long_help().to_string(),
+        Some(mut subcommand) => {
+            // clap's long renderer unconditionally uses the spaced
+            // next-line layout (one blank line per flag), tripling the
+            // height of helps whose flags are all one-liners. Render the
+            // compact layout whenever the long layout would add no
+            // information; commands with real long-form flag docs keep
+            // the spaced layout so their exposition stays readable
+            // (heddle#652).
+            if command_has_long_help_content(&subcommand) {
+                subcommand.render_long_help().to_string()
+            } else {
+                subcommand.render_help().to_string()
+            }
+        }
         None => render_help(cmd, &path),
     })
+}
+
+/// Whether `command`'s help carries long-form content that clap's compact
+/// (`-h`-style) renderer would drop: a long about, a long after-help, or
+/// a visible argument with a multi-paragraph long help or per-value docs.
+/// When this is false the compact and spaced layouts carry identical
+/// information, so [`render_direct_help_for_raw`] picks the compact one.
+fn command_has_long_help_content(command: &clap::Command) -> bool {
+    command.get_long_about().is_some()
+        || command.get_after_long_help().is_some()
+        || command.get_arguments().any(|arg| {
+            !arg.is_hide_set()
+                && (arg.get_long_help().is_some()
+                    || arg
+                        .get_possible_values()
+                        .iter()
+                        .any(|value| value.get_help().is_some()))
+        })
 }
 
 /// Clap arg ids of the agent-automation flags on `capture` that are
@@ -437,6 +482,8 @@ pub fn topic_text(topic: &str) -> Option<&'static str> {
         "advanced" => ADVANCED_HELP,
         "agent-flags" => AGENT_FLAGS_TOPIC,
         "agent" | "daemon" => DAEMON_TOPIC,
+        "output-formats" | "output-format" | "output" => OUTPUT_FORMATS_TOPIC,
+        "clone" => CLONE_TOPIC,
         "git-overlay" => GIT_OVERLAY_TOPIC,
         "model" | "mental-model" | "concepts" => MODEL_TOPIC,
         "threads" => THREADS_TOPIC,
@@ -463,6 +510,68 @@ docs.\n\
 This is intentional. The everyday surface stays minimal so first-time users aren't\n\
 overwhelmed; agents and power users reach for the advanced affordances when they\n\
 need them.\n";
+
+// The single full statement of the --output machine contract (plus the
+// one-paragraph version on the top-level `heddle help`). The global
+// `--output` flag's own help is one line pointing here, so the contract
+// is not restated on every command's --help (heddle#652).
+const OUTPUT_FORMATS_TOPIC: &str = "Output formats — `--output text | json | json-compact`.\n\
+\n\
+`text` is the default, always. There is no TTY/pipe auto-detection — the\n\
+default never switches under you, so scripts and humans see the same thing\n\
+until a flag says otherwise.\n\
+\n\
+`--output json` emits the full machine contract: a stable `output_kind`\n\
+discriminator, exit codes, and recovery templates. Schemas per verb:\n\
+`heddle schemas <verb>`; the catalog of which commands emit what:\n\
+`heddle commands --output json`.\n\
+\n\
+`--output json-compact` emits only the decision-surface fields —\n\
+`output_kind`, `status`/`coordination_status`, `blockers`, `next_action`,\n\
+`changed_paths`, `conflicts` — fewer tokens, same `output_kind`, so callers\n\
+can still dispatch on it. Commands advertise `supports_json_compact` in the\n\
+command catalog.\n\
+\n\
+Related: `heddle help operation-ids` for idempotent retries, `heddle help\n\
+agent-flags` for capture attribution overrides.\n";
+
+// `heddle clone --help` keeps the signature + flags + a one-screen
+// summary; this topic carries the full default-thread fallback chain and
+// --depth exposition that used to bloat the after-help (heddle#652).
+const CLONE_TOPIC: &str = "Cloning — Git repositories and Heddle remotes.\n\
+\n\
+    heddle clone <remote> <dir> [--thread <name>] [--depth <n>]\n\
+\n\
+Run `heddle clone --help` for the flag list.\n\
+\n\
+# Which thread the clone lands on (no --thread)\n\
+\n\
+- Git-overlay clones (cloning a Git repository) land on the remote's\n\
+  advertised default branch (its Git HEAD); if the remote advertises\n\
+  none, they fall back to a thread named `main`, then to the\n\
+  alphabetically first imported thread.\n\
+- Native-local and hosted Heddle clones target `main` directly with no\n\
+  fallback chain; if the remote has no `main` thread the clone fails —\n\
+  pass `--thread <name>` to select one.\n\
+- Clone never prompts.\n\
+\n\
+# Shallow clones (--depth, Heddle remotes only)\n\
+\n\
+`--depth 0` (the default) clones full history. `--depth N` fetches only\n\
+the tip plus N generations of ancestry, so `heddle log` stops at the\n\
+depth boundary; history older than that is not present locally —\n\
+re-clone at a greater `--depth` (or `--depth 0`) to obtain it.\n\
+Git-overlay clones reject a nonzero `--depth`; `--depth 0` is accepted\n\
+and clones full history.\n\
+\n\
+Depth controls history extent only — how many states the clone fetches —\n\
+and says nothing about object contents. Whether a state's blobs are\n\
+present locally or fetched lazily is a separate concern that `--depth`\n\
+never governs (see the hidden `--lazy` / `--filter blob:none` flags in\n\
+`heddle clone --help`; hosted/network Heddle remotes only).\n\
+\n\
+See `heddle help threads` for the thread model and `heddle help remotes`\n\
+for remote management.\n";
 
 const AGENT_FLAGS_TOPIC: &str = r#"Agent automation flags for `heddle capture`.
 
@@ -900,6 +1009,10 @@ mod tests {
             "notes",
             "signals",
             "risk-signals",
+            "output-formats",
+            "output-format",
+            "output",
+            "clone",
         ] {
             assert!(topic_text(topic).is_some(), "{topic}");
         }
@@ -1125,6 +1238,133 @@ mod tests {
         assert!(
             !wants_reveal(&["--output", "text", "status", "--help-agent"]),
             "`--output text status --help-agent` — verb is `status`, no reveal"
+        );
+    }
+
+    /// heddle#652. The `--output` machine-contract blurb (json vs
+    /// json-compact fields, recovery templates) is stated in full exactly
+    /// once on the top-level help — plus the dedicated `output-formats`
+    /// topic — instead of being stamped by the global arg onto every
+    /// command's --help. Per-command help carries only the one-line flag
+    /// summary with the topic breadcrumb.
+    #[test]
+    fn output_blurb_stated_once_not_per_command() {
+        let marker = "full machine contract";
+        let top = render_for_args(&["--help"]).expect("top-level help renders");
+        assert_eq!(
+            top.matches(marker).count(),
+            1,
+            "top-level help should state the --output contract exactly once: {top}"
+        );
+        assert!(
+            topic_text("output-formats")
+                .expect("output-formats topic exists")
+                .contains(marker),
+            "the output-formats topic carries the full contract"
+        );
+        for argv in [
+            &["clone", "--help"][..],
+            &["status", "--help"][..],
+            &["commit", "--help"][..],
+            &["thread", "--help"][..],
+            &["push", "--help"][..],
+        ] {
+            let help = render_for_args(argv).expect("command help renders");
+            assert!(
+                !help.contains(marker),
+                "`{argv:?}` should not restate the --output machine contract: {help}"
+            );
+            assert!(
+                help.contains("heddle help output-formats"),
+                "`{argv:?}` should breadcrumb to the output-formats topic: {help}"
+            );
+        }
+    }
+
+    /// heddle#652. `clone --help` stays within one screen: signature,
+    /// flags, a short Behavior summary, the hidden-flags breadcrumb
+    /// (heddle#646), and examples. The full default-thread / --depth
+    /// exposition lives in `heddle help clone`.
+    #[test]
+    fn clone_help_fits_one_screen() {
+        let help = render_for_args(&["clone", "--help"]).expect("clone help renders");
+        let lines = help.lines().count();
+        assert!(
+            lines <= 40,
+            "clone --help should fit one screen (<= 40 lines), got {lines}:\n{help}"
+        );
+        // The trim must not cost discoverability: the hidden-flag
+        // affordance and the deep-dive breadcrumb both survive.
+        assert!(
+            help.contains("Advanced (hidden) flags:"),
+            "clone --help keeps the hidden-flags affordance: {help}"
+        );
+        assert!(
+            help.contains("heddle help clone"),
+            "clone --help points at the clone topic for the full behavior: {help}"
+        );
+    }
+
+    /// heddle#652. `heddle help advanced` renders area groups instead of
+    /// one flat alphabetical wall of commands.
+    #[test]
+    fn advanced_help_renders_area_groups() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let advanced = render_help(&cmd, &["advanced".to_string()]);
+        for header in [
+            "Threads and integration:",
+            "States and history:",
+            "Recovery and integrity:",
+            "Repo and environment:",
+            "Agents and automation:",
+            "Git interop:",
+            "Admin and maintenance:",
+        ] {
+            assert!(
+                advanced.contains(&format!("\n{header}\n")),
+                "advanced help should render the `{header}` group: {advanced}"
+            );
+        }
+        assert!(
+            !advanced.contains("Advanced commands:"),
+            "the flat list header is replaced by area groups: {advanced}"
+        );
+    }
+
+    /// heddle#652. The grouped advanced surface is exhaustive and
+    /// non-overlapping: every advanced verb appears in exactly one group.
+    /// Because native commands group by the `help_category` on their
+    /// contract registration, a new advanced native root command that
+    /// forgets to pick a category fails here instead of silently
+    /// vanishing from `heddle help advanced`.
+    #[test]
+    fn advanced_help_groups_cover_every_advanced_verb() {
+        let grouped: Vec<&str> = crate::cli::commands::advanced_help_groups()
+            .into_iter()
+            .flat_map(|(_, verbs)| verbs)
+            .collect();
+        let mut deduped = grouped.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            grouped.len(),
+            "no verb may appear in two advanced-help groups: {grouped:?}"
+        );
+        let grouped: std::collections::HashSet<&str> = grouped.into_iter().collect();
+        let flat: std::collections::HashSet<&str> = advanced_verbs().into_iter().collect();
+        let missing: Vec<&&str> = flat.difference(&grouped).collect();
+        assert!(
+            missing.is_empty(),
+            "advanced verbs missing from every group — native advanced root \
+             commands must register a help_category in the command contract \
+             table: {missing:?}"
+        );
+        let extra: Vec<&&str> = grouped.difference(&flat).collect();
+        assert!(
+            extra.is_empty(),
+            "grouped verbs not on the advanced surface: {extra:?}"
         );
     }
 

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -48,27 +48,49 @@ fn help_render_matches_spawned_binary() {
     }
 }
 
-/// `heddle clone --help` must keep its Behavior stanza: the prose that
-/// answers Priya's "wait, where am I?" — default-thread resolution and
-/// what `--depth` actually materializes (heddle#257).
+/// The clone behavior prose must keep answering Priya's "wait, where am
+/// I?" — default-thread resolution and what `--depth` actually
+/// materializes (heddle#257). The full exposition lives on the
+/// `heddle help clone` topic page since the heddle#652 help-budget pass;
+/// `clone --help` keeps a one-screen Behavior summary plus the breadcrumb
+/// to the topic. Both surfaces are pinned: the summary so the first
+/// screen still orients, the topic so the moved prose keeps every
+/// accuracy fix the old in-help stanza accumulated.
 #[test]
 fn clone_help_pins_behavior_stanza() {
-    let help = heddle_help(&["clone", "--help"]);
+    let summary = heddle_help(&["clone", "--help"]);
 
     assert!(
-        help.contains("Behavior:"),
-        "clone help should include a Behavior stanza: {help}"
+        summary.contains("Behavior:"),
+        "clone help should include a Behavior stanza: {summary}"
     );
+    // The one-screen summary still answers the headline questions —
+    // where an unhinted clone lands per remote kind — and points at the
+    // topic page for the rest.
+    assert!(
+        summary.contains("default branch") && summary.contains("`main`"),
+        "clone help summary should say where clones land: {summary}"
+    );
+    assert!(
+        summary.contains("--thread"),
+        "clone help summary should name the escape hatch: {summary}"
+    );
+    assert!(
+        summary.contains("heddle help clone"),
+        "clone help should breadcrumb to the full clone topic: {summary}"
+    );
+
+    let help = heddle_help(&["help", "clone"]);
     // Default-thread resolution for Git-overlay clones: lands on the
     // remote's advertised default branch (its Git HEAD).
     assert!(
         help.contains("no --thread") && help.contains("default branch"),
-        "clone help should explain where an unhinted clone lands: {help}"
+        "clone topic should explain where an unhinted clone lands: {help}"
     );
     // The Git-overlay fallback chain (main, then first imported thread).
     assert!(
         help.contains("`main`") && help.contains("alphabetically first"),
-        "clone help should name the default-thread fallback chain: {help}"
+        "clone topic should name the default-thread fallback chain: {help}"
     );
     // The transport distinction: native-local and hosted Heddle clones target
     // `main` directly (no Git-HEAD fallback chain) — the inaccuracy this stanza
@@ -76,22 +98,22 @@ fn clone_help_pins_behavior_stanza() {
     assert!(
         help.contains("Native-local and hosted Heddle clones")
             && help.contains("target `main` directly"),
-        "clone help should distinguish the Heddle-remote default from the Git-overlay chain: {help}"
+        "clone topic should distinguish the Heddle-remote default from the Git-overlay chain: {help}"
     );
     // The failure mode: an unhinted native/hosted clone fails when the remote
     // has no `main` thread, and the user must pass `--thread <name>`.
     assert!(
         help.contains("the clone fails") && help.contains("--thread <name>"),
-        "clone help should document that an unhinted native/hosted clone fails when the remote has no `main` thread: {help}"
+        "clone topic should document that an unhinted native/hosted clone fails when the remote has no `main` thread: {help}"
     );
     // Depth semantics: 0 means full history, N keeps the tip plus N ancestry levels.
     assert!(
         help.contains("--depth 0") && help.contains("full history"),
-        "clone help should explain that --depth 0 is full history: {help}"
+        "clone topic should explain that --depth 0 is full history: {help}"
     );
     assert!(
         help.contains("depth boundary") && help.contains("re-clone at a greater --depth"),
-        "clone help should explain that history past the depth boundary is absent and recovered by re-cloning at a greater depth: {help}"
+        "clone topic should explain that history past the depth boundary is absent and recovered by re-cloning at a greater depth: {help}"
     );
     // Depth on Git-overlay clones: nonzero is rejected, --depth 0 is accepted
     // (= the full-clone default, since cmd_clone normalizes 0 to None before
@@ -99,17 +121,17 @@ fn clone_help_pins_behavior_stanza() {
     assert!(
         help.contains("Git-overlay clones reject a nonzero --depth")
             && help.contains("--depth 0 is accepted"),
-        "clone help should distinguish nonzero --depth (rejected) from --depth 0 (accepted) for Git-overlay clones: {help}"
+        "clone topic should distinguish nonzero --depth (rejected) from --depth 0 (accepted) for Git-overlay clones: {help}"
     );
     // Depth-1 materializes the tip plus its immediate parents, not just the tip.
     assert!(
         help.contains("tip plus its immediate parents"),
-        "clone help should explain that --depth 1 keeps the tip plus immediate parents: {help}"
+        "clone topic should explain that --depth 1 keeps the tip plus immediate parents: {help}"
     );
     // Cross-reference to the thread model topic.
     assert!(
         help.contains("heddle help threads"),
-        "clone help should point at the threads topic: {help}"
+        "clone topic should point at the threads topic: {help}"
     );
 }
 


### PR DESCRIPTION
Fixes #652

One structural pass over the three findings from the 2026-06-11 QoL persona-eval: the `--output` blurb stamped on every command's `--help`, the 61-line `clone --help`, and the flat 77-command advanced list. Layers on top of #658's content edits (hidden-flag breadcrumbs and onboarding wording all preserved — `oss_cli_polish` asserts them).

## 1. `--output` blurb: stated once, breadcrumbed everywhere

The blurb was the doc comment on the `global = true` `--output` arg, so clap propagated all 7 lines onto 100+ command helps. It is now a one-line flag summary pointing at a new `heddle help output-formats` topic; the full machine contract (json vs json-compact fields, no-TTY-autodetect guarantee) is stated exactly once on the top-level `heddle help` and once in the topic. `--op-id` (also global, revealed on every `supports_op_id` command) got the same one-line treatment with its existing `operation-ids` topic as the reveal surface.

**Mechanism note:** clap's long renderer (`render_long_help`) unconditionally uses the spaced next-line layout (clap 4.5 `help_template.rs`: `arg_next_line_help` returns true when `use_long`), so trimming the text alone still left three lines per flag. `render_direct_help_for_raw` now picks clap's compact layout when the command has no long-form content the compact renderer would drop (no long about / long after-help / multi-paragraph flag docs / per-value docs) — pure layout change, zero information loss, and commands with real exposition (e.g. `start`) keep the spaced layout. This was the least-magic option that actually moves the needle: the alternative (always compact) destroys multi-paragraph flag docs, and a hand-rolled help template forks clap's renderer.

## 2. `clone --help`: 64 → 28 lines

Before: 64 lines (Behavior exposition + full `--output`/`--op-id` blurbs + spaced layout). After:

```
Options:
      --thread <THREAD>  Thread to check out after cloning
      --depth <DEPTH>    Create a shallow clone with the specified depth. `0` means full history
      --output <OUTPUT>  Output format: `text` (default), `json`, or `json-compact`. See `heddle help output-formats` [possible values: json, json-compact, text]
      ...
Behavior:
  Git-overlay clones land on the remote's default branch; Heddle remotes check out `main` (pass --thread to pick another). --depth N limits history on Heddle remotes only. Never prompts. Full details: `heddle help clone`.

Advanced (hidden) flags:
  --lazy and --filter blob:none skip blob content and hydrate it on demand. ...
```

The default-thread fallback chain and `--depth` exposition moved verbatim to a new `heddle help clone` topic page. The #646 hidden-flag affordance (`--lazy` / `--filter blob:none` / v0.3.1 breadcrumb) survives in the after-help, still gated by `hidden_flags_carry_discovery_affordances` and the `oss_cli_polish` clone-breadcrumb test.

## 3. Advanced list: grouped by area, from contract-table data

`heddle help advanced` now renders eight area groups instead of one flat alphabetical wall:

```
Threads and integration:
  attempt         Run a command in N parallel sandboxed ephemeral threads and rank the results
  delegate        Fan a parent thread into one or more delegated child threads
  ...
States and history: ...
Collaboration and review: ...
Recovery and integrity: ...
Repo and environment: ...
Agents and automation: ...
Git interop:
  branch          Git-compatible alias for the Heddle thread command family [use `thread`]
  ...
Admin and maintenance: ...
```

The grouping is registration data, not a hand-maintained help string: native advanced root commands carry a new `help_category` on their `CommandContract` (set via a `category(...)` const-fn wrapper at registration); `automation` / `admin` / `git_adapter` commands derive their group from the `surface` they already declare — the same seam `heddle commands`' text sections use. The group header replaces the old per-line `[advanced]`-style label; the `[use `thread`]` canonical redirect stays.

## Tests

- `output_blurb_stated_once_not_per_command` — the machine-contract blurb appears exactly once in `heddle --help`, never in a sample of per-command helps (clone/status/commit/thread/push), and each carries the `output-formats` breadcrumb.
- `clone_help_fits_one_screen` — `clone --help` ≤ 40 lines (currently 28) with the hidden-flag affordance and topic breadcrumb intact.
- `advanced_help_renders_area_groups` — group headers render; flat-list header gone.
- `advanced_help_groups_cover_every_advanced_verb` — exhaustive + non-overlapping: a new advanced native root command that forgets to register a `help_category` fails the build instead of silently vanishing from `heddle help advanced`.

## Gates (all run locally)

- `cargo build --locked --workspace` (default features) — pass
- `cargo build --locked --workspace --all-features` — pass
- `bash scripts/check-no-silent-default-tree-load.sh` — pass (548 files scanned)
- `cargo test -p heddle-cli` — lib 709 passed; `cli_integration` 931 passed / 3 failed, all three the known pre-existing `oss_cli_polish` actor harness-detection failures (host process-tree leakage; fail on clean main). The 2 known `multi_agent_worktrees` flakes did not reproduce this run. Nothing new fails.
- `cargo test -p heddle-mount` — 149 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783831778&installation_id=132405951&pr_number=663&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F663&signature=eae506070d958f5bedb65afe58bacf7c7210ec10bdcf48de3d38b15fcddeff7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->