### PR TITLE
feat(mount): HeddleHost onboarding UX + macOS 15.4+ compat + build recipe

### DIFF
--- a/crates/mount/swift/HeddleHost/BUILD.md
+++ b/crates/mount/swift/HeddleHost/BUILD.md
@@ -1,0 +1,188 @@
+# HeddleHost Manual Build, Sign, Notarize, Test
+
+This is the maintainer-run Mac recipe for tonight. CI can automate it later with
+the Apple secrets tracked for #666; this document is intentionally self-contained
+for a local Developer ID build.
+
+## Requirements
+
+- macOS 15.4 or newer with Xcode installed. The project deployment target is
+  15.4; newer SDKs are fine as long as APIs above 15.4 stay availability-guarded.
+- Apple Developer Program team with the `com.apple.developer.fskit.fsmodule`
+  entitlement approved.
+- Developer ID Application certificate in the login keychain.
+- Developer ID provisioning profiles for both bundle IDs, with the FSKit
+  entitlement enabled:
+  - `sh.heddle.HeddleHost`
+  - `sh.heddle.HeddleHost.HeddleFSModule`
+- A notarytool keychain profile:
+
+```bash
+xcrun notarytool store-credentials "HeddleNotary" \
+  --apple-id "you@example.com" \
+  --team-id "33V6242M8S" \
+  --password "app-specific-password"
+```
+
+Set these shell variables before building:
+
+```bash
+export HEDDLE_TEAM_ID="33V6242M8S"
+export HEDDLE_DEVELOPER_ID="Developer ID Application: HeddleCo, LLC (33V6242M8S)"
+export HEDDLE_NOTARY_PROFILE="HeddleNotary"
+```
+
+## 1. Build a universal Rust static library
+
+The Xcode extension links `target/release/libmount.a`. For a universal app, make
+that archive contain both Apple Silicon and Intel slices.
+
+```bash
+cd /path/to/heddle
+
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+cargo build --release -p heddle-mount --features fskit \
+  --target aarch64-apple-darwin
+cargo build --release -p heddle-mount --features fskit \
+  --target x86_64-apple-darwin
+
+mkdir -p target/release
+lipo -create \
+  target/aarch64-apple-darwin/release/libmount.a \
+  target/x86_64-apple-darwin/release/libmount.a \
+  -output target/release/libmount.a
+
+lipo -info target/release/libmount.a
+```
+
+Expected output includes `x86_64 arm64`.
+
+## 2. Archive HeddleHost
+
+Open `crates/mount/swift/HeddleHost/HeddleHost.xcodeproj` once and confirm both
+targets are set to manual signing with the Developer ID provisioning profiles
+above. Do not remove the FSKit capability or sandbox entitlement; Xcode may
+silently rewrite these settings.
+
+Then archive from the command line:
+
+```bash
+cd crates/mount/swift/HeddleHost
+rm -rf build/HeddleHost.xcarchive build/export
+
+xcodebuild archive \
+  -project HeddleHost.xcodeproj \
+  -scheme HeddleHost \
+  -configuration Release \
+  -archivePath "$PWD/build/HeddleHost.xcarchive" \
+  SKIP_INSTALL=NO \
+  ARCHS="arm64 x86_64" \
+  ONLY_ACTIVE_ARCH=NO \
+  MACOSX_DEPLOYMENT_TARGET=15.4 \
+  DEVELOPMENT_TEAM="$HEDDLE_TEAM_ID" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="$HEDDLE_DEVELOPER_ID" \
+  OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime"
+```
+
+The built app is:
+
+```bash
+APP="$PWD/build/HeddleHost.xcarchive/Products/Applications/HeddleHost.app"
+EXT="$APP/Contents/Extensions/HeddleFSModule.appex"
+```
+
+## 3. Verify and, if needed, re-sign
+
+If Xcode used the correct Developer ID profiles, verification should pass:
+
+```bash
+codesign --verify --strict --verbose=2 "$EXT"
+codesign --verify --strict --verbose=2 "$APP"
+codesign -d --entitlements :- "$APP"
+codesign -d --entitlements :- "$EXT"
+```
+
+Both entitlement dumps must include:
+
+- `com.apple.developer.fskit.fsmodule`
+- `com.apple.security.app-sandbox`
+
+If manual re-signing is needed, embed the matching provisioning profiles first,
+then sign inside-out:
+
+```bash
+cp /path/to/HeddleHost.provisionprofile \
+  "$APP/Contents/embedded.provisionprofile"
+cp /path/to/HeddleFSModule.provisionprofile \
+  "$EXT/Contents/embedded.provisionprofile"
+
+codesign --force --timestamp --options runtime \
+  --sign "$HEDDLE_DEVELOPER_ID" "$EXT"
+codesign --force --timestamp --options runtime \
+  --sign "$HEDDLE_DEVELOPER_ID" "$APP"
+
+codesign --verify --deep --strict --verbose=2 "$APP"
+spctl -a -vvv -t install "$APP"
+```
+
+## 4. Notarize and staple
+
+```bash
+ditto -c -k --keepParent "$APP" build/HeddleHost.zip
+
+xcrun notarytool submit build/HeddleHost.zip \
+  --keychain-profile "$HEDDLE_NOTARY_PROFILE" \
+  --wait
+
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+spctl -a -vvv -t install "$APP"
+```
+
+## 5. Local install and approval test
+
+Install the notarized app into `/Applications`, then force LaunchServices to
+scan it:
+
+```bash
+sudo rm -rf /Applications/HeddleHost.app
+sudo ditto "$APP" /Applications/HeddleHost.app
+
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Support/lsregister"
+"$LSREGISTER" -f /Applications/HeddleHost.app
+
+pluginkit -m -p com.apple.fskit.fsmodule | grep sh.heddle.HeddleHost.HeddleFSModule
+open /Applications/HeddleHost.app
+```
+
+Open:
+
+```text
+System Settings > General > Login Items & Extensions > File System Extensions
+```
+
+Switch to the category-grouped Extensions view if the app-grouped toggle does
+not move. Toggle `Heddle` on, then confirm pluginkit reports a leading `+`:
+
+```bash
+pluginkit -m -p com.apple.fskit.fsmodule | grep sh.heddle.HeddleHost.HeddleFSModule
+```
+
+Finally test the CLI path with the same repo format produced by this checkout:
+
+```bash
+cd /path/to/test/repo
+heddle start fskit-smoke --workspace virtualized
+```
+
+Expected result: the command mounts the virtualized workspace through FSKit
+rather than falling back to NFS.
+
+## CI note for #666
+
+The eventual CI version should source the Developer ID certificate, Apple team
+ID, FSKit provisioning profiles, and notarytool credentials from #666's secrets.
+Keep this manual recipe as the fallback path whenever the Swift/Xcode archive is
+not buildable in Linux CI.

