### PR TITLE
Fix undo restoring thread base_state

### DIFF
--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -507,8 +507,7 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
     let Some(target_state_obj) = repo.store().get_state(&target_state)? else {
         return Ok(None);
     };
-    let old_state = super::thread_cmd::current_thread_ref_state(repo, &thread)?;
-    let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
+    let before_update = super::thread_cmd::capture_thread_update_before(repo, &manager, &thread)?;
 
     thread.base_state = target_state.short();
     thread.base_root = target_state_obj.tree.short();
@@ -527,9 +526,8 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
         repo,
         &manager,
         &thread,
-        old_state,
+        before_update,
         current_state,
-        old_manager_snapshot,
     )?;
 
     let action = super::thread_landing::land_command_for_thread(repo, &thread_id);

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -507,6 +507,8 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
     let Some(target_state_obj) = repo.store().get_state(&target_state)? else {
         return Ok(None);
     };
+    let old_state = super::thread_cmd::current_thread_ref_state(repo, &thread)?;
+    let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
 
     thread.base_state = target_state.short();
     thread.base_root = target_state_obj.tree.short();
@@ -521,7 +523,14 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
     thread.updated_at = Utc::now();
     let thread_id = thread.id.clone();
     let target = thread.target_thread.clone();
-    manager.save(&thread)?;
+    super::thread_cmd::save_thread_update_with_oplog(
+        repo,
+        &manager,
+        &thread,
+        old_state,
+        current_state,
+        old_manager_snapshot,
+    )?;
 
     let action = super::thread_landing::land_command_for_thread(repo, &thread_id);
     Ok(Some(super::thread::contextual_thread_action(

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -59,16 +59,12 @@ pub(crate) fn current_thread_ref_state(repo: &Repository, thread: &Thread) -> Re
         return Ok(state);
     }
     if let Some(current_state) = thread.current_state.as_deref() {
-        return ChangeId::parse(current_state).map_err(|err| {
-            anyhow!(
-                "invalid current state for thread '{}': {}",
-                thread.thread,
-                err
-            )
-        });
+        return repo
+            .resolve_state(current_state)?
+            .ok_or_else(|| anyhow!("current state not found for thread '{}'", thread.thread));
     }
-    ChangeId::parse(&thread.base_state)
-        .map_err(|err| anyhow!("invalid base state for thread '{}': {}", thread.thread, err))
+    repo.resolve_state(&thread.base_state)?
+        .ok_or_else(|| anyhow!("base state not found for thread '{}'", thread.thread))
 }
 
 pub(crate) fn save_thread_update_with_oplog(
@@ -1973,5 +1969,48 @@ mod cleanup_tests {
         assert_eq!(format_bytes(512), "512 B");
         assert_eq!(format_bytes(2048), "2.0 KB");
         assert_eq!(format_bytes(1024 * 1024 * 5), "5.0 MB");
+    }
+
+    #[test]
+    fn current_thread_ref_state_resolves_persisted_short_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        fs::write(dir.path().join("file.txt"), "content\n").unwrap();
+        let state = repo.snapshot(Some("content".to_string()), None).unwrap();
+
+        let thread = Thread {
+            id: "feature".to_string(),
+            thread: "feature".to_string(),
+            target_thread: Some("main".to_string()),
+            parent_thread: Some("main".to_string()),
+            mode: ThreadMode::Materialized,
+            state: ThreadState::Active,
+            base_state: state.change_id.short(),
+            base_root: state.tree.short(),
+            current_state: Some(state.change_id.short()),
+            merged_state: None,
+            task: None,
+            execution_path: dir.path().to_path_buf(),
+            materialized_path: None,
+            changed_paths: Vec::new(),
+            impact_categories: Vec::new(),
+            heavy_impact_paths: Vec::new(),
+            promotion_suggested: false,
+            freshness: ThreadFreshness::Unknown,
+            verification_summary: Default::default(),
+            confidence_summary: Default::default(),
+            integration_policy_result: Default::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        };
+
+        let resolved = current_thread_ref_state(&repo, &thread).unwrap();
+        assert_eq!(
+            resolved, state.change_id,
+            "fallback must resolve thread-record short current_state values"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -9,7 +9,12 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use chrono::Utc;
-use objects::{fs_ops::remove_path_recursively, object::ThreadName, store::AgentRegistry};
+use objects::{
+    fs_ops::remove_path_recursively,
+    object::{ChangeId, ThreadName},
+    store::AgentRegistry,
+};
+use oplog::OpLogBackend;
 use refs::Head;
 use repo::{
     Repository, Thread, ThreadFreshness, ThreadManager, ThreadMode, ThreadState,
@@ -47,6 +52,43 @@ struct ThreadOutput {
 
 pub(crate) fn thread_manager(repo: &Repository) -> ThreadManager {
     ThreadManager::new(repo.heddle_dir())
+}
+
+pub(crate) fn current_thread_ref_state(repo: &Repository, thread: &Thread) -> Result<ChangeId> {
+    if let Some(state) = repo.refs().get_thread(&ThreadName::new(&thread.thread))? {
+        return Ok(state);
+    }
+    if let Some(current_state) = thread.current_state.as_deref() {
+        return ChangeId::parse(current_state).map_err(|err| {
+            anyhow!(
+                "invalid current state for thread '{}': {}",
+                thread.thread,
+                err
+            )
+        });
+    }
+    ChangeId::parse(&thread.base_state)
+        .map_err(|err| anyhow!("invalid base state for thread '{}': {}", thread.thread, err))
+}
+
+pub(crate) fn save_thread_update_with_oplog(
+    repo: &Repository,
+    manager: &ThreadManager,
+    thread: &Thread,
+    old_state: ChangeId,
+    new_state: ChangeId,
+    old_manager_snapshot: Option<Vec<u8>>,
+) -> Result<()> {
+    let new_manager_snapshot = Some(manager.encode_thread_record_snapshot(thread)?);
+    repo.oplog().record_thread_update(
+        &ThreadName::new(&thread.thread),
+        &old_state,
+        &new_state,
+        old_manager_snapshot,
+        new_manager_snapshot,
+        Some(&repo.op_scope()),
+    )?;
+    Ok(manager.save(thread)?)
 }
 
 /// Resolve an optional positional thread identifier to a concrete
@@ -439,6 +481,8 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
             thread_repo.root(),
         )));
     }
+    let old_state = current_thread_ref_state(repo, &thread)?;
+    let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
     let rebase_state_path = thread_repo.heddle_dir().join("REBASE_STATE");
     if rebase_state_path.exists() {
         super::rebase::cmd_rebase_silent(thread_repo, None, false, true)?;
@@ -533,7 +577,14 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
     thread.integration_policy_result.manual_resolution_state = Some(current_state.short());
     thread.updated_at = Utc::now();
     thread.freshness = ThreadFreshness::Current;
-    manager.save(&thread)?;
+    save_thread_update_with_oplog(
+        repo,
+        &manager,
+        &thread,
+        old_state,
+        current_state,
+        old_manager_snapshot,
+    )?;
     Ok(thread)
 }
 

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -14,7 +14,7 @@ use objects::{
     object::{ChangeId, ThreadName},
     store::AgentRegistry,
 };
-use oplog::OpLogBackend;
+use oplog::{OpLogBackend, ThreadUpdateSnapshots};
 use refs::Head;
 use repo::{
     Repository, Thread, ThreadFreshness, ThreadManager, ThreadMode, ThreadState,
@@ -50,41 +50,107 @@ struct ThreadOutput {
     changed_path_count: usize,
 }
 
+pub(crate) struct ThreadRefState {
+    pub state: ChangeId,
+    pub ref_absent: bool,
+}
+
+pub(crate) struct ThreadUpdateBefore {
+    pub state: ChangeId,
+    pub ref_absent: bool,
+    pub manager_snapshot: Option<Vec<u8>>,
+    pub manager_records: Vec<Thread>,
+}
+
 pub(crate) fn thread_manager(repo: &Repository) -> ThreadManager {
     ThreadManager::new(repo.heddle_dir())
 }
 
-pub(crate) fn current_thread_ref_state(repo: &Repository, thread: &Thread) -> Result<ChangeId> {
+pub(crate) fn current_thread_ref_state_with_presence(
+    repo: &Repository,
+    thread: &Thread,
+) -> Result<ThreadRefState> {
     if let Some(state) = repo.refs().get_thread(&ThreadName::new(&thread.thread))? {
-        return Ok(state);
+        return Ok(ThreadRefState {
+            state,
+            ref_absent: false,
+        });
     }
-    if let Some(current_state) = thread.current_state.as_deref() {
-        return repo
-            .resolve_state(current_state)?
-            .ok_or_else(|| anyhow!("current state not found for thread '{}'", thread.thread));
-    }
-    repo.resolve_state(&thread.base_state)?
-        .ok_or_else(|| anyhow!("base state not found for thread '{}'", thread.thread))
+    let state = if let Some(current_state) = thread.current_state.as_deref() {
+        repo.resolve_state(current_state)?
+            .ok_or_else(|| anyhow!("current state not found for thread '{}'", thread.thread))?
+    } else {
+        repo.resolve_state(&thread.base_state)?
+            .ok_or_else(|| anyhow!("base state not found for thread '{}'", thread.thread))?
+    };
+    Ok(ThreadRefState {
+        state,
+        ref_absent: true,
+    })
+}
+
+pub(crate) fn current_thread_ref_state(repo: &Repository, thread: &Thread) -> Result<ChangeId> {
+    Ok(current_thread_ref_state_with_presence(repo, thread)?.state)
+}
+
+pub(crate) fn capture_thread_update_before(
+    repo: &Repository,
+    manager: &ThreadManager,
+    thread: &Thread,
+) -> Result<ThreadUpdateBefore> {
+    let ref_state = current_thread_ref_state_with_presence(repo, thread)?;
+    Ok(ThreadUpdateBefore {
+        state: ref_state.state,
+        ref_absent: ref_state.ref_absent,
+        manager_snapshot: manager.snapshot_thread_record(&thread.thread)?,
+        manager_records: manager.snapshot_records(&thread.thread)?,
+    })
 }
 
 pub(crate) fn save_thread_update_with_oplog(
     repo: &Repository,
     manager: &ThreadManager,
     thread: &Thread,
-    old_state: ChangeId,
+    before: ThreadUpdateBefore,
     new_state: ChangeId,
-    old_manager_snapshot: Option<Vec<u8>>,
 ) -> Result<()> {
     let new_manager_snapshot = Some(manager.encode_thread_record_snapshot(thread)?);
+    let mut new_manager_records = before.manager_records.clone();
+    if let Some(existing) = new_manager_records
+        .iter_mut()
+        .find(|record| record.id == thread.id)
+    {
+        *existing = thread.clone();
+    } else {
+        new_manager_records.push(thread.clone());
+    }
+    let old_manager_records = encode_thread_records(manager, &before.manager_records)?;
+    let new_manager_records = encode_thread_records(manager, &new_manager_records)?;
     repo.oplog().record_thread_update(
         &ThreadName::new(&thread.thread),
-        &old_state,
+        &before.state,
         &new_state,
-        old_manager_snapshot,
-        new_manager_snapshot,
+        ThreadUpdateSnapshots::from_record_sets(
+            before.manager_snapshot,
+            new_manager_snapshot,
+            old_manager_records,
+            new_manager_records,
+            before.ref_absent,
+        ),
         Some(&repo.op_scope()),
     )?;
     Ok(manager.save(thread)?)
+}
+
+fn encode_thread_records(manager: &ThreadManager, records: &[Thread]) -> Result<Vec<Vec<u8>>> {
+    records
+        .iter()
+        .map(|record| {
+            manager
+                .encode_thread_record_snapshot(record)
+                .map_err(Into::into)
+        })
+        .collect()
 }
 
 /// Resolve an optional positional thread identifier to a concrete
@@ -477,8 +543,7 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
             thread_repo.root(),
         )));
     }
