### PR TITLE
Expose hidden flags in command catalog

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -1109,8 +1109,7 @@ pub struct PullArgs {
 Behavior:
   Git-overlay clones land on the remote's default branch; Heddle remotes check out `main` (pass --thread to pick another). --depth N limits history on Heddle remotes only. Never prompts. Full details: `heddle help clone`.
 
-Advanced (hidden) flags:
-  --lazy and --filter blob:none skip blob content and hydrate it on demand. Hosted/network Heddle remotes only; Git-overlay clones (plain `https://…/repo.git` URLs and local-path clones) reject them today — lazy hydration over the Git transport is planned for v0.3.1.
+Advanced/planned flags: see `heddle help clone`.
 
 Examples:
   heddle clone https://example.com/repo.git ./clone   # Git repo: lands on the remote's default branch

--- a/crates/cli/src/cli/commands/command_catalog.rs
+++ b/crates/cli/src/cli/commands/command_catalog.rs
@@ -122,6 +122,7 @@ pub struct CommandCatalogOption {
     pub help: Option<String>,
     pub required: bool,
     pub global: bool,
+    pub hidden: bool,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -2827,7 +2828,7 @@ pub fn build_command_catalog() -> CommandCatalogOutput {
     let command = Cli::command();
     let mut global_options: Vec<_> = command
         .get_arguments()
-        .filter(|arg| arg.is_global_set() && should_catalog_global_option(arg))
+        .filter(|arg| arg.is_global_set())
         .map(catalog_option)
         .collect();
     if !command.is_disable_help_flag_set() {
@@ -2935,7 +2936,7 @@ fn catalog_entry(
 ) -> CommandCatalogEntry {
     let mut options = Vec::new();
     let mut arguments = Vec::new();
-    for arg in command.get_arguments().filter(|arg| !arg.is_hide_set()) {
+    for arg in command.get_arguments() {
         if arg.get_long().is_some() || arg.get_short().is_some() {
             options.push(catalog_option(arg));
         } else {
@@ -3219,10 +3220,6 @@ fn clean_catalog_summary(summary: String) -> String {
     }
 }
 
-fn should_catalog_global_option(arg: &clap::Arg) -> bool {
-    !arg.is_hide_set()
-}
-
 fn side_effect_class(contract: CommandContract) -> &'static str {
     if contract.observe_only {
         "observe_only"
@@ -3371,6 +3368,7 @@ fn catalog_option(arg: &clap::Arg) -> CommandCatalogOption {
         help: arg.get_help().map(|help| help.to_string()),
         required: arg.is_required_set(),
         global: arg.is_global_set(),
+        hidden: arg.is_hide_set(),
     }
 }
 
@@ -3387,6 +3385,7 @@ fn generated_help_option() -> CommandCatalogOption {
         help: Some("Print help".to_string()),
         required: false,
         global: true,
+        hidden: false,
     }
 }
 
@@ -5529,6 +5528,83 @@ mod tests {
                 "`{display}` must advertise its streaming JSON contract"
             );
         }
+    }
+
+    #[test]
+    fn hidden_clap_flags_are_present_in_machine_catalog() {
+        fn walk_clap_hidden_flags(
+            command: &clap::Command,
+            path: &mut Vec<String>,
+            hidden_flags: &mut Vec<(String, String)>,
+        ) {
+            let display = path.join(" ");
+            for arg in command.get_arguments() {
+                if !arg.is_hide_set() {
+                    continue;
+                }
+                if arg.get_long().is_some() || arg.get_short().is_some() {
+                    hidden_flags.push((display.clone(), arg.get_id().as_str().to_string()));
+                }
+            }
+
+            for subcommand in command.get_subcommands() {
+                path.push(subcommand.get_name().to_string());
+                walk_clap_hidden_flags(subcommand, path, hidden_flags);
+                path.pop();
+            }
+        }
+
+        let clap = Cli::command();
+        let catalog = build_command_catalog();
+        let mut hidden_flags = Vec::new();
+        walk_clap_hidden_flags(&clap, &mut Vec::new(), &mut hidden_flags);
+
+        let mut failures = Vec::new();
+        for (display, id) in hidden_flags {
+            if display.is_empty() {
+                let Some(option) = catalog.global_options.iter().find(|option| option.id == id)
+                else {
+                    failures.push(format!("global hidden flag `{id}` missing from catalog"));
+                    continue;
+                };
+                if !option.hidden {
+                    failures.push(format!(
+                        "global hidden flag `{id}` is cataloged but hidden=false"
+                    ));
+                }
+                continue;
+            }
+
+            let Some(entry) = catalog.command_by_display(&display) else {
+                if command_contract_removed_alias_root(
+                    display.split_whitespace().next().unwrap_or(""),
+                ) {
+                    continue;
+                }
+                failures.push(format!(
+                    "{display}: hidden flag `{id}` command missing from catalog"
+                ));
+                continue;
+            };
+            let Some(option) = entry.options.iter().find(|option| option.id == id) else {
+                failures.push(format!(
+                    "{display}: hidden flag `{id}` missing from catalog options"
+                ));
+                continue;
+            };
+            if !option.hidden {
+                failures.push(format!(
+                    "{display}: hidden flag `{id}` is cataloged but hidden=false"
+                ));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "every clap `hide = true` flag must remain machine-discoverable in \
+             `heddle help --output json` with `hidden: true`:\n  {}",
+            failures.join("\n  ")
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/help.rs
+++ b/crates/cli/src/cli/help.rs
@@ -569,8 +569,9 @@ and clones full history.
 Depth controls history extent only — how many states the clone fetches —
 and says nothing about object contents. Whether a state's blobs are
 present locally or fetched lazily is a separate concern that `--depth`
-never governs (see the hidden `--lazy` / `--filter blob:none` flags in
-`heddle clone --help`; hosted/network Heddle remotes only).
+never governs. Advanced/planned flags `--lazy` and `--filter blob:none`
+skip blob content and hydrate it on demand for hosted/network Heddle
+remotes; local and Git-overlay clone paths reject them today.
 
 See `heddle help threads` for the thread model and `heddle help remotes`
 for remote management.
@@ -1300,7 +1301,7 @@ mod tests {
         // The trim must not cost discoverability: the hidden-flag
         // affordance and the deep-dive breadcrumb both survive.
         assert!(
-            help.contains("Advanced (hidden) flags:"),
+            help.contains("Advanced/planned flags: see `heddle help clone`."),
             "clone --help keeps the hidden-flags affordance: {help}"
         );
         assert!(
@@ -1431,8 +1432,9 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
             let after_lower = after_help.to_lowercase();
-            let breadcrumb_marker =
-                after_lower.contains("hidden") || after_lower.contains("advanced flag");
+            let breadcrumb_marker = after_lower.contains("hidden")
+                || after_lower.contains("advanced flag")
+                || after_lower.contains("advanced/planned flags");
             let points_at_reveal =
                 after_help.contains("heddle help ") || after_help.contains("--help-agent");
 

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -198,20 +198,19 @@ fn capture_help_keeps_help_agent_hidden_but_keeps_the_pointer() {
 }
 
 /// heddle#646. The hidden `--lazy`/`--filter` clone flags need a discovery
-/// affordance: a git veteran who knows `git clone --filter` must be able to
-/// learn from `clone --help` that the flags exist, where they work today
-/// (hosted/network remotes), and the Git-transport timeline (v0.3.1) —
-/// before a failure teaches them.
+/// affordance without bloating first-run help: human `clone --help` carries a
+/// one-line breadcrumb to the topic, while the machine catalog names the
+/// hidden flags.
 #[test]
 fn clone_help_carries_hidden_flag_breadcrumb() {
     let help = heddle_help(&["clone", "--help"]);
     assert!(
-        help.contains("--lazy") && help.contains("--filter blob:none"),
-        "clone help should name the hidden lazy/filter flags: {help}"
+        help.contains("Advanced/planned flags: see `heddle help clone`."),
+        "clone help should point to the advanced/planned flag topic: {help}"
     );
     assert!(
-        help.contains("planned for v0.3.1"),
-        "clone help should state the Git-transport timeline for lazy clones: {help}"
+        !help.contains("--lazy") && !help.contains("--filter"),
+        "clone help should keep hidden flags out of the human options/body: {help}"
     );
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8137,17 +8137,14 @@ fn advanced_help_does_not_repeat_everyday_human_path() {
     );
 
     let clone_help = heddle_help(&["clone", "--help"]);
-    let (clone_first_run, clone_breadcrumb) = clone_help
-        .split_once("Advanced (hidden) flags:")
-        .expect("clone help carries the advanced-flags breadcrumb (heddle#646)");
+    assert!(
+        clone_help.contains("Advanced/planned flags: see `heddle help clone`."),
+        "clone help carries the advanced/planned flags breadcrumb (heddle#646): {clone_help}"
+    );
     for hidden in ["--lazy", "--filter", "v0.3.1", "blob:none"] {
         assert!(
-            !clone_first_run.contains(hidden),
+            !clone_help.contains(hidden),
             "clone help should not lead with planned partial-clone machinery: {clone_help}"
-        );
-        assert!(
-            clone_breadcrumb.contains(hidden),
-            "clone help's advanced-flags breadcrumb should name `{hidden}`: {clone_help}"
         );
     }
 
@@ -8894,8 +8891,10 @@ fn command_catalog_exposes_public_surface_for_agents() {
             .as_array()
             .unwrap()
             .iter()
-            .all(|option| option["long"] != "op-id" && option["id"] != "op_id"),
-        "catalog should not imply --op-id is accepted by every command; use per-command op_id_behavior: {json}"
+            .any(|option| option["long"] == "op-id"
+                && option["id"] == "op_id"
+                && option["hidden"] == true),
+        "catalog should expose hidden global --op-id as machine metadata; use per-command op_id_behavior for acceptance: {json}"
     );
     let commit = commands
         .iter()
@@ -8906,7 +8905,9 @@ fn command_catalog_exposes_public_surface_for_agents() {
             .as_array()
             .unwrap()
             .iter()
-            .any(|option| option["long"] == "op-id" && option["global"] == true),
+            .any(|option| option["long"] == "op-id"
+                && option["global"] == true
+                && option["hidden"] == true),
         "op-id capable commands should expose --op-id as a per-command option: {commit}"
     );
     let status = commands

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -463,21 +463,18 @@ fn test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged() {
 }
 
 /// heddle#646: the planned lazy/partial-clone flags stay `hide = true`
-/// (out of the options list) but are named once in the after-help
-/// "Advanced (hidden) flags" breadcrumb so they're discoverable.
+/// (out of the human options list), and human help carries a one-line
+/// breadcrumb to the detailed topic.
 #[test]
 fn test_cli_clone_help_keeps_planned_lazy_flag_to_breadcrumb() {
     let output = heddle_help(&["clone", "--help"]);
-    let (first_run, breadcrumb) = output
-        .split_once("Advanced (hidden) flags:")
-        .expect("clone help carries the advanced-flags breadcrumb (heddle#646)");
     assert!(
-        !first_run.contains("--lazy") && !first_run.contains("--filter"),
-        "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
+        output.contains("Advanced/planned flags: see `heddle help clone`."),
+        "clone help carries the advanced/planned flags breadcrumb: {output}"
     );
     assert!(
-        breadcrumb.contains("--lazy") && breadcrumb.contains("--filter"),
-        "clone help's breadcrumb should name the hidden lazy/filter flags: {output}"
+        !output.contains("--lazy") && !output.contains("--filter"),
+        "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
     );
 }
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2017,9 +2017,9 @@ set should filter the returned `commands` array by `display`, `tier`,
 | `commands[].json_kind` | string | required | JSON output class (`json`, `jsonl`, `json_or_jsonl`, or `none`). |
 | `commands[].schema_verbs` | array<string> | required | Runtime schema verb(s) registered for this command. |
 | `commands[].documented_schema_verbs` | array<string> | required | Schema verb(s) checked against samples in this document. |
-| `commands[].options` | array<object> | required | Public flags/options local to that command. |
+| `commands[].options` | array<object> | required | Flags/options local to that command, including hidden advanced or plumbing flags marked with `hidden: true`. |
 | `commands[].arguments` | array<object> | required | Public positional arguments local to that command. |
-| `global_options` | array<object> | required | Public global flags accepted across commands. Hidden conditional flags such as `--op-id` are described by per-command fields instead of this broad list. |
+| `global_options` | array<object> | required | Global flags accepted across commands, including hidden globals marked with `hidden: true`. Conditional behavior such as `--op-id` support is still described by per-command fields. |
 | `recommended_action_placeholders` | array<string> | required | Explicit display-only placeholders that cannot parse directly through Clap until the caller supplies the missing value. |
 | `recommended_action_templates` | array<object> | required | Structured fillable forms for display-only recommended actions. Agents may fill templates only when `agent_may_fill` is true. |
 


### PR DESCRIPTION
Fixes #646

## Summary
- include hidden clap options in the machine command catalog with `hidden: true`
- add a one-line clone help breadcrumb to `heddle help clone` while keeping hidden flags out of human option lists
- add a conformance test that walks clap hidden flags and fails if the catalog omits them or marks them visible
- document the command catalog option/global option contract update

## Validation
- `cargo build --workspace`
- `cargo build --workspace --all-features`
- `scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-cli --lib --tests`
- `scripts/gen-ts-types.sh` (no generated diff; catalog output schema is documented, not part of generated per-verb schema bundle)
- `cargo clippy --workspace -- -D warnings`
- `cargo run -p heddle-cli --bin heddle -- doctor docs --all`

## Note
- `cargo clippy --workspace --all-features -- -D warnings` currently fails on an existing `clippy::large_enum_variant` lint for `AnyStore` under the `s3` feature in `crates/objects/src/store/mod.rs`, unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783919224&installation_id=132405951&pr_number=693&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F693&signature=3f560e51b5a8e4298f277e11aa3df4b0c7ba7b14eb1757152e46b870e51a3f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->