### PR TITLE
harden(cli): route remaining action-field emitters through serialize_empty_action_as_null

### DIFF
--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -17,7 +17,10 @@ use serde::Serialize;
 
 use crate::cli::{
     cli_args::{Cli, ConflictCommands, ConflictShowArgs},
-    commands::command_catalog::{ActionTemplate, recommended_action_template},
+    commands::{
+        command_catalog::{ActionTemplate, recommended_action_template},
+        git_overlay_health::serialize_empty_action_as_null,
+    },
     should_output_json,
 };
 
@@ -45,8 +48,10 @@ struct ActiveMergeConflictShowOutput {
     theirs_state: String,
     base_state: Option<String>,
     worktree_content: Option<String>,
+    #[serde(serialize_with = "serialize_empty_action_as_null")]
     recommended_action: String,
     recommended_action_template: Option<ActionTemplate>,
+    #[serde(serialize_with = "serialize_empty_action_as_null")]
     next_action: String,
     next_action_template: Option<ActionTemplate>,
 }
@@ -278,5 +283,39 @@ fn short_body(s: &str) -> String {
         format!("{}…", &first[..60])
     } else {
         first.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActiveMergeConflictShowOutput;
+
+    /// Action-field presence contract (HeddleCo/heddle#645): empty
+    /// `recommended_action`/`next_action` must serialize as `null`, never
+    /// `""` — the serialization-boundary walker hard-fails the whole
+    /// command on a raw empty. Both fields are non-empty literals by
+    /// construction today; this pins the safe-by-construction wire shape
+    /// regardless.
+    #[test]
+    fn active_merge_conflict_show_serializes_empty_actions_as_null() {
+        let value = serde_json::to_value(ActiveMergeConflictShowOutput {
+            output_kind: "conflict_show",
+            kind: "active_merge_conflict",
+            id: "src/lib.rs".to_string(),
+            file: "src/lib.rs".to_string(),
+            symbol: "text_merge".to_string(),
+            resolved: false,
+            ours_state: "abc1234".to_string(),
+            theirs_state: "def5678".to_string(),
+            base_state: None,
+            worktree_content: None,
+            recommended_action: String::new(),
+            recommended_action_template: None,
+            next_action: String::new(),
+            next_action_template: None,
+        })
+        .unwrap();
+        assert!(value["recommended_action"].is_null());
+        assert!(value["next_action"].is_null());
     }
 }

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -222,6 +222,7 @@ struct PlainGitStatusOutput {
     git_overlay_health: GitOverlayHealth,
     #[serde(rename = "verification")]
     trust: RepositoryVerificationState,
+    #[serde(serialize_with = "serialize_empty_action_as_null")]
     recommended_action: String,
     recommended_action_template: Option<super::command_catalog::ActionTemplate>,
     recovery_commands: Vec<String>,
@@ -2449,7 +2450,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        CoordinationStatus, MaterializedThreadInfo, assess_materialized_threads,
+        ChangesInfo, CoordinationStatus, GitOverlayHealth, MaterializedThreadInfo,
+        PlainGitStatusOutput, RepositoryVerificationState, assess_materialized_threads,
         combined_verdict_axes, coordination_axis_clean, coordination_label,
         render_status_materialized, resolve_coordination_with_trust,
     };