--- a/crates/mount/swift/HeddleHost/HeddleHost.xcodeproj/project.pbxproj
+++ b/crates/mount/swift/HeddleHost/HeddleHost.xcodeproj/project.pbxproj
@@ -247,6 +247,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -297,10 +301,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -311,6 +315,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -355,7 +363,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -368,6 +376,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				CODE_SIGN_ENTITLEMENTS = HeddleHost/HeddleHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -387,7 +399,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.heddle.HeddleHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -407,6 +419,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				CODE_SIGN_ENTITLEMENTS = HeddleHost/HeddleHost.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -426,7 +442,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = sh.heddle.HeddleHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -447,6 +463,10 @@
 				CODE_SIGN_ENTITLEMENTS = HeddleFSModule/HeddleFSModule.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 33V6242M8S;
 				ENABLE_APP_SANDBOX = YES;
@@ -475,7 +495,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../../target/release",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -500,6 +520,10 @@
 				CODE_SIGN_ENTITLEMENTS = HeddleFSModule/HeddleFSModule.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 33V6242M8S;
 				ENABLE_APP_SANDBOX = YES;
@@ -528,7 +552,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../../target/release",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.4;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/crates/mount/swift/HeddleHost/HeddleHost/ContentView.swift
+++ b/crates/mount/swift/HeddleHost/HeddleHost/ContentView.swift
@@ -6,67 +6,227 @@ struct ContentView: View {
     @State private var manager = ExtensionManager()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Heddle FSKit module")
-                .font(.title2)
-                .bold()
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Enable Heddle FSKit")
+                        .font(.title2)
+                        .fontWeight(.semibold)
 
-            Text(
-                "On macOS 26+, FSKit modules ship as ExtensionKit " +
-                "extensions. Enable the Heddle extension in System " +
-                "Settings; then mount a thread with " +
-                "`mount -t heddle -o t=<thread> /path/to/repo /mnt`."
-            )
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-
-            Divider()
-
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(statusColor(for: manager.status))
-                    .frame(width: 10, height: 10)
-                Text(manager.statusLabel)
-                    .font(.callout)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            if !manager.lastMessage.isEmpty {
-                Text(manager.lastMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
-                    .padding(.vertical, 4)
-            }
-
-            HStack {
-                Button("Open System Settings") {
-                    manager.openFileSystemExtensionsSettings()
-                }
-                .keyboardShortcut(.defaultAction)
-
-                Button("Reveal app in Finder") {
-                    manager.revealAppInFinder()
+                    Text("Turn on Heddle once so virtualized workspaces can mount through the macOS file-system extension.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer()
 
-                Button("Refresh") {
+                StatusPill(status: manager.status)
+            }
+
+            SettingsGuideMock()
+
+            Text(ExtensionManager.settingsPath)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(manager.statusDetail)
+                    .font(.callout)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if !manager.lastMessage.isEmpty {
+                    Text(manager.lastMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    manager.openFileSystemExtensionsSettings()
+                } label: {
+                    Label("Open System Settings", systemImage: "gearshape")
+                }
+                .keyboardShortcut(.defaultAction)
+
+                if manager.canRevealApp {
+                    Button {
+                        manager.revealAppInFinder()
+                    } label: {
+                        Label("Reveal App", systemImage: "folder")
+                    }
+                }
+
+                Spacer()
+
+                Button {
                     manager.refresh()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
                 }
             }
         }
         .padding(24)
-        .frame(minWidth: 480, idealWidth: 540)
+        .frame(minWidth: 560, idealWidth: 640)
     }
 }
 
-private func statusColor(for status: ExtensionManager.Status) -> Color {
-    switch status {
-    case .registered:   .green
-    case .unregistered: .yellow
+private struct StatusPill: View {
+    let status: ExtensionManager.Status
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+
+            Text(label)
+                .font(.caption)
+                .fontWeight(.semibold)
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 6)
+        .background(color.opacity(0.14))
+        .overlay {
+            Capsule()
+                .stroke(color.opacity(0.35), lineWidth: 1)
+        }
+        .clipShape(Capsule())
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        switch status {
+        case .registeredEnabled:
+            return "FSKit enabled"
+        case .registeredDisabled:
+            return "Toggle required"
+        case .unregistered:
+            return "Extension not registered"
+        case .devLocation:
+            return "Move to /Applications"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case .registeredEnabled:
+            return .green
+        case .registeredDisabled:
+            return .orange
+        case .unregistered, .devLocation:
+            return .gray
+        }
+    }
+}
+
+private struct SettingsGuideMock: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "gearshape.fill")
+                    .foregroundStyle(.secondary)
+                Text("Login Items & Extensions")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color(nsColor: .windowBackgroundColor))
+
+            Divider()
+
+            HStack(alignment: .top, spacing: 14) {
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("Extensions")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    Text("File System Extensions")
+                        .font(.callout)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Color.accentColor.opacity(0.13))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .frame(width: 190, alignment: .leading)
+
+                VStack(spacing: 0) {
+                    HStack(spacing: 10) {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.accentColor.opacity(0.16))
+                            .frame(width: 34, height: 34)
+                            .overlay {
+                                Image(systemName: "externaldrive.connected.to.line.below")
+                                    .foregroundStyle(Color.accentColor)
+                            }
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Heddle")
+                                .font(.callout)
+                                .fontWeight(.semibold)
+                            Text("sh.heddle.HeddleHost.HeddleFSModule")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+
+                        Spacer()
+
+                        ToggleMock()
+                    }
+                    .padding(12)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.orange, lineWidth: 2)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Text("Flip this Heddle toggle on.")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.orange)
+                    }
+                    .padding(.top, 7)
+                }
+            }
+            .padding(16)
+            .background(Color(nsColor: .textBackgroundColor))
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+    }
+}
+
+private struct ToggleMock: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 11)
+            .fill(Color.orange.opacity(0.22))
+            .frame(width: 44, height: 24)
+            .overlay(alignment: .trailing) {
+                Circle()
+                    .fill(Color.orange)
+                    .frame(width: 18, height: 18)
+                    .padding(.trailing, 3)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 11)
+                    .stroke(Color.orange.opacity(0.7), lineWidth: 1)
+            }
+            .accessibilityHidden(true)
     }
 }
 