-    let old_state = current_thread_ref_state(repo, &thread)?;
-    let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
+    let before_update = capture_thread_update_before(repo, &manager, &thread)?;
     let rebase_state_path = thread_repo.heddle_dir().join("REBASE_STATE");
     if rebase_state_path.exists() {
         super::rebase::cmd_rebase_silent(thread_repo, None, false, true)?;
@@ -577,9 +642,8 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
         repo,
         &manager,
         &thread,
-        old_state,
+        before_update,
         current_state,
-        old_manager_snapshot,
     )?;
     Ok(thread)
 }

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -23,8 +23,8 @@ use super::{
     ready_cmd::worktree_dirty,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
     thread_cmd::{
-        current_thread_ref_state, load_thread, refresh_thread, refresh_thread_freshness,
-        save_thread_update_with_oplog, thread_not_found_advice,
+        capture_thread_update_before, current_thread_ref_state, load_thread, refresh_thread,
+        refresh_thread_freshness, save_thread_update_with_oplog, thread_not_found_advice,
     },
     thread_landing::{land_command_for_thread, land_command_with_push_target},
 };
@@ -287,9 +287,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 let mut refreshed_thread = manager.load(&thread_id)?.ok_or_else(|| {
                     anyhow!(thread_not_found_advice(&thread_id, "resolve thread"))
                 })?;
-                let old_state = current_thread_ref_state(&repo, &refreshed_thread)?;
-                let old_manager_snapshot =
-                    manager.snapshot_thread_record(&refreshed_thread.thread)?;
+                let before_update =
+                    capture_thread_update_before(&repo, &manager, &refreshed_thread)?;
                 let resolved_state = repo
                     .refs()
                     .get_thread(&ThreadName::new(&refreshed_thread.thread))?
@@ -306,9 +305,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                     &repo,
                     &manager,
                     &refreshed_thread,
-                    old_state,
+                    before_update,
                     new_state,
