### PR TITLE
Normalize output_kind wire values

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -6129,7 +6129,10 @@
         },
         "output_kind": {
           "enum": [
-            "thread_list"
+            "thread_create",
+            "thread_drop",
+            "thread_list",
+            "thread_rename"
           ],
           "type": "string"
         },
@@ -8550,7 +8553,8 @@
         },
         "output_kind": {
           "enum": [
-            "clone"
+            "clone",
+            "clone_connection"
           ],
           "type": "string"
         },
@@ -21592,6 +21596,7 @@
         },
         "output_kind": {
           "enum": [
+            "goto",
             "thread_switch"
           ],
           "type": "string"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -12969,6 +12969,490 @@
     },
     "inspect": {
       "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "ActorInfoSchema": {
+          "properties": {
+            "model": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "CoordinationStatusSchema": {
+          "enum": [
+            "clean",
+            "ahead",
+            "diverged",
+            "blocked",
+            "merge-ready"
+          ],
+          "type": "string"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "RepositoryContextInfoSchema": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "parent_repository": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parent_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MachineContractCoverageSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
         "ShowAgentSchema": {
           "properties": {
             "model": {
@@ -13012,95 +13496,551 @@
             "email"
           ],
           "type": "object"
+        },
+        "ShowSchema": {
+          "properties": {
+            "agent": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ShowAgentSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "change_id": {
+              "type": "string"
+            },
+            "change_id_full": {
+              "type": "string"
+            },
+            "confidence": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "content_hash": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "git_checkpoint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "intent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "output_kind": {
+              "type": "string"
+            },
+            "parents": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "principal": {
+              "$ref": "#/$defs/ShowPrincipalSchema"
+            },
+            "repository_capability": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "storage_model": {
+              "type": "string"
+            },
+            "tree": {
+              "type": "string"
+            },
+            "verification": true
+          },
+          "required": [
+            "output_kind",
+            "repository_capability",
+            "storage_model",
+            "change_id",
+            "change_id_full",
+            "content_hash",
+            "tree",
+            "parents",
+            "principal",
+            "created_at",
+            "status"
+          ],
+          "type": "object"
+        },
+        "ThreadFreshnessSchema": {
+          "enum": [
+            "current",
+            "stale",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ThreadImpactCategorySchema": {
+          "enum": [
+            "dependency_graph",
+            "build_runtime_config",
+            "generated_outputs",
+            "repo_wide_refactor",
+            "public_api_surface"
+          ],
+          "type": "string"
+        },
+        "ThreadModeSchema": {
+          "enum": [
+            "materialized",
+            "virtualized",
+            "solid"
+          ],
+          "type": "string"
+        },
+        "ThreadShowSchema": {
+          "properties": {
+            "actor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActorInfoSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "attach_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "auto": {
+              "type": "boolean"
+            },
+            "base_root": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "base_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "blockers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "changed_paths": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "child_threads": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "confidence_summary": true,
+            "coordination_status": {
+              "$ref": "#/$defs/CoordinationStatusSchema"
+            },
+            "current_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "execution_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "freshness": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ThreadFreshnessSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "git_branch_tip": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "harness": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heavy_impact_paths": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "heddle_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "history_imported": {
+              "type": "boolean"
+            },
+            "impact_categories": {
+              "items": {
+                "$ref": "#/$defs/ThreadImpactCategorySchema"
+              },
+              "type": "array"
+            },
+            "integration_policy_result": true,
+            "is_current": {
+              "type": "boolean"
+            },
+            "is_isolated": {
+              "type": "boolean"
+            },
+            "last_activity_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "last_progress_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "native_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_parent_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "next_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "next_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "operation": true,
+            "output_kind": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parent_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "probe_confidence": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "probe_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "promotion_suggested": {
+              "type": "boolean"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_tracking": true,
+            "report_flush_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repository_context": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RepositoryContextInfoSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "repository_label": {
+              "type": "string"
+            },
+            "session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "shared_target_dir": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sibling_threads": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "stack_depth": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "stale_from_parent": {
+              "type": "boolean"
+            },
+            "target_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "task": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "thinking_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "thread_health": {
+              "type": "string"
+            },
+            "thread_mode": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ThreadModeSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "thread_state": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ThreadStateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "usage_summary": true,
+            "verification": {
+              "$ref": "#/$defs/RepositoryVerificationStateSchema"
+            },
+            "verification_summary": true,
+            "visibility": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository_label",
+            "name",
+            "visibility",
+            "child_threads",
+            "sibling_threads",
+            "stack_depth",
+            "stale_from_parent",
+            "changed_paths",
+            "promotion_suggested",
+            "impact_categories",
+            "heavy_impact_paths",
+            "verification_summary",
+            "confidence_summary",
+            "integration_policy_result",
+            "coordination_status",
+            "is_current",
+            "is_isolated",
+            "thread_health",
+            "blockers",
+            "history_imported",
+            "auto",
+            "verification",
+            "recovery_commands"
+          ],
+          "type": "object"
+        },
+        "ThreadStateSchema": {
+          "enum": [
+            "draft",
+            "active",
+            "ready",
+            "blocked",
+            "merged",
+            "abandoned",
+            "promoted"
+          ],
+          "type": "string"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ShowSchema"
+        },
+        {
+          "$ref": "#/$defs/ThreadShowSchema"
+        }
+      ],
       "properties": {
-        "agent": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ShowAgentSchema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "change_id": {
-          "type": "string"
-        },
-        "change_id_full": {
-          "type": "string"
-        },
-        "confidence": {
-          "format": "float",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "content_hash": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "git_checkpoint": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "intent": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "output_kind": {
           "enum": [
             "inspect_state"
           ],
           "type": "string"
-        },
-        "parents": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "principal": {
-          "$ref": "#/$defs/ShowPrincipalSchema"
-        },
-        "repository_capability": {
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
-        },
-        "storage_model": {
-          "type": "string"
-        },
-        "tree": {
-          "type": "string"
-        },
-        "verification": true
+        }
       },
       "required": [
-        "output_kind",
-        "repository_capability",
-        "storage_model",
-        "change_id",
-        "change_id_full",
-        "content_hash",
-        "tree",
-        "parents",
-        "principal",
-        "created_at",
-        "status"
+        "output_kind"
       ],
-      "title": "ShowSchema",
-      "type": "object"
+      "title": "InspectSchema"
     },
     "integration doctor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -9516,6 +9516,17 @@
     "conflict show": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "conflict_show"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
@@ -12958,490 +12969,6 @@
     },
     "inspect": {
       "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "ActorInfoSchema": {
-          "properties": {
-            "model": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "provider": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "CoordinationStatusSchema": {
-          "enum": [
-            "clean",
-            "ahead",
-            "diverged",
-            "blocked",
-            "merge-ready"
-          ],
-          "type": "string"
-        },
-        "MachineContractCoverageSchema": {
-          "properties": {
-            "accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "accepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope": {
-              "type": "string"
-            },
-            "advanced_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "advanced_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "documented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "jsonl_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "missing_mutating_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "supports_op_id_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "unaccepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "unaccepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "undocumented_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "undocumented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope": {
-              "type": "string"
-            },
-            "verified_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "status",
-            "verified_scope",
-            "advanced_scope",
-            "summary",
-            "catalog_commands_total",
-            "catalog_mutating_commands_total",
-            "json_commands_total",
-            "json_mutating_commands_total",
-            "json_commands_with_schema",
-            "json_commands_with_accepted_opaque_schema",
-            "json_commands_without_schema",
-            "verified_scope_json_commands_total",
-            "verified_scope_json_commands_with_schema",
-            "verified_scope_json_commands_with_accepted_opaque_schema",
-            "verified_scope_json_commands_without_schema",
-            "advanced_scope_json_commands_total",
-            "advanced_scope_json_commands_with_accepted_opaque_schema",
-            "mutating_commands_total",
-            "mutating_commands_with_schema",
-            "mutating_commands_with_accepted_opaque_schema",
-            "mutating_commands_without_schema",
-            "verified_scope_mutating_commands_total",
-            "verified_scope_mutating_commands_with_schema",
-            "verified_scope_mutating_commands_with_accepted_opaque_schema",
-            "verified_scope_mutating_commands_without_schema",
-            "advanced_scope_mutating_commands_total",
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-            "schema_verbs_total",
-            "documented_schema_verbs_total",
-            "undocumented_schema_verbs_total",
-            "opaque_schema_verbs_total",
-            "accepted_opaque_schema_verbs_total",
-            "unaccepted_opaque_schema_verbs_total",
-            "supports_op_id_total",
-            "jsonl_commands_total",
-            "missing_schema_examples",
-            "missing_mutating_schema_examples",
-            "verified_scope_missing_schema_examples",
-            "verified_scope_accepted_opaque_schema_examples",
-            "advanced_scope_accepted_opaque_schema_examples",
-            "accepted_opaque_schema_examples",
-            "unaccepted_opaque_schema_examples",
-            "undocumented_schema_examples"
-          ],
-          "type": "object"
-        },
-        "RepositoryContextInfoSchema": {
-          "properties": {
-            "kind": {
-              "type": "string"
-            },
-            "parent_repository": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "parent_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "target_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "kind"
-          ],
-          "type": "object"
-        },
-        "RepositoryVerificationStateSchema": {
-          "properties": {
-            "active_operation": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "checks": {
-              "items": {
-                "$ref": "#/$defs/VerificationCheckSchema"
-              },
-              "type": "array"
-            },
-            "clone_verification": {
-              "type": "string"
-            },
-            "default_remote": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git_branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_initialized": {
-              "type": "boolean"
-            },
-            "heddle_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "import_state": {
-              "type": "string"
-            },
-            "machine_contract": {
-              "type": "string"
-            },
-            "machine_contract_coverage": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/MachineContractCoverageSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "mapping_state": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_drift": {
-              "type": "string"
-            },
-            "repository_mode": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "verified": {
-              "type": "boolean"
-            },
-            "workflow_status": {
-              "type": "string"
-            },
-            "workflow_summary": {
-              "type": "string"
-            },
-            "worktree_dirty": {
-              "type": "boolean"
-            },
-            "worktree_state": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "verified",
-            "status",
-            "repository_mode",
-            "heddle_initialized",
-            "worktree_dirty",
-            "worktree_state",
-            "import_state",
-            "mapping_state",
-            "remote_drift",
-            "clone_verification",
-            "machine_contract",
-            "workflow_status",
-            "workflow_summary",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "checks"
-          ],
-          "type": "object"
-        },
         "ShowAgentSchema": {
           "properties": {
             "model": {
@@ -13485,536 +13012,95 @@
             "email"
           ],
           "type": "object"
-        },
-        "ShowSchema": {
-          "properties": {
-            "agent": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ShowAgentSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "change_id": {
-              "type": "string"
-            },
-            "change_id_full": {
-              "type": "string"
-            },
-            "confidence": {
-              "format": "float",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "content_hash": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "git_checkpoint": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "intent": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "parents": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "principal": {
-              "$ref": "#/$defs/ShowPrincipalSchema"
-            },
-            "repository_capability": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "storage_model": {
-              "type": "string"
-            },
-            "tree": {
-              "type": "string"
-            },
-            "verification": true
-          },
-          "required": [
-            "repository_capability",
-            "storage_model",
-            "change_id",
-            "change_id_full",
-            "content_hash",
-            "tree",
-            "parents",
-            "principal",
-            "created_at",
-            "status"
-          ],
-          "type": "object"
-        },
-        "ThreadFreshnessSchema": {
-          "enum": [
-            "current",
-            "stale",
-            "unknown"
-          ],
-          "type": "string"
-        },
-        "ThreadImpactCategorySchema": {
-          "enum": [
-            "dependency_graph",
-            "build_runtime_config",
-            "generated_outputs",
-            "repo_wide_refactor",
-            "public_api_surface"
-          ],
-          "type": "string"
-        },
-        "ThreadModeSchema": {
-          "enum": [
-            "materialized",
-            "virtualized",
-            "solid"
-          ],
-          "type": "string"
-        },
-        "ThreadShowSchema": {
-          "properties": {
-            "actor": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActorInfoSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "attach_reason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "auto": {
-              "type": "boolean"
-            },
-            "base_root": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "base_state": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "blockers": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "changed_paths": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "child_threads": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "confidence_summary": true,
-            "coordination_status": {
-              "$ref": "#/$defs/CoordinationStatusSchema"
-            },
-            "current_state": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "execution_path": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "freshness": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ThreadFreshnessSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "git_branch_tip": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "harness": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heavy_impact_paths": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "heddle_session_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "history_imported": {
-              "type": "boolean"
-            },
-            "impact_categories": {
-              "items": {
-                "$ref": "#/$defs/ThreadImpactCategorySchema"
-              },
-              "type": "array"
-            },
-            "integration_policy_result": true,
-            "is_current": {
-              "type": "boolean"
-            },
-            "is_isolated": {
-              "type": "boolean"
-            },
-            "last_activity_at": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "last_progress_at": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "name": {
-              "type": "string"
-            },
-            "native_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_parent_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "next_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "next_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "operation": true,
-            "output_kind": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "parent_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "path": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "probe_confidence": {
-              "format": "float",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "probe_source": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "promotion_suggested": {
-              "type": "boolean"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_tracking": true,
-            "report_flush_state": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "repository_context": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/RepositoryContextInfoSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "repository_label": {
-              "type": "string"
-            },
-            "session_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "shared_target_dir": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "sibling_threads": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "stack_depth": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "stale_from_parent": {
-              "type": "boolean"
-            },
-            "target_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "task": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "thinking_level": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "thread_health": {
-              "type": "string"
-            },
-            "thread_mode": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ThreadModeSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "thread_state": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ThreadStateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "usage_summary": true,
-            "verification": {
-              "$ref": "#/$defs/RepositoryVerificationStateSchema"
-            },
-            "verification_summary": true,
-            "visibility": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "repository_label",
-            "name",
-            "visibility",
-            "child_threads",
-            "sibling_threads",
-            "stack_depth",
-            "stale_from_parent",
-            "changed_paths",
-            "promotion_suggested",
-            "impact_categories",
-            "heavy_impact_paths",
-            "verification_summary",
-            "confidence_summary",
-            "integration_policy_result",
-            "coordination_status",
-            "is_current",
-            "is_isolated",
-            "thread_health",
-            "blockers",
-            "history_imported",
-            "auto",
-            "verification",
-            "recovery_commands"
-          ],
-          "type": "object"
-        },
-        "ThreadStateSchema": {
-          "enum": [
-            "draft",
-            "active",
-            "ready",
-            "blocked",
-            "merged",
-            "abandoned",
-            "promoted"
-          ],
-          "type": "string"
-        },
-        "VerificationCheckSchema": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "details": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "status",
-            "clean",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "details"
-          ],
-          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ShowSchema"
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShowAgentSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        {
-          "$ref": "#/$defs/ThreadShowSchema"
-        }
+        "change_id": {
+          "type": "string"
+        },
+        "change_id_full": {
+          "type": "string"
+        },
+        "confidence": {
+          "format": "float",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "content_hash": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "git_checkpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "intent": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "inspect_state"
+          ],
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "principal": {
+          "$ref": "#/$defs/ShowPrincipalSchema"
+        },
+        "repository_capability": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "storage_model": {
+          "type": "string"
+        },
+        "tree": {
+          "type": "string"
+        },
+        "verification": true
+      },
+      "required": [
+        "output_kind",
+        "repository_capability",
+        "storage_model",
+        "change_id",
+        "change_id_full",
+        "content_hash",
+        "tree",
+        "parents",
+        "principal",
+        "created_at",
+        "status"
       ],
-      "title": "InspectSchema"
+      "title": "ShowSchema",
+      "type": "object"
     },
     "integration doctor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -16292,6 +15378,12 @@
             }
           ]
         },
+        "output_kind": {
+          "enum": [
+            "rebase_progress"
+          ],
+          "type": "string"
+        },
         "replayed": {
           "type": [
             "boolean",
@@ -16299,6 +15391,9 @@
           ]
         }
       },
+      "required": [
+        "output_kind"
+      ],
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
@@ -18921,6 +18016,12 @@
             "null"
           ]
         },
+        "output_kind": {
+          "enum": [
+            "show"
+          ],
+          "type": "string"
+        },
         "parents": {
           "items": {
             "type": "string"
@@ -18945,6 +18046,7 @@
         "verification": true
       },
       "required": [
+        "output_kind",
         "repository_capability",
         "storage_model",
         "change_id",
@@ -22356,7 +21458,7 @@
         },
         "output_kind": {
           "enum": [
-            "thread.cleanup"
+            "thread_cleanup"
           ],
           "type": "string"
         },
@@ -23431,7 +22533,7 @@
         },
         "output_kind": {
           "enum": [
-            "thread"
+            "thread_drop"
           ],
           "type": "string"
         },
@@ -25044,7 +24146,7 @@
         },
         "output_kind": {
           "enum": [
-            "thread"
+            "thread_promote"
           ],
           "type": "string"
         },
@@ -25567,7 +24669,7 @@
         },
         "output_kind": {
           "enum": [
-            "thread"
+            "thread_refresh"
           ],
           "type": "string"
         },