--- a/crates/mount/swift/HeddleHost/HeddleHost/ExtensionManager.swift
+++ b/crates/mount/swift/HeddleHost/HeddleHost/ExtensionManager.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// On macOS 26+, FSKit modules ship as ExtensionKit extensions
+// On macOS 15.4+, FSKit modules ship as ExtensionKit extensions
 // (productType `extensionkit-extension`, marked by
 // `EXAppExtensionAttributes` in Info.plist). Unlike legacy System
 // Extensions, ExtensionKit doesn't expose a programmatic
@@ -17,9 +17,10 @@
 //   3. The user toggles it on in System Settings → General →
 //      Login Items & Extensions → File System Extensions.
 //
-// This manager surfaces the workflow: it reports whether the
-// app is launching from a registered location, and provides a
-// deep link straight to the FSKit-extensions pane.
+// This manager surfaces the workflow: it asks pluginkit for the
+// real FSKit module state, keeps polling while the onboarding
+// window is visible, and provides a deep link to the best-known
+// Settings pane for the current macOS release.
 
 import AppKit
 import Foundation
@@ -28,58 +29,108 @@ import Observation
 @MainActor
 @Observable
 final class ExtensionManager {
+    nonisolated static let bundleIdentifier = "sh.heddle.HeddleHost.HeddleFSModule"
+    nonisolated static let settingsPath =
+        "System Settings > General > Login Items & Extensions > File System Extensions"
+
     enum Status {
-        /// App is running from /Applications (or another LS-known
-        /// location); the OS should be aware of the embedded
-        /// extension.
-        case registered
-        /// App is running from DerivedData / a temp dir / etc. The
-        /// OS won't surface the extension until the app is moved
-        /// to /Applications.
+        /// pluginkit lists the FSKit module with a leading "+".
+        case registeredEnabled
+        /// pluginkit lists the FSKit module with a leading "-".
+        case registeredDisabled
+        /// pluginkit did not list the module, even though the app
+        /// appears to be installed in a LaunchServices-scanned
+        /// location.
         case unregistered
+        /// App is running from DerivedData / a temp dir / etc. The
+        /// OS won't surface the extension until the app is moved to
+        /// /Applications and LaunchServices scans it.
+        case devLocation(String)
     }
 
     private(set) var status: Status = .unregistered
     private(set) var lastMessage: String = ""
+    private(set) var lastRefreshed: Date?
+
+    private var isRefreshing = false
+    private var pollTimer: Timer?
 
     init() {
         refresh()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.refresh()
+            }
+        }
+    }
+
+    deinit {
+        pollTimer?.invalidate()
     }
 
     var statusLabel: String {
         switch status {
-        case .registered:
-            return "App is in a registered location — open System Settings to toggle the extension on."
+        case .registeredEnabled:
+            return "FSKit enabled"
+        case .registeredDisabled:
+            return "Toggle required"
         case .unregistered:
-            return "App is running from a dev location. Move to /Applications so the extension is discoverable."
+            return "Extension not registered"
+        case .devLocation:
+            return "Move to /Applications"
         }
     }
 
