### PR TITLE
Warn on placeholder principal identity

### DIFF
--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -39,6 +39,7 @@ use super::{
     next_action::{NextActionValidationContext, write_full_command_json},
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
+        is_placeholder_principal, placeholder_principal_warning,
         preflight_large_capture_for_compat_commit, resolve_principal,
     },
     thread_cmd::cmd_thread,
@@ -68,6 +69,8 @@ struct CommitCompatOutput {
     included_pending_capture: Option<String>,
     principal: CommitPrincipalOutput,
     agent: Option<CommitAgentOutput>,
+    #[serde(skip)]
+    placeholder_principal_warning: Option<String>,
     next_action: Option<String>,
     next_action_template: Option<ActionTemplate>,
     recommended_action: Option<String>,
@@ -137,6 +140,8 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         return Err(anyhow!(advice));
     }
     let user_config = UserConfig::load_default().unwrap_or_default();
+    let placeholder_principal_warning =
+        placeholder_principal_first_commit_warning(&repo, &user_config)?;
     if let Some(state) = repo.current_state()? {
         let tree = repo.require_tree(&state.tree)?;
         let status = repo.compare_worktree_cached_with_options(
@@ -184,6 +189,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
                     included_pending_capture: Some(state.change_id.short()),
                     principal: state.attribution.principal.into(),
                     agent: state.attribution.agent.map(CommitAgentOutput::from),
+                    placeholder_principal_warning: placeholder_principal_warning.clone(),
                     next_action: commit_next_action(&trust),
                     next_action_template: None,
                     recommended_action: None,
@@ -240,6 +246,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
                 .attribution
                 .agent
                 .map(CommitAgentOutput::from),
+            placeholder_principal_warning: placeholder_principal_warning.clone(),
             next_action: commit_next_action(&trust),
             next_action_template: None,
             recommended_action: None,
@@ -346,6 +353,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             .attribution
             .agent
             .map(CommitAgentOutput::from),
+        placeholder_principal_warning: placeholder_principal_warning.clone(),
         next_action: commit_next_action(&trust),
         next_action_template: None,
         recommended_action: None,
@@ -431,6 +439,10 @@ fn commit_staged_index(
             .attribution
             .agent
             .map(CommitAgentOutput::from),
+        placeholder_principal_warning: placeholder_principal_first_commit_warning(
+            repo,
+            user_config,
+        )?,
         next_action: commit_next_action(&trust),
         next_action_template: None,
         recommended_action: None,
@@ -1214,6 +1226,30 @@ fn git_head_oid(root: &Path) -> Option<String> {
     git.head_id().ok().map(|id| id.to_string())
 }
 
+fn placeholder_principal_first_commit_warning(
+    repo: &Repository,
+    user_config: &UserConfig,
+) -> Result<Option<String>> {
+    if !current_state_is_bootstrap(repo)? {
+        return Ok(None);
+    }
+    let principal = resolve_principal(repo, user_config)?;
+    if is_placeholder_principal(&principal) {
+        return Ok(Some(placeholder_principal_warning(&principal)));
+    }
+    Ok(None)
+}
+
+fn current_state_is_bootstrap(repo: &Repository) -> Result<bool> {
+    let Some(state) = repo.current_state()? else {
+        return Ok(true);
+    };
+    Ok(state
+        .intent
+        .as_deref()
+        .is_none_or(|intent| intent.trim().is_empty()))
+}
+
 fn render_commit_compat(
     output: &CommitCompatOutput,
     json: bool,
@@ -1264,6 +1300,9 @@ fn render_commit_compat(
                 style::bold(&agent.provider),
                 style::dim(&agent.model)
             );
+        }
+        if let Some(warning) = output.placeholder_principal_warning.as_deref() {
+            eprintln!("{}", style::warn(warning));
         }
         if let Some(plan) = &output.git_index {
             println!("Commit scope: {}", commit_scope_text(plan));

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -18,7 +18,10 @@ use super::{
     action_line::print_next,
     checkpoint::create_git_checkpoint,
     git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
-    snapshot::{SnapshotAgentOverrides, create_snapshot},
+    snapshot::{
+        SnapshotAgentOverrides, create_snapshot, is_placeholder_principal,
+        placeholder_principal_warning,
+    },
 };
 use crate::{
     bridge::{
@@ -61,6 +64,8 @@ struct InitOutput {
     principal_source: Option<String>,
     principal: Option<InitPrincipalOutput>,
     principal_recommended_action: Option<String>,
+    #[serde(skip)]
+    placeholder_principal_warning: Option<String>,
     side_effects: Vec<String>,
     message: String,
     next_action: Option<String>,
@@ -414,6 +419,13 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         Some("heddle commit -m \"...\"".to_string())
     };
     let principal_status = init_principal_status(&repo, &user_config)?;
+    let placeholder_principal_warning = principal_status
+        .principal
+        .as_ref()
+        .map(|principal| Principal::new(&principal.name, &principal.email))
+        .filter(is_placeholder_principal)
+        .map(|principal| placeholder_principal_warning(&principal));
+
     let output = InitOutput {
         output_kind: "init",
         status: "initialized".to_string(),
@@ -428,6 +440,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         principal_source: principal_status.source,
         principal: principal_status.principal,
         principal_recommended_action: principal_status.recommended_action,
+        placeholder_principal_warning,
         side_effects: init_side_effects(repo_is_git_overlay, principal_configured),
         message,
         next_action: next_action.clone(),
@@ -472,6 +485,9 @@ fn render_init(output: &InitOutput, json: bool) -> Result<()> {
                     println!("  set with: {action}");
                 }
             }
+        }
+        if let Some(warning) = output.placeholder_principal_warning.as_deref() {
+            eprintln!("{}", style::warn(warning));
         }
         if !output.side_effects.is_empty() {
             println!("Side effects:");

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -1056,6 +1056,21 @@ pub(crate) fn resolve_principal(repo: &Repository, user_config: &UserConfig) -> 
     Ok(principal)
 }
 
+pub(crate) fn is_placeholder_principal(principal: &Principal) -> bool {
+    let name = principal.name.trim();
+    let email = principal.email.trim().to_ascii_lowercase();
+    name.is_empty()
+        || email.is_empty()
+        || (name == "T" && email == "t@e.c")
+        || email.ends_with("@e.c")
+}
+
+pub(crate) fn placeholder_principal_warning(principal: &Principal) -> String {
+    format!(
+        "WARNING: principal attribution looks like a placeholder: {principal}. Set a real identity with `heddle init --principal-name <name> --principal-email <email>`."
+    )
+}
+
 fn is_default_unknown_principal(principal: &Principal) -> bool {
     principal.name.trim().is_empty()
         || principal.email.trim().is_empty()

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -70,6 +70,8 @@ mod output_kind_runtime;
 mod output_mode_no_auto;
 #[path = "cli_integration/perf_core_loop.rs"]
 mod perf_core_loop;
+#[path = "cli_integration/placeholder_identity.rs"]
+mod placeholder_identity;
 #[path = "cli_integration/quickstart.rs"]
 mod quickstart;
 #[path = "cli_integration/realworld_git.rs"]

--- a/crates/cli/tests/cli_integration/placeholder_identity.rs
+++ b/crates/cli/tests/cli_integration/placeholder_identity.rs
@@ -1,0 +1,100 @@
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::heddle_output_with_env;
+
+fn write_user_config(dir: &TempDir, name: &str, email: &str) -> std::path::PathBuf {
+    let config = dir.path().join("user-config.toml");
+    fs::write(
+        &config,
+        format!("[principal]\nname = \"{name}\"\nemail = \"{email}\"\n"),
+    )
+    .expect("write user config");
+    config
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn init_warns_when_user_config_principal_is_placeholder() {
+    let temp = TempDir::new().unwrap();
+    let config = write_user_config(&temp, "T", "t@e.c");
+
+    let output = heddle_output_with_env(
+        &["init"],
+        Some(temp.path()),
+        &[("HEDDLE_CONFIG", config.to_str().unwrap())],
+    )
+    .expect("run init");
+
+    assert!(output.status.success(), "init should warn, not fail");
+    let stderr = stderr(&output);
+    assert!(
+        stderr.contains("WARNING: principal attribution looks like a placeholder")
+            && stderr.contains("T <t@e.c>")
+            && stderr.contains("heddle init --principal-name <name> --principal-email <email>"),
+        "init should explain the placeholder identity and fix: {stderr}"
+    );
+}
+
+#[test]
+fn first_commit_warns_once_when_user_config_principal_is_placeholder() {
+    let temp = TempDir::new().unwrap();
+    let config = write_user_config(&temp, "T", "t@e.c");
+    let env = [("HEDDLE_CONFIG", config.to_str().unwrap())];
+
+    let init = heddle_output_with_env(&["init"], Some(temp.path()), &env).expect("run init");
+    assert!(init.status.success(), "init should succeed");
+
+    fs::write(temp.path().join("one.txt"), "one\n").expect("write first file");
+    let first = heddle_output_with_env(&["commit", "-m", "first"], Some(temp.path()), &env)
+        .expect("run first commit");
+    assert!(first.status.success(), "first commit should warn, not fail");
+    let first_stderr = stderr(&first);
+    assert!(
+        first_stderr.contains("WARNING: principal attribution looks like a placeholder")
+            && first_stderr.contains("T <t@e.c>"),
+        "first commit should warn about placeholder attribution: {first_stderr}"
+    );
+
+    fs::write(temp.path().join("two.txt"), "two\n").expect("write second file");
+    let second = heddle_output_with_env(&["commit", "-m", "second"], Some(temp.path()), &env)
+        .expect("run second commit");
+    assert!(
+        second.status.success(),
+        "second commit should still succeed"
+    );
+    let second_stderr = stderr(&second);
+    assert!(
+        !second_stderr.contains("principal attribution looks like a placeholder"),
+        "later commits should not spam the placeholder warning: {second_stderr}"
+    );
+}
+
+#[test]
+fn real_user_config_principal_does_not_warn_on_init_or_first_commit() {
+    let temp = TempDir::new().unwrap();
+    let config = write_user_config(&temp, "Ada Lovelace", "ada@users.test");
+    let env = [("HEDDLE_CONFIG", config.to_str().unwrap())];
+
+    let init = heddle_output_with_env(&["init"], Some(temp.path()), &env).expect("run init");
+    assert!(init.status.success(), "init should succeed");
+    let init_stderr = stderr(&init);
+    assert!(
+        !init_stderr.contains("principal attribution looks like a placeholder"),
+        "real init identity should not warn: {init_stderr}"
+    );
+
+    fs::write(temp.path().join("file.txt"), "content\n").expect("write file");
+    let commit = heddle_output_with_env(&["commit", "-m", "first"], Some(temp.path()), &env)
+        .expect("run first commit");
+    assert!(commit.status.success(), "commit should succeed");
+    let commit_stderr = stderr(&commit);
+    assert!(
+        !commit_stderr.contains("principal attribution looks like a placeholder"),
+        "real commit identity should not warn: {commit_stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #684

## Summary
- warn during init when the resolved principal looks like a placeholder
- warn on the first user commit when placeholder attribution would be recorded
- add CLI integration coverage for placeholder and real identities

## Tests
- CARGO_TARGET_DIR=/tmp/heddle-684-target cargo test -p heddle-cli --test cli_integration placeholder_identity -- --nocapture
- CARGO_TARGET_DIR=/tmp/heddle-684-target cargo build
- CARGO_TARGET_DIR=/tmp/heddle-684-target cargo build --all-features
- CARGO_TARGET_DIR=/tmp/heddle-684-target bash scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/tmp/heddle-684-target cargo test -p heddle-cli --lib --tests
- CARGO_TARGET_DIR=/tmp/heddle-684-target cargo clippy --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783914251&installation_id=132405951&pr_number=689&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F689&signature=dc16c6d69086e1e7a446c1d1eeca89bab2903356540788f6807662a85a07642a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->