### PR TITLE
Enforce repository format gate

### DIFF
--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -441,6 +441,31 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
                         command,
                     );
                 }
+                HeddleError::RepositoryFormatTooNew {
+                    found,
+                    supported,
+                    ..
+                } => {
+                    return ErrorClassification {
+                        kind: "repository_format_too_new".to_string(),
+                        human_error: Some(heddle_err.to_string()),
+                        hint:
+                            "Upgrade heddle to a binary that supports this repository format, or run the repository migration command with a compatible binary."
+                                .to_string(),
+                        unsafe_condition: format!(
+                            "repository format {found} is newer than this binary's supported format {supported}"
+                        ),
+                        would_change:
+                            "opening a newer-format repository could misread unstamped on-disk data"
+                                .to_string(),
+                        preserved:
+                            "no repository objects, refs, metadata, or worktree files were changed"
+                                .to_string(),
+                        primary_command: "heddle status".to_string(),
+                        recovery_commands: vec!["heddle status".to_string()],
+                        extra_json_fields: serde_json::Map::new(),
+                    };
+                }
                 HeddleError::RepositoryExists(_) => {
                     return ErrorClassification::known(
                         "repository_exists",

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -98,6 +98,9 @@ impl HeddleExitCode {
                     // A missing repository is a missing precondition
                     // (initialize/point at one), not an IO failure.
                     objects::error::HeddleError::RepositoryNotFound(_) => return Self::Config,
+                    objects::error::HeddleError::RepositoryFormatTooNew { .. } => {
+                        return Self::DataErr;
+                    }
                     // Stored state that fails msgpack decoding is corrupted
                     // data, not a transient IO problem — same class as the
                     // serde_json/toml parse failures below.

--- a/crates/objects/src/error.rs
+++ b/crates/objects/src/error.rs
@@ -16,6 +16,14 @@ pub enum HeddleError {
     RepositoryNotFound(std::path::PathBuf),
     #[error("repository already exists at {0}")]
     RepositoryExists(std::path::PathBuf),
+    #[error(
+        "repository config at {path} uses repository format {found} but this binary supports {supported}; upgrade heddle or run `heddle migrate`"
+    )]
+    RepositoryFormatTooNew {
+        path: std::path::PathBuf,
+        found: u32,
+        supported: u32,
+    },
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("serialization error: {0}")]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use super::Result;
 use crate::FsMonitorConfig;
 
+pub(crate) const SUPPORTED_REPO_FORMAT: u32 = 1;
+
 /// Repository configuration stored in `.heddle/config.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoConfig {
@@ -426,7 +428,9 @@ impl Default for DisplayConfig {
 impl Default for RepoConfig {
     fn default() -> Self {
         Self {
-            repository: RepositoryConfig { version: 1 },
+            repository: RepositoryConfig {
+                version: SUPPORTED_REPO_FORMAT,
+            },
             principal: None,
             agent: AgentConfig::default(),
             worktree: WorktreeConfig::default(),

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -378,6 +378,19 @@ pub(crate) fn compute_op_scope(root: &Path) -> String {
     format!("wt-{}", &digest.to_hex().as_str()[..16])
 }
 
+fn ensure_supported_repo_format(config_path: &Path, config: &RepoConfig) -> Result<()> {
+    let found = config.repository.version;
+    let supported = repo_config::SUPPORTED_REPO_FORMAT;
+    if found > supported {
+        return Err(HeddleError::RepositoryFormatTooNew {
+            path: config_path.to_path_buf(),
+            found,
+            supported,
+        });
+    }
+    Ok(())
+}
+
 impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
     fn open_raw(
         root: PathBuf,
@@ -430,7 +443,9 @@ impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
                 ))
             })?
             .to_path_buf();
-        let config = RepoConfig::load(&heddle_dir.join("config.toml"))?;
+        let config_path = heddle_dir.join("config.toml");
+        let config = RepoConfig::load(&config_path)?;
+        ensure_supported_repo_format(&config_path, &config)?;
         let refs = RefManager::new(&heddle_dir);
         Self::open_raw(root, heddle_dir, store, config, refs)
     }
@@ -729,7 +744,9 @@ impl Repository {
                         )));
                     }
 