-    /// Refresh the registration state. Today this just checks the
-    /// running bundle's path; a more sophisticated probe would
-    /// ask `pluginkit` whether our extension is known to the
-    /// system. The bundle-path heuristic matches what
-    /// LaunchServices uses to decide if extensions are surfaced.
+    var statusDetail: String {
+        switch status {
+        case .registeredEnabled:
+            return "Heddle is enabled in File System Extensions. Re-run `heddle start --workspace virtualized` to mount through FSKit."
+        case .registeredDisabled:
+            return "Heddle is installed but macOS has it turned off. Toggle the Heddle row on in File System Extensions."
+        case .unregistered:
+            return "macOS has not registered the bundled FSKit module yet. Confirm HeddleHost.app is in /Applications, then refresh LaunchServices."
+        case .devLocation(let path):
+            return "This copy is running from \(path). Move HeddleHost.app to /Applications so macOS can register the embedded extension."
+        }
+    }
+
+    var canRevealApp: Bool {
+        if case .devLocation = status {
+            return true
+        }
+        return false
+    }
+
+    /// Refresh the registration state using the same pluginkit
+    /// signal the CLI uses: "+" means enabled, "-" means installed
+    /// but disabled, and absence means the module is not registered.
     func refresh() {
-        let bundleURL = Bundle.main.bundleURL.path
-        if bundleURL.hasPrefix("/Applications/") {
-            status = .registered
-            lastMessage = ""
-        } else {
-            status = .unregistered
-            lastMessage =
-                "Detected bundle path: \(bundleURL)\n" +
-                "Drag HeddleHost.app into /Applications, relaunch from there, " +
-                "then click \"Open System Settings\" to enable the extension."
+        guard !isRefreshing else {
+            return
+        }
+
+        isRefreshing = true
+        let bundlePath = Bundle.main.bundleURL.path
+
+        Task {
+            let probe = await Self.runPluginKitProbe()
+            apply(probe: probe, bundlePath: bundlePath)
+            isRefreshing = false
         }
     }
 
-    /// Open the FSKit extensions pane directly. URL is the
-    /// documented preference-pane anchor for this section.
+    /// Open the best-known Settings URL for File System Extensions.
+    ///
+    /// Apple documents the visible path, not a stable public URL
+    /// contract. Keep the user-facing path in the UI and treat these
+    /// anchors as conveniences: if a future macOS changes the anchor,
+    /// the fallback still lands in Login Items & Extensions.
     func openFileSystemExtensionsSettings() {
-        let url = URL(
-            string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?Extensions"
-        )!
+        guard let url = settingsDestination().url else {
+            openSystemSettingsApp()
+            return
+        }
+
         NSWorkspace.shared.open(url)
     }
 
@@ -90,4 +141,151 @@ final class ExtensionManager {
         let url = Bundle.main.bundleURL
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
+
+    private func apply(probe: PluginKitProbe, bundlePath: String) {
+        lastRefreshed = Date()
+
+        switch probe {
+        case .enabled:
+            status = .registeredEnabled
+            lastMessage = ""
+        case .disabled:
+            status = .registeredDisabled
+            lastMessage = "pluginkit lists \(Self.bundleIdentifier) with a disabled marker (-)."
+        case .absent:
+            if isLikelyDevLocation(bundlePath) {
+                status = .devLocation(bundlePath)
+                lastMessage =
+                    "Drag HeddleHost.app into /Applications, relaunch it from there, " +
+                    "then open System Settings."
+            } else {
+                status = .unregistered
+                lastMessage =
+                    "pluginkit did not list \(Self.bundleIdentifier). Run lsregister for /Applications/HeddleHost.app if the app was just copied."
+            }
+        case .failed(let message):
+            if isLikelyDevLocation(bundlePath) {
+                status = .devLocation(bundlePath)
+            } else {
+                status = .unregistered
+            }
+            lastMessage = "Could not run pluginkit probe: \(message)"
+        }
+    }
+
+    private func settingsDestination() -> SettingsDestination {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+
+        if #available(macOS 26, *) {
+            // macOS 26 Tahoe: the category-grouped Extensions tab is the
+            // reliable user path for toggling FSKit modules. The anchor is
+            // best-effort and may still land on the parent pane.
+            return SettingsDestination(
+                url: URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?Extensions")
+            )
+        }
+
+        switch version.majorVersion {
+        case 15:
+            // macOS 15 Sequoia places System/File System Extensions under
+            // General > Login Items & Extensions.
+            return SettingsDestination(
+                url: URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?Extensions")
+            )
+        default:
+            return SettingsDestination(
+                url: URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension")
+            )
+        }
+    }
+
+    private func openSystemSettingsApp() {
+        guard let appURL = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.systempreferences"
+        ) else {
+            return
+        }
+
+        NSWorkspace.shared.open(appURL)
+    }
+
+    private func isLikelyDevLocation(_ bundlePath: String) -> Bool {
+        if bundlePath.hasPrefix("/Applications/") {
+            return false
+        }
+
+        if bundlePath.hasPrefix("/System/Applications/") {
+            return false
+        }
+
+        return true
+    }
+
+    private nonisolated static func runPluginKitProbe() async -> PluginKitProbe {
+        await Task.detached(priority: .utility) {
+            let process = Process()
+            let outputPipe = Pipe()
+
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/pluginkit")
+            process.arguments = ["-m", "-p", "com.apple.fskit.fsmodule"]
+            process.standardOutput = outputPipe
+            process.standardError = outputPipe
+
+            do {
+                try process.run()
+            } catch {
+                return .failed(error.localizedDescription)
+            }
+
+            process.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8) ?? ""
+
+            guard process.terminationStatus == 0 else {
+                let message = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                if message.isEmpty {
+                    return .failed("pluginkit exited with status \(process.terminationStatus)")
+                }
+                return .failed(message)
+            }
+
+            return parsePluginKitOutput(output)
+        }.value
+    }
+
+    private nonisolated static func parsePluginKitOutput(_ output: String) -> PluginKitProbe {
+        for line in output.components(separatedBy: .newlines) {
+            guard line.contains(bundleIdentifier) else {
+                continue
+            }
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let marker = trimmed.first else {
+                continue
+            }
+
+            switch marker {
+            case "+":
+                return .enabled
+            case "-":
+                return .disabled
+            default:
+                return .absent
+            }
+        }
+
+        return .absent
+    }
+}
+
+private struct SettingsDestination {
+    let url: URL?
+}
+
+private enum PluginKitProbe: Sendable {
+    case enabled
+    case disabled
+    case absent
+    case failed(String)
 }