-                    old_manager_snapshot,
                 )?;
                 let operator = if rebase_state_path.exists() {
                     thread_resolve_rebase_followup_operator(
@@ -415,8 +413,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
     }
     if blockers.is_empty() {
         let manager = super::thread_cmd::thread_manager(&repo);
-        let thread_state = current_thread_ref_state(&repo, &thread)?;
-        let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
+        let before_update = capture_thread_update_before(&repo, &manager, &thread)?;
+        let thread_state = before_update.state;
         thread.integration_policy_result.status = Some("manual_resolved".to_string());
         thread.integration_policy_result.reason =
             Some("manual integration resolution captured".to_string());
@@ -428,9 +426,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
             &repo,
             &manager,
             &thread,
+            before_update,
             thread_state,
-            thread_state,
-            old_manager_snapshot,
         )?;
     }
     let recommended_action = if blockers.is_empty() {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -22,7 +22,10 @@ use super::{
     operator_loop::primary_next_action,
     ready_cmd::worktree_dirty,
     snapshot::{SnapshotAgentOverrides, create_snapshot},
-    thread_cmd::{load_thread, refresh_thread, refresh_thread_freshness, thread_not_found_advice},
+    thread_cmd::{
+        current_thread_ref_state, load_thread, refresh_thread, refresh_thread_freshness,
+        save_thread_update_with_oplog, thread_not_found_advice,
+    },
     thread_landing::{land_command_for_thread, land_command_with_push_target},
 };
 use crate::{
@@ -284,10 +287,14 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 let mut refreshed_thread = manager.load(&thread_id)?.ok_or_else(|| {
                     anyhow!(thread_not_found_advice(&thread_id, "resolve thread"))
                 })?;
+                let old_state = current_thread_ref_state(&repo, &refreshed_thread)?;
+                let old_manager_snapshot =
+                    manager.snapshot_thread_record(&refreshed_thread.thread)?;
                 let resolved_state = repo
                     .refs()
                     .get_thread(&ThreadName::new(&refreshed_thread.thread))?
                     .map(|id| id.short());
+                let new_state = current_thread_ref_state(&repo, &refreshed_thread)?;
                 refreshed_thread.integration_policy_result.status =
                     Some("manual_resolved".to_string());
                 refreshed_thread.integration_policy_result.reason =
@@ -295,7 +302,14 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 refreshed_thread
                     .integration_policy_result
                     .manual_resolution_state = resolved_state;
-                manager.save(&refreshed_thread)?;
+                save_thread_update_with_oplog(
+                    &repo,
+                    &manager,
+                    &refreshed_thread,
+                    old_state,
+                    new_state,
+                    old_manager_snapshot,
+                )?;
                 let operator = if rebase_state_path.exists() {
                     thread_resolve_rebase_followup_operator(
                         &source_repo,
@@ -401,6 +415,9 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
     }
     if blockers.is_empty() {
         let manager = super::thread_cmd::thread_manager(&repo);
+        let old_state = current_thread_ref_state(&repo, &thread)?;
+        let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
+        let new_state = current_thread_ref_state(&repo, &thread)?;
         thread.integration_policy_result.status = Some("manual_resolved".to_string());
         thread.integration_policy_result.reason =
             Some("manual integration resolution captured".to_string());
@@ -408,7 +425,14 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
             .refs()
             .get_thread(&ThreadName::new(&thread.thread))?
             .map(|id| id.short());
-        manager.save(&thread)?;
+        save_thread_update_with_oplog(
+            &repo,
+            &manager,
+            &thread,
+            old_state,
+            new_state,
+            old_manager_snapshot,
+        )?;
     }
     let recommended_action = if blockers.is_empty() {
         if rebase_state_path.exists() {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -415,9 +415,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
     }
     if blockers.is_empty() {
         let manager = super::thread_cmd::thread_manager(&repo);
-        let old_state = current_thread_ref_state(&repo, &thread)?;
+        let thread_state = current_thread_ref_state(&repo, &thread)?;
         let old_manager_snapshot = manager.snapshot_thread_record(&thread.thread)?;
-        let new_state = current_thread_ref_state(&repo, &thread)?;
         thread.integration_policy_result.status = Some("manual_resolved".to_string());
         thread.integration_policy_result.reason =
             Some("manual integration resolution captured".to_string());
@@ -429,8 +428,8 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
             &repo,
             &manager,
             &thread,
-            old_state,
-            new_state,
+            thread_state,
+            thread_state,
             old_manager_snapshot,
         )?;
     }

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -495,6 +495,30 @@ impl<'a> EntrySteps<'_, 'a> {
         )
     }
 
+    fn restore_thread_record_set(
+        &mut self,
+        name: &str,
+        snapshots: &[Vec<u8>],
+        op_label: &'static str,
+    ) -> HeddleResult<()> {
+        let manager = ThreadManager::new(self.repo().heddle_dir());
+        let mut restored = Vec::with_capacity(snapshots.len());
+        for bytes in snapshots {
+            match manager.decode_thread_record_snapshot(bytes) {
+                Ok(record) => restored.push(record),
+                Err(e) => {
+                    eprintln!(
+                        "warning: replay of `{}` for '{}' skipped ThreadManager record-set \
+                         restore because one snapshot failed to decode ({}).",
+                        op_label, name, e
+                    );
+                    return Ok(());
+                }
+            }
+        }
+        self.converge_thread_records(name, restored)
+    }
+
     /// Remove a redaction record from its per-blob sidecar. NON-atomic and
     /// re-exposing: `remove_redaction` rewrites or deletes the sidecar file, so
     /// the capture snapshots the whole sidecar (bytes or absence) and registers a
@@ -682,13 +706,25 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             manager_snapshots,
             ..
         } => {
-            steps.set_thread(name.as_str(), *old_state)?;
-            steps.restore_active_thread_worktree(name.as_str(), *old_state)?;
-            if let Some(bytes) = manager_snapshots
+            if manager_snapshots
                 .as_ref()
-                .and_then(|snapshots| snapshots.old.as_ref())
+                .is_some_and(|snapshots| snapshots.old_ref_absent)
             {
-                steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+                steps.delete_thread(name.as_str())?;
+            } else {
+                steps.set_thread(name.as_str(), *old_state)?;
+                steps.restore_active_thread_worktree(name.as_str(), *old_state)?;
+            }
+            if let Some(snapshots) = manager_snapshots.as_ref() {
+                if !snapshots.old_records.is_empty() || !snapshots.new_records.is_empty() {
+                    steps.restore_thread_record_set(
+                        name,
+                        &snapshots.old_records,
+                        "ThreadUpdate",
+                    )?;
+                } else if let Some(bytes) = snapshots.old.as_ref() {
+                    steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+                }
             }
         }
         OpRecord::MarkerCreate { name, .. } => {
@@ -869,11 +905,16 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         } => {
             steps.set_thread(name.as_str(), *new_state)?;
             steps.restore_active_thread_worktree(name.as_str(), *new_state)?;
-            if let Some(bytes) = manager_snapshots
-                .as_ref()
-                .and_then(|snapshots| snapshots.new.as_ref())
-            {
-                steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+            if let Some(snapshots) = manager_snapshots.as_ref() {
+                if !snapshots.old_records.is_empty() || !snapshots.new_records.is_empty() {
+                    steps.restore_thread_record_set(
+                        name,
+                        &snapshots.new_records,
+                        "ThreadUpdate",
+                    )?;
+                } else if let Some(bytes) = snapshots.new.as_ref() {
+                    steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+                }
             }
         }
         OpRecord::MarkerCreate { name, state } => {
@@ -2038,6 +2079,7 @@ impl AtomicMutation for RedoOp {
 #[cfg(test)]
 mod atomic_tests {
     use super::*;
+    use oplog::ThreadUpdateSnapshots;
     use tempfile::TempDir;
 
     /// Init a repo and create two snapshots on `main`. The worktree at `s2`
@@ -2893,6 +2935,203 @@ mod atomic_tests {
             auto: false,
             shared_target_dir: None,
         }
+    }
+
+    fn encode_thread_record_set(manager: &ThreadManager, records: &[Thread]) -> Vec<Vec<u8>> {
+        records
+            .iter()
+            .map(|record| manager.encode_thread_record_snapshot(record).unwrap())
+            .collect()
+    }
+
+    fn apply_undo_once(repo: &Repository, scope: &str) {
+        let batches = repo.oplog().undo_batches_scoped(1, Some(scope)).unwrap();
+        let recovery_head = repo.head().unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("undo", scope, generation, &batches);
+        repo::atomic::execute(repo, UndoOp::new(batches, recovery_head, txid)).unwrap();
+    }
+
+    fn apply_redo_once(repo: &Repository, scope: &str) {
+        let batches = repo.oplog().redo_batches_scoped(1, Some(scope)).unwrap();
+        let generation = repo.oplog().head_id().unwrap();
+        let txid = undo_redo_transaction_id("redo", scope, generation, &batches);
+        repo::atomic::execute(repo, RedoOp::new(batches, txid)).unwrap();
+    }
+
+    #[test]
+    fn thread_update_undo_preserves_missing_ref_fallback_absence() {
+        let (_temp, repo, s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let mut old_record = sample_main_thread(&s1.short(), "/work/missing-ref");
+        old_record.id = "missing-ref".to_string();
+        old_record.thread = "missing-ref".to_string();
+        old_record.base_state = s1.short();
+        old_record.current_state = Some(s1.short());
+        let mut new_record = old_record.clone();
+        new_record.current_state = Some(s2.short());
+        new_record.updated_at = old_record.updated_at + chrono::Duration::seconds(1);
+        manager.save(&new_record).unwrap();
+        repo.refs()
+            .delete_thread(&ThreadName::new("missing-ref"))
+            .unwrap();
+
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::ThreadUpdate {
+                    name: "missing-ref".to_string(),
+                    old_state: s1,
+                    new_state: s2,
+                    manager_snapshots: ThreadUpdateSnapshots::from_record_sets(
+                        Some(manager.encode_thread_record_snapshot(&old_record).unwrap()),
+                        Some(manager.encode_thread_record_snapshot(&new_record).unwrap()),
+                        encode_thread_record_set(&manager, std::slice::from_ref(&old_record)),
+                        encode_thread_record_set(&manager, std::slice::from_ref(&new_record)),
+                        true,
+                    ),
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+
+        apply_undo_once(&repo, &scope);
+        assert_eq!(
+            repo.refs()
+                .get_thread(&ThreadName::new("missing-ref"))
+                .unwrap(),
+            None,
+            "undo restores the pre-update absence instead of fabricating a ref"
+        );
+        assert_eq!(
+            manager
+                .find_by_thread("missing-ref")
+                .unwrap()
+                .unwrap()
+                .current_state
+                .as_deref(),
+            Some(s1.short().as_str()),
+            "undo restores the old ThreadManager record"
+        );
+
+        apply_redo_once(&repo, &scope);
+        assert_eq!(
+            repo.refs()
+                .get_thread(&ThreadName::new("missing-ref"))
+                .unwrap(),
+            Some(s2),
+            "redo recreates the post-update thread ref"
+        );
+        assert_eq!(
+            manager
+                .find_by_thread("missing-ref")
+                .unwrap()
+                .unwrap()
+                .current_state
+                .as_deref(),
+            Some(s2.short().as_str()),
+            "redo restores the new ThreadManager record"
+        );
+    }
+
+    #[test]
+    fn thread_update_undo_redo_restores_duplicate_same_name_record_sets() {
+        let (_temp, repo, s1, s2) = repo_with_two_snapshots();
+        let scope = repo.op_scope();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let mut winner_old = sample_main_thread(&s1.short(), "/work/winner-old");
+        winner_old.id = "rec-winner".to_string();
+        winner_old.updated_at = chrono::Utc::now();
+        let mut duplicate = sample_main_thread(&s1.short(), "/work/duplicate");
+        duplicate.id = "rec-duplicate".to_string();
+        duplicate.updated_at = winner_old.updated_at - chrono::Duration::seconds(30);
+        let mut winner_new = winner_old.clone();
+        winner_new.current_state = Some(s2.short());
+        winner_new.materialized_path = Some(PathBuf::from("/work/winner-new"));
+        winner_new.updated_at = winner_old.updated_at + chrono::Duration::seconds(30);
+        manager.save(&winner_new).unwrap();
+        manager.save(&duplicate).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("main"), &s2)
+            .unwrap();
+
+        let old_records = vec![winner_old.clone(), duplicate.clone()];
+        let new_records = vec![winner_new.clone(), duplicate.clone()];
+        repo.oplog()
+            .record_batch_scoped(
+                vec![OpRecord::ThreadUpdate {
+                    name: "main".to_string(),
+                    old_state: s1,
+                    new_state: s2,
+                    manager_snapshots: ThreadUpdateSnapshots::from_record_sets(
+                        Some(manager.encode_thread_record_snapshot(&winner_old).unwrap()),
+                        Some(manager.encode_thread_record_snapshot(&winner_new).unwrap()),
+                        encode_thread_record_set(&manager, &old_records),
+                        encode_thread_record_set(&manager, &new_records),
+                        false,
+                    ),
+                }],
+                Some(&scope),
+            )
+            .unwrap();
+
+        apply_undo_once(&repo, &scope);
+        let undone = manager.snapshot_records("main").unwrap();
+        let undone_ids: std::collections::HashSet<_> =
+            undone.iter().map(|record| record.id.as_str()).collect();
+        assert_eq!(
+            undone_ids,
+            std::collections::HashSet::from(["rec-winner", "rec-duplicate"]),
+            "undo preserves every same-name record"
+        );
+        assert_eq!(
+            manager
+                .load("rec-winner")
+                .unwrap()
+                .unwrap()
+                .current_state
+                .as_deref(),
+            Some(s1.short().as_str()),
+            "undo restores the winner's old body"
+        );
+        assert_eq!(
+            manager
+                .load("rec-duplicate")
+                .unwrap()
+                .unwrap()
+                .materialized_path,
+            Some(PathBuf::from("/work/duplicate")),
+            "undo keeps the non-winner duplicate worktree metadata"
+        );
+
+        apply_redo_once(&repo, &scope);
+        let redone = manager.snapshot_records("main").unwrap();
+        let redone_ids: std::collections::HashSet<_> =
+            redone.iter().map(|record| record.id.as_str()).collect();
+        assert_eq!(
+            redone_ids,
+            std::collections::HashSet::from(["rec-winner", "rec-duplicate"]),
+            "redo preserves every same-name record"
+        );
+        assert_eq!(
+            manager
+                .load("rec-winner")
+                .unwrap()
+                .unwrap()
+                .current_state
+                .as_deref(),
+            Some(s2.short().as_str()),
+            "redo restores the winner's new body"
+        );
+        assert_eq!(
+            manager
+                .load("rec-duplicate")
+                .unwrap()
+                .unwrap()
+                .materialized_path,
+            Some(PathBuf::from("/work/duplicate")),
+            "redo keeps the non-winner duplicate worktree metadata"
+        );
     }
 
     /// Test-only deferred mutation that saves ONE thread record through the

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -661,11 +661,14 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::ThreadUpdate {
             name,
             old_state,
-            old_manager_snapshot,
+            manager_snapshots,
             ..
         } => {
             steps.set_thread(name.as_str(), *old_state)?;
-            if let Some(bytes) = old_manager_snapshot {
+            if let Some(bytes) = manager_snapshots
+                .as_ref()
+                .and_then(|snapshots| snapshots.old.as_ref())
+            {
                 steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
             }
         }
@@ -842,11 +845,14 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::ThreadUpdate {
             name,
             new_state,
-            new_manager_snapshot,
+            manager_snapshots,
             ..
         } => {
             steps.set_thread(name.as_str(), *new_state)?;
-            if let Some(bytes) = new_manager_snapshot {
+            if let Some(bytes) = manager_snapshots
+                .as_ref()
+                .and_then(|snapshots| snapshots.new.as_ref())
+            {
                 steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
             }
         }
@@ -2438,8 +2444,7 @@ mod atomic_tests {
                         name: "main".to_string(),
                         old_state: main_state,
                         new_state: main_state,
-                        old_manager_snapshot: None,
-                        new_manager_snapshot: None,
+                        manager_snapshots: None,
                     },
                     OpRecord::MarkerCreate {
                         name: "mc".to_string(),
@@ -2499,8 +2504,7 @@ mod atomic_tests {
                         name: "main".to_string(),
                         old_state: main_state,
                         new_state: main_state,
-                        old_manager_snapshot: None,
-                        new_manager_snapshot: None,
+                        manager_snapshots: None,
                     },
                     OpRecord::ThreadCreate {
                         name: "old".to_string(),
@@ -3366,8 +3370,7 @@ mod atomic_tests {
                     name: "main".to_string(),
                     old_state: main_state,
                     new_state: main_state,
-                    old_manager_snapshot: None,
-                    new_manager_snapshot: None,
+                    manager_snapshots: None,
                 }],
                 Some(&scope),
             )

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -301,6 +301,24 @@ impl<'a> EntrySteps<'_, 'a> {
         )
     }
 
+    /// Re-materialize the currently attached thread at `target`, preserving its
+    /// attached HEAD. No-op when undo/redo is replaying a different thread's ref.
+    fn restore_active_thread_worktree(&mut self, name: &str, target: ChangeId) -> HeddleResult<()> {
+        let repo = self.repo();
+        let head_ref = repo.head_ref()?;
+        let Head::Attached { thread } = &head_ref else {
+            return Ok(());
+        };
+        if thread != name {
+            return Ok(());
+        }
+        self.step_nonatomic(
+            move || Ok((repo.head()?, repo.head_ref()?)),
+            move |(prev_state, prev_head_ref)| restore_head(repo, prev_state, &prev_head_ref),
+            move || repo.fast_forward_attached_without_record_discard_local(&target),
+        )
+    }
+
     /// Write HEAD to `head`; inverse restores the prior HEAD ref. A single ref
     /// write — genuinely all-or-nothing.
     fn write_head(&mut self, head: Head) -> HeddleResult<()> {
@@ -665,6 +683,7 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             ..
         } => {
             steps.set_thread(name.as_str(), *old_state)?;
+            steps.restore_active_thread_worktree(name.as_str(), *old_state)?;
             if let Some(bytes) = manager_snapshots
                 .as_ref()
                 .and_then(|snapshots| snapshots.old.as_ref())
@@ -849,6 +868,7 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             ..
         } => {
             steps.set_thread(name.as_str(), *new_state)?;
+            steps.restore_active_thread_worktree(name.as_str(), *new_state)?;
             if let Some(bytes) = manager_snapshots
                 .as_ref()
                 .and_then(|snapshots| snapshots.new.as_ref())

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -437,7 +437,12 @@ impl<'a> EntrySteps<'_, 'a> {
     /// a non-fatal warning that writes nothing — the on-disk set stays the
     /// captured prior set (a no-op converge), preserving the pre-migration
     /// ref-only fallback.
-    fn restore_thread_record(&mut self, name: &str, bytes: &[u8]) -> HeddleResult<()> {
+    fn restore_thread_record(
+        &mut self,
+        name: &str,
+        bytes: &[u8],
+        op_label: &'static str,
+    ) -> HeddleResult<()> {
         let repo = self.repo();
         let forward_name = name.to_string();
         let restore_name = name.to_string();
@@ -457,11 +462,11 @@ impl<'a> EntrySteps<'_, 'a> {
                     }
                     Err(e) => {
                         eprintln!(
-                            "warning: redo of `ThreadCreate` for '{}' restored the ref but failed \
+                            "warning: replay of `{}` for '{}' restored the ref but failed \
                              to decode the ThreadManager record snapshot ({}). Record-backed \
                              commands (`thread cd`, delegate) may degrade on this thread — run \
                              `heddle thread start {}` to recreate the record.",
-                            warn_name, e, warn_name
+                            op_label, warn_name, e, warn_name
                         );
                         // Write nothing: the on-disk set is unchanged (== the
                         // captured prior set), i.e. a no-op converge.
@@ -654,9 +659,15 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             steps.set_thread(name.as_str(), *state)?;
         }
         OpRecord::ThreadUpdate {
-            name, old_state, ..
+            name,
+            old_state,
+            old_manager_snapshot,
+            ..
         } => {
             steps.set_thread(name.as_str(), *old_state)?;
+            if let Some(bytes) = old_manager_snapshot {
+                steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+            }
         }
         OpRecord::MarkerCreate { name, .. } => {
             steps.delete_marker(name.as_str())?;
@@ -822,16 +833,22 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         } => {
             steps.set_thread(name.as_str(), *state)?;
             if let Some(bytes) = manager_snapshot {
-                steps.restore_thread_record(name, bytes)?;
+                steps.restore_thread_record(name, bytes, "ThreadCreate")?;
             }
         }
         OpRecord::ThreadDelete { name, .. } => {
             delete_thread_safely(steps, &ThreadName::new(name.as_str()))?;
         }
         OpRecord::ThreadUpdate {
-            name, new_state, ..
+            name,
+            new_state,
+            new_manager_snapshot,
+            ..
         } => {
             steps.set_thread(name.as_str(), *new_state)?;
+            if let Some(bytes) = new_manager_snapshot {
+                steps.restore_thread_record(name, bytes, "ThreadUpdate")?;
+            }
         }
         OpRecord::MarkerCreate { name, state } => {
             steps.create_marker(name.as_str(), *state)?;
@@ -2421,6 +2438,8 @@ mod atomic_tests {
                         name: "main".to_string(),
                         old_state: main_state,
                         new_state: main_state,
+                        old_manager_snapshot: None,
+                        new_manager_snapshot: None,
                     },
                     OpRecord::MarkerCreate {
                         name: "mc".to_string(),
@@ -2480,6 +2499,8 @@ mod atomic_tests {
                         name: "main".to_string(),
                         old_state: main_state,
                         new_state: main_state,
+                        old_manager_snapshot: None,
+                        new_manager_snapshot: None,
                     },
                     OpRecord::ThreadCreate {
                         name: "old".to_string(),
@@ -3018,7 +3039,7 @@ mod atomic_tests {
 
         fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
             let mut steps = EntrySteps::new(tx);
-            steps.restore_thread_record(&self.name, &self.bytes)?;
+            steps.restore_thread_record(&self.name, &self.bytes, "ThreadCreate")?;
             Ok(StagedCommit::pure(()))
         }
     }
@@ -3345,6 +3366,8 @@ mod atomic_tests {
                     name: "main".to_string(),
                     old_state: main_state,
                     new_state: main_state,
+                    old_manager_snapshot: None,
+                    new_manager_snapshot: None,
                 }],
                 Some(&scope),
             )

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -989,8 +989,7 @@ mod tests {
                 name: "x".into(),
                 old_state: cid,
                 new_state: cid,
-                old_manager_snapshot: None,
-                new_manager_snapshot: None,
+                manager_snapshots: None,
             },
             OpRecord::Fork {
                 from: cid,

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -989,6 +989,8 @@ mod tests {
                 name: "x".into(),
                 old_state: cid,
                 new_state: cid,
+                old_manager_snapshot: None,
+                new_manager_snapshot: None,
             },
             OpRecord::Fork {
                 from: cid,

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -2105,6 +2105,93 @@ fn test_redo_thread_create_restores_manager_record() {
     );
 }
 
+/// heddle#469: `thread refresh` updates both the thread ref and the
+/// ThreadManager record's base metadata. Undo must restore the whole
+/// thread record, including `base_state`, not just the ref pointer.
+#[test]
+fn test_undo_thread_refresh_restores_base_state() {
+    use repo::ThreadManager;
+
+    let temp = bootstrap_repo_with_initial_state();
+
+    heddle_must_succeed(&["thread", "create", "feature"], temp.path());
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+    std::fs::write(temp.path().join("feature.txt"), "feature\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "feature work"], temp.path());
+    let feature_tip_before_refresh = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "main"], temp.path());
+    std::fs::write(temp.path().join("main.txt"), "main\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "main advance"], temp.path());
+    let refreshed_base = head_short(temp.path());
+
+    heddle_must_succeed(&["thread", "switch", "feature"], temp.path());
+
+    let (base_before_refresh, current_before_refresh) = {
+        let repo = Repository::open(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let record = manager
+            .find_by_thread("feature")
+            .unwrap()
+            .expect("feature record exists before refresh");
+        (
+            record.base_state.clone(),
+            record
+                .current_state
+                .clone()
+                .expect("feature has current state before refresh"),
+        )
+    };
+
+    heddle_must_succeed(&["thread", "refresh", "feature"], temp.path());
+
+    {
+        let repo = Repository::open(temp.path()).unwrap();
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let record = manager
+            .find_by_thread("feature")
+            .unwrap()
+            .expect("feature record exists after refresh");
+        assert_eq!(
+            record.base_state, refreshed_base,
+            "refresh must advance feature's recorded base to main"
+        );
+        assert_ne!(
+            record.base_state, base_before_refresh,
+            "test setup must actually change base_state"
+        );
+    }
+
+    heddle_must_succeed(&["undo"], temp.path());
+
+    let repo = Repository::open(temp.path()).unwrap();
+    let feature_ref = repo
+        .refs()
+        .get_thread(&ThreadName::new("feature"))
+        .unwrap()
+        .expect("feature ref survives refresh undo")
+        .short();
+    assert_eq!(
+        feature_ref, feature_tip_before_refresh,
+        "undo of refresh must restore the feature ref"
+    );
+
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let restored = manager
+        .find_by_thread("feature")
+        .unwrap()
+        .expect("feature record survives refresh undo");
+    assert_eq!(
+        restored.base_state, base_before_refresh,
+        "undo of refresh must restore the prior base_state"
+    );
+    assert_eq!(
+        restored.current_state.as_deref(),
+        Some(current_before_refresh.as_str()),
+        "undo of refresh must restore the manager record's current_state too"
+    );
+}
+
 /// `heddle undo --preview` (alias `--dry-run`) must surface the
 /// worktree-attached refusal pre-mutation, matching the same
 /// preview-honesty rule used by the redaction gate at undo.rs:88.

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -2144,6 +2144,15 @@ fn test_undo_thread_refresh_restores_base_state() {
     };
 
     heddle_must_succeed(&["thread", "refresh", "feature"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+        "feature\n",
+        "refresh must keep the feature work materialized"
+    );
+    assert!(
+        temp.path().join("main.txt").exists(),
+        "test setup must materialize the refreshed base on disk"
+    );
 
     {
         let repo = Repository::open(temp.path()).unwrap();
@@ -2174,6 +2183,15 @@ fn test_undo_thread_refresh_restores_base_state() {
     assert_eq!(
         feature_ref, feature_tip_before_refresh,
         "undo of refresh must restore the feature ref"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+        "feature\n",
+        "undo of refresh must restore the pre-refresh worktree content"
+    );
+    assert!(
+        !temp.path().join("main.txt").exists(),
+        "undo of refresh on the checked-out thread must remove files introduced by refresh"
     );
 
     let manager = ThreadManager::new(repo.heddle_dir());

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -214,8 +214,7 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                             name: short_name.to_string(),
                             old_state: old_cid,
                             new_state: new_cid,
-                            old_manager_snapshot: None,
-                            new_manager_snapshot: None,
+                            manager_snapshots: None,
                         }],
                         scope,
                     )

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -214,6 +214,8 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                             name: short_name.to_string(),
                             old_state: old_cid,
                             new_state: new_cid,
+                            old_manager_snapshot: None,
+                            new_manager_snapshot: None,
                         }],
                         scope,
                     )
@@ -394,7 +396,12 @@ mod tests {
         );
         assert!(matches!(
             &ops[1],
-            OpRecord::ThreadUpdate { name, old_state, new_state }
+            OpRecord::ThreadUpdate {
+                name,
+                old_state,
+                new_state,
+                ..
+            }
                 if name == "main" && *old_state == cid_a && *new_state == cid_b
         ));
         assert!(

--- a/crates/oplog/benches/oplog_io.rs
+++ b/crates/oplog/benches/oplog_io.rs
@@ -94,6 +94,8 @@ fn update_record(i: usize) -> OpRecord {
         name: thread_name(i),
         old_state: cid_for(i),
         new_state: cid_for(i + 1),
+        old_manager_snapshot: None,
+        new_manager_snapshot: None,
     }
 }
 

--- a/crates/oplog/benches/oplog_io.rs
+++ b/crates/oplog/benches/oplog_io.rs
@@ -94,8 +94,7 @@ fn update_record(i: usize) -> OpRecord {
         name: thread_name(i),
         old_state: cid_for(i),
         new_state: cid_for(i + 1),
-        old_manager_snapshot: None,
-        new_manager_snapshot: None,
+        manager_snapshots: None,
     }
 }
 

--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -17,7 +17,7 @@ pub use oplog_backend::{OpLogBackend, VisibilitySidecarSnapshots};
 pub use oplog_core::OpLog;
 pub use oplog_types::{
     ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    RedactionUndoClass, isolation_keys_for_record,
+    RedactionUndoClass, ThreadUpdateSnapshots, isolation_keys_for_record,
 };
 #[cfg(feature = "postgres")]
 pub use pg_oplog::PgOpLogBackend;

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -1337,6 +1337,18 @@ mod tests {
                 new_state: cid(7),
                 manager_snapshots: ThreadUpdateSnapshots::from_parts(None, Some(vec![7])),
             },
+            OpRecord::ThreadUpdate {
+                name: "main".into(),
+                old_state: cid(6),
+                new_state: cid(7),
+                manager_snapshots: ThreadUpdateSnapshots::from_record_sets(
+                    Some(vec![6]),
+                    Some(vec![7]),
+                    vec![vec![60], vec![61]],
+                    vec![vec![70], vec![71]],
+                    true,
+                ),
+            },
         ];
         for expected in records {
             let bytes = encode_latest_record(&expected).unwrap();

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -187,6 +187,10 @@ enum StrictCurrentOpRecord {
         name: String,
         old_state: ChangeId,
         new_state: ChangeId,
+        #[serde(default)]
+        old_manager_snapshot: Option<Vec<u8>>,
+        #[serde(default)]
+        new_manager_snapshot: Option<Vec<u8>>,
     },
     Fork {
         from: ChangeId,
@@ -321,10 +325,14 @@ impl StrictCurrentOpRecord {
                 name,
                 old_state,
                 new_state,
+                old_manager_snapshot,
+                new_manager_snapshot,
             } => OpRecord::ThreadUpdate {
                 name,
                 old_state,
                 new_state,
+                old_manager_snapshot,
+                new_manager_snapshot,
             },
             Self::Fork {
                 from,
@@ -594,6 +602,8 @@ impl PreAtomicOpRecord {
                 name,
                 old_state,
                 new_state,
+                old_manager_snapshot: None,
+                new_manager_snapshot: None,
             },
             Self::Fork { from, new_state } => {
                 // The pre-Atomic CLI was the only caller and recorded these two
@@ -828,6 +838,8 @@ impl AtomicNoHeadOpRecord {
                 name,
                 old_state,
                 new_state,
+                old_manager_snapshot: None,
+                new_manager_snapshot: None,
             },
             Self::Fork {
                 from,
@@ -993,6 +1005,8 @@ mod tests {
                 name: "main".into(),
                 old_state: cid(6),
                 new_state: cid(7),
+                old_manager_snapshot: None,
+                new_manager_snapshot: None,
             },
             OpRecord::Fork {
                 from: cid(8),
@@ -1316,6 +1330,22 @@ mod tests {
     }
 
     #[test]
+    fn current_schema_round_trips_thread_update_manager_snapshots() {
+        let expected = OpRecord::ThreadUpdate {
+            name: "main".into(),
+            old_state: cid(6),
+            new_state: cid(7),
+            old_manager_snapshot: Some(vec![6]),
+            new_manager_snapshot: Some(vec![7]),
+        };
+        let bytes = encode_latest_record(&expected).unwrap();
+        let decoded = CurrentOpRecordSchema::decode(&bytes).unwrap();
+        assert_same_record(&decoded, &expected);
+        let decoded = decode_versioned_record(&bytes, OpRecordSchemaVersion::Current).unwrap();
+        assert_same_record(&decoded, &expected);
+    }
+
+    #[test]
     fn current_schema_round_trips_through_versioned_decoder() {
         for expected in atomic_no_head_records() {
             let bytes = encode_latest_record(&expected).unwrap();
@@ -1377,6 +1407,7 @@ pub(crate) mod tests_support {
                     name,
                     old_state,
                     new_state,
+                    ..
                 } => Self::ThreadUpdate {
                     name: name.clone(),
                     old_state: *old_state,
@@ -1527,6 +1558,7 @@ pub(crate) mod tests_support {
                     name,
                     old_state,
                     new_state,
+                    ..
                 } => Self::ThreadUpdate {
                     name: name.clone(),
                     old_state: *old_state,

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -30,7 +30,7 @@ use objects::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::oplog_types::OpRecord;
+use super::oplog_types::{OpRecord, ThreadUpdateSnapshots};
 
 pub(crate) const LATEST_RECORD_SCHEMA_VERSION: u32 = LatestOpRecordSchema::VERSION;
 
@@ -188,9 +188,7 @@ enum StrictCurrentOpRecord {
         old_state: ChangeId,
         new_state: ChangeId,
         #[serde(default)]
-        old_manager_snapshot: Option<Vec<u8>>,
-        #[serde(default)]
-        new_manager_snapshot: Option<Vec<u8>>,
+        manager_snapshots: Option<ThreadUpdateSnapshots>,
     },
     Fork {
         from: ChangeId,
@@ -325,14 +323,12 @@ impl StrictCurrentOpRecord {
                 name,
                 old_state,
                 new_state,
-                old_manager_snapshot,
-                new_manager_snapshot,
+                manager_snapshots,
             } => OpRecord::ThreadUpdate {
                 name,
                 old_state,
                 new_state,
-                old_manager_snapshot,
-                new_manager_snapshot,
+                manager_snapshots,
             },
             Self::Fork {
                 from,
@@ -602,8 +598,7 @@ impl PreAtomicOpRecord {
                 name,
                 old_state,
                 new_state,
-                old_manager_snapshot: None,
-                new_manager_snapshot: None,
+                manager_snapshots: None,
             },
             Self::Fork { from, new_state } => {
                 // The pre-Atomic CLI was the only caller and recorded these two
@@ -838,8 +833,7 @@ impl AtomicNoHeadOpRecord {
                 name,
                 old_state,
                 new_state,
-                old_manager_snapshot: None,
-                new_manager_snapshot: None,
+                manager_snapshots: None,
             },
             Self::Fork {
                 from,
@@ -1005,8 +999,7 @@ mod tests {
                 name: "main".into(),
                 old_state: cid(6),
                 new_state: cid(7),
-                old_manager_snapshot: None,
-                new_manager_snapshot: None,
+                manager_snapshots: None,
             },
             OpRecord::Fork {
                 from: cid(8),
@@ -1331,18 +1324,67 @@ mod tests {
 
     #[test]
     fn current_schema_round_trips_thread_update_manager_snapshots() {
+        let records = [
+            OpRecord::ThreadUpdate {
+                name: "main".into(),
+                old_state: cid(6),
+                new_state: cid(7),
+                manager_snapshots: ThreadUpdateSnapshots::from_parts(Some(vec![6]), Some(vec![7])),
+            },
+            OpRecord::ThreadUpdate {
+                name: "main".into(),
+                old_state: cid(6),
+                new_state: cid(7),
+                manager_snapshots: ThreadUpdateSnapshots::from_parts(None, Some(vec![7])),
+            },
+        ];
+        for expected in records {
+            let bytes = encode_latest_record(&expected).unwrap();
+            let decoded = CurrentOpRecordSchema::decode(&bytes).unwrap();
+            assert_same_record(&decoded, &expected);
+            let decoded = decode_versioned_record(&bytes, OpRecordSchemaVersion::Current).unwrap();
+            assert_same_record(&decoded, &expected);
+        }
+    }
+
+    #[test]
+    fn thread_update_without_snapshots_keeps_legacy_bytes() {
         let expected = OpRecord::ThreadUpdate {
             name: "main".into(),
             old_state: cid(6),
             new_state: cid(7),
-            old_manager_snapshot: Some(vec![6]),
-            new_manager_snapshot: Some(vec![7]),
+            manager_snapshots: None,
         };
         let bytes = encode_latest_record(&expected).unwrap();
-        let decoded = CurrentOpRecordSchema::decode(&bytes).unwrap();
+        let legacy_bytes = tests_support::encode_atomic_no_head(&expected).unwrap();
+
+        assert_eq!(bytes, legacy_bytes);
+        assert_eq!(
+            bytes,
+            vec![
+                129, 172, 84, 104, 114, 101, 97, 100, 85, 112, 100, 97, 116, 101, 147, 164, 109,
+                97, 105, 110, 220, 0, 16, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 220, 0,
+                16, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            ]
+        );
+        let decoded = AtomicNoHeadOpRecordSchema::decode(&bytes).unwrap();
         assert_same_record(&decoded, &expected);
-        let decoded = decode_versioned_record(&bytes, OpRecordSchemaVersion::Current).unwrap();
-        assert_same_record(&decoded, &expected);
+    }
+
+    #[test]
+    fn old_thread_update_reader_refuses_snapshot_tail() {
+        let expected = OpRecord::ThreadUpdate {
+            name: "main".into(),
+            old_state: cid(6),
+            new_state: cid(7),
+            manager_snapshots: ThreadUpdateSnapshots::from_parts(None, Some(vec![7])),
+        };
+        let bytes = encode_latest_record(&expected).unwrap();
+        let error = rmp_serde::from_slice::<AtomicNoHeadOpRecord>(&bytes).unwrap_err();
+        assert!(
+            format!("{error:?}").contains("LengthMismatch"),
+            "expected positional length refusal, got {error}"
+        );
     }
 
     #[test]

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -234,8 +234,7 @@ pub trait OpLogBackend: Send + Sync {
         name: &ThreadName,
         old_state: &ChangeId,
         new_state: &ChangeId,
-        old_manager_snapshot: Option<Vec<u8>>,
-        new_manager_snapshot: Option<Vec<u8>>,
+        manager_snapshots: Option<ThreadUpdateSnapshots>,
         scope: Option<&str>,
     ) -> Result<u64> {
         let ids = self.record_batch_scoped(
@@ -243,10 +242,7 @@ pub trait OpLogBackend: Send + Sync {
                 name: name.to_string(),
                 old_state: *old_state,
                 new_state: *new_state,
-                manager_snapshots: ThreadUpdateSnapshots::from_parts(
-                    old_manager_snapshot,
-                    new_manager_snapshot,
-                ),
+                manager_snapshots,
             }],
             scope,
         )?;

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -13,6 +13,7 @@ use objects::{
 
 use super::oplog_types::{
     ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
+    ThreadUpdateSnapshots,
 };
 
 /// Before/after snapshots of a per-state visibility sidecar, captured around a
@@ -242,8 +243,10 @@ pub trait OpLogBackend: Send + Sync {
                 name: name.to_string(),
                 old_state: *old_state,
                 new_state: *new_state,
-                old_manager_snapshot,
-                new_manager_snapshot,
+                manager_snapshots: ThreadUpdateSnapshots::from_parts(
+                    old_manager_snapshot,
+                    new_manager_snapshot,
+                ),
             }],
             scope,
         )?;

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -228,6 +228,28 @@ pub trait OpLogBackend: Send + Sync {
         Ok(ids[0])
     }
 
+    fn record_thread_update(
+        &self,
+        name: &ThreadName,
+        old_state: &ChangeId,
+        new_state: &ChangeId,
+        old_manager_snapshot: Option<Vec<u8>>,
+        new_manager_snapshot: Option<Vec<u8>>,
+        scope: Option<&str>,
+    ) -> Result<u64> {
+        let ids = self.record_batch_scoped(
+            vec![OpRecord::ThreadUpdate {
+                name: name.to_string(),
+                old_state: *old_state,
+                new_state: *new_state,
+                old_manager_snapshot,
+                new_manager_snapshot,
+            }],
+            scope,
+        )?;
+        Ok(ids[0])
+    }
+
     fn record_thread_rename(
         &self,
         old_name: &ThreadName,

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -538,8 +538,7 @@ fn op_record_variants_roundtrip_and_describe() {
             name: "feat".into(),
             old_state: st2,
             new_state: st,
-            old_manager_snapshot: None,
-            new_manager_snapshot: None,
+            manager_snapshots: None,
         },
         // Fork retrofit: both published-ref shapes (attached thread / detached head).
         OpRecord::Fork {

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -538,6 +538,8 @@ fn op_record_variants_roundtrip_and_describe() {
             name: "feat".into(),
             old_state: st2,
             new_state: st,
+            old_manager_snapshot: None,
+            new_manager_snapshot: None,
         },
         // Fork retrofit: both published-ref shapes (attached thread / detached head).
         OpRecord::Fork {

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -94,14 +94,14 @@ pub enum OpRecord {
         name: String,
         old_state: ChangeId,
         new_state: ChangeId,
-        /// rmp-serde-encoded `Thread` record body before the update, or
-        /// `None` when the forward path only moved the ref.
-        #[serde(default)]
-        old_manager_snapshot: Option<Vec<u8>>,
-        /// rmp-serde-encoded `Thread` record body after the update, or
-        /// `None` when the forward path only moved the ref.
-        #[serde(default)]
-        new_manager_snapshot: Option<Vec<u8>>,
+        /// rmp-serde-encoded `Thread` record bodies around the update.
+        ///
+        /// This is intentionally one sparse tail field rather than two
+        /// independently-skipped fields: rmp-serde encodes enum variant fields
+        /// positionally, so skipping only the old slot would shift the new
+        /// snapshot into the old position for older readers.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        manager_snapshots: Option<ThreadUpdateSnapshots>,
     },
     /// Fork operation.
     ///
@@ -323,6 +323,27 @@ pub enum OpRecord {
         #[serde(default)]
         new_sidecar: Option<Vec<u8>>,
     },
+}
+
+/// Optional ThreadManager record snapshots captured around a [`ThreadUpdate`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThreadUpdateSnapshots {
+    /// rmp-serde-encoded `Thread` record body before the update, or `None`
+    /// when no record existed before the forward path.
+    pub old: Option<Vec<u8>>,
+    /// rmp-serde-encoded `Thread` record body after the update, or `None`
+    /// when the forward path only moved the ref.
+    pub new: Option<Vec<u8>>,
+}
+
+impl ThreadUpdateSnapshots {
+    pub fn from_parts(old: Option<Vec<u8>>, new: Option<Vec<u8>>) -> Option<Self> {
+        if old.is_none() && new.is_none() {
+            None
+        } else {
+            Some(Self { old, new })
+        }
+    }
 }
 
 /// The logical isolation keys touched by one committed record.
@@ -969,8 +990,7 @@ mod verb_catalog_tests {
                 name: "t".into(),
                 old_state: cid(),
                 new_state: cid(),
-                old_manager_snapshot: None,
-                new_manager_snapshot: None,
+                manager_snapshots: None,
             },
             OpRecord::Fork {
                 from: cid(),

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -334,6 +334,19 @@ pub struct ThreadUpdateSnapshots {
     /// rmp-serde-encoded `Thread` record body after the update, or `None`
     /// when the forward path only moved the ref.
     pub new: Option<Vec<u8>>,
+    /// Complete same-thread record set before the update. Empty for records
+    /// written before duplicate-record convergence needed full-set restore.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub old_records: Vec<Vec<u8>>,
+    /// Complete same-thread record set after the update. Empty for records
+    /// written before duplicate-record convergence needed full-set restore.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub new_records: Vec<Vec<u8>>,
+    /// Whether the thread ref was absent before the update. This lets undo of
+    /// a metadata-only repair remove a recreated ref instead of setting it to a
+    /// fallback state that was only used to identify the record.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub old_ref_absent: bool,
 }
 
 impl ThreadUpdateSnapshots {
@@ -341,9 +354,44 @@ impl ThreadUpdateSnapshots {
         if old.is_none() && new.is_none() {
             None
         } else {
-            Some(Self { old, new })
+            Some(Self {
+                old,
+                new,
+                old_records: Vec::new(),
+                new_records: Vec::new(),
+                old_ref_absent: false,
+            })
         }
     }
+
+    pub fn from_record_sets(
+        old: Option<Vec<u8>>,
+        new: Option<Vec<u8>>,
+        old_records: Vec<Vec<u8>>,
+        new_records: Vec<Vec<u8>>,
+        old_ref_absent: bool,
+    ) -> Option<Self> {
+        if old.is_none()
+            && new.is_none()
+            && old_records.is_empty()
+            && new_records.is_empty()
+            && !old_ref_absent
+        {
+            None
+        } else {
+            Some(Self {
+                old,
+                new,
+                old_records,
+                new_records,
+                old_ref_absent,
+            })
+        }
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// The logical isolation keys touched by one committed record.

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -94,6 +94,14 @@ pub enum OpRecord {
         name: String,
         old_state: ChangeId,
         new_state: ChangeId,
+        /// rmp-serde-encoded `Thread` record body before the update, or
+        /// `None` when the forward path only moved the ref.
+        #[serde(default)]
+        old_manager_snapshot: Option<Vec<u8>>,
+        /// rmp-serde-encoded `Thread` record body after the update, or
+        /// `None` when the forward path only moved the ref.
+        #[serde(default)]
+        new_manager_snapshot: Option<Vec<u8>>,
     },
     /// Fork operation.
     ///
@@ -961,6 +969,8 @@ mod verb_catalog_tests {
                 name: "t".into(),
                 old_state: cid(),
                 new_state: cid(),
+                old_manager_snapshot: None,
+                new_manager_snapshot: None,
             },
             OpRecord::Fork {
                 from: cid(),

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1220,6 +1220,8 @@ fn reconcile_folds_every_record_shape() {
         name: "t_v1".to_string(),
         old_state: v1,
         new_state: v1b,
+        old_manager_snapshot: None,
+        new_manager_snapshot: None,
     }])
     .unwrap();
     // V2 create + a delete (folds to None).
@@ -2809,6 +2811,8 @@ fn non_atomic_delete_is_not_clobbered_by_a_committed_record() {
             name: "x".to_string(),
             old_state: v_old,
             new_state: v_new,
+            old_manager_snapshot: None,
+            new_manager_snapshot: None,
         }])
         .unwrap();
 

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1220,8 +1220,7 @@ fn reconcile_folds_every_record_shape() {
         name: "t_v1".to_string(),
         old_state: v1,
         new_state: v1b,
-        old_manager_snapshot: None,
-        new_manager_snapshot: None,
+        manager_snapshots: None,
     }])
     .unwrap();
     // V2 create + a delete (folds to None).
@@ -2811,8 +2810,7 @@ fn non_atomic_delete_is_not_clobbered_by_a_committed_record() {
             name: "x".to_string(),
             old_state: v_old,
             new_state: v_new,
-            old_manager_snapshot: None,
-            new_manager_snapshot: None,
+            manager_snapshots: None,
         }])
         .unwrap();
 

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -434,13 +434,18 @@ impl ThreadManager {
         let Some(thread) = self.find_by_thread(thread_name)? else {
             return Ok(None);
         };
-        let bytes = rmp_serde::to_vec_named(&thread).map_err(|e| {
+        self.encode_thread_record_snapshot(&thread).map(Some)
+    }
+
+    /// Encode a concrete `Thread` record using the same opaque snapshot format
+    /// as [`snapshot_thread_record`](Self::snapshot_thread_record).
+    pub fn encode_thread_record_snapshot(&self, thread: &Thread) -> Result<Vec<u8>> {
+        rmp_serde::to_vec_named(thread).map_err(|e| {
             HeddleError::Serialization(format!(
                 "encode thread record snapshot for '{}': {}",
-                thread_name, e
+                thread.thread, e
             ))
-        })?;
-        Ok(Some(bytes))
+        })
     }
 
     /// Decode a `Thread` record from rmp-serde bytes produced by


### PR DESCRIPTION
Fixes #469

## Summary
- record thread refresh/manual-resolution ThreadUpdate records with ThreadManager snapshots, including base_state/base_root changes
- extend ThreadUpdate snapshots so undo/redo can restore full thread record sets and pre-update ref absence
- add regression coverage for op -> undo -> restored thread base_state and record-set edge cases

## Gates
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo build
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo build --all-features
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo test -p heddle-cli --lib
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo test -p heddle-cli --test core_functionality undo_and_special -- --nocapture
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo test -p heddle-cli --test state_management -- --nocapture
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo test -p heddle-cli --test cli_integration -- --nocapture
- CARGO_TARGET_DIR=/tmp/heddle-469-target bash scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/tmp/heddle-469-target cargo clippy -- -D warnings
- CARGO_TARGET_DIR=/tmp/heddle-469-target bash scripts/gen-ts-types.sh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885550&installation_id=132405951&pr_number=679&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F679&signature=250a7a62cf1a3d9afe00fcc35e8abfd3c97edb88f27fc5ab98038a00767b035e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->