### PR TITLE
Collapse v2 op record variants

### DIFF
--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Stable JSON-first agent reservation API.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 use objects::object::ThreadName;
+use objects::store::ObjectStore;
 use objects::store::{
     AgentEntry, AgentRegistry, AgentStatus, AgentUsageSummary, ReserveOutcome, current_boot_id,
 };
@@ -222,9 +222,15 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
     let reservation_path = existing_thread_execution_path(&repo, &thread_name)?;
     let probe = crate::harness::probe_current_process_harness(
         &repo,
-        std::env::var("HEDDLE_AGENT_PROVIDER").ok().and_then(crate::attribution::clean_attribution_value),
-        std::env::var("HEDDLE_AGENT_MODEL").ok().and_then(crate::attribution::clean_attribution_value),
-        std::env::var("HEDDLE_AGENT_POLICY").ok().and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_PROVIDER")
+            .ok()
+            .and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_MODEL")
+            .ok()
+            .and_then(crate::attribution::clean_attribution_value),
+        std::env::var("HEDDLE_AGENT_POLICY")
+            .ok()
+            .and_then(crate::attribution::clean_attribution_value),
     )?;
     // `--hold-for-pid PID` binds the reservation to an external
     // process (typically the orchestrator that wraps the heddle
@@ -320,16 +326,12 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
             // Agent-reservation flow writes the ThreadManager record via
             // `ensure_thread_record` below, after this op is recorded —
             // so there's no record to snapshot at recording time. Pass
-            // `None`; the op records as `ThreadCreateV2` with no
+            // `None`; the op records as `ThreadCreate` with no
             // manager snapshot. Reservations are an agent-internal API
             // that aren't expected to participate in human undo/redo
             // flows in 0.3. heddle#23 r2.
-            repo.oplog().record_thread_create(
-                &tn,
-                &anchor,
-                None,
-                Some(&repo.op_scope()),
-            )?;
+            repo.oplog()
+                .record_thread_create(&tn, &anchor, None, Some(&repo.op_scope()))?;
         }
 
         // Ensure a Thread record exists so downstream commands

--- a/crates/cli/src/cli/commands/ff_record.rs
+++ b/crates/cli/src/cli/commands/ff_record.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared helper for fast-forward call sites that need to record an
-//! `OpRecord::FastForwardV2` instead of the implicit `OpRecord::Goto`.
+//! `OpRecord::FastForward` instead of the implicit `OpRecord::Goto`.
 //!
 //! See heddle#99 (merge FF) and heddle#110 (rebase / land /
 //! merge-abort): recording a thread-advancing fast-forward as a plain
 //! `OpRecord::Goto` strands the target thread ref on undo, because the
 //! `Goto` inverse only rewinds HEAD. The fix is to perform the FF
 //! without recording the implicit `Goto`, then explicitly emit an
-//! `OpRecord::FastForwardV2` carrying both `pre_target_id` (undo
+//! `OpRecord::FastForward` carrying both `pre_target_id` (undo
 //! target) and `post_target_id` (redo target — heddle#99 r2's
 //! deterministic-redo contract).
 //!
@@ -119,7 +119,7 @@ pub(super) fn ff_advance_deferred(
         repo.fast_forward_attached_without_record(post_target_id)?;
     }
     Ok(match head_before {
-        Head::Attached { thread } => OpRecord::FastForwardV2 {
+        Head::Attached { thread } => OpRecord::FastForward {
             source_thread: source_thread.to_string(),
             target_thread: thread.to_string(),
             pre_target_id,
@@ -248,7 +248,7 @@ mod tests {
                 .flat_map(|batch| &batch.entries)
                 .any(|entry| matches!(
                     &entry.operation,
-                    oplog::OpRecord::FastForwardV2 {
+                    oplog::OpRecord::FastForward {
                         source_thread,
                         target_thread,
                         pre_target_id,

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -24,8 +24,8 @@ use super::{
     diff::{DiffOutput, SemanticChangeEntry, compute_state_diff, compute_tree_diff},
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
-        override_trust_recommended_action,
-        repository_verification_blocked_advice, serialize_empty_action_as_null,
+        override_trust_recommended_action, repository_verification_blocked_advice,
+        serialize_empty_action_as_null,
     },
     next_action::{NextActionValidationContext, write_command_json},
     operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
@@ -621,7 +621,7 @@ pub(crate) fn merge_thread_into_current(
             // `merge_fast_forward_advances_current_thread`.
             //
             // We perform the FF *without recording* an `OpRecord::Goto`
-            // and then explicitly record `OpRecord::FastForwardV2` so
+            // and then explicitly record `OpRecord::FastForward` so
             // both ends of the FF are captured. r1 (heddle#99) added the
             // variant to fix stranded-ref-on-undo. r2 added
             // `post_target_id` so redo replays the recorded SHA instead
@@ -900,9 +900,10 @@ pub(crate) fn merge_thread_into_current(
             && thread
                 .as_ref()
                 .is_some_and(|thread| thread.state == ThreadState::Ready)
-            && let Some(thread) = thread.as_ref() {
-                mark_merge_previewed(repo, &thread.id)?;
-            }
+            && let Some(thread) = thread.as_ref()
+        {
+            mark_merge_previewed(repo, &thread.id)?;
+        }
         return Ok(merge_output_from_report(MergeOutputInput {
             repo,
             thread: &thread,
@@ -1443,17 +1444,16 @@ fn merge_op_targets_state(op: &OpRecord, state: &ChangeId) -> bool {
     match op {
         OpRecord::Snapshot { new_state, .. } => new_state == state,
         OpRecord::Goto { target, .. } => target == state,
-        OpRecord::FastForwardV2 { post_target_id, .. } => post_target_id == state,
+        OpRecord::FastForward { post_target_id, .. } => post_target_id == state,
         OpRecord::Checkpoint {
             state: checkpoint_state,
             ..
         } => checkpoint_state == state,
         // These records don't advance HEAD/thread to the merge state the merge
-        // flow tracks (legacy V1 `FastForward` carries no post-target id).
+        // flow tracks.
         // Enumerated explicitly (no wildcard) so a new state-advancing variant
         // must be considered as a possible merge target here (heddle#354 r9).
         OpRecord::ThreadCreate { .. }
-        | OpRecord::ThreadCreateV2 { .. }
         | OpRecord::ThreadDelete { .. }
         | OpRecord::ThreadUpdate { .. }
         | OpRecord::Fork { .. }
@@ -1466,7 +1466,6 @@ fn merge_op_targets_state(op: &OpRecord, state: &ChangeId) -> bool {
         | OpRecord::TransactionCommit { .. }
         | OpRecord::Redact { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. }
         | OpRecord::GitCheckpoint { .. }
         | OpRecord::RemoteThreadUpdate { .. }
         | OpRecord::RemoteThreadDelete { .. }
@@ -1870,7 +1869,10 @@ fn build_thread_preview_report_with_graph(
         advice.thread_health = "clean".to_string();
     }
 
-    let thread_tip = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.map(|id| id.short());
+    let thread_tip = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .map(|id| id.short());
     let manual_resolution_current = thread
         .integration_policy_result
         .manual_resolution_state
@@ -1979,7 +1981,10 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
     let stale_refresh_action = input.preview_report.and_then(|report| {
         (report.freshness == ThreadFreshness::Stale.to_string()).then(|| {
             if report.recommended_action.trim().is_empty() {
-                format!("heddle sync --thread {}", recommended_action_quote(&report.thread))
+                format!(
+                    "heddle sync --thread {}",
+                    recommended_action_quote(&report.thread)
+                )
             } else {
                 report.recommended_action.clone()
             }
@@ -2332,7 +2337,10 @@ fn stale_thread_merge_blocked_output(
     preview_only: bool,
 ) -> MergeOutput {
     let recommended_action = if preview_report.recommended_action.trim().is_empty() {
-        format!("heddle sync --thread {}", recommended_action_quote(&preview_report.thread))
+        format!(
+            "heddle sync --thread {}",
+            recommended_action_quote(&preview_report.thread)
+        )
     } else {
         preview_report.recommended_action.clone()
     };

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::cli::{Cli, should_output_json};
 
-/// Synthetic `source_thread` for `OpRecord::FastForwardV2` entries
+/// Synthetic `source_thread` for `OpRecord::FastForward` entries
 /// emitted during a rebase replay. Each replayed commit becomes its
 /// own FF op (advancing the attached thread's tip), so listing them
 /// under `<rebase>` keeps `heddle watch` / `heddle log` honest about
@@ -71,15 +71,12 @@ fn replay_commits_internal(
 
     while state.current_index < state.commits_to_replay.len() {
         let commit_id = state.commits_to_replay[state.current_index];
-        let commit_state = repo
-            .store()
-            .get_state(&commit_id)?
-            .ok_or_else(|| {
-                anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                    &commit_id.to_string(),
-                    "commit",
-                ))
-            })?;
+        let commit_state = repo.store().get_state(&commit_id)?.ok_or_else(|| {
+            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+                &commit_id.to_string(),
+                "commit",
+            ))
+        })?;
 
         if let Some(cli) = cli
             && should_output_json(cli, Some(repo.config()))
@@ -92,12 +89,7 @@ fn replay_commits_internal(
             println!("Applying {}...", commit_id.short());
         }
 
-        let result = apply_commit(
-            repo,
-            &commit_state,
-            &current_head,
-            discard_local_changes,
-        )?;
+        let result = apply_commit(repo, &commit_state, &current_head, discard_local_changes)?;
 
         match result {
             ApplyResult::Success { new_head, advance } => {
@@ -227,14 +219,12 @@ fn resume_manual_resolution_if_present(
         return Ok(());
     };
 
-    let current_state = repo
-        .current_state()?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                "<current>",
-                "current state",
-            ))
-        })?;
+    let current_state = repo.current_state()?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            "<current>",
+            "current state",
+        ))
+    })?;
 
     if current_state.change_id == pre_conflict_head || current_state.change_id == pending_commit {
         if let Some(cli) = cli
@@ -265,7 +255,7 @@ fn resume_manual_resolution_if_present(
     // `current_index` so the batch envelope reflects the full rebase
     // even when it paused for a manual fix-up.
     let resolution_advance = match repo.head_ref()? {
-        Head::Attached { thread } => OpRecord::FastForwardV2 {
+        Head::Attached { thread } => OpRecord::FastForward {
             source_thread: REBASE_REPLAY_SOURCE.to_string(),
             target_thread: thread.to_string(),
             pre_target_id: pre_conflict_head,
@@ -324,25 +314,19 @@ fn apply_commit(
     let current_tree_hash = get_tree_for_state(repo, current_head)?;
     let commit_tree_hash = commit_state.tree;
 
-    let current_tree = repo
-        .store()
-        .get_tree(&current_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &current_tree_hash.to_string(),
-                "current tree",
-            ))
-        })?;
+    let current_tree = repo.store().get_tree(&current_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &current_tree_hash.to_string(),
+            "current tree",
+        ))
+    })?;
 
-    let commit_tree = repo
-        .store()
-        .get_tree(&commit_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &commit_tree_hash.to_string(),
-                "commit tree",
-            ))
-        })?;
+    let commit_tree = repo.store().get_tree(&commit_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &commit_tree_hash.to_string(),
+            "commit tree",
+        ))
+    })?;
 
     let parent_tree_hash = if let Some(parent_id) = commit_state.parents.first() {
         get_tree_for_state(repo, parent_id)?
@@ -356,15 +340,12 @@ fn apply_commit(
         );
     };
 
-    let parent_tree = repo
-        .store()
-        .get_tree(&parent_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &parent_tree_hash.to_string(),
-                "parent tree",
-            ))
-        })?;
+    let parent_tree = repo.store().get_tree(&parent_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &parent_tree_hash.to_string(),
+            "parent tree",
+        ))
+    })?;
 
     let changes = compute_tree_diff(&parent_tree, &commit_tree);
 
@@ -605,15 +586,12 @@ fn copy_state_metadata(
 }
 
 fn get_tree_for_state(repo: &Repository, state_id: &ChangeId) -> Result<ContentHash> {
-    let state = repo
-        .store()
-        .get_state(state_id)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &state_id.to_string(),
-                "state",
-            ))
-        })?;
+    let state = repo.store().get_state(state_id)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &state_id.to_string(),
+            "state",
+        ))
+    })?;
     Ok(state.tree)
 }
 

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -4,7 +4,7 @@
 use objects::store::ObjectStore;
 use std::{fs, io::Write};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use objects::object::ChangeId;
 use oplog::OpRecord;
 use repo::Repository;