--- a/crates/mount/swift/HeddleHost/HeddleHost/HeddleHostApp.swift
+++ b/crates/mount/swift/HeddleHost/HeddleHost/HeddleHostApp.swift
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// HeddleHostApp — the macOS container app whose only job is to
-// register and activate the bundled `HeddleFSModule.appex` System
-// Extension. The Heddle CLI itself doesn't ship as a `.app`, so
-// this host is what users open once to install the FSKit module;
-// after that, `heddle thread start --workspace light` mounts via
-// the registered extension without touching the GUI.
+// HeddleHostApp — the macOS container app whose main job is to
+// make the bundled `HeddleFSModule.appex` discoverable to
+// LaunchServices. The Heddle CLI itself doesn't ship as a `.app`,
+// so this host is what users open when macOS needs the FSKit
+// module enabled; after that, `heddle start --workspace virtualized`
+// mounts via the registered extension without touching the GUI.
 //
 // Nothing here owns the mount lifecycle — that's the CLI's job
 // (see `crates/cli/src/cli/commands/mount_lifecycle.rs`). This

--- a/crates/mount/swift/HeddleHost/README.md
+++ b/crates/mount/swift/HeddleHost/README.md
@@ -5,13 +5,13 @@ FSKit module. It exists alongside (not inside) the `heddle` CLI:
 the CLI is platform-agnostic Rust, this project is the per-OS
 surface required by Apple for FSKit.
 
