### PR TITLE
Document ActionTemplate fill semantics

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -9,6 +9,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -162,6 +163,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -284,6 +286,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -900,6 +903,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -2077,6 +2081,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -2722,6 +2727,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -3108,6 +3114,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -3714,6 +3721,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -4215,6 +4223,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -4963,6 +4972,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -5548,6 +5558,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -5694,6 +5705,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -6339,6 +6351,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -6501,6 +6514,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -6738,6 +6752,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -7242,6 +7257,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -7897,6 +7913,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -8998,6 +9015,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -10091,6 +10109,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -10975,6 +10994,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -11567,6 +11587,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -12051,6 +12072,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -12609,6 +12631,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -14422,6 +14445,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -15436,6 +15460,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -16393,6 +16418,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -17494,6 +17520,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -18035,6 +18062,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -18646,6 +18674,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -18894,6 +18923,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -19434,6 +19464,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -19957,6 +19988,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -21381,6 +21413,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -21904,6 +21937,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -22427,6 +22461,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -22954,6 +22989,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -23183,6 +23219,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -24110,6 +24147,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -24822,6 +24860,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -25007,6 +25046,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -25236,6 +25276,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {
@@ -25395,6 +25436,7 @@
               "type": "string"
             },
             "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
               "type": "boolean"
             },
             "argv_template": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -24,6 +24,7 @@ export interface AbortSchema {
 
 export interface ActionTemplateSchema {
   action: string;
+  /** Whether an agent may replace placeholders in `argv_template`. When `agent_may_fill` is false, treat `action` and `argv_template` as display-only: do not substitute `<name>`/`<url>` placeholders. Surface the template to a human or discard it. Substituting and running it will pass literal `<name>` to Heddle and fail. */
   agent_may_fill: boolean;
   argv_template: string[];
   required_inputs: string[];

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -137,6 +137,12 @@ pub struct ActionTemplate {
     pub action: String,
     pub argv_template: Vec<String>,
     pub required_inputs: Vec<String>,
+    /// Whether an agent may replace placeholders in `argv_template`.
+    ///
+    /// When `agent_may_fill` is false, treat `action` and `argv_template` as
+    /// display-only: do not substitute `<name>`/`<url>` placeholders. Surface
+    /// the template to a human or discard it. Substituting and running it will
+    /// pass literal `<name>` to Heddle and fail.
     pub agent_may_fill: bool,
 }
 

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -2129,6 +2129,12 @@ pub struct ActionTemplateSchema {
     pub action: String,
     pub argv_template: Vec<String>,
     pub required_inputs: Vec<String>,
+    /// Whether an agent may replace placeholders in `argv_template`.
+    ///
+    /// When `agent_may_fill` is false, treat `action` and `argv_template` as
+    /// display-only: do not substitute `<name>`/`<url>` placeholders. Surface
+    /// the template to a human or discard it. Substituting and running it will
+    /// pass literal `<name>` to Heddle and fail.
     pub agent_may_fill: bool,
 }
 
@@ -3153,6 +3159,33 @@ mod tests {
                 "status schema missing property '{required}'"
             );
         }
+    }
+
+    #[test]
+    fn action_template_agent_may_fill_schema_describes_false_semantics() {
+        let schema = schema_for_verb("verify").expect("verify schema");
+        let action_template = schema
+            .get("$defs")
+            .or_else(|| schema.get("definitions"))
+            .and_then(|defs| defs.get("ActionTemplateSchema"))
+            .expect("verify schema includes ActionTemplateSchema definition");
+        let description = property_schema(action_template, "agent_may_fill")
+            .get("description")
+            .and_then(Value::as_str)
+            .expect("agent_may_fill schema description is present");
+
+        assert!(
+            description.contains("When `agent_may_fill` is false"),
+            "agent_may_fill schema description must document false semantics: {description}"
+        );
+        assert!(
+            description.contains("display-only"),
+            "agent_may_fill schema description must warn agents not to execute display-only templates: {description}"
+        );
+        assert!(
+            description.contains("do not substitute `<name>`/`<url>` placeholders"),
+            "agent_may_fill schema description must prohibit placeholder substitution when false: {description}"
+        );
     }
 
     /// HeddleCo/heddle#645 conformance: the action-field presence contract.

