### PR TITLE
[codex] Add Git concept help topic

### DIFF
--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -354,5 +354,6 @@ fn render_adopt(output: &AdoptOutput, json: bool) -> Result<()> {
     if !output.trust.recommended_action.is_empty() {
         print_next(&output.trust.recommended_action);
     }
+    println!("New to Heddle from Git? Run `heddle help git-concepts`.");
     Ok(())
 }

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -128,6 +128,10 @@ pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
                 out,
                 "Start here: `heddle init`, `heddle adopt`, or `heddle clone`."
             );
+            let _ = writeln!(
+                out,
+                "Coming from Git? Run `heddle help git-concepts` for the concept map."
+            );
             let _ = writeln!(out);
             // The ONE place the --output machine-contract blurb is stated
             // in full on a help screen; per-command --help carries only the
@@ -146,7 +150,8 @@ pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
                 out,
                 "Run `heddle help model` for the short mental model, \
                  `heddle help advanced` for power surfaces, automation, and Git interop, \
-                 or `heddle help <topic>` for a topic page (e.g. `git-overlay`, \
+                 or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
+                 `git-overlay`, \
                  `threads`, `daemon`, `signals`, `bridge`, `operation-ids`, \
                  `remotes`, `output-formats`, `git-dependencies`)."
             );
@@ -486,6 +491,7 @@ pub fn topic_text(topic: &str) -> Option<&'static str> {
         "output-formats" | "output-format" | "output" => OUTPUT_FORMATS_TOPIC,
         "clone" => CLONE_TOPIC,
         "git-overlay" => GIT_OVERLAY_TOPIC,
+        "git-concepts" | "git-concept-map" | "git-veteran" => GIT_CONCEPTS_TOPIC,
         "model" | "mental-model" | "concepts" => MODEL_TOPIC,
         "threads" => THREADS_TOPIC,
         "operation-ids" | "idempotency" => OPERATION_IDS_TOPIC,
@@ -659,6 +665,41 @@ Existing Git checkout:
 
 If a command refuses, read the first `Next:` line. Heddle fails closed when it
 cannot prove the move is safe.