@@ -213,18 +213,17 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                     Err(e) => return Err(e),
                     Ok(advance) => match advance {
                         // heddle#198 r4 (Codex PR #218 P2): only the
-                        // FF-advance variants (FFV2, Goto) plus the
-                        // legacy V1 FastForward read-back path can
-                        // legitimately appear in a rebase batch.
+                        // FF-advance variants plus `Goto` can legitimately
+                        // appear in a rebase batch.
                         // Anything else — MarkerCreate, ThreadX,
                         // Snapshot — would land in the committed batch
                         // verbatim and pollute undo/redo with records
                         // the rebase never produced. Strict loader
                         // rejects; abort silently drops them since the
                         // buffered FF history is discarded on rewind.
-                        OpRecord::FastForward { .. }
-                        | OpRecord::FastForwardV2 { .. }
-                        | OpRecord::Goto { .. } => pending_advances.push(advance),
+                        OpRecord::FastForward { .. } | OpRecord::Goto { .. } => {
+                            pending_advances.push(advance)
+                        }
                         // Anything else would land in the committed batch
                         // verbatim and pollute undo/redo with records the
                         // rebase never produced. Abort silently drops them (the
@@ -234,7 +233,6 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                         // here rather than silently rejected (heddle#354 r9).
                         OpRecord::Snapshot { .. }
                         | OpRecord::ThreadCreate { .. }
-                        | OpRecord::ThreadCreateV2 { .. }
                         | OpRecord::ThreadDelete { .. }
                         | OpRecord::ThreadUpdate { .. }
                         | OpRecord::Fork { .. }
@@ -260,7 +258,7 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                             return Err(anyhow!(RecoveryAdvice::rebase_state_corrupted(
                                 "Unexpected pending_advance variant in rebase state",
                                 format!(
-                                    "{} — only FastForward/FastForwardV2/Goto are accepted",
+                                    "{} — only FastForward/Goto are accepted",
                                     advance.description()
                                 ),
                             )));
@@ -374,7 +372,7 @@ mod tests {
     }
 
     fn ff_record() -> OpRecord {
-        OpRecord::FastForwardV2 {
+        OpRecord::FastForward {
             source_thread: "<rebase>".to_string(),
             target_thread: "main".to_string(),
             pre_target_id: ChangeId::generate(),
@@ -671,9 +669,8 @@ mod tests {
     /// decodes can inject non-rebase operations (e.g. `MarkerCreate`,
     /// `ThreadDelete`) into the rebase's undo/redo history — undo would
     /// replay records the rebase never produced. The strict loader
-    /// must whitelist only the FF-advance variants (`FastForwardV2`
-    /// / `Goto`) plus the legacy V1 `FastForward` read-back path,
-    /// and reject anything else.
+    /// must whitelist only the FF-advance records (`FastForward` / `Goto`) and
+    /// reject anything else.
     #[test]
     fn load_strict_rejects_non_advance_pending_record() {
         let tmp = TempDir::new().unwrap();

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -90,7 +90,7 @@ pub(crate) fn abort_merge_state(
     // (conflict markers) but did not move HEAD or the target thread
     // ref — both stay at `ours` throughout the conflicted-merge
     // window. The FF here is therefore a worktree reset to `ours`,
-    // not a thread advance, so the recorded `FastForwardV2`'s
+    // not a thread advance, so the recorded `FastForward`'s
     // `pre_target_id` and `post_target_id` are equal. Migrated as
     // part of the heddle#110 Rule-7 sweep for uniformity with the
     // other `fast_forward_attached` callers: a future merge variant

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -250,7 +250,6 @@ pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
                 // (heddle#354 r9).
                 OpRecord::Goto { .. }
                 | OpRecord::ThreadCreate { .. }
-                | OpRecord::ThreadCreateV2 { .. }
                 | OpRecord::ThreadDelete { .. }
                 | OpRecord::ThreadUpdate { .. }
                 | OpRecord::Fork { .. }
@@ -263,7 +262,6 @@ pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
                 | OpRecord::Redact { .. }
                 | OpRecord::Purge { .. }
                 | OpRecord::FastForward { .. }
-                | OpRecord::FastForwardV2 { .. }
                 | OpRecord::GitCheckpoint { .. }
                 | OpRecord::RemoteThreadUpdate { .. }
                 | OpRecord::RemoteThreadDelete { .. }
@@ -351,7 +349,6 @@ fn find_recent_turn_ts(repo: &Repository) -> Result<Option<DateTime<Utc>>> {
                 // intent-carrying variant is considered here (heddle#354 r9).
                 OpRecord::Goto { .. }
                 | OpRecord::ThreadCreate { .. }
-                | OpRecord::ThreadCreateV2 { .. }
                 | OpRecord::ThreadDelete { .. }
                 | OpRecord::ThreadUpdate { .. }
                 | OpRecord::Fork { .. }
@@ -365,7 +362,6 @@ fn find_recent_turn_ts(repo: &Repository) -> Result<Option<DateTime<Utc>>> {
                 | OpRecord::Redact { .. }
                 | OpRecord::Purge { .. }
                 | OpRecord::FastForward { .. }
-                | OpRecord::FastForwardV2 { .. }
                 | OpRecord::GitCheckpoint { .. }
                 | OpRecord::RemoteThreadUpdate { .. }
                 | OpRecord::RemoteThreadDelete { .. }

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -25,7 +25,7 @@
 //!   * **Thread-record writes** route through [`ThreadManager::converge_records`]
 //!     — the same lock-atomic record-set chokepoint undo/redo uses — captured
 //!     via [`ThreadManager::snapshot_records`] for the converge-back inverse.
-//!   * **The oplog `ThreadCreateV2`** is the staged domain record handed to the
+//!   * **The oplog `ThreadCreate`** is the staged domain record handed to the
 //!     executor's single commit point (it is NOT appended inside `apply`); the
 //!     commit marker dedups on the stable `transaction_id`.
 //!
@@ -90,7 +90,10 @@ fn apply_error(err: anyhow::Error) -> HeddleError {
         // carry the full context chain (`{err:#}`) as the message so the
         // path/action survives. Extract the kind first so the `downcast_ref`
         // borrow is dropped before we format `err`.
-        Err(err) => match err.downcast_ref::<std::io::Error>().map(std::io::Error::kind) {
+        Err(err) => match err
+            .downcast_ref::<std::io::Error>()
+            .map(std::io::Error::kind)
+        {
             Some(kind) => HeddleError::Io(std::io::Error::new(kind, format!("{err:#}"))),
             None => HeddleError::Conflict(format!("{err:#}")),
         },
@@ -610,7 +613,7 @@ pub(crate) struct StartThread {
     pub base_state: ChangeId,
     /// `Some(prior)` when a thread ref already exists (re-start reuses it via a
     /// CAS against `prior`); `None` for a brand-new thread (CAS-against-missing
-    /// + a staged `ThreadCreateV2` commit record).
+    /// + a staged `ThreadCreate` commit record).
     pub existing_thread_state: Option<ChangeId>,
     pub thread_mode: ThreadMode,
     /// The materialization target (mount point for virtualized).
@@ -670,7 +673,7 @@ impl StartThread {
     }
 
     /// Stage the thread-ref write (atomic, forward-first), pushing the staged
-    /// `ThreadCreateV2` commit record for a brand-new thread.
+    /// `ThreadCreate` commit record for a brand-new thread.
     fn stage_ref(&self, tx: &mut Tx<'_>, oplog: &mut Vec<OpRecord>) -> HeddleResult<()> {
         let repo = tx.repo();
         let base_state = self.base_state;
@@ -759,8 +762,9 @@ impl StartThread {
                 // means only the courtesy stub is on disk, so the manifest stage
                 // must NOT stat the unmaterialized real tree (heddle#316 r9
                 // Finding 3).
-                let outcome = write_isolated_checkout(repo, &checkout_root, &base_state, Some(&name))
-                    .map_err(apply_error)?;
+                let outcome =
+                    write_isolated_checkout(repo, &checkout_root, &base_state, Some(&name))
+                        .map_err(apply_error)?;
                 checkout_outcome.set(Some(outcome));
                 Ok(())
             },
@@ -1022,7 +1026,7 @@ impl AtomicMutation for StartThread {
         //    inverse runs last and a self-created dir never leaks).
         self.stage_target_dir(tx, Rc::clone(&target_claim))?;
 
-        // 1. Thread ref (+ staged ThreadCreateV2 for a brand-new thread).
+        // 1. Thread ref (+ staged ThreadCreate for a brand-new thread).
         self.stage_ref(tx, &mut oplog)?;
 
         // 2. Mode-specific materialization.
@@ -1030,7 +1034,11 @@ impl AtomicMutation for StartThread {
             ThreadMode::Solid | ThreadMode::Materialized => {
                 self.stage_checkout(tx, Rc::clone(&target_claim), Rc::clone(&checkout_outcome))?;
                 if matches!(self.thread_mode, ThreadMode::Materialized) {
-                    self.stage_manifest(tx, Rc::clone(&target_claim), Rc::clone(&checkout_outcome))?;
+                    self.stage_manifest(
+                        tx,
+                        Rc::clone(&target_claim),
+                        Rc::clone(&checkout_outcome),
+                    )?;
                 }
                 if let Some(dir) = self.shared_target_dir.clone() {
                     let applied = self.stage_cargo_config(tx, &dir, Rc::clone(&target_claim))?;

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -1917,7 +1917,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     // — runs as ONE atomic transaction on the heddle#330 primitive (impl-c). A
     // failure anywhere mid-materialize rewinds every applied effect, with
     // precise directory + symlink rewind, back to the exact pre-start state;
-    // the oplog `ThreadCreateV2` is the staged commit record appended once at
+    // the oplog `ThreadCreate` is the staged commit record appended once at
     // the single commit point. See `start_atomic::StartThread`.
     let mount_ownership =
         mount_lifecycle::MountOwnership::from_flags(args.daemon, args.no_daemon);
@@ -2431,7 +2431,7 @@ pub(crate) fn cmd_thread_create(
     // can recreate it after `heddle undo` destroys it. Without this,
     // redo restores only the ref and record-backed commands (`thread
     // cd`, delegate, integration policy) silently degrade. heddle#23 r2
-    // Codex P1 (mirrors the heddle#99 r2 FastForwardV2 pattern — record
+    // Codex P1 (mirrors the heddle#99 r2 FastForward pattern — record
     // what redo needs).
     //
     // Snapshot failure is fatal here: we just wrote the record, so a

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Undo and redo commands.
 
-use objects::store::ObjectStore;
 use anyhow::{Result, anyhow};
 use objects::object::{ChangeId, ContentHash};
+use objects::store::ObjectStore;
 use oplog::{OpBatch, RedactionUndoClass};
 use refs::UNDO_RECOVERY_HANDLE;
 use repo::{Repository, ThreadManager};
@@ -216,11 +216,9 @@ pub fn cmd_undo(
     let recovery_state = repo.head()?;
     let generation = repo.oplog().head_id()?;
     let transaction_id = undo_redo_transaction_id("undo", &scope, generation, &batches);
-    let updated_batches = repo::atomic::execute(
-        &repo,
-        UndoOp::new(batches, recovery_state, transaction_id),
-    )
-    .map_err(|e| anyhow!(e))?;
+    let updated_batches =
+        repo::atomic::execute(&repo, UndoOp::new(batches, recovery_state, transaction_id))
+            .map_err(|e| anyhow!(e))?;
 
     let post_undo_repo = Repository::open(repo.root())?;
     let post_undo_trust = build_repository_verification_state(&post_undo_repo);
@@ -338,8 +336,8 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
     // failure mid-redo rewinds every applied step (mirror of `cmd_undo`).
     let generation = repo.oplog().head_id()?;
     let transaction_id = undo_redo_transaction_id("redo", &scope, generation, &batches);
-    let updated_batches =
-        repo::atomic::execute(&repo, RedoOp::new(batches, transaction_id)).map_err(|e| anyhow!(e))?;
+    let updated_batches = repo::atomic::execute(&repo, RedoOp::new(batches, transaction_id))
+        .map_err(|e| anyhow!(e))?;
 
     let post_redo_trust = build_repository_verification_state(&repo);
     let recommended_action = ActionFields::from_action(&post_redo_trust.recommended_action);
@@ -642,9 +640,7 @@ fn ensure_undo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Resul
 /// inside `goto`, identical in shape to the undo destructive-boundary
 /// case. The redo arms that touch the object store at apply time are
 /// `Snapshot`, `Goto`, `ThreadCreate`, `ThreadUpdate`, `MarkerCreate`,
-/// and `FastForwardV2`; all carry the post-state SHA directly. The
-/// legacy V1 `FastForward` redo re-resolves `source_thread → tip` and
-/// has its own error path, so we skip it here.
+/// and `FastForward`; all carry the post-state SHA directly.
 fn ensure_redo_states_reachable(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
     let mut missing: Vec<(u64, ChangeId)> = Vec::new();
     for batch in batches {
@@ -721,12 +717,14 @@ fn ensure_redaction_undo_safe(
                 RedactionUndoClass::Purge { redaction_id } => {
                     purge_ops.push((entry.id, *redaction_id))
                 }
-                RedactionUndoClass::Redact { blob, state, path } => redact_ops.push(RedactSummary {
-                    op_id: entry.id,
-                    blob: *blob,
-                    state: *state,
-                    path: path.to_string(),
-                }),
+                RedactionUndoClass::Redact { blob, state, path } => {
+                    redact_ops.push(RedactSummary {
+                        op_id: entry.id,
+                        blob: *blob,
+                        state: *state,
+                        path: path.to_string(),
+                    })
+                }
                 RedactionUndoClass::Other => {}
             }
         }
@@ -877,9 +875,8 @@ fn ensure_thread_worktree_undo_safe(repo: &Repository, batches: &[OpBatch]) -> R
 
     for batch in batches {
         for entry in &batch.entries {
-            // V1 and V2 thread-creates (the rename batch's new-name arm and all
-            // post-heddle#23-r2 creates) share the worktree-orphan hazard on
-            // undo; every other record is irrelevant to this preflight.
+            // Thread creates share the worktree-orphan hazard on undo; every
+            // other record is irrelevant to this preflight.
             let Some(name) = entry.operation.thread_worktree_undo_hazard_name() else {
                 continue;
             };
@@ -1020,14 +1017,17 @@ mod tests {
         assert_eq!(winner_seen.id, "rec-winner");
         assert!(!winner_seen.materialized_path.unwrap().exists());
 
-        // Record a `ThreadCreateV2` for the name; its undo converges the name to
+        // Record a `ThreadCreate` for the name; its undo converges the name to
         // empty, removing BOTH same-name records.
         std::fs::write(temp.path().join("f.txt"), "x").unwrap();
-        let state = repo.snapshot(Some("s".to_string()), None).unwrap().change_id;
+        let state = repo
+            .snapshot(Some("s".to_string()), None)
+            .unwrap()
+            .change_id;
         let scope = repo.op_scope();
         repo.oplog()
             .record_batch_scoped(
-                vec![OpRecord::ThreadCreateV2 {
+                vec![OpRecord::ThreadCreate {
                     name: "feature/x".to_string(),
                     state,
                     manager_snapshot: None,
@@ -1039,9 +1039,9 @@ mod tests {
         assert!(
             batches.iter().any(|b| b.entries.iter().any(|e| matches!(
                 &e.operation,
-                OpRecord::ThreadCreateV2 { name, .. } if name == "feature/x"
+                OpRecord::ThreadCreate { name, .. } if name == "feature/x"
             ))),
-            "the recorded ThreadCreateV2 is the undoable batch"
+            "the recorded ThreadCreate is the undoable batch"
         );
 
         let result = ensure_thread_worktree_undo_safe(&repo, &batches);

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -632,7 +632,7 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         | OpRecord::Goto {
             prev_head: None, ..
         } => {}
-        OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
+        OpRecord::ThreadCreate { name, .. } => {
             delete_thread_safely(steps, &ThreadName::new(name.as_str()))?;
             // Cross-thread contract rule 4 (docs/design/cross-thread-undo.md):
             // the inverse of `ThreadCreate` must also remove the matching
@@ -643,13 +643,11 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             // record we hit here has `materialized_path = None` or a path
             // that no longer exists — either way, dropping the record is
             // safe. Missing record is fine: not every `ThreadCreate` path
-            // writes one (legacy oplog entries may predate the record
-            // store).
+            // writes one.
             //
-            // Both V1 and V2 use the same undo: V2's `manager_snapshot`
-            // is recorded for redo, so undo can still destroy the live
-            // record without losing the data needed to put it back.
-            // Matches the FastForward/V2 shared-undo shape.
+            // `manager_snapshot` is recorded for redo, so undo can still
+            // destroy the live record without losing the data needed to put it
+            // back.
             remove_thread_manager_record(steps, name)?;
         }
         OpRecord::ThreadDelete { name, state } => {
@@ -700,15 +698,7 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         // during the FF, so it's untouched. Closes heddle#99 r1 — the
         // bug where recording an FF as `OpRecord::Goto` left the target
         // thread ref stranded at the FF target after undo.
-        //
-        // V1 and V2 share the same undo: both carry `pre_target_id`.
         OpRecord::FastForward {
-            source_thread,
-            target_thread,
-            pre_target_id,
-            ..
-        }
-        | OpRecord::FastForwardV2 {
             source_thread,
             target_thread,
             pre_target_id,
@@ -818,36 +808,14 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::Goto { target, .. } => {
             steps.goto(*target)?;
         }
-        // V1 ThreadCreate redo: ref-only, with a stderr note that the
-        // ThreadManager record is not being restored. V1 records were
-        // written by code pre-heddle#23 r2 that didn't carry a record
-        // snapshot in the OpRecord; redo can't reconstruct the body
-        // (mode, base_state, base_root, …) from `(name, state)` alone.
-        // Record-backed commands (`thread cd`, delegate, integration
-        // policy) will silently degrade on this thread — pointed out
-        // on stderr so the operator can rerun `heddle thread start
-        // <name>` if they want the record back. V1 ages out as the
-        // live oplog window slides forward.
-        OpRecord::ThreadCreate { name, state } => {
-            steps.set_thread(name.as_str(), *state)?;
-            eprintln!(
-                "warning: redo of legacy V1 `ThreadCreate` for '{}' restores the ref only — \
-                 the matching ThreadManager record body was not snapshotted by this oplog entry. \
-                 Run `heddle thread start {}` to re-establish the record if record-backed \
-                 commands (`thread cd`, delegate, integration policy) misbehave.",
-                name, name
-            );
-        }
-        // V2 ThreadCreate redo (heddle#23 r2): restore both the thread
-        // ref and the ThreadManager record body from the snapshot
-        // captured at recording time. Mirrors the FastForwardV2 redo
-        // pattern (record what redo needs).
+        // Restore both the thread ref and the ThreadManager record body
+        // from the snapshot captured at recording time.
         //
         // `manager_snapshot = None` means the forward path didn't have
         // a record to snapshot (cmd_start before materialization, the
         // rename batch's new-name arm, ingest, harness/agent stubs).
         // Restore the ref only in that case — no record to put back.
-        OpRecord::ThreadCreateV2 {
+        OpRecord::ThreadCreate {
             name,
             state,
             manager_snapshot,
@@ -871,14 +839,14 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::MarkerDelete { name, .. } => {
             steps.delete_marker(name.as_str())?;
         }
-        // FF merge redo (V2): replay the *recorded* FF target. We do
+        // FF merge redo: replay the *recorded* FF target. We do
         // not re-read `source_thread` — the recorded `post_target_id`
         // is the exact state the target advanced to at the original
         // FF, so redo is deterministic regardless of what the source
         // thread did between undo and redo (advanced, was deleted,
         // etc.). Closes heddle#99 r2 — Codex's non-determinism finding
         // on the r1 implementation.
-        OpRecord::FastForwardV2 {
+        OpRecord::FastForward {
             source_thread,
             target_thread,
             post_target_id,
@@ -893,31 +861,6 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             ..
         } => {
             apply_git_checkpoint_redo(steps, branch, previous_git_oid.as_deref(), new_git_oid)?;
-        }
-        // FF merge redo (V1, legacy): the r1 implementation didn't
-        // record `post_target_id`, so we have to re-resolve
-        // `source_thread → tip`. This is the non-deterministic redo
-        // Codex flagged; V1 records can only be written by the r1
-        // implementation and age out as the undo window slides
-        // forward. New ops are recorded as `FastForwardV2` so this
-        // path stops accumulating.
-        OpRecord::FastForward {
-            source_thread,
-            target_thread,
-            ..
-        } => {
-            let source_tip = steps
-                .repo()
-                .refs()
-                .get_thread(&ThreadName::new(source_thread.as_str()))?
-                .ok_or_else(|| {
-                    HeddleError::Conflict(format!(
-                        "cannot redo fast-forward: source thread '{}' no longer exists \
-                         (legacy V1 oplog record; re-run the merge or `heddle maintenance gc --prune` to prune)",
-                        source_thread
-                    ))
-                })?;
-            apply_ff_redo(steps, source_thread, target_thread, &source_tip)?;
         }
         // No redo replay: these records don't re-advance a ref redo touches, or
         // they are refused upstream. Enumerated explicitly (no wildcard) so a
@@ -1618,8 +1561,8 @@ fn change_contains(repo: &Repository, ancestor: &ChangeId, descendant: &ChangeId
 
 /// Remove EVERY ThreadManager record filed under `thread_name`, converging the
 /// name to EMPTY as ONE lock-atomic `step_nonatomic` (cid 3331603131). Used by
-/// the `ThreadCreate`/`ThreadCreateV2` inverse to keep refs and record-store
-/// state in lockstep (cross-thread undo contract rule 4).
+/// the `ThreadCreate` inverse to keep refs and record-store state in lockstep
+/// (cross-thread undo contract rule 4).
 ///
 /// Converging to empty under a SINGLE write lock via
 /// [`ThreadManager::converge_records`] — rather than taking an unlocked `list()`
@@ -2541,6 +2484,7 @@ mod atomic_tests {
                     OpRecord::ThreadCreate {
                         name: "old".to_string(),
                         state: s1,
+                        manager_snapshot: None,
                     },
                     OpRecord::ThreadDelete {
                         name: "new".to_string(),
@@ -3082,7 +3026,7 @@ mod atomic_tests {
     impl DeferredMutation for RestoreSnapshotOnly {}
 
     /// The redo-snapshot sibling of `..._restores_replacement_save_...`: the redo
-    /// of a `ThreadCreateV2` restores the record from an opaque snapshot whose
+    /// of a `ThreadCreate` restores the record from an opaque snapshot whose
     /// record id is NOT known to the applier. The forward writes that snapshot-id
     /// record (newer timestamp); on rollback the converge must drop it so
     /// `find_by_thread` returns ONLY the prior record. A re-save-only restore
@@ -3148,7 +3092,7 @@ mod atomic_tests {
         assert_eq!(restored.current_state.as_deref(), Some("current-A"));
     }
 
-    /// SUCCESS-path postcondition of the redo `ThreadCreateV2` restore (cid
+    /// SUCCESS-path postcondition of the redo `ThreadCreate` restore (cid
     /// 3331603135): when a pre-existing DUPLICATE is already filed under the name,
     /// redoing the create restores the snapshot AND leaves ONLY the restored
     /// record — the success path has the same single-record postcondition as the
@@ -3221,9 +3165,9 @@ mod atomic_tests {
     }
 
     /// Test-only deferred mutation that runs `remove_thread_manager_record` — the
-    /// `ThreadCreate`/`ThreadCreateV2` inverse — through the `EntrySteps` applier,
-    /// so its single lock-atomic `converge_records`-to-empty step and the
-    /// converge-back-to-prior rollback can be exercised in isolation.
+    /// `ThreadCreate` inverse — through the `EntrySteps` applier, so its single
+    /// lock-atomic `converge_records`-to-empty step and the converge-back-to-prior
+    /// rollback can be exercised in isolation.
     struct RemoveRecordOnly {
         name: String,
     }

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -452,17 +452,14 @@ fn kind_for(op: &OpRecord) -> String {
 fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
     match op {
         OpRecord::Snapshot { thread, .. } => thread.clone(),
-        OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
-            Some(name.clone())
-        }
+        OpRecord::ThreadCreate { name, .. } => Some(name.clone()),
         OpRecord::ThreadDelete { name, .. } => Some(name.clone()),
         OpRecord::ThreadUpdate { name, .. } => Some(name.clone()),
         OpRecord::MarkerCreate { name, .. } => Some(name.clone()),
         OpRecord::MarkerDelete { name, .. } => Some(name.clone()),
         OpRecord::Checkpoint { thread, .. } => thread.clone(),
         OpRecord::EphemeralThreadCollapse { thread, .. } => Some(thread.clone()),
-        OpRecord::FastForward { target_thread, .. }
-        | OpRecord::FastForwardV2 { target_thread, .. } => Some(target_thread.clone()),
+        OpRecord::FastForward { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
         OpRecord::RemoteThreadUpdate { thread, .. }
         | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
@@ -487,9 +484,7 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
     match op {
         OpRecord::Snapshot { new_state, .. } => Some(*new_state),
         OpRecord::Goto { target, .. } => Some(*target),
-        OpRecord::ThreadCreate { state, .. } | OpRecord::ThreadCreateV2 { state, .. } => {
-            Some(*state)
-        }
+        OpRecord::ThreadCreate { state, .. } => Some(*state),
         OpRecord::ThreadDelete { state, .. } => Some(*state),
         OpRecord::ThreadUpdate { new_state, .. } => Some(*new_state),
         OpRecord::Fork { new_state, .. } => Some(*new_state),
@@ -502,15 +497,15 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::Redact { state, .. } => Some(*state),
         OpRecord::StateVisibilitySet { state, .. }
         | OpRecord::StateVisibilityPromote { state, .. } => Some(*state),
-        OpRecord::RemoteThreadUpdate { state, .. }
-        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. } | OpRecord::RemoteThreadDelete { state, .. } => {
+            Some(*state)
+        }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. }
-        | OpRecord::FastForwardV2 { .. } => None,
+        | OpRecord::FastForward { .. } => None,
     }
 }
 
@@ -818,6 +813,7 @@ mod tests {
                 OpRecord::ThreadCreate {
                     name: "approach-anthropic".into(),
                     state: cid_b,
+                    manager_snapshot: None,
                 },
             ],
         );
@@ -867,6 +863,7 @@ mod tests {
                 OpRecord::ThreadCreate {
                     name: "x".into(),
                     state: ChangeId::generate(),
+                    manager_snapshot: None,
                 },
             ),
             kind: "thread_create".into(),
@@ -982,6 +979,7 @@ mod tests {
             OpRecord::ThreadCreate {
                 name: "x".into(),
                 state: cid,
+                manager_snapshot: None,
             },
             OpRecord::ThreadDelete {
                 name: "x".into(),

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
+use objects::store::ObjectStore;
 use oplog::{OpBatch, OpLogBackend, OpRecord};
 use repo::{Repository, Thread, ThreadIntegrationPolicy, thread_flag};
 use serde::Serialize;
@@ -12,6 +12,7 @@ use super::{
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     merge::{build_thread_preview_report, merge_thread_into_current},
+    next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
     operator_core::{
         OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
     },
@@ -22,7 +23,6 @@ use super::{
     thread_cmd::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
-    next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
     thread_landing::{land_local_command, switch_thread_command},
 };
 use crate::{
@@ -552,9 +552,11 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recovery_scope = recovery_scope_checkout(&merge_thread, repo.root());
-        let recommended_action =
-            integration_blocker_recommended_action(&integration_blockers, recovery_scope.as_deref())
-                .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
+        let recommended_action = integration_blocker_recommended_action(
+            &integration_blockers,
+            recovery_scope.as_deref(),
+        )
+        .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -769,7 +771,8 @@ fn land_performed_steps(
         (pushed, "push"),
     ]
     .into_iter()
-    .filter(|&(done, _step)| done).map(|(_done, step)| step.to_string())
+    .filter(|&(done, _step)| done)
+    .map(|(_done, step)| step.to_string())
     .collect()
 }
 
@@ -790,7 +793,8 @@ fn land_skipped_steps(
         (!pushed && !integrated, "push(not reached)"),
     ]
     .into_iter()
-    .filter(|&(skipped, _step)| skipped).map(|(_skipped, step)| step.to_string())
+    .filter(|&(skipped, _step)| skipped)
+    .map(|(_skipped, step)| step.to_string())
     .collect()
 }
 
@@ -1217,17 +1221,14 @@ fn op_targets_merge_state(op: &OpRecord, merge_state: &str) -> bool {
         OpRecord::Snapshot { new_state, .. } => change_id_matches_display(new_state, merge_state),
         OpRecord::Checkpoint { state, .. } => change_id_matches_display(state, merge_state),
         OpRecord::Goto { target, .. } => change_id_matches_display(target, merge_state),
-        OpRecord::FastForwardV2 { post_target_id, .. } => {
+        OpRecord::FastForward { post_target_id, .. } => {
             change_id_matches_display(post_target_id, merge_state)
         }
         // These records don't advance HEAD/thread to a merge target the land
-        // flow tracks (legacy V1 `FastForward` re-resolves at apply time and
-        // carries no post-target id). Enumerated explicitly (no wildcard) so a
-        // new state-advancing variant must be considered as a possible merge
+        // flow tracks. Enumerated explicitly (no wildcard) so a new
+        // state-advancing variant must be considered as a possible merge
         // target here (heddle#354 r9).
-        OpRecord::FastForward { .. }
-        | OpRecord::ThreadCreate { .. }
-        | OpRecord::ThreadCreateV2 { .. }
+        OpRecord::ThreadCreate { .. }
         | OpRecord::ThreadDelete { .. }
         | OpRecord::ThreadUpdate { .. }
         | OpRecord::Fork { .. }
@@ -1261,12 +1262,15 @@ fn adopt_manual_resolution(repo: &Repository, thread_id: &str) -> Result<String>
             "adopt manual resolution"
         ))
     })?;
-    let target = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.ok_or_else(|| {
-        anyhow!(
-            "Thread '{}' has no current state to integrate",
-            thread.thread
-        )
-    })?;
+    let target = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Thread '{}' has no current state to integrate",
+                thread.thread
+            )
+        })?;
     super::ff_record::record_ff_advance(repo, &thread.thread, &target)?;
     thread.state = repo::ThreadState::Merged;
     thread.merged_state = Some(target.short());
@@ -1301,13 +1305,13 @@ pub(crate) fn auto_land_policy_blockers(repo: &Repository, thread: &Thread) -> V
     let agent_authored = thread_is_agent_authored(repo, thread);
     if agent_authored
         && let Some(confidence) = thread.confidence_summary.value
-            && confidence < AUTO_LAND_CONFIDENCE_THRESHOLD
-        {
-            blockers.push(format!(
-                "confidence {:.2} is below the auto-land threshold of 0.75",
-                confidence
-            ));
-        }
+        && confidence < AUTO_LAND_CONFIDENCE_THRESHOLD
+    {
+        blockers.push(format!(
+            "confidence {:.2} is below the auto-land threshold of 0.75",
+            confidence
+        ));
+    }
     if matches!(thread.verification_summary.tests_passed, Some(false)) {
         blockers.push("verification summary reports failing tests".to_string());
     }
@@ -1361,7 +1365,8 @@ pub(crate) fn recovery_scope_checkout(
     if execution_path.as_os_str().is_empty() {
         return None;
     }
-    let canonical = |path: &std::path::Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let canonical =
+        |path: &std::path::Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     (canonical(execution_path) != canonical(current_checkout)).then(|| execution_path.clone())
 }
 
@@ -1408,7 +1413,12 @@ fn thread_is_agent_authored(repo: &Repository, thread: &Thread) -> bool {
         .current_state
         .as_deref()
         .and_then(|state| repo.resolve_state(state).ok().flatten())
-        .or_else(|| repo.refs().get_thread(&ThreadName::new(&thread.thread)).ok().flatten());
+        .or_else(|| {
+            repo.refs()
+                .get_thread(&ThreadName::new(&thread.thread))
+                .ok()
+                .flatten()
+        });
     current_state
         .and_then(|id| repo.store().get_state(&id).ok().flatten())
         .map(|state| state.attribution.agent.is_some())

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -111,10 +111,11 @@ fn test_undo_preserves_ignored_siblings_in_tracked_dirs() {
     assert!(!temp.path().join("main.rs").exists());
     assert!(!temp.path().join("web/index.html").exists());
     // Ignored siblings preserved across the apply.
-    assert!(temp
-        .path()
-        .join("web/node_modules/lodash/index.js")
-        .exists());
+    assert!(
+        temp.path()
+            .join("web/node_modules/lodash/index.js")
+            .exists()
+    );
     assert!(temp.path().join("target/foo.bin").exists());
 
     // HEAD advanced and disk matches state — no divergence.
@@ -140,11 +141,8 @@ fn test_undo_refuses_when_untracked_file_present() {
     let untracked = temp.path().join("my-notes.md");
     std::fs::write(&untracked, "user-written content").unwrap();
 
-    let err = heddle(
-        &["undo", "-n", "1", "--output", "json"],
-        Some(temp.path()),
-    )
-    .expect_err("undo must refuse on dirty worktree");
+    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
+        .expect_err("undo must refuse on dirty worktree");
     assert!(
         err.contains("untracked"),
         "error should mention untracked: {err}"
@@ -168,11 +166,8 @@ fn test_undo_refuses_when_tracked_file_modified() {
 
     std::fs::write(temp.path().join("a.txt"), "uncommitted edit").unwrap();
 
-    let err = heddle(
-        &["undo", "-n", "1", "--output", "json"],
-        Some(temp.path()),
-    )
-    .expect_err("undo must refuse with modified file");
+    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
+        .expect_err("undo must refuse with modified file");
     assert!(
         err.contains("modified"),
         "error should mention modified: {err}"
@@ -659,7 +654,10 @@ fn test_undo_recovery_lives_outside_user_marker_namespace() {
     heddle_must_succeed(&["marker", "delete", "undo-recovery"], temp.path());
     let repo = Repository::open(temp.path()).unwrap();
     assert_eq!(
-        repo.refs().get_undo_recovery().unwrap().map(|id| id.short()),
+        repo.refs()
+            .get_undo_recovery()
+            .unwrap()
+            .map(|id| id.short()),
         Some(friction_state),
         "user marker create/delete must not touch the internal recovery ref"
     );
@@ -914,7 +912,7 @@ fn test_redo_ff_merge_restores_head_and_thread_ref() {
 /// result SHA) at recording time and uses it directly on redo, so the
 /// replay is deterministic.
 ///
-/// Pinned the bug pre-fix: this test was red before `FastForwardV2` landed.
+/// Pinned the bug pre-fix: this test was red before `FastForward` landed.
 #[test]
 fn test_redo_ff_merge_pins_recorded_tip_when_source_advances() {
     let temp = TempDir::new().unwrap();
@@ -2147,7 +2145,7 @@ fn test_undo_preview_surfaces_worktree_refusal() {
 // recorded an implicit `OpRecord::Goto` for its FF, and the `Goto`
 // inverse only rewinds HEAD — silently stranding the attached thread
 // ref at the post-FF target. heddle#99 closed the bug for `merge` by
-// emitting `OpRecord::FastForwardV2` instead; this PR extends the same
+// emitting `OpRecord::FastForward` instead; this PR extends the same
 // pattern to the other call sites. Per-site tests below pin each fix.
 // ---------------------------------------------------------------------------
 
@@ -2215,7 +2213,7 @@ fn test_undo_rebase_ancestor_ff_restores_thread_ref() {
 
 /// Rebase replay: when the threads have diverged, rebase replays
 /// each commit one at a time. Each replay step records its own
-/// `OpRecord::FastForwardV2`, so a single `heddle undo` after the
+/// `OpRecord::FastForward`, so a single `heddle undo` after the
 /// rebase rewinds exactly one replayed commit — and the thread ref
 /// rewinds with it. Pre-fix, the ref was stranded at the last
 /// replayed commit while HEAD rewound to the prior step.
@@ -2336,12 +2334,12 @@ fn test_undo_pull_local_restores_thread_ref() {
 /// worktree back to the pre-merge state. During a 3-way conflict
 /// merge HEAD never moves (only the worktree gets conflict markers),
 /// so the FF is a worktree reset and the recorded
-/// `FastForwardV2`'s pre/post target ids are equal. The contract
+/// `FastForward`'s pre/post target ids are equal. The contract
 /// pinned here is that undo of the abort leaves the thread ref at
 /// `ours` — same as before the abort — rather than stranding it
 /// elsewhere. Pre-fix the implicit `OpRecord::Goto` happened to
 /// produce the same observable end state here (no strand because
-/// pre = post), but the migration to `FastForwardV2` keeps the
+/// pre = post), but the migration to `FastForward` keeps the
 /// invariant uniform across all `fast_forward_attached` call sites
 /// and future-proofs against a partial-apply merge variant that
 /// might move HEAD before abort.
@@ -2381,7 +2379,7 @@ fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
         "abort must leave HEAD at feature's pre-refresh tip"
     );
 
-    // Undo the abort — `FastForwardV2 { pre = post = feature_tip_before }`
+    // Undo the abort — `FastForward { pre = post = feature_tip_before }`
     // so the observable state is unchanged.
     heddle_must_succeed(&["undo"], temp.path());
     let repo = Repository::open(temp.path()).unwrap();
@@ -2494,7 +2492,7 @@ fn test_undo_ship_manual_resolution_restores_thread_ref() {
 /// source thread → redo must replay to the recorded post-FF SHA,
 /// not re-resolve from the source thread's (now advanced) tip. This
 /// pins heddle#99 r2's deterministic-redo contract for the rebase
-/// call sites: the recorded FastForwardV2 carries `post_target_id`
+/// call sites: the recorded FastForward carries `post_target_id`
 /// so the OpRecord is self-sufficient.
 #[test]
 fn test_redo_rebase_pins_recorded_tip_when_source_advances() {
@@ -2512,7 +2510,7 @@ fn test_redo_rebase_pins_recorded_tip_when_source_advances() {
 
     heddle_must_succeed(&["thread", "switch", "main"], temp.path());
     let main_tip_before = head_short(temp.path());
-    // Ancestor FF (main → feature): records FastForwardV2 with
+    // Ancestor FF (main → feature): records FastForward with
     // post_target_id = feature's current tip.
     heddle_must_succeed(&["rebase", "feature"], temp.path());
     assert_eq!(head_short(temp.path()), feature_at_rebase);
@@ -2550,7 +2548,7 @@ fn test_redo_rebase_pins_recorded_tip_when_source_advances() {
 /// remote source thread → redo must replay to the recorded pulled
 /// SHA, not re-resolve the remote's current tip. The bug shape is
 /// identical to the rebase case above; this pin guarantees the
-/// FastForwardV2 contract holds on the pull call site too.
+/// FastForward contract holds on the pull call site too.
 #[test]
 fn test_redo_pull_pins_recorded_tip_when_source_advances() {
     let source = TempDir::new().unwrap();
@@ -2592,7 +2590,7 @@ fn test_redo_pull_pins_recorded_tip_when_source_advances() {
 // ---------------------------------------------------------------------------
 // heddle#198 — `heddle undo` for `heddle rebase` via transaction grouping.
 //
-// Pre-fix, `rebase_ops::replay_commits` recorded one `FastForwardV2` op
+// Pre-fix, `rebase_ops::replay_commits` recorded one `FastForward` op
 // per replayed commit, each in its own undo batch. A 3-commit rebase
 // therefore needed 3 `heddle undo` invocations to roll back, and an
 // undo chain that stopped one or two steps in left the thread tip
@@ -2624,7 +2622,7 @@ fn test_undo_rebase_replay_multi_commit_rewinds_whole_transaction() {
 
     // main accumulates THREE commits on disjoint paths so the rebase
     // produces three apply_commit calls, each of which today records
-    // its own FastForwardV2 entry.
+    // its own FastForward entry.
     heddle_must_succeed(&["thread", "switch", "main"], temp.path());
     std::fs::write(temp.path().join("a.txt"), "a1").unwrap();
     heddle_must_succeed(&["capture", "-m", "a"], temp.path());

--- a/crates/daemon/src/grpc_local_impl/operation_log_query.rs
+++ b/crates/daemon/src/grpc_local_impl/operation_log_query.rs
@@ -64,7 +64,12 @@ fn build_query(req: &QueryOperationsRequest) -> OperationLogQuery {
         // a hand-maintained list — so a new `OpRecord` variant is surfaced by
         // default the moment it joins the catalog, instead of being silently
         // dropped from the default query (heddle#354 r9, cid 3330304663).
-        q.verbs = Some(OpRecord::verbs(false).iter().map(|s| s.to_string()).collect());
+        q.verbs = Some(
+            OpRecord::verbs(false)
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
     }
     q
 }
@@ -187,17 +192,14 @@ fn indexed_operation_matches(hit: &IndexedOperation, query: &OperationLogQuery) 
 fn thread_for(op: &OpRecord) -> Option<String> {
     match op {
         OpRecord::Snapshot { thread, .. } => thread.clone(),
-        OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
-            Some(name.clone())
-        }
+        OpRecord::ThreadCreate { name, .. } => Some(name.clone()),
         OpRecord::ThreadDelete { name, .. } => Some(name.clone()),
         OpRecord::ThreadUpdate { name, .. } => Some(name.clone()),
         OpRecord::MarkerCreate { name, .. } => Some(name.clone()),
         OpRecord::MarkerDelete { name, .. } => Some(name.clone()),
         OpRecord::Checkpoint { thread, .. } => thread.clone(),
         OpRecord::EphemeralThreadCollapse { thread, .. } => Some(thread.clone()),
-        OpRecord::FastForward { target_thread, .. }
-        | OpRecord::FastForwardV2 { target_thread, .. } => Some(target_thread.clone()),
+        OpRecord::FastForward { target_thread, .. } => Some(target_thread.clone()),
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
         OpRecord::RemoteThreadUpdate { thread, .. }
         | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
@@ -219,9 +221,7 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
     match op {
         OpRecord::Snapshot { new_state, .. } => Some(*new_state),
         OpRecord::Goto { target, .. } => Some(*target),
-        OpRecord::ThreadCreate { state, .. } | OpRecord::ThreadCreateV2 { state, .. } => {
-            Some(*state)
-        }
+        OpRecord::ThreadCreate { state, .. } => Some(*state),
         OpRecord::ThreadDelete { state, .. } => Some(*state),
         OpRecord::ThreadUpdate { new_state, .. } => Some(*new_state),
         OpRecord::Fork { new_state, .. } => Some(*new_state),
@@ -234,15 +234,15 @@ fn primary_change_id(op: &OpRecord) -> Option<ChangeId> {
         OpRecord::Redact { state, .. } => Some(*state),
         OpRecord::StateVisibilitySet { state, .. }
         | OpRecord::StateVisibilityPromote { state, .. } => Some(*state),
-        OpRecord::RemoteThreadUpdate { state, .. }
-        | OpRecord::RemoteThreadDelete { state, .. } => Some(*state),
+        OpRecord::RemoteThreadUpdate { state, .. } | OpRecord::RemoteThreadDelete { state, .. } => {
+            Some(*state)
+        }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. }
-        | OpRecord::FastForwardV2 { .. } => None,
+        | OpRecord::FastForward { .. } => None,
     }
 }
 
@@ -408,7 +408,11 @@ mod tests {
             .unwrap()
             .into_inner();
 
-        assert_eq!(resp.hits.len(), 1, "newer non-checkpoint verb must not be dropped");
+        assert_eq!(
+            resp.hits.len(),
+            1,
+            "newer non-checkpoint verb must not be dropped"
+        );
         assert_eq!(resp.hits[0].verb, "transaction_commit");
     }
 

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -386,7 +386,10 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
                 .unwrap_or_default();
             if !entries.is_empty() {
                 if !self.options.lossy {
-                    return Err(fail_lossy_entry(&rebase_lossy_entry(path_prefix, &entries[0])));
+                    return Err(fail_lossy_entry(&rebase_lossy_entry(
+                        path_prefix,
+                        &entries[0],
+                    )));
                 }
                 self.stats.lossy_entries.extend(
                     entries
@@ -882,7 +885,10 @@ mod tests {
             .expect_err("default import must not reuse cached lossy tree silently");
         let message = err.to_string();
 
-        assert!(message.contains("bad"), "error names cached entry: {message}");
+        assert!(
+            message.contains("bad"),
+            "error names cached entry: {message}"
+        );
         assert!(
             message.contains("not valid UTF-8"),
             "error explains cached conversion: {message}"
@@ -913,11 +919,7 @@ mod tests {
 
         assert_eq!(second.lossy_entries.len(), 1);
         assert_eq!(second.lossy_entries[0].path, "bad\u{fffd}name");
-        assert!(
-            second.lossy_entries[0]
-                .summary_line()
-                .contains("converted")
-        );
+        assert!(second.lossy_entries[0].summary_line().contains("converted"));
     }
 
     #[test]
@@ -1044,7 +1046,6 @@ mod tests {
         for entry in &recent {
             match &entry.operation {
                 OpRecord::ThreadCreate { .. }
-                | OpRecord::ThreadCreateV2 { .. }
                 | OpRecord::ThreadUpdate { .. }
                 | OpRecord::ThreadDelete { .. }
                 | OpRecord::MarkerCreate { .. }

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -51,7 +51,7 @@ use objects::object::{MarkerName, ThreadName};
 use oplog::oplog::OpLogBackend;
 use tracing::warn;
 
-use crate::{git_walk::ReflogEntry, sha_map::ShaMap, IngestError};
+use crate::{IngestError, git_walk::ReflogEntry, sha_map::ShaMap};
 
 /// Rolling tally returned by [`OplogEmitter::emit`].
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -177,7 +177,7 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 // Git-history ingest does not write a ThreadManager
                 // record — those exist for native heddle threads. Pass
                 // `None` for the snapshot; the recorded
-                // `ThreadCreateV2` carries no record body to restore
+                // `ThreadCreate` carries no record body to restore
                 // on redo. heddle#23 r2.
                 let thread_name = ThreadName::from(short_name);
                 self.oplog
@@ -390,7 +390,7 @@ mod tests {
         let ops = all_ops(&log);
         assert_eq!(ops.len(), 3);
         assert!(
-            matches!(ops[0], OpRecord::ThreadCreateV2 { ref name, state, manager_snapshot: None } if name == "main" && state == cid_a)
+            matches!(ops[0], OpRecord::ThreadCreate { ref name, state, manager_snapshot: None } if name == "main" && state == cid_a)
         );
         assert!(matches!(
             &ops[1],
@@ -421,7 +421,7 @@ mod tests {
         let ops = all_ops(&log);
         assert!(matches!(
             &ops[0],
-            OpRecord::ThreadCreateV2 { name, .. } if name == "feature/ingest"
+            OpRecord::ThreadCreate { name, .. } if name == "feature/ingest"
         ));
     }
 

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -16,6 +16,13 @@
 //! `decode_unversioned` path exists only for pre-versioned v2/v3 oplogs and
 //! tries frozen schemas explicitly; new formats must never blind-deserialize a
 //! payload without a schema version.
+//!
+//! Documented exception (#352, pre-v0.3.0): the V2 OpRecord variant collapse
+//! rewrote the legacy schema mirrors to the collapsed shapes instead of
+//! keeping frozen V1/V2 arms — accepted under the no-production-oplogs
+//! premise. Old dev oplogs containing thread-create/fast-forward records do
+//! not decode past this point. This exception must not be repeated once
+//! public binaries exist.
 
 use objects::{
     error::{HeddleError, Result},

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -170,6 +170,7 @@ enum StrictCurrentOpRecord {
     ThreadCreate {
         name: String,
         state: ChangeId,
+        manager_snapshot: Option<Vec<u8>>,
     },
     ThreadDelete {
         name: String,
@@ -234,17 +235,7 @@ enum StrictCurrentOpRecord {
         source_thread: String,
         target_thread: String,
         pre_target_id: ChangeId,
-    },
-    FastForwardV2 {
-        source_thread: String,
-        target_thread: String,
-        pre_target_id: ChangeId,
         post_target_id: ChangeId,
-    },
-    ThreadCreateV2 {
-        name: String,
-        state: ChangeId,
-        manager_snapshot: Option<Vec<u8>>,
     },
     GitCheckpoint {
         branch: String,
@@ -309,7 +300,15 @@ impl StrictCurrentOpRecord {
                 prev_head,
                 head,
             },
-            Self::ThreadCreate { name, state } => OpRecord::ThreadCreate { name, state },
+            Self::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            } => OpRecord::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            },
             Self::ThreadDelete { name, state } => OpRecord::ThreadDelete { name, state },
             Self::ThreadUpdate {
                 name,
@@ -395,30 +394,12 @@ impl StrictCurrentOpRecord {
                 source_thread,
                 target_thread,
                 pre_target_id,
+                post_target_id,
             } => OpRecord::FastForward {
                 source_thread,
                 target_thread,
                 pre_target_id,
-            },
-            Self::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
                 post_target_id,
-            } => OpRecord::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
-                post_target_id,
-            },
-            Self::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
-            } => OpRecord::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
             },
             Self::GitCheckpoint {
                 branch,
@@ -498,6 +479,7 @@ enum PreAtomicOpRecord {
     ThreadCreate {
         name: String,
         state: ChangeId,
+        manager_snapshot: Option<Vec<u8>>,
     },
     ThreadDelete {
         name: String,
@@ -559,17 +541,7 @@ enum PreAtomicOpRecord {
         source_thread: String,
         target_thread: String,
         pre_target_id: ChangeId,
-    },
-    FastForwardV2 {
-        source_thread: String,
-        target_thread: String,
-        pre_target_id: ChangeId,
         post_target_id: ChangeId,
-    },
-    ThreadCreateV2 {
-        name: String,
-        state: ChangeId,
-        manager_snapshot: Option<Vec<u8>>,
     },
     GitCheckpoint {
         branch: String,
@@ -597,7 +569,15 @@ impl PreAtomicOpRecord {
                 prev_head,
                 head: target,
             },
-            Self::ThreadCreate { name, state } => OpRecord::ThreadCreate { name, state },
+            Self::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            } => OpRecord::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            },
             Self::ThreadDelete { name, state } => OpRecord::ThreadDelete { name, state },
             Self::ThreadUpdate {
                 name,
@@ -678,30 +658,12 @@ impl PreAtomicOpRecord {
                 source_thread,
                 target_thread,
                 pre_target_id,
+                post_target_id,
             } => OpRecord::FastForward {
                 source_thread,
                 target_thread,
                 pre_target_id,
-            },
-            Self::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
                 post_target_id,
-            } => OpRecord::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
-                post_target_id,
-            },
-            Self::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
-            } => OpRecord::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
             },
             Self::GitCheckpoint {
                 branch,
@@ -735,6 +697,7 @@ enum AtomicNoHeadOpRecord {
     ThreadCreate {
         name: String,
         state: ChangeId,
+        manager_snapshot: Option<Vec<u8>>,
     },
     ThreadDelete {
         name: String,
@@ -799,17 +762,7 @@ enum AtomicNoHeadOpRecord {
         source_thread: String,
         target_thread: String,
         pre_target_id: ChangeId,
-    },
-    FastForwardV2 {
-        source_thread: String,
-        target_thread: String,
-        pre_target_id: ChangeId,
         post_target_id: ChangeId,
-    },
-    ThreadCreateV2 {
-        name: String,
-        state: ChangeId,
-        manager_snapshot: Option<Vec<u8>>,
     },
     GitCheckpoint {
         branch: String,
@@ -850,7 +803,15 @@ impl AtomicNoHeadOpRecord {
                 prev_head,
                 head: target,
             },
-            Self::ThreadCreate { name, state } => OpRecord::ThreadCreate { name, state },
+            Self::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            } => OpRecord::ThreadCreate {
+                name,
+                state,
+                manager_snapshot,
+            },
             Self::ThreadDelete { name, state } => OpRecord::ThreadDelete { name, state },
             Self::ThreadUpdate {
                 name,
@@ -936,30 +897,12 @@ impl AtomicNoHeadOpRecord {
                 source_thread,
                 target_thread,
                 pre_target_id,
+                post_target_id,
             } => OpRecord::FastForward {
                 source_thread,
                 target_thread,
                 pre_target_id,
-            },
-            Self::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
                 post_target_id,
-            } => OpRecord::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
-                post_target_id,
-            },
-            Self::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
-            } => OpRecord::ThreadCreateV2 {
-                name,
-                state,
-                manager_snapshot,
             },
             Self::GitCheckpoint {
                 branch,
@@ -1033,6 +976,7 @@ mod tests {
             OpRecord::ThreadCreate {
                 name: "topic".into(),
                 state: cid(4),
+                manager_snapshot: Some(vec![1, 2, 3]),
             },
             OpRecord::ThreadDelete {
                 name: "old".into(),
@@ -1096,18 +1040,8 @@ mod tests {
             OpRecord::FastForward {
                 source_thread: "feature".into(),
                 target_thread: "main".into(),
-                pre_target_id: cid(16),
-            },
-            OpRecord::FastForwardV2 {
-                source_thread: "feature".into(),
-                target_thread: "main".into(),
                 pre_target_id: cid(17),
                 post_target_id: cid(18),
-            },
-            OpRecord::ThreadCreateV2 {
-                name: "recorded".into(),
-                state: cid(19),
-                manager_snapshot: Some(vec![1, 2, 3]),
             },
             OpRecord::GitCheckpoint {
                 branch: "main".into(),
@@ -1419,9 +1353,14 @@ pub(crate) mod tests_support {
                     target: *target,
                     prev_head: *prev_head,
                 },
-                OpRecord::ThreadCreate { name, state } => Self::ThreadCreate {
+                OpRecord::ThreadCreate {
+                    name,
+                    state,
+                    manager_snapshot,
+                } => Self::ThreadCreate {
                     name: name.clone(),
                     state: *state,
+                    manager_snapshot: manager_snapshot.clone(),
                 },
                 OpRecord::ThreadDelete { name, state } => Self::ThreadDelete {
                     name: name.clone(),
@@ -1516,30 +1455,12 @@ pub(crate) mod tests_support {
                     source_thread,
                     target_thread,
                     pre_target_id,
+                    post_target_id,
                 } => Self::FastForward {
                     source_thread: source_thread.clone(),
                     target_thread: target_thread.clone(),
                     pre_target_id: *pre_target_id,
-                },
-                OpRecord::FastForwardV2 {
-                    source_thread,
-                    target_thread,
-                    pre_target_id,
-                    post_target_id,
-                } => Self::FastForwardV2 {
-                    source_thread: source_thread.clone(),
-                    target_thread: target_thread.clone(),
-                    pre_target_id: *pre_target_id,
                     post_target_id: *post_target_id,
-                },
-                OpRecord::ThreadCreateV2 {
-                    name,
-                    state,
-                    manager_snapshot,
-                } => Self::ThreadCreateV2 {
-                    name: name.clone(),
-                    state: *state,
-                    manager_snapshot: manager_snapshot.clone(),
                 },
                 OpRecord::GitCheckpoint {
                     branch,
@@ -1582,9 +1503,14 @@ pub(crate) mod tests_support {
                     target: *target,
                     prev_head: *prev_head,
                 },
-                OpRecord::ThreadCreate { name, state } => Self::ThreadCreate {
+                OpRecord::ThreadCreate {
+                    name,
+                    state,
+                    manager_snapshot,
+                } => Self::ThreadCreate {
                     name: name.clone(),
                     state: *state,
+                    manager_snapshot: manager_snapshot.clone(),
                 },
                 OpRecord::ThreadDelete { name, state } => Self::ThreadDelete {
                     name: name.clone(),
@@ -1683,30 +1609,12 @@ pub(crate) mod tests_support {
                     source_thread,
                     target_thread,
                     pre_target_id,
+                    post_target_id,
                 } => Self::FastForward {
                     source_thread: source_thread.clone(),
                     target_thread: target_thread.clone(),
                     pre_target_id: *pre_target_id,
-                },
-                OpRecord::FastForwardV2 {
-                    source_thread,
-                    target_thread,
-                    pre_target_id,
-                    post_target_id,
-                } => Self::FastForwardV2 {
-                    source_thread: source_thread.clone(),
-                    target_thread: target_thread.clone(),
-                    pre_target_id: *pre_target_id,
                     post_target_id: *post_target_id,
-                },
-                OpRecord::ThreadCreateV2 {
-                    name,
-                    state,
-                    manager_snapshot,
-                } => Self::ThreadCreateV2 {
-                    name: name.clone(),
-                    state: *state,
-                    manager_snapshot: manager_snapshot.clone(),
                 },
                 OpRecord::GitCheckpoint {
                     branch,

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -191,9 +191,9 @@ pub trait OpLogBackend: Send + Sync {
     /// alongside the create (rename batch's new-name arm, ingest,
     /// harness/agent stubs that write the record later or not at all).
     ///
-    /// Always emits `OpRecord::ThreadCreate`. V1
-    /// (`OpRecord::ThreadCreate`) is retained as read-back-only for
-    /// legacy oplog entries written before heddle#23 r2.
+    /// Always emits `OpRecord::ThreadCreate` (the collapsed canonical
+    /// shape — the V1/V2 split was removed in #352 under the
+    /// no-production-oplogs premise).
     fn record_thread_create(
         &self,
         name: &ThreadName,

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -191,7 +191,7 @@ pub trait OpLogBackend: Send + Sync {
     /// alongside the create (rename batch's new-name arm, ingest,
     /// harness/agent stubs that write the record later or not at all).
     ///
-    /// Always emits `OpRecord::ThreadCreateV2`. V1
+    /// Always emits `OpRecord::ThreadCreate`. V1
     /// (`OpRecord::ThreadCreate`) is retained as read-back-only for
     /// legacy oplog entries written before heddle#23 r2.
     fn record_thread_create(
@@ -202,7 +202,7 @@ pub trait OpLogBackend: Send + Sync {
         scope: Option<&str>,
     ) -> Result<u64> {
         let ids = self.record_batch_scoped(
-            vec![OpRecord::ThreadCreateV2 {
+            vec![OpRecord::ThreadCreate {
                 name: name.to_string(),
                 state: *state,
                 manager_snapshot,
@@ -237,7 +237,7 @@ pub trait OpLogBackend: Send + Sync {
     ) -> Result<Vec<u64>> {
         self.record_batch_scoped(
             vec![
-                OpRecord::ThreadCreateV2 {
+                OpRecord::ThreadCreate {
                     name: new_name.to_string(),
                     state: *state,
                     manager_snapshot: None,
@@ -479,8 +479,8 @@ pub trait OpLogBackend: Send + Sync {
     /// time — closes heddle#99 r1 (stranded ref on undo) and r2 (redo
     /// non-determinism).
     ///
-    /// Always emits the V2 variant. V1 (`OpRecord::FastForward`) is
-    /// retained as read-back-only.
+    /// Emits the canonical `OpRecord::FastForward` shape with both pre- and
+    /// post-target ids.
     fn record_fast_forward(
         &self,
         source_thread: &ThreadName,
@@ -490,7 +490,7 @@ pub trait OpLogBackend: Send + Sync {
         scope: Option<&str>,
     ) -> Result<u64> {
         let ids = self.record_batch_scoped(
-            vec![OpRecord::FastForwardV2 {
+            vec![OpRecord::FastForward {
                 source_thread: source_thread.to_string(),
                 target_thread: target_thread.to_string(),
                 pre_target_id: *pre_target_id,

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -80,6 +80,7 @@ fn test_record_batch() {
             OpRecord::ThreadCreate {
                 name: "main".to_string(),
                 state,
+                manager_snapshot: None,
             },
             OpRecord::ThreadDelete {
                 name: "legacy".to_string(),
@@ -527,6 +528,7 @@ fn op_record_variants_roundtrip_and_describe() {
         OpRecord::ThreadCreate {
             name: "feat".into(),
             state: st,
+            manager_snapshot: Some(vec![1, 2, 3]),
         },
         OpRecord::ThreadDelete {
             name: "feat".into(),
@@ -609,17 +611,7 @@ fn op_record_variants_roundtrip_and_describe() {
             source_thread: "topic".into(),
             target_thread: "main".into(),
             pre_target_id: st2,
-        },
-        OpRecord::FastForwardV2 {
-            source_thread: "topic".into(),
-            target_thread: "main".into(),
-            pre_target_id: st2,
             post_target_id: st,
-        },
-        OpRecord::ThreadCreateV2 {
-            name: "feat".into(),
-            state: st,
-            manager_snapshot: Some(vec![1, 2, 3]),
         },
         OpRecord::GitCheckpoint {
             branch: "main".into(),
@@ -728,7 +720,12 @@ fn record_methods_persist_expected_variants() {
         .record_goto(&result, Some(&from), Some("lane"))
         .unwrap();
     oplog
-        .record_thread_create(&ThreadName::new("feat"), &result, Some(vec![9, 8, 7]), Some("lane"))
+        .record_thread_create(
+            &ThreadName::new("feat"),
+            &result,
+            Some(vec![9, 8, 7]),
+            Some("lane"),
+        )
         .unwrap();
     oplog
         .record_thread_delete(&ThreadName::new("legacy"), &result, None)
@@ -790,9 +787,9 @@ fn record_methods_persist_expected_variants() {
     assert_eq!(fork.2.as_deref(), Some("topic"));
     assert_eq!(fork.3, None);
 
-    // A ThreadCreate is always emitted as the V2 variant with the snapshot.
+    // A ThreadCreate is always emitted with the snapshot.
     let created = entries.iter().find_map(|e| match &e.operation {
-        OpRecord::ThreadCreateV2 {
+        OpRecord::ThreadCreate {
             name,
             manager_snapshot,
             ..
@@ -801,10 +798,10 @@ fn record_methods_persist_expected_variants() {
     });
     assert_eq!(created, Some(Some(vec![9u8, 8, 7])));
 
-    // The fast-forward always lands as the V2 variant carrying post_target_id.
+    // The fast-forward always carries post_target_id.
     assert!(entries.iter().any(|e| matches!(
         &e.operation,
-        OpRecord::FastForwardV2 { post_target_id, .. } if *post_target_id == result
+        OpRecord::FastForward { post_target_id, .. } if *post_target_id == result
     )));
 }
 
@@ -1105,7 +1102,7 @@ mod default_backend {
         )));
         assert!(ops.iter().any(|o| matches!(
             o,
-            OpRecord::ThreadCreateV2 { name, manager_snapshot, .. }
+            OpRecord::ThreadCreate { name, manager_snapshot, .. }
                 if name == "ft" && manager_snapshot.as_deref() == Some(&[1u8, 2, 3][..])
         )));
         assert!(ops.iter().any(|o| matches!(
@@ -1118,7 +1115,7 @@ mod default_backend {
         );
         assert!(ops.iter().any(|o| matches!(
             o,
-            OpRecord::FastForwardV2 { post_target_id, .. } if *post_target_id == cid
+            OpRecord::FastForward { post_target_id, .. } if *post_target_id == cid
         )));
     }
 }

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum IsolationKey {
     Thread(String),
-    LocalHead { scope: String },
+    LocalHead {
+        scope: String,
+    },
     /// Per-state visibility key (heddle#317). Every `StateVisibilitySet` /
     /// `StateVisibilityPromote` record on a state contributes this key, so a
     /// visibility mutation on state `S` conflicts with an in-flight undo/redo of
@@ -70,7 +72,21 @@ pub enum OpRecord {
         head: ChangeId,
     },
     /// Thread creation.
-    ThreadCreate { name: String, state: ChangeId },
+    ///
+    /// `manager_snapshot` is opaque rmp-serde bytes of the `Thread`
+    /// record body. Opaque to keep the `oplog` crate independent of
+    /// `repo`-level types; the `repo` crate owns the encoding via
+    /// `ThreadManager::snapshot_thread_record` /
+    /// `ThreadManager::decode_thread_record_snapshot`. `None` for
+    /// callsites that don't write a ThreadManager record alongside the
+    /// op (rename batch's new-name arm, ingest, harness/agent stubs).
+    ThreadCreate {
+        name: String,
+        state: ChangeId,
+        /// rmp-serde-encoded `Thread` record body, or `None` when no
+        /// record was written by the forward path.
+        manager_snapshot: Option<Vec<u8>>,
+    },
     /// Thread deletion.
     ThreadDelete { name: String, state: ChangeId },
     /// Thread update.
@@ -191,27 +207,6 @@ pub enum OpRecord {
         /// Blob hash whose bytes were physically removed.
         blob: ContentHash,
     },
-    /// Fast-forward merge — **legacy V1, read-only.** Predates the
-    /// heddle#99 r2 redo-determinism fix and is no longer emitted; new
-    /// recordings use [`FastForwardV2`].
-    ///
-    /// Lacks `post_target_id`, so a redo of this variant has to
-    /// re-resolve `source_thread → tip` at apply time — non-deterministic
-    /// if the source thread advanced or was deleted between undo and
-    /// redo. The undo direction is fine (uses `pre_target_id` directly).
-    /// Records of this shape age out as the live oplog window slides
-    /// forward.
-    FastForward {
-        /// The thread that was merged in. Its ref never moves during
-        /// an FF merge — recorded only for forensic context.
-        source_thread: String,
-        /// The thread that fast-forwarded. Undo restores this ref to
-        /// `pre_target_id`.
-        target_thread: String,
-        /// `target_thread`'s tip before the FF. Undo restores both
-        /// HEAD and the target thread ref to this state.
-        pre_target_id: ChangeId,
-    },
     /// Fast-forward merge: `target_thread` advanced from `pre_target_id`
     /// to `post_target_id` (the source's tip at the time of the FF)
     /// without writing a synthetic merge state. `source_thread` is
@@ -222,16 +217,11 @@ pub enum OpRecord {
     /// stranded the merged-into thread ref at the FF target — the bug
     /// closed by heddle#99 r1.
     ///
-    /// V2 (heddle#99 r2) adds `post_target_id` so redo replays the
-    /// recorded operation byte-for-byte instead of re-resolving
-    /// `source_thread → tip` at apply time. The r1 redo was
-    /// non-deterministic: if the source thread had advanced after
-    /// undo, redo silently pulled in commits that were never part of
-    /// the original merge; if the source thread had been deleted,
-    /// redo errored even though the merged state is recoverable from
-    /// the recorded SHA. `source_thread` is kept for forensic context
-    /// only — neither inverse reads it.
-    FastForwardV2 {
+    /// `post_target_id` makes redo deterministic: it replays the recorded
+    /// operation byte-for-byte instead of re-resolving `source_thread → tip`
+    /// at apply time. `source_thread` is kept for forensic context only —
+    /// neither inverse reads it.
+    FastForward {
         /// The thread that was merged in. Forensic-only — neither
         /// undo nor redo reads it.
         source_thread: String,
@@ -245,44 +235,6 @@ pub enum OpRecord {
         /// deterministic regardless of what `source_thread` does
         /// later.
         post_target_id: ChangeId,
-    },
-    /// Thread creation — V2 with a ThreadManager record snapshot so redo
-    /// can recreate the record body after undo destroyed it.
-    ///
-    /// V1 (`ThreadCreate`) carried only `(name, state)`. The undo inverse
-    /// added under heddle#23 r1 also deletes the matching ThreadManager
-    /// record so refs and record-store state stay in lockstep (contract
-    /// rule 4). That left redo broken: `apply_redo_entry` could only
-    /// restore the ref via `set_thread` — the record body (mode,
-    /// execution_path, materialized_path, base_state, base_root, …) was
-    /// gone and not reconstructible from V1's `(name, state)`. Record-
-    /// backed commands (`thread cd`, delegate, integration policy) then
-    /// silently degraded after an undo→redo round-trip. heddle#23 r2
-    /// Codex P1 (PR #112, thread 3254698975).
-    ///
-    /// Same hazard shape as heddle#99 r2 (FastForward → FastForwardV2
-    /// with `post_target_id`): undo destroys state that redo cannot
-    /// reconstruct from the OpRecord alone. The fix is the same — record
-    /// what redo needs.
-    ///
-    /// `manager_snapshot` is opaque rmp-serde bytes of the `Thread`
-    /// record body. Opaque to keep the `oplog` crate independent of
-    /// `repo`-level types; the `repo` crate owns the encoding via
-    /// `ThreadManager::snapshot_thread_record` /
-    /// `ThreadManager::decode_thread_record_snapshot`. `None` for
-    /// callsites that don't write a ThreadManager record alongside the
-    /// op (rename batch's new-name arm, ingest, harness/agent stubs).
-    ///
-    /// V1 records remain readable: `apply_undo_entry` keeps its V1 arm,
-    /// and `apply_redo_entry` falls back to ref-only restore with a
-    /// stderr warning so legacy oplog entries don't error — they
-    /// degrade gracefully as the live window slides forward.
-    ThreadCreateV2 {
-        name: String,
-        state: ChangeId,
-        /// rmp-serde-encoded `Thread` record body, or `None` when no
-        /// record was written by the forward path.
-        manager_snapshot: Option<Vec<u8>>,
     },
     /// Git-overlay checkpoint written to the real Git checkout.
     GitCheckpoint {
@@ -384,7 +336,6 @@ pub fn isolation_keys_for_record(record: &OpRecord, scope: Option<&str>) -> BTre
         | OpRecord::ThreadDelete { name: thread, .. }
         | OpRecord::ThreadUpdate { name: thread, .. }
         | OpRecord::EphemeralThreadCollapse { thread, .. }
-        | OpRecord::ThreadCreateV2 { name: thread, .. }
         | OpRecord::GitCheckpoint { branch: thread, .. }
         | OpRecord::RemoteThreadUpdate { thread, .. }
         | OpRecord::RemoteThreadDelete { thread, .. } => {
@@ -401,11 +352,6 @@ pub fn isolation_keys_for_record(record: &OpRecord, scope: Option<&str>) -> BTre
             }
         }
         OpRecord::FastForward {
-            source_thread,
-            target_thread,
-            ..
-        }
-        | OpRecord::FastForwardV2 {
             source_thread,
             target_thread,
             ..
@@ -540,18 +486,6 @@ impl OpRecord {
                 source_thread,
                 target_thread,
                 pre_target_id,
-            } => {
-                format!(
-                    "fast-forward {} into {} (was at {})",
-                    source_thread,
-                    target_thread,
-                    pre_target_id.short()
-                )
-            }
-            OpRecord::FastForwardV2 {
-                source_thread,
-                target_thread,
-                pre_target_id,
                 post_target_id,
             } => {
                 format!(
@@ -561,9 +495,6 @@ impl OpRecord {
                     pre_target_id.short(),
                     post_target_id.short()
                 )
-            }
-            OpRecord::ThreadCreateV2 { name, .. } => {
-                format!("create thread {}", name)
             }
             OpRecord::GitCheckpoint {
                 branch,
@@ -624,7 +555,7 @@ macro_rules! op_verb_catalog {
             /// The stable snake-case verb for this record's variant. Exhaustive
             /// match — a new `OpRecord` variant fails to compile until it has a
             /// verb here. Verbs are shared across variants that fold to one
-            /// concept (e.g. `ThreadCreate`/`ThreadCreateV2` → `thread_create`).
+            /// concept.
             pub fn verb(&self) -> &'static str {
                 match self {
                     $( OpRecord::$variant { .. } => $verb, )+
@@ -669,8 +600,6 @@ op_verb_catalog! {
     Redact => ("redact", checkpoint = false),
     Purge => ("purge", checkpoint = false),
     FastForward => ("fast_forward", checkpoint = false),
-    FastForwardV2 => ("fast_forward", checkpoint = false),
-    ThreadCreateV2 => ("thread_create", checkpoint = false),
     GitCheckpoint => ("git_checkpoint", checkpoint = false),
     RemoteThreadUpdate => ("remote_thread_update", checkpoint = false),
     RemoteThreadDelete => ("remote_thread_delete", checkpoint = false),
@@ -745,11 +674,13 @@ impl OpRecord {
             OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
             OpRecord::MarkerDelete { state, .. } => vec![*state],
             OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
-            OpRecord::FastForwardV2 { pre_target_id, .. } => vec![*pre_target_id],
-            OpRecord::Snapshot { prev_head: None, .. }
-            | OpRecord::Goto { prev_head: None, .. }
+            OpRecord::Snapshot {
+                prev_head: None, ..
+            }
+            | OpRecord::Goto {
+                prev_head: None, ..
+            }
             | OpRecord::ThreadCreate { .. }
-            | OpRecord::ThreadCreateV2 { .. }
             | OpRecord::Fork { .. }
             | OpRecord::Collapse { .. }
             | OpRecord::MarkerCreate { .. }
@@ -770,19 +701,17 @@ impl OpRecord {
     }
 
     /// State IDs the *redo* replay must load from the object store. Variants
-    /// whose redo is a no-op, deletes a ref, touches only sidecars/Git OIDs,
-    /// or (legacy V1 `FastForward`) re-resolves `source_thread → tip` through
-    /// its own error path return an empty list. Enumerated explicitly so a new
-    /// state-carrying variant must declare its redo target (heddle#354 r9).
+    /// whose redo is a no-op, deletes a ref, or touches only sidecars/Git OIDs
+    /// return an empty list. Enumerated explicitly so a new state-carrying
+    /// variant must declare its redo target (heddle#354 r9).
     pub fn states_required_for_redo(&self) -> Vec<ChangeId> {
         match self {
             OpRecord::Snapshot { new_state, .. } => vec![*new_state],
             OpRecord::Goto { target, .. } => vec![*target],
             OpRecord::ThreadCreate { state, .. } => vec![*state],
-            OpRecord::ThreadCreateV2 { state, .. } => vec![*state],
             OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
             OpRecord::MarkerCreate { state, .. } => vec![*state],
-            OpRecord::FastForwardV2 { post_target_id, .. } => vec![*post_target_id],
+            OpRecord::FastForward { post_target_id, .. } => vec![*post_target_id],
             OpRecord::ThreadDelete { .. }
             | OpRecord::MarkerDelete { .. }
             | OpRecord::Fork { .. }
@@ -794,7 +723,6 @@ impl OpRecord {
             | OpRecord::TransactionCommit { .. }
             | OpRecord::Redact { .. }
             | OpRecord::Purge { .. }
-            | OpRecord::FastForward { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }
@@ -816,7 +744,6 @@ impl OpRecord {
             OpRecord::Snapshot { .. }
             | OpRecord::Goto { .. }
             | OpRecord::ThreadCreate { .. }
-            | OpRecord::ThreadCreateV2 { .. }
             | OpRecord::ThreadDelete { .. }
             | OpRecord::ThreadUpdate { .. }
             | OpRecord::Fork { .. }
@@ -829,7 +756,6 @@ impl OpRecord {
             | OpRecord::ConflictResolved { .. }
             | OpRecord::TransactionCommit { .. }
             | OpRecord::FastForward { .. }
-            | OpRecord::FastForwardV2 { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }
@@ -851,7 +777,6 @@ impl OpRecord {
             OpRecord::Snapshot { .. }
             | OpRecord::Goto { .. }
             | OpRecord::ThreadCreate { .. }
-            | OpRecord::ThreadCreateV2 { .. }
             | OpRecord::ThreadDelete { .. }
             | OpRecord::ThreadUpdate { .. }
             | OpRecord::Fork { .. }
@@ -864,7 +789,6 @@ impl OpRecord {
             | OpRecord::ConflictResolved { .. }
             | OpRecord::TransactionCommit { .. }
             | OpRecord::FastForward { .. }
-            | OpRecord::FastForwardV2 { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }
@@ -875,15 +799,13 @@ impl OpRecord {
     }
 
     /// The thread name if undoing this record carries the worktree-orphan
-    /// hazard — i.e. a thread-create (V1 or V2) whose inverse only removes the
-    /// ref, leaving any materialized worktree orphaned. `None` for every other
+    /// hazard — i.e. a thread-create whose inverse removes the ref, leaving
+    /// any materialized worktree orphaned. `None` for every other
     /// record. Enumerated explicitly so a future worktree-creating variant
     /// must be classified here (heddle#354 r9).
     pub fn thread_worktree_undo_hazard_name(&self) -> Option<&str> {
         match self {
-            OpRecord::ThreadCreate { name, .. } | OpRecord::ThreadCreateV2 { name, .. } => {
-                Some(name)
-            }
+            OpRecord::ThreadCreate { name, .. } => Some(name),
             OpRecord::Snapshot { .. }
             | OpRecord::Goto { .. }
             | OpRecord::ThreadDelete { .. }
@@ -900,7 +822,6 @@ impl OpRecord {
             | OpRecord::Redact { .. }
             | OpRecord::Purge { .. }
             | OpRecord::FastForward { .. }
-            | OpRecord::FastForwardV2 { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }
@@ -1013,8 +934,6 @@ mod verb_catalog_tests {
             | OpRecord::Redact { .. }
             | OpRecord::Purge { .. }
             | OpRecord::FastForward { .. }
-            | OpRecord::FastForwardV2 { .. }
-            | OpRecord::ThreadCreateV2 { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }
@@ -1032,6 +951,7 @@ mod verb_catalog_tests {
             OpRecord::ThreadCreate {
                 name: "t".into(),
                 state: cid(),
+                manager_snapshot: None,
             },
             OpRecord::ThreadDelete {
                 name: "t".into(),
@@ -1096,14 +1016,9 @@ mod verb_catalog_tests {
                 source_thread: "s".into(),
                 target_thread: "t".into(),
                 pre_target_id: cid(),
-            },
-            OpRecord::FastForwardV2 {
-                source_thread: "s".into(),
-                target_thread: "t".into(),
-                pre_target_id: cid(),
                 post_target_id: cid(),
             },
-            OpRecord::ThreadCreateV2 {
+            OpRecord::ThreadCreate {
                 name: "t".into(),
                 state: cid(),
                 manager_snapshot: None,

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -2309,7 +2309,7 @@ mod tests {
         entries.push(collapse);
 
         let mut thread_create = make_batch_entry(6, 6, 0, Some("lane"));
-        thread_create.operation = OpRecord::ThreadCreateV2 {
+        thread_create.operation = OpRecord::ThreadCreate {
             name: "main".to_string(),
             state: thread_state,
             manager_snapshot: Some(vec![1, 2, 3]),

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -125,15 +125,12 @@ impl Fold {
                     }
                 }
             },
-            OpRecord::ThreadCreate { name, state }
+            OpRecord::ThreadCreate { name, state, .. }
             | OpRecord::ThreadUpdate {
                 name,
                 new_state: state,
                 ..
             } => {
-                self.threads.insert(name.clone(), Some(*state));
-            }
-            OpRecord::ThreadCreateV2 { name, state, .. } => {
                 self.threads.insert(name.clone(), Some(*state));
             }
             OpRecord::ThreadDelete { name, .. } => {
@@ -194,7 +191,7 @@ impl Fold {
                 // write (symmetric with the detached `Snapshot` arm).
                 None => self.head = HeadFold::Canonical,
             },
-            OpRecord::FastForwardV2 {
+            OpRecord::FastForward {
                 target_thread,
                 post_target_id,
                 ..
@@ -226,13 +223,6 @@ impl Fold {
             }
             OpRecord::Goto { head, .. } => {
                 self.head = HeadFold::Republish(Head::Detached { state: *head });
-            }
-            // Publish-first HEAD move: legacy V1 `FastForward` moved HEAD via a
-            // direct write. Canonical already reflects it (and may carry a
-            // newer unrecorded re-attach), so defer — while masking any earlier
-            // `Republish` so a stale Fork cannot resurrect.
-            OpRecord::FastForward { .. } => {
-                self.head = HeadFold::Canonical;
             }
             // Records that do not move canonical HEAD: transaction markers,
             // conflict resolution, redaction bookkeeping, and the Git-overlay

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -712,7 +712,7 @@ fn write_chokepoint_records_before_publishing() {
     let state = ChangeId::generate();
     {
         let repo = Repository::init_default(temp.path()).unwrap();
-        let record = OpRecord::ThreadCreateV2 {
+        let record = OpRecord::ThreadCreate {
             name: "feature".to_string(),
             state,
             manager_snapshot: None,
@@ -736,7 +736,7 @@ fn write_chokepoint_records_before_publishing() {
     assert!(
         recent.iter().any(|e| matches!(
             &e.operation,
-            OpRecord::ThreadCreateV2 { name, .. } if name == "feature"
+            OpRecord::ThreadCreate { name, .. } if name == "feature"
         )),
         "every published ref must have a preceding ref-carrying record"
     );
@@ -1167,7 +1167,7 @@ fn staged_record_keys_are_covered_by_declared_root_keys() {
     });
     let records = vec![
         snapshot_on("main"),
-        OpRecord::FastForwardV2 {
+        OpRecord::FastForward {
             source_thread: "feature".to_string(),
             target_thread: "main".to_string(),
             pre_target_id: ChangeId::generate(),
@@ -1209,10 +1209,11 @@ fn reconcile_folds_every_record_shape() {
     let remote = ChangeId::generate();
     let undo = ChangeId::generate();
 
-    // Legacy read-back-only variants (V1 create + update).
+    // Thread create + update records.
     op.record_batch(vec![OpRecord::ThreadCreate {
         name: "t_v1".to_string(),
         state: v1,
+        manager_snapshot: None,
     }])
     .unwrap();
     op.record_batch(vec![OpRecord::ThreadUpdate {
@@ -1615,7 +1616,7 @@ fn validation_failure_appends_no_record() {
 
     // Publish "dup" with a backing record through the chokepoint.
     repo.commit_and_publish(
-        vec![OpRecord::ThreadCreateV2 {
+        vec![OpRecord::ThreadCreate {
             name: "dup".to_string(),
             state: existing,
             manager_snapshot: None,
@@ -1964,9 +1965,9 @@ fn fork_then_goto_reconcile_yields_goto_target_not_stale_fork() {
 }
 
 /// FastForward-after-Fork: a fast-forward re-attaches HEAD and writes it
-/// directly before recording `FastForwardV2`. The reconcile must defer to the
+/// directly before recording `FastForward`. The reconcile must defer to the
 /// re-attached canonical HEAD, not the stale fork. (This is the exact
-/// stale-HEAD clobber a Fork/Collapse-only allowlist re-opens: `FastForwardV2`
+/// stale-HEAD clobber a Fork/Collapse-only allowlist re-opens: `FastForward`
 /// is publish-first, so the fork's reconstruction must be masked.)
 #[test]
 fn fast_forward_after_fork_reconcile_defers_to_reattached_head() {
@@ -1997,7 +1998,7 @@ fn fast_forward_after_fork_reconcile_defers_to_reattached_head() {
 
     // A fast-forward advances "main" to ff_target and re-attaches HEAD
     // (`fast_forward_attached`): canonical HEAD = Attached{main}, written
-    // directly before the FastForwardV2 record.
+    // directly before the FastForward record.
     let ff_target = ChangeId::generate();
     repo.refs()
         .set_thread(&ThreadName::new("main"), &ff_target)
@@ -2626,7 +2627,7 @@ fn persisted_watermark_does_not_resurrect_unrecorded_delete() {
         let repo = Repository::init_default(temp.path()).unwrap();
         // Create through the chokepoint (records + publishes).
         repo.commit_and_publish(
-            vec![OpRecord::ThreadCreateV2 {
+            vec![OpRecord::ThreadCreate {
                 name: "fcn".to_string(),
                 state,
                 manager_snapshot: None,
@@ -2696,7 +2697,7 @@ fn shared_watermark_is_cross_worktree_no_resurrect() {
         let repo_a = Repository::open(&wt_a).unwrap();
         repo_a
             .commit_and_publish(
-                vec![OpRecord::ThreadCreateV2 {
+                vec![OpRecord::ThreadCreate {
                     name: "shared-thread".to_string(),
                     state: created,
                     manager_snapshot: None,
@@ -2755,7 +2756,7 @@ fn non_atomic_write_materializes_committed_tail() {
     // Phase-4 only: a committed-but-unpublished thread "x" (canonical absent,
     // watermark behind).
     repo.oplog()
-        .record_batch(vec![OpRecord::ThreadCreateV2 {
+        .record_batch(vec![OpRecord::ThreadCreate {
             name: "x".to_string(),
             state: v_new,
             manager_snapshot: None,

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -112,7 +112,7 @@ impl Repository {
 
     /// Variant of [`Self::fast_forward_attached`] that performs the
     /// fast-forward without recording an `OpRecord::Goto`. The merge
-    /// command uses this so it can record an `OpRecord::FastForwardV2`
+    /// command uses this so it can record an `OpRecord::FastForward`
     /// instead — the FF-specific variant carries both `pre_target_id`
     /// (for undo) and `post_target_id` (for deterministic redo). The
     /// generic `Goto` inverse only rewinds HEAD, which stranded the

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -192,8 +192,6 @@ impl AtomicMutation for SnapshotMutation<'_> {
             | OpRecord::Redact { .. }
             | OpRecord::Purge { .. }
             | OpRecord::FastForward { .. }
-            | OpRecord::FastForwardV2 { .. }
-            | OpRecord::ThreadCreateV2 { .. }
             | OpRecord::GitCheckpoint { .. }
             | OpRecord::RemoteThreadUpdate { .. }
             | OpRecord::RemoteThreadDelete { .. }

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -480,14 +480,14 @@ impl Repository {
 
     /// The staged domain commit record for a brand-new materialized-thread
     /// start. The repo owns the op-record shape so callers don't reconstruct
-    /// `OpRecord::ThreadCreateV2`'s fields. `manager_snapshot` is `None`: the
+    /// `OpRecord::ThreadCreate`'s fields. `manager_snapshot` is `None`: the
     /// thread record is written by the start's converge step (so there is
     /// nothing to snapshot at record-construction time — heddle#23 r2). The
     /// caller stages this as the executor's single commit record (it is NOT
     /// appended eagerly); the commit marker dedups on the stable
     /// `transaction_id`.
     pub fn thread_create_op_record(&self, name: &str, state: ChangeId) -> OpRecord {
-        OpRecord::ThreadCreateV2 {
+        OpRecord::ThreadCreate {
             name: name.to_string(),
             state,
             manager_snapshot: None,
@@ -1620,7 +1620,8 @@ mod tests {
 
         // State S1 (visible): contains the secret that must not linger later.
         fs::write(repo_dir.path().join("old-secret.txt"), b"launch codes\n").unwrap();
-        repo.snapshot(Some("seed with secret".into()), None).unwrap();
+        repo.snapshot(Some("seed with secret".into()), None)
+            .unwrap();
 
         // Root A materialized VISIBLE at S1 — the real bytes land on disk and the
         // clobber-proof per-root record for A captures `old-secret.txt`.
@@ -1650,8 +1651,12 @@ mod tests {
         // now resolves to B, the precise race that reopened the leak in r7.
         let b_holder = TempDir::new().unwrap();
         let root_b = b_holder.path().join("root-b");
-        repo.materialize_thread("main", &root_b, &AudienceTier::Restricted("sec-embargo".into()))
-            .unwrap();
+        repo.materialize_thread(
+            "main",
+            &root_b,
+            &AudienceTier::Restricted("sec-embargo".into()),
+        )
+        .unwrap();
         assert!(root_b.join("kept.txt").exists());
         // Confirm the clobber really happened: the per-thread manifest no longer
         // records root A.
@@ -1804,8 +1809,14 @@ mod tests {
             dest.join(COURTESY_STUB_FILENAME).exists(),
             "stub must be written for the under-tier checkout"
         );
-        assert!(manifest.files.is_empty(), "no tracked files in a stub checkout");
-        assert!(manifest.withheld, "manifest must mark the checkout withheld");
+        assert!(
+            manifest.files.is_empty(),
+            "no tracked files in a stub checkout"
+        );
+        assert!(
+            manifest.withheld,
+            "manifest must mark the checkout withheld"
+        );
 
         let head_before = repo
             .refs()
@@ -1935,7 +1946,12 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(captured_tree.entries().iter().any(|e| e.name == "extra.rs"));
-        assert!(captured_tree.entries().iter().any(|e| e.name == "secret.rs"));
+        assert!(
+            captured_tree
+                .entries()
+                .iter()
+                .any(|e| e.name == "secret.rs")
+        );
         assert!(
             !captured_tree
                 .entries()
@@ -2043,7 +2059,11 @@ mod tests {
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         let dest = TempDir::new().unwrap();
         let err = repo
-            .materialize_thread("no-such-thread", &dest.path().join("out"), &AudienceTier::Internal)
+            .materialize_thread(
+                "no-such-thread",
+                &dest.path().join("out"),
+                &AudienceTier::Internal,
+            )
             .expect_err("should fail");
         assert!(format!("{err}").contains("unknown thread"));
     }
@@ -2057,11 +2077,17 @@ mod tests {
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         fs::write(repo_dir.path().join("hello.txt"), b"hello\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let before = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let before = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let materialize_manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let materialize_manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Mutate a file in the materialized worktree.
         fs::write(dest.join("hello.txt"), b"hello world\n").unwrap();
@@ -2075,7 +2101,11 @@ mod tests {
         };
 
         // Thread head advanced.
-        let after = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let after = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_ne!(before, after);
         assert_eq!(after, new_state);
 
@@ -2096,17 +2126,26 @@ mod tests {
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         fs::write(repo_dir.path().join("steady.txt"), b"unchanged\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let before = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let before = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         let outcome = repo.capture_thread_from_disk("main", &dest).unwrap();
         assert_eq!(outcome, ThreadCaptureOutcome::NoOp);
 
         // Thread head unchanged.
-        let after = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let after = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_eq!(before, after);
     }
 
@@ -2128,7 +2167,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
         assert_eq!(manifest.files.len(), 20);
 
         // The fast-path predicate alone — without touching the
@@ -2156,7 +2197,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Sleep briefly so the mtime moves; APFS gives sub-ms
         // resolution on modern macOS but Linux ext4 is only
@@ -2187,7 +2230,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         fs::write(dest.join("b.txt"), b"b\n").unwrap();
 
@@ -2278,7 +2323,9 @@ mod tests {
         // records `dest_holder/out` as the worktree.
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let materialize_manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let materialize_manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
         let materialize_state_id = materialize_manifest.state_id;
         let materialize_tree_hash = materialize_manifest.tree_hash;
         let materialized_path = materialize_manifest.worktree_path.clone();
@@ -2323,7 +2370,11 @@ mod tests {
         // And `heddle status`'s staleness check should now correctly
         // report the materialized worktree as stale (head moved,
         // manifest didn't).
-        let head_now = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let head_now = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         assert_ne!(
             head_now, after.state_id,
             "post-fix invariant: main head advanced past manifest's recorded state → stale"
@@ -2354,7 +2405,8 @@ mod tests {
         // exposes the bug.
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("thread-worktree");
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Edit a non-symlink file so the slow path fires (the fast
         // stat-cache no-op would mask the bug). Sleep so the mtime
@@ -2394,7 +2446,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
         assert!(manifest.files.contains_key("secret.txt"));
 
         // Tighten the ignore set in the source repo to exclude
@@ -2432,7 +2486,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Sanity: the empty dir landed on disk after materialise.
         assert!(
@@ -2466,7 +2522,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Add an empty directory that has no manifest entry.
         fs::create_dir_all(dest.join("brand-new-empty-dir")).unwrap();
@@ -2491,7 +2549,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         // Remove the leaf file AND its parent dir. The file-side
         // check already catches the file removal, but if we then
@@ -2518,7 +2578,9 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        let manifest = repo.materialize_thread("main", &dest, &AudienceTier::Internal).unwrap();
+        let manifest = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
 
         fs::remove_file(dest.join("a.txt")).unwrap();
 
@@ -2550,15 +2612,21 @@ mod tests {
         let repo = Arc::new(Repository::init_default(repo_dir.path()).unwrap());
         fs::write(repo_dir.path().join("shared.txt"), b"seed\n").unwrap();
         repo.snapshot(Some("seed".into()), None).unwrap();
-        let initial_head = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("seeded");
+        let initial_head = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("seeded");
 
         // Two sibling materialized worktrees of the same thread.
         let dest_a_holder = TempDir::new().unwrap();
         let dest_a = dest_a_holder.path().join("a");
-        repo.materialize_thread("main", &dest_a, &AudienceTier::Internal).unwrap();
+        repo.materialize_thread("main", &dest_a, &AudienceTier::Internal)
+            .unwrap();
         let dest_b_holder = TempDir::new().unwrap();
         let dest_b = dest_b_holder.path().join("b");
-        repo.materialize_thread("main", &dest_b, &AudienceTier::Internal).unwrap();
+        repo.materialize_thread("main", &dest_b, &AudienceTier::Internal)
+            .unwrap();
 
         // Disjoint edits so each capture has real work to do (no
         // stat-cache no-op short-circuit).
@@ -2598,7 +2666,11 @@ mod tests {
         // the loser's parent would be `initial_head`. With the
         // lock, the loser's parent is the winner's id and the
         // winner's parent is `initial_head`.
-        let final_head = repo.refs().get_thread(&ThreadName::new("main")).unwrap().expect("head");
+        let final_head = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("head");
         let winner_id = final_head;
         let loser_id = if final_head == id_a { id_b } else { id_a };
 

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -418,7 +418,7 @@ impl ThreadManager {
     }
 
     /// Encode the `Thread` record matching `thread_name` to opaque
-    /// rmp-serde bytes for inclusion in `OpRecord::ThreadCreateV2`'s
+    /// rmp-serde bytes for inclusion in `OpRecord::ThreadCreate`'s
     /// `manager_snapshot` field. Returns `Ok(None)` when no record
     /// exists for that thread (the caller doesn't have a record to
     /// snapshot — e.g. `cmd_start --path` writes the record only after
@@ -445,8 +445,8 @@ impl ThreadManager {
 
     /// Decode a `Thread` record from rmp-serde bytes produced by
     /// `snapshot_thread_record`. Used by `heddle redo` of a
-    /// `ThreadCreateV2` to reconstruct the record body that undo destroyed
-    /// (heddle#23 r2 Codex P1, mirroring the FastForwardV2 pattern from
+    /// `ThreadCreate` to reconstruct the record body that undo destroyed
+    /// (heddle#23 r2 Codex P1, mirroring the FastForward pattern from
     /// heddle#99 r2 — record what redo needs).
     ///
     /// Decode ONLY — it does NOT persist. The redo applier converges the
@@ -597,7 +597,9 @@ mod tests {
             "precondition: newer leaked record shadows prev"
         );
 
-        manager.converge_records(name, std::slice::from_ref(&prev)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&prev))
+            .unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -653,7 +655,9 @@ mod tests {
             "precondition: the newer same-name record shadows the target"
         );
 
-        manager.converge_records(name, std::slice::from_ref(&target)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&target))
+            .unwrap();
 
         let under_name: Vec<_> = manager
             .list()
@@ -661,7 +665,11 @@ mod tests {
             .into_iter()
             .filter(|t| t.thread == name)
             .collect();
-        assert_eq!(under_name.len(), 1, "exactly the target remains under the name");
+        assert_eq!(
+            under_name.len(),
+            1,
+            "exactly the target remains under the name"
+        );
         assert_eq!(under_name[0].id, "rec-target");
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,
@@ -712,7 +720,12 @@ mod tests {
         drop_c.updated_at = keep_a.updated_at + chrono::Duration::seconds(10);
         manager.save(&drop_c).unwrap();
         assert_eq!(
-            manager.list().unwrap().iter().filter(|t| t.thread == name).count(),
+            manager
+                .list()
+                .unwrap()
+                .iter()
+                .filter(|t| t.thread == name)
+                .count(),
             3,
             "precondition: three records under the name"
         );
@@ -790,7 +803,9 @@ mod tests {
         rec.thread = name.to_string();
         manager.save(&rec).unwrap();
 
-        manager.converge_records(name, std::slice::from_ref(&rec)).unwrap();
+        manager
+            .converge_records(name, std::slice::from_ref(&rec))
+            .unwrap();
 
         assert_eq!(
             manager.find_by_thread(name).unwrap().unwrap().id,

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -44,7 +44,7 @@ than HEAD's? Does today's inverse correctly restore it?
 | `Snapshot` | No — snapshot is on HEAD's thread by construction | ✅ | Single-thread by definition |
 | `Goto` | No — only moves HEAD | ✅ | Single-thread by definition |
 | `ThreadCreate` (V1, legacy read-only) | **Yes** — creates a ref for a thread the user is not (necessarily) on; also writes a ThreadManager record | Undo: delete ref + delete record. Redo: ref-only + stderr warning (V1 doesn't carry a snapshot for redo to read back). | V1 records age out as the live oplog window slides forward |
-| `ThreadCreateV2` | **Yes** — same as V1; carries `manager_snapshot` for symmetric undo/redo | ✅ — undo deletes ref + record; redo restores both from `manager_snapshot` | heddle#23 r2 Codex P1 fix; same shape as `FastForwardV2` |
+| `ThreadCreate` | **Yes** — same as V1; carries `manager_snapshot` for symmetric undo/redo | ✅ — undo deletes ref + record; redo restores both from `manager_snapshot` | heddle#23 r2 Codex P1 fix; same shape as `FastForward` |
 | `ThreadDelete` | **Yes** when emitted — but the user-facing `heddle thread drop --delete-thread` path does *not* record this variant (drop tears the worktree down through `drop_thread_silent` in thread_cmd.rs:562 without touching the oplog); it is emitted only by the `rename` batch and a legacy `cmd_thread_delete` helper no longer wired to the CLI verb | Ref-only restore via `set_thread`. Sufficient for the rename round-trip path; no record-cleanup work is reachable here because `cmd_thread_rename` doesn't write a record under the new name | See "Out of scope" |
 | `ThreadUpdate` | Defined but never emitted today | n/a | Inverse code path exists; unused |
 | `Fork`, `Collapse` | n/a — never emitted today | n/a | Reserved for future thread-graph ops |
@@ -52,12 +52,12 @@ than HEAD's? Does today's inverse correctly restore it?
 | `Checkpoint` | No (single-thread, agent-frequent-save) | n/a — no inverse arm yet | Tracked separately; see docs/undo.md |
 | `Redact`, `Purge` | No — sidecar mutation on a specific (blob, state, path) | ✅ (`Redact` with `--allow-redact-undo`; `Purge` irreversible) | Documented in heddle#98 |
 | `FastForward` (V1, legacy read-only) | **Yes** — advances target_thread ref | ✅ — inverse restores both HEAD and target_thread to `pre_target_id` | heddle#99 r1 fix |
-| `FastForwardV2` | **Yes** — same as V1; carries `post_target_id` for deterministic redo | ✅ | heddle#99 r2 fix |
+| `FastForward` | **Yes** — same as V1; carries `post_target_id` for deterministic redo | ✅ | heddle#99 r2 fix |
 | `EphemeralThreadCollapse` | Touches a thread but only to retire its pointer | n/a — no inverse arm | Out of scope; thread auto-expired |
 | `TransactionAbort`, `TransactionCommit`, `ConflictResolved` | No ref mutation | n/a — no inverse arm | Forensic-only records |
 
 The two **already-correct** cross-thread cases are `FastForward` and
-`FastForwardV2`. Their inverses restore HEAD *and* the target thread ref. They
+`FastForward`. Their inverses restore HEAD *and* the target thread ref. They
 work because both variants carry the thread name and the pre-state explicitly;
 the inverse has everything it needs.
 
@@ -83,7 +83,7 @@ by integration tests in `crates/cli/tests/core_functionality/undo_and_special.rs
    when HEAD is not on that thread.
 2. **HEAD only moves when the recorded op moved it.** A cross-thread inverse
    does not detach, re-attach, or otherwise touch HEAD unless the original op
-   did. (`FastForward[V2]` is the only cross-thread variant that recorded a
+   did. (`FastForward` is the only cross-thread variant that recorded a
    HEAD move; its inverse correctly restores HEAD too.)
 3. **No worktree file rewrites in another checkout.** The originating
    worktree's files may be rewritten when HEAD moves; another worktree's
@@ -226,12 +226,12 @@ The change is concentrated in `crates/cli/src/cli/commands/undo_apply.rs` and
   `materialized_path = Some(path)` where `path` still exists on disk.
   Called from `cmd_undo` before the worktree-clean check and before the
   `--preview` short-circuit so preview output stays honest.
-- `apply_undo_entry`'s `ThreadCreate`/`ThreadCreateV2` arms share a
+- `apply_undo_entry`'s `ThreadCreate`/`ThreadCreate` arms share a
   single body: delete the ref via `delete_thread_safely`, then delete
   the matching ThreadManager record (best-effort — a missing record is
   not an error). V2 is fine to destroy alongside the live record because
   the OpRecord retains `manager_snapshot` for redo (see below).
-- `apply_redo_entry`'s `ThreadCreateV2` arm restores **both** the ref
+- `apply_redo_entry`'s `ThreadCreate` arm restores **both** the ref
   and the ThreadManager record from `manager_snapshot`. Without the
   record body restored, record-backed commands (`thread cd`, delegate,
   integration policy) silently degrade after an undo→redo round-trip —
@@ -243,7 +243,7 @@ The change is concentrated in `crates/cli/src/cli/commands/undo_apply.rs` and
   `heddle start <name>` to re-establish the record. V1 records
   age out as the live oplog window slides forward.
 
-**New `OpRecord` variant**: `ThreadCreateV2 { name, state,
+**New `OpRecord` variant**: `ThreadCreate { name, state,
 manager_snapshot: Option<Vec<u8>> }`. The snapshot is opaque rmp-serde
 bytes of the `Thread` record body — kept opaque so the `oplog` crate
 stays independent of `repo`-level types. The `repo` crate owns the
@@ -281,7 +281,7 @@ red-commit-first.
 
 After heddle#23 r2 closed the second instance of "undo destroys state
 that redo can't reconstruct from the OpRecord alone" (the first was
-heddle#99 r2's FastForward → FastForwardV2 fix), we walked every
+heddle#99 r2's FastForward → FastForward fix), we walked every
 `OpRecord` arm in `apply_undo_entry` / `apply_redo_entry` and asked: does
 undo destroy state that redo re-derives by *name* (which can change), or
 which isn't reconstructible from the OpRecord fields?
@@ -291,33 +291,33 @@ which isn't reconstructible from the OpRecord fields?
 | `Snapshot { prev_head: Some, … }` | HEAD position, thread ref | `new_state` field | No | OK |
 | `Goto { prev_head: Some, … }` | HEAD position | `target` field | No | OK |
 | `ThreadCreate` (V1) | ref + record body | ref-only + warning | **Latent** | V1 read-back-only; ages out. New ops emit V2. |
-| `ThreadCreateV2` | ref + record body | `manager_snapshot` bytes | No | **Fixed this PR** |
+| `ThreadCreate` | ref + record body | `manager_snapshot` bytes | No | **Fixed this PR** |
 | `ThreadDelete` | ref | `state` field (ref restored); record body **not** restored | **Latent** | No forward callsite exercises the hazard today: the user-facing delete (`thread drop --delete-thread`) records no oplog entry, and the rename batch's `ThreadDelete` half deletes the old name under which no record exists anyway (the forward rename doesn't re-key the record). Becomes load-bearing if a future forward path records `ThreadDelete` against a thread with a live record. Tracked alongside `cmd_thread_rename`'s pre-existing forward-path bug. |
 | `ThreadUpdate` | thread ref | `new_state`/`old_state` | No | Not emitted today; symmetric on paper. |
 | `MarkerCreate` / `MarkerDelete` | marker ref | recorded `state` | No | OK — markers have no record-store sidecar. |
 | `Redact` | redaction sidecar entry | redo refuses (no `Redaction` snapshot in OpRecord — reason, redactor, signature missing) | **Yes — loud refusal** | Documented under heddle#98. A future `RedactV2` carrying the full `Redaction` snapshot would close it; today the loud refusal is the contract. |
 | `Purge` | blob bytes | irreversible by design | n/a | Intentional; `cmd_undo` refuses pre-mutation. |
-| `FastForward` (V1) | HEAD + target ref | re-resolves `source_thread → tip` (non-deterministic) | **Latent** | V1 read-back-only; FastForwardV2 fixes. heddle#99 r2. |
-| `FastForwardV2` | HEAD + target ref | `post_target_id` field | No | OK. |
+| `FastForward` (V1) | HEAD + target ref | re-resolves `source_thread → tip` (non-deterministic) | **Latent** | V1 read-back-only; FastForward fixes. heddle#99 r2. |
+| `FastForward` | HEAD + target ref | `post_target_id` field | No | OK. |
 | `Fork` / `Collapse` / `Checkpoint` / `TransactionAbort` / `TransactionCommit` / `EphemeralThreadCollapse` / `ConflictResolved` | (no inverse arm) | n/a | n/a | Forensic-only or not yet wired. |
 
-Net: two fixed instances of the hazard class (`FastForwardV2`,
-`ThreadCreateV2`), one loud-refusal'd (`Redact`), and one dormant-by-
+Net: two fixed instances of the hazard class (`FastForward`,
+`ThreadCreate`), one loud-refusal'd (`Redact`), and one dormant-by-
 construction (`ThreadDelete`). No silent corruption paths remain across
 the implemented inverses. If a future forward path lights up the
 `ThreadDelete` hazard, the same V2-snapshot pattern applies — file a
 `ThreadDeleteV2` with the record snapshot.
 
-### `FastForwardV2` emission sites (heddle#110)
+### `FastForward` emission sites (heddle#110)
 
 heddle#99 originally migrated *only* `cmd_merge`'s FF path to record
-`FastForwardV2`. The Rule-7 sweep filed under heddle#110 extended the
+`FastForward`. The Rule-7 sweep filed under heddle#110 extended the
 same migration to the remaining `Repository::fast_forward_attached`
 callers — each of which previously recorded the implicit
 `OpRecord::Goto` (whose inverse only rewinds HEAD) and so silently
 stranded the attached thread ref at the post-FF target on undo.
 
-Today's call sites that emit `FastForwardV2` (via the shared
+Today's call sites that emit `FastForward` (via the shared
 `commands::ff_record::record_ff_advance` helper, which falls back to
 `Goto` on detached HEAD):
 

--- a/docs/spikes/heddle-330-atomic-mutation-primitive.md
+++ b/docs/spikes/heddle-330-atomic-mutation-primitive.md
@@ -168,7 +168,7 @@ sketch.
   single record (r16) because some atomic ref batches back **multiple** records: a
   thread-rename publishes new-thread + old-thread-delete (± a HEAD move) in **one**
   atomic `update_refs` vector (`thread.rs:3074-3100`) while the oplog records a **batch
-  of two** via `record_thread_rename` → `ThreadCreateV2` + `ThreadDelete`
+  of two** via `record_thread_rename` → `ThreadCreate` + `ThreadDelete`
   (`oplog_records.rs:96-110`). A one-`OpRecord` chokepoint would either **drop** a
   backing record for one published ref or **split** the atomic batch into two publishes
   (breaking atomicity); the batch signature represents the multi-record case faithfully —
@@ -542,7 +542,7 @@ could not know **which** ref to materialize on replay — the record is unreplay
 atomic `update_refs` batch** — create the new thread, delete the old thread, and (when
 HEAD was attached to the renamed thread) move `HEAD` — all in a single `updates` vector
 (`thread.rs:3074-3100`), then records via `record_thread_rename` (`thread.rs:3101-3102`),
-which appends a **batch of two `OpRecord`s** — `ThreadCreateV2 { name: new, … }` +
+which appends a **batch of two `OpRecord`s** — `ThreadCreate { name: new, … }` +
 `ThreadDelete { name: old, … }` (`oplog_records.rs:96-110`). So this atomic ref batch is
 backed by **multiple** records, not one. A chokepoint whose signature took a single
 `OpRecord` could not represent this faithfully: it would either **drop** a backing
@@ -560,7 +560,7 @@ pushes a **third** update onto the vector — `RefUpdate::Head` re-attaching HEA
 old thread name to the new (`thread.rs:3090-3099`) — so the published batch carries
 **three** refs: new-thread create, old-thread delete, **and** the HEAD move. But
 `record_thread_rename` (`oplog_records.rs:96-110`) appends only **two** records
-(`ThreadCreateV2` + `ThreadDelete`) in *every* case — there is **no record for the HEAD
+(`ThreadCreate` + `ThreadDelete`) in *every* case — there is **no record for the HEAD
 move**. So an attached rename routed through `commit_and_publish` would publish a HEAD ref
 whose backing record is absent: a crash after phase 4 (commit) and before phase 5
 (publish) leaves reconciliation with **no ref-carrying record for the HEAD move**, and the
@@ -609,7 +609,7 @@ first**:
 > because some atomic ref batches are backed by **multiple** records: thread-rename
 > publishes new-thread + old-thread-delete (± a HEAD move) in one atomic `update_refs`
 > vector (`thread.rs:3074-3100`) while `record_thread_rename` records a **batch of two**
-> (`ThreadCreateV2` + `ThreadDelete`, `oplog_records.rs:96-110`). A single-`OpRecord`
+> (`ThreadCreate` + `ThreadDelete`, `oplog_records.rs:96-110`). A single-`OpRecord`
 > signature would force such a writer to drop a backing record or split the atomic batch
 > into multiple publishes (breaking atomicity); the batch signature lets the atomic ref
 > batch and **all** its backing records commit-then-publish together. Single-record ops
@@ -640,7 +640,7 @@ The callers split by whether they carry a high-level operation:
   `RefUpdate::Thread`/`RefUpdate::Head`. `cmd_collapse` builds a one-element batch
   `[OpRecord::Collapse { sources, result, <published-ref discriminant> }]` (thread name
   or detached-HEAD marker) and the matching `RefUpdate`. **`cmd_thread_rename` builds a
-  *two*-element batch** `[ThreadCreateV2 { name: new, … }, ThreadDelete { name: old, … }]`
+  *two*-element batch** `[ThreadCreate { name: new, … }, ThreadDelete { name: old, … }]`
   (its existing `record_thread_rename` records, `oplog_records.rs:96-110`) for the
   detached / HEAD-unaffected case — **or a *three*-element batch** that adds a HEAD-move
   record when HEAD was attached to the renamed thread and the published vector therefore
@@ -831,7 +831,7 @@ record-before-publish guarantee in one of two ways, both honoring phase-4-before
   append-records then publish-refs in a single call (for a plain ref edit the thin
   `set_thread`/`write_head`/`set_marker` wrapper builds a one-element generic record and
   makes that call for it; fork/collapse hand in a one-element rich batch; thread-rename
-  hands in its two-element `ThreadCreateV2`+`ThreadDelete` batch with the matching atomic
+  hands in its two-element `ThreadCreate`+`ThreadDelete` batch with the matching atomic
   ref vector). This
   is what closes the class for code that has *not* yet been migrated to
   `AtomicMutation`, exactly as `reconciled_load` reconciles for readers that were never
@@ -863,16 +863,16 @@ confirms the proposed variant names appear only in this doc):
 |---|---|---|---|---|
 | `Snapshot { new_state, prev_head, thread }` (`:18`) | EXISTING | thread + HEAD | ✅ `thread` name + `new_state` target | none — already correct |
 | `Goto { target, prev_head }` (`:24`) | EXISTING | HEAD | ✅ HEAD is the unique implicit ref; `target` is its value | none — already correct |
-| `ThreadCreate`/`ThreadCreateV2`/`ThreadUpdate`/`ThreadDelete` (`:29`,`:215`,`:33`,`:31`) | EXISTING | thread | ✅ `name` + `state` | none — already correct |
+| `ThreadCreate`/`ThreadCreate`/`ThreadUpdate`/`ThreadDelete` (`:29`,`:215`,`:33`,`:31`) | EXISTING | thread | ✅ `name` + `state` | none — already correct |
 | `MarkerCreate`/`MarkerDelete { name, state }` (`:46`,`:47`) | EXISTING | marker | ✅ `name` + `state` | none — already correct |
 | `Checkpoint { parent, state, thread }` (`:53`) | EXISTING | thread + HEAD | ✅ `thread` + `state` | none — already correct |
-| `FastForwardV2 { source_thread, target_thread, pre_target_id, post_target_id }` (`:169`) | EXISTING | `target_thread` ref | ✅ `target_thread` + `post_target_id` — **the precedent**: heddle#99 r2 added `post_target_id` *specifically* so replay names the published ref *and* its target | none — already correct |
+| `FastForward { source_thread, target_thread, pre_target_id, post_target_id }` (`:169`) | EXISTING | `target_thread` ref | ✅ `target_thread` + `post_target_id` — **the precedent**: heddle#99 r2 added `post_target_id` *specifically* so replay names the published ref *and* its target | none — already correct |
 | `RemoteThreadUpdate`/`RemoteThreadDelete`/`UndoRecoveryUpdate` | **PROPOSED (r9)** — **do NOT exist** in the tree; enum tail ends at `GitCheckpoint` (`oplog_types.rs:223`); the corresponding writes (`set_remote_thread`/`delete_remote_thread`/`set_undo_recovery`, `refs_manager.rs:261`,`:284`,`:242`) currently write the ref **directly with no `OpRecord`** | remote-thread / undo-recovery | (designed to) ✅ remote+thread / recovery target | **BUILD** → add these three tail variants + route the three direct setters through the oplog-commit path so their reconciliation is non-vacuous |
 | **`Fork { from, new_state }`** (`:39`) | **EXISTING, ref-blind → EXTENDED IN PLACE** | thread + HEAD (`fork.rs:85`,`:88`) | ❌ **no** published thread name, **no** HEAD | **BUILD** → extend the existing variant in place to `Fork { from, new_state, thread: Option<String>, head }` (published thread name, `None` for detached, + the HEAD it set), modelled on `ThreadUpdate`'s `{ name, state }` shape |
 | **`Collapse { sources, result }`** (`:41-44`) | **EXISTING, ref-blind → EXTENDED IN PLACE** | thread *or* detached HEAD (`collapse.rs:101`,`:104`) | ❌ carries `result` target but **not** which ref it published | **BUILD** → extend the existing variant in place to `Collapse { sources, result, <published-ref discriminant> }` (thread name or detached-HEAD marker) |
 
 So among the variants **in the tree today**, only **`Fork` and `Collapse`** lack ref
-identity (every other *existing* publishing variant — including `FastForwardV2`, which
+identity (every other *existing* publishing variant — including `FastForward`, which
 already carries it — needs no change); and the **remote-thread / undo-recovery** publishing
 variants **do not exist at all yet** — they are net-new spike-proposed work, not
 "covered." The retrofit adds the ref identity by **mutating the existing `Fork`/`Collapse`
@@ -1653,7 +1653,7 @@ Together they hold the invariant for every writer, reader, and crash timing:
   one primitive, which enforces ordering + atomicity *universally* regardless of which
   records it is handed. It accepts a **batch** (r16) so a multi-record atomic op is faithful:
   thread-rename publishes new-thread + old-thread-delete (± HEAD) in one atomic ref vector
-  (`thread.rs:3074-3100`) backed by a two-record batch (`ThreadCreateV2`+`ThreadDelete`,
+  (`thread.rs:3074-3100`) backed by a two-record batch (`ThreadCreate`+`ThreadDelete`,
   `oplog_records.rs:96-110`) — a single-`OpRecord` chokepoint would have dropped a backing
   record or split that atomic batch. **And the batch must back EVERY ref it publishes
   (full-batch-record-coverage, r17, cid 3329019021):** when the renamed thread is the
@@ -2076,7 +2076,7 @@ impl AtomicMutation for StartThread {
         tx.enroll(RecordThreadManifest::new(…))?;
         tx.enroll(SaveThreadRecord::new(record))?;               // rewind: delete the record
         tx.enroll(CreateAgentEntry::new(entry))?;                // rewind: strip the entry
-        Ok(StagedCommit { output: …, oplog: vec![/* ThreadCreateV2 */] })
+        Ok(StagedCommit { output: …, oplog: vec![/* ThreadCreate */] })
     }
 }
 ```
@@ -2200,7 +2200,7 @@ commit-then-publish primitive `commit_and_publish(op_records: &[OpRecord], ref_u
 4) before publishing the atomic ref batch (phase 5) without splitting it. It takes a
 **batch** rather than a single record (r16) so a multi-record atomic op — thread-rename's
 new-thread+old-thread-delete (± HEAD) ref vector (`thread.rs:3074-3100`) backed by a
-two-record `ThreadCreateV2`+`ThreadDelete` batch (`oplog_records.rs:96-110`) — **three
+two-record `ThreadCreate`+`ThreadDelete` batch (`oplog_records.rs:96-110`) — **three
 records when HEAD was attached to the renamed thread and the vector therefore carries a
 `RefUpdate::Head` (`thread.rs:3090-3099`), the HEAD-move record added per
 full-batch-record-coverage (r17, cid 3329019021)** — commits
@@ -2248,7 +2248,7 @@ preceding ref-carrying record" holds for the Postgres backend too, by its own me
 | remote/undo refs | `refs_manager.rs:242`,`:261`,`:284` | n/a | no | — | were direct-write, no `OpRecord` (cid 3328869364); r9 routes through oplog-commit + new variants so reconciliation is non-vacuous |
 | fork | `fork.rs:74-92` | no | no | — | published thread+HEAD *before* `record_fork` (`:94`), passed `record_fork`'s args **reversed** (`oplog_records.rs:113` vs `:94-95`, r15), and `OpRecord::Fork` was ref-blind (cid 3328926767); fix: `cmd_fork` builds `Fork { from: source_state, new_state, thread, head }` (corrected order + published ref) and calls `commit_and_publish(&[op_record], ref_updates)` (one-element batch; r11 chokepoint, records-first; existing variant extended in place, pre-1.0 clean format break, no shim) |
 | collapse | `collapse.rs:99-108` | no | no | — | published thread/HEAD *before* `record_collapse` (`:112`) and `OpRecord::Collapse` was ref-blind (cid 3328926767); fix: `cmd_collapse` builds `Collapse { sources, result, <published-ref> }` and calls `commit_and_publish(&[op_record], ref_updates)` (one-element batch; r11 chokepoint, records-first; existing variant extended in place, pre-1.0 clean format break, no shim) |
-| thread-rename | `thread.rs:3061-3116` | no | no | — | publishes an **atomic ref batch** — create-new + delete-old (± HEAD move) in one `update_refs` vector (`:3074-3100`) — backed by a **two-record** batch (`ThreadCreateV2`+`ThreadDelete`, `oplog_records.rs:96-110`); the **multi-record motivator for the batch chokepoint (r16, cid 3329003333)**: a single-`OpRecord` primitive would drop a backing record or split the atomic batch. Fix: `cmd_thread_rename` calls `commit_and_publish(&[create, delete], ref_updates)` — full record batch + atomic ref batch, published together |
+| thread-rename | `thread.rs:3061-3116` | no | no | — | publishes an **atomic ref batch** — create-new + delete-old (± HEAD move) in one `update_refs` vector (`:3074-3100`) — backed by a **two-record** batch (`ThreadCreate`+`ThreadDelete`, `oplog_records.rs:96-110`); the **multi-record motivator for the batch chokepoint (r16, cid 3329003333)**: a single-`OpRecord` primitive would drop a backing record or split the atomic batch. Fix: `cmd_thread_rename` calls `commit_and_publish(&[create, delete], ref_updates)` — full record batch + atomic ref batch, published together |
 | pg ref backend | `pg_refs.rs:35`,`:324`,`:328` | n/a | no | — | second `RefBackend` impl (`ref_backend.rs:15`); `update_refs` published thread/marker/HEAD via its **own** SQL `pool.begin()…tx.commit()`, bypassing the file temp→rename seam (cid 3329052679); fix (r18): `commit_and_publish` is a **`RefBackend`-trait method** — `PgRefBackend` inserts the ref-carrying record(s) + ref/head rows in **one** SQL tx (`PgOpLogBackend` shares the pool, `pg_oplog.rs:40`,`:259`), native ACID atomicity, no reconciliation/watermark; its raw SQL publish made private behind the seam |
 
 ---
@@ -2413,7 +2413,7 @@ preceding ref-carrying record" holds for the Postgres backend too, by its own me
   (r16, cid 3329003333)**, because some atomic ref batches back multiple records:
   thread-rename publishes create-new + delete-old (± HEAD) in one atomic `update_refs`
   vector (`thread.rs:3074-3100`) while `record_thread_rename` records a two-record batch
-  (`ThreadCreateV2`+`ThreadDelete`, `oplog_records.rs:96-110`) — which, per r17 (cid
+  (`ThreadCreate`+`ThreadDelete`, `oplog_records.rs:96-110`) — which, per r17 (cid
   3329019021), must become a *three*-record batch in the attached-HEAD case so the
   published `RefUpdate::Head` (`thread.rs:3090-3099`) has a backing record; see (e). A
   single-`OpRecord`
@@ -2467,7 +2467,7 @@ preceding ref-carrying record" holds for the Postgres backend too, by its own me
   must survive, but because the new field shapes must land coherently across every
   reader/writer of these variants. **(e)** Route `cmd_thread_rename`
   (`thread.rs:3061-3116`) through the chokepoint with its **full record batch** — its
-  existing `record_thread_rename` records (`ThreadCreateV2`+`ThreadDelete`,
+  existing `record_thread_rename` records (`ThreadCreate`+`ThreadDelete`,
   `oplog_records.rs:96-110`) handed in as `&[create, delete]` alongside the atomic
   `update_refs` vector it already builds (`thread.rs:3074-3100`). This is the concrete
   case that drives the batch signature in (a): the create + delete ref batch and its two
@@ -2540,7 +2540,7 @@ publication routes through one commit-then-publish primitive
 **all** of the **caller-supplied** ref-carrying record batch (phase 4) *before*
 publishing the atomic canonical-ref batch (phase 5) without splitting it. It takes a
 **batch** (r16) so multi-record atomic ops — thread-rename's create-new+delete-old
-(± HEAD) ref vector backed by a two-record `ThreadCreateV2`+`ThreadDelete` batch
+(± HEAD) ref vector backed by a two-record `ThreadCreate`+`ThreadDelete` batch
 (`thread.rs:3074-3100`, `oplog_records.rs:96-110`), or **three records** when HEAD was
 attached to the renamed thread so the published `RefUpdate::Head` (`thread.rs:3090-3099`)
 gets a backing HEAD-move record (full-batch-record-coverage, r17, cid 3329019021) — are
@@ -2807,13 +2807,13 @@ revision, only one migration is in flight, not five.
   not a single record (r16), because some atomic ref batches back multiple records:
   `cmd_thread_rename` (`thread.rs:3061-3116`) publishes create-new + delete-old (± HEAD)
   in **one** atomic `update_refs` vector (`:3074-3100`) backed by a **two-record** batch
-  (`ThreadCreateV2`+`ThreadDelete` via `record_thread_rename`, `oplog_records.rs:96-110`)
+  (`ThreadCreate`+`ThreadDelete` via `record_thread_rename`, `oplog_records.rs:96-110`)
   — a single-`OpRecord` chokepoint would drop a backing record or split the atomic batch;
   the batch signature commits every record then publishes the whole ref batch together
   (single-record ops pass a one-element batch), so **every published ref in a batch has a
   backing record in the same atomic publish** — including the attached-HEAD thread-rename,
   whose third `RefUpdate::Head` (`thread.rs:3090-3099`) requires `record_thread_rename`
-  (which today emits only `ThreadCreateV2`+`ThreadDelete`, `oplog_records.rs:96-110`) to
+  (which today emits only `ThreadCreate`+`ThreadDelete`, `oplog_records.rs:96-110`) to
   add a third HEAD-move record, so the count of refs backed by a record equals the count
   of refs published (full-batch-record-coverage, r17, cid 3329019021).
   The primitive **takes** the caller's records rather than synthesizing them (r15): the

--- a/docs/spikes/heddle-382-same-thread-isolation.md
+++ b/docs/spikes/heddle-382-same-thread-isolation.md
@@ -184,7 +184,7 @@ The mapper should be explicit and shared by tests. Examples:
   `ThreadCreate* { name: t, .. }`, `ThreadDelete { name: t, .. }`,
   `ThreadUpdate { name: t, .. }`, `EphemeralThreadCollapse { thread: t, .. }`
   touch `Thread(t)`.
-- `FastForwardV2 { target_thread, source_thread, .. }` touches both: target is
+- `FastForward { target_thread, source_thread, .. }` touches both: target is
   written, source was read to define the operation.
 - `RemoteThreadUpdate/Delete { thread, .. }` touch `Thread(thread)`.
 - `Snapshot { thread: None, .. }`, `Goto`, and local undo-recovery movement


### PR DESCRIPTION
## Summary
- collapse ThreadCreateV2 into ThreadCreate and FastForwardV2 into FastForward in place
- update oplog serde/msgpack round-trip fixtures and codec mirrors to use the canonical record shapes
- remove legacy V1/V2 redo and reconciler branches instead of adding migration or compatibility paths

## Format premise
This is an in-place pre-v0.3.0 format change. Per #352, no production oplogs exist for these V2 encodings yet, so the PR intentionally deletes and replaces the variant names without migration code or a compatibility read path.

## Grep proof
```
rg -n --glob '!target/**' --glob '!/target/**' 'ThreadCreateV2|FastForwardV2|ThreadCreate/ThreadCreate|FastForward/FastForward|FFV2|FastForward\[V2\]'
```
returned no matches before commit.

## Validation
- CARGO_TARGET_DIR=/tmp/heddle-352-target cargo build --locked --workspace
- CARGO_TARGET_DIR=/tmp/heddle-352-target cargo build --locked --workspace --all-features
- ./scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/tmp/heddle-352-target cargo test -p heddle-oplog
- CARGO_TARGET_DIR=/tmp/heddle-352-target cargo test --workspace
- CARGO_TARGET_DIR=/tmp/heddle-352-target cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

Fixes #352

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783858830&installation_id=132405951&pr_number=670&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F670&signature=231a497d0c33198a34fe90721441d305177e18bdeaa5ec39792d10fb507e110b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->