### PR TITLE
Polish npm client executor errors

### DIFF
--- a/clients/npm/src/errors.ts
+++ b/clients/npm/src/errors.ts
@@ -73,8 +73,7 @@ export class HeddleError extends Error {
     const { verb, exitCode, stdout, stderr, envelope } = args;
     const message =
       envelope?.error ??
-      stderr.trim() ??
-      `heddle ${verb} exited with code ${exitCode}`;
+      stderr.trim();
     super(message || `heddle ${verb} exited with code ${exitCode}`);
     this.name = "HeddleError";
     this.verb = verb;

--- a/clients/npm/src/executor.ts
+++ b/clients/npm/src/executor.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { HeddleError, HeddleExitCode } from "./errors.js";
+
+const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 
 /**
  * One CLI invocation, transport-neutral. The `verb` is the canonical
@@ -72,6 +75,12 @@ export interface SpawnExecutorOptions {
   cwd?: string | undefined;
   /** Extra environment overlaid on `process.env`. */
   env?: Record<string, string> | undefined;
+  /**
+   * Maximum buffered stdout + stderr per invocation. Defaults to 64 MiB:
+   * high enough for large JSON envelopes/diffs, but finite so a bad verb or
+   * unexpected stream cannot grow the Node process without bound.
+   */
+  maxOutputBytes?: number | undefined;
 }
 
 /**
@@ -84,12 +93,14 @@ export class SpawnExecutor implements Executor {
   private readonly repoPath: string | undefined;
   private readonly cwd: string | undefined;
   private readonly env: Record<string, string> | undefined;
+  private readonly maxOutputBytes: number;
 
   constructor(options: SpawnExecutorOptions = {}) {
     this.binaryPath = options.binaryPath ?? "heddle";
     this.repoPath = options.repoPath;
     this.cwd = options.cwd;
     this.env = options.env;
+    this.maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
   }
 
   exec(req: ExecRequest): Promise<ExecResult> {
@@ -104,10 +115,33 @@ export class SpawnExecutor implements Executor {
       const child = spawn(this.binaryPath, argv, spawnOptions);
       const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
-      child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
-      child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
-      child.on("error", reject);
+      let totalOutputBytes = 0;
+      let settled = false;
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        reject(err);
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGTERM");
+        }
+      };
+      const collect = (stream: "stdout" | "stderr", chunk: Buffer) => {
+        totalOutputBytes += chunk.byteLength;
+        if (totalOutputBytes > this.maxOutputBytes) {
+          fail(this.outputTooLargeError(req.verb, totalOutputBytes));
+          return;
+        }
+        if (stream === "stdout") stdout.push(chunk);
+        else stderr.push(chunk);
+      };
+      child.stdout?.on("data", (chunk: Buffer) => collect("stdout", chunk));
+      child.stderr?.on("data", (chunk: Buffer) => collect("stderr", chunk));
+      child.on("error", (err: Error) => {
+        fail(this.spawnError(req.verb, err));
+      });
       child.on("close", (code, signal) => {
+        if (settled) return;
+        settled = true;
         resolve({
           // A signal kill reports `code === null`; surface 128+signal-ish
           // as a generic IO failure so callers still get a non-zero code.
@@ -129,11 +163,23 @@ export class SpawnExecutor implements Executor {
 
     const child = spawn(this.binaryPath, argv, spawnOptions);
     const stderr: Buffer[] = [];
-    child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+    let totalOutputBytes = 0;
+    let streamFailure: HeddleError | undefined;
+    const trackOutput = (bytes: number) => {
+      totalOutputBytes += bytes;
+      if (totalOutputBytes > this.maxOutputBytes) {
+        streamFailure = this.outputTooLargeError(req.verb, totalOutputBytes);
+        child.kill("SIGTERM");
+      }
+    };
+    child.stderr?.on("data", (chunk: Buffer) => {
+      trackOutput(chunk.byteLength);
+      if (!streamFailure) stderr.push(chunk);
+    });
     const childExit = this.waitForExit(child);
-    let spawnError: Error | undefined;
+    let spawnError: HeddleError | undefined;
     child.on("error", (err: Error) => {
-      spawnError = err;
+      spawnError = this.spawnError(req.verb, err);
     });
 
     const stdoutLines: string[] = [];
@@ -144,6 +190,8 @@ export class SpawnExecutor implements Executor {
         // readline yields each line as it arrives on stdout — the loop
         // produces values during the child's lifetime, not after exit.
         for await (const line of rl) {
+          trackOutput(Buffer.byteLength(line, "utf8") + 1);
+          if (streamFailure) throw streamFailure;
           stdoutLines.push(line);
           yield line;
         }
@@ -157,6 +205,7 @@ export class SpawnExecutor implements Executor {
 
     const exitCode = await childExit;
 
+    if (streamFailure) throw streamFailure;
     if (spawnError) throw spawnError;
     if (exitCode !== 0) {
       throw new ExecStreamError({
@@ -210,5 +259,59 @@ export class SpawnExecutor implements Executor {
     } finally {
       clearTimeout(killTimer);
     }
+  }
+
+  private spawnError(verb: string, err: Error): HeddleError {
+    const nodeCode = typeof (err as NodeJS.ErrnoException).code === "string"
+      ? (err as NodeJS.ErrnoException).code
+      : undefined;
+    const kind = nodeCode === "ENOENT"
+      ? "binary_not_found"
+      : nodeCode === "EACCES"
+        ? "binary_not_executable"
+        : "spawn_failed";
+    return new HeddleError({
+      verb,
+      exitCode: HeddleExitCode.IoErr,
+      stdout: "",
+      stderr: err.message,
+      envelope: {
+        error: err.message,
+        exit_code: HeddleExitCode.IoErr,
+        hint: nodeCode === "ENOENT"
+          ? "Install heddle or pass binaryPath to the Heddle client."
+          : "Check that the heddle binary can be executed.",
+        kind,
+        preserved: "no repository objects, refs, metadata, or worktree files were changed",
+        primary_command: "heddle --version",
+        primary_command_template: null,
+        recovery_action_templates: [],
+        recovery_commands: ["heddle --version"],
+        unsafe_condition: `the client could not start the heddle binary`,
+        would_change: "the command did not start",
+      },
+    });
+  }
+
+  private outputTooLargeError(verb: string, bytes: number): HeddleError {
+    return new HeddleError({
+      verb,
+      exitCode: HeddleExitCode.IoErr,
+      stdout: "",
+      stderr: `heddle ${verb} exceeded buffered output limit of ${this.maxOutputBytes} bytes`,
+      envelope: {
+        error: `heddle ${verb} exceeded buffered output limit of ${this.maxOutputBytes} bytes`,
+        exit_code: HeddleExitCode.IoErr,
+        hint: "Use a narrower query or a streaming API for unbounded output.",
+        kind: "output_too_large",
+        preserved: "no buffered output beyond the configured client limit was retained",
+        primary_command: `heddle ${verb}`,
+        primary_command_template: null,
+        recovery_action_templates: [],
+        recovery_commands: [],
+        unsafe_condition: `the invocation emitted ${bytes} bytes, above the client buffer limit`,
+        would_change: "continuing to buffer output could exhaust the Node process memory",
+      },
+    });
   }
 }

--- a/clients/npm/test/fixtures/generate-output.cjs
+++ b/clients/npm/test/fixtures/generate-output.cjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const size = Number(process.argv.at(-1) ?? 0);
+process.stdout.write("x".repeat(size));

--- a/clients/npm/test/heddle.test.ts
+++ b/clients/npm/test/heddle.test.ts
@@ -2,6 +2,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { Heddle, HeddleError, HeddleStreamingVerbError, ExecStreamError, type Executor, type ExecRequest, type ExecResult } from "../src/index.js";
 import type { StatusSchema, WatchLineSchema } from "../generated/heddle-schemas.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 /** A deterministic in-memory executor — proves the parsing/error seam works
  *  without building or spawning the real binary. The real-binary smoke test
@@ -257,6 +259,26 @@ test("real-binary smoke test", { skip: !process.env["HEDDLE_BIN"] }, async () =>
   assert.ok(schemas, "schemas payload should parse");
 });
 
+test("real-binary error envelope maps status outside a repo", { skip: !process.env["HEDDLE_BIN"] }, async () => {
+  const nonRepo = await mkdtemp(join(tmpdir(), "heddle-npm-client-"));
+  try {
+    const heddle = new Heddle({
+      binaryPath: process.env["HEDDLE_BIN"],
+      cwd: nonRepo,
+    });
+    await assert.rejects(
+      () => heddle.status(),
+      (err: unknown) => {
+        assert.ok(err instanceof HeddleError);
+        assert.equal(err.code, "repository_not_found");
+        return true;
+      },
+    );
+  } finally {
+    await rm(nonRepo, { recursive: true, force: true });
+  }
+});
+
 // --- SpawnExecutor regression tests (codex catch-up findings, 2026-06-12) ---
 
 import { SpawnExecutor } from "../src/index.js";
@@ -264,6 +286,7 @@ import { join } from "node:path";
 
 const ECHO_ARGV = join(process.cwd(), "test", "fixtures", "echo-argv.cjs");
 const STREAM_FOREVER = join(process.cwd(), "test", "fixtures", "stream-forever.cjs");
+const GENERATE_OUTPUT = join(process.cwd(), "test", "fixtures", "generate-output.cjs");
 
 test("buildArgv puts global flags before verb tokens (value-taking verb flags)", async () => {
   // Regression: `thread marker delete --prefix` ends in a value-taking flag; with
@@ -281,9 +304,36 @@ test("buildArgv puts global flags before verb tokens (value-taking verb flags)",
     "--output", "json",
     "-C", "/repos/demo",
     "--op-id", "op-9",
-    "marker", "delete", "--prefix",
+    "thread", "marker", "delete", "--prefix",
     "foo",
   ]);
+});
+
+test("missing heddle binary rejects as a typed HeddleError", async () => {
+  const heddle = new Heddle({ binaryPath: "heddle-definitely-not-on-path-for-test" });
+  await assert.rejects(
+    () => heddle.status(),
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.exitCode, 74);
+      assert.equal(err.code, "binary_not_found");
+      assert.equal(err.retryable, false);
+      return true;
+    },
+  );
+});
+
+test("SpawnExecutor rejects when buffered output exceeds the configured cap", async () => {
+  const exec = new SpawnExecutor({ binaryPath: GENERATE_OUTPUT, maxOutputBytes: 8 });
+  await assert.rejects(
+    () => exec.exec({ verb: "status", args: ["16"] }),
+    (err: unknown) => {
+      assert.ok(err instanceof HeddleError);
+      assert.equal(err.exitCode, 74);
+      assert.equal(err.code, "output_too_large");
+      return true;
+    },
+  );
 });
 
 test("execStream kills the child when the consumer stops early", async () => {


### PR DESCRIPTION
Fixes #632

## Summary
- Wrap spawn-level failures in typed HeddleError envelopes for missing/unexecutable binaries
- Add a 64 MiB SpawnExecutor output cap with typed output_too_large failures
- Pin the real-binary status error envelope path against repository_not_found

## Verification
- npm test
- npm run typecheck
- HEDDLE_BIN=/home/heddleco/dev/HeddleCo/workspace/issue-632/target/debug/heddle npm test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783918039&installation_id=132405951&pr_number=691&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F691&signature=fd60cce8b7e55c1c285fcc1a43dc8d36ef19b7fd646163b296a6323450950db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->