+"#;
+
+const GIT_CONCEPTS_TOPIC: &str = r#"Git to Heddle concept map.
+
+| Git concept | Heddle concept + semantic difference |
+|-------------|--------------------------------------|
+| `git commit` | `heddle commit -m "..."`: saves a Heddle State. In native Heddle this is the authored snapshot; in Git-overlay mode it also writes the matching Git checkpoint when safe. |
+| Git commit SHA | Heddle `hd-...` change id. Use it with `heddle show`, `log`, and `diff`; Git SHAs remain the interop handle for Git tooling. |
+| `git branch foo` | `heddle start foo` for a working thread, or `heddle thread create foo` for a ref only. A thread is a unit of work with checkout, captured history, metadata, and readiness state, not just a movable ref. |
+| `git checkout foo` / `git switch foo` | `heddle thread switch foo`. Heddle switches between thread checkouts and may auto-capture the thread you leave; raw Git checkout only moves the Git layer. |
+| `git tag v1.0` | `heddle thread marker create v1.0`. A marker names a Heddle State; it is for pinning a state in Heddle history, not for creating a signed or annotated Git tag object. |
+| `git remote add origin <url>` | `heddle remote add origin <url>`. Heddle remotes can be native Heddle endpoints, hosted addresses, local paths, or Git remotes depending on repository mode. |
+| `git push` / `git pull` | `heddle push` / `heddle pull`. Heddle pushes or pulls the selected thread/state through its remote contract and refuses when verification says the mapping is unsafe. |
+| `git fetch` | `heddle fetch`. Fetch updates remote knowledge without making your current thread's checkout silently absorb changes. |
+| `git rebase` to catch up | `heddle sync`. Sync refreshes a stale thread onto its target when replay is clean; conflicts route through `heddle resolve` / `heddle continue`. |
+
+Reconciliation examples:
+
+    git branch feature/auth
+    git checkout feature/auth
+    # Heddle: create/resume an isolated unit of work instead
+    heddle start feature/auth --path ../feature-auth
+
+    git tag v1.0
+    # Heddle: pin the current State by name
+    heddle thread marker create v1.0
+
+    git fetch origin
+    git rebase origin/main
+    # Heddle: update remote knowledge, then refresh the current thread when safe
+    heddle fetch origin
+    heddle sync
+
+For an existing Git checkout, start with `heddle status`; it prints the exact
+`heddle adopt` command when Heddle needs to import Git refs first.
 "#;
 
 const THREADS_TOPIC: &str = "Threads — Heddle's unit of in-progress work.\n\
@@ -992,6 +1033,9 @@ mod tests {
         for topic in [
             "advanced",
             "agent-flags",
+            "git-concepts",
+            "git-concept-map",
+            "git-veteran",
             "git-overlay",
             "agent",
             "daemon",

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -29,6 +29,7 @@ fn help_render_matches_spawned_binary() {
         // Curated topic page + `heddle help <verb>` clap fall-through.
         vec!["help"],
         vec!["help", "advanced"],
+        vec!["help", "git-concepts"],
         vec!["help", "threads"],
         vec!["help", "git-overlay"],
         vec!["help", "status"],
@@ -296,5 +297,63 @@ fn commit_help_explains_intent_alias() {
     assert!(
         help.contains("--intent") && help.contains("WHY"),
         "commit help should explain the deliberate --intent alias: {help}"
+    );
+}
+
+/// heddle#649. Git veterans need one explicit translation page instead of
+/// inferring Heddle's nouns from scattered command help.
+#[test]
+fn git_concepts_topic_maps_git_veteran_terms() {
+    let help = heddle_help(&["help", "git-concepts"]);
+
+    assert!(
+        help.contains("| Git concept | Heddle concept + semantic difference |"),
+        "git-concepts topic should be a two-column concept table: {help}"
+    );
+    for row in [
+        "`git commit`",
+        "Git commit SHA",
+        "`git branch foo`",
+        "`git checkout foo` / `git switch foo`",
+        "`git tag v1.0`",
+        "`git remote add origin <url>`",
+        "`git push` / `git pull`",
+        "`git fetch`",
+        "`git rebase` to catch up",
+    ] {
+        assert!(
+            help.contains(row),
+            "git-concepts topic missing row `{row}`: {help}"
+        );
+    }
+    for heddle in [
+        "heddle commit -m",
+        "heddle start foo",
+        "heddle thread create foo",
+        "heddle thread marker create v1.0",
+        "heddle remote add origin <url>",
+        "heddle push",
+        "heddle pull",
+        "heddle fetch",
+        "heddle sync",
+    ] {
+        assert!(
+            help.contains(heddle),
+            "git-concepts topic missing Heddle mapping `{heddle}`: {help}"
+        );
+    }
+    assert!(
+        help.contains("Reconciliation examples:")
+            && help.contains("heddle start feature/auth --path ../feature-auth")
+            && help.contains("heddle thread marker create v1.0")
+            && help.contains("heddle fetch origin")
+            && help.contains("heddle sync"),
+        "git-concepts topic should include practical reconciliation examples: {help}"
+    );
+
+    let top = heddle_help(&["help"]);
+    assert!(
+        top.contains("heddle help git-concepts"),
+        "main help should link the git concept map from Start here: {top}"
     );
 }


### PR DESCRIPTION
## Summary

- Add `heddle help git-concepts` as a registered help topic for Git-to-Heddle concept mapping.
- Link the topic from the main help start area and from text-mode `heddle adopt` output.
- Add help consistency coverage for the new topic and rendered output path.

Fixes #649

## Validation

- `CARGO_TARGET_DIR=/tmp/heddle-649-target cargo build`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target cargo build --all-features`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target bash scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target cargo test -p heddle-cli`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target cargo clippy -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target scripts/gen-ts-types.sh`
- `CARGO_TARGET_DIR=/tmp/heddle-649-target /tmp/heddle-649-target/debug/heddle doctor docs --all`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783914233&installation_id=132405951&pr_number=688&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F688&signature=459f29e3562a37c87a90361518964bba1a6b178fc7b00bc418c5dfe41f94c908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->