-On macOS 26+, FSKit modules ship as **ExtensionKit** extensions
+On macOS 15.4+, FSKit modules ship as **ExtensionKit** extensions
 (not the legacy System Extension model). The host app's only job
 is to be a discoverable bundle in `/Applications` so LaunchServices
-can register the embedded `.appex`. It has no UI: the
+can register the embedded `.appex`. The app remains quiet by default: the
 `LSUIElement = YES` Info.plist key suppresses the Dock icon, and
 no window opens on launch unless the user explicitly opens the
-app from Finder.
+app from Finder or the CLI deep-links to it after FSKit needs approval.
 
 ## Target user experience
 
@@ -27,18 +27,20 @@ $ heddle start mybranch --workspace virtualized
    ✓ mounted at .repo-heddle-mounts/mybranch (via FSKit)
 ```
 
-Zero windows to dismiss, zero buttons to click in the host app.
-The toggle in System Settings is the only user interaction macOS
-requires, and we can't bypass it — Apple enforces it as a
-security check for any file-system extension.
+Zero windows to dismiss in the normal CLI path. If the host app is
+opened directly, it shows an onboarding card with the live pluginkit
+state, a System Settings button, and an annotated SwiftUI mock of the
+File System Extensions toggle. The toggle in System Settings is the
+only user interaction macOS requires, and we can't bypass it — Apple
+enforces it as a security check for any file-system extension.
 
 ## What's here
 
 ```
 HeddleHost/                  ← macOS host app target (invisible)
   HeddleHostApp.swift         App entry (SwiftUI, no Dock icon)