@@ -26256,7 +25358,7 @@
         },
         "output_kind": {
           "enum": [
-            "resolve"
+            "thread_resolve"
           ],
           "type": "string"
         },

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -14023,22 +14023,47 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [
         {
-          "$ref": "#/$defs/ShowSchema"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ShowSchema"
+            },
+            {
+              "properties": {
+                "output_kind": {
+                  "enum": [
+                    "inspect_state"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "output_kind"
+              ],
+              "type": "object"
+            }
+          ]
         },
         {
-          "$ref": "#/$defs/ThreadShowSchema"
+          "allOf": [
+            {
+              "$ref": "#/$defs/ThreadShowSchema"
+            },
+            {
+              "properties": {
+                "output_kind": {
+                  "enum": [
+                    "thread_show"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "output_kind"
+              ],
+              "type": "object"
+            }
+          ]
         }
-      ],
-      "properties": {
-        "output_kind": {
-          "enum": [
-            "inspect_state"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "output_kind"
       ],
       "title": "InspectSchema"
     },

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -825,7 +825,10 @@ export interface CommitSchema {
 
 export type ConflictListSchema = Record<string, unknown>;
 
-export type ConflictShowSchema = Record<string, unknown>;
+export interface ConflictShowSchema {
+  output_kind: "conflict_show";
+  [key: string]: unknown;
+}
 
 export interface ContextAuditSchema {
   output_kind: "context_audit";
@@ -1334,7 +1337,24 @@ export interface InitSchema {
   status: string;
 }
 
-export type InspectSchema = ShowSchema | ThreadShowSchema;
+export interface InspectSchema {
+  agent?: ShowAgentSchema | null;
+  change_id: string;
+  change_id_full: string;
+  confidence?: number | null;
+  content_hash: string;
+  created_at: string;
+  git_checkpoint?: string | null;
+  intent?: string | null;
+  output_kind: "inspect_state";
+  parents: string[];
+  principal: ShowPrincipalSchema;
+  repository_capability: string;
+  status: string;
+  storage_model: string;
+  tree: string;
+  verification?: unknown;
+}
 
 export type IntegrationDoctorSchema = Record<string, unknown>;
 
@@ -1707,6 +1727,7 @@ export interface RebaseSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "rebase_progress";
   replayed?: boolean | null;
   [key: string]: unknown;
 }
@@ -2101,6 +2122,7 @@ export interface ShowSchema {
   created_at: string;
   git_checkpoint?: string | null;
   intent?: string | null;
+  output_kind: "show";
   parents: string[];
   principal: ShowPrincipalSchema;
   repository_capability: string;
@@ -2384,7 +2406,7 @@ export interface ThreadCleanupSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread.cleanup";
+  output_kind: "thread_cleanup";
   reclaimed_bytes: number;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2435,7 +2457,7 @@ export interface ThreadDropSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread";
+  output_kind: "thread_drop";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2514,7 +2536,7 @@ export interface ThreadPromoteSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread";
+  output_kind: "thread_promote";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2533,7 +2555,7 @@ export interface ThreadRefreshSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread";
+  output_kind: "thread_refresh";
   path?: string | null;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -2570,7 +2592,7 @@ export interface ThreadResolveSchema {
   next_action_template?: ActionTemplateSchema | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "resolve";
+  output_kind: "thread_resolve";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -2590,67 +2612,6 @@ export interface ThreadRevokeApprovalSchema {
 }
 
 export interface ThreadShowSchema {
-  actor?: ActorInfoSchema | null;
-  attach_reason?: string | null;
-  auto: boolean;
-  base_root?: string | null;
-  base_state?: string | null;
-  blockers: string[];
-  changed_paths: string[];
-  child_threads: string[];
-  confidence_summary: unknown;
-  coordination_status: CoordinationStatusSchema;
-  current_state?: string | null;
-  execution_path?: string | null;
-  freshness?: ThreadFreshnessSchema | null;
-  git_branch_tip?: string | null;
-  harness?: string | null;
-  heavy_impact_paths: string[];
-  heddle_session_id?: string | null;
-  history_imported: boolean;
-  impact_categories: ThreadImpactCategorySchema[];
-  integration_policy_result: unknown;
-  is_current: boolean;
-  is_isolated: boolean;
-  last_activity_at?: string | null;
-  last_progress_at?: string | null;
-  name: string;
-  native_actor_key?: string | null;
-  native_parent_actor_key?: string | null;
-  next_action?: string | null;
-  next_action_template?: ActionTemplateSchema | null;
-  operation?: unknown;
-  output_kind?: string | null;
-  parent_thread?: string | null;
-  path?: string | null;
-  probe_confidence?: number | null;
-  probe_source?: string | null;
-  promotion_suggested: boolean;
-  recommended_action?: string | null;
-  recommended_action_template?: ActionTemplateSchema | null;
-  recovery_commands: string[];
-  remote_tracking?: unknown;
-  report_flush_state?: string | null;
-  repository_context?: RepositoryContextInfoSchema | null;
-  repository_label: string;
-  session_id?: string | null;
-  shared_target_dir?: string | null;
-  sibling_threads: string[];
-  stack_depth: number;
-  stale_from_parent: boolean;
-  target_thread?: string | null;
-  task?: string | null;
-  thinking_level?: string | null;
-  thread_health: string;
-  thread_mode?: ThreadModeSchema | null;
-  thread_state?: ThreadStateSchema | null;
-  usage_summary?: unknown;
-  verification: RepositoryVerificationStateSchema;
-  verification_summary: unknown;
-  visibility: string;
-}
-
-export interface ThreadShowSchema2 {
   actor?: ActorInfoSchema | null;
   attach_reason?: string | null;
   auto: boolean;
@@ -3135,7 +3096,7 @@ export interface HeddleVerbOutputs {
   "thread rename": ThreadRenameSchema;
   "thread resolve": ThreadResolveSchema;
   "thread revoke-approval": ThreadRevokeApprovalSchema;
-  "thread show": ThreadShowSchema2;
+  "thread show": ThreadShowSchema;
   "thread switch": ThreadSwitchSchema;
   "transaction abort": TransactionAbortSchema;
   "transaction begin": TransactionBeginSchema;

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1337,24 +1337,7 @@ export interface InitSchema {
   status: string;
 }
 
-export interface InspectSchema {
-  agent?: ShowAgentSchema | null;
-  change_id: string;
-  change_id_full: string;
-  confidence?: number | null;
-  content_hash: string;
-  created_at: string;
-  git_checkpoint?: string | null;
-  intent?: string | null;
-  output_kind: "inspect_state";
-  parents: string[];
-  principal: ShowPrincipalSchema;
-  repository_capability: string;
-  status: string;
-  storage_model: string;
-  tree: string;
-  verification?: unknown;
-}
+export type InspectSchema = ShowSchema | ThreadShowSchema;
 
 export type IntegrationDoctorSchema = Record<string, unknown>;
 
@@ -2122,6 +2105,25 @@ export interface ShowSchema {
   created_at: string;
   git_checkpoint?: string | null;
   intent?: string | null;
+  output_kind: string;
+  parents: string[];
+  principal: ShowPrincipalSchema;
+  repository_capability: string;
+  status: string;
+  storage_model: string;
+  tree: string;
+  verification?: unknown;
+}
+
+export interface ShowSchema2 {
+  agent?: ShowAgentSchema | null;
+  change_id: string;
+  change_id_full: string;
+  confidence?: number | null;
+  content_hash: string;
+  created_at: string;
+  git_checkpoint?: string | null;
+  intent?: string | null;
   output_kind: "show";
   parents: string[];
   principal: ShowPrincipalSchema;
@@ -2642,6 +2644,67 @@ export interface ThreadShowSchema {
   next_action?: string | null;
   next_action_template?: ActionTemplateSchema | null;
   operation?: unknown;
+  output_kind?: string | null;
+  parent_thread?: string | null;
+  path?: string | null;
+  probe_confidence?: number | null;
+  probe_source?: string | null;
+  promotion_suggested: boolean;
+  recommended_action?: string | null;
+  recommended_action_template?: ActionTemplateSchema | null;
+  recovery_commands: string[];
+  remote_tracking?: unknown;
+  report_flush_state?: string | null;
+  repository_context?: RepositoryContextInfoSchema | null;
+  repository_label: string;
+  session_id?: string | null;
+  shared_target_dir?: string | null;
+  sibling_threads: string[];
+  stack_depth: number;
+  stale_from_parent: boolean;
+  target_thread?: string | null;
+  task?: string | null;
+  thinking_level?: string | null;
+  thread_health: string;
+  thread_mode?: ThreadModeSchema | null;
+  thread_state?: ThreadStateSchema | null;
+  usage_summary?: unknown;
+  verification: RepositoryVerificationStateSchema;
+  verification_summary: unknown;
+  visibility: string;
+}
+
+export interface ThreadShowSchema2 {
+  actor?: ActorInfoSchema | null;
+  attach_reason?: string | null;
+  auto: boolean;
+  base_root?: string | null;
+  base_state?: string | null;
+  blockers: string[];
+  changed_paths: string[];
+  child_threads: string[];
+  confidence_summary: unknown;
+  coordination_status: CoordinationStatusSchema;
+  current_state?: string | null;
+  execution_path?: string | null;
+  freshness?: ThreadFreshnessSchema | null;
+  git_branch_tip?: string | null;
+  harness?: string | null;
+  heavy_impact_paths: string[];
+  heddle_session_id?: string | null;
+  history_imported: boolean;
+  impact_categories: ThreadImpactCategorySchema[];
+  integration_policy_result: unknown;
+  is_current: boolean;
+  is_isolated: boolean;
+  last_activity_at?: string | null;
+  last_progress_at?: string | null;
+  name: string;
+  native_actor_key?: string | null;
+  native_parent_actor_key?: string | null;
+  next_action?: string | null;
+  next_action_template?: ActionTemplateSchema | null;
+  operation?: unknown;
   output_kind: "thread_show";
   parent_thread?: string | null;
   path?: string | null;
@@ -3065,7 +3128,7 @@ export interface HeddleVerbOutputs {
   "session segment": SessionSegmentEnvelopeSchema;
   "session show": SessionShowSchema;
   "session start": SessionStartSchema;
-  show: ShowSchema;
+  show: ShowSchema2;
   stack: StackSchema;
   "stack ready": StackReadySchema;
   "stack snapshot": StackSnapshotSchema;
@@ -3096,7 +3159,7 @@ export interface HeddleVerbOutputs {
   "thread rename": ThreadRenameSchema;
   "thread resolve": ThreadResolveSchema;
   "thread revoke-approval": ThreadRevokeApprovalSchema;
-  "thread show": ThreadShowSchema;
+  "thread show": ThreadShowSchema2;
   "thread switch": ThreadSwitchSchema;
   "transaction abort": TransactionAbortSchema;
   "transaction begin": TransactionBeginSchema;

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1337,7 +1337,7 @@ export interface InitSchema {
   status: string;
 }
 
-export type InspectSchema = ShowSchema | ThreadShowSchema;
+export type InspectSchema = ShowSchema & { output_kind: "inspect_state"; } | ThreadShowSchema & { output_kind: "thread_show"; };
 
 export type IntegrationDoctorSchema = Record<string, unknown>;
 

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -375,7 +375,7 @@ export interface BranchCompatSchema {
   name?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread_list";
+  output_kind: "thread_create" | "thread_drop" | "thread_list" | "thread_rename";
   path?: string | null;
   recommended_action?: string | null;
   recovery_commands?: string[] | null;
@@ -625,7 +625,7 @@ export interface CloneSchema {
   objects?: number | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "clone";
+  output_kind: "clone" | "clone_connection";
   remote?: string | null;
   replayed?: boolean | null;
   repository_capability?: string | null;
@@ -2311,7 +2311,7 @@ export interface SwitchCheckoutSchema {
   name?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "thread_switch";
+  output_kind: "goto" | "thread_switch";
   path?: string | null;
   replayed?: boolean | null;
   target?: string | null;

--- a/crates/cli/src/cli/commands/advice.rs
+++ b/crates/cli/src/cli/commands/advice.rs
@@ -433,6 +433,7 @@ impl RecoveryAdvice {
         )
     }
 
+    #[cfg(not(feature = "client"))]
     pub(crate) fn network_feature_unavailable(operation: &str) -> Self {
         Self::safety_refusal(
             "network_feature_unavailable",

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -1933,15 +1933,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["inspect"],
         category(
             json_discriminators(
-                documented_schemas(READ_JSON, &["inspect"]),
+                documented_schemas(READ_JSON, &["inspect", "thread show"]),
                 &[
                     json_discriminator(Some("inspect"), "output_kind", "inspect_state"),
-                    json_discriminator_no_schema(
-                        "inspect without a state target aliases `thread show`; the \
-                         registered `inspect` schema mirrors the state-inspection path",
-                        "output_kind",
-                        "thread_show",
-                    ),
+                    json_discriminator(Some("thread show"), "output_kind", "thread_show"),
                 ],
             ),
             "states",
@@ -3690,6 +3685,21 @@ fn raw_command_contract_for_path<'a>(
         .iter()
         .find(|entry| entry.path == path.as_slice())
         .map(|entry| entry.contract)
+}
+
+#[cfg(test)]
+pub(crate) fn sibling_documented_schema_verbs(schema_verb: &str) -> Vec<&'static str> {
+    active_command_contract_entries()
+        .iter()
+        .filter(|entry| {
+            entry
+                .contract
+                .documented_schema_verbs
+                .contains(&schema_verb)
+        })
+        .flat_map(|entry| entry.contract.documented_schema_verbs.iter().copied())
+        .filter(|documented| *documented != schema_verb)
+        .collect()
 }
 
 fn active_command_contract_entries() -> &'static [&'static CommandContractEntry] {
@@ -6007,7 +6017,8 @@ mod tests {
             if schema.get("anyOf").is_some() {
                 expected_discriminators.extend(command_json_discriminators().into_iter().filter(
                     |discriminator| {
-                        discriminator.display == verb && discriminator.schema_verb.is_none()
+                        discriminator.display == verb
+                            && discriminator.schema_verb.as_deref() != Some(verb)
                     },
                 ));
             }
@@ -6068,7 +6079,7 @@ mod tests {
             "JSON discriminator table contains duplicate (path, value) pairs"
         );
 
-        let mut schema_verbs = BTreeSet::new();
+        let mut schema_verb_values = std::collections::BTreeMap::new();
         for (path, discriminator) in raw_discriminators {
             let display = path.join(" ");
             let contract = raw_command_contract_for_path(path.iter().copied())
@@ -6089,10 +6100,14 @@ mod tests {
             );
 
             if let Some(schema_verb) = discriminator.schema_verb {
-                assert!(
-                    schema_verbs.insert(schema_verb),
-                    "JSON discriminator schema verb `{schema_verb}` is registered more than once"
-                );
+                let schema_value = (discriminator.field, discriminator.value);
+                if let Some(previous) = schema_verb_values.insert(schema_verb, schema_value) {
+                    assert_eq!(
+                        previous, schema_value,
+                        "JSON discriminator schema verb `{schema_verb}` is registered with \
+                         conflicting discriminator values"
+                    );
+                }
                 assert!(
                     contract.schema_verbs.contains(&schema_verb),
                     "`{display}` advertises discriminator schema verb `{schema_verb}` not present in its command contract"

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -283,6 +283,7 @@ struct CommandContract {
     external_command: bool,
     requires_git_executable: bool,
     destructive_data: bool,
+    operator_envelope: bool,
     json_kind: &'static str,
     json_discriminators: &'static [CommandJsonDiscriminatorSpec],
     schema_verbs: &'static [&'static str],
@@ -696,6 +697,7 @@ const READ_JSON: CommandContract = CommandContract {
     external_command: false,
     requires_git_executable: false,
     destructive_data: false,
+    operator_envelope: false,
     json_kind: "json",
     json_discriminators: &[],
     schema_verbs: &[],
@@ -769,6 +771,13 @@ const CAPTURE: CommandContract = CommandContract { ..MUTATING };
 const fn compact_json(contract: CommandContract) -> CommandContract {
     CommandContract {
         supports_json_compact: true,
+        ..contract
+    }
+}
+
+const fn operator_envelope(contract: CommandContract) -> CommandContract {
+    CommandContract {
+        operator_envelope: true,
         ..contract
     }
 }
@@ -1037,7 +1046,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["abort"],
         category(
             json_discriminators(
-                documented_schemas(compact_json(MUTATING), &["abort"]),
+                documented_schemas(operator_envelope(compact_json(MUTATING)), &["abort"]),
                 &[json_discriminator(Some("abort"), "output_kind", "abort")],
             ),
             "recovery",
@@ -1584,7 +1593,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["continue"],
         category(
             json_discriminators(
-                documented_schemas(compact_json(MUTATING), &["continue"]),
+                documented_schemas(operator_envelope(compact_json(MUTATING)), &["continue"]),
                 &[json_discriminator(
                     Some("continue"),
                     "output_kind",
@@ -2682,7 +2691,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["sync"],
         category(
             json_discriminators(
-                documented_schemas(compact_json(MUTATING), &["sync"]),
+                documented_schemas(operator_envelope(compact_json(MUTATING)), &["sync"]),
                 &[json_discriminator(Some("sync"), "output_kind", "sync")],
             ),
             "threads",
@@ -3739,6 +3748,15 @@ pub fn command_json_discriminators() -> Vec<CommandJsonDiscriminator> {
                 .iter()
                 .map(move |discriminator| json_discriminator_metadata(entry.path, discriminator))
         })
+        .collect()
+}
+
+pub fn operator_envelope_verbs() -> Vec<String> {
+    active_command_contract_entries()
+        .iter()
+        .copied()
+        .filter(|entry| entry.contract.operator_envelope)
+        .map(|entry| entry.path.join(" "))
         .collect()
 }
 

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -3732,9 +3732,18 @@ pub fn command_json_discriminators() -> Vec<CommandJsonDiscriminator> {
         .collect()
 }
 
+#[cfg(test)]
 pub fn command_json_discriminator_for_schema_verb(
     schema_verb: &str,
 ) -> Option<CommandJsonDiscriminator> {
+    command_json_discriminators_for_schema_verb(schema_verb)
+        .into_iter()
+        .next()
+}
+
+pub fn command_json_discriminators_for_schema_verb(
+    schema_verb: &str,
+) -> Vec<CommandJsonDiscriminator> {
     active_command_contract_entries()
         .iter()
         .copied()
@@ -3745,8 +3754,9 @@ pub fn command_json_discriminator_for_schema_verb(
                 .iter()
                 .map(move |discriminator| (entry.path, discriminator))
         })
-        .find(|(_, discriminator)| discriminator.schema_verb == Some(schema_verb))
+        .filter(|(_, discriminator)| discriminator.schema_verb == Some(schema_verb))
         .map(|(path, discriminator)| json_discriminator_metadata(path, discriminator))
+        .collect()
 }
 
 fn json_discriminators_for_path<'a>(
@@ -5904,6 +5914,62 @@ mod tests {
     #[test]
     fn schema_output_kind_discriminators_are_complete_and_consistent() {
         use crate::cli::commands::schema_for_verb;
+        use std::collections::BTreeSet;
+
+        fn resolve_schema_ref<'a>(
+            root: &'a serde_json::Value,
+            reference: &str,
+        ) -> &'a serde_json::Value {
+            reference
+                .strip_prefix("#/$defs/")
+                .or_else(|| reference.strip_prefix("#/definitions/"))
+                .and_then(|name| {
+                    root.get("$defs")
+                        .or_else(|| root.get("definitions"))
+                        .and_then(|defs| defs.get(name))
+                })
+                .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"))
+        }
+
+        fn collect_output_kind_values<'a>(
+            root: &'a serde_json::Value,
+            schema: &'a serde_json::Value,
+            values: &mut BTreeSet<String>,
+        ) {
+            if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
+                collect_output_kind_values(root, resolve_schema_ref(root, reference), values);
+                return;
+            }
+
+            if let Some(enum_values) = schema
+                .get("properties")
+                .and_then(|properties| properties.get("output_kind"))
+                .and_then(|property| property.get("enum"))
+                .and_then(|values| values.as_array())
+            {
+                values.extend(
+                    enum_values
+                        .iter()
+                        .filter_map(|value| value.as_str())
+                        .map(str::to_string),
+                );
+            } else if let Some(value) = schema
+                .get("properties")
+                .and_then(|properties| properties.get("output_kind"))
+                .and_then(|property| property.get("const"))
+                .and_then(|value| value.as_str())
+            {
+                values.insert(value.to_string());
+            }
+
+            for combinator in ["anyOf", "oneOf", "allOf"] {
+                if let Some(schemas) = schema.get(combinator).and_then(|value| value.as_array()) {
+                    for schema in schemas {
+                        collect_output_kind_values(root, schema, values);
+                    }
+                }
+            }
+        }
 
         let mut missing = Vec::new();
         let mut mismatched = Vec::new();
@@ -5913,10 +5979,9 @@ mod tests {
             let Some(schema) = schema_for_verb(verb) else {
                 panic!("catalog schema verb `{verb}` has no registered schema");
             };
-            let Some(property) = schema
-                .get("properties")
-                .and_then(|properties| properties.get("output_kind"))
-            else {
+            let mut actual = BTreeSet::new();
+            collect_output_kind_values(&schema, &schema, &mut actual);
+            if actual.is_empty() {
                 // The schema does not declare `output_kind` — the verb's
                 // runtime payload genuinely lacks the discriminator (the
                 // UNSWEPT_TODO rolldown in output_kind_invariant.rs).
@@ -5924,32 +5989,31 @@ mod tests {
             };
             checked += 1;
 
-            let Some(discriminator) = command_json_discriminator_for_schema_verb(verb) else {
+            let mut expected_discriminators = command_json_discriminators_for_schema_verb(verb);
+            if schema.get("anyOf").is_some() {
+                expected_discriminators.extend(command_json_discriminators().into_iter().filter(
+                    |discriminator| {
+                        discriminator.display == verb && discriminator.schema_verb.is_none()
+                    },
+                ));
+            }
+            let expected = expected_discriminators
+                .into_iter()
+                .filter(|discriminator| discriminator.field == "output_kind")
+                .map(|discriminator| discriminator.value)
+                .collect::<BTreeSet<_>>();
+            if expected.is_empty() {
                 missing.push(format!(
                     "`{verb}`: schema declares an `output_kind` property but the \
                      catalog advertises no json_discriminator for it"
                 ));
                 continue;
-            };
+            }
 
-            let const_value = property
-                .get("enum")
-                .and_then(|values| values.as_array())
-                .and_then(|values| values.first())
-                .and_then(|value| value.as_str())
-                .or_else(|| property.get("const").and_then(|value| value.as_str()));
-            match const_value {
-                None => missing.push(format!(
-                    "`{verb}`: schema declares `output_kind` without an enum/const \
-                     even though the catalog advertises `{}` — the discriminator \
-                     injection regressed",
-                    discriminator.value
-                )),
-                Some(value) if value != discriminator.value => mismatched.push(format!(
-                    "`{verb}`: schema const `{value}` != catalog discriminator `{}`",
-                    discriminator.value
-                )),
-                Some(_) => {}
+            if actual != expected {
+                mismatched.push(format!(
+                    "`{verb}`: schema output_kind values {actual:?} != catalog discriminators {expected:?}"
+                ));
             }
         }
 

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -11,11 +11,10 @@ use serde::Serialize;
 #[cfg(feature = "semantic")]
 use crate::cli::SemanticCommands;
 use crate::cli::{
-    ActorCommands, AgentCommands, Cli, Commands, ContextCommands, DaemonCommands,
-    DoctorCommands, HookCommands, IntegrationCommands, MaintenanceCommands, MarkerCommands,
-    PurgeCommands, RedactCommands, RedactTrustCommands, RemoteCommands, SessionCommands,
-    ShellCommands, StackCommands, StashCommands, ThreadCommands, VisibilityCommands,
-    WorkspaceCommands,
+    ActorCommands, AgentCommands, Cli, Commands, ContextCommands, DaemonCommands, DoctorCommands,
+    HookCommands, IntegrationCommands, MaintenanceCommands, MarkerCommands, PurgeCommands,
+    RedactCommands, RedactTrustCommands, RemoteCommands, SessionCommands, ShellCommands,
+    StackCommands, StashCommands, ThreadCommands, VisibilityCommands, WorkspaceCommands,
     cli_args::{
         CommandCatalogArgs, ConflictCommands, DiscussCommands, ReviewCommands, TransactionCommands,
     },
@@ -1086,7 +1085,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(DAEMON_MUTATION, &["agent serve"]),
-                &[json_discriminator(Some("agent serve"), "output_kind", "agent_serve")],
+                &[json_discriminator(
+                    Some("agent serve"),
+                    "output_kind",
+                    "agent_serve",
+                )],
             ),
             "automation",
         ),
@@ -1096,7 +1099,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(READ_JSON, &["agent status"]),
-                &[json_discriminator(Some("agent status"), "output_kind", "agent_status")],
+                &[json_discriminator(
+                    Some("agent status"),
+                    "output_kind",
+                    "agent_status",
+                )],
             ),
             "automation",
         ),
@@ -1106,7 +1113,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(DAEMON_MUTATION, &["agent stop"]),
-                &[json_discriminator(Some("agent stop"), "output_kind", "agent_stop")],
+                &[json_discriminator(
+                    Some("agent stop"),
+                    "output_kind",
+                    "agent_stop",
+                )],
             ),
             "automation",
         ),
@@ -1130,7 +1141,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(CAPTURE, &["agent capture"]),
-                &[json_discriminator(Some("agent capture"), "output_kind", "capture")],
+                &[json_discriminator(
+                    Some("agent capture"),
+                    "output_kind",
+                    "capture",
+                )],
             ),
             "automation",
         ),
@@ -1140,7 +1155,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(CAPTURE, &["agent ready"]),
-                &[json_discriminator(Some("agent ready"), "output_kind", "ready")],
+                &[json_discriminator(
+                    Some("agent ready"),
+                    "output_kind",
+                    "ready",
+                )],
             ),
             "automation",
         ),
@@ -1164,13 +1183,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         ),
     ),
     #[cfg(feature = "client")]
-    entry(
-        &["auth"],
-        category(
-            GROUP,
-            "repo",
-        ),
-    ),
+    entry(&["auth"], category(GROUP, "repo")),
     #[cfg(feature = "client")]
     entry(&["auth", "login"], MUTATING_TEXT),
     #[cfg(feature = "client")]
@@ -1210,6 +1223,18 @@ const CONTRACTS: &[CommandContractEntry] = &[
                          listing shape",
                         "output_kind",
                         "thread_create",
+                    ),
+                    json_discriminator_no_schema(
+                        "branch -m delegates to `thread rename`; the registered \
+                         `branch` schema mirrors only the no-arg listing shape",
+                        "output_kind",
+                        "thread_rename",
+                    ),
+                    json_discriminator_no_schema(
+                        "branch -d delegates to `thread drop`; the registered \
+                         `branch` schema mirrors only the no-arg listing shape",
+                        "output_kind",
+                        "thread_drop",
                     ),
                 ],
             ),
@@ -1332,7 +1357,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     },
                     &["bridge git push"],
                 ),
-                &[json_discriminator(Some("bridge git push"), "output_kind", "bridge_git_push")],
+                &[json_discriminator(
+                    Some("bridge git push"),
+                    "output_kind",
+                    "bridge_git_push",
+                )],
             ),
             "push",
         ),
@@ -1349,7 +1378,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     },
                     &["bridge git pull"],
                 ),
-                &[json_discriminator(Some("bridge git pull"), "output_kind", "bridge_git_pull")],
+                &[json_discriminator(
+                    Some("bridge git pull"),
+                    "output_kind",
+                    "bridge_git_pull",
+                )],
             ),
             "pull",
         ),
@@ -1480,10 +1513,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["collapse"],
-        category(
-            opaque_schemas(MUTATING, &["collapse"]),
-            "states",
-        ),
+        category(opaque_schemas(MUTATING, &["collapse"]), "states"),
     ),
     entry(
         &["commit"],
@@ -1529,13 +1559,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(
-        &["conflict"],
-        category(
-            GROUP,
-            "recovery",
-        ),
-    ),
+    entry(&["conflict"], category(GROUP, "recovery")),
     entry(
         &["conflict", "list"],
         opaque_schemas(READ_JSON, &["conflict list"]),
@@ -1549,18 +1573,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
         category(
             json_discriminators(
                 documented_schemas(compact_json(MUTATING), &["continue"]),
-                &[json_discriminator(Some("continue"), "output_kind", "continue")],
+                &[json_discriminator(
+                    Some("continue"),
+                    "output_kind",
+                    "continue",
+                )],
             ),
             "recovery",
         ),
     ),
-    entry(
-        &["context"],
-        category(
-            GROUP,
-            "collab",
-        ),
-    ),
+    entry(&["context"], category(GROUP, "collab")),
     entry(
         &["context", "set"],
         json_discriminators(
@@ -1711,13 +1733,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             20,
         ),
     ),
-    entry(
-        &["discuss"],
-        category(
-            GROUP,
-            "collab",
-        ),
-    ),
+    entry(&["discuss"], category(GROUP, "collab")),
     entry(
         &["discuss", "open"],
         json_discriminators(
@@ -1778,7 +1794,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         front_door(
             json_discriminators(
                 documented_schemas(READ_JSON, &["doctor"]),
-                &[json_discriminator(Some("doctor"), "output_kind", "diagnose")],
+                &[json_discriminator(
+                    Some("doctor"),
+                    "output_kind",
+                    "diagnose",
+                )],
             ),
             120,
         ),
@@ -1836,17 +1856,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["fsck"],
-        category(
-            documented_schemas(MUTATING, &["fsck"]),
-            "recovery",
-        ),
+        category(documented_schemas(MUTATING, &["fsck"]), "recovery"),
     ),
     entry(
         &["git-overlay"],
-        category(
-            documented_schemas(READ_JSON, &["git-overlay"]),
-            "repo",
-        ),
+        category(documented_schemas(READ_JSON, &["git-overlay"]), "repo"),
     ),
     entry(
         &["goto"],
@@ -1862,13 +1876,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["harness-bridge"],
         hidden(opaque_schemas(READ_JSONL, &["harness-bridge"])),
     ),
-    entry(
-        &["help"],
-        category(
-            READ_TEXT,
-            "repo",
-        ),
-    ),
+    entry(&["help"], category(READ_TEXT, "repo")),
     entry(&["hook"], surface(GROUP, "automation")),
     entry(
         &["hook", "list"],
@@ -1911,10 +1919,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["inspect"],
-        category(
-            documented_schemas(READ_JSON, &["inspect"]),
-            "states",
-        ),
+        category(documented_schemas(READ_JSON, &["inspect"]), "states"),
     ),
     entry(&["integration"], surface(GROUP, "admin")),
     entry(
@@ -1974,7 +1979,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 opaque_schemas(GC_MUTATION, &["maintenance gc"]),
-                &[json_discriminator(Some("maintenance gc"), "output_kind", "gc")],
+                &[json_discriminator(
+                    Some("maintenance gc"),
+                    "output_kind",
+                    "gc",
+                )],
             ),
             "admin",
         ),
@@ -1984,7 +1993,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         surface(
             json_discriminators(
                 documented_schemas(READ_JSON, &["maintenance index"]),
-                &[json_discriminator(Some("maintenance index"), "output_kind", "index")],
+                &[json_discriminator(
+                    Some("maintenance index"),
+                    "output_kind",
+                    "index",
+                )],
             ),
             "admin",
         ),
@@ -1993,13 +2006,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["maintenance", "monitor"],
         surface(opaque_schemas(READ_JSON, &["maintenance monitor"]), "admin"),
     ),
-    entry(
-        &["marker"],
-        category(
-            GROUP,
-            "collab",
-        ),
-    ),
+    entry(&["marker"], category(GROUP, "collab")),
     entry(
         &["marker", "list"],
         documented_schemas(READ_JSON, &["marker list"]),
@@ -2023,8 +2030,15 @@ const CONTRACTS: &[CommandContractEntry] = &[
                 surface(
                     advertised_action(
                         json_discriminators(
-                            documented_schemas(compact_json(WORKTREE_MUTATION), &["merge --preview"]),
-                            &[json_discriminator(Some("merge --preview"), "output_kind", "merge")],
+                            documented_schemas(
+                                compact_json(WORKTREE_MUTATION),
+                                &["merge --preview"],
+                            ),
+                            &[json_discriminator(
+                                Some("merge --preview"),
+                                "output_kind",
+                                "merge",
+                            )],
                         ),
                         "heddle merge <thread> --preview",
                         &["heddle", "merge", "<thread>", "--preview"],
@@ -2077,10 +2091,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["presence"],
-        category(
-            feature_gated(READ_JSON, "client"),
-            "collab",
-        ),
+        category(feature_gated(READ_JSON, "client"), "collab"),
     ),
     entry(&["presence", "publish"], feature_gated(READ_JSON, "client")),
     entry(
@@ -2108,13 +2119,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(
-        &["purge"],
-        category(
-            GROUP,
-            "recovery",
-        ),
-    ),
+    entry(&["purge"], category(GROUP, "recovery")),
     entry(
         &["purge", "apply"],
         json_discriminators(
@@ -2200,18 +2205,9 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["rebase"],
-        category(
-            opaque_schemas(WORKTREE_MUTATION, &["rebase"]),
-            "threads",
-        ),
+        category(opaque_schemas(WORKTREE_MUTATION, &["rebase"]), "threads"),
     ),
-    entry(
-        &["redact"],
-        category(
-            GROUP,
-            "recovery",
-        ),
-    ),
+    entry(&["redact"], category(GROUP, "recovery")),
     entry(
         &["redact", "apply"],
         json_discriminators(
@@ -2293,46 +2289,60 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "recovery",
         ),
     ),
-    entry(
-        &["remote"],
-        category(
-            surface(GROUP, "native"),
-            "repo",
-        ),
-    ),
+    entry(&["remote"], category(surface(GROUP, "native"), "repo")),
     entry(
         &["remote", "list"],
         json_discriminators(
             documented_schemas(READ_JSON, &["remote list"]),
-            &[json_discriminator(Some("remote list"), "output_kind", "remote_list")],
+            &[json_discriminator(
+                Some("remote list"),
+                "output_kind",
+                "remote_list",
+            )],
         ),
     ),
     entry(
         &["remote", "add"],
         json_discriminators(
             documented_schemas(CONFIG_MUTATION, &["remote add"]),
-            &[json_discriminator(Some("remote add"), "output_kind", "remote_add")],
+            &[json_discriminator(
+                Some("remote add"),
+                "output_kind",
+                "remote_add",
+            )],
         ),
     ),
     entry(
         &["remote", "remove"],
         json_discriminators(
             documented_schemas(CONFIG_MUTATION, &["remote remove"]),
-            &[json_discriminator(Some("remote remove"), "output_kind", "remote_remove")],
+            &[json_discriminator(
+                Some("remote remove"),
+                "output_kind",
+                "remote_remove",
+            )],
         ),
     ),
     entry(
         &["remote", "set-default"],
         json_discriminators(
             documented_schemas(CONFIG_MUTATION, &["remote set-default"]),
-            &[json_discriminator(Some("remote set-default"), "output_kind", "remote_set_default")],
+            &[json_discriminator(
+                Some("remote set-default"),
+                "output_kind",
+                "remote_set_default",
+            )],
         ),
     ),
     entry(
         &["remote", "show"],
         json_discriminators(
             documented_schemas(READ_JSON, &["remote show"]),
-            &[json_discriminator(Some("remote show"), "output_kind", "remote_show")],
+            &[json_discriminator(
+                Some("remote show"),
+                "output_kind",
+                "remote_show",
+            )],
         ),
     ),
     entry(
@@ -2341,10 +2351,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["retro"],
-        category(
-            documented_schemas(READ_JSON, &["retro"]),
-            "states",
-        ),
+        category(documented_schemas(READ_JSON, &["retro"]), "states"),
     ),
     entry(
         &["revert"],
@@ -2356,13 +2363,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "states",
         ),
     ),
-    entry(
-        &["review"],
-        category(
-            GROUP,
-            "collab",
-        ),
-    ),
+    entry(&["review"], category(GROUP, "collab")),
     entry(
         &["review", "show"],
         json_discriminators(
@@ -2422,13 +2423,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(
-        &["semantic"],
-        category(
-            GROUP,
-            "states",
-        ),
-    ),
+    entry(&["semantic"], category(GROUP, "states")),
     entry(
         &["semantic", "hot"],
         opaque_schemas(READ_JSON, &["semantic hot"]),
@@ -2466,13 +2461,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(
-        &["shell"],
-        category(
-            READ_TEXT,
-            "repo",
-        ),
-    ),
+    entry(&["shell"], category(READ_TEXT, "repo")),
     entry(&["shell", "init"], READ_TEXT),
     entry(&["shell", "completion"], READ_TEXT),
     entry(
@@ -2615,10 +2604,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["support"],
-        category(
-            feature_gated(MUTATING, "client"),
-            "repo",
-        ),
+        category(feature_gated(MUTATING, "client"), "repo"),
     ),
     entry(
         &["support", "grant"],
@@ -2665,18 +2651,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "threads",
         ),
     ),
-    entry(
-        &["thread"],
-        category(
-            surface(GROUP, "native"),
-            "threads",
-        ),
-    ),
+    entry(&["thread"], category(surface(GROUP, "native"), "threads")),
     entry(
         &["thread", "create"],
         json_discriminators(
             documented_schemas(MUTATING, &["thread create"]),
-            &[json_discriminator(Some("thread create"), "output_kind", "thread_create")],
+            &[json_discriminator(
+                Some("thread create"),
+                "output_kind",
+                "thread_create",
+            )],
         ),
     ),
     entry(
@@ -2687,7 +2671,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["thread", "switch"],
         json_discriminators(
             documented_schemas(WORKTREE_MUTATION, &["thread switch"]),
-            &[json_discriminator(Some("thread switch"), "output_kind", "thread_switch")],
+            &[json_discriminator(
+                Some("thread switch"),
+                "output_kind",
+                "thread_switch",
+            )],
         ),
     ),
     entry(&["thread", "cd"], READ_TEXT),
@@ -2721,14 +2709,22 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["thread", "rename"],
         json_discriminators(
             documented_schemas(MUTATING, &["thread rename"]),
-            &[json_discriminator(Some("thread rename"), "output_kind", "thread_rename")],
+            &[json_discriminator(
+                Some("thread rename"),
+                "output_kind",
+                "thread_rename",
+            )],
         ),
     ),
     entry(
         &["thread", "refresh"],
         json_discriminators(
             documented_schemas(WORKTREE_MUTATION, &["thread refresh"]),
-            &[json_discriminator(Some("thread refresh"), "output_kind", "thread")],
+            &[json_discriminator(
+                Some("thread refresh"),
+                "output_kind",
+                "thread_refresh",
+            )],
         ),
     ),
     entry(
@@ -2743,21 +2739,33 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["thread", "resolve"],
         json_discriminators(
             documented_schemas(MUTATING, &["thread resolve"]),
-            &[json_discriminator(Some("thread resolve"), "output_kind", "resolve")],
+            &[json_discriminator(
+                Some("thread resolve"),
+                "output_kind",
+                "thread_resolve",
+            )],
         ),
     ),
     entry(
         &["thread", "promote"],
         json_discriminators(
             documented_schemas(WORKTREE_MUTATION, &["thread promote"]),
-            &[json_discriminator(Some("thread promote"), "output_kind", "thread")],
+            &[json_discriminator(
+                Some("thread promote"),
+                "output_kind",
+                "thread_promote",
+            )],
         ),
     ),
     entry(
         &["thread", "drop"],
         json_discriminators(
             documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread drop"]),
-            &[json_discriminator(Some("thread drop"), "output_kind", "thread")],
+            &[json_discriminator(
+                Some("thread drop"),
+                "output_kind",
+                "thread_drop",
+            )],
         ),
     ),
     entry(
@@ -2787,7 +2795,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["thread", "cleanup"],
         json_discriminators(
             documented_schemas(DESTRUCTIVE_WORKTREE_MUTATION, &["thread cleanup"]),
-            &[json_discriminator(Some("thread cleanup"), "output_kind", "thread.cleanup")],
+            &[json_discriminator(
+                Some("thread cleanup"),
+                "output_kind",
+                "thread_cleanup",
+            )],
         ),
     ),
     entry(&["transaction"], hidden(GROUP)),
@@ -2824,13 +2836,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(
-        &["visibility"],
-        category(
-            GROUP,
-            "collab",
-        ),
-    ),
+    entry(&["visibility"], category(GROUP, "collab")),
     entry(
         &["visibility", "set"],
         json_discriminators(
@@ -2999,8 +3005,7 @@ fn apply_command_catalog_filters(output: &mut CommandCatalogOutput, args: &Comma
             || command_filters
                 .iter()
                 .any(|filter| command_matches_filter(command, filter)))
-            && (tier_filters.is_empty()
-                || tier_filters.contains(&command.tier.as_str()))
+            && (tier_filters.is_empty() || tier_filters.contains(&command.tier.as_str()))
             && (!args.mutating || command.mutates)
             && (!args.supports_op_id || command.supports_op_id)
     });
@@ -3125,9 +3130,10 @@ fn catalog_entry(
 
     let contract = command_contract(path);
     if contract.supports_op_id
-        && let Some(op_id_option) = op_id_option {
-            options.push(op_id_option.clone());
-        }
+        && let Some(op_id_option) = op_id_option
+    {
+        options.push(op_id_option.clone());
+    }
     CommandCatalogEntry {
         path: path.to_vec(),
         display: path.join(" "),
@@ -5402,8 +5408,7 @@ mod tests {
                 .unwrap_or_else(|err| panic!("failed to parse sample {argv:?}: {err}"));
             let runtime = command_runtime_contract_for_command(&cli.command);
             assert!(
-                runtime.supports_json_compact
-                    || !expected_compact.contains(&runtime.display),
+                runtime.supports_json_compact || !expected_compact.contains(&runtime.display),
                 "`{}` accepts json-compact at parse time but lacks an explicit compact projection; main must reject it before command execution",
                 runtime.display
             );
@@ -5722,6 +5727,8 @@ mod tests {
                 "agent capture",
                 "agent ready",
                 "blame",
+                "branch",
+                "branch",
                 "branch",
                 "branch",
                 "bridge git status",

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -779,6 +779,11 @@ const WORKTREE_MUTATION: CommandContract = CommandContract {
     ..MUTATING
 };
 
+const WORKTREE_MUTATION_JSONL: CommandContract = CommandContract {
+    json_kind: "jsonl",
+    ..WORKTREE_MUTATION
+};
+
 const WORKTREE_ONLY_MUTATION: CommandContract = CommandContract {
     may_move_ref: false,
     writes_heddle_refs: false,
@@ -1566,7 +1571,14 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["conflict", "show"],
-        opaque_schemas(READ_JSON, &["conflict show"]),
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["conflict show"]),
+            &[json_discriminator(
+                Some("conflict show"),
+                "output_kind",
+                "conflict_show",
+            )],
+        ),
     ),
     entry(
         &["continue"],
@@ -1919,7 +1931,21 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["inspect"],
-        category(documented_schemas(READ_JSON, &["inspect"]), "states"),
+        category(
+            json_discriminators(
+                documented_schemas(READ_JSON, &["inspect"]),
+                &[
+                    json_discriminator(Some("inspect"), "output_kind", "inspect_state"),
+                    json_discriminator_no_schema(
+                        "inspect without a state target aliases `thread show`; the \
+                         registered `inspect` schema mirrors the state-inspection path",
+                        "output_kind",
+                        "thread_show",
+                    ),
+                ],
+            ),
+            "states",
+        ),
     ),
     entry(&["integration"], surface(GROUP, "admin")),
     entry(
@@ -2205,7 +2231,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["rebase"],
-        category(opaque_schemas(WORKTREE_MUTATION, &["rebase"]), "threads"),
+        category(
+            json_discriminators(
+                opaque_schemas(WORKTREE_MUTATION_JSONL, &["rebase"]),
+                &[json_discriminator(
+                    Some("rebase"),
+                    "output_kind",
+                    "rebase_progress",
+                )],
+            ),
+            "threads",
+        ),
     ),
     entry(&["redact"], category(GROUP, "recovery")),
     entry(
@@ -2483,7 +2519,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["show"],
-        front_door(documented_schemas(READ_JSON, &["show"]), 140),
+        front_door(
+            json_discriminators(
+                documented_schemas(READ_JSON, &["show"]),
+                &[json_discriminator(Some("show"), "output_kind", "show")],
+            ),
+            140,
+        ),
     ),
     entry(
         &["start"],
@@ -5672,6 +5714,7 @@ mod tests {
         let catalog = build_command_catalog();
         for (display, kind) in [
             ("watch", "jsonl"),
+            ("rebase", "jsonl"),
             ("status", "json_or_jsonl"),
             ("thread show", "json_or_jsonl"),
             ("workspace show", "json_or_jsonl"),
@@ -5746,6 +5789,7 @@ mod tests {
                 "clone",
                 "commit",
                 "commands",
+                "conflict show",
                 "continue",
                 "context set",
                 "context get",
@@ -5771,6 +5815,8 @@ mod tests {
                 "fork",
                 "goto",
                 "init",
+                "inspect",
+                "inspect",
                 // `log` appears twice: the entry advertises both `log` and the
                 // `log --reflog` variant (`log_reflog`), mirroring `undo`/`clone`.
                 "log",
@@ -5787,6 +5833,7 @@ mod tests {
                 "push",
                 "query",
                 "ready",
+                "rebase",
                 "redact apply",
                 "redact list",
                 "redact show",
@@ -5806,6 +5853,7 @@ mod tests {
                 "review health",
                 "schemas",
                 "land",
+                "show",
                 "start",
                 "stash list",
                 "stash show",

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -3747,15 +3747,29 @@ pub fn command_json_discriminators_for_schema_verb(
     active_command_contract_entries()
         .iter()
         .copied()
-        .flat_map(|entry| {
+        .filter(|entry| {
             entry
                 .contract
                 .json_discriminators
                 .iter()
-                .map(move |discriminator| (entry.path, discriminator))
+                .any(|discriminator| discriminator.schema_verb == Some(schema_verb))
         })
-        .filter(|(_, discriminator)| discriminator.schema_verb == Some(schema_verb))
-        .map(|(path, discriminator)| json_discriminator_metadata(path, discriminator))
+        .flat_map(|entry| {
+            let include_same_command_siblings = entry.contract.schema_verbs.len() == 1
+                && entry.contract.schema_verbs[0] == schema_verb;
+            entry.contract.json_discriminators.iter().filter_map(
+                move |discriminator| {
+                    if discriminator.schema_verb == Some(schema_verb)
+                        || (include_same_command_siblings
+                            && discriminator.schema_verb.is_none())
+                    {
+                        Some(json_discriminator_metadata(entry.path, discriminator))
+                    } else {
+                        None
+                    }
+                },
+            )
+        })
         .collect()
 }
 

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -56,6 +56,14 @@ struct ActiveMergeConflictShowOutput {
     next_action_template: Option<ActionTemplate>,
 }
 
+#[derive(Serialize)]
+struct StructuredConflictShowOutput<'a> {
+    output_kind: &'static str,
+    kind: &'static str,
+    #[serde(flatten)]
+    conflict: &'a ConflictSymbol,
+}
+
 pub async fn run(cli: &Cli, command: &ConflictCommands) -> Result<()> {
     match command {
         ConflictCommands::List => run_list(cli).await,
@@ -156,9 +164,14 @@ fn render_structured_conflict(
     conflict: &ConflictSymbol,
 ) -> Result<()> {
     if should_output_json(cli, Some(repo.config())) {
+        let view = StructuredConflictShowOutput {
+            output_kind: "conflict_show",
+            kind: "stored_structured_conflict",
+            conflict,
+        };
         println!(
             "{}",
-            serde_json::to_string(conflict).context("serialize conflict")?
+            serde_json::to_string(&view).context("serialize conflict")?
         );
     } else {
         println!("conflict {}", conflict.id);

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -10,7 +10,7 @@
 use objects::store::ObjectStore;
 use std::fs;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use objects::object::{ConflictSymbol, StructuredConflict};
 use repo::{MergeState, Repository};
 use serde::Serialize;
@@ -145,18 +145,9 @@ async fn run_show(cli: &Cli, args: &ConflictShowArgs) -> Result<()> {
         .iter()
         .find(|c| c.id == args.conflict_id);
     let Some(conflict) = conflict else {
-        render_conflict_not_found(cli, &repo, &args.conflict_id);
-        return Ok(());
+        return Err(anyhow!(conflict_not_found_advice(&args.conflict_id)));
     };
     render_structured_conflict(cli, &repo, conflict)
-}
-
-fn render_conflict_not_found(cli: &Cli, repo: &Repository, conflict_id: &str) {
-    if should_output_json(cli, Some(repo.config())) {
-        println!("null");
-    } else {
-        println!("conflict {conflict_id} not found");
-    }
 }
 
 fn render_structured_conflict(
@@ -199,8 +190,7 @@ fn render_active_merge_conflict(
         .iter()
         .find(|path| path.as_str() == args.conflict_id)
     else {
-        render_conflict_not_found(cli, repo, &args.conflict_id);
-        return Ok(());
+        return Err(anyhow!(conflict_not_found_advice(&args.conflict_id)));
     };
     let resolved = merge_state.resolved.iter().any(|resolved| resolved == path);
     let worktree_content = fs::read_to_string(repo.root().join(path)).ok();
@@ -251,6 +241,19 @@ fn render_active_merge_conflict(
         println!("  next: {}", view.next_action);
     }
     Ok(())
+}
+
+fn conflict_not_found_advice(conflict_id: &str) -> crate::cli::commands::RecoveryAdvice {
+    crate::cli::commands::RecoveryAdvice::safety_refusal(
+        "conflict_not_found",
+        format!("Conflict '{conflict_id}' not found"),
+        "Run `heddle conflict list` to inspect available conflicts, then retry with an id from the list.",
+        format!("conflict show was requested for missing conflict id '{conflict_id}'"),
+        "showing a nonexistent conflict would give automation an ambiguous empty payload",
+        "no conflict state, refs, or worktree files were changed",
+        "heddle conflict list",
+        vec!["heddle conflict list".to_string()],
+    )
 }
 
 fn load_head_conflicts(repo: &Repository) -> Result<StructuredConflict> {

--- a/crates/cli/src/cli/commands/conflict.rs
+++ b/crates/cli/src/cli/commands/conflict.rs
@@ -20,9 +20,11 @@ use crate::cli::{
     commands::{
         command_catalog::{ActionTemplate, recommended_action_template},
         git_overlay_health::serialize_empty_action_as_null,
+        print_error_with_hint_with_config,
     },
     should_output_json,
 };
+use crate::exit::HeddleExitCode;
 
 #[derive(Serialize)]
 struct ConflictListOutput {
@@ -153,7 +155,7 @@ async fn run_show(cli: &Cli, args: &ConflictShowArgs) -> Result<()> {
         .iter()
         .find(|c| c.id == args.conflict_id);
     let Some(conflict) = conflict else {
-        return Err(anyhow!(conflict_not_found_advice(&args.conflict_id)));
+        render_conflict_not_found(cli, &repo, &args.conflict_id);
     };
     render_structured_conflict(cli, &repo, conflict)
 }
@@ -203,7 +205,7 @@ fn render_active_merge_conflict(
         .iter()
         .find(|path| path.as_str() == args.conflict_id)
     else {
-        return Err(anyhow!(conflict_not_found_advice(&args.conflict_id)));
+        render_conflict_not_found(cli, repo, &args.conflict_id);
     };
     let resolved = merge_state.resolved.iter().any(|resolved| resolved == path);
     let worktree_content = fs::read_to_string(repo.root().join(path)).ok();
@@ -254,6 +256,13 @@ fn render_active_merge_conflict(
         println!("  next: {}", view.next_action);
     }
     Ok(())
+}
+
+fn render_conflict_not_found(cli: &Cli, repo: &Repository, conflict_id: &str) -> ! {
+    let err = anyhow!(conflict_not_found_advice(conflict_id));
+    let code = HeddleExitCode::from_error(&err);
+    print_error_with_hint_with_config(cli, &err, repo.config());
+    std::process::exit(code.into());
 }
 
 fn conflict_not_found_advice(conflict_id: &str) -> crate::cli::commands::RecoveryAdvice {

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -2,6 +2,7 @@
 //! Shared stderr error envelopes for CLI failures.
 
 use clap::error::Error as ClapError;
+use repo::Config;
 
 use super::{
     RecoveryAdvice,
@@ -21,12 +22,20 @@ use crate::{
 /// parse it cleanly. The envelope is a stderr-only contract — the stdout schemas in
 /// `crates/cli/src/cli/commands/schemas.rs` are untouched.
 pub fn print_error_with_hint(cli: &Cli, err: &anyhow::Error) {
+    print_error_with_hint_inner(cli, err, None);
+}
+
+pub fn print_error_with_hint_with_config(cli: &Cli, err: &anyhow::Error, config: &Config) {
+    print_error_with_hint_inner(cli, err, Some(config));
+}
+
+fn print_error_with_hint_inner(cli: &Cli, err: &anyhow::Error, config: Option<&Config>) {
     let verb_help = verb_specific_help_command(cli);
     let classification = classify_error_with_verb(err, verb_help.as_deref());
     let hint = classification.hint.clone();
     let kind = classification.kind.clone();
     let error = display_error_message(err, &kind);
-    let json = should_output_json(cli, None);
+    let json = should_output_json(cli, config);
     if json {
         let envelope_error = classification
             .human_error
@@ -342,10 +351,7 @@ fn classify_error(err: &anyhow::Error) -> ErrorClassification {
     classify_error_with_verb(err, None)
 }
 
-fn classify_error_with_verb(
-    err: &anyhow::Error,
-    verb_help: Option<&str>,
-) -> ErrorClassification {
+fn classify_error_with_verb(err: &anyhow::Error, verb_help: Option<&str>) -> ErrorClassification {
     let mut classification = classify_error_inner(err);
     if classification.kind == "runtime_error"
         && let Some(help) = verb_help
@@ -376,9 +382,10 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
             };
         }
         if let Some(git_error) = cause.downcast_ref::<crate::bridge::git_core::GitBridgeError>()
-            && let Some(advice) = RecoveryAdvice::from_git_bridge_error(git_error) {
-                return ErrorClassification::from_advice(&advice);
-            }
+            && let Some(advice) = RecoveryAdvice::from_git_bridge_error(git_error)
+        {
+            return ErrorClassification::from_advice(&advice);
+        }
         if let Some(heddle_err) = cause.downcast_ref::<HeddleError>() {
             // `output.format = "auto"` is rejected at config-parse time by
             // the hand-rolled `OutputFormat` deserializer (see
@@ -425,9 +432,9 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
                 // internals — `heddle status` is the natural recovery probe
                 // and would otherwise dead-end on the same opaque error.
                 HeddleError::Serialization(detail) => {
-                    return ErrorClassification::from_advice(
-                        &RecoveryAdvice::serialization_error(detail),
-                    );
+                    return ErrorClassification::from_advice(&RecoveryAdvice::serialization_error(
+                        detail,
+                    ));
                 }
                 HeddleError::RepositoryNotFound(path) => {
                     let command =

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -24,11 +24,11 @@ use super::{
     diff::{DiffOutput, SemanticChangeEntry, compute_state_diff, compute_tree_diff},
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
-        override_trust_recommended_action,
-        repository_verification_blocked_advice, serialize_empty_action_as_null,
+        override_trust_recommended_action, repository_verification_blocked_advice,
+        serialize_empty_action_as_null,
     },
     next_action::{NextActionValidationContext, write_command_json},
-    operator_core::{OperatorCommandOutput, blocked_operator_exit_code},
+    operator_core::{OperatorAction, OperatorCommandOutput, blocked_operator_exit_code},
     ready_cmd::{worktree_dirty, worktree_dirty_paths},
     snapshot::ensure_current_state,
     thread_cmd::{refresh_thread_freshness, thread_not_found_advice},
@@ -741,7 +741,7 @@ pub(crate) fn merge_thread_into_current(
         return Ok(MergeOutput {
             operator: OperatorCommandOutput {
                 status: if preview { "preview" } else { "completed" }.to_string(),
-                action: "merge".to_string(),
+                action: OperatorAction::Merge,
                 message: match (preview, git_commit, repo.head_ref()?) {
                     (true, true, Head::Attached { thread }) => {
                         format!(
@@ -900,9 +900,10 @@ pub(crate) fn merge_thread_into_current(
             && thread
                 .as_ref()
                 .is_some_and(|thread| thread.state == ThreadState::Ready)
-            && let Some(thread) = thread.as_ref() {
-                mark_merge_previewed(repo, &thread.id)?;
-            }
+            && let Some(thread) = thread.as_ref()
+        {
+            mark_merge_previewed(repo, &thread.id)?;
+        }
         return Ok(merge_output_from_report(MergeOutputInput {
             repo,
             thread: &thread,
@@ -1870,7 +1871,10 @@ fn build_thread_preview_report_with_graph(
         advice.thread_health = "clean".to_string();
     }
 
-    let thread_tip = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.map(|id| id.short());
+    let thread_tip = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .map(|id| id.short());
     let manual_resolution_current = thread
         .integration_policy_result
         .manual_resolution_state
@@ -1979,7 +1983,10 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
     let stale_refresh_action = input.preview_report.and_then(|report| {
         (report.freshness == ThreadFreshness::Stale.to_string()).then(|| {
             if report.recommended_action.trim().is_empty() {
-                format!("heddle sync --thread {}", recommended_action_quote(&report.thread))
+                format!(
+                    "heddle sync --thread {}",
+                    recommended_action_quote(&report.thread)
+                )
             } else {
                 report.recommended_action.clone()
             }
@@ -2034,7 +2041,7 @@ fn merge_output_from_report(input: MergeOutputInput<'_>) -> MergeOutput {
     MergeOutput {
         operator: OperatorCommandOutput {
             status: status.to_string(),
-            action: "merge".to_string(),
+            action: OperatorAction::Merge,
             message: input.message,
             blockers: real_blockers,
             warnings: preview_warnings,
@@ -2269,7 +2276,7 @@ fn merge_blocked_by_trust_output(
 ) -> MergeOutput {
     MergeOutput {
         operator: OperatorCommandOutput::blocked_by_repository_verification(
-            "merge",
+            OperatorAction::Merge,
             trust_blocked_merge_message(&trust, preview_only),
             &trust,
         ),
@@ -2332,7 +2339,10 @@ fn stale_thread_merge_blocked_output(
     preview_only: bool,
 ) -> MergeOutput {
     let recommended_action = if preview_report.recommended_action.trim().is_empty() {
-        format!("heddle sync --thread {}", recommended_action_quote(&preview_report.thread))
+        format!(
+            "heddle sync --thread {}",
+            recommended_action_quote(&preview_report.thread)
+        )
     } else {
         preview_report.recommended_action.clone()
     };
@@ -2360,7 +2370,7 @@ fn stale_thread_merge_blocked_output(
     MergeOutput {
         operator: OperatorCommandOutput {
             status: "blocked".to_string(),
-            action: "merge".to_string(),
+            action: OperatorAction::Merge,
             message: format!(
                 "Thread '{}' is stale{}; merge {}did not run",
                 preview_report.thread,

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -131,7 +131,7 @@ pub use command_catalog::{
     command_help_visibility, command_path, command_persists_op_id, command_runtime_contract,
     command_runtime_contract_for_command, command_supports_json_for_command,
     command_supports_op_id, command_supports_op_id_for_command, command_surface,
-    command_uses_bootstrap_op_id_store, observe_only_root_commands,
+    command_uses_bootstrap_op_id_store, observe_only_root_commands, operator_envelope_verbs,
     root_commands_for_advanced_help, root_commands_for_help_visibility,
 };
 pub use completion::cmd_completion;
@@ -178,6 +178,7 @@ pub use marker::cmd_marker;
 pub use merge::cmd_merge;
 pub(crate) use merge::{bench_detect_renames, bench_find_merge_base, bench_three_way_merge};
 pub use monitor::cmd_monitor;
+pub use operator_core::operator_emission_output_kinds;
 pub use operator_loop::{cmd_abort, cmd_continue, cmd_sync_smart};
 #[cfg(feature = "git-overlay")]
 pub use oss::cmd_git_overlay_guide;

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -198,7 +198,7 @@ pub use session::{
     cmd_session_end, cmd_session_list, cmd_session_segment, cmd_session_show, cmd_session_start,
 };
 pub use shell::cmd_shell;
-pub use show::cmd_show;
+pub use show::{cmd_inspect_state, cmd_show};
 pub use snapshot::{SnapshotAgentOverrides, cmd_snapshot};
 pub use stack::cmd_stack;
 pub use stash::cmd_stash;

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -127,11 +127,11 @@ pub use clone::{
 pub use collapse::cmd_collapse;
 pub use command_catalog::{
     CommandCatalogOutput, advanced_help_groups, build_command_catalog, cmd_commands,
-    command_canonical_command,
-    command_contract_root_commands, command_help_tier, command_help_visibility, command_path,
-    command_persists_op_id, command_runtime_contract, command_runtime_contract_for_command,
-    command_supports_json_for_command, command_supports_op_id, command_supports_op_id_for_command,
-    command_surface, command_uses_bootstrap_op_id_store, observe_only_root_commands,
+    command_canonical_command, command_contract_root_commands, command_help_tier,
+    command_help_visibility, command_path, command_persists_op_id, command_runtime_contract,
+    command_runtime_contract_for_command, command_supports_json_for_command,
+    command_supports_op_id, command_supports_op_id_for_command, command_surface,
+    command_uses_bootstrap_op_id_store, observe_only_root_commands,
     root_commands_for_advanced_help, root_commands_for_help_visibility,
 };
 pub use completion::cmd_completion;
@@ -148,7 +148,9 @@ pub use diff::cmd_diff;
 pub use discuss::run as cmd_discuss;
 pub use doctor_docs::cmd_doctor_docs;
 pub use doctor_schemas::{cmd_doctor_schemas, documented_samples_with_bound_verbs};
-pub use error_envelope::{print_error_with_hint, print_parse_error_json_envelope};
+pub use error_envelope::{
+    print_error_with_hint, print_error_with_hint_with_config, print_parse_error_json_envelope,
+};
 pub use fetch::cmd_fetch;
 pub use fork::cmd_fork;
 pub use fsck::cmd_fsck;
@@ -184,7 +186,6 @@ pub use query::run as cmd_query;
 pub use ready_cmd::cmd_ready;
 pub use rebase::cmd_rebase;
 pub use redact::cmd_redact;
-pub use visibility::cmd_visibility;
 pub use remote::{cmd_pull, cmd_push, cmd_remote};
 pub use resolve::cmd_resolve;
 pub use retro::{RetroCommandOptions, cmd_retro};
@@ -212,6 +213,7 @@ pub use transaction::run as cmd_transaction;
 pub use try_cmd::cmd_try;
 pub use undo::{cmd_redo, cmd_undo};
 pub use verify::cmd_verify;
+pub use visibility::cmd_visibility;
 pub use watch::cmd_watch;
 pub use workflow::{cmd_delegate, cmd_land, cmd_sync};
 pub use workspace::{cmd_workspace, cmd_workspace_show};

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -7,24 +7,24 @@ use chrono::Utc;
 use gix::bstr::ByteSlice;
 use objects::object::ThreadName;
 use repo::{
-    GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind, OperationScope, Repository,
-    RepositoryOperationStatus, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
-    ThreadState, shell_quote, update_thread_state_from_state,
+    shell_quote, update_thread_state_from_state, GitOverlayImportHint, GitRemoteTrackingStatus,
+    OperationKind, OperationScope, Repository, RepositoryOperationStatus, ThreadFreshness,
+    ThreadIntegrationPolicy, ThreadManager, ThreadState,
 };
-use serde::{Serialize, Serializer, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 
 use super::{
     git_overlay_health::{
-        RepositoryVerificationState, action_template, repository_verification_blockers,
-        repository_verification_primary_command,
+        action_template, repository_verification_blockers, repository_verification_primary_command,
+        RepositoryVerificationState,
     },
-    next_action::{NextActionInput, effective_next_action},
+    next_action::{effective_next_action, NextActionInput},
     rebase::{
-        OperatorContinueStatus, cmd_rebase_silent, continue_rebase_for_operator,
-        has_persisted_rebase_state,
+        cmd_rebase_silent, continue_rebase_for_operator, has_persisted_rebase_state,
+        OperatorContinueStatus,
     },
     resolve::abort_merge_state,
-    snapshot::{SnapshotAgentOverrides, create_snapshot},
+    snapshot::{create_snapshot, SnapshotAgentOverrides},
 };
 use crate::config::UserConfig;
 
@@ -66,6 +66,15 @@ impl OperatorAction {
             Self::ThreadPromote => "thread_promote",
             Self::ThreadRefresh => "thread_refresh",
             Self::ThreadResolve => "thread_resolve",
+        }
+    }
+
+    pub(crate) fn for_emitting_command(command: &[&str]) -> Option<Self> {
+        match command {
+            ["abort"] => Some(Self::Abort),
+            ["continue"] => Some(Self::Continue),
+            ["sync"] => Some(Self::Sync),
+            _ => None,
         }
     }
 }
@@ -216,6 +225,29 @@ impl Serialize for OperatorCommandOutput {
     where
         S: Serializer,
     {
+        self.serialize_with_output_kind(serializer, self.action)
+    }
+}
+
+impl OperatorCommandOutput {
+    pub(crate) fn envelope_for_command(
+        &self,
+        output_kind: OperatorAction,
+    ) -> OperatorCommandEnvelope<'_> {
+        OperatorCommandEnvelope {
+            output: self,
+            output_kind,
+        }
+    }
+
+    fn serialize_with_output_kind<S>(
+        &self,
+        serializer: S,
+        output_kind: OperatorAction,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         let next_action = normalized_action(self.next_action.as_deref());
         let recommended_action = normalized_action(self.recommended_action.as_deref());
         let next_action_template = next_action.and_then(action_template);
@@ -230,7 +262,7 @@ impl Serialize for OperatorCommandOutput {
         }
 
         let mut state = serializer.serialize_struct("OperatorCommandOutput", len)?;
-        state.serialize_field("output_kind", &self.action.wire_value())?;
+        state.serialize_field("output_kind", &output_kind.wire_value())?;
         state.serialize_field("status", &self.status)?;
         state.serialize_field("action", &self.action)?;
         state.serialize_field("message", &self.message)?;
@@ -248,6 +280,21 @@ impl Serialize for OperatorCommandOutput {
     }
 }
 
+pub(crate) struct OperatorCommandEnvelope<'a> {
+    output: &'a OperatorCommandOutput,
+    output_kind: OperatorAction,
+}
+
+impl Serialize for OperatorCommandEnvelope<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.output
+            .serialize_with_output_kind(serializer, self.output_kind)
+    }
+}
+
 fn normalized_action(action: Option<&str>) -> Option<&str> {
     action.filter(|action| !action.trim().is_empty())
 }
@@ -260,17 +307,32 @@ impl super::compact::CompactProjection for OperatorCommandOutput {
     /// also carry changed-path / conflict axes layer those on top of the
     /// returned value.
     fn compact(&self) -> super::compact::CompactOutput {
+        self.compact_with_output_kind(self.action)
+    }
+}
+
+impl OperatorCommandOutput {
+    fn compact_with_output_kind(
+        &self,
+        output_kind: OperatorAction,
+    ) -> super::compact::CompactOutput {
         // Prefer the validated `recommended_action`; fall back to
         // `next_action`. Both are the same canonical breadcrumb in the
         // full envelope — compact emits exactly one, as `next_action`.
         let action = normalized_action(self.recommended_action.as_deref())
             .or_else(|| normalized_action(self.next_action.as_deref()));
-        let mut compact = super::compact::CompactOutput::new(self.action.wire_value());
+        let mut compact = super::compact::CompactOutput::new(output_kind.wire_value());
         compact.status = Some(self.status.clone());
         compact.blockers = self.blockers.clone();
         compact.next_action = action.map(str::to_string);
         compact.next_action_template = action.and_then(action_template);
         compact
+    }
+}
+
+impl super::compact::CompactProjection for OperatorCommandEnvelope<'_> {
+    fn compact(&self) -> super::compact::CompactOutput {
+        self.output.compact_with_output_kind(self.output_kind)
     }
 }
 
@@ -295,7 +357,7 @@ pub(crate) fn continue_operator(repo: &Repository) -> Result<OperatorCommandOutp
             let recommended_action = format!("heddle resolve {}", shell_quote(&unresolved[0]));
             return Ok(OperatorCommandOutput {
                 status: "blocked".to_string(),
-                action: OperatorAction::Continue,
+                action: OperatorAction::Merge,
                 message: format!(
                     "Merge still has unresolved conflicts: {}. After removing conflict markers, mark each file resolved with `heddle resolve <path>`.",
                     unresolved.join(", ")
@@ -636,7 +698,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::cli::commands::git_overlay_health::{VerificationCheck, machine_contract_coverage};
+    use crate::cli::commands::git_overlay_health::{machine_contract_coverage, VerificationCheck};
 
     // heddle#464 close-the-class (paths): a conflict path can contain spaces.
     // `continue` builds `recommended_action = heddle resolve <path>`, a VALIDATED
@@ -646,7 +708,7 @@ mod tests {
     #[test]
     fn validated_resolve_action_with_spaced_path_passes_only_when_quoted() {
         use crate::cli::commands::next_action::{
-            NextActionValidationContext, validated_json_string,
+            validated_json_string, NextActionValidationContext,
         };
         use repo::shell_quote;
 
@@ -695,7 +757,7 @@ mod tests {
     #[test]
     fn blocked_land_with_unvalidated_thread_id_passes_only_when_quoted() {
         use crate::cli::commands::next_action::{
-            NextActionValidationContext, validated_json_string,
+            validated_json_string, NextActionValidationContext,
         };
         use repo::shell_quote;
 
@@ -754,18 +816,14 @@ mod tests {
         );
         assert!(output.message.contains("no-git runtime"));
         assert!(output.message.contains("conflict.txt"));
-        assert!(
-            output
-                .blockers
-                .iter()
-                .any(|path| path == "unresolved: conflict.txt")
-        );
-        assert!(
-            !output
-                .recommended_action
-                .as_deref()
-                .is_some_and(|action| action.starts_with("git "))
-        );
+        assert!(output
+            .blockers
+            .iter()
+            .any(|path| path == "unresolved: conflict.txt"));
+        assert!(!output
+            .recommended_action
+            .as_deref()
+            .is_some_and(|action| action.starts_with("git ")));
     }
 
     #[test]
@@ -792,11 +850,9 @@ mod tests {
             output.recommended_action.as_deref(),
             Some("heddle commit -m \"...\"")
         );
-        assert!(
-            output
-                .message
-                .contains("repository verification is blocked")
-        );
+        assert!(output
+            .message
+            .contains("repository verification is blocked"));
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -28,11 +28,12 @@ use super::{
 };
 use crate::config::UserConfig;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OperatorAction {
     Abort,
     Bisect,
     CherryPick,
+    #[default]
     Continue,
     Land,
     Merge,
@@ -66,12 +67,6 @@ impl OperatorAction {
             Self::ThreadRefresh => "thread_refresh",
             Self::ThreadResolve => "thread_resolve",
         }
-    }
-}
-
-impl Default for OperatorAction {
-    fn default() -> Self {
-        Self::Continue
     }
 }
 

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -48,6 +48,45 @@ pub(crate) enum OperatorAction {
     ThreadResolve,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OperatorEmission {
+    pub(crate) command: &'static [&'static str],
+    pub(crate) output_kind: OperatorAction,
+}
+
+pub(crate) const ABORT_OPERATOR_EMISSION: OperatorEmission = OperatorEmission {
+    command: &["abort"],
+    output_kind: OperatorAction::Abort,
+};
+
+pub(crate) const CONTINUE_OPERATOR_EMISSION: OperatorEmission = OperatorEmission {
+    command: &["continue"],
+    output_kind: OperatorAction::Continue,
+};
+
+pub(crate) const SYNC_OPERATOR_EMISSION: OperatorEmission = OperatorEmission {
+    command: &["sync"],
+    output_kind: OperatorAction::Sync,
+};
+
+pub(crate) const OPERATOR_EMISSIONS: &[OperatorEmission] = &[
+    ABORT_OPERATOR_EMISSION,
+    CONTINUE_OPERATOR_EMISSION,
+    SYNC_OPERATOR_EMISSION,
+];
+
+pub fn operator_emission_output_kinds() -> Vec<(String, String)> {
+    OPERATOR_EMISSIONS
+        .iter()
+        .map(|emission| {
+            (
+                emission.command.join(" "),
+                emission.output_kind.wire_value().to_string(),
+            )
+        })
+        .collect()
+}
+
 impl OperatorAction {
     const fn wire_value(self) -> &'static str {
         match self {
@@ -66,15 +105,6 @@ impl OperatorAction {
             Self::ThreadPromote => "thread_promote",
             Self::ThreadRefresh => "thread_refresh",
             Self::ThreadResolve => "thread_resolve",
-        }
-    }
-
-    pub(crate) fn for_emitting_command(command: &[&str]) -> Option<Self> {
-        match command {
-            ["abort"] => Some(Self::Abort),
-            ["continue"] => Some(Self::Continue),
-            ["sync"] => Some(Self::Sync),
-            _ => None,
         }
     }
 }

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -7,31 +7,99 @@ use chrono::Utc;
 use gix::bstr::ByteSlice;
 use objects::object::ThreadName;
 use repo::{
-    shell_quote, update_thread_state_from_state, GitOverlayImportHint, GitRemoteTrackingStatus,
-    OperationKind, OperationScope, Repository, RepositoryOperationStatus, ThreadFreshness,
-    ThreadIntegrationPolicy, ThreadManager, ThreadState,
+    GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind, OperationScope, Repository,
+    RepositoryOperationStatus, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
+    ThreadState, shell_quote, update_thread_state_from_state,
 };
-use serde::{ser::SerializeStruct, Serialize, Serializer};
+use serde::{Serialize, Serializer, ser::SerializeStruct};
 
 use super::{
     git_overlay_health::{
-        action_template, repository_verification_blockers,
-        repository_verification_primary_command, RepositoryVerificationState,
+        RepositoryVerificationState, action_template, repository_verification_blockers,
+        repository_verification_primary_command,
     },
-    next_action::{effective_next_action, NextActionInput},
+    next_action::{NextActionInput, effective_next_action},
     rebase::{
-        cmd_rebase_silent, continue_rebase_for_operator, has_persisted_rebase_state,
-        OperatorContinueStatus,
+        OperatorContinueStatus, cmd_rebase_silent, continue_rebase_for_operator,
+        has_persisted_rebase_state,
     },
     resolve::abort_merge_state,
-    snapshot::{create_snapshot, SnapshotAgentOverrides},
+    snapshot::{SnapshotAgentOverrides, create_snapshot},
 };
 use crate::config::UserConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OperatorAction {
+    Abort,
+    Bisect,
+    CherryPick,
+    Continue,
+    Land,
+    Merge,
+    Ready,
+    Rebase,
+    Revert,
+    Sync,
+    ThreadCleanup,
+    ThreadDrop,
+    ThreadPromote,
+    ThreadRefresh,
+    ThreadResolve,
+}
+
+impl OperatorAction {
+    const fn wire_value(self) -> &'static str {
+        match self {
+            Self::Abort => "abort",
+            Self::Bisect => "bisect",
+            Self::CherryPick => "cherry-pick",
+            Self::Continue => "continue",
+            Self::Land => "land",
+            Self::Merge => "merge",
+            Self::Ready => "ready",
+            Self::Rebase => "rebase",
+            Self::Revert => "revert",
+            Self::Sync => "sync",
+            Self::ThreadCleanup => "thread_cleanup",
+            Self::ThreadDrop => "thread_drop",
+            Self::ThreadPromote => "thread_promote",
+            Self::ThreadRefresh => "thread_refresh",
+            Self::ThreadResolve => "thread_resolve",
+        }
+    }
+}
+
+impl Default for OperatorAction {
+    fn default() -> Self {
+        Self::Continue
+    }
+}
+
+impl Serialize for OperatorAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.wire_value())
+    }
+}
+
+impl From<&OperationKind> for OperatorAction {
+    fn from(kind: &OperationKind) -> Self {
+        match kind {
+            OperationKind::Merge => Self::Merge,
+            OperationKind::Rebase => Self::Rebase,
+            OperationKind::CherryPick => Self::CherryPick,
+            OperationKind::Revert => Self::Revert,
+            OperationKind::Bisect => Self::Bisect,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct OperatorCommandOutput {
     pub status: String,
-    pub action: String,
+    pub action: OperatorAction,
     pub message: String,
     /// Reasons the operation could not advance state. Only populated
     /// when `status == "blocked"` or `status == "failed"`. When the
@@ -48,14 +116,14 @@ pub(crate) struct OperatorCommandOutput {
 
 impl OperatorCommandOutput {
     pub(crate) fn blocked_by_repository_verification(
-        action: impl Into<String>,
+        action: OperatorAction,
         message: impl Into<String>,
         trust: &RepositoryVerificationState,
     ) -> Self {
         let recommended_action = repository_verification_primary_command(trust);
         Self {
             status: "blocked".to_string(),
-            action: action.into(),
+            action,
             message: message.into(),
             blockers: repository_verification_blockers(trust),
             warnings: Vec::new(),
@@ -74,7 +142,7 @@ impl OperatorCommandOutput {
             return;
         }
         *self = Self::blocked_by_repository_verification(
-            self.action.clone(),
+            self.action,
             format!(
                 "{} reached local checks, but repository verification is blocked: {}",
                 local_context.into(),
@@ -116,7 +184,7 @@ fn repository_verification_allows_success_claim(
         return true;
     }
     if policy.allow_land_publish_followup
-        && output.action == "land"
+        && output.action == OperatorAction::Land
         && output.status == "landed"
         && trust.recommended_action == "heddle push"
         && matches!(
@@ -167,7 +235,7 @@ impl Serialize for OperatorCommandOutput {
         }
 
         let mut state = serializer.serialize_struct("OperatorCommandOutput", len)?;
-        state.serialize_field("output_kind", &self.action)?;
+        state.serialize_field("output_kind", &self.action.wire_value())?;
         state.serialize_field("status", &self.status)?;
         state.serialize_field("action", &self.action)?;
         state.serialize_field("message", &self.message)?;
@@ -202,7 +270,7 @@ impl super::compact::CompactProjection for OperatorCommandOutput {
         // full envelope — compact emits exactly one, as `next_action`.
         let action = normalized_action(self.recommended_action.as_deref())
             .or_else(|| normalized_action(self.next_action.as_deref()));
-        let mut compact = super::compact::CompactOutput::new(self.action.clone());
+        let mut compact = super::compact::CompactOutput::new(self.action.wire_value());
         compact.status = Some(self.status.clone());
         compact.blockers = self.blockers.clone();
         compact.next_action = action.map(str::to_string);
@@ -232,7 +300,7 @@ pub(crate) fn continue_operator(repo: &Repository) -> Result<OperatorCommandOutp
             let recommended_action = format!("heddle resolve {}", shell_quote(&unresolved[0]));
             return Ok(OperatorCommandOutput {
                 status: "blocked".to_string(),
-                action: "continue".to_string(),
+                action: OperatorAction::Continue,
                 message: format!(
                     "Merge still has unresolved conflicts: {}. After removing conflict markers, mark each file resolved with `heddle resolve <path>`.",
                     unresolved.join(", ")
@@ -262,7 +330,7 @@ pub(crate) fn continue_operator(repo: &Repository) -> Result<OperatorCommandOutp
         let next_action = complete_current_thread_manual_resolution(repo)?;
         return Ok(OperatorCommandOutput {
             status: "continued".to_string(),
-            action: "merge".to_string(),
+            action: OperatorAction::Merge,
             message: "Completed the in-progress Heddle merge".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -277,7 +345,7 @@ pub(crate) fn continue_operator(repo: &Repository) -> Result<OperatorCommandOutp
 
     Ok(OperatorCommandOutput {
         status: "noop".to_string(),
-        action: "continue".to_string(),
+        action: OperatorAction::Continue,
         message: "No in-progress operation needs continuing".to_string(),
         blockers: Vec::new(),
         warnings: Vec::new(),
@@ -291,7 +359,7 @@ pub(crate) fn abort_operator(repo: &Repository) -> Result<OperatorCommandOutput>
         abort_merge_state(repo, &repo.merge_state_manager())?;
         return Ok(OperatorCommandOutput {
             status: "aborted".to_string(),
-            action: "merge".to_string(),
+            action: OperatorAction::Merge,
             message: "Aborted the in-progress Heddle merge".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -304,7 +372,7 @@ pub(crate) fn abort_operator(repo: &Repository) -> Result<OperatorCommandOutput>
         cmd_rebase_silent(repo, None, true, false)?;
         return Ok(OperatorCommandOutput {
             status: "aborted".to_string(),
-            action: "rebase".to_string(),
+            action: OperatorAction::Rebase,
             message: "Aborted the in-progress Heddle rebase".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -319,7 +387,7 @@ pub(crate) fn abort_operator(repo: &Repository) -> Result<OperatorCommandOutput>
 
     Ok(OperatorCommandOutput {
         status: "noop".to_string(),
-        action: "abort".to_string(),
+        action: OperatorAction::Abort,
         message: "No in-progress operation can be aborted".to_string(),
         blockers: Vec::new(),
         warnings: Vec::new(),
@@ -386,7 +454,7 @@ fn continue_from_operation(
             Ok(match continue_rebase_for_operator(repo)? {
                 OperatorContinueStatus::Blocked => OperatorCommandOutput {
                     status: "blocked".to_string(),
-                    action: "rebase".to_string(),
+                    action: OperatorAction::Rebase,
                     message:
                         "Rebase still needs a captured manual resolution before it can continue"
                             .to_string(),
@@ -397,7 +465,7 @@ fn continue_from_operation(
                 },
                 OperatorContinueStatus::Continued => OperatorCommandOutput {
                     status: "continued".to_string(),
-                    action: "rebase".to_string(),
+                    action: OperatorAction::Rebase,
                     message: "Continued the in-progress Heddle rebase".to_string(),
                     blockers: Vec::new(),
                     warnings: Vec::new(),
@@ -406,7 +474,7 @@ fn continue_from_operation(
                 },
                 OperatorContinueStatus::Completed => OperatorCommandOutput {
                     status: "completed".to_string(),
-                    action: "rebase".to_string(),
+                    action: OperatorAction::Rebase,
                     message: "Completed the in-progress Heddle rebase".to_string(),
                     blockers: Vec::new(),
                     warnings: Vec::new(),
@@ -417,7 +485,7 @@ fn continue_from_operation(
         }
         (OperationScope::Heddle, OperationKind::Bisect) => Ok(OperatorCommandOutput {
             status: "blocked".to_string(),
-            action: "bisect".to_string(),
+            action: OperatorAction::Bisect,
             message: "A stale bisect state from an older Heddle version is present; \
                       the bisect command has been removed. Abort to clear it."
                 .to_string(),
@@ -448,7 +516,7 @@ fn continue_from_operation(
         (OperationScope::Heddle, OperationKind::Merge) => unreachable!(),
         _ => Ok(OperatorCommandOutput {
             status: "noop".to_string(),
-            action: "continue".to_string(),
+            action: OperatorAction::Continue,
             message: "No in-progress operation needs continuing".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -483,7 +551,7 @@ fn abort_from_operation(
 
     Ok(OperatorCommandOutput {
         status: "aborted".to_string(),
-        action: operation.kind.to_string(),
+        action: OperatorAction::from(&operation.kind),
         message: format!(
             "Aborted the in-progress {} {}",
             operation.scope, operation.kind
@@ -514,7 +582,7 @@ fn raw_git_operation_handoff(
     let recovery_text = raw_git_operation_recovery_text(&operation.kind, &primary);
     OperatorCommandOutput {
         status: "blocked".to_string(),
-        action: operation.kind.to_string(),
+        action: OperatorAction::from(&operation.kind),
         message: format!(
             "Cannot {attempted_action} the active raw Git {} inside Heddle's no-git runtime. Heddle did not start this Git sequencer operation, so it left Git metadata, refs, index, and worktree files unchanged.{unresolved_summary} {recovery_text}",
             operation.kind
@@ -573,7 +641,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::cli::commands::git_overlay_health::{machine_contract_coverage, VerificationCheck};
+    use crate::cli::commands::git_overlay_health::{VerificationCheck, machine_contract_coverage};
 
     // heddle#464 close-the-class (paths): a conflict path can contain spaces.
     // `continue` builds `recommended_action = heddle resolve <path>`, a VALIDATED
@@ -583,7 +651,7 @@ mod tests {
     #[test]
     fn validated_resolve_action_with_spaced_path_passes_only_when_quoted() {
         use crate::cli::commands::next_action::{
-            validated_json_string, NextActionValidationContext,
+            NextActionValidationContext, validated_json_string,
         };
         use repo::shell_quote;
 
@@ -592,7 +660,7 @@ mod tests {
 
         let quoted = OperatorCommandOutput {
             status: "blocked".to_string(),
-            action: "continue".to_string(),
+            action: OperatorAction::Continue,
             message: "conflicts remain".to_string(),
             blockers: vec![path.to_string()],
             warnings: Vec::new(),
@@ -632,7 +700,7 @@ mod tests {
     #[test]
     fn blocked_land_with_unvalidated_thread_id_passes_only_when_quoted() {
         use crate::cli::commands::next_action::{
-            validated_json_string, NextActionValidationContext,
+            NextActionValidationContext, validated_json_string,
         };
         use repo::shell_quote;
 
@@ -643,7 +711,7 @@ mod tests {
 
         let quoted = OperatorCommandOutput {
             status: "blocked".to_string(),
-            action: "land".to_string(),
+            action: OperatorAction::Land,
             message: format!("Thread '{unsafe_id}' must be synced manually"),
             blockers: vec!["thread is stale".to_string()],
             warnings: Vec::new(),
@@ -691,14 +759,18 @@ mod tests {
         );
         assert!(output.message.contains("no-git runtime"));
         assert!(output.message.contains("conflict.txt"));
-        assert!(output
-            .blockers
-            .iter()
-            .any(|path| path == "unresolved: conflict.txt"));
-        assert!(!output
-            .recommended_action
-            .as_deref()
-            .is_some_and(|action| action.starts_with("git ")));
+        assert!(
+            output
+                .blockers
+                .iter()
+                .any(|path| path == "unresolved: conflict.txt")
+        );
+        assert!(
+            !output
+                .recommended_action
+                .as_deref()
+                .is_some_and(|action| action.starts_with("git "))
+        );
     }
 
     #[test]
@@ -706,7 +778,7 @@ mod tests {
         let trust = verification_state(false, "needs_checkpoint", "heddle commit -m \"...\"");
         let mut output = OperatorCommandOutput {
             status: "synced".to_string(),
-            action: "sync".to_string(),
+            action: OperatorAction::Sync,
             message: "Thread is already current".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -725,9 +797,11 @@ mod tests {
             output.recommended_action.as_deref(),
             Some("heddle commit -m \"...\"")
         );
-        assert!(output
-            .message
-            .contains("repository verification is blocked"));
+        assert!(
+            output
+                .message
+                .contains("repository verification is blocked")
+        );
     }
 
     #[test]
@@ -735,7 +809,7 @@ mod tests {
         let trust = verification_state(false, "remote_ahead", "heddle push");
         let landed = || OperatorCommandOutput {
             status: "landed".to_string(),
-            action: "land".to_string(),
+            action: OperatorAction::Land,
             message: "Landed thread 'feature'".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -9,7 +9,8 @@ use super::{
         NextActionInput, NextActionValidationContext, effective_next_action, write_command_json,
     },
     operator_core::{
-        OperatorAction, OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
+        ABORT_OPERATOR_EMISSION, CONTINUE_OPERATOR_EMISSION, OperatorAction, OperatorCommandOutput,
+        OperatorEmission, SYNC_OPERATOR_EMISSION, abort_operator, exit_if_blocked_operator_status,
         open_operator_repo_from_path, recommend_next_action,
     },
     remote::resolve_default_remote_name,
@@ -27,7 +28,7 @@ pub async fn cmd_continue(cli: &Cli) -> Result<()> {
     let repo = open_operator_repo_from_path(cwd)?;
     let output = super::operator_core::continue_operator(&repo)?;
     let status = output.status.clone();
-    emit(cli, &repo, output, &["continue"])?;
+    emit(cli, &repo, output, CONTINUE_OPERATOR_EMISSION)?;
     exit_if_blocked_operator_status(&status);
     Ok(())
 }
@@ -37,7 +38,7 @@ pub fn cmd_abort(cli: &Cli) -> Result<()> {
     let cwd = cli.repo.as_ref().unwrap_or(&current_dir);
     let repo = open_operator_repo_from_path(cwd)?;
     let output = abort_operator(&repo)?;
-    emit(cli, &repo, output, &["abort"])
+    emit(cli, &repo, output, ABORT_OPERATOR_EMISSION)
 }
 
 pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
@@ -57,7 +58,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 next_action: Some("heddle continue".to_string()),
                 recommended_action: Some("heddle continue".to_string()),
             },
-            &["sync"],
+            SYNC_OPERATOR_EMISSION,
         );
     }
 
@@ -83,7 +84,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: Some(recommended_action.clone()),
                     recommended_action: Some(recommended_action),
                 },
-                &["sync"],
+                SYNC_OPERATOR_EMISSION,
             );
         }
         if remote_decision.status == "remote_behind" {
@@ -93,7 +94,12 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
             let outcome = bridge.pull(&remote_name)?;
             let verification = build_repository_verification_state(&repo);
             if !verification.verified {
-                return emit(cli, &repo, sync_blocked_by_trust(verification), &["sync"]);
+                return emit(
+                    cli,
+                    &repo,
+                    sync_blocked_by_trust(verification),
+                    SYNC_OPERATOR_EMISSION,
+                );
             }
             return emit(
                 cli,
@@ -110,7 +116,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: None,
                     recommended_action: None,
                 },
-                &["sync"],
+                SYNC_OPERATOR_EMISSION,
             );
         }
         if remote_decision.status == "remote_ahead" {
@@ -126,7 +132,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                     next_action: Some("heddle push".to_string()),
                     recommended_action: Some("heddle push".to_string()),
                 },
-                &["sync"],
+                SYNC_OPERATOR_EMISSION,
             );
         }
     }
@@ -149,16 +155,14 @@ fn emit(
     cli: &Cli,
     repo: &repo::Repository,
     output: OperatorCommandOutput,
-    emitting_command: &[&str],
+    emission: OperatorEmission,
 ) -> Result<()> {
     if should_output_json(cli, None) {
-        let output_kind =
-            OperatorAction::for_emitting_command(emitting_command).unwrap_or(output.action);
-        let envelope = output.envelope_for_command(output_kind);
+        let envelope = output.envelope_for_command(emission.output_kind);
         write_command_json(
             &envelope,
             output_is_compact(cli),
-            NextActionValidationContext::new(emitting_command, repo.capability()),
+            NextActionValidationContext::new(emission.command, repo.capability()),
         )?;
     } else {
         let message = match output.status.as_str() {

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -9,7 +9,7 @@ use super::{
         NextActionInput, NextActionValidationContext, effective_next_action, write_command_json,
     },
     operator_core::{
-        OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
+        OperatorAction, OperatorCommandOutput, abort_operator, exit_if_blocked_operator_status,
         open_operator_repo_from_path, recommend_next_action,
     },
     remote::resolve_default_remote_name,
@@ -50,7 +50,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
             &repo,
             OperatorCommandOutput {
                 status: "blocked".to_string(),
-                action: "sync".to_string(),
+                action: OperatorAction::Sync,
                 message: "Finish the in-progress operation before syncing".to_string(),
                 blockers: Vec::new(),
                 warnings: Vec::new(),
@@ -73,7 +73,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 &repo,
                 OperatorCommandOutput {
                     status: "blocked".to_string(),
-                    action: "sync".to_string(),
+                    action: OperatorAction::Sync,
                     message: remote.message,
                     blockers: vec![
                         "Git branch and upstream both contain commits the other side lacks"
@@ -100,7 +100,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 &repo,
                 OperatorCommandOutput {
                     status: "synced".to_string(),
-                    action: "sync".to_string(),
+                    action: OperatorAction::Sync,
                     message: format!(
                         "Synced branch '{}' with remote '{}' ({} commit(s) seen, {} state(s) imported)",
                         remote.branch, remote_name, outcome.commits_seen, outcome.states_created,
@@ -119,7 +119,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
                 &repo,
                 OperatorCommandOutput {
                     status: "ahead".to_string(),
-                    action: "sync".to_string(),
+                    action: OperatorAction::Sync,
                     message: remote.message,
                     blockers: Vec::new(),
                     warnings: Vec::new(),
@@ -136,7 +136,7 @@ pub async fn cmd_sync_smart(cli: &Cli, args: SyncArgs) -> Result<()> {
 
 fn sync_blocked_by_trust(trust: RepositoryVerificationState) -> OperatorCommandOutput {
     OperatorCommandOutput::blocked_by_repository_verification(
-        "sync",
+        OperatorAction::Sync,
         format!(
             "Sync changed the checkout, but repository verification is still blocked: {}",
             trust.summary

--- a/crates/cli/src/cli/commands/operator_loop.rs
+++ b/crates/cli/src/cli/commands/operator_loop.rs
@@ -152,8 +152,11 @@ fn emit(
     emitting_command: &[&str],
 ) -> Result<()> {
     if should_output_json(cli, None) {
+        let output_kind =
+            OperatorAction::for_emitting_command(emitting_command).unwrap_or(output.action);
+        let envelope = output.envelope_for_command(output_kind);
         write_command_json(
-            &output,
+            &envelope,
             output_is_compact(cli),
             NextActionValidationContext::new(emitting_command, repo.capability()),
         )?;

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -23,7 +23,8 @@ use super::{
         normalized_action, write_command_json,
     },
     operator_core::{
-        OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
+        OperatorAction, OperatorCommandOutput, VerificationClaimPolicy,
+        exit_if_blocked_operator_status,
     },
     snapshot::{SnapshotAgentOverrides, create_snapshot, ensure_current_state},
     thread::contextual_thread_action,
@@ -135,7 +136,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         let output = ReadyOutput {
             operator: OperatorCommandOutput {
                 status: "blocked".to_string(),
-                action: "ready".to_string(),
+                action: OperatorAction::Ready,
                 message: message.clone(),
                 blockers: trust_blockers,
                 warnings: Vec::new(),
@@ -201,8 +202,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
                     report.blockers.push(blocker);
                 }
             }
-            let recovery_scope =
-                super::workflow::recovery_scope_checkout(&thread, repo.root());
+            let recovery_scope = super::workflow::recovery_scope_checkout(&thread, repo.root());
             if let Some(action) = super::workflow::integration_blocker_recommended_action(
                 &report.blockers,
                 recovery_scope.as_deref(),
@@ -298,7 +298,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
     };
     let mut operator = OperatorCommandOutput {
         status: status.to_string(),
-        action: "ready".to_string(),
+        action: OperatorAction::Ready,
         message: message.clone(),
         blockers: report.blockers.clone(),
         warnings: Vec::new(),
@@ -458,8 +458,11 @@ fn trust_blocked_ready_output(
         "Thread '{thread}' cannot run readiness checks until repository verification is restored: {}",
         trust.summary
     );
-    let operator =
-        OperatorCommandOutput::blocked_by_repository_verification("ready", message, &trust);
+    let operator = OperatorCommandOutput::blocked_by_repository_verification(
+        OperatorAction::Ready,
+        message,
+        &trust,
+    );
     let recommended_action = operator
         .recommended_action
         .clone()
@@ -551,7 +554,7 @@ fn missing_ready_capture_intent_output(
     Ok(ReadyOutput {
         operator: OperatorCommandOutput {
             status: "blocked".to_string(),
-            action: "ready".to_string(),
+            action: OperatorAction::Ready,
             message: format!(
                 "Thread '{thread}' has uncaptured work; provide an intent before readiness checks"
             ),
@@ -589,7 +592,9 @@ fn missing_ready_capture_intent_report_for(
         semantic_result: "not_checked".to_string(),
         conflicts: Vec::new(),
         conflict_count: 0,
-        blockers: vec!["commit the work with -m/--message/--intent before readiness checks".to_string()],
+        blockers: vec![
+            "commit the work with -m/--message/--intent before readiness checks".to_string(),
+        ],
         recommended_action: recommended_action.to_string(),
         recommended_action_template: super::git_overlay_health::action_template(recommended_action),
         thread_health: "blocked".to_string(),

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -13,6 +13,7 @@ use serde_json::{Value, json};
 use super::{
     action_line::print_next_step,
     advice::RecoveryAdvice,
+    command_runtime_contract,
     ff_record::record_ff_advance,
     git_overlay_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
@@ -22,7 +23,7 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::{
-    cli::{Cli, should_output_json},
+    cli::{Cli, JsonOutputMode, json_output_mode_for_kind},
     config::UserConfig,
 };
 
@@ -50,7 +51,11 @@ pub(super) fn emit_rebase_progress(
     let Some(cli) = cli else {
         return Ok(false);
     };
-    if !should_output_json(cli, Some(repo.config())) {
+    let contract =
+        command_runtime_contract("rebase").expect("rebase command contract should be registered");
+    if json_output_mode_for_kind(cli, Some(repo.config()), contract.json_kind)
+        != JsonOutputMode::Jsonl
+    {
         return Ok(false);
     }
 
@@ -320,23 +325,23 @@ fn emit_up_to_date_blocked_by_trust(
     trust: RepositoryVerificationState,
 ) -> Result<()> {
     let recommended_action = repository_verification_primary_command(&trust);
-    if should_output_json(cli, Some(repo.config())) {
-        emit_rebase_progress(
-            repo,
-            Some(cli),
-            json!({
-                "status": "blocked",
-                "reason": "repository_verification",
-                "summary": trust.summary,
-                "recommended_action": recommended_action.clone(),
-                "recommended_action_template": action_template(&recommended_action),
-                "recovery_commands": trust.recovery_commands,
-            }),
-        )?;
-    } else {
+    let summary = trust.summary;
+    let recovery_commands = trust.recovery_commands;
+    if !emit_rebase_progress(
+        repo,
+        Some(cli),
+        json!({
+            "status": "blocked",
+            "reason": "repository_verification",
+            "summary": summary,
+            "recommended_action": recommended_action.clone(),
+            "recommended_action_template": action_template(&recommended_action),
+            "recovery_commands": recovery_commands,
+        }),
+    )? {
         println!(
             "Rebase is up to date, but repository verification is blocked: {}",
-            trust.summary
+            summary
         );
         print_next_step(&recommended_action);
     }

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -201,8 +201,12 @@ fn run_rebase(
             && should_output_json(cli, Some(repo.config()))
         {
             println!(
-                "{{\"status\": \"fast_forwarded\", \"to\": \"{}\"}}",
-                target_change_id
+                "{}",
+                serde_json::json!({
+                    "output_kind": "rebase_progress",
+                    "status": "fast_forwarded",
+                    "to": target_change_id,
+                })
             );
         } else if cli.is_some() {
             // Lead with the active thread name (where applicable) so
@@ -271,7 +275,13 @@ fn emit_up_to_date_if_trusted(repo: &Repository, cli: Option<&Cli>) -> Result<()
     let trust = build_repository_verification_state(repo);
     if trust.verified {
         if should_output_json(cli, Some(repo.config())) {
-            println!("{{\"status\": \"up_to_date\"}}");
+            println!(
+                "{}",
+                serde_json::json!({
+                    "output_kind": "rebase_progress",
+                    "status": "up_to_date",
+                })
+            );
         } else {
             println!("Already up to date");
         }
@@ -291,6 +301,7 @@ fn emit_up_to_date_blocked_by_trust(
         println!(
             "{}",
             serde_json::to_string(&json!({
+                "output_kind": "rebase_progress",
                 "status": "blocked",
                 "reason": "repository_verification",
                 "summary": trust.summary,
@@ -371,7 +382,13 @@ fn handle_abort(
     if let Some(cli) = cli
         && should_output_json(cli, Some(repo.config()))
     {
-        println!("{{\"status\": \"aborted\"}}");
+        println!(
+            "{}",
+            serde_json::json!({
+                "output_kind": "rebase_progress",
+                "status": "aborted",
+            })
+        );
     } else if cli.is_some() {
         println!("Rebase aborted");
     }

--- a/crates/cli/src/cli/commands/rebase/mod.rs
+++ b/crates/cli/src/cli/commands/rebase/mod.rs
@@ -4,11 +4,11 @@
 use objects::store::ObjectStore;
 use std::fs;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use objects::object::ThreadName;
 use refs::Head;
 use repo::Repository;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::{
     action_line::print_next_step,
@@ -41,6 +41,33 @@ use rebase_state::{
 };
 
 const REBASE_STATE_FILE: &str = "REBASE_STATE";
+
+pub(super) fn emit_rebase_progress(
+    repo: &Repository,
+    cli: Option<&Cli>,
+    payload: Value,
+) -> Result<bool> {
+    let Some(cli) = cli else {
+        return Ok(false);
+    };
+    if !should_output_json(cli, Some(repo.config())) {
+        return Ok(false);
+    }
+
+    let mut object = payload
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("rebase progress payload must be a JSON object"))?;
+    object.insert(
+        "output_kind".to_string(),
+        Value::String("rebase_progress".to_string()),
+    );
+    println!(
+        "{}",
+        serde_json::to_string(&Value::Object(object)).context("serialize rebase progress")?
+    );
+    Ok(true)
+}
 
 pub(crate) enum OperatorContinueStatus {
     Continued,
@@ -197,18 +224,15 @@ fn run_rebase(
         )?;
         flush_rebase_batch(repo, &[advance], &mint_rebase_transaction_id())?;
 
-        if let Some(cli) = cli
-            && should_output_json(cli, Some(repo.config()))
+        if !emit_rebase_progress(
+            repo,
+            cli,
+            json!({
+                "status": "fast_forwarded",
+                "to": target_change_id.to_string(),
+            }),
+        )? && cli.is_some()
         {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "rebase_progress",
-                    "status": "fast_forwarded",
-                    "to": target_change_id,
-                })
-            );
-        } else if cli.is_some() {
             // Lead with the active thread name (where applicable) so
             // operators don't need to map a worktree path back to a
             // thread mentally. JSON output is unchanged.
@@ -246,14 +270,15 @@ fn run_rebase(
 
     save_rebase_state(&rebase_state_path, &rebase_state)?;
 
-    if let Some(cli) = cli
-        && should_output_json(cli, Some(repo.config()))
+    if !emit_rebase_progress(
+        repo,
+        cli,
+        json!({
+            "status": "started",
+            "commits": commits_to_replay.len(),
+        }),
+    )? && cli.is_some()
     {
-        println!(
-            "{{\"status\": \"started\", \"commits\": {}}}",
-            commits_to_replay.len()
-        );
-    } else if cli.is_some() {
         println!(
             "Rebasing {} commits onto {}",
             commits_to_replay.len(),
@@ -274,15 +299,13 @@ fn emit_up_to_date_if_trusted(repo: &Repository, cli: Option<&Cli>) -> Result<()
     };
     let trust = build_repository_verification_state(repo);
     if trust.verified {
-        if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "rebase_progress",
-                    "status": "up_to_date",
-                })
-            );
-        } else {
+        if !emit_rebase_progress(
+            repo,
+            Some(cli),
+            json!({
+                "status": "up_to_date",
+            }),
+        )? {
             println!("Already up to date");
         }
         return Ok(());
@@ -298,18 +321,18 @@ fn emit_up_to_date_blocked_by_trust(
 ) -> Result<()> {
     let recommended_action = repository_verification_primary_command(&trust);
     if should_output_json(cli, Some(repo.config())) {
-        println!(
-            "{}",
-            serde_json::to_string(&json!({
-                "output_kind": "rebase_progress",
+        emit_rebase_progress(
+            repo,
+            Some(cli),
+            json!({
                 "status": "blocked",
                 "reason": "repository_verification",
                 "summary": trust.summary,
                 "recommended_action": recommended_action.clone(),
                 "recommended_action_template": action_template(&recommended_action),
                 "recovery_commands": trust.recovery_commands,
-            }))?
-        );
+            }),
+        )?;
     } else {
         println!(
             "Rebase is up to date, but repository verification is blocked: {}",
@@ -379,17 +402,14 @@ fn handle_abort(
 
     fs::remove_file(rebase_state_path)?;
 
-    if let Some(cli) = cli
-        && should_output_json(cli, Some(repo.config()))
+    if !emit_rebase_progress(
+        repo,
+        cli,
+        json!({
+            "status": "aborted",
+        }),
+    )? && cli.is_some()
     {
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "rebase_progress",
-                "status": "aborted",
-            })
-        );
-    } else if cli.is_some() {
         println!("Rebase aborted");
     }
 

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -12,9 +12,10 @@ use repo::Repository;
 
 use super::{
     super::{advice::RecoveryAdvice, ff_record::ff_advance_deferred},
+    emit_rebase_progress,
     rebase_state::{load_rebase_state, save_rebase_state},
 };
-use crate::cli::{Cli, should_output_json};
+use crate::cli::Cli;
 
 /// Synthetic `source_thread` for `OpRecord::FastForwardV2` entries
 /// emitted during a rebase replay. Each replayed commit becomes its
@@ -71,37 +72,26 @@ fn replay_commits_internal(
 
     while state.current_index < state.commits_to_replay.len() {
         let commit_id = state.commits_to_replay[state.current_index];
-        let commit_state = repo
-            .store()
-            .get_state(&commit_id)?
-            .ok_or_else(|| {
-                anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                    &commit_id.to_string(),
-                    "commit",
-                ))
-            })?;
+        let commit_state = repo.store().get_state(&commit_id)?.ok_or_else(|| {
+            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+                &commit_id.to_string(),
+                "commit",
+            ))
+        })?;
 
-        if let Some(cli) = cli
-            && should_output_json(cli, Some(repo.config()))
+        if !emit_rebase_progress(
+            repo,
+            cli,
+            serde_json::json!({
+                "status": "applying",
+                "commit": commit_id.short(),
+            }),
+        )? && cli.is_some()
         {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "rebase_progress",
-                    "status": "applying",
-                    "commit": commit_id.short(),
-                })
-            );
-        } else if cli.is_some() {
             println!("Applying {}...", commit_id.short());
         }
 
-        let result = apply_commit(
-            repo,
-            &commit_state,
-            &current_head,
-            discard_local_changes,
-        )?;
+        let result = apply_commit(repo, &commit_state, &current_head, discard_local_changes)?;
 
         match result {
             ApplyResult::Success { new_head, advance } => {
@@ -116,18 +106,15 @@ fn replay_commits_internal(
                 state.pending_manual_resolution = Some(commit_id);
                 state.pre_conflict_head = Some(current_head);
                 save_rebase_state(rebase_state_path, &state)?;
-                if let Some(cli) = cli
-                    && should_output_json(cli, Some(repo.config()))
+                if !emit_rebase_progress(
+                    repo,
+                    cli,
+                    serde_json::json!({
+                        "status": "conflict",
+                        "commit": commit_id.short(),
+                    }),
+                )? && cli.is_some()
                 {
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "output_kind": "rebase_progress",
-                            "status": "conflict",
-                            "commit": commit_id.short(),
-                        })
-                    );
-                } else if cli.is_some() {
                     println!(
                         "Conflict applying {}. Fix conflicts and run 'heddle rebase --continue'",
                         commit_id.short()
@@ -152,14 +139,15 @@ fn replay_commits_internal(
 
     fs::remove_file(rebase_state_path)?;
 
-    if let Some(cli) = cli
-        && should_output_json(cli, Some(repo.config()))
+    if !emit_rebase_progress(
+        repo,
+        cli,
+        serde_json::json!({
+            "status": "completed",
+            "onto": state.onto.to_string(),
+        }),
+    )? && cli.is_some()
     {
-        println!(
-            "{{\"status\": \"completed\", \"onto\": \"{}\"}}",
-            state.onto
-        );
-    } else if cli.is_some() {
         println!("Rebase completed");
     }
 
@@ -235,28 +223,23 @@ fn resume_manual_resolution_if_present(
         return Ok(());
     };
 
-    let current_state = repo
-        .current_state()?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                "<current>",
-                "current state",
-            ))
-        })?;
+    let current_state = repo.current_state()?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            "<current>",
+            "current state",
+        ))
+    })?;
 
     if current_state.change_id == pre_conflict_head || current_state.change_id == pending_commit {
-        if let Some(cli) = cli
-            && should_output_json(cli, Some(repo.config()))
+        if !emit_rebase_progress(
+            repo,
+            cli,
+            serde_json::json!({
+                "status": "conflict",
+                "commit": pending_commit.short(),
+            }),
+        )? && cli.is_some()
         {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "output_kind": "rebase_progress",
-                    "status": "conflict",
-                    "commit": pending_commit.short(),
-                })
-            );
-        } else if cli.is_some() {
             println!(
                 "Conflict applying {}. Capture a manual resolution, then run 'heddle rebase --continue'",
                 pending_commit.short()
@@ -295,19 +278,16 @@ fn resume_manual_resolution_if_present(
     state.pre_conflict_head = None;
     save_rebase_state(rebase_state_path, state)?;
 
-    if let Some(cli) = cli
-        && should_output_json(cli, Some(repo.config()))
+    if !emit_rebase_progress(
+        repo,
+        cli,
+        serde_json::json!({
+            "status": "manual-resolution-accepted",
+            "commit": pending_commit.short(),
+            "resolved_as": current_state.change_id.short(),
+        }),
+    )? && cli.is_some()
     {
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "rebase_progress",
-                "status": "manual-resolution-accepted",
-                "commit": pending_commit.short(),
-                "resolved_as": current_state.change_id.short(),
-            })
-        );
-    } else if cli.is_some() {
         println!(
             "Accepted manual resolution for {} as {}",
             pending_commit.short(),
@@ -340,25 +320,19 @@ fn apply_commit(
     let current_tree_hash = get_tree_for_state(repo, current_head)?;
     let commit_tree_hash = commit_state.tree;
 
-    let current_tree = repo
-        .store()
-        .get_tree(&current_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &current_tree_hash.to_string(),
-                "current tree",
-            ))
-        })?;
+    let current_tree = repo.store().get_tree(&current_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &current_tree_hash.to_string(),
+            "current tree",
+        ))
+    })?;
 
-    let commit_tree = repo
-        .store()
-        .get_tree(&commit_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &commit_tree_hash.to_string(),
-                "commit tree",
-            ))
-        })?;
+    let commit_tree = repo.store().get_tree(&commit_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &commit_tree_hash.to_string(),
+            "commit tree",
+        ))
+    })?;
 
     let parent_tree_hash = if let Some(parent_id) = commit_state.parents.first() {
         get_tree_for_state(repo, parent_id)?
@@ -372,15 +346,12 @@ fn apply_commit(
         );
     };
 
-    let parent_tree = repo
-        .store()
-        .get_tree(&parent_tree_hash)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &parent_tree_hash.to_string(),
-                "parent tree",
-            ))
-        })?;
+    let parent_tree = repo.store().get_tree(&parent_tree_hash)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &parent_tree_hash.to_string(),
+            "parent tree",
+        ))
+    })?;
 
     let changes = compute_tree_diff(&parent_tree, &commit_tree);
 
@@ -621,15 +592,12 @@ fn copy_state_metadata(
 }
 
 fn get_tree_for_state(repo: &Repository, state_id: &ChangeId) -> Result<ContentHash> {
-    let state = repo
-        .store()
-        .get_state(state_id)?
-        .ok_or_else(|| {
-            anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
-                &state_id.to_string(),
-                "state",
-            ))
-        })?;
+    let state = repo.store().get_state(state_id)?.ok_or_else(|| {
+        anyhow!(RecoveryAdvice::rebase_referenced_state_missing(
+            &state_id.to_string(),
+            "state",
+        ))
+    })?;
     Ok(state.tree)
 }
 

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -85,8 +85,12 @@ fn replay_commits_internal(
             && should_output_json(cli, Some(repo.config()))
         {
             println!(
-                "{{\"status\": \"applying\", \"commit\": \"{}\"}}",
-                commit_id.short()
+                "{}",
+                serde_json::json!({
+                    "output_kind": "rebase_progress",
+                    "status": "applying",
+                    "commit": commit_id.short(),
+                })
             );
         } else if cli.is_some() {
             println!("Applying {}...", commit_id.short());
@@ -116,8 +120,12 @@ fn replay_commits_internal(
                     && should_output_json(cli, Some(repo.config()))
                 {
                     println!(
-                        "{{\"status\": \"conflict\", \"commit\": \"{}\"}}",
-                        commit_id.short()
+                        "{}",
+                        serde_json::json!({
+                            "output_kind": "rebase_progress",
+                            "status": "conflict",
+                            "commit": commit_id.short(),
+                        })
                     );
                 } else if cli.is_some() {
                     println!(
@@ -241,8 +249,12 @@ fn resume_manual_resolution_if_present(
             && should_output_json(cli, Some(repo.config()))
         {
             println!(
-                "{{\"status\": \"conflict\", \"commit\": \"{}\"}}",
-                pending_commit.short()
+                "{}",
+                serde_json::json!({
+                    "output_kind": "rebase_progress",
+                    "status": "conflict",
+                    "commit": pending_commit.short(),
+                })
             );
         } else if cli.is_some() {
             println!(
@@ -287,9 +299,13 @@ fn resume_manual_resolution_if_present(
         && should_output_json(cli, Some(repo.config()))
     {
         println!(
-            "{{\"status\": \"manual-resolution-accepted\", \"commit\": \"{}\", \"resolved_as\": \"{}\"}}",
-            pending_commit.short(),
-            current_state.change_id.short()
+            "{}",
+            serde_json::json!({
+                "output_kind": "rebase_progress",
+                "status": "manual-resolution-accepted",
+                "commit": pending_commit.short(),
+                "resolved_as": current_state.change_id.short(),
+            })
         );
     } else if cli.is_some() {
         println!(

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -16,13 +16,13 @@
 
 use std::{collections::BTreeMap, sync::OnceLock};
 
-use anyhow::{anyhow, Result};
-use schemars::{schema_for, JsonSchema};
+use anyhow::{Result, anyhow};
+use schemars::{JsonSchema, schema_for};
 use serde::Serialize;
 use serde_json::Value;
 
-use super::{command_catalog, command_runtime_contract, CommandCatalogOutput, RecoveryAdvice};
-use crate::cli::{should_output_json, Cli};
+use super::{CommandCatalogOutput, RecoveryAdvice, command_catalog, command_runtime_contract};
+use crate::cli::{Cli, should_output_json};
 
 static SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
 static DOCUMENTED_SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
@@ -108,7 +108,7 @@ schema_registry! {
     (&["bridge git status"], BridgeGitStatusSchema),
     (&["log"], LogSchema),
     (&["log --reflog"], LogReflogSchema),
-    (&["show", "inspect"], ShowSchema),
+    (&["show"], ShowSchema),
     (&["marker list"], MarkerListSchema),
     (&["marker create", "marker delete", "marker show"], MarkerOpSchema),
     (&["marker delete --prefix"], MarkerBulkDeleteSchema),
@@ -2802,18 +2802,53 @@ mod tests {
             .unwrap_or_else(|| panic!("schema has `{property}` property"))
     }
 
+    fn resolve_schema_ref<'a>(root: &'a Value, reference: &str) -> &'a Value {
+        reference
+            .strip_prefix("#/$defs/")
+            .or_else(|| reference.strip_prefix("#/definitions/"))
+            .and_then(|name| {
+                root.get("$defs")
+                    .or_else(|| root.get("definitions"))
+                    .and_then(|defs| defs.get(name))
+            })
+            .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"))
+    }
+
+    fn schema_declares_property(root: &Value, schema: &Value, property: &str) -> bool {
+        if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
+            return schema_declares_property(root, resolve_schema_ref(root, reference), property);
+        }
+
+        if schema
+            .get("properties")
+            .and_then(|properties| properties.get(property))
+            .is_some()
+        {
+            return true;
+        }
+
+        for combinator in ["anyOf", "oneOf"] {
+            if let Some(schemas) = schema.get(combinator).and_then(|value| value.as_array()) {
+                return !schemas.is_empty()
+                    && schemas
+                        .iter()
+                        .all(|schema| schema_declares_property(root, schema, property));
+            }
+        }
+
+        schema
+            .get("allOf")
+            .and_then(|value| value.as_array())
+            .is_some_and(|schemas| {
+                schemas
+                    .iter()
+                    .any(|schema| schema_declares_property(root, schema, property))
+            })
+    }
+
     fn schema_allows_null(root: &Value, schema: &Value) -> bool {
         if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
-            let definition = reference
-                .strip_prefix("#/$defs/")
-                .or_else(|| reference.strip_prefix("#/definitions/"))
-                .and_then(|name| {
-                    root.get("$defs")
-                        .or_else(|| root.get("definitions"))
-                        .and_then(|defs| defs.get(name))
-                })
-                .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"));
-            return schema_allows_null(root, definition);
+            return schema_allows_null(root, resolve_schema_ref(root, reference));
         }
 
         if schema.get("type") == Some(&Value::String("null".to_string())) {
@@ -2841,16 +2876,7 @@ mod tests {
 
     fn collect_string_enums<'a>(root: &'a Value, schema: &'a Value, values: &mut Vec<&'a str>) {
         if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
-            let definition = reference
-                .strip_prefix("#/$defs/")
-                .or_else(|| reference.strip_prefix("#/definitions/"))
-                .and_then(|name| {
-                    root.get("$defs")
-                        .or_else(|| root.get("definitions"))
-                        .and_then(|defs| defs.get(name))
-                })
-                .unwrap_or_else(|| panic!("schema reference `{reference}` resolves"));
-            collect_string_enums(root, definition, values);
+            collect_string_enums(root, resolve_schema_ref(root, reference), values);
         }
 
         if let Some(enum_values) = schema.get("enum").and_then(|value| value.as_array()) {
@@ -2929,10 +2955,7 @@ mod tests {
             }
             let bare = schema_for_registered_verb(verb)
                 .unwrap_or_else(|| panic!("documented verb `{verb}` has no registered schema"));
-            let declares = bare
-                .get("properties")
-                .and_then(|properties| properties.get("output_kind"))
-                .is_some();
+            let declares = schema_declares_property(&bare, &bare, "output_kind");
             if !declares {
                 missing.push(format!(
                     "{verb}: catalog advertises output_kind=`{}` but the schema struct declares no `output_kind` property",
@@ -3096,9 +3119,7 @@ mod tests {
         fn walk(root: &Value, schema: &Value, verb: &str, path: &str) {
             match schema {
                 Value::Object(object) => {
-                    if let Some(properties) =
-                        object.get("properties").and_then(|p| p.as_object())
-                    {
+                    if let Some(properties) = object.get("properties").and_then(|p| p.as_object()) {
                         let required: Vec<&str> = object
                             .get("required")
                             .and_then(|value| value.as_array())

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -16,13 +16,13 @@
 
 use std::{collections::BTreeMap, sync::OnceLock};
 
-use anyhow::{Result, anyhow};
-use schemars::{JsonSchema, schema_for};
+use anyhow::{anyhow, Result};
+use schemars::{schema_for, JsonSchema};
 use serde::Serialize;
 use serde_json::Value;
 
-use super::{CommandCatalogOutput, RecoveryAdvice, command_catalog, command_runtime_contract};
-use crate::cli::{Cli, should_output_json};
+use super::{command_catalog, command_runtime_contract, CommandCatalogOutput, RecoveryAdvice};
+use crate::cli::{should_output_json, Cli};
 
 static SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
 static DOCUMENTED_SCHEMA_VERBS: OnceLock<Vec<&'static str>> = OnceLock::new();
@@ -283,10 +283,115 @@ fn add_op_id_replay_fields_if_supported(verb: &str, schema: &mut Value) {
 }
 
 fn add_json_discriminator_if_advertised(verb: &str, schema: &mut Value) {
-    let Some(discriminator) = command_catalog::command_json_discriminator_for_schema_verb(verb)
-    else {
+    let mut discriminators = command_catalog::command_json_discriminators_for_schema_verb(verb);
+    if schema.get("anyOf").is_some() {
+        for discriminator in command_catalog::command_json_discriminators()
+            .into_iter()
+            .filter(|discriminator| {
+                discriminator.display == verb && discriminator.schema_verb.is_none()
+            })
+        {
+            discriminators.push(discriminator);
+        }
+    }
+    discriminators.sort_by(|left, right| {
+        (&left.field, &left.value, &left.display).cmp(&(&right.field, &right.value, &right.display))
+    });
+    discriminators.dedup_by(|left, right| left.field == right.field && left.value == right.value);
+
+    if discriminators.is_empty() {
         return;
     };
+
+    if add_json_discriminators_to_union_branches(verb, schema, &discriminators) {
+        return;
+    }
+
+    let field = discriminators[0].field.as_str();
+    let values = discriminators
+        .iter()
+        .filter(|discriminator| discriminator.field == field)
+        .map(|discriminator| discriminator.value.as_str())
+        .collect::<Vec<_>>();
+    add_json_discriminator_to_schema_object(schema, field, &values);
+}
+
+fn add_json_discriminators_to_union_branches(
+    verb: &str,
+    schema: &mut Value,
+    discriminators: &[command_catalog::CommandJsonDiscriminator],
+) -> bool {
+    let Some(branches) = schema
+        .get_mut("anyOf")
+        .and_then(|value| value.as_array_mut())
+    else {
+        return false;
+    };
+
+    let mut injected = 0usize;
+    for branch in branches {
+        let Some(branch_ref) = branch
+            .get("$ref")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let Some(discriminator) = discriminator_for_union_branch(verb, &branch_ref, discriminators)
+        else {
+            continue;
+        };
+        let original_branch = branch.clone();
+        let mut discriminator_schema = serde_json::json!({ "type": "object" });
+        add_json_discriminator_to_schema_object(
+            &mut discriminator_schema,
+            &discriminator.field,
+            &[&discriminator.value],
+        );
+        *branch = serde_json::json!({
+            "allOf": [original_branch, discriminator_schema],
+        });
+        injected += 1;
+    }
+
+    injected > 0
+}
+
+fn discriminator_for_union_branch<'a>(
+    verb: &str,
+    branch_ref: &str,
+    discriminators: &'a [command_catalog::CommandJsonDiscriminator],
+) -> Option<&'a command_catalog::CommandJsonDiscriminator> {
+    if discriminators.len() == 1 {
+        return discriminators.first();
+    }
+
+    let def_name = schema_ref_name(branch_ref)?;
+    if verb == "inspect" {
+        let value = match def_name {
+            "ShowSchema" => "inspect_state",
+            "ThreadShowSchema" => "thread_show",
+            _ => return None,
+        };
+        return discriminators
+            .iter()
+            .find(|discriminator| discriminator.value == value);
+    }
+
+    None
+}
+
+fn schema_ref_name(reference: &str) -> Option<&str> {
+    reference
+        .strip_prefix("#/$defs/")
+        .or_else(|| reference.strip_prefix("#/definitions/"))
+}
+
+fn add_json_discriminator_to_schema_object(schema: &mut Value, field: &str, values: &[&str]) {
+    let enum_values = values
+        .iter()
+        .map(|value| Value::String((*value).to_string()))
+        .collect::<Vec<_>>();
 
     let Some(object) = schema.as_object_mut() else {
         return;
@@ -298,10 +403,10 @@ fn add_json_discriminator_if_advertised(verb: &str, schema: &mut Value) {
         return;
     };
     properties.insert(
-        discriminator.field.clone(),
+        field.to_string(),
         serde_json::json!({
             "type": "string",
-            "enum": [discriminator.value],
+            "enum": enum_values,
         }),
     );
 
@@ -313,9 +418,9 @@ fn add_json_discriminator_if_advertised(verb: &str, schema: &mut Value) {
     };
     if !required
         .iter()
-        .any(|field| field.as_str() == Some(discriminator.field.as_str()))
+        .any(|required_field| required_field.as_str() == Some(field))
     {
-        required.push(Value::String(discriminator.field));
+        required.push(Value::String(field.to_string()));
     }
 }
 
@@ -2896,6 +3001,72 @@ mod tests {
         }
     }
 
+    fn collect_discriminator_values<'a>(
+        root: &'a Value,
+        schema: &'a Value,
+        field: &str,
+        values: &mut Vec<&'a str>,
+    ) {
+        if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
+            collect_discriminator_values(root, resolve_schema_ref(root, reference), field, values);
+            return;
+        }
+
+        if let Some(property) = schema
+            .get("properties")
+            .and_then(|properties| properties.get(field))
+        {
+            collect_string_enums(root, property, values);
+        }
+
+        for combinator in ["anyOf", "oneOf", "allOf"] {
+            if let Some(schemas) = schema.get(combinator).and_then(|value| value.as_array()) {
+                for schema in schemas {
+                    collect_discriminator_values(root, schema, field, values);
+                }
+            }
+        }
+    }
+
+    fn schema_requires_discriminator(root: &Value, schema: &Value, field: &str) -> bool {
+        if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) {
+            return schema_requires_discriminator(root, resolve_schema_ref(root, reference), field);
+        }
+
+        if schema
+            .get("properties")
+            .and_then(|properties| properties.get(field))
+            .is_some()
+        {
+            return schema
+                .get("required")
+                .and_then(|value| value.as_array())
+                .is_some_and(|required| {
+                    required
+                        .iter()
+                        .any(|required_field| required_field.as_str() == Some(field))
+                });
+        }
+
+        for combinator in ["anyOf", "oneOf"] {
+            if let Some(schemas) = schema.get(combinator).and_then(|value| value.as_array()) {
+                return !schemas.is_empty()
+                    && schemas
+                        .iter()
+                        .all(|schema| schema_requires_discriminator(root, schema, field));
+            }
+        }
+
+        schema
+            .get("allOf")
+            .and_then(|value| value.as_array())
+            .is_some_and(|schemas| {
+                schemas
+                    .iter()
+                    .any(|schema| schema_requires_discriminator(root, schema, field))
+            })
+    }
+
     /// Every schema verb advertised by the command contract table must
     /// produce a schema.
     /// Otherwise `heddle doctor schemas` would silently miss drift on
@@ -3298,44 +3469,67 @@ mod tests {
 
     #[test]
     fn advertised_json_discriminators_are_reflected_in_schemas() {
-        for discriminator in command_catalog::command_json_discriminators() {
-            let Some(schema_verb) = discriminator.schema_verb.as_deref() else {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        for schema_verb in schema_verbs() {
+            let mut discriminators =
+                command_catalog::command_json_discriminators_for_schema_verb(schema_verb);
+            if discriminators.is_empty() {
                 continue;
             };
             let schema =
                 schema_for_verb(schema_verb).unwrap_or_else(|| panic!("{schema_verb} schema"));
-            let properties = schema
-                .get("properties")
-                .and_then(|p| p.as_object())
-                .unwrap_or_else(|| panic!("{schema_verb} schema has properties"));
-            let property = properties.get(&discriminator.field).unwrap_or_else(|| {
-                panic!(
-                    "{schema_verb} schema missing discriminator field `{}`",
-                    discriminator.field
-                )
-            });
-            let enum_values = property
-                .get("enum")
-                .and_then(|value| value.as_array())
-                .map(Vec::as_slice);
-            assert_eq!(
-                enum_values,
-                Some([Value::String(discriminator.value.clone())].as_slice()),
-                "{schema_verb} schema must narrow `{}` to `{}`",
-                discriminator.field,
-                discriminator.value
-            );
+            if schema.get("anyOf").is_some() {
+                for discriminator in command_catalog::command_json_discriminators()
+                    .into_iter()
+                    .filter(|discriminator| {
+                        discriminator.display == *schema_verb && discriminator.schema_verb.is_none()
+                    })
+                {
+                    discriminators.push(discriminator);
+                }
+            }
 
-            let required = schema
-                .get("required")
-                .and_then(|value| value.as_array())
-                .unwrap_or_else(|| panic!("{schema_verb} schema has required fields"));
-            assert!(
-                required.contains(&Value::String(discriminator.field.clone())),
-                "{schema_verb} schema must require discriminator field `{}`",
-                discriminator.field
-            );
+            let mut expected_by_field = BTreeMap::<String, BTreeSet<String>>::new();
+            for discriminator in discriminators {
+                expected_by_field
+                    .entry(discriminator.field)
+                    .or_default()
+                    .insert(discriminator.value);
+            }
+
+            for (field, expected) in expected_by_field {
+                let mut actual = Vec::new();
+                collect_discriminator_values(&schema, &schema, &field, &mut actual);
+                let actual = actual
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(
+                    actual, expected,
+                    "{schema_verb} schema must narrow `{field}` to every catalog-advertised value"
+                );
+                assert!(
+                    schema_requires_discriminator(&schema, &schema, &field),
+                    "{schema_verb} schema must require discriminator field `{field}`"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn inspect_schema_accepts_both_advertised_output_kinds() {
+        use std::collections::BTreeSet;
+
+        let schema = schema_for_verb("inspect").expect("inspect schema");
+        let mut values = Vec::new();
+        collect_discriminator_values(&schema, &schema, "output_kind", &mut values);
+        let values = values.into_iter().collect::<BTreeSet<_>>();
+        assert_eq!(
+            values,
+            BTreeSet::from(["inspect_state", "thread_show"]),
+            "inspect aliases state inspection and thread show, so both output kinds must be represented"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -288,7 +288,7 @@ fn add_json_discriminator_if_advertised(verb: &str, schema: &mut Value) {
         for discriminator in command_catalog::command_json_discriminators()
             .into_iter()
             .filter(|discriminator| {
-                discriminator.display == verb && discriminator.schema_verb.is_none()
+                discriminator.display == verb && discriminator.schema_verb.as_deref() != Some(verb)
             })
         {
             discriminators.push(discriminator);
@@ -3480,10 +3480,21 @@ mod tests {
             let schema =
                 schema_for_verb(schema_verb).unwrap_or_else(|| panic!("{schema_verb} schema"));
             if schema.get("anyOf").is_some() {
+                // A union schema published under this verb covers every schema
+                // verb its catalog entry documents — the expected discriminator
+                // set must include the siblings (e.g. inspect's union carries
+                // the `thread show` branch's thread_show).
+                for sibling in command_catalog::sibling_documented_schema_verbs(schema_verb) {
+                    discriminators
+                        .extend(command_catalog::command_json_discriminators_for_schema_verb(
+                            sibling,
+                        ));
+                }
                 for discriminator in command_catalog::command_json_discriminators()
                     .into_iter()
                     .filter(|discriminator| {
-                        discriminator.display == *schema_verb && discriminator.schema_verb.is_none()
+                        discriminator.display == *schema_verb
+                            && discriminator.schema_verb.as_deref() != Some(schema_verb)
                     })
                 {
                     discriminators.push(discriminator);

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -108,7 +108,7 @@ schema_registry! {
     (&["bridge git status"], BridgeGitStatusSchema),
     (&["log"], LogSchema),
     (&["log --reflog"], LogReflogSchema),
-    (&["show"], ShowSchema),
+    (&["show", "inspect"], ShowSchema),
     (&["marker list"], MarkerListSchema),
     (&["marker create", "marker delete", "marker show"], MarkerOpSchema),
     (&["marker delete --prefix"], MarkerBulkDeleteSchema),
@@ -2178,6 +2178,7 @@ pub struct ReflogEntrySchema {
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ShowSchema {
+    pub output_kind: String,
     pub repository_capability: String,
     pub storage_model: String,
     pub change_id: String,

--- a/crates/cli/src/cli/commands/show.rs
+++ b/crates/cli/src/cli/commands/show.rs
@@ -18,6 +18,7 @@ use crate::{
 
 #[derive(Serialize)]
 struct ShowOutput {
+    output_kind: &'static str,
     repository_capability: String,
     storage_model: String,
     change_id: String,
@@ -73,11 +74,23 @@ struct ShowGitOverlayImportHintOutput {
 }
 
 pub fn cmd_show(cli: &Cli, state_spec: Option<String>) -> Result<()> {
+    cmd_show_with_output_kind(cli, state_spec, "show")
+}
+
+pub fn cmd_inspect_state(cli: &Cli, state_spec: Option<String>) -> Result<()> {
+    cmd_show_with_output_kind(cli, state_spec, "inspect_state")
+}
+
+fn cmd_show_with_output_kind(
+    cli: &Cli,
+    state_spec: Option<String>,
+    output_kind: &'static str,
+) -> Result<()> {
     let state_spec = state_spec.unwrap_or_else(|| "HEAD".to_string());
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
     if let Some(probe) = build_plain_git_verification_probe(start)? {
-        return render_plain_git_show(cli, &probe, &state_spec);
+        return render_plain_git_show(cli, &probe, &state_spec, output_kind);
     }
 
     let repo = Repository::open(start)?;
@@ -93,6 +106,7 @@ pub fn cmd_show(cli: &Cli, state_spec: Option<String>) -> Result<()> {
     let state = require_resolved_state(&repo, &id)?;
 
     let output = ShowOutput {
+        output_kind,
         repository_capability: repo.capability_label().to_string(),
         storage_model: repo.storage_model_label().to_string(),
         git_overlay_import_hint: repo.git_overlay_import_hint()?.map(|hint| {
@@ -149,12 +163,14 @@ fn render_plain_git_show(
     cli: &Cli,
     probe: &PlainGitVerificationProbe,
     state_spec: &str,
+    output_kind: &'static str,
 ) -> Result<()> {
     if should_output_json(cli, None) {
         println!(
             "{}",
             serde_json::to_string(&serde_json::json!({
                 "repository_capability": "plain-git",
+                "output_kind": output_kind,
                 "storage_model": "git",
                 "requested": state_spec,
                 "state": null,

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -23,8 +23,8 @@ use super::{
     advice::RecoveryAdvice,
     git_overlay_health::{PlainGitVerificationProbe, build_plain_git_verification_probe},
     mount_lifecycle,
-    operator_core::OperatorCommandOutput,
     next_action::normalized_action,
+    operator_core::{OperatorAction, OperatorCommandOutput},
     operator_loop::primary_next_action,
     thread::{
         cmd_thread_cd, cmd_thread_create, cmd_thread_current, cmd_thread_delete, cmd_thread_list,
@@ -142,9 +142,15 @@ pub(crate) fn current_thread(repo: &Repository) -> Result<Option<Thread>> {
 pub(crate) fn load_thread(repo: &Repository, thread_id: &str) -> Result<Thread> {
     match thread_manager(repo).load(thread_id)? {
         Some(thread) => Ok(thread),
-        None if repo.refs().get_thread(&ThreadName::new(thread_id))?.is_some() => Err(anyhow!(
-            imported_git_ref_not_managed_thread_advice(thread_id)
-        )),
+        None if repo
+            .refs()
+            .get_thread(&ThreadName::new(thread_id))?
+            .is_some() =>
+        {
+            Err(anyhow!(imported_git_ref_not_managed_thread_advice(
+                thread_id
+            )))
+        }
         None => Err(anyhow!(thread_not_found_advice(thread_id, "load thread"))),
     }
 }
@@ -374,6 +380,7 @@ fn cmd_thread_refresh(cli: &Cli, repo: &Repository, thread_id: &str) -> Result<(
     print_thread_output(
         cli,
         repo,
+        OperatorAction::ThreadRefresh,
         thread,
         format!("Refreshed thread '{}'", thread_id),
     )
@@ -384,10 +391,12 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
     let mut thread = manager
         .load(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "refresh thread")))?;
-    let target_thread = thread
-        .target_thread
-        .clone()
-        .ok_or_else(|| anyhow!(RecoveryAdvice::missing_target_thread(thread_id, "refresh thread")))?;
+    let target_thread = thread.target_thread.clone().ok_or_else(|| {
+        anyhow!(RecoveryAdvice::missing_target_thread(
+            thread_id,
+            "refresh thread"
+        ))
+    })?;
 
     refresh_thread_freshness(repo, &mut thread)?;
     if thread.freshness == ThreadFreshness::Current {
@@ -813,11 +822,8 @@ fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice
 }
 
 fn current_thread_drop_advice(repo: &Repository, thread_id: &str) -> RecoveryAdvice {
-    let (primary, recovery, hint) = super::thread::current_thread_drop_recovery(
-        repo,
-        thread_id,
-        super::thread::DropMode::Drop,
-    );
+    let (primary, recovery, hint) =
+        super::thread::current_thread_drop_recovery(repo, thread_id, super::thread::DropMode::Drop);
     RecoveryAdvice::safety_refusal(
         "current_thread_not_droppable",
         format!("Thread '{thread_id}' is the current checkout thread and cannot be dropped"),
@@ -1031,7 +1037,9 @@ fn try_three_way_merge_refresh(
             // Thread is strictly behind target — fast-forward the
             // thread ref. We do this against the parent repo so the
             // ref move is visible to the caller's bookkeeping.
-            parent_repo.refs().set_thread(&ThreadName::new(&thread.thread), &target)?;
+            parent_repo
+                .refs()
+                .set_thread(&ThreadName::new(&thread.thread), &target)?;
             // Materialize the target tree to the thread's worktree.
             // Without this, HEAD metadata advances while the files on
             // disk stay stale and subsequent operations run against a
@@ -1095,12 +1103,15 @@ fn cmd_thread_promote(
     let mut thread = manager
         .load(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "promote thread")))?;
-    let state_id = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.ok_or_else(|| {
-        anyhow!(
-            "managed thread '{}' is missing its ref during promote",
-            thread.thread
-        )
-    })?;
+    let state_id = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .ok_or_else(|| {
+            anyhow!(
+                "managed thread '{}' is missing its ref during promote",
+                thread.thread
+            )
+        })?;
     if !force {
         if thread.execution_path.exists()
             && thread.execution_path != *repo.root()
@@ -1176,6 +1187,7 @@ fn cmd_thread_promote(
     print_thread_output(
         cli,
         repo,
+        OperatorAction::ThreadPromote,
         thread,
         format!(
             "Promoted thread '{}' to '{}'",
@@ -1197,6 +1209,7 @@ pub(crate) fn cmd_thread_drop(
         DropOutcome::Dropped(thread) => print_thread_output(
             cli,
             repo,
+            OperatorAction::ThreadDrop,
             *thread,
             format!("Dropped thread '{}'", thread_id),
         ),
@@ -1308,6 +1321,7 @@ pub(crate) fn drop_thread_silent(
 fn print_thread_output(
     cli: &Cli,
     repo: &Repository,
+    action: OperatorAction,
     mut thread: Thread,
     message: String,
 ) -> Result<()> {
@@ -1333,7 +1347,7 @@ fn print_thread_output(
             serde_json::to_string(&ThreadOutput {
                 operator: OperatorCommandOutput {
                     status: "completed".to_string(),
-                    action: "thread".to_string(),
+                    action,
                     message,
                     blockers: advice.blockers.clone(),
                     warnings: Vec::new(),
@@ -1736,7 +1750,7 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
     let output = ThreadCleanupOutput {
         operator: OperatorCommandOutput {
             status: "completed".to_string(),
-            action: "thread.cleanup".to_string(),
+            action: OperatorAction::ThreadCleanup,
             message: summary_message.clone(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -1845,8 +1859,7 @@ mod cleanup_tests {
         let repo = Repository::init_default(dir.path()).unwrap();
         for id in ["foo", "foo/bar", "team@scope", "feature/foo"] {
             let promote = default_materialized_thread_path(&repo, id);
-            let canonical =
-                repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
+            let canonical = repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
             assert_eq!(
                 promote, canonical,
                 "promote default must match the canonical thread_dir for {id:?}"

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -5,7 +5,10 @@ use objects::store::ObjectStore;
 use std::{fs, path::Path};
 
 use anyhow::{Result, anyhow};
-use objects::{fs_ops::remove_path_recursively, object::{ChangeId, ThreadName}};
+use objects::{
+    fs_ops::remove_path_recursively,
+    object::{ChangeId, ThreadName},
+};
 use repo::{GitOverlayImportHint, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus};
 use serde::Serialize;
 
@@ -14,9 +17,9 @@ use super::{
     advice::RecoveryAdvice,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     merge::merge_thread_into_current,
-    operator_core::OperatorCommandOutput,
-    operator_loop::primary_next_action,
     next_action::{NextActionValidationContext, write_command_json},
+    operator_core::{OperatorAction, OperatorCommandOutput},
+    operator_loop::primary_next_action,
     ready_cmd::worktree_dirty,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread_cmd::{load_thread, refresh_thread, refresh_thread_freshness, thread_not_found_advice},
@@ -401,8 +404,10 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
         thread.integration_policy_result.status = Some("manual_resolved".to_string());
         thread.integration_policy_result.reason =
             Some("manual integration resolution captured".to_string());
-        thread.integration_policy_result.manual_resolution_state =
-            repo.refs().get_thread(&ThreadName::new(&thread.thread))?.map(|id| id.short());
+        thread.integration_policy_result.manual_resolution_state = repo
+            .refs()
+            .get_thread(&ThreadName::new(&thread.thread))?
+            .map(|id| id.short());
         manager.save(&thread)?;
     }
     let recommended_action = if blockers.is_empty() {
@@ -434,7 +439,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 } else {
                     "blocked".to_string()
                 },
-                action: "resolve".to_string(),
+                action: OperatorAction::ThreadResolve,
                 message: if blockers.is_empty() {
                     if warnings.is_empty() {
                         "Thread manual resolution recorded".to_string()
@@ -487,7 +492,8 @@ fn thread_resolve_rebase_followup_operator(
     let next_action = "heddle continue".to_string();
     let mut blockers = Vec::new();
     if rebase_state
-        .pre_conflict_head.is_none_or(|head| head == current_state.change_id)
+        .pre_conflict_head
+        .is_none_or(|head| head == current_state.change_id)
     {
         blockers.push(
             "refresh has a rebase in progress; capture a manual resolution in the thread checkout, then run `heddle rebase --continue`".to_string(),
@@ -500,7 +506,7 @@ fn thread_resolve_rebase_followup_operator(
         } else {
             "blocked".to_string()
         },
-        action: "resolve".to_string(),
+        action: OperatorAction::ThreadResolve,
         message: if blockers.is_empty() {
             "Thread manual resolution recorded; continue the rebase".to_string()
         } else {
@@ -537,7 +543,7 @@ fn thread_resolve_conflict_recovery_operator(
     };
     Ok(Some(OperatorCommandOutput {
         status: "blocked".to_string(),
-        action: "resolve".to_string(),
+        action: OperatorAction::ThreadResolve,
         message: format!(
             "Thread '{thread_id}' has conflict markers in its checkout; resolve them there, then continue"
         ),
@@ -556,7 +562,7 @@ fn thread_resolve_refresh_operator(
     if trust.verified {
         return OperatorCommandOutput {
             status: "synced".to_string(),
-            action: "resolve".to_string(),
+            action: OperatorAction::ThreadResolve,
             message: "Thread refreshed cleanly".to_string(),
             blockers: Vec::new(),
             warnings: Vec::new(),
@@ -566,7 +572,7 @@ fn thread_resolve_refresh_operator(
     }
 
     OperatorCommandOutput::blocked_by_repository_verification(
-        "resolve",
+        OperatorAction::ThreadResolve,
         format!(
             "Thread refreshed cleanly, but repository verification is blocked: {}",
             trust.summary
@@ -765,11 +771,7 @@ fn emit<T: Serialize>(cli: &Cli, output: &T) -> Result<()> {
     Ok(())
 }
 
-fn emit_thread_resolve(
-    cli: &Cli,
-    repo: &Repository,
-    output: &ThreadResolveOutput,
-) -> Result<()> {
+fn emit_thread_resolve(cli: &Cli, repo: &Repository, output: &ThreadResolveOutput) -> Result<()> {
     if should_output_json(cli, None) {
         write_command_json(
             output,

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-use objects::store::ObjectStore;
 use anyhow::{Context, Result, anyhow};
 use objects::object::{ChangeId, ThreadName};
+use objects::store::ObjectStore;
 use oplog::{OpBatch, OpLogBackend, OpRecord};
 use repo::{Repository, Thread, ThreadIntegrationPolicy, thread_flag};
 use serde::Serialize;
@@ -12,8 +12,10 @@ use super::{
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     merge::{build_thread_preview_report, merge_thread_into_current},
+    next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
     operator_core::{
-        OperatorCommandOutput, VerificationClaimPolicy, exit_if_blocked_operator_status,
+        OperatorAction, OperatorCommandOutput, VerificationClaimPolicy,
+        exit_if_blocked_operator_status,
     },
     operator_loop::primary_next_action,
     ready_cmd::worktree_dirty,
@@ -22,7 +24,6 @@ use super::{
     thread_cmd::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
-    next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
     thread_landing::{land_local_command, switch_thread_command},
 };
 use crate::{
@@ -107,7 +108,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
         SyncOutput {
             operator: OperatorCommandOutput {
                 status: "current".to_string(),
-                action: "sync".to_string(),
+                action: OperatorAction::Sync,
                 message: format!("Thread '{}' is already current", thread.id),
                 blockers: vec![],
                 warnings: Vec::new(),
@@ -149,7 +150,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
         SyncOutput {
             operator: OperatorCommandOutput {
                 status: "blocked".to_string(),
-                action: "sync".to_string(),
+                action: OperatorAction::Sync,
                 message: format!("Thread '{}' needs manual sync", thread.id),
                 blockers: stale_report.blockers.clone(),
                 warnings: Vec::new(),
@@ -190,7 +191,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                 SyncOutput {
                     operator: OperatorCommandOutput {
                         status: "refreshed".to_string(),
-                        action: "sync".to_string(),
+                        action: OperatorAction::Sync,
                         message: format!("Refreshed thread '{}'", refreshed.id),
                         blockers: vec![],
                         warnings: Vec::new(),
@@ -221,7 +222,7 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                 SyncOutput {
                     operator: OperatorCommandOutput {
                         status: "blocked".to_string(),
-                        action: "sync".to_string(),
+                        action: OperatorAction::Sync,
                         message: format!("Thread '{}' has merge conflicts to resolve", thread.id),
                         blockers: stale_report.blockers.clone(),
                         warnings: Vec::new(),
@@ -387,7 +388,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                 &LandOutput {
                     operator: OperatorCommandOutput {
                         status: "blocked".to_string(),
-                        action: "land".to_string(),
+                        action: OperatorAction::Land,
                         message: format!(
                             "Thread '{}' must be synced manually",
                             refreshed_thread.id
@@ -496,7 +497,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         let post_land_action = integrated_land_next_action(true, pushed, &trust);
         let mut operator = OperatorCommandOutput {
             status: "landed".to_string(),
-            action: "land".to_string(),
+            action: OperatorAction::Land,
             message: format!(
                 "Landed thread '{}' from a manually resolved integration state",
                 merge_thread.id
@@ -552,9 +553,11 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         // operator through `sync`, which materializes and resolves a genuine
         // conflict before a land retry. (heddle#464 close-the-class.)
         let recovery_scope = recovery_scope_checkout(&merge_thread, repo.root());
-        let recommended_action =
-            integration_blocker_recommended_action(&integration_blockers, recovery_scope.as_deref())
-                .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
+        let recommended_action = integration_blocker_recommended_action(
+            &integration_blockers,
+            recovery_scope.as_deref(),
+        )
+        .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
         update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
         return write_land_output(
             cli,
@@ -562,7 +565,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             &LandOutput {
                 operator: OperatorCommandOutput {
                     status: "blocked".to_string(),
-                    action: "land".to_string(),
+                    action: OperatorAction::Land,
                     message: format!("Thread '{}' is not eligible for auto-land", merge_thread.id),
                     blockers: land_blockers_for_preview(&preview, &integration_blockers),
                     warnings: Vec::new(),
@@ -670,7 +673,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     let integrated_next_action = integrated_land_next_action(integrated, pushed, &trust);
     let mut operator = OperatorCommandOutput {
         status: if integrated { "landed" } else { "blocked" }.to_string(),
-        action: "land".to_string(),
+        action: OperatorAction::Land,
         message: if integrated {
             format!("Landed thread '{}'", merge_thread.id)
         } else {
@@ -769,7 +772,8 @@ fn land_performed_steps(
         (pushed, "push"),
     ]
     .into_iter()
-    .filter(|&(done, _step)| done).map(|(_done, step)| step.to_string())
+    .filter(|&(done, _step)| done)
+    .map(|(_done, step)| step.to_string())
     .collect()
 }
 
@@ -790,7 +794,8 @@ fn land_skipped_steps(
         (!pushed && !integrated, "push(not reached)"),
     ]
     .into_iter()
-    .filter(|&(skipped, _step)| skipped).map(|(_skipped, step)| step.to_string())
+    .filter(|&(skipped, _step)| skipped)
+    .map(|(_skipped, step)| step.to_string())
     .collect()
 }
 
@@ -1261,12 +1266,15 @@ fn adopt_manual_resolution(repo: &Repository, thread_id: &str) -> Result<String>
             "adopt manual resolution"
         ))
     })?;
-    let target = repo.refs().get_thread(&ThreadName::new(&thread.thread))?.ok_or_else(|| {
-        anyhow!(
-            "Thread '{}' has no current state to integrate",
-            thread.thread
-        )
-    })?;
+    let target = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Thread '{}' has no current state to integrate",
+                thread.thread
+            )
+        })?;
     super::ff_record::record_ff_advance(repo, &thread.thread, &target)?;
     thread.state = repo::ThreadState::Merged;
     thread.merged_state = Some(target.short());
@@ -1301,13 +1309,13 @@ pub(crate) fn auto_land_policy_blockers(repo: &Repository, thread: &Thread) -> V
     let agent_authored = thread_is_agent_authored(repo, thread);
     if agent_authored
         && let Some(confidence) = thread.confidence_summary.value
-            && confidence < AUTO_LAND_CONFIDENCE_THRESHOLD
-        {
-            blockers.push(format!(
-                "confidence {:.2} is below the auto-land threshold of 0.75",
-                confidence
-            ));
-        }
+        && confidence < AUTO_LAND_CONFIDENCE_THRESHOLD
+    {
+        blockers.push(format!(
+            "confidence {:.2} is below the auto-land threshold of 0.75",
+            confidence
+        ));
+    }
     if matches!(thread.verification_summary.tests_passed, Some(false)) {
         blockers.push("verification summary reports failing tests".to_string());
     }
@@ -1361,7 +1369,8 @@ pub(crate) fn recovery_scope_checkout(
     if execution_path.as_os_str().is_empty() {
         return None;
     }
-    let canonical = |path: &std::path::Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let canonical =
+        |path: &std::path::Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     (canonical(execution_path) != canonical(current_checkout)).then(|| execution_path.clone())
 }
 
@@ -1408,7 +1417,12 @@ fn thread_is_agent_authored(repo: &Repository, thread: &Thread) -> bool {
         .current_state
         .as_deref()
         .and_then(|state| repo.resolve_state(state).ok().flatten())
-        .or_else(|| repo.refs().get_thread(&ThreadName::new(&thread.thread)).ok().flatten());
+        .or_else(|| {
+            repo.refs()
+                .get_thread(&ThreadName::new(&thread.thread))
+                .ok()
+                .flatten()
+        });
     current_state
         .and_then(|id| repo.store().get_state(&id).ok().flatten())
         .map(|state| state.attribution.agent.is_some())

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -73,6 +73,7 @@ impl HeddleExitCode {
             | "reconcile_direction_required"
             | "dirty_worktree"
             | "state_corrupted"
+            | "conflict_not_found"
             | "json_unsupported"
             | "json_compact_unsupported" => Some(Self::DataErr),
             _ => None,
@@ -328,6 +329,7 @@ mod tests {
             ("reconcile_direction_required", HeddleExitCode::DataErr),
             ("dirty_worktree", HeddleExitCode::DataErr),
             ("state_corrupted", HeddleExitCode::DataErr),
+            ("conflict_not_found", HeddleExitCode::DataErr),
             ("json_unsupported", HeddleExitCode::DataErr),
             ("json_compact_unsupported", HeddleExitCode::DataErr),
         ] {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -30,11 +30,11 @@ use cli::{
             cmd_context_suggest, cmd_context_supersede, cmd_continue, cmd_daemon_serve,
             cmd_daemon_status, cmd_daemon_stop, cmd_delegate, cmd_diagnose, cmd_diff, cmd_discuss,
             cmd_doctor_docs, cmd_doctor_schemas, cmd_fetch, cmd_fork, cmd_fsck, cmd_goto,
-            cmd_harness_bridge, cmd_hook, cmd_init, cmd_integration, cmd_log,
-            cmd_maintenance, cmd_marker, cmd_merge, cmd_pull, cmd_push, cmd_query,
+            cmd_harness_bridge, cmd_hook, cmd_init, cmd_inspect_state, cmd_integration, cmd_land,
+            cmd_log, cmd_maintenance, cmd_marker, cmd_merge, cmd_pull, cmd_push, cmd_query,
             cmd_ready, cmd_rebase, cmd_redo, cmd_remote, cmd_resolve, cmd_retro, cmd_revert,
             cmd_review, cmd_run, cmd_schemas, cmd_session_end, cmd_session_list,
-            cmd_session_segment, cmd_session_show, cmd_session_start, cmd_shell, cmd_land,
+            cmd_session_segment, cmd_session_show, cmd_session_start, cmd_shell,
             cmd_show, cmd_snapshot, cmd_stack, cmd_start, cmd_stash, cmd_status,
             cmd_switch_compat, cmd_sync_smart, cmd_thread, cmd_thread_show, cmd_transaction,
             cmd_try, cmd_undo, cmd_verify, cmd_watch, cmd_workspace,
@@ -480,14 +480,14 @@ async fn async_main() -> Result<()> {
             if let Some(state) = target
                 && is_plain_git_without_heddle(start)
             {
-                return cmd_show(&cli, Some(state.clone()));
+                return cmd_inspect_state(&cli, Some(state.clone()));
             }
             let repo = repo::Repository::open(start)?;
             match target {
                 Some(name) if repo.refs().get_thread(&objects::object::ThreadName::new(name.as_str()))?.is_some() => {
                     cmd_thread_show(&cli, &repo, Some(name.clone()))
                 }
-                Some(state) => cmd_show(&cli, Some(state.clone())),
+                Some(state) => cmd_inspect_state(&cli, Some(state.clone())),
                 None => cmd_thread_show(&cli, &repo, None),
             }
         }

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -209,6 +209,41 @@ fn unsupported_output_json_compact_is_data_err() {
 }
 
 #[test]
+fn conflict_show_missing_id_is_data_err_with_error_envelope() {
+    let repo = init_repo();
+    let output = heddle_output(
+        &["--output", "json", "conflict", "show", "missing-id"],
+        Some(repo.path()),
+    )
+    .expect("spawn conflict show missing-id");
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "missing conflict id should exit 65 (DataErr); stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "missing conflict id must not print a success payload on stdout"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let envelope: serde_json::Value = serde_json::from_str(stderr.trim()).unwrap_or_else(|err| {
+        panic!("conflict missing-id envelope not JSON: {err}\n  stderr: {stderr}")
+    });
+    assert_eq!(envelope["kind"], "conflict_not_found");
+    assert_eq!(envelope["exit_code"], 65);
+    assert!(
+        envelope["recovery_commands"]
+            .as_array()
+            .is_some_and(|commands| commands
+                .iter()
+                .any(|command| command == "heddle conflict list")),
+        "missing conflict id should point callers at conflict list: {envelope}"
+    );
+}
+
+#[test]
 fn status_on_corrupted_state_is_data_err_with_recovery_path() {
     // HeddleCo/heddle#642: corrupted msgpack state must not dead-end on
     // raw decoder internals. `heddle status` is the natural recovery

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -7475,7 +7475,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_then_retry_ships() {
     heddle(&["resolve", "conflict.txt"], Some(&thread_path)).unwrap();
     let continued = json(&thread_path, &["--output", "json", "continue"]);
     assert_eq!(continued["status"], "continued");
-    assert_operator_json_contract(&continued, "merge");
+    assert_operator_json_contract(&continued, "continue");
     assert!(
         continued["recommended_action"]
             .as_str()
@@ -7621,7 +7621,7 @@ fn git_overlay_matrix_stale_ship_manual_resolution_pushes_when_requested() {
     heddle(&["resolve", "conflict.txt"], Some(&thread_path)).unwrap();
     let continued = json(&thread_path, &["--output", "json", "continue"]);
     assert_eq!(continued["status"], "continued");
-    assert_operator_json_contract(&continued, "merge");
+    assert_operator_json_contract(&continued, "continue");
     heddle(
         &["thread", "resolve", "feature/manual-push"],
         Some(temp.path()),
@@ -8564,7 +8564,7 @@ fn git_overlay_matrix_continue_retry_loops_block_then_succeed_after_resolution()
     heddle(&["resolve", "--all", "--ours"], Some(heddle_merge.path())).unwrap();
     let continued = json(heddle_merge.path(), &["--output", "json", "continue"]);
     assert_eq!(continued["status"], "continued");
-    assert_operator_json_contract(&continued, "merge");
+    assert_operator_json_contract(&continued, "continue");
 
     let git_merge = TempDir::new().unwrap();
     init_git_repo_with_branch(git_merge.path(), "feature/drop-in");
@@ -8600,7 +8600,7 @@ fn git_overlay_matrix_continue_retry_loops_block_then_succeed_after_resolution()
             .is_some_and(|message| message.contains("no-git runtime")),
         "raw Git continue should explain the native no-git boundary: {continued_git}"
     );
-    assert_operator_json_contract(&continued_git, "merge");
+    assert_operator_json_contract(&continued_git, "continue");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -791,8 +791,13 @@ fn runtime_top_level_keys(argv: &[&str], dir: &std::path::Path) -> BTreeSet<Stri
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let first_line = stdout.lines().next().unwrap_or("").trim();
-    let parsed: Value = serde_json::from_str(first_line)
-        .unwrap_or_else(|err| panic!("{argv:?} stdout not JSON: {err}\n  line: {first_line}"));
+    let parsed: Value = serde_json::from_str(first_line).unwrap_or_else(|line_err| {
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|full_err| {
+            panic!(
+                "{argv:?} stdout not JSON: first line error: {line_err}; full stdout error: {full_err}\n  stdout: {stdout}"
+            )
+        })
+    });
     parsed
         .as_object()
         .unwrap_or_else(|| panic!("{argv:?} top-level JSON is not an object: {first_line}"))
@@ -883,6 +888,12 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             std::fs::write(t.path().join("a.txt"), "base").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             (t, sv(&["goto", "main"]))
+        }
+        "inspect_state" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
+            (t, sv(&["inspect", "HEAD"]))
         }
         "revert" => {
             let t = init_fixture();

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -279,17 +279,6 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         // The maintenance wrappers emit their inner tool's kind.
         "maintenance gc" => Some("gc"),
         "maintenance index" => Some("index"),
-        // The thread lifecycle verbs that route through the shared
-        // operator envelope emit the generic `thread` (drop / promote /
-        // refresh), `resolve`, or the dotted `thread.cleanup` action
-        // name. Flagged as struct-level inconsistencies for a follow-up
-        // sweep; until the structs change, the catalog must advertise
-        // the live values.
-        "thread cleanup" => Some("thread.cleanup"),
-        "thread drop" => Some("thread"),
-        "thread promote" => Some("thread"),
-        "thread refresh" => Some("thread"),
-        "thread resolve" => Some("resolve"),
         _ => None,
     }
 }
@@ -420,11 +409,10 @@ fn kind_field_exceptions_use_kind_intentionally() {
             .commands
             .iter()
             .find(|c| c.display == display)
-            .unwrap_or_else(|| panic!("`{display}` listed in KIND_FIELD_EXCEPTIONS is not in the catalog"));
-        let has_kind = entry
-            .json_discriminators
-            .iter()
-            .any(|d| d.field == "kind");
+            .unwrap_or_else(|| {
+                panic!("`{display}` listed in KIND_FIELD_EXCEPTIONS is not in the catalog")
+            });
+        let has_kind = entry.json_discriminators.iter().any(|d| d.field == "kind");
         assert!(
             has_kind,
             "`{display}` is documented as a `kind`-rather-than-output_kind exception but the catalog declares no `kind` discriminator. Update the catalog or drop the exception."
@@ -667,7 +655,9 @@ fn init_fixture() -> TempDir {
 /// whether the verb is expected to exit zero. Some named verbs need a
 /// non-trivial fixture (e.g. `revert` requires a state to revert); we
 /// skip those here and rely on dedicated tests elsewhere.
-fn runtime_invocation_args(display: &str) -> Option<(&'static [&'static str], bool /* expect_ok */)> {
+fn runtime_invocation_args(
+    display: &str,
+) -> Option<(&'static [&'static str], bool /* expect_ok */)> {
     match display {
         "stack" => Some((&["stack"], true)),
         "stack ready" => Some((&["stack", "ready"], true)),
@@ -737,8 +727,7 @@ fn runtime_init_emits_output_kind() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let first_line = stdout.lines().next().unwrap_or("").trim();
-    let parsed: Value =
-        serde_json::from_str(first_line).expect("init stdout is parseable JSON");
+    let parsed: Value = serde_json::from_str(first_line).expect("init stdout is parseable JSON");
     assert_eq!(
         parsed.get("output_kind").and_then(|v| v.as_str()),
         Some("init"),
@@ -750,8 +739,8 @@ fn runtime_init_emits_output_kind() {
 /// `dir`. Panics with the captured output on failure so doc-vs-runtime
 /// mismatches surface a readable diff.
 fn runtime_top_level_keys(argv: &[&str], dir: &std::path::Path) -> BTreeSet<String> {
-    let output = heddle_output(argv, Some(dir))
-        .unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
+    let output =
+        heddle_output(argv, Some(dir)).unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
     assert!(
         output.status.success(),
         "{argv:?} exited non-zero: stdout={} stderr={}",
@@ -865,8 +854,11 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         "stack_ready" => (init_fixture(), sv(&["stack", "ready"])),
         "stack_snapshot" => {
             let t = init_fixture();
-            heddle(&["start", "feature-x", "--workspace", "solid"], Some(t.path()))
-                .expect("start feature-x");
+            heddle(
+                &["start", "feature-x", "--workspace", "solid"],
+                Some(t.path()),
+            )
+            .expect("start feature-x");
             (t, sv(&["stack", "snapshot", "--thread", "feature-x"]))
         }
         "stash_list" => (init_fixture(), sv(&["stash", "list"])),
@@ -896,7 +888,15 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             (
                 t,
-                sv(&["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"]),
+                sv(&[
+                    "redact",
+                    "apply",
+                    "HEAD",
+                    "--path",
+                    "secrets.env",
+                    "--reason",
+                    "credential",
+                ]),
             )
         }
         "purge_apply" => {
@@ -904,7 +904,15 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             std::fs::write(t.path().join("secrets.env"), "TOKEN=abc").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             heddle(
-                &["redact", "apply", "HEAD", "--path", "secrets.env", "--reason", "credential"],
+                &[
+                    "redact",
+                    "apply",
+                    "HEAD",
+                    "--path",
+                    "secrets.env",
+                    "--reason",
+                    "credential",
+                ],
                 Some(t.path()),
             )
             .expect("redact apply");
@@ -916,15 +924,25 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         "redact_trust_add" => (
             init_fixture(),
             sv(&[
-                "redact", "trust", "add", "--public-key", "abc123def456", "--algorithm", "ed25519",
-                "--label", "security",
+                "redact",
+                "trust",
+                "add",
+                "--public-key",
+                "abc123def456",
+                "--algorithm",
+                "ed25519",
+                "--label",
+                "security",
             ]),
         ),
         "discuss_open" => {
             let t = init_fixture();
             std::fs::write(t.path().join("a.txt"), "fn verify(){}").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
-            (t, sv(&["discuss", "open", "a.txt", "verify", "check edge case"]))
+            (
+                t,
+                sv(&["discuss", "open", "a.txt", "verify", "check edge case"]),
+            )
         }
         "discuss_list" => (init_fixture(), sv(&["discuss", "list"])),
         "context_set" => {
@@ -933,7 +951,16 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             (
                 t,
-                sv(&["context", "set", "--path", "a.txt", "--scope", "file", "-m", "owner note"]),
+                sv(&[
+                    "context",
+                    "set",
+                    "--path",
+                    "a.txt",
+                    "--scope",
+                    "file",
+                    "-m",
+                    "owner note",
+                ]),
             )
         }
         "context_list" => (init_fixture(), sv(&["context", "list"])),
@@ -963,11 +990,22 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             std::fs::write(t.path().join("a.txt"), "base").unwrap();
             heddle(&["commit", "-m", "base"], Some(t.path())).expect("commit");
             heddle(
-                &["visibility", "set", "HEAD", "--tier", "restricted", "--label", "secret"],
+                &[
+                    "visibility",
+                    "set",
+                    "HEAD",
+                    "--tier",
+                    "restricted",
+                    "--label",
+                    "secret",
+                ],
                 Some(t.path()),
             )
             .expect("visibility set");
-            (t, sv(&["visibility", "promote", "HEAD", "--tier", "internal"]))
+            (
+                t,
+                sv(&["visibility", "promote", "HEAD", "--tier", "internal"]),
+            )
         }
         "visibility_show" => {
             let t = init_fixture();

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -32,7 +32,8 @@ use tempfile::TempDir;
 
 use cli::cli::commands::{
     CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, build_command_catalog,
-    documented_samples_with_bound_verbs, schema_for_verb,
+    documented_samples_with_bound_verbs, operator_emission_output_kinds, operator_envelope_verbs,
+    schema_for_verb,
 };
 
 use super::{heddle, heddle_output};
@@ -407,6 +408,66 @@ fn swept_verbs_declare_output_kind_in_catalog() {
              path (snake-cased).\n\n{msg}"
         );
     }
+}
+
+#[test]
+fn operator_envelope_verbs_have_declared_emissions() {
+    let catalog_verbs: BTreeSet<String> = operator_envelope_verbs().into_iter().collect();
+    let emissions: BTreeSet<String> = operator_emission_output_kinds()
+        .into_iter()
+        .map(|(display, _)| display)
+        .collect();
+    let missing: Vec<&str> = catalog_verbs
+        .difference(&emissions)
+        .map(String::as_str)
+        .collect();
+    let stale: Vec<&str> = emissions
+        .difference(&catalog_verbs)
+        .map(String::as_str)
+        .collect();
+
+    assert!(
+        missing.is_empty() && stale.is_empty(),
+        "Operator envelope verbs must be registered in the catalog and in the \
+         closed emission table. A missing emission would otherwise allow the \
+         output_kind source to drift back toward the live operation action.\n\
+         Missing emission declaration(s): {missing:?}\n\
+         Stale emission declaration(s): {stale:?}"
+    );
+}
+
+#[test]
+fn operator_emissions_match_catalog_discriminators() {
+    let catalog = build_command_catalog();
+    let mut failures = Vec::new();
+
+    for (display, output_kind) in operator_emission_output_kinds() {
+        let Some(entry) = catalog
+            .commands
+            .iter()
+            .find(|entry| entry.display == display)
+        else {
+            failures.push(format!("{display}: not present in command catalog"));
+            continue;
+        };
+        let advertised: BTreeSet<&str> = entry
+            .json_discriminators
+            .iter()
+            .filter(|discriminator| discriminator.field == "output_kind")
+            .map(|discriminator| discriminator.value.as_str())
+            .collect();
+        if !advertised.contains(output_kind.as_str()) {
+            failures.push(format!(
+                "{display}: emission declares output_kind=`{output_kind}` but catalog advertises {advertised:?}"
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Operator emission declarations drifted from the catalog:\n  - {}",
+        failures.join("\n  - ")
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -108,6 +108,12 @@ const SWEPT: &[&str] = &[
     "review next",
     "review health",
     "cherry-pick",
+    // heddle#662 — additive discriminator paths for state inspection,
+    // rebase progress JSONL, and conflict show success.
+    "conflict show",
+    "inspect",
+    "rebase",
+    "show",
     // heddle#641 — swept the remaining verbs whose runtime JSON already
     // emits `output_kind`. Every value below was probed live against the
     // built binary (or read off the emitting struct for the daemon-style
@@ -184,7 +190,6 @@ const UNSWEPT_TODO: &[&str] = &[
     "bridge git reason",
     "collapse",
     "conflict list",
-    "conflict show",
     "daemon serve",
     "daemon status",
     "delegate",
@@ -195,7 +200,6 @@ const UNSWEPT_TODO: &[&str] = &[
     "hook install",
     "hook list",
     "hook uninstall",
-    "inspect",
     "integration doctor",
     "integration install",
     "integration list",
@@ -209,7 +213,6 @@ const UNSWEPT_TODO: &[&str] = &[
     "marker delete",
     "marker list",
     "marker show",
-    "rebase",
     "resolve",
     "retro",
     "semantic hot",
@@ -218,7 +221,6 @@ const UNSWEPT_TODO: &[&str] = &[
     "session segment",
     "session show",
     "session start",
-    "show",
     "stash apply",
     "stash clear",
     "stash drop",
@@ -279,6 +281,12 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         // The maintenance wrappers emit their inner tool's kind.
         "maintenance gc" => Some("gc"),
         "maintenance index" => Some("index"),
+        // `inspect` defaults to `thread show`, but the registered
+        // state-inspection schema is discriminated as `inspect_state`.
+        "inspect" => Some("inspect_state"),
+        // Rebase emits JSONL progress records rather than a single
+        // command-shaped object.
+        "rebase" => Some("rebase_progress"),
         _ => None,
     }
 }
@@ -648,6 +656,40 @@ fn init_fixture() -> TempDir {
         Some(temp.path()),
     )
     .expect("heddle init");
+    temp
+}
+
+fn init_conflicted_merge_fixture() -> TempDir {
+    let temp = init_fixture();
+    std::fs::write(temp.path().join("conflict.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+    heddle(&["thread", "create", "feature"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("conflict.txt"), "feature version\n").unwrap();
+    heddle(&["capture", "-m", "Feature change"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("conflict.txt"), "main version\n").unwrap();
+    heddle(&["capture", "-m", "Main change"], Some(temp.path())).unwrap();
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+
+    let merge = heddle_output(&["merge", "main"], Some(temp.path()))
+        .expect("heddle merge should run and report conflict state");
+    assert!(
+        !merge.status.success(),
+        "conflicted merge should exit nonzero: stdout={} stderr={}",
+        String::from_utf8_lossy(&merge.stdout),
+        String::from_utf8_lossy(&merge.stderr)
+    );
+    temp
+}
+
+fn init_rebase_fast_forward_fixture() -> TempDir {
+    let temp = init_fixture();
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("thread create feature");
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature");
+    std::fs::write(temp.path().join("feat.txt"), "feature work\n").expect("write feature file");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+    heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
     temp
 }
 
@@ -1032,6 +1074,14 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         // heddle#641 — the newly-swept generic-schema verbs. Their opaque
         // mirrors pin no fields, so the documented sample must be compared
         // against the live payload here.
+        "conflict_show" => (
+            init_conflicted_merge_fixture(),
+            sv(&["conflict", "show", "conflict.txt"]),
+        ),
+        "rebase_progress" => (
+            init_rebase_fast_forward_fixture(),
+            sv(&["rebase", "feature"]),
+        ),
         "gc" => (init_fixture(), sv(&["maintenance", "gc"])),
         // Stopping a daemon that is not running still exits 0 with the
         // full `daemon_stop` payload, so a bare init fixture suffices.

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -30,8 +30,11 @@ fn init_and_capture() -> TempDir {
 
 /// Capture a second state on top of the seeded one so `HEAD~1` resolves.
 fn capture_second(temp: &TempDir) {
-    fs::write(temp.path().join("main.rs"), "fn main() { println!(\"hi\"); }\n")
-        .expect("modify main.rs");
+    fs::write(
+        temp.path().join("main.rs"),
+        "fn main() { println!(\"hi\"); }\n",
+    )
+    .expect("modify main.rs");
     heddle(&["capture", "-m", "second"], Some(temp.path())).expect("second capture");
 }
 
@@ -55,6 +58,17 @@ fn assert_output_kind(value: &Value, expected: &str) {
         value.get("output_kind").and_then(|v| v.as_str()),
         Some(expected),
         "expected output_kind={expected}, got payload: {value}"
+    );
+}
+
+fn assert_not_output_kind(value: &Value, disallowed: &[&str]) {
+    let actual = value
+        .get("output_kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<missing>");
+    assert!(
+        !disallowed.contains(&actual),
+        "payload used disallowed output_kind={actual}: {value}"
     );
 }
 
@@ -169,9 +183,9 @@ fn clean_dry_run_emits_output_kind() {
         value
             .get("removed")
             .and_then(|v| v.as_array())
-            .is_some_and(|arr| arr.iter().any(|entry| entry
-                .as_str()
-                .is_some_and(|s| s.contains("stray.txt")))),
+            .is_some_and(|arr| arr
+                .iter()
+                .any(|entry| entry.as_str().is_some_and(|s| s.contains("stray.txt")))),
         "clean --dry-run must list the would-remove paths: {value}"
     );
 }
@@ -226,6 +240,54 @@ fn cherry_pick_commit_emits_output_kind_with_new_commit() {
     );
 }
 
+#[test]
+fn thread_operator_envelopes_emit_approved_thread_kinds() {
+    let temp = init_and_capture();
+    heddle(&["thread", "create", "side"], Some(temp.path())).expect("thread create side");
+
+    let refresh = heddle_json(&["thread", "refresh", "side"], &temp);
+    assert_output_kind(&refresh, "thread_refresh");
+    assert_not_output_kind(&refresh, &["thread"]);
+    assert_eq!(refresh["action"].as_str(), Some("thread_refresh"));
+
+    let resolve = heddle_json(&["thread", "resolve", "side"], &temp);
+    assert_output_kind(&resolve, "thread_resolve");
+    assert_not_output_kind(&resolve, &["resolve"]);
+    assert_eq!(resolve["action"].as_str(), Some("thread_resolve"));
+
+    let drop = heddle_json(&["thread", "drop", "side"], &temp);
+    assert_output_kind(&drop, "thread_drop");
+    assert_not_output_kind(&drop, &["thread"]);
+    assert_eq!(drop["action"].as_str(), Some("thread_drop"));
+}
+
+#[test]
+fn thread_promote_and_cleanup_emit_approved_thread_kinds() {
+    let temp = init_and_capture();
+    heddle(&["start", "promo"], Some(temp.path())).expect("start promo thread");
+
+    let promote = heddle_json(&["thread", "promote", "promo"], &temp);
+    assert_output_kind(&promote, "thread_promote");
+    assert_not_output_kind(&promote, &["thread"]);
+    assert_eq!(promote["action"].as_str(), Some("thread_promote"));
+
+    let cleanup = heddle_json(&["thread", "cleanup", "--merged", "--dry-run"], &temp);
+    assert_output_kind(&cleanup, "thread_cleanup");
+    assert_not_output_kind(&cleanup, &["thread.cleanup"]);
+    assert_eq!(cleanup["action"].as_str(), Some("thread_cleanup"));
+}
+
+#[test]
+fn branch_rename_and_delete_advertised_thread_kinds_are_runtime_truths() {
+    let temp = init_and_capture();
+    heddle(&["branch", "side"], Some(temp.path())).expect("branch side");
+
+    let rename = heddle_json(&["branch", "-m", "side", "renamed"], &temp);
+    assert_output_kind(&rename, "thread_rename");
+
+    let delete = heddle_json(&["branch", "-d", "renamed"], &temp);
+    assert_output_kind(&delete, "thread_drop");
+}
 
 #[test]
 fn stash_show_emits_output_kind() {
@@ -327,9 +389,7 @@ fn purge_apply_emits_output_kind() {
     .expect("redact apply");
 
     let value = heddle_json(
-        &[
-            "purge", "apply", &state, "--path", "main.rs", "--force",
-        ],
+        &["purge", "apply", &state, "--path", "main.rs", "--force"],
         &temp,
     );
     assert_output_kind(&value, "purge_apply");
@@ -428,10 +488,7 @@ fn context_set_get_history_audit_check_emit_output_kind() {
         "context suggest envelope must carry an `items` array: {suggest}"
     );
 
-    let rm = heddle_json(
-        &["context", "rm", "--path", "main.rs", "--all"],
-        &temp,
-    );
+    let rm = heddle_json(&["context", "rm", "--path", "main.rs", "--all"], &temp);
     assert_output_kind(&rm, "context_rm");
     assert_eq!(rm["removed"].as_bool(), Some(true));
 }
@@ -454,8 +511,16 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
     let populated_temp = init_and_capture();
     heddle(
         &[
-            "context", "set", "--path", "main.rs", "--scope", "file", "--kind",
-            "rationale", "-m", "entry point",
+            "context",
+            "set",
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "rationale",
+            "-m",
+            "entry point",
         ],
         Some(populated_temp.path()),
     )
@@ -484,7 +549,10 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
         "context list row must keep its `target`: {populated}"
     );
     assert!(
-        items[0].get("annotations").and_then(|v| v.as_array()).is_some(),
+        items[0]
+            .get("annotations")
+            .and_then(|v| v.as_array())
+            .is_some(),
         "context list row must keep its `annotations` array: {populated}"
     );
 }
@@ -493,16 +561,7 @@ fn context_list_envelope_wraps_items_for_empty_and_populated() {
 fn discuss_open_show_append_emit_output_kind() {
     let temp = init_and_capture();
 
-    let open = heddle_json(
-        &[
-            "discuss",
-            "open",
-            "main.rs",
-            "main",
-            "first turn",
-        ],
-        &temp,
-    );
+    let open = heddle_json(&["discuss", "open", "main.rs", "main", "first turn"], &temp);
     assert_output_kind(&open, "discuss_open");
     let discussion_id = open["id"]
         .as_str()
@@ -522,10 +581,7 @@ fn discuss_open_show_append_emit_output_kind() {
     // Flattened `turns` field must surface both turns at the top
     // level — the envelope must not nest the discussion payload.
     assert_eq!(
-        show["turns"]
-            .as_array()
-            .map(|arr| arr.len())
-            .unwrap_or(0),
+        show["turns"].as_array().map(|arr| arr.len()).unwrap_or(0),
         2,
         "discuss show must flatten `turns` at the top level: {show}"
     );
@@ -589,9 +645,7 @@ fn purge_list_envelope_includes_recent_apply() {
     )
     .expect("redact apply");
     heddle(
-        &[
-            "purge", "apply", &state, "--path", "main.rs", "--force",
-        ],
+        &["purge", "apply", &state, "--path", "main.rs", "--force"],
         Some(temp.path()),
     )
     .expect("purge apply");
@@ -612,8 +666,11 @@ fn stack_snapshot_text_mode_still_emits_envelope_with_output_kind() {
     // sessions can still route on it.
     let temp = init_and_capture();
     detach_head(&temp);
-    let output = heddle_output(&["--output", "text", "stack", "snapshot"], Some(temp.path()))
-        .expect("invoke stack snapshot text");
+    let output = heddle_output(
+        &["--output", "text", "stack", "snapshot"],
+        Some(temp.path()),
+    )
+    .expect("invoke stack snapshot text");
     assert!(
         output.status.success(),
         "stack snapshot text must succeed: stderr={}",

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -61,6 +61,43 @@ fn heddle_json(args: &[&str], temp: &TempDir) -> Value {
         .unwrap_or_else(|err| panic!("heddle {argv:?} stdout not JSON: {err}\n  line: {line}"))
 }
 
+fn heddle_stdout_json_allow_failure(args: &[&str], temp: &TempDir) -> Value {
+    let mut argv: Vec<&str> = vec!["--output", "json"];
+    argv.extend(args.iter().copied());
+    let output = heddle_output(&argv, Some(temp.path()))
+        .unwrap_or_else(|err| panic!("heddle {argv:?} failed to run: {err}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| {
+            panic!(
+                "heddle {argv:?} produced no JSON stdout: status={:?} stderr={}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    serde_json::from_str(line)
+        .unwrap_or_else(|err| panic!("heddle {argv:?} stdout line not JSON: {err}\n  line: {line}"))
+}
+
+fn heddle_stderr_json_allow_failure(args: &[&str], temp: &TempDir) -> Value {
+    let output = heddle_output(args, Some(temp.path()))
+        .unwrap_or_else(|err| panic!("heddle {args:?} failed to run: {err}"));
+    assert!(
+        !output.status.success(),
+        "heddle {args:?} should fail for this recovery-envelope fixture"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "error envelopes should stay on stderr, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|err| panic!("heddle {args:?} stderr not JSON: {err}\n{stderr}"))
+}
+
 fn assert_output_kind(value: &Value, expected: &str) {
     assert_eq!(
         value.get("output_kind").and_then(|v| v.as_str()),
@@ -429,6 +466,123 @@ fn set_repo_output_format_json(temp: &TempDir) {
     let mut config = RepoConfig::load(&config_path).expect("load repo config");
     config.output.format = Some(OutputFormat::Json);
     config.save(&config_path).expect("save repo config");
+}
+
+fn init_active_merge_fixture() -> TempDir {
+    let temp = init_and_capture();
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("thread create feature");
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature");
+    fs::write(temp.path().join("main.rs"), "fn main() { feature(); }\n")
+        .expect("write feature conflict");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+    heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
+    fs::write(temp.path().join("main.rs"), "fn main() { mainline(); }\n")
+        .expect("write main conflict");
+    heddle(&["capture", "-m", "main"], Some(temp.path())).expect("main capture");
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature again");
+
+    let output =
+        heddle_output(&["merge", "main"], Some(temp.path())).expect("conflicted merge runs");
+    assert!(
+        temp.path().join(".heddle").join("MERGE_STATE").exists(),
+        "merge fixture must leave active MERGE_STATE: status={:?} stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    temp
+}
+
+fn init_active_rebase_fixture() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    heddle(&["init"], Some(temp.path())).expect("heddle init");
+    fs::write(temp.path().join("conflict.txt"), "base\n").expect("write base");
+    heddle(&["capture", "-m", "base"], Some(temp.path())).expect("base capture");
+
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("thread create feature");
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature");
+    fs::write(temp.path().join("conflict.txt"), "feature\n").expect("write feature");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+
+    heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
+    fs::write(temp.path().join("conflict.txt"), "main\n").expect("write main");
+    heddle(&["capture", "-m", "main"], Some(temp.path())).expect("main capture");
+
+    let output =
+        heddle_output(&["rebase", "feature"], Some(temp.path())).expect("conflicted rebase runs");
+    assert!(
+        temp.path().join(".heddle").join("REBASE_STATE").exists(),
+        "rebase fixture must leave active REBASE_STATE: status={:?} stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    temp
+}
+
+#[derive(Clone, Copy)]
+enum RecoveryFixture {
+    Idle,
+    ActiveMerge,
+    ActiveRebase,
+}
+
+impl RecoveryFixture {
+    fn init(self) -> TempDir {
+        match self {
+            Self::Idle => init_and_capture(),
+            Self::ActiveMerge => init_active_merge_fixture(),
+            Self::ActiveRebase => init_active_rebase_fixture(),
+        }
+    }
+
+    fn expected_action(self, verb: &str) -> &str {
+        match self {
+            Self::Idle => verb,
+            Self::ActiveMerge => "merge",
+            Self::ActiveRebase => "rebase",
+        }
+    }
+}
+
+#[test]
+fn recovery_path_family_output_kind_matches_invoked_verb() {
+    for (verb, fixture) in [
+        ("continue", RecoveryFixture::Idle),
+        ("abort", RecoveryFixture::Idle),
+        ("continue", RecoveryFixture::ActiveMerge),
+        ("abort", RecoveryFixture::ActiveMerge),
+        ("continue", RecoveryFixture::ActiveRebase),
+        ("abort", RecoveryFixture::ActiveRebase),
+    ] {
+        let temp = fixture.init();
+        let value = heddle_stdout_json_allow_failure(&[verb], &temp);
+        assert_output_kind(&value, verb);
+        assert_eq!(
+            value["action"].as_str(),
+            Some(fixture.expected_action(verb)),
+            "{verb} should keep the operation action while output_kind stays tied to the invoked command: {value}"
+        );
+        if !matches!(fixture, RecoveryFixture::Idle) {
+            assert_not_output_kind(&value, &["merge", "rebase"]);
+        }
+    }
+}
+
+#[test]
+fn conflict_not_found_honors_repo_json_config_for_stored_and_active_merge() {
+    let stored = init_and_capture();
+    set_repo_output_format_json(&stored);
+    let stored_error = heddle_stderr_json_allow_failure(&["conflict", "show", "missing"], &stored);
+    assert_eq!(stored_error["kind"].as_str(), Some("conflict_not_found"));
+    assert_eq!(stored_error["exit_code"].as_u64(), Some(65));
+
+    let active_merge = init_active_merge_fixture();
+    set_repo_output_format_json(&active_merge);
+    let active_error =
+        heddle_stderr_json_allow_failure(&["conflict", "show", "missing"], &active_merge);
+    assert_eq!(active_error["kind"].as_str(), Some("conflict_not_found"));
+    assert_eq!(active_error["exit_code"].as_u64(), Some(65));
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -45,6 +45,9 @@ fn heddle_json(args: &[&str], temp: &TempDir) -> Value {
     let stdout = heddle(&argv, Some(temp.path())).unwrap_or_else(|err| {
         panic!("heddle {argv:?} failed: {err}");
     });
+    if let Ok(value) = serde_json::from_str(stdout.trim()) {
+        return value;
+    }
     let line = stdout
         .lines()
         .next()
@@ -287,6 +290,49 @@ fn branch_rename_and_delete_advertised_thread_kinds_are_runtime_truths() {
 
     let delete = heddle_json(&["branch", "-d", "renamed"], &temp);
     assert_output_kind(&delete, "thread_drop");
+}
+
+#[test]
+fn show_and_inspect_state_emit_distinct_output_kinds() {
+    let temp = init_and_capture();
+
+    let show = heddle_json(&["show", "HEAD"], &temp);
+    assert_output_kind(&show, "show");
+
+    let inspect_state = heddle_json(&["inspect", "HEAD"], &temp);
+    assert_output_kind(&inspect_state, "inspect_state");
+
+    let inspect_thread = heddle_json(&["inspect"], &temp);
+    assert_output_kind(&inspect_thread, "thread_show");
+}
+
+#[test]
+fn rebase_json_records_emit_progress_output_kind() {
+    let temp = init_and_capture();
+    heddle(&["thread", "create", "feature"], Some(temp.path())).expect("thread create feature");
+    heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature");
+    fs::write(temp.path().join("feat.txt"), "feature work\n").expect("write feature file");
+    heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
+    heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
+
+    let output = heddle(
+        &["rebase", "feature", "--output", "json"],
+        Some(temp.path()),
+    )
+    .expect("rebase feature");
+    let lines = output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    assert!(
+        !lines.is_empty(),
+        "rebase JSON output should emit at least one record"
+    );
+    for line in lines {
+        let value: Value = serde_json::from_str(line)
+            .unwrap_or_else(|err| panic!("rebase line not JSON: {err}\n  line: {line}"));
+        assert_output_kind(&value, "rebase_progress");
+    }
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -14,6 +14,11 @@
 
 use std::fs;
 
+use objects::{
+    object::{Blob, ConflictSide, ConflictSymbol, StructuredConflict, SymbolAnchor},
+    store::ObjectStore,
+};
+use repo::Repository;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -314,6 +319,8 @@ fn rebase_json_records_emit_progress_output_kind() {
     fs::write(temp.path().join("feat.txt"), "feature work\n").expect("write feature file");
     heddle(&["capture", "-m", "feature"], Some(temp.path())).expect("feature capture");
     heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
+    fs::write(temp.path().join("main.txt"), "main work\n").expect("write main file");
+    heddle(&["capture", "-m", "main"], Some(temp.path())).expect("main capture");
 
     let output = heddle(
         &["rebase", "feature", "--output", "json"],
@@ -328,11 +335,57 @@ fn rebase_json_records_emit_progress_output_kind() {
         !lines.is_empty(),
         "rebase JSON output should emit at least one record"
     );
+    let mut statuses = Vec::new();
     for line in lines {
         let value: Value = serde_json::from_str(line)
             .unwrap_or_else(|err| panic!("rebase line not JSON: {err}\n  line: {line}"));
         assert_output_kind(&value, "rebase_progress");
+        statuses.push(
+            value["status"]
+                .as_str()
+                .unwrap_or_else(|| panic!("rebase line missing status: {value}"))
+                .to_string(),
+        );
     }
+    assert_eq!(
+        statuses,
+        vec!["started", "applying", "completed"],
+        "fixture must exercise replay JSONL, not the fast-forward path"
+    );
+}
+
+#[test]
+fn conflict_show_stored_conflict_emits_output_kind() {
+    let temp = init_and_capture();
+    let repo = Repository::open(temp.path()).expect("open repo");
+    let head = repo
+        .current_state()
+        .expect("read current state")
+        .expect("current state exists");
+
+    let conflict = ConflictSymbol {
+        id: "stored-1".to_string(),
+        anchor: SymbolAnchor::new("main.rs", "main"),
+        base: ConflictSide::from_body(Some(head.change_id), "fn main() {}\n"),
+        ours: ConflictSide::from_body(Some(head.change_id), "fn main() { ours(); }\n"),
+        theirs: ConflictSide::from_body(Some(head.change_id), "fn main() { theirs(); }\n"),
+        candidate_resolutions: Vec::new(),
+    };
+    let structured = StructuredConflict::new(vec![conflict]);
+    let blob_hash = repo
+        .store()
+        .put_blob(&Blob::new(structured.encode().expect("encode conflict")))
+        .expect("store structured conflict blob");
+    let updated = head.with_structured_conflicts(blob_hash);
+    repo.store()
+        .put_state(&updated)
+        .expect("overwrite head state");
+
+    let value = heddle_json(&["conflict", "show", "stored-1"], &temp);
+    assert_output_kind(&value, "conflict_show");
+    assert_eq!(value["kind"].as_str(), Some("stored_structured_conflict"));
+    assert_eq!(value["id"].as_str(), Some("stored-1"));
+    assert_eq!(value["anchor"]["file"].as_str(), Some("main.rs"));
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -144,6 +144,18 @@ fn schema_accepts_payload(root: &Value, schema: &Value, payload: &Value) -> Resu
         return Err(format!("payload matched no anyOf branch: {errors:?}"));
     }
 
+    if let Some(subschemas) = schema.get("allOf").and_then(|value| value.as_array()) {
+        let mut errors = Vec::new();
+        for subschema in subschemas {
+            if let Err(err) = schema_accepts_payload(root, subschema, payload) {
+                errors.push(err);
+            }
+        }
+        if !errors.is_empty() {
+            return Err(format!("payload failed allOf subschema(s): {errors:?}"));
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -22,6 +22,8 @@ use repo::{OutputFormat, RepoConfig, Repository};
 use serde_json::Value;
 use tempfile::TempDir;
 
+use cli::cli::commands::{build_command_catalog, operator_envelope_verbs};
+
 use super::{heddle, heddle_output};
 
 /// Init a repo, write a tracked file, capture one state.
@@ -537,34 +539,67 @@ impl RecoveryFixture {
     }
 
     fn expected_action(self, verb: &str) -> &str {
-        match self {
-            Self::Idle => verb,
-            Self::ActiveMerge => "merge",
-            Self::ActiveRebase => "rebase",
+        match (self, verb) {
+            (Self::Idle, _) | (_, "sync") => verb,
+            (Self::ActiveMerge, _) => "merge",
+            (Self::ActiveRebase, _) => "rebase",
         }
     }
 }
 
+fn catalog_operator_envelope_output_kinds() -> Vec<(String, String)> {
+    let catalog = build_command_catalog();
+    operator_envelope_verbs()
+        .into_iter()
+        .map(|display| {
+            let entry = catalog
+                .commands
+                .iter()
+                .find(|entry| entry.display == display)
+                .unwrap_or_else(|| panic!("operator envelope verb `{display}` is cataloged"));
+            let output_kind = entry
+                .json_discriminators
+                .iter()
+                .find(|discriminator| discriminator.field == "output_kind")
+                .unwrap_or_else(|| {
+                    panic!("operator envelope verb `{display}` declares output_kind")
+                })
+                .value
+                .clone();
+            (display, output_kind)
+        })
+        .collect()
+}
+
 #[test]
 fn recovery_path_family_output_kind_matches_invoked_verb() {
-    for (verb, fixture) in [
-        ("continue", RecoveryFixture::Idle),
-        ("abort", RecoveryFixture::Idle),
-        ("continue", RecoveryFixture::ActiveMerge),
-        ("abort", RecoveryFixture::ActiveMerge),
-        ("continue", RecoveryFixture::ActiveRebase),
-        ("abort", RecoveryFixture::ActiveRebase),
+    let operator_verbs = catalog_operator_envelope_output_kinds();
+    assert!(
+        operator_verbs.iter().any(|(display, _)| display == "sync"),
+        "catalog-driven operator envelope sweep must include `sync`: {operator_verbs:?}"
+    );
+
+    for fixture in [
+        RecoveryFixture::Idle,
+        RecoveryFixture::ActiveMerge,
+        RecoveryFixture::ActiveRebase,
     ] {
-        let temp = fixture.init();
-        let value = heddle_stdout_json_allow_failure(&[verb], &temp);
-        assert_output_kind(&value, verb);
-        assert_eq!(
-            value["action"].as_str(),
-            Some(fixture.expected_action(verb)),
-            "{verb} should keep the operation action while output_kind stays tied to the invoked command: {value}"
-        );
-        if !matches!(fixture, RecoveryFixture::Idle) {
-            assert_not_output_kind(&value, &["merge", "rebase"]);
+        for (verb, output_kind) in &operator_verbs {
+            if matches!(fixture, RecoveryFixture::Idle) && verb == "sync" {
+                continue;
+            }
+            let temp = fixture.init();
+            let args = verb.split_whitespace().collect::<Vec<_>>();
+            let value = heddle_stdout_json_allow_failure(&args, &temp);
+            assert_output_kind(&value, output_kind);
+            assert_eq!(
+                value["action"].as_str(),
+                Some(fixture.expected_action(verb)),
+                "{verb} should keep the operation action while output_kind stays tied to the invoked command: {value}"
+            );
+            if !matches!(fixture, RecoveryFixture::Idle) {
+                assert_not_output_kind(&value, &["merge", "rebase"]);
+            }
         }
     }
 }

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -18,7 +18,7 @@ use objects::{
     object::{Blob, ConflictSide, ConflictSymbol, StructuredConflict, SymbolAnchor},
     store::ObjectStore,
 };
-use repo::Repository;
+use repo::{OutputFormat, RepoConfig, Repository};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -78,6 +78,78 @@ fn assert_not_output_kind(value: &Value, disallowed: &[&str]) {
         !disallowed.contains(&actual),
         "payload used disallowed output_kind={actual}: {value}"
     );
+}
+
+fn schema_ref<'a>(root: &'a Value, schema: &'a Value) -> &'a Value {
+    let Some(reference) = schema.get("$ref").and_then(|value| value.as_str()) else {
+        return schema;
+    };
+    reference
+        .strip_prefix("#/$defs/")
+        .or_else(|| reference.strip_prefix("#/definitions/"))
+        .and_then(|name| {
+            root.get("$defs")
+                .or_else(|| root.get("definitions"))
+                .and_then(|defs| defs.get(name))
+        })
+        .unwrap_or_else(|| panic!("schema reference {reference:?} resolves"))
+}
+
+fn schema_property_accepts(root: &Value, schema: &Value, value: &Value) -> Result<(), String> {
+    let schema = schema_ref(root, schema);
+    if let Some(enum_values) = schema.get("enum").and_then(|value| value.as_array())
+        && !enum_values.contains(value)
+    {
+        return Err(format!("value {value} is not in enum {enum_values:?}"));
+    }
+    if let Some(const_value) = schema.get("const")
+        && const_value != value
+    {
+        return Err(format!("value {value} does not match const {const_value}"));
+    }
+    Ok(())
+}
+
+fn schema_accepts_payload(root: &Value, schema: &Value, payload: &Value) -> Result<(), String> {
+    let schema = schema_ref(root, schema);
+    let payload_object = payload
+        .as_object()
+        .ok_or_else(|| format!("payload is not an object: {payload}"))?;
+
+    if let Some(required) = schema.get("required").and_then(|value| value.as_array()) {
+        for field in required.iter().filter_map(|value| value.as_str()) {
+            if !payload_object.contains_key(field) {
+                return Err(format!("payload is missing required field {field:?}"));
+            }
+        }
+    }
+
+    if let Some(properties) = schema.get("properties").and_then(|value| value.as_object()) {
+        for (field, property_schema) in properties {
+            if let Some(value) = payload_object.get(field) {
+                schema_property_accepts(root, property_schema, value)
+                    .map_err(|err| format!("property {field:?} rejected payload: {err}"))?;
+            }
+        }
+    }
+
+    if let Some(branches) = schema.get("anyOf").and_then(|value| value.as_array()) {
+        let mut errors = Vec::new();
+        for branch in branches {
+            match schema_accepts_payload(root, branch, payload) {
+                Ok(()) => return Ok(()),
+                Err(err) => errors.push(err),
+            }
+        }
+        return Err(format!("payload matched no anyOf branch: {errors:?}"));
+    }
+
+    Ok(())
+}
+
+fn assert_schema_accepts_payload(schema: &Value, payload: &Value) {
+    schema_accepts_payload(schema, schema, payload)
+        .unwrap_or_else(|err| panic!("published schema rejected payload: {err}\n{payload}"));
 }
 
 /// Detach HEAD onto the current state so `stack snapshot` follows the
@@ -312,7 +384,23 @@ fn show_and_inspect_state_emit_distinct_output_kinds() {
 }
 
 #[test]
-fn rebase_json_records_emit_progress_output_kind() {
+fn inspect_schema_accepts_state_and_thread_show_payloads() {
+    let temp = init_and_capture();
+    let schema: Value = serde_json::from_str(
+        &heddle(&["schemas", "inspect"], Some(temp.path())).expect("schemas inspect"),
+    )
+    .expect("schemas inspect emits JSON schema");
+
+    let inspect_state = heddle_json(&["inspect", "HEAD"], &temp);
+    assert_output_kind(&inspect_state, "inspect_state");
+    assert_schema_accepts_payload(&schema, &inspect_state);
+
+    let inspect_thread = heddle_json(&["inspect"], &temp);
+    assert_output_kind(&inspect_thread, "thread_show");
+    assert_schema_accepts_payload(&schema, &inspect_thread);
+}
+
+fn init_rebase_replay_fixture() -> TempDir {
     let temp = init_and_capture();
     heddle(&["thread", "create", "feature"], Some(temp.path())).expect("thread create feature");
     heddle(&["thread", "switch", "feature"], Some(temp.path())).expect("switch feature");
@@ -321,9 +409,22 @@ fn rebase_json_records_emit_progress_output_kind() {
     heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
     fs::write(temp.path().join("main.txt"), "main work\n").expect("write main file");
     heddle(&["capture", "-m", "main"], Some(temp.path())).expect("main capture");
+    temp
+}
+
+fn set_repo_output_format_json(temp: &TempDir) {
+    let config_path = temp.path().join(".heddle").join("config.toml");
+    let mut config = RepoConfig::load(&config_path).expect("load repo config");
+    config.output.format = Some(OutputFormat::Json);
+    config.save(&config_path).expect("save repo config");
+}
+
+#[test]
+fn rebase_json_records_emit_progress_output_kind() {
+    let temp = init_rebase_replay_fixture();
 
     let output = heddle(
-        &["rebase", "feature", "--output", "json"],
+        &["--output", "json", "rebase", "feature"],
         Some(temp.path()),
     )
     .expect("rebase feature");
@@ -351,6 +452,27 @@ fn rebase_json_records_emit_progress_output_kind() {
         statuses,
         vec!["started", "applying", "completed"],
         "fixture must exercise replay JSONL, not the fast-forward path"
+    );
+}
+
+#[test]
+fn rebase_repo_json_config_without_output_flag_stays_text() {
+    let temp = init_rebase_replay_fixture();
+    set_repo_output_format_json(&temp);
+
+    let output = heddle(&["rebase", "feature"], Some(temp.path())).expect("rebase feature");
+    assert!(
+        output.contains("Rebasing ")
+            && output.contains("Applying ")
+            && output.contains("Rebase completed"),
+        "plain rebase under repo output.format=json should emit text, got: {output}"
+    );
+    assert!(
+        output
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .all(|line| serde_json::from_str::<Value>(line).is_err()),
+        "plain rebase under repo output.format=json must not emit JSONL: {output}"
     );
 }
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -231,7 +231,6 @@ in-progress operation.
       "accepted_opaque_schema_verbs_total": 56,
       "unaccepted_opaque_schema_verbs_total": 0,
       "supports_op_id_total": 99,
-      "jsonl_commands_total": 5,
       "missing_schema_examples": [],
       "missing_mutating_schema_examples": [],
       "verified_scope_missing_schema_examples": [],

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1782,6 +1782,7 @@ State detail view, pretty-printed.
 
 ```json
 {
+  "output_kind": "show",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
   "change_id": "hd-def456",
@@ -2977,10 +2978,16 @@ true` and `status` is `"applied"`:
 {"change_id": "hd-collapsed123", "collapsed": 3, "message": "collapse feature checkpoints", "parents": ["hd-base123"]}
 ```
 
-`heddle conflict list|show --output json` emit:
+`heddle conflict list --output json` emits:
 
 ```json
 {"conflicts": [{"id": "conflict-1", "kind": "content", "path": "src/lib.rs", "candidate_resolutions": []}]}
+```
+
+`heddle conflict show --output json` emits:
+
+```json
+{"output_kind": "conflict_show", "kind": "active_merge_conflict", "id": "conflict-1", "file": "src/lib.rs", "symbol": "text_merge", "resolved": false, "ours_state": "hd-ours123", "theirs_state": "hd-theirs456", "base_state": "hd-base789", "worktree_content": "<<<<<<< ours\n...\n>>>>>>> theirs\n", "recommended_action": "heddle resolve src/lib.rs", "recommended_action_template": {"argv_template": ["heddle", "resolve", "src/lib.rs"]}, "next_action": "heddle resolve src/lib.rs", "next_action_template": {"argv_template": ["heddle", "resolve", "src/lib.rs"]}}
 ```
 
 `heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
@@ -3045,7 +3052,7 @@ names a new thread for the fork):
 `heddle inspect --output json` emits:
 
 ```json
-{"repository_capability": "native", "storage_model": "native", "change_id": "hd-sqr398d", "change_id_full": "hd-sqr398dvx9ay", "content_hash": "sha256:abc123", "tree": "sha256:def456", "parents": ["hd-base123"], "intent": "capture parser fix", "confidence": 0.91, "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "codex", "model": "gpt-5", "session_id": "session-123"}, "created_at": "2026-01-01T00:00:00Z", "status": "Complete", "verification": {"tests_passed": true}, "git_checkpoint": "abc123"}
+{"output_kind": "inspect_state", "repository_capability": "native", "storage_model": "native", "change_id": "hd-sqr398d", "change_id_full": "hd-sqr398dvx9ay", "content_hash": "sha256:abc123", "tree": "sha256:def456", "parents": ["hd-base123"], "intent": "capture parser fix", "confidence": 0.91, "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "codex", "model": "gpt-5", "session_id": "session-123"}, "created_at": "2026-01-01T00:00:00Z", "status": "Complete", "verification": {"tests_passed": true}, "git_checkpoint": "abc123"}
 ```
 
 `heddle integration list|install|doctor|uninstall|upgrade --output json` emit:
@@ -3086,7 +3093,7 @@ set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`).
 `heddle rebase --output json` emits:
 
 ```json
-{"rebased": true, "old_base": "hd-old123", "new_base": "hd-new456", "change_id": "hd-result789", "conflicts": []}
+{"output_kind": "rebase_progress", "status": "fast_forwarded", "to": "hd-result789"}
 ```
 
 `heddle redact apply|list|show --output json` emit (each carries

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -231,6 +231,7 @@ in-progress operation.
       "accepted_opaque_schema_verbs_total": 56,
       "unaccepted_opaque_schema_verbs_total": 0,
       "supports_op_id_total": 99,
+      "jsonl_commands_total": 6,
       "missing_schema_examples": [],
       "missing_mutating_schema_examples": [],
       "verified_scope_missing_schema_examples": [],

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -808,9 +808,9 @@ List recent saved states on a thread.
 
 ```json
 {
-  "output_kind": "thread",
+  "output_kind": "thread_drop",
   "status": "completed",
-  "action": "thread drop",
+  "action": "thread_drop",
   "name": "feature/parser",
   "message": "Dropped thread 'feature/parser'",
   "next_action": null,
@@ -865,9 +865,9 @@ Report manual follow-up after a blocked or refreshed thread.
 
 ```json
 {
-  "output_kind": "resolve",
+  "output_kind": "thread_resolve",
   "status": "completed",
-  "action": "resolve",
+  "action": "thread_resolve",
   "message": "Thread requires a manual follow-up",
   "blockers": [],
   "warnings": [],
@@ -958,9 +958,9 @@ emits an array of the same object.
 
 ```json
 {
-  "output_kind": "thread.cleanup",
+  "output_kind": "thread_cleanup",
   "status": "completed",
-  "action": "thread.cleanup",
+  "action": "thread_cleanup",
   "message": "would drop 1 merged thread(s) (would reclaim 12.0 KB)",
   "blockers": [],
   "warnings": [],


### PR DESCRIPTION
## Summary

- Normalize thread/operator envelope discriminators to the approved `thread_*` wire values via an explicit `OperatorAction` enum.
- Add missing `output_kind` discriminators for `show`, `inspect <state>`, `rebase --output json` progress records, and `conflict show` success output.
- Change `conflict show <missing-id>` from `null`/exit 0 to a typed `conflict_not_found` recovery envelope with sysexits `DataErr` (65).
- Update catalog discriminator rows, schema mirrors, docs samples, conformance/runtime tests, and generated npm schema types.

## Wire value changes

| Surface | Before | After |
|---|---:|---:|
| `thread drop` operator envelope `output_kind` | `thread` | `thread_drop` |
| `thread drop` operator envelope `action` | `thread drop` | `thread_drop` |
| `thread promote` operator envelope `output_kind` | `thread` | `thread_promote` |
| `thread refresh` operator envelope `output_kind` | `thread` | `thread_refresh` |
| `thread resolve` operator envelope `output_kind` | `resolve` | `thread_resolve` |
| `thread resolve` operator envelope `action` | `resolve` | `thread_resolve` |
| `thread cleanup` operator envelope `output_kind` | `thread.cleanup` | `thread_cleanup` |
| `thread cleanup` operator envelope `action` | `thread.cleanup` | `thread_cleanup` |
| `branch -d` catalog advertisement | no `thread_drop` row | `thread_drop` |
| `branch -m` catalog advertisement | no `thread_rename` row | `thread_rename` |
| `show --output json` | missing `output_kind` | `show` |
| `inspect <state> --output json` | missing `output_kind` | `inspect_state` |
| `inspect` / `inspect <thread>` | `thread_show` | `thread_show` (documented alias row) |
| `rebase --output json` JSONL progress records | missing `output_kind` | `rebase_progress` |
| `conflict show --output json` success catalog/runtime discriminator | no catalog discriminator | `conflict_show` |
| `conflict show <missing-id> --output json` | stdout `null`, exit 0 | stderr recovery envelope `kind=conflict_not_found`, exit 65 |

## Verification

- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo build --locked --workspace`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo build --locked --workspace --all-features`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target bash scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --lib --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test cli_integration thread --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test cli_integration conflict --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test cli_integration rebase --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test cli_integration inspect --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test cli_integration --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo test -p heddle-cli --test ts_types_in_sync --locked`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/heddle-661-target scripts/gen-ts-types.sh`
- `/tmp/heddle-661-target/debug/heddle --repo "$PWD" doctor schemas --output json`

Fixes #661
Fixes #662

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783866037&installation_id=132405951&pr_number=671&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F671&signature=ad72451b318cecb9242f170accf7688d63b02f82703074081b8a163d55a6d1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->