-                    let config = RepoConfig::load(&shared_galeed_dir.join("config.toml"))?;
+                    let config_path = shared_galeed_dir.join("config.toml");
+                    let config = RepoConfig::load(&config_path)?;
+                    ensure_supported_repo_format(&config_path, &config)?;
                     let store = Self::build_store(&config, &shared_galeed_dir)?;
                     let local_head_path = heddle_path.join("HEAD");
                     let refs = RefManager::new(&shared_galeed_dir).with_local_head(local_head_path);
@@ -741,7 +758,9 @@ impl Repository {
 
                 if objects_dir.is_dir() {
                     // Main repo mode.
-                    let config = RepoConfig::load(&heddle_path.join("config.toml"))?;
+                    let config_path = heddle_path.join("config.toml");
+                    let config = RepoConfig::load(&config_path)?;
+                    ensure_supported_repo_format(&config_path, &config)?;
                     let store = Self::build_store(&config, &heddle_path)?;
                     let refs = RefManager::new(&heddle_path);
                     let repo = Self::open_raw(dir.to_path_buf(), heddle_path, store, config, refs)?;

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -11,6 +11,7 @@ use refs::Head;
 use serde_json::json;
 use tempfile::TempDir;
 
+use super::repo_config::SUPPORTED_REPO_FORMAT;
 use super::repository_snapshot::{with_snapshot_fault, SnapshotFault};
 use crate::{
     ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
@@ -71,6 +72,61 @@ fn test_open_with_store_threads_a_custom_object_store() {
         repo.store().get_blob(&hash).unwrap().unwrap().content(),
         blob.content()
     );
+}
+
+#[test]
+fn open_refuses_newer_repository_format_with_recovery_advice() {
+    let temp_dir = TempDir::new().unwrap();
+    Repository::init_default(temp_dir.path()).unwrap();
+
+    let config_path = temp_dir.path().join(".heddle/config.toml");
+    fs::write(&config_path, "[repository]\nversion = 99\n").unwrap();
+
+    let err = match Repository::open(temp_dir.path()) {
+        Ok(_) => panic!("newer repo format must refuse"),
+        Err(err) => err,
+    };
+    match &err {
+        HeddleError::RepositoryFormatTooNew {
+            path,
+            found,
+            supported,
+        } => {
+            assert_eq!(path, &config_path);
+            assert_eq!(*found, 99);
+            assert_eq!(*supported, SUPPORTED_REPO_FORMAT);
+        }
+        other => panic!("expected RepositoryFormatTooNew, got {other:?}"),
+    }
+
+    let message = err.to_string();
+    assert!(
+        message.contains("repository format 99"),
+        "error should name found format: {message}"
+    );
+    assert!(
+        message.contains(&format!("this binary supports {SUPPORTED_REPO_FORMAT}")),
+        "error should name supported format: {message}"
+    );
+    assert!(
+        message.contains("upgrade heddle or run `heddle migrate`"),
+        "error should include recovery advice: {message}"
+    );
+}
+
+#[test]
+fn open_accepts_supported_repository_format() {
+    let temp_dir = TempDir::new().unwrap();
+    Repository::init_default(temp_dir.path()).unwrap();
+
+    let config_path = temp_dir.path().join(".heddle/config.toml");
+    fs::write(
+        &config_path,
+        format!("[repository]\nversion = {SUPPORTED_REPO_FORMAT}\n"),
+    )
+    .unwrap();
+
+    Repository::open(temp_dir.path()).expect("supported repo format should open");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a supported repo format constant for `[repository] version`
- make `Repository::open` and `open_with_store` refuse newer repo formats before store/oplog access
- surface a typed, actionable error naming found vs supported and advising upgrade/migration
- cover version 99 refusal and supported-version acceptance in `heddle-repo` tests

Fixes #673

## Validation
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo build --locked --workspace`
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo build --locked --workspace --all-features` (passed with existing dead-code warning for `network_feature_unavailable`)
- `CARGO_TARGET_DIR=/tmp/heddle-673-target bash scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo test -p heddle-repo`
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo test -p heddle-cli --lib`
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo test -p heddle-cli --test cli_integration -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/heddle-673-target cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783873018&installation_id=132405951&pr_number=676&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F676&signature=5ff019c36caac0385ddf689c3eee136539b44b6b877174fc6f0f1133590110cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->