@@ -2811,5 +2813,79 @@ mod tests {
             resolve_coordination_with_trust(CoordinationStatus::Clean, true, true);
         assert!(matches!(coordination, CoordinationStatus::Clean), "no override → axis stays clean");
         assert!(!blocked_by_trust_only);
+    }
+
+    /// Action-field presence contract (HeddleCo/heddle#645): an empty
+    /// `recommended_action` must serialize as `null`, never `""` — the
+    /// serialization-boundary walker hard-fails the whole command on a
+    /// raw empty. `PlainGitStatusOutput.recommended_action` is cloned
+    /// from `trust.recommended_action`, which CAN legitimately be empty;
+    /// this pins the safe-by-construction wire shape.
+    #[test]
+    fn plain_git_status_serializes_empty_recommended_action_as_null() {
+        let machine_contract_coverage =
+            crate::cli::commands::git_overlay_health::machine_contract_coverage();
+        let trust = RepositoryVerificationState {
+            verified: true,
+            status: "verified".to_string(),
+            repository_mode: "plain-git".to_string(),
+            heddle_initialized: false,
+            git_branch: Some("main".to_string()),
+            heddle_thread: None,
+            worktree_dirty: false,
+            worktree_state: "clean".to_string(),
+            import_state: "not_applicable".to_string(),
+            mapping_state: "not_applicable".to_string(),
+            remote_drift: "clean".to_string(),
+            active_operation: None,
+            default_remote: None,
+            clone_verification: "not_applicable".to_string(),
+            machine_contract: crate::cli::commands::git_overlay_health::machine_contract_status(
+                &machine_contract_coverage,
+            )
+            .to_string(),
+            machine_contract_coverage,
+            workflow_status: "clean".to_string(),
+            workflow_summary: "no ready threads are waiting to land".to_string(),
+            summary: "plain Git repository".to_string(),
+            recommended_action: String::new(),
+            recommended_action_template: None,
+            recovery_commands: Vec::new(),
+            recovery_action_templates: Vec::new(),
+            checks: Vec::new(),
+        };
+        let output = PlainGitStatusOutput {
+            output_kind: "status",
+            repository_capability: "plain-git".to_string(),
+            repository_label: crate::cli::render::repository_mode_label("plain-git", "git-only"),
+            storage_model: "git-only".to_string(),
+            heddle_initialized: false,
+            git_branch: Some("main".to_string()),
+            path: "/tmp/repo".to_string(),
+            git_overlay_health: GitOverlayHealth {
+                status: "healthy".to_string(),
+                clean: true,
+                summary: "plain Git repository".to_string(),
+                recovery_commands: Vec::new(),
+                checks: Vec::new(),
+            },
+            recommended_action: trust.recommended_action.clone(),
+            recommended_action_template: trust.recommended_action_template.clone(),
+            recovery_commands: trust.recovery_commands.clone(),
+            recovery_action_templates: trust.recovery_action_templates.clone(),
+            thread_health: trust.status.clone(),
+            changed_path_count: 0,
+            changes: ChangesInfo {
+                modified: Vec::new(),
+                added: Vec::new(),
+                deleted: Vec::new(),
+            },
+            git_index: None,
+            trust,
+        };
+
+        let value = serde_json::to_value(&output).unwrap();
+        assert!(value["recommended_action"].is_null());
+        assert!(value["verification"]["recommended_action"].is_null());
     }
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -158,6 +158,7 @@ pub struct ThreadSummary {
 pub struct AvailableGitRef {
     pub name: String,
     pub git_commit: String,
+    #[serde(serialize_with = "serialize_empty_action_as_null")]
     pub recommended_action: String,
     pub recommended_action_template: Option<ActionTemplate>,
 }
@@ -3603,5 +3604,23 @@ mod tests {
         // Distinct slashed/dashed ids no longer collide.
         let other = default_thread_checkout_path(&repo, "foo-bar");
         assert_ne!(checkout, other);
+    }
+
+    /// Action-field presence contract (HeddleCo/heddle#645): an empty
+    /// `recommended_action` must serialize as `null`, never `""` — the
+    /// serialization-boundary walker hard-fails the whole command on a
+    /// raw empty. `AvailableGitRef` is non-empty by construction today
+    /// (available refs always get `canonical_adopt_ref_command`); this
+    /// pins the safe-by-construction wire shape regardless.
+    #[test]
+    fn available_git_ref_serializes_empty_recommended_action_as_null() {
+        let value = serde_json::to_value(AvailableGitRef {
+            name: "main".to_string(),
+            git_commit: "0123456789abcdef".to_string(),
+            recommended_action: String::new(),
+            recommended_action_template: None,
+        })
+        .unwrap();
+        assert!(value["recommended_action"].is_null());
     }
 }


### PR DESCRIPTION
## What

Routes the last three raw-`String` action-field emitters through `#[serde(serialize_with = "serialize_empty_action_as_null")]`, matching siblings `ThreadListOutput` (thread.rs), `ThreadSummary` (thread.rs), and `ThreadPreviewReport` (merge/mod.rs):

| Struct | Field(s) | Why it matters |
|---|---|---|
| `AvailableGitRef` (thread.rs) | `recommended_action` | Non-empty by construction today (`split_available_git_refs` runs before `suppress_thread_actions_while_trust_blocked`; available refs always get `canonical_adopt_ref_command`) — but unenforced. |
| `PlainGitStatusOutput` (status.rs) | `recommended_action` | Cloned from `trust.recommended_action`, which **can** legitimately be empty — the most realistic leak path. |
| `ActiveMergeConflictShowOutput` (conflict.rs) | `recommended_action`, `next_action` | Non-empty literals today; added for uniformity — the contract's point is that no emitter can leak `""` regardless of today's construction. |

## Why

Defense-in-depth for the action-field presence contract (#645, landed in #659): the runtime boundary walker `validate_next_actions_at_path` now **hard-fails the whole command** when a raw `""` reaches serialization. Emitters must therefore be safe-by-construction — an unguarded `String` field is a latent runtime failure waiting for a refactor to expose it.

Schema mirrors need no change: `AvailableGitRefSchema.recommended_action` is already `Option<String>` (schemas.rs), and the `status` schema's nullability is pinned by `status_schema_allows_null_recommended_action`. Conflict show has no registered schema mirror. No `schemas.rs` diff → no TS-types regeneration needed.

## Test evidence

One unit test per touched struct pinning empty → `null` on the wire:
- `thread::tests::available_git_ref_serializes_empty_recommended_action_as_null`
- `status::tests::plain_git_status_serializes_empty_recommended_action_as_null` (also asserts the nested `verification.recommended_action` null)
- `conflict::tests::active_merge_conflict_show_serializes_empty_actions_as_null` (both fields)

Gates run locally (all green):
- `cargo build --locked --workspace` (default features) and `--all-features`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-cli --lib` — 708 passed, 0 failed (includes `action_fields_follow_presence_contract_in_every_schema` + the boundary-walker tests)
- `cargo test -p heddle-mount` — 4 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Follow-up to #659 / Part of #645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783831936&installation_id=132405951&pr_number=664&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F664&signature=054a8dab304973afd2a5dfee75ef4a2790a02305de952fadbeefd44dc5c55230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->