### PR TITLE
Squash landed threads by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ heddle blame path/to/file.rs
 
 `heddle status` reports the current branch or thread, what is dirty, whether another operation is in progress, and the recommended next command. The same `recommended_action` field is carried through `heddle doctor`, `heddle thread show`, and `heddle workspace show` for programmatic use.
 
+In Git-overlay repositories, `heddle land` projects a landed thread as one atomic Git commit by default. The original per-State captures remain in Heddle history. Use `heddle land --no-squash` for a single invocation that should export one Git commit per State.
+
 ## Core concepts
 
 | Concept | Description |
@@ -184,6 +186,8 @@ Heddle uses three local config scopes:
 - `UserConfig` (`~/.config/heddle/config.toml`) — user identity, agent defaults, output preferences, hosted-client credentials
 - `RepoConfig` (`.heddle/config.toml`) — repository-local behavior, ignore defaults, storage coordinates, remote aliases, repository format version
 - `WorktreeState` — per-checkout runtime state (current session, segment) tracked separately from repo config
+
+Set `[land] squash = false` in user config to make `heddle land` preserve per-State Git export by default. The command-line `--no-squash` flag provides the same opt-out for one land operation.
 
 Precedence: CLI flags override the relevant config scope; env vars override file-backed config where supported; repo config stays repo-local; worktree state stays checkout-local.
 

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -31,6 +31,8 @@ pub struct UserConfig {
     pub remote: UserRemoteConfig,
     #[serde(default)]
     pub harness: UserHarnessConfig,
+    #[serde(default)]
+    pub land: UserLandConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,6 +137,12 @@ pub struct UserRemoteConfig {
     pub auth_proof_key_pem_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserLandConfig {
+    #[serde(default = "default_land_squash")]
+    pub squash: bool,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum HarnessMode {
@@ -232,6 +240,10 @@ fn default_auto_infer() -> bool {
     true
 }
 
+fn default_land_squash() -> bool {
+    true
+}
+
 impl Default for UserDisplayConfig {
     fn default() -> Self {
         Self {
@@ -250,6 +262,14 @@ impl Default for UserHarnessConfig {
             auto_infer: default_auto_infer(),
             threading: UserHarnessThreadingConfig::default(),
             harnesses: BTreeMap::new(),
+        }
+    }
+}
+
+impl Default for UserLandConfig {
+    fn default() -> Self {
+        Self {
+            squash: default_land_squash(),
         }
     }
 }

--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -907,6 +907,10 @@ pub struct LandArgs {
     #[arg(short = 'm', long)]
     pub message: Option<String>,
 
+    /// Preserve per-State Git export instead of squashing the landed thread.
+    #[arg(long)]
+    pub no_squash: bool,
+
     /// Push after integration completes.
     #[arg(long)]
     pub push: bool,

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -151,15 +151,23 @@ pub(crate) fn collapse_resolved_states(
     // materialization, replacing the prior publish-then-record order. The
     // `Collapse` record names the published ref (a thread when HEAD was
     // attached, or a detached HEAD at the collapse result).
-    let (ref_updates, published_thread): (Vec<RefUpdate>, Option<String>) = match published_ref {
-        CollapsePublishedRef::Thread(thread) => (
-            vec![RefUpdate::Thread {
-                name: thread.clone(),
-                expected: RefExpectation::Any,
-                new: Some(new_state.change_id),
-            }],
-            Some(thread.to_string()),
-        ),
+    let (ref_updates, published_thread, pre_thread_state): (
+        Vec<RefUpdate>,
+        Option<String>,
+        Option<ChangeId>,
+    ) = match published_ref {
+        CollapsePublishedRef::Thread(thread) => {
+            let previous = repo.refs().get_thread(&thread)?;
+            (
+                vec![RefUpdate::Thread {
+                    name: thread.clone(),
+                    expected: RefExpectation::Any,
+                    new: Some(new_state.change_id),
+                }],
+                Some(thread.to_string()),
+                previous,
+            )
+        }
         CollapsePublishedRef::DetachedHead => (
             vec![RefUpdate::Head {
                 expected: RefExpectation::Any,
@@ -167,6 +175,7 @@ pub(crate) fn collapse_resolved_states(
                     state: new_state.change_id,
                 },
             }],
+            None,
             None,
         ),
     };
@@ -176,6 +185,7 @@ pub(crate) fn collapse_resolved_states(
         sources: source_ids,
         result: new_state.change_id,
         thread: published_thread,
+        pre_thread_state,
     };
     repo.commit_and_publish(vec![collapse_record], &ref_updates)?;
 

--- a/crates/cli/src/cli/commands/collapse.rs
+++ b/crates/cli/src/cli/commands/collapse.rs
@@ -4,7 +4,7 @@
 use std::time::Instant;
 
 use anyhow::Result;
-use objects::object::State;
+use objects::object::{ChangeId, State, ThreadName};
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
 use serde::Serialize;
@@ -62,74 +62,29 @@ pub fn cmd_collapse(
         resolved_states.push(state);
     }
 
-    // The new state uses:
-    // - Tree from the LAST state (most recent content)
-    // - Parents from the FIRST state (preserving history connection)
-    let first_state = &resolved_states[0];
+    // The new state uses the tree from the last state and the parents of the
+    // first state, preserving the history connection.
     let last_state = &resolved_states[resolved_states.len() - 1];
     if !json {
         eprintln!("Using final tree from {}", last_state.change_id.short());
     }
 
-    // Get attribution for the new state
     let user_config = UserConfig::load_default()?;
-    let attribution = resolve_attribution(&repo, &user_config)?;
-
-    // Create the collapsed state
-    let mut new_state =
-        State::new_collapse_of(last_state.tree, first_state.parents.clone(), attribution);
-    new_state = new_state.with_intent(into.clone());
-
-    if let Some(provenance) = repo.get_state_provenance_root(last_state)? {
-        new_state = new_state.with_provenance(provenance);
-    }
-
-    if let Some(conf) = confidence {
-        new_state = new_state.with_confidence(conf);
-    }
-
-    // Store the new state through the authored-state chokepoint (heddle#482):
-    // a collapse mints a new author-created state, so it is auto-signed like a
-    // capture rather than carrying any source state's signature forward.
-    repo.put_authored_state(&mut new_state)?;
+    let published_ref = match repo.refs().read_head()? {
+        Head::Attached { ref thread } => CollapsePublishedRef::Thread(thread.clone()),
+        Head::Detached { .. } => CollapsePublishedRef::DetachedHead,
+    };
+    let new_state = collapse_resolved_states(
+        &repo,
+        &user_config,
+        &resolved_states,
+        into.clone(),
+        confidence,
+        published_ref,
+    )?;
     if !json {
         eprintln!("Writing collapsed state {}...", new_state.change_id.short());
     }
-
-    // Build the published ref batch + its matching `Collapse` record, then
-    // publish record-first through the write chokepoint (heddle#330 §2.2): the
-    // record is the commit point and the ref publish is a post-commit
-    // materialization, replacing the prior publish-then-record order. The
-    // `Collapse` record names the published ref (a thread when HEAD was
-    // attached, or a detached HEAD at the collapse result).
-    let (ref_updates, published_thread): (Vec<RefUpdate>, Option<String>) =
-        match repo.refs().read_head()? {
-            Head::Attached { ref thread } => (
-                vec![RefUpdate::Thread {
-                    name: thread.clone(),
-                    expected: RefExpectation::Any,
-                    new: Some(new_state.change_id),
-                }],
-                Some(thread.to_string()),
-            ),
-            Head::Detached { .. } => (
-                vec![RefUpdate::Head {
-                    expected: RefExpectation::Any,
-                    new: Head::Detached {
-                        state: new_state.change_id,
-                    },
-                }],
-                None,
-            ),
-        };
-
-    let source_ids: Vec<_> = resolved_states.iter().map(|s| s.change_id).collect();
-    let collapse_record = OpRecord::Collapse {
-        sources: source_ids,
-        result: new_state.change_id,
-        thread: published_thread,
-    };
-    repo.commit_and_publish(vec![collapse_record], &ref_updates)?;
 
     let output = CollapseOutput {
         change_id: new_state.change_id.short(),
@@ -154,6 +109,77 @@ pub fn cmd_collapse(
     }
 
     Ok(())
+}
+
+pub(crate) enum CollapsePublishedRef {
+    Thread(ThreadName),
+    DetachedHead,
+}
+
+pub(crate) fn collapse_resolved_states(
+    repo: &repo::Repository,
+    user_config: &UserConfig,
+    resolved_states: &[State],
+    into: String,
+    confidence: Option<f32>,
+    published_ref: CollapsePublishedRef,
+) -> Result<State> {
+    let first_state = &resolved_states[0];
+    let last_state = &resolved_states[resolved_states.len() - 1];
+    let attribution = resolve_attribution(repo, user_config)?;
+
+    let mut new_state =
+        State::new_collapse_of(last_state.tree, first_state.parents.clone(), attribution);
+    new_state = new_state.with_intent(into);
+
+    if let Some(provenance) = repo.get_state_provenance_root(last_state)? {
+        new_state = new_state.with_provenance(provenance);
+    }
+
+    if let Some(conf) = confidence {
+        new_state = new_state.with_confidence(conf);
+    }
+
+    // Store the new state through the authored-state chokepoint (heddle#482):
+    // a collapse mints a new author-created state, so it is auto-signed like a
+    // capture rather than carrying any source state's signature forward.
+    repo.put_authored_state(&mut new_state)?;
+
+    // Build the published ref batch + its matching `Collapse` record, then
+    // publish record-first through the write chokepoint (heddle#330 §2.2): the
+    // record is the commit point and the ref publish is a post-commit
+    // materialization, replacing the prior publish-then-record order. The
+    // `Collapse` record names the published ref (a thread when HEAD was
+    // attached, or a detached HEAD at the collapse result).
+    let (ref_updates, published_thread): (Vec<RefUpdate>, Option<String>) = match published_ref {
+        CollapsePublishedRef::Thread(thread) => (
+            vec![RefUpdate::Thread {
+                name: thread.clone(),
+                expected: RefExpectation::Any,
+                new: Some(new_state.change_id),
+            }],
+            Some(thread.to_string()),
+        ),
+        CollapsePublishedRef::DetachedHead => (
+            vec![RefUpdate::Head {
+                expected: RefExpectation::Any,
+                new: Head::Detached {
+                    state: new_state.change_id,
+                },
+            }],
+            None,
+        ),
+    };
+
+    let source_ids: Vec<ChangeId> = resolved_states.iter().map(|s| s.change_id).collect();
+    let collapse_record = OpRecord::Collapse {
+        sources: source_ids,
+        result: new_state.change_id,
+        thread: published_thread,
+    };
+    repo.commit_and_publish(vec![collapse_record], &ref_updates)?;
+
+    Ok(new_state)
 }
 
 fn collapse_requires_states_advice() -> RecoveryAdvice {

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -664,6 +664,15 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::MarkerDelete { name, state } => {
             steps.create_marker(name.as_str(), *state)?;
         }
+        OpRecord::Collapse {
+            thread: Some(thread),
+            pre_thread_state: Some(pre_thread_state),
+            ..
+        } => {
+            steps.set_thread(thread.as_str(), *pre_thread_state)?;
+            sync_thread_record_state(steps, thread, *pre_thread_state)?;
+        }
+        OpRecord::Collapse { .. } => {}
         // Redaction inverse: drop the specific redaction record so
         // subsequent materialize calls restore the original blob
         // bytes. The opt-in flag + purged-bytes check are enforced in
@@ -745,8 +754,8 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         // oplog replay. Enumerated explicitly (no wildcard) so a new
         // `OpRecord` variant is a COMPILE error here until its undo behavior
         // is decided (heddle#354 r9):
-        //   - Fork / Collapse: structural ops; HEAD/thread restoration is
-        //     driven by the surrounding records in the same batch.
+        //   - Fork: structural op; HEAD/thread restoration is driven by
+        //     surrounding records in the same batch.
         //   - Checkpoint: addressable save, goto-reachable; nothing to invert.
         //   - TransactionAbort / TransactionCommit / ConflictResolved: forensic
         //     / audit records, no ref to restore.
@@ -757,7 +766,6 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         //   - RemoteThreadUpdate / RemoteThreadDelete / UndoRecoveryUpdate:
         //     reconcile-class bookkeeping refs, outside the user undo chain.
         OpRecord::Fork { .. }
-        | OpRecord::Collapse { .. }
         | OpRecord::Checkpoint { .. }
         | OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
@@ -839,6 +847,16 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::MarkerDelete { name, .. } => {
             steps.delete_marker(name.as_str())?;
         }
+        OpRecord::Collapse {
+            thread: Some(thread),
+            result,
+            pre_thread_state: Some(_),
+            ..
+        } => {
+            steps.set_thread(thread.as_str(), *result)?;
+            sync_thread_record_state(steps, thread, *result)?;
+        }
+        OpRecord::Collapse { .. } => {}
         // FF merge redo: replay the *recorded* FF target. We do
         // not re-read `source_thread` — the recorded `post_target_id`
         // is the exact state the target advanced to at the original
@@ -900,7 +918,6 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
             steps.restore_visibility_sidecar(*state, prior_sidecar.clone(), new_sidecar.clone())?;
         }
         OpRecord::Fork { .. }
-        | OpRecord::Collapse { .. }
         | OpRecord::Checkpoint { .. }
         | OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -1000,6 +1000,7 @@ mod tests {
                 sources: vec![cid],
                 result: cid,
                 thread: None,
+                pre_thread_state: None,
             },
             OpRecord::MarkerCreate {
                 name: "m".into(),

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -437,7 +437,23 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     let preview = build_thread_preview_report(&repo, &mut merge_thread, true)?;
     let integration_blockers = integration_blockers(&repo, &merge_thread, &preview);
     let manual_resolution_current = manual_resolution_current(&repo, &merge_thread);
+    let squash_land = should_squash_land(&args, &user_config);
     if manual_resolution_current {
+        let land_collapse_state = if squash_land
+            && repo.capability() == repo::RepositoryCapability::GitOverlay
+        {
+            collapse_thread_for_land(&repo, &user_config, &merge_thread, args.message.as_deref())?
+        } else {
+            None
+        };
+        if land_collapse_state.is_some() {
+            merge_thread = resolve_thread(
+                &repo,
+                Some(&merge_thread.id),
+                "land",
+                "heddle land --thread <name>",
+            )?;
+        }
         let merge_state = adopt_manual_resolution(&repo, &merge_thread.id)?;
         let mut checkpointed = false;
         let mut git_commit = None;
@@ -469,7 +485,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             &repo,
             Some(&merge_state),
             git_commit.as_deref(),
-            None,
+            land_collapse_state.as_ref(),
         )
         .context(
             "land completed but failed to record manual integration and Git checkpoint as one undo batch",
@@ -593,7 +609,6 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         );
     }
 
-    let squash_land = should_squash_land(&args, &user_config);
     let land_collapse_state =
         if squash_land && repo.capability() == repo::RepositoryCapability::GitOverlay {
             collapse_thread_for_land(&repo, &user_config, &merge_thread, args.message.as_deref())?

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
+use std::collections::HashSet;
+
 use anyhow::{Context, Result, anyhow};
-use objects::object::{ChangeId, ThreadName};
+use objects::object::{ChangeId, State, ThreadName};
 use objects::store::ObjectStore;
 use oplog::{OpBatch, OpLogBackend, OpRecord};
 use repo::{Repository, Thread, ThreadIntegrationPolicy, thread_flag};
@@ -10,6 +12,7 @@ use super::{
     action_line::print_next,
     advice::RecoveryAdvice,
     checkpoint::create_git_checkpoint,
+    collapse::{CollapsePublishedRef, collapse_resolved_states},
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
     merge::{build_thread_preview_report, merge_thread_into_current},
     next_action::{NextActionValidationContext, write_command_json, write_full_command_json},
@@ -466,6 +469,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             &repo,
             Some(&merge_state),
             git_commit.as_deref(),
+            None,
         )
         .context(
             "land completed but failed to record manual integration and Git checkpoint as one undo batch",
@@ -589,6 +593,22 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         );
     }
 
+    let squash_land = should_squash_land(&args, &user_config);
+    let land_collapse_state =
+        if squash_land && repo.capability() == repo::RepositoryCapability::GitOverlay {
+            collapse_thread_for_land(&repo, &user_config, &merge_thread, args.message.as_deref())?
+        } else {
+            None
+        };
+    if land_collapse_state.is_some() {
+        merge_thread = resolve_thread(
+            &repo,
+            Some(&merge_thread.id),
+            "land",
+            "heddle land --thread <name>",
+        )?;
+    }
+
     let merge_output = merge_thread_into_current(
         &repo,
         &merge_thread.id,
@@ -639,6 +659,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         &repo,
         merge_output.merge_state.as_deref(),
         git_commit.as_deref(),
+        land_collapse_state.as_ref(),
     )
     .context("land completed but failed to record merge and Git checkpoint as one undo batch")?;
 
@@ -735,6 +756,84 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             },
         },
     )
+}
+
+fn should_squash_land(args: &LandArgs, user_config: &UserConfig) -> bool {
+    !args.no_squash && user_config.land.squash
+}
+
+fn collapse_thread_for_land(
+    repo: &Repository,
+    user_config: &UserConfig,
+    thread: &Thread,
+    message: Option<&str>,
+) -> Result<Option<ChangeId>> {
+    let sources = thread_source_states(repo, thread)?;
+    if sources.len() <= 1 {
+        return Ok(None);
+    }
+    let intent = message
+        .map(ToOwned::to_owned)
+        .or_else(|| thread.task.clone())
+        .unwrap_or_else(|| format!("Land {}", thread.id));
+    let result = collapse_resolved_states(
+        repo,
+        user_config,
+        &sources,
+        intent,
+        None,
+        CollapsePublishedRef::Thread(ThreadName::new(&thread.id)),
+    )?;
+    Ok(Some(result.change_id))
+}
+
+fn thread_source_states(repo: &Repository, thread: &Thread) -> Result<Vec<State>> {
+    let Some(tip) = repo.refs().get_thread(&ThreadName::new(&thread.id))? else {
+        return Ok(Vec::new());
+    };
+    let base = repo.resolve_state(&thread.base_state)?;
+    let base_reachable = match base {
+        Some(base) => reachable_state_set(repo, base)?,
+        None => HashSet::new(),
+    };
+    let mut visited = HashSet::new();
+    let mut ordered = Vec::new();
+    collect_thread_sources(repo, tip, &base_reachable, &mut visited, &mut ordered)?;
+    Ok(ordered)
+}
+
+fn collect_thread_sources(
+    repo: &Repository,
+    state_id: ChangeId,
+    excluded: &HashSet<ChangeId>,
+    visited: &mut HashSet<ChangeId>,
+    ordered: &mut Vec<State>,
+) -> Result<()> {
+    if excluded.contains(&state_id) || !visited.insert(state_id) {
+        return Ok(());
+    }
+    let Some(state) = repo.store().get_state(&state_id)? else {
+        return Ok(());
+    };
+    for parent in &state.parents {
+        collect_thread_sources(repo, *parent, excluded, visited, ordered)?;
+    }
+    ordered.push(state);
+    Ok(())
+}
+
+fn reachable_state_set(repo: &Repository, root: ChangeId) -> Result<HashSet<ChangeId>> {
+    let mut reachable = HashSet::new();
+    let mut stack = vec![root];
+    while let Some(state_id) = stack.pop() {
+        if !reachable.insert(state_id) {
+            continue;
+        }
+        if let Some(state) = repo.store().get_state(&state_id)? {
+            stack.extend(state.parents.iter().copied());
+        }
+    }
+    Ok(reachable)
 }
 
 async fn push_after_land(
@@ -1174,6 +1273,7 @@ fn coalesce_land_integration_and_checkpoint(
     repo: &Repository,
     merge_state: Option<&str>,
     git_commit: Option<&str>,
+    collapse_state: Option<&ChangeId>,
 ) -> Result<()> {
     let Some(merge_state) = merge_state else {
         return Ok(());
@@ -1186,7 +1286,30 @@ fn coalesce_land_integration_and_checkpoint(
     let checkpoint_batch = find_recent_land_git_checkpoint_batch(repo, git_commit)?;
     repo.oplog()
         .coalesce_batches(integration_batch.id, checkpoint_batch.id)?;
+    if let Some(collapse_state) = collapse_state {
+        let collapse_batch = find_recent_land_collapse_batch(repo, collapse_state)?;
+        repo.oplog()
+            .coalesce_batches(integration_batch.id, collapse_batch.id)?;
+    }
     Ok(())
+}
+
+fn find_recent_land_collapse_batch(
+    repo: &Repository,
+    collapse_state: &ChangeId,
+) -> Result<OpBatch> {
+    repo.oplog()
+        .recent_batches_scoped(12, Some(&repo.op_scope()))?
+        .into_iter()
+        .find(|batch| {
+            batch.entries.iter().any(|entry| {
+                matches!(
+                    &entry.operation,
+                    OpRecord::Collapse { result, .. } if result == collapse_state
+                )
+            })
+        })
+        .ok_or_else(|| anyhow!("land squash succeeded but its oplog batch was not found"))
 }
 
 fn find_recent_land_integration_batch(repo: &Repository, merge_state: &str) -> Result<OpBatch> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -353,6 +353,7 @@ async fn async_main() -> Result<()> {
         Commands::Land(LandArgs {
             thread,
             message,
+            no_squash,
             push,
             no_push,
             remote,
@@ -362,6 +363,7 @@ async fn async_main() -> Result<()> {
                 LandArgs {
                     thread: thread.clone(),
                     message: message.clone(),
+                    no_squash: *no_squash,
                     push: *push,
                     no_push: *no_push,
                     remote: remote.clone(),

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use oplog::{OpLogBackend, OpRecord};
 
 /// The `bisect` verb was removed in the whole-CLI consolidation (heddle#473),
 /// but the operation-status layer still detects a lingering `BISECT_STATE`
@@ -6198,6 +6199,177 @@ fn git_overlay_matrix_ship_uses_thread_intent_for_git_checkpoint_subject() {
             .any(|record| record["summary"] == "Add evaluation tags"),
         "land should record the meaningful thread intent as the Git checkpoint summary: {checkpoint_records}"
     );
+}
+
+fn setup_two_capture_land_thread(temp: &TempDir, thread: &str) -> (std::path::PathBuf, String) {
+    init_git_repo_with_branch(temp.path(), "main");
+    std::fs::write(temp.path().join("README.md"), "base\n").unwrap();
+    git_commit_all(temp.path(), "base");
+    let base = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
+    heddle_adopt(temp.path());
+
+    let checkout = temp.path().with_extension(thread.replace('/', "-"));
+    json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "start",
+            thread,
+            "--path",
+            checkout.to_str().unwrap(),
+        ],
+    );
+    std::fs::write(checkout.join("one.txt"), "one\n").unwrap();
+    json(
+        &checkout,
+        &["--output", "json", "capture", "-m", "first source"],
+    );
+    std::fs::write(checkout.join("two.txt"), "two\n").unwrap();
+    json(
+        &checkout,
+        &["--output", "json", "ready", "-m", "second source"],
+    );
+
+    (checkout, base)
+}
+
+fn collapse_records(path: &std::path::Path) -> Vec<(Vec<String>, String, Option<String>)> {
+    let repo = Repository::open(path).expect("repo should open");
+    repo.oplog()
+        .recent(128)
+        .expect("read oplog")
+        .into_iter()
+        .filter_map(|entry| match entry.operation {
+            OpRecord::Collapse {
+                sources,
+                result,
+                thread,
+            } => Some((
+                sources.into_iter().map(|id| id.short()).collect(),
+                result.short(),
+                thread,
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn git_overlay_matrix_land_squashes_thread_to_one_git_commit_by_default() {
+    let temp = TempDir::new().unwrap();
+    let (_checkout, base) = setup_two_capture_land_thread(&temp, "feature/squash-default");
+
+    let land = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/squash-default",
+            "--no-push",
+        ],
+    );
+    assert_eq!(land["status"], "landed");
+    assert_eq!(land["checkpointed"], true);
+    assert_eq!(
+        git_stdout(
+            temp.path(),
+            &["rev-list", "--count", &format!("{base}..HEAD")]
+        ),
+        "1",
+        "default land should project the thread as one Git commit"
+    );
+    assert_eq!(git_stdout(temp.path(), &["show", "HEAD:one.txt"]), "one");
+    assert_eq!(git_stdout(temp.path(), &["show", "HEAD:two.txt"]), "two");
+
+    let records = collapse_records(temp.path());
+    let record = records
+        .iter()
+        .find(|(_, _, thread)| thread.as_deref() == Some("feature/squash-default"))
+        .unwrap_or_else(|| panic!("land should record thread collapse: {records:?}"));
+    assert_eq!(
+        record.0.len(),
+        2,
+        "collapse record should retain the full ordered source list"
+    );
+}
+
+#[test]
+fn git_overlay_matrix_land_no_squash_preserves_per_state_git_export() {
+    let temp = TempDir::new().unwrap();
+    let (_checkout, base) = setup_two_capture_land_thread(&temp, "feature/no-squash");
+
+    let land = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/no-squash",
+            "--no-squash",
+            "--no-push",
+        ],
+    );
+    assert_eq!(land["status"], "landed");
+    assert_eq!(
+        git_stdout(
+            temp.path(),
+            &["rev-list", "--count", &format!("{base}..HEAD")]
+        ),
+        "2",
+        "--no-squash should preserve one Git commit per source state"
+    );
+    assert!(
+        collapse_records(temp.path()).is_empty(),
+        "--no-squash land should not mint a collapse result"
+    );
+}
+
+#[test]
+fn git_overlay_matrix_land_config_can_opt_out_of_squash() {
+    let temp = TempDir::new().unwrap();
+    let (_checkout, base) = setup_two_capture_land_thread(&temp, "feature/config-no-squash");
+    let config_dir = TempDir::new().unwrap();
+    let config = config_dir.path().join("land-no-squash-config.toml");
+    std::fs::write(
+        &config,
+        "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n\n[land]\nsquash = false\n",
+    )
+    .unwrap();
+
+    let output = heddle_output_with_env(
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/config-no-squash",
+            "--no-push",
+        ],
+        Some(temp.path()),
+        &[("HEDDLE_CONFIG", config.to_str().unwrap())],
+    )
+    .expect("land with config should run");
+    assert!(
+        output.status.success(),
+        "config opt-out land should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let land: Value = serde_json::from_slice(&output.stdout).expect("land JSON should parse");
+    assert_eq!(land["status"], "landed");
+    assert_eq!(
+        git_stdout(
+            temp.path(),
+            &["rev-list", "--count", &format!("{base}..HEAD")]
+        ),
+        "2",
+        "land.squash=false should preserve per-State Git export"
+    );
+    assert!(collapse_records(temp.path()).is_empty());
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -6245,6 +6245,7 @@ fn collapse_records(path: &std::path::Path) -> Vec<(Vec<String>, String, Option<
                 sources,
                 result,
                 thread,
+                ..
             } => Some((
                 sources.into_iter().map(|id| id.short()).collect(),
                 result.short(),
@@ -6253,6 +6254,64 @@ fn collapse_records(path: &std::path::Path) -> Vec<(Vec<String>, String, Option<
             _ => None,
         })
         .collect()
+}
+
+fn thread_tip(path: &std::path::Path, thread: &str) -> String {
+    let repo = Repository::open(path).expect("repo should open");
+    repo.refs()
+        .get_thread(&objects::object::ThreadName::new(thread))
+        .expect("thread ref lookup should succeed")
+        .unwrap_or_else(|| panic!("thread {thread} should exist"))
+        .short()
+}
+
+fn assert_latest_undo_batch_has_land_squash_ops(path: &std::path::Path) {
+    let undo_list = json(
+        path,
+        &["--output", "json", "undo", "--list", "--depth", "1"],
+    );
+    let batches = undo_list["batches"]
+        .as_array()
+        .expect("undo list should expose batches");
+    assert_eq!(
+        batches.len(),
+        1,
+        "land should expose one latest undo batch: {undo_list}"
+    );
+    let operations = batches[0]["operations"]
+        .as_array()
+        .expect("undo list should expose operations");
+    let logical_operations: Vec<_> = operations
+        .iter()
+        .filter(|op| {
+            !op["description"]
+                .as_str()
+                .is_some_and(|description| description.starts_with("transaction commit "))
+        })
+        .collect();
+    assert_eq!(
+        logical_operations.len(),
+        3,
+        "squashed land should coalesce collapse + integration + Git checkpoint: {undo_list}"
+    );
+    assert!(
+        logical_operations.iter().any(|op| op["description"]
+            .as_str()
+            .is_some_and(|description| description.starts_with("collapse "))),
+        "squashed land undo batch should include the source collapse: {undo_list}"
+    );
+    assert!(
+        logical_operations.iter().any(|op| op["description"]
+            .as_str()
+            .is_some_and(|description| description.starts_with("fast-forward "))),
+        "squashed land undo batch should include the target integration: {undo_list}"
+    );
+    assert!(
+        logical_operations.iter().any(|op| op["description"]
+            .as_str()
+            .is_some_and(|description| description.starts_with("git checkpoint "))),
+        "squashed land undo batch should include the Git checkpoint: {undo_list}"
+    );
 }
 
 #[test]
@@ -6294,6 +6353,115 @@ fn git_overlay_matrix_land_squashes_thread_to_one_git_commit_by_default() {
         2,
         "collapse record should retain the full ordered source list"
     );
+}
+
+#[test]
+fn git_overlay_matrix_squashed_land_undo_restores_git_target_and_source_thread() {
+    let temp = TempDir::new().unwrap();
+    let (_checkout, base_git) = setup_two_capture_land_thread(&temp, "feature/squash-undo");
+    let source_tip_before = thread_tip(temp.path(), "feature/squash-undo");
+    let target_tip_before = thread_tip(temp.path(), "main");
+
+    let land = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/squash-undo",
+            "--no-push",
+        ],
+    );
+    assert_eq!(land["status"], "landed");
+    assert_eq!(
+        git_stdout(
+            temp.path(),
+            &["rev-list", "--count", &format!("{base_git}..HEAD")]
+        ),
+        "1",
+        "default land should project the multi-state source as one Git commit"
+    );
+    assert_ne!(
+        thread_tip(temp.path(), "feature/squash-undo"),
+        source_tip_before,
+        "land squash should move the source thread to the synthetic collapse state"
+    );
+    assert_ne!(thread_tip(temp.path(), "main"), target_tip_before);
+
+    assert_latest_undo_batch_has_land_squash_ops(temp.path());
+    let undo = json(temp.path(), &["--output", "json", "undo"]);
+    assert_eq!(undo["status"], "completed", "{undo}");
+    assert_eq!(git_stdout(temp.path(), &["rev-parse", "HEAD"]), base_git);
+    assert_eq!(thread_tip(temp.path(), "main"), target_tip_before);
+    assert_eq!(
+        thread_tip(temp.path(), "feature/squash-undo"),
+        source_tip_before,
+        "undo must restore the source thread to its pre-collapse tip"
+    );
+    assert_eq!(git_status_short(temp.path()), "");
+}
+
+#[test]
+fn git_overlay_matrix_manual_resolution_land_squashes_and_undo_restores_source_thread() {
+    let temp = TempDir::new().unwrap();
+    let (_checkout, _base_git) = setup_two_capture_land_thread(&temp, "feature/manual-squash");
+
+    std::fs::write(temp.path().join("main-only.txt"), "main\n").unwrap();
+    let main_commit = json(
+        temp.path(),
+        &["--output", "json", "commit", "-m", "main advance"],
+    );
+    assert_eq!(main_commit["output_kind"], "commit", "{main_commit}");
+    let pre_land_git = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
+    let target_tip_before = thread_tip(temp.path(), "main");
+
+    let refresh = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "thread",
+            "refresh",
+            "feature/manual-squash",
+        ],
+    );
+    assert_eq!(refresh["status"], "completed", "{refresh}");
+    let source_tip_before_land = thread_tip(temp.path(), "feature/manual-squash");
+
+    let land = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/manual-squash",
+            "--no-push",
+        ],
+    );
+    assert_eq!(land["status"], "landed", "{land}");
+    assert_eq!(land["checkpointed"], true);
+    assert_eq!(
+        git_stdout(
+            temp.path(),
+            &["rev-list", "--count", &format!("{pre_land_git}..HEAD")]
+        ),
+        "1",
+        "manual-resolution land should squash the refreshed multi-state thread by default"
+    );
+
+    assert_latest_undo_batch_has_land_squash_ops(temp.path());
+    let undo = json(temp.path(), &["--output", "json", "undo"]);
+    assert_eq!(undo["status"], "completed", "{undo}");
+    assert_eq!(git_stdout(temp.path(), &["rev-parse", "HEAD"]), pre_land_git);
+    assert_eq!(thread_tip(temp.path(), "main"), target_tip_before);
+    assert_eq!(
+        thread_tip(temp.path(), "feature/manual-squash"),
+        source_tip_before_land,
+        "undo must restore the refreshed source thread tip that existed before land"
+    );
+    assert_eq!(git_status_short(temp.path()), "");
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8863,6 +8863,23 @@ fn command_catalog_exposes_public_surface_for_agents() {
         merge["command_action"]["template"]["argv_template"],
         heddle_argv_json(["merge", "<thread>", "--preview"])
     );
+    let land = commands
+        .iter()
+        .find(|entry| entry["display"] == "land")
+        .expect("land command should be cataloged");
+    assert!(
+        land["options"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|option| option["long"] == "no-squash"),
+        "land catalog entry should advertise the per-invocation squash override: {land}"
+    );
+    let land_help = heddle_help(&["land", "--help"]);
+    assert!(
+        land_help.contains("--no-squash") && land_help.contains("Preserve per-State Git export"),
+        "land help should make the squash override discoverable: {land_help}"
+    );
     let checkpoint = commands
         .iter()
         .find(|entry| entry["display"] == "checkpoint")

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -1248,12 +1248,6 @@ mod tests {
                 thread: None,
                 head: Some(cid(13)),
             },
-            OpRecord::Collapse {
-                sources: vec![cid(10), cid(11)],
-                result: cid(14),
-                thread: Some("main".into()),
-                pre_thread_state: None,
-            },
             OpRecord::RemoteThreadUpdate {
                 remote: "origin".into(),
                 thread: "main".into(),
@@ -1272,6 +1266,56 @@ mod tests {
             let decoded = CurrentOpRecordSchema::decode(&bytes).unwrap();
             assert_same_record(&decoded, &expected);
         }
+    }
+
+    #[test]
+    fn atomic_no_head_legacy_collapse_payload_decodes_with_no_pre_thread_state() {
+        let legacy_payload = [
+            129, 168, 67, 111, 108, 108, 97, 112, 115, 101, 147, 146, 220, 0, 16, 10, 10, 10, 10,
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 220, 0, 16, 11, 11, 11, 11, 11, 11, 11,
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 220, 0, 16, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+            12, 12, 12, 12, 12, 12, 164, 109, 97, 105, 110,
+        ];
+        let expected = OpRecord::Collapse {
+            sources: vec![cid(10), cid(11)],
+            result: cid(12),
+            thread: Some("main".into()),
+            pre_thread_state: None,
+        };
+
+        assert!(CurrentOpRecordSchema::decode(&legacy_payload).is_err());
+        let decoded = AtomicNoHeadOpRecordSchema::decode(&legacy_payload).unwrap();
+        assert_same_record(&decoded, &expected);
+        let decoded =
+            decode_versioned_record(&legacy_payload, OpRecordSchemaVersion::AtomicNoHead).unwrap();
+        assert_same_record(&decoded, &expected);
+    }
+
+    #[test]
+    fn current_collapse_payload_round_trips_with_pre_thread_state() {
+        let expected = OpRecord::Collapse {
+            sources: vec![cid(10), cid(11)],
+            result: cid(12),
+            thread: Some("main".into()),
+            pre_thread_state: Some(cid(9)),
+        };
+        let bytes = encode_latest_record(&expected).unwrap();
+        assert_eq!(
+            bytes,
+            vec![
+                129, 168, 67, 111, 108, 108, 97, 112, 115, 101, 148, 146, 220, 0, 16, 10, 10, 10,
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 220, 0, 16, 11, 11, 11, 11, 11,
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 220, 0, 16, 12, 12, 12, 12, 12, 12, 12,
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 164, 109, 97, 105, 110, 220, 0, 16, 9, 9, 9, 9,
+                9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+            ]
+        );
+
+        let decoded = CurrentOpRecordSchema::decode(&bytes).unwrap();
+        assert_same_record(&decoded, &expected);
+        let decoded = decode_versioned_record(&bytes, OpRecordSchemaVersion::Current).unwrap();
+        assert_same_record(&decoded, &expected);
+        assert!(AtomicNoHeadOpRecordSchema::decode(&bytes).is_err());
     }
 
     #[test]

--- a/crates/oplog/src/oplog/op_record_codec.rs
+++ b/crates/oplog/src/oplog/op_record_codec.rs
@@ -198,6 +198,7 @@ enum StrictCurrentOpRecord {
         sources: Vec<ChangeId>,
         result: ChangeId,
         thread: Option<String>,
+        pre_thread_state: Option<ChangeId>,
     },
     MarkerCreate {
         name: String,
@@ -341,10 +342,12 @@ impl StrictCurrentOpRecord {
                 sources,
                 result,
                 thread,
+                pre_thread_state,
             } => OpRecord::Collapse {
                 sources,
                 result,
                 thread,
+                pre_thread_state,
             },
             Self::MarkerCreate { name, state } => OpRecord::MarkerCreate { name, state },
             Self::MarkerDelete { name, state } => OpRecord::MarkerDelete { name, state },
@@ -609,6 +612,7 @@ impl PreAtomicOpRecord {
                 sources,
                 result,
                 thread: None,
+                pre_thread_state: None,
             },
             Self::MarkerCreate { name, state } => OpRecord::MarkerCreate { name, state },
             Self::MarkerDelete { name, state } => OpRecord::MarkerDelete { name, state },
@@ -848,6 +852,7 @@ impl AtomicNoHeadOpRecord {
                 sources,
                 result,
                 thread,
+                pre_thread_state: None,
             },
             Self::MarkerCreate { name, state } => OpRecord::MarkerCreate { name, state },
             Self::MarkerDelete { name, state } => OpRecord::MarkerDelete { name, state },
@@ -1004,6 +1009,7 @@ mod tests {
                 sources: vec![cid(8), cid(9)],
                 result: cid(10),
                 thread: None,
+                pre_thread_state: None,
             },
             OpRecord::MarkerCreate {
                 name: "release".into(),
@@ -1071,6 +1077,7 @@ mod tests {
             sources: vec![cid(22)],
             result: cid(23),
             thread: Some("main".into()),
+            pre_thread_state: None,
         });
         records.push(OpRecord::RemoteThreadUpdate {
             remote: "origin".into(),
@@ -1161,6 +1168,7 @@ mod tests {
                 sources: vec![cid(4), cid(5)],
                 result: cid(6),
                 thread: None,
+                pre_thread_state: None,
             },
         ];
         for legacy in pre_atomic_reshaped {
@@ -1212,6 +1220,7 @@ mod tests {
                 sources: vec![cid(1), cid(2)],
                 result: cid(3),
                 thread: None,
+                pre_thread_state: None,
             },
         ];
 
@@ -1243,6 +1252,7 @@ mod tests {
                 sources: vec![cid(10), cid(11)],
                 result: cid(14),
                 thread: Some("main".into()),
+                pre_thread_state: None,
             },
             OpRecord::RemoteThreadUpdate {
                 remote: "origin".into(),
@@ -1547,6 +1557,7 @@ pub(crate) mod tests_support {
                     sources,
                     result,
                     thread,
+                    pre_thread_state: _,
                 } => Self::Collapse {
                     sources: sources.clone(),
                     result: *result,

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -298,6 +298,7 @@ pub trait OpLogBackend: Send + Sync {
                 sources: sources.to_vec(),
                 result: *result,
                 thread: thread.map(str::to_string),
+                pre_thread_state: None,
             }],
             scope,
         )?;

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -557,11 +557,13 @@ fn op_record_variants_roundtrip_and_describe() {
             sources: vec![st, st2],
             result: st,
             thread: Some("trunk".into()),
+            pre_thread_state: None,
         },
         OpRecord::Collapse {
             sources: vec![st],
             result: st2,
             thread: None,
+            pre_thread_state: None,
         },
         OpRecord::MarkerCreate {
             name: "v1".into(),
@@ -688,6 +690,7 @@ fn fork_collapse_published_ref_fields_roundtrip() {
         sources: vec![from, new_state],
         result: new_state,
         thread: Some("trunk".into()),
+        pre_thread_state: Some(from),
     };
     let back: OpRecord = rmp_serde::from_slice(&rmp_serde::to_vec(&collapse).unwrap()).unwrap();
     match back {
@@ -695,9 +698,11 @@ fn fork_collapse_published_ref_fields_roundtrip() {
             sources,
             result,
             thread,
+            pre_thread_state,
         } => {
             assert_eq!(sources, vec![from, new_state]);
             assert_eq!(result, new_state);
+            assert_eq!(pre_thread_state, Some(from));
             assert_eq!(thread.as_deref(), Some("trunk"));
         }
         other => panic!("expected Collapse, got {other:?}"),

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -122,6 +122,8 @@ pub enum OpRecord {
         result: ChangeId,
         #[serde(default)]
         thread: Option<String>,
+        #[serde(default)]
+        pre_thread_state: Option<ChangeId>,
     },
     /// Marker creation.
     MarkerCreate { name: String, state: ChangeId },
@@ -972,6 +974,7 @@ mod verb_catalog_tests {
                 sources: vec![cid()],
                 result: cid(),
                 thread: None,
+                pre_thread_state: None,
             },
             OpRecord::MarkerCreate {
                 name: "m".into(),

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -2305,6 +2305,7 @@ mod tests {
             sources: vec![collapse_source, fork_result],
             result: collapse_result,
             thread: None,
+            pre_thread_state: None,
         };
         entries.push(collapse);
 
@@ -2356,7 +2357,7 @@ mod tests {
         ));
         assert!(matches!(
             &loaded.entries[4].operation,
-            OpRecord::Collapse { sources, result, thread: None }
+            OpRecord::Collapse { sources, result, thread: None, pre_thread_state: None }
                 if sources == &vec![collapse_source, fork_result] && *result == collapse_result
         ));
 
@@ -2689,6 +2690,7 @@ mod tests {
             sources: vec![state_4, state_5],
             result: state_6,
             thread: Some("main".to_string()),
+            pre_thread_state: None,
         };
         entries.push(collapse);
 

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1237,6 +1237,7 @@ fn reconcile_folds_every_record_shape() {
         sources: vec![v1],
         result: coll,
         thread: None,
+        pre_thread_state: None,
     }])
     .unwrap();
     // Checkpoint with a thread, and one without (thread = None arm).


### PR DESCRIPTION
Summary:
- Default Git-overlay land now squashes a landed thread into one atomic Git commit while preserving per-State Heddle history.
- Added the per-invocation --no-squash override and [land] squash = false user config opt-out.
- Covered default, flag override, config override, catalog/help discoverability, and docs.

Validation:
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo build
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo build --all-features
- CARGO_TARGET_DIR=/tmp/heddle-634-target bash scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo test -p heddle-cli --lib
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo test -p heddle-cli --test cli_integration git_overlay_matrix::
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo test -p heddle-cli --test cli_integration bridge::
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo test -p heddle-cli --test roundtrip_fidelity
- CARGO_TARGET_DIR=/tmp/heddle-634-target cargo clippy -- -D warnings
- gen-ts-types not run; schemas were not moved.

Part of #634 (AC1+AC2; AC3 — heddle expand + log collapse annotation — tracked separately)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783886290&installation_id=132405951&pr_number=680&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F680&signature=ec29be381b2c921b2396765dc85c24ffaa5bcd5c351ccc6eaea32a8c50ddda11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->