--- a/crates/cli/tests/snapshots/agent_api_schema.json
+++ b/crates/cli/tests/snapshots/agent_api_schema.json
@@ -7,6 +7,7 @@
             "type": "string"
           },
           "agent_may_fill": {
+            "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
             "type": "boolean"
           },
           "argv_template": {
@@ -596,6 +597,7 @@
             "type": "string"
           },
           "agent_may_fill": {
+            "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
             "type": "boolean"
           },
           "argv_template": {

--- a/docs/VERIFICATION_STATE_LOGIC_MAP.md
+++ b/docs/VERIFICATION_STATE_LOGIC_MAP.md
@@ -29,8 +29,12 @@ Target rows describe the next model and must not be cited as shipped behavior.
 - `recommended_action` is human display text. `recommended_action_template` is
   the canonical machine-readable form: `argv_template` is the executable argv
   (always present for a valid action), and `required_inputs`/`agent_may_fill`
-  describe placeholders such as a commit message or thread name. (The always-null
-  `recommended_action_argv` sidecar was dropped — see HeddleCo/heddle#254.)
+  describe placeholders such as a commit message or thread name. When
+  `agent_may_fill` is false, treat `action` and `argv_template` as
+  display-only: do not substitute `<name>`/`<url>` placeholders. Surface the
+  template to a human or discard it; substituting and running it will pass
+  literal `<name>` to Heddle and fail. (The always-null `recommended_action_argv`
+  sidecar was dropped - see HeddleCo/heddle#254.)
 
 ## Verification State Dimensions
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -401,7 +401,7 @@ blocked verification state on stdout.
 | `summary` | string | required | Human-sized explanation of the top verification state. |
 | `checks` | array<object> | required | Public checklist rows for Git, Heddle, Mapping, Worktree, Remote, Operation, Machine contract, and Clone. |
 | `recommended_action` | string \| null | required | Display command for the primary next step. `null` when no action is needed. |
-| `recommended_action_template` | object \| null | required | Fillable template for `recommended_action` — `argv_template` (executable argv, current Heddle executable path as argv[0]), `required_inputs`, `agent_may_fill`. Present for every valid action; `null` only when the display command is null. The canonical machine-readable action shape — the always-null `_argv` sidecar was dropped (HeddleCo/heddle#254). |
+| `recommended_action_template` | object \| null | required | Fillable template for `recommended_action` — `argv_template` (executable argv, current Heddle executable path as argv[0]), `required_inputs`, `agent_may_fill`. Present for every valid action; `null` only when the display command is null. When `agent_may_fill` is false, treat `action`/`argv_template` as display-only: do not substitute `<name>`/`<url>` placeholders; surface the template to a human or discard it. Substituting and running it will pass literal `<name>` to Heddle and fail. The canonical machine-readable action shape — the always-null `_argv` sidecar was dropped (HeddleCo/heddle#254). |
 | `recovery_commands` | array<string> | required | Display commands for recovery, in priority order. Empty when verified. |
 | `recovery_action_templates` | array<object> | required | Fillable templates mirroring `recovery_commands`. |
 | `checks[].recommended_action_template`, `checks[].recovery_action_templates` | object/array/null | required | Structured fillable action metadata scoped to the check row. |
@@ -2021,7 +2021,7 @@ set should filter the returned `commands` array by `display`, `tier`,
 | `commands[].arguments` | array<object> | required | Public positional arguments local to that command. |
 | `global_options` | array<object> | required | Public global flags accepted across commands. Hidden conditional flags such as `--op-id` are described by per-command fields instead of this broad list. |
 | `recommended_action_placeholders` | array<string> | required | Explicit display-only placeholders that cannot parse directly through Clap until the caller supplies the missing value. |
-| `recommended_action_templates` | array<object> | required | Structured fillable forms for display-only recommended actions. Agents may fill templates only when `agent_may_fill` is true. |
+| `recommended_action_templates` | array<object> | required | Structured fillable forms for display-only recommended actions. Agents may fill templates only when `agent_may_fill` is true. When `agent_may_fill` is false, treat `action`/`argv_template` as display-only: do not substitute `<name>`/`<url>` placeholders; surface the template to a human or discard it. Substituting and running it will pass literal `<name>` to Heddle and fail. |
 
 `command_action` is the per-command action contract. For example, `push`
 advertises executable argv `["/path/to/heddle", "push"]`, while `adopt`
@@ -2029,7 +2029,8 @@ advertises the fillable template `["/path/to/heddle", "adopt", "--ref",
 "<branch>"]` and `merge` advertises `["/path/to/heddle", "merge",
 "<thread>", "--preview"]`.
 Agents should execute `argv` directly and fill `template.argv_template`
-only when they can supply every `required_inputs` value.
+only when they can supply every `required_inputs` value and
+`agent_may_fill` is true.
 
 Op-id behavior is deliberately split so agents can avoid assuming more
 than the command provides:
@@ -2991,7 +2992,7 @@ without scraping freeform text.
 | `would_change` | string | required | What could be lost, duplicated, or changed by proceeding blindly. |
 | `preserved` | string | required | What Heddle preserved or left untouched before failing. |
 | `primary_command` | string | required | Main recovery/inspection command. |
-| `primary_command_template` | object \| null | required | Fillable template (`argv_template`/`required_inputs`/`agent_may_fill`) for `primary_command`. The canonical machine-readable shape; the always-null `_argv` sidecar was dropped (HeddleCo/heddle#254). |
+| `primary_command_template` | object \| null | required | Fillable template (`argv_template`/`required_inputs`/`agent_may_fill`) for `primary_command`. When `agent_may_fill` is false, treat `action`/`argv_template` as display-only: do not substitute `<name>`/`<url>` placeholders; surface the template to a human or discard it. Substituting and running it will pass literal `<name>` to Heddle and fail. The canonical machine-readable shape; the always-null `_argv` sidecar was dropped (HeddleCo/heddle#254). |
 | `recovery_commands` | array<string> | required | Recovery commands in priority order. |
 | `recovery_action_templates` | array<object> | required | Fillable templates mirroring `recovery_commands`. |
 | `verification` | object | present for `kind: "verify_failed"` | Nested `RepositoryVerificationState` for the blocked `heddle verify` invocation. JSON callers should read this from stderr; blocked `verify` never writes the verification object to stdout. |


### PR DESCRIPTION
## Summary

- document `ActionTemplate.agent_may_fill=false` as display-only semantics in the runtime type and schema mirror
- regenerate checked-in npm schema/type artifacts and agent API schema snapshot so agent-read schemas include the description
- update agent-facing JSON schema docs with the same operational warning

## Validation

- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo test -p heddle-cli action_template_agent_may_fill_schema_describes_false_semantics`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target scripts/gen-ts-types.sh`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target HEDDLE_BLESS_AGENT_API_SCHEMA=1 cargo test -p heddle-cli agent_api_schema_matches_committed_snapshot`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo build --workspace`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo build --workspace --all-features`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo test -p heddle-cli --lib --tests`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo test -p heddle-cli --features git-overlay,native,semantic,zstd --test ts_types_in_sync`
- `/tmp/heddle-651-target/debug/heddle doctor docs --all --output json`
- `/tmp/heddle-651-target/debug/heddle schemas verify | rg -n 'When \`agent_may_fill\` is false|do not substitute \`<name>\`/\`<url>\` placeholders|display-only'`

Note: `CARGO_TARGET_DIR=/tmp/heddle-651-target cargo clippy --workspace --all-targets --all-features -- -D warnings` was also attempted and failed on an unrelated existing `clippy::large_enum_variant` lint in `crates/objects/src/store/mod.rs:56` for `AnyStore` under the optional S3 feature.

Fixes #651

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783914331&installation_id=132405951&pr_number=690&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F690&signature=31eec69c34670198525f09da71c8155d41a520017a5b41b7d65227a9cc5ea9ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->