-  ContentView.swift           Diagnostic window (only visible if user opens .app)
-  ExtensionManager.swift      Status probe + Settings deeplink
+  ContentView.swift           Onboarding window (only visible if user opens .app)
+  ExtensionManager.swift      pluginkit status probe + Settings deeplink
   HeddleHost.entitlements     Sandbox only — no programmatic activation needed
   Assets.xcassets/            Stock icon + accent color
 HeddleFSModule/              ← ExtensionKit extension target (.appex)
@@ -53,7 +55,21 @@ HeddleFSModule/              ← ExtensionKit extension target (.appex)
 HeddleHost.xcodeproj/        ← Xcode project (synced folder groups)
   xcshareddata/xcschemes/     ← Shared scheme: Run = HeddleHost.app
 README.md                    ← this file
+BUILD.md                     ← Manual Mac build/sign/notarize/test recipe
 ```
+
+## Compatibility and build shape
+
+- Host app deployment target: macOS 15.4.
+- HeddleFSModule deployment target: macOS 15.4.
+- Build SDK: macOS 15.4 or newer; do not require unguarded APIs above 15.4.
+- Archive architecture: universal `arm64` + `x86_64`.
+- Tahoe-only code must stay behind `if #available(macOS 26, *)`; the
+  current host UI only uses that guard for Settings URL selection.
+- The user-facing Settings path is the compatibility contract:
+  `System Settings > General > Login Items & Extensions > File System Extensions`.
+  The `x-apple.systempreferences:` anchors are best-effort conveniences and
+  fall back to the parent Login Items & Extensions pane if Apple changes them.
 
 ## How the CLI knows whether FSKit is ready
 
@@ -68,6 +84,16 @@ Possible results:
 | `NeedsApproval` (line starts with `-`) | Prints the setup hint, opens System Settings, falls through to NFS for this run |
 | `NotInstalled` (no line for our ID) | Silent fallback to NFS (host app not in /Applications yet) |
 | `Unknown` (`pluginkit` failed) | Silent fallback to NFS |
