### PR TITLE
harden: OSS-readiness polish bundle (key perms, FSKit null, Link-header host check, .lock components, peercred docs)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -818,3 +818,22 @@ jobs:
 
       - name: sccache stats
         run: sccache --show-stats
+
+  # The fskit feature is cfg(target_os = "macos") and OFF by default, so no
+  # other lane ever compiles it (release.yml builds default features; this
+  # workflow runs on Linux). Without this job, FSKit changes land
+  # compile-unverified — caught on PR #667, whose FSKit fix was authored on
+  # a Linux box. `cargo check` also exercises build.rs's swiftc compile of
+  # the HeddleFSKit bridge, so the Swift side is validated too.
+  fskit-check:
+    name: FSKit compile check (macOS)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: fskit-check
+      - name: cargo check with fskit
+        run: cargo check --locked -p heddle-mount --features fskit

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -829,6 +829,11 @@ jobs:
     name: FSKit compile check (macOS)
     runs-on: macos-14
     timeout-minutes: 30
+    env:
+      # The workflow-level RUSTC_WRAPPER points at sccache, which only the
+      # main job installs; without this override cargo dies at startup.
+      RUSTC_WRAPPER: ""
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -41,7 +41,9 @@ impl std::fmt::Display for SignerError {
             SignerError::KeyNotFound(path) => write!(f, "key file not found: {}", path.display()),
             SignerError::InsecureKeyPermissions { path, mode } => write!(
                 f,
-                "private key file {} is group/world-accessible ({mode:o}); set permissions to 0600",
+                "private key file {} is group/world-accessible (mode {mode:04o}, required 0600 \
+                 or stricter); fix with: chmod 600 {}",
+                path.display(),
                 path.display()
             ),
             SignerError::VerificationFailed => write!(f, "signature verification failed"),

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -176,5 +176,28 @@ mod tests {
             err,
             SignerError::InsecureKeyPermissions { mode: 0o644, .. }
         ));
+        // The refusal must be actionable: name the offending path, the
+        // observed + required modes, and the exact chmod to run.
+        let msg = err.to_string();
+        assert!(msg.contains(&key_path.display().to_string()), "{msg}");
+        assert!(msg.contains("0644"), "{msg}");
+        assert!(msg.contains("0600"), "{msg}");
+        assert!(msg.contains("chmod 600"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_signer_accepts_owner_only_private_key() {
+        let temp = TempDir::new().expect("create temp dir");
+        let key_path = temp.path().join("test_ed25519.pem");
+
+        let signer = Ed25519Signer::generate().expect("generate key");
+        let pem = signer.to_pem().expect("export to PEM");
+        write_file_atomic_secret(&key_path, pem.as_bytes()).expect("write key file");
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))
+            .expect("set owner-only mode");
+
+        let loaded = load_signer(&key_path, Some("ed25519")).expect("0600 key must load");
+        assert_eq!(loaded.public_key(), signer.public_key());
     }
 }