+
+The host app's `ExtensionManager` now uses the same pluginkit signal and polls
+about every two seconds while the onboarding window is open:
+
+| Host state | Source |
+|---|---|
+| `FSKit enabled` | line for `sh.heddle.HeddleHost.HeddleFSModule` starts with `+` |
+| `Toggle required` | line for the bundle ID starts with `-` |
+| `Extension not registered` | no line for the bundle ID, app appears installed |
+| `Move to /Applications` | no line and this copy is running from a dev location |
 
 The integration lives in
 [`crates/cli/src/cli/commands/mount_lifecycle.rs`](../../../../cli/src/cli/commands/mount_lifecycle.rs)
@@ -93,13 +119,10 @@ Open `HeddleHost.xcodeproj` in Xcode, ensure the "HeddleHost"
 scheme is selected in the toolbar, and Run (or Archive for a
 release build).
 
-For headless / CI builds:
-```bash
-xcodebuild -project HeddleHost.xcodeproj \
-  -scheme HeddleHost -configuration Release \
-  CODE_SIGN_IDENTITY="Developer ID Application: …" \
-  build
-```
+For the Developer ID archive, signing, notarization, and local smoke test,
+follow [`BUILD.md`](BUILD.md). The release archive is universal
+`arm64` + `x86_64` and keeps both app and extension deployment targets at
+macOS 15.4.
 
 ### 3. Install
 
@@ -295,12 +318,12 @@ shipping the cask is the signing/notarization pipeline.
 | Piece | State |
 |---|---|
 | Xcode project | Clean, builds host + extension |
-| Host app | Invisible (`LSUIElement`), diagnostic window only |
+| Host app | Invisible (`LSUIElement`), onboarding window only |
 | Extension entry point | `@main UnaryFileSystemExtension` wired |
 | `FSUnaryFileSystem` ops | `probeResource` + `loadResource` working |
 | `FSVolume.Operations` | Conformed — lookup, getattr, read, write, enumerate, flush dispatch into Rust |
 | Rust C ABI bridge | `heddle_fskit_open_thread` connects extension → mount core |
-| Readiness probe | `pluginkit`-based, wired into `mount_lifecycle.rs` |
+| Readiness probe | `pluginkit`-based, wired into `mount_lifecycle.rs` and host onboarding |
 | NFS fallback | Always-available, picks up when FSKit isn't ready |
 | End-to-end mount + read | Working on macOS 26.4 (`mount -t heddle … && cat <mp>/file` succeeds) |
 | `mtime` on returned items | Wired through the C ABI; shows mount bootstrap time in `ls -l` |


### PR DESCRIPTION
## Summary

- Replace the HeddleHost diagnostic stub with an onboarding card: live FSKit status pill, System Settings button, and an annotated SwiftUI mock of the File System Extensions Heddle toggle.
- Switch ExtensionManager to the real pluginkit probe (`pluginkit -m -p com.apple.fskit.fsmodule`) with enabled, disabled/NeedsApproval, unregistered, and dev-location states, plus a 2s polling refresh while the window is open.
- Make the Settings opener version-aware for macOS 15 Sequoia and macOS 26 Tahoe, with the visible text path as the compatibility fallback.
- Set the host app and HeddleFSModule deployment targets to macOS 15.4 and make the Xcode archive settings universal (`arm64` + `x86_64`).
- Add `crates/mount/swift/HeddleHost/BUILD.md` with the manual Mac build/sign/notarize/local-test recipe.

## Maintainer

Build, sign, notarize, and smoke test on a Mac per `crates/mount/swift/HeddleHost/BUILD.md`. Swift/Xcode is unbuildable in CI/Linux from this environment, so this PR is reviewed-not-compiled here.

Part of #666

## Validation

- `git diff --check`
- `git diff --cached --check`
- Static review for no force unwraps in the new Swift path
- Confirmed no Rust `crates/*/src` files were touched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783907735&installation_id=132405951&pr_number=686&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F686&signature=42005d85a5587ef9ab0b63a71f546568f0951e36b0c3bb6c592b6345fccf1fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->