--- a/crates/mount/src/error.rs
+++ b/crates/mount/src/error.rs
@@ -59,6 +59,13 @@ pub enum MountError {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
 
+    /// The platform shell failed to construct its mount session
+    /// (e.g. the Swift FSKit shim returned a null session handle).
+    /// Maps to `EIO`: the mount never came up, nothing to retry
+    /// at the filesystem layer.
+    #[error("mount session initialization failed: {0}")]
+    SessionInit(String),
+
     /// Errors bubbling up from the underlying object store / repo.
     #[error(transparent)]
     Store(#[from] HeddleError),
@@ -84,6 +91,7 @@ impl MountError {
             MountError::IsADirectory(_) => libc::EISDIR,
             MountError::NotEmpty(_) => libc::ENOTEMPTY,
             MountError::InvalidArgument(_) => libc::EINVAL,
+            MountError::SessionInit(_) => libc::EIO,
             MountError::Store(HeddleError::NotFound(_))
             | MountError::Store(HeddleError::StateNotFound(_))
             | MountError::Store(HeddleError::MissingObject { .. }) => libc::ENOENT,

--- a/crates/mount/src/fskit/mod.rs
+++ b/crates/mount/src/fskit/mod.rs
@@ -36,7 +36,8 @@
 //! task. See `crates/mount/README.md` for the install steps.
 //!
 //! What works today:
-//!   * `FSKitShell::new` constructs a session; `Drop` releases it.
+//!   * `FSKitShell::new` constructs a session (erroring, not
+//!     aborting, if the Swift shim fails); `Drop` releases it.
 //!   * Every kernel callback FSKit will eventually invoke is
 //!     wired through to the trait.
 //!   * [`Self::is_runtime_available`] reports whether the host can
@@ -96,14 +97,29 @@ unsafe impl Sync for FSKitShell {}
 
 impl FSKitShell {
     /// Wrap a mount into an FSKit session.
-    pub fn new(mount: ContentAddressedMount) -> Self {
+    ///
+    /// Errors with [`MountError::SessionInit`] when the Swift shim
+    /// fails to allocate a session (see [`Self::from_shell`]).
+    pub fn new(mount: ContentAddressedMount) -> Result<Self> {
         Self::from_shell(Arc::new(mount))
     }
 
     /// Construct from any [`PlatformShell`]. Useful in tests where
     /// you want to wire a mock shell into the FSKit ABI without
     /// spinning up a real `ContentAddressedMount`.
-    pub fn from_shell(shell: Arc<dyn PlatformShell + Send + Sync>) -> Self {
+    ///
+    /// Errors with [`MountError::SessionInit`] when
+    /// `heddle_fskit_session_new` returns null — a hard failure of
+    /// the Swift shim (allocation failure or shim-internal init
+    /// error), not a runtime condition we expect. This is the live
+    /// mount path on shipped macOS binaries, so it must surface as
+    /// a recoverable error to the caller rather than aborting the
+    /// process. The null branch isn't unit-testable from Rust: the
+    /// constructor is a Swift static-lib symbol (only linked under
+    /// `--features fskit` on macOS) declared in [`c_abi`], so there
+    /// is no seam to substitute a null-returning mock without
+    /// faking the whole extern block.
+    pub fn from_shell(shell: Arc<dyn PlatformShell + Send + Sync>) -> Result<Self> {
         // Box the shell once and leak the pointer into the C ABI.
         // The Swift session calls `drop_callback` exactly once when
         // the session is freed; that reclaims the box.
@@ -123,17 +139,22 @@ impl FSKitShell {
             )
         };
         if handle.is_null() {
-            // Reclaim the box so we don't leak. `session_new`
-            // returning null is a hard failure of the Swift shim,
-            // not a runtime condition we expect.
+            // Reclaim the box so we don't leak: the Swift side never
+            // saw a session, so `trampoline_drop` will never fire.
+            // SAFETY: `user_data` came from `Box::into_raw` above and
+            // ownership never transferred (no session was created).
             unsafe {
                 drop(Box::from_raw(
                     user_data as *mut Arc<dyn PlatformShell + Send + Sync>,
                 ))
             };
-            panic!("heddle_fskit_session_new returned null");
+            return Err(MountError::SessionInit(
+                "heddle_fskit_session_new returned null (Swift FSKit shim \
+                 failed to allocate a session)"
+                    .to_string(),
+            ));
         }
-        Self { handle }
+        Ok(Self { handle })
     }
 
     /// Returns true when the host OS can actually load the FSKit
@@ -309,8 +330,15 @@ pub(super) fn open_thread(repo_path: &str, thread_id: &str) -> c_abi::HeddleFSKi
             return std::ptr::null_mut();
         }
     };
+    let shell = match FSKitShell::new(mount) {
+        Ok(s) => s,
+        Err(e) => {
+            fskit_log(&format!("FSKitShell::new FAILED: {e:?}"));
+            return std::ptr::null_mut();
+        }
+    };
     fskit_log("open_thread returning handle");
-    FSKitShell::new(mount).into_handle()
+    shell.into_handle()
 }
 
 // ----------------------------------------------------------------
@@ -652,7 +680,7 @@ mod tests {
     fn fskit_session_lifecycle_drops_inner_shell() {
         let (counting, drops) = CountingShell::new();
         let shell = Arc::new(counting);
-        let fskit = FSKitShell::from_shell(shell);
+        let fskit = FSKitShell::from_shell(shell).expect("construct FSKit session");
         // Construction alone shouldn't drop the inner shell.
         assert_eq!(drops.load(Ordering::SeqCst), 0);
         drop(fskit);

--- a/crates/mount/src/nfs.rs
+++ b/crates/mount/src/nfs.rs
@@ -693,6 +693,10 @@ fn mount_err_to_nfs(err: &MountError) -> nfsstat3 {
         MountError::IsADirectory(_) => nfsstat3::NFS3ERR_ISDIR,
         MountError::NotEmpty(_) => nfsstat3::NFS3ERR_NOTEMPTY,
         MountError::InvalidArgument(_) => nfsstat3::NFS3ERR_INVAL,
+        // Session construction happens before the NFS server ever
+        // dispatches a request, so this can't surface mid-protocol;
+        // map it like any other infrastructure failure.
+        MountError::SessionInit(_) => nfsstat3::NFS3ERR_IO,
         MountError::Store(_) => nfsstat3::NFS3ERR_IO,
     }
 }

--- a/crates/mount/tests/fskit_smoke.rs
+++ b/crates/mount/tests/fskit_smoke.rs
@@ -59,7 +59,8 @@ fn fskit_mount_serves_blob_content() {
     // `mount(at:)` returns ENOSYS — the assertion below pins
     // the contract: construct + mount returns the documented
     // not-implemented errno, drop cleans up.
-    match FSKitShell::new(mount).mount_background(mountpoint.path()) {
+    let shell = FSKitShell::new(mount).expect("construct FSKit session");
+    match shell.mount_background(mountpoint.path()) {
         Ok(session) => {
             // Future-proof: once the System Extension lands, the
             // mount succeeds and the read assertion below pins

--- a/crates/refs/src/refs/name.rs
+++ b/crates/refs/src/refs/name.rs
@@ -24,7 +24,10 @@ pub fn validate_ref_name(name: &str) -> Result<(), RefNameError> {
     if name.starts_with('.') {
         return Err(invalid(name));
     }
-    if name.ends_with(".lock") {
+    // Git refname rule: no path *component* may end in `.lock` (not just
+    // the whole ref) — `refs/heads/foo.lock/bar` would collide with the
+    // on-disk lockfile of `refs/heads/foo`.
+    if name.split('/').any(|component| component.ends_with(".lock")) {
         return Err(invalid(name));
     }
     Ok(())
@@ -33,5 +36,36 @@ pub fn validate_ref_name(name: &str) -> Result<(), RefNameError> {
 fn invalid(name: &str) -> RefNameError {
     RefNameError {
         name: name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_ref_name;
+
+    #[test]
+    fn rejects_ref_ending_in_lock() {
+        assert!(validate_ref_name("refs/heads/foo.lock").is_err());
+    }
+
+    #[test]
+    fn rejects_any_component_ending_in_lock() {
+        // The git refname rule is per-component: a `.lock` directory
+        // collides with the sibling ref's lockfile.
+        assert!(validate_ref_name("refs/heads/foo.lock/bar").is_err());
+        assert!(validate_ref_name("refs/foo.lock/heads/bar").is_err());
+    }
+
+    #[test]
+    fn allows_lock_as_non_suffix() {
+        // `.lock` must be a component *suffix* to be rejected.
+        assert!(validate_ref_name("refs/heads/foo.locker").is_ok());
+        assert!(validate_ref_name("refs/heads/lock").is_ok());
+        assert!(validate_ref_name("refs/heads/foo.lock.bak").is_ok());
+    }
+
+    #[test]
+    fn allows_plain_ref() {
+        assert!(validate_ref_name("refs/heads/main").is_ok());
     }
 }


### PR DESCRIPTION
OSS-readiness polish bundle from the codex crate-by-crate review, release-blocking for v0.3.0. Three items needed code; three were already fixed by intervening hardening PRs and are verified-and-struck below with citations.

## Items with code changes

### 1. crypto — insecure key-permission refusal (completed)
The 0600-or-stricter gate itself already shipped in #428 (`eafedb96`): `load_signer` calls `reject_group_or_world_readable_key` (cfg(unix), checks `mode & 0o077`) before reading the key, matching the #364 secret-file hardening pattern. What was missing vs. the issue's ask: the refusal message did not include the exact remediation. The error now names the path, the observed mode, the required mode (0600), and the literal `chmod 600 <path>` command. Tests pin the 0644-refused / 0600-accepted split and the message shape (`crates/crypto/src/lib.rs`).

### 5. refs — `.lock` rejected per path component
`validate_ref_name` only rejected a whole ref ending in `.lock`; git's refname rule is per-component (`refs/heads/foo.lock/bar` collides with the lockfile of `refs/heads/foo`). Now checked component-by-component (`crates/refs/src/refs/name.rs`). Tests: `refs/heads/foo.lock` rejected (kept), `refs/heads/foo.lock/bar` rejected (new), `refs/heads/foo.locker` allowed.

### 3. mount — FSKit null session handle no longer aborts
`FSKitShell::new`/`from_shell` panicked (→ abort across the C ABI) when the Swift `heddle_fskit_session_new` shim returned null — on the live mount path for shipped macOS binaries. Both constructors now return `Result<Self>` with a new `MountError::SessionInit` variant (maps to `EIO`; arm added to `to_errno` and the NFS status map). `open_thread` logs the failure and returns a null handle to its Swift caller, same as it already does for repo/mount construction failures. The leaked shell box is reclaimed on the error path (the Swift side never saw a session, so `trampoline_drop` can never fire).

**Why the null path has no unit test:** the constructor is a Swift static-lib symbol only linked under `--features fskit` on macOS; there is no seam to substitute a null-returning mock without faking the entire extern block. Documented on `from_shell`.

## Verified-and-struck (already fixed; no change needed)

### 2. daemon — SO_PEERCRED claim is no longer false
**Decision: docs and code already agree — the helper IS in the serve path.** #626 (`96552a78`) wired per-connection enforcement: `serve` filters the accept stream through `guard_peer_connection` → `check_peer_uid_matches_self` (SO_PEERCRED / `getpeereid`), dropping mismatched-uid peers before tonic sees them, with socket mode 0600 as the first layer (`crates/daemon/src/local_daemon.rs:340-420`). Tests cover admit/reject/uid-mismatch (`enforce_peer_uid_*`, `guard_admits_same_process_peer`, `check_peer_uid_matches_self_admits_socketpair`). Nothing to change.

### 4. proto — upward namespace access already removed
Fixed by #628 (`fd6e0557`, downward-only grants) and #638 (`53f6b89b`, segment-aware `scope_contains` replacing prefix matching). `can_access_namespace` delegates to `scope_contains`, which denies upward access, siblings, non-boundary prefixes, and any `.`/`..`/empty segment. Directionality tests already exist at both layers: `test_namespace_tree_no_upward_access` / `test_namespace_tree_downward_access` (`crates/proto/src/auth_tests.rs`) and `upward_access_denied` (`crates/proto/src/scope_match.rs`). No missing test to add.

### 6. review — Link-header pagination origin already validated
Fixed by #627 (`c9b95713`): `validate_pagination_origin` parses each `rel="next"` URL and requires scheme + host + port to match the configured API base (`api_base_url`, which supports non-github.com GH Enterprise bases) before following; redirects are disabled on the client so `Location` can't bypass it. Tests cover foreign host, scheme downgrade, foreign port, unparseable URL, and an end-to-end malicious-Link-header case (`fetch_files_rejects_cross_origin_pagination_url`). Nothing to change.

## Gates
- `cargo build --locked --workspace` (default features) — green
- `cargo build --locked --workspace --all-features` — green
- `bash scripts/check-no-silent-default-tree-load.sh` — clean (548 files)
- `cargo test -p heddle-crypto -p heddle-mount -p heddle-proto -p heddle-refs -p heddle-review` — all green
- `cargo test --workspace` — green except the 5 known host-env failures (3 oss_cli_polish + 2 multi_agent_worktrees)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Note: the fskit module is `cfg(all(target_os = "macos", feature = "fskit"))` and does not compile on the Linux dev host; the FSKit change is parse-checked and review-verified, exercised by macOS CI/local opt-in (`fskit_smoke`).

Fixes #375

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783834681&installation_id=132405951&pr_number=667&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F667&signature=7edc8f865939ab2146a7fde3f90357c6d0444606683e9d57713a888bc665e267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->