### PR TITLE
[codex] Fix git object size truncation

### DIFF
--- a/crates/cli/src/bridge/git_notes.rs
+++ b/crates/cli/src/bridge/git_notes.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![deny(clippy::cast_possible_truncation)]
+
 //! Git notes attached at `refs/notes/heddle` carry Heddle state metadata
 //! (change_id, agent, confidence, status) without polluting the commit
 //! message — and so without changing the commit SHA.
@@ -345,10 +347,10 @@ pub fn read_all_notes(repo: &gix::Repository) -> GitResult<HashMap<ObjectId, Hed
 }
 
 fn bridge_notes_signature() -> gix::actor::Signature {
-    let seconds = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
+    let seconds = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    };
     gix::actor::Signature {
         name: "Heddle".into(),
         email: "heddle@local".into(),

--- a/crates/cli/src/bridge/git_reconstruct.rs
+++ b/crates/cli/src/bridge/git_reconstruct.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![deny(clippy::cast_possible_truncation)]
+
 //! Byte-exact git commit object serialization from a Heddle [`State`] (#566).
 //!
 //! Reconstructs the exact bytes `git cat-file commit <sha>` prints from the
@@ -17,7 +19,7 @@
 
 use gix::hash::ObjectId;
 use objects::object::{Principal, State};
-use objects::store::ObjectStore;
+use objects::store::{ObjectStore, StoreError};
 use repo::Repository as HeddleRepository;
 
 use crate::bridge::git_core::{GitBridge, GitBridgeError, GitResult, SyncMapping, git_err};
@@ -75,7 +77,7 @@ pub fn reconstruct_commit_bytes(
                 .ok_or(GitBridgeError::StateNotFound(*parent))
         })
         .collect::<GitResult<Vec<_>>>()?;
-    Ok(build_commit_content(state, &tree_oid, &parent_oids))
+    build_commit_content(state, &tree_oid, &parent_oids)
 }
 
 /// Frame + write a reconstructed commit object's `content` bytes into `repo`'s
@@ -98,7 +100,11 @@ pub fn write_commit_object(repo: &gix::Repository, content: &[u8]) -> GitResult<
 /// Assemble the commit content bytes from already-resolved OIDs. Pure (no repo,
 /// no mapping) so the byte layout — header order, actor lines, header folding,
 /// verbatim message — is unit-testable in isolation (§1/§2/§5/§6).
-fn build_commit_content(state: &State, tree_oid: &ObjectId, parent_oids: &[ObjectId]) -> Vec<u8> {
+fn build_commit_content(
+    state: &State,
+    tree_oid: &ObjectId,
+    parent_oids: &[ObjectId],
+) -> GitResult<Vec<u8>> {
     let mut out = Vec::new();
 
     // `tree` is always first, exactly once (§1.1).
@@ -125,7 +131,7 @@ fn build_commit_content(state: &State, tree_oid: &ObjectId, parent_oids: &[Objec
         &state.attribution.principal,
         author_seconds,
         state.authored_tz_offset,
-    );
+    )?;
     let committer = state
         .committer
         .as_ref()
@@ -136,7 +142,7 @@ fn build_commit_content(state: &State, tree_oid: &ObjectId, parent_oids: &[Objec
         committer,
         state.created_at.timestamp(),
         state.committer_tz_offset,
-    );
+    )?;
 
     // Extension headers (`encoding`/`gpgsig`/`mergetag`/unknown) at their captured
     // ordinal, multi-line values re-folded (§1.4/§2). The ordered `Vec` is the
@@ -160,7 +166,7 @@ fn build_commit_content(state: &State, tree_oid: &ObjectId, parent_oids: &[Objec
         out.extend_from_slice(message);
     }
 
-    out
+    Ok(out)
 }
 
 /// `<label> <name> <<email>> <unix-seconds> <±HHMM>\n` (§5).
@@ -170,7 +176,8 @@ fn write_actor_line(
     who: &Principal,
     seconds: i64,
     tz_offset_secs: i32,
-) {
+) -> GitResult<()> {
+    let seconds = checked_actor_timestamp(label, seconds, tz_offset_secs)?;
     out.extend_from_slice(label);
     out.push(b' ');
     out.extend_from_slice(who.name.as_bytes());
@@ -181,6 +188,22 @@ fn write_actor_line(
     out.push(b' ');
     out.extend_from_slice(format_tz_offset(tz_offset_secs).as_bytes());
     out.push(b'\n');
+    Ok(())
+}
+
+fn checked_actor_timestamp(label: &[u8], seconds: i64, tz_offset_secs: i32) -> GitResult<i64> {
+    // Git serializes UTC seconds plus a timezone offset. Validate the local
+    // seconds implied by that pair so malformed fidelity data cannot overflow
+    // reconstruct-time timestamp arithmetic.
+    seconds
+        .checked_add(i64::from(tz_offset_secs))
+        .map(|_| seconds)
+        .ok_or_else(|| {
+            let label = String::from_utf8_lossy(label);
+            GitBridgeError::Store(StoreError::InvalidObject(format!(
+                "{label} timestamp {seconds} with timezone offset {tz_offset_secs} overflows i64"
+            )))
+        })
 }
 
 /// Render a timezone offset — stored as **seconds** east of UTC (#565's `i32`
@@ -347,5 +370,34 @@ mod tests {
         assert_eq!(headers.len(), 1);
         assert_eq!(headers[0].0, b"gpgsig");
         assert_eq!(headers[0].1, value);
+    }
+
+    #[test]
+    fn write_actor_line_rejects_overflowing_timestamp_offset_arithmetic() {
+        let principal = Principal::new("A", "a@example.com");
+        let mut out = Vec::new();
+
+        let error = write_actor_line(&mut out, b"author", &principal, i64::MAX, 1)
+            .expect_err("timestamp plus timezone offset must not overflow");
+
+        assert!(
+            matches!(&error, GitBridgeError::Store(StoreError::InvalidObject(message)) if message.contains("overflows i64")),
+            "expected InvalidObject overflow error, got: {error:?}",
+        );
+        assert!(
+            out.is_empty(),
+            "failed actor line must not emit partial bytes"
+        );
+    }
+
+    #[test]
+    fn write_actor_line_valid_timestamp_is_unchanged() {
+        let principal = Principal::new("A", "a@example.com");
+        let mut out = Vec::new();
+
+        write_actor_line(&mut out, b"author", &principal, 1_700_000_000, -8 * 3600)
+            .expect("valid timestamp should serialize");
+
+        assert_eq!(out, b"author A <a@example.com> 1700000000 -0800\n");
     }
 }

--- a/crates/objects/src/store/compression/mod.rs
+++ b/crates/objects/src/store/compression/mod.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![deny(clippy::cast_possible_truncation)]
+
 //! Compression utilities for Heddle storage.
 //!
 //! Provides configurable compression with support for:
@@ -134,10 +136,11 @@ pub fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionEr
 /// Decompress zstd data while enforcing the recorded output size.
 pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
     validate_size(expected_size)?;
+    let expected_capacity = checked_size_to_usize("zstd expected size", expected_size)?;
 
     let mut decoder = zstd::stream::read::Decoder::new(data)
         .map_err(|e| CompressionError::DecompressionFailed(e.to_string()))?;
-    let mut decompressed = Vec::with_capacity(expected_size as usize);
+    let mut decompressed = Vec::with_capacity(expected_capacity);
     let mut buffer = [0u8; 8192];
 
     loop {
@@ -148,7 +151,12 @@ pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, Compr
             break;
         }
 
-        let next_size = (decompressed.len() + bytes_read) as u64;
+        let next_size = decompressed.len().checked_add(bytes_read).ok_or_else(|| {
+            CompressionError::CorruptedData("decompressed size overflows".to_string())
+        })?;
+        let next_size = u64::try_from(next_size).map_err(|_| {
+            CompressionError::CorruptedData("decompressed size exceeds platform limits".to_string())
+        })?;
         if next_size > expected_size {
             return Err(CompressionError::CorruptedData(format!(
                 "decompressed size exceeds recorded header size: expected {expected_size}, got at least {next_size}",
@@ -377,6 +385,8 @@ where
     F: Fn(&[u8]) -> Result<u64, CompressionError>,
 {
     let uncompressed_size = read_size(delta_data)?;
+    let uncompressed_size_usize =
+        checked_size_to_usize("delta uncompressed size", uncompressed_size)?;
 
     if uncompressed_size > MAX_DELTA_OUTPUT_SIZE as u64 {
         return Err(CompressionError::DecompressionFailed(format!(
@@ -386,7 +396,7 @@ where
     }
 
     let delta = &delta_data[header_len..];
-    let decompressed = DeltaDecoder::decode(base, delta, uncompressed_size as usize)
+    let decompressed = DeltaDecoder::decode(base, delta, uncompressed_size_usize)
         .map_err(|error| CompressionError::DecompressionFailed(error.to_string()))?;
     validate_decompressed_len(uncompressed_size, decompressed.len())?;
     Ok(decompressed)
@@ -416,6 +426,12 @@ fn validate_size(size: u64) -> Result<(), CompressionError> {
     }
 
     Ok(())
+}
+
+#[cfg(any(feature = "zstd", test))]
+fn checked_size_to_usize(field: &str, size: u64) -> Result<usize, CompressionError> {
+    usize::try_from(size)
+        .map_err(|_| CompressionError::CorruptedData(format!("{field} exceeds platform limits")))
 }
 
 fn validate_decompressed_len(expected: u64, actual: usize) -> Result<(), CompressionError> {

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![deny(clippy::cast_possible_truncation)]
+
 //! IO helpers for FsStore.
 
 use std::{
@@ -172,7 +174,11 @@ pub(super) fn read_file_header(path: &Path, header_len: usize) -> Result<Option<
 
     let metadata = file.metadata()?;
     let len = metadata.len();
-    let to_read = std::cmp::min(header_len as u64, len) as usize;
+    let to_read = if len > header_len as u64 {
+        header_len
+    } else {
+        checked_file_len_to_usize(len)?
+    };
     let mut header = vec![0u8; to_read];
     if to_read > 0 {
         use std::io::Read as _;
@@ -195,14 +201,14 @@ pub fn read_file_bytes_for_pack(path: &Path) -> Result<Bytes> {
     }
     if len >= MMAP_THRESHOLD_BYTES {
         let mmap = unsafe { memmap2::MmapOptions::new().map(&file)? };
-        if mmap.len() != len as usize {
+        if mmap.len() != checked_file_len_to_usize(len)? {
             return Err(HeddleError::InvalidObject(
                 "pack file size changed during memory mapping".to_string(),
             ));
         }
         return Ok(Bytes::from_owner(mmap));
     }
-    let mut data = Vec::with_capacity(len as usize);
+    let mut data = Vec::with_capacity(checked_file_len_to_usize(len)?);
     let mut reader = file;
     reader.read_to_end(&mut data)?;
     Ok(Bytes::from(data))
@@ -222,7 +228,7 @@ pub(super) fn read_file_bytes(path: &Path) -> Result<Option<FileBytes>> {
     }
     if len >= MMAP_THRESHOLD_BYTES {
         let mmap = unsafe { memmap2::MmapOptions::new().map(&file)? };
-        if mmap.len() != len as usize {
+        if mmap.len() != checked_file_len_to_usize(len)? {
             return Err(crate::store::HeddleError::InvalidObject(
                 "file size changed during memory mapping".to_string(),
             ));
@@ -230,10 +236,16 @@ pub(super) fn read_file_bytes(path: &Path) -> Result<Option<FileBytes>> {
         return Ok(Some(FileBytes::Mmap(mmap)));
     }
 
-    let mut data = Vec::with_capacity(len as usize);
+    let mut data = Vec::with_capacity(checked_file_len_to_usize(len)?);
     let mut reader = file;
     reader.read_to_end(&mut data)?;
     Ok(Some(FileBytes::Vec(data)))
+}
+
+fn checked_file_len_to_usize(len: u64) -> Result<usize> {
+    usize::try_from(len).map_err(|_| {
+        HeddleError::InvalidObject(format!("file length {len} exceeds platform limits"))
+    })
 }
 
 /// List all content hashes from a sharded directory structure (aa/bbcc... → aabbcc...).

--- a/crates/objects/src/store/pack/pack_reader.rs
+++ b/crates/objects/src/store/pack/pack_reader.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use bytes::Bytes;
 
 use super::{
-    decompress_pack_payload, has_zstd_magic, pack_container_spec, pack_index::PackIndex, varint,
-    verify_container, ObjectType, PackObjectId, PackObjectRecord,
+    ObjectType, PackObjectId, PackObjectRecord, decompress_pack_payload, has_zstd_magic,
+    pack_container_spec, pack_index::PackIndex, varint, verify_container,
 };
 use crate::{
     object::ContentHash,
@@ -68,10 +68,7 @@ impl PackReader<'static> {
         })
     }
 
-    pub fn from_bytes(
-        pack_data: impl Into<Bytes>,
-        index_data: impl AsRef<[u8]>,
-    ) -> Result<Self> {
+    pub fn from_bytes(pack_data: impl Into<Bytes>, index_data: impl AsRef<[u8]>) -> Result<Self> {
         let pack_data = pack_data.into();
         let (_, _, content_end) = verify_container(&pack_data, pack_container_spec())?;
         let index = PackIndex::from_bytes(index_data.as_ref())?;
@@ -376,8 +373,16 @@ fn checked_index_offset(offset: u64) -> Result<usize> {
 }
 
 fn checked_decoded_size(field: &str, size: u64) -> Result<usize> {
-    usize::try_from(size)
-        .map_err(|_| StoreError::InvalidObject(format!("Decoded {field} exceeds platform limits")))
+    let size = usize::try_from(size).map_err(|_| {
+        StoreError::InvalidObject(format!("Decoded {field} exceeds platform limits"))
+    })?;
+    if field == "uncompressed_size" && size > super::shared::MAX_PACK_OBJECT_OUTPUT_SIZE {
+        return Err(StoreError::InvalidObject(format!(
+            "Pack object output size {size} exceeds max {}",
+            super::shared::MAX_PACK_OBJECT_OUTPUT_SIZE
+        )));
+    }
+    Ok(size)
 }
 
 fn checked_index_add(start: usize, len: usize, field: &str) -> Result<usize> {
@@ -427,7 +432,7 @@ fn verify_record_id_matches(requested: &PackObjectId, found: &PackObjectId) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::{verify_record_id_matches, PackObjectId, PackReader};
+    use super::{PackObjectId, PackReader, verify_record_id_matches};
     use crate::{object::ContentHash, store::StoreError};
 
     #[test]

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -3,11 +3,11 @@
 
 use tempfile::TempDir;
 
-use super::{pack_index::PackIndex, ObjectType, PackBuilder, PackObjectId, PackReader};
+use super::{ObjectType, PackBuilder, PackObjectId, PackReader, pack_index::PackIndex};
 use crate::{
     delta::MAX_DELTA_OUTPUT_SIZE,
     object::{ChangeId, ContentHash},
-    store::{compression::CompressionConfig, pack::pack_container_spec, StoreError},
+    store::{StoreError, compression::CompressionConfig, pack::pack_container_spec},
 };
 
 fn create_test_hash(n: u8) -> ContentHash {
@@ -144,7 +144,7 @@ fn test_delta_compression() {
 fn test_pack_reader_rejects_compressed_size_that_overflows_record_end() {
     let hash = create_test_hash(42);
     let (pack_data, index_data) = single_record_pack(hash, |record| {
-        super::varint::encode_type_and_size(ObjectType::Blob, u64::MAX, record);
+        super::varint::encode_type_and_size(ObjectType::Blob, 1, record);
         super::varint::encode_varint(u64::MAX, record);
     });
     let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
@@ -172,6 +172,27 @@ fn test_pack_reader_rejects_compressed_size_that_overflows_record_end() {
         ),
         "expected overflow/platform-limit error, got: {bytes_error:?}",
     );
+}
+
+#[test]
+fn test_pack_reader_rejects_uncompressed_size_above_pack_object_limit() {
+    let hash = create_test_hash(48);
+    let (pack_data, index_data) = single_record_pack(hash, |record| {
+        super::varint::encode_type_and_size(ObjectType::Blob, u64::from(u32::MAX) + 1, record);
+        super::varint::encode_varint(1, record);
+        record.push(0);
+    });
+    let reader = PackReader::from_bytes(pack_data, index_data).expect("container is well-formed");
+
+    let error = reader
+        .get_hashed_object(&hash)
+        .expect_err("absurd uncompressed_size must fail before allocation");
+    assert_invalid_object_message_contains(error, "Pack object output size");
+
+    let bytes_error = reader
+        .get_hashed_object_bytes(&hash)
+        .expect_err("zero-copy path must reject absurd uncompressed_size too");
+    assert_invalid_object_message_contains(bytes_error, "Pack object output size");
 }
 
 #[test]
@@ -248,7 +269,8 @@ fn test_pack_reader_rejects_delta_output_above_limit() {
     let index_path = temp_dir.path().join("test.idx");
 
     let target_hash = create_test_hash(9);
-    let oversized = (MAX_DELTA_OUTPUT_SIZE + 1) as u64;
+    let oversized =
+        u64::try_from(MAX_DELTA_OUTPUT_SIZE).expect("MAX_DELTA_OUTPUT_SIZE fits in u64") + 1;
 
     // Build a valid pack with a delta entry whose uncompressed size exceeds the limit
     let mut pack_data = Vec::new();
@@ -258,24 +280,11 @@ fn test_pack_reader_rejects_delta_output_above_limit() {
 
     let entry_offset = pack_data.len() as u64;
 
-    let record = super::PackObjectRecord {
-        id: PackObjectId::Hash(target_hash),
-        obj_type: ObjectType::Blob,
-        data: vec![0],
-        delta_base: Some(PackObjectId::Hash(create_test_hash(1))),
-        path_hint: None,
-    };
-    let mut encoded = Vec::new();
-    super::encode_tagged_entry_parts(
-        &mut encoded,
-        record.id,
-        ObjectType::Delta,
-        oversized as usize,
-        record.delta_base,
-        &[0, b'x'],
-    )
-    .unwrap();
-    pack_data.extend_from_slice(&encoded);
+    PackObjectId::Hash(target_hash).encode_tagged(&mut pack_data);
+    super::varint::encode_type_and_size(ObjectType::Delta, oversized, &mut pack_data);
+    super::varint::encode_varint(2, &mut pack_data);
+    PackObjectId::Hash(create_test_hash(1)).encode_tagged(&mut pack_data);
+    pack_data.extend_from_slice(&[0, b'x']);
 
     let checksum = blake3::hash(&pack_data);
     pack_data.extend_from_slice(checksum.as_bytes());
@@ -503,7 +512,7 @@ fn test_pack_reader_missing_object_returns_none() {
 /// with the expected diagnostic phrase.
 #[test]
 fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
-    use crate::store::{pack::pack_index::PackIndex, StoreError};
+    use crate::store::{StoreError, pack::pack_index::PackIndex};
 
     let blob_a = b"alpha-payload alpha-payload alpha-payload alpha".to_vec();
     let blob_b = b"bravo-payload bravo-payload bravo-payload bravo".to_vec();

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![deny(clippy::cast_possible_truncation)]
+
 use super::{ObjectType, varint};
 use crate::{
     object::{ChangeId, ContentHash},
@@ -192,8 +194,8 @@ pub fn decode_tagged_entry_header(data: &[u8]) -> Result<PackEntryHeader> {
     Ok(PackEntryHeader {
         id,
         obj_type,
-        uncompressed_size: uncompressed_size as usize,
-        compressed_size: compressed_size as usize,
+        uncompressed_size: checked_decoded_size("uncompressed_size", uncompressed_size)?,
+        compressed_size: checked_decoded_size("compressed_size", compressed_size)?,
         delta_base,
         header_len,
     })
@@ -283,11 +285,21 @@ pub fn try_decode_tagged_entry_header(data: &[u8]) -> Result<Option<PackEntryHea
     Ok(Some(PackEntryHeader {
         id,
         obj_type,
-        uncompressed_size: uncompressed_size as usize,
-        compressed_size: compressed_size as usize,
+        uncompressed_size: checked_decoded_size("uncompressed_size", uncompressed_size)?,
+        compressed_size: checked_decoded_size("compressed_size", compressed_size)?,
         delta_base,
         header_len,
     }))
+}
+
+fn checked_decoded_size(field: &str, size: u64) -> Result<usize> {
+    let size = usize::try_from(size).map_err(|_| {
+        StoreError::InvalidObject(format!("Decoded {field} exceeds platform limits"))
+    })?;
+    if field == "uncompressed_size" {
+        reject_pack_object_output_over_limit(size, MAX_PACK_OBJECT_OUTPUT_SIZE)?;
+    }
+    Ok(size)
 }
 
 pub fn compress_pack_payload(data: &[u8], config: &CompressionConfig) -> Result<Vec<u8>> {
@@ -426,5 +438,41 @@ mod tests {
         assert_eq!(decoded.uncompressed_size, 5);
         assert_eq!(decoded.compressed_size, 5);
         assert_eq!(decoded.delta_base, None);
+    }
+
+    #[test]
+    fn tagged_entry_header_rejects_size_that_truncates_on_32_bit() {
+        let mut encoded = Vec::new();
+        PackObjectId::Hash(ContentHash::compute(b"oversized-pack-object"))
+            .encode_tagged(&mut encoded);
+        varint::encode_type_and_size(ObjectType::Blob, u64::from(u32::MAX) + 1, &mut encoded);
+        varint::encode_varint(1, &mut encoded);
+        encoded.push(0);
+
+        let result = decode_tagged_entry_header(&encoded);
+
+        let error = result.expect_err("absurd 32-bit-overflow size must be rejected");
+        assert!(
+            matches!(&error, StoreError::InvalidObject(message) if message.contains("platform limits") || message.contains("Pack object output size")),
+            "expected size-limit InvalidObject, got: {error:?}",
+        );
+    }
+
+    #[test]
+    fn tagged_entry_header_rejects_u64_max_size_when_platform_cannot_represent_it() {
+        let mut encoded = Vec::new();
+        PackObjectId::Hash(ContentHash::compute(b"u64-max-pack-object"))
+            .encode_tagged(&mut encoded);
+        varint::encode_type_and_size(ObjectType::Blob, u64::MAX, &mut encoded);
+        varint::encode_varint(1, &mut encoded);
+        encoded.push(0);
+
+        let result = decode_tagged_entry_header(&encoded);
+
+        let error = result.expect_err("absurd u64::MAX size must be rejected");
+        assert!(
+            matches!(&error, StoreError::InvalidObject(message) if message.contains("platform limits") || message.contains("Pack object output size")),
+            "expected size-limit InvalidObject, got: {error:?}",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #623.

This closes the silent integer-truncation class around git/native pack object sizes and makes reconstruct timestamp arithmetic fallible.

## Changed Cast Sites

- `crates/objects/src/store/pack/shared.rs`: `decode_tagged_entry_header` and `try_decode_tagged_entry_header` now convert decoded `uncompressed_size` and `compressed_size` through `usize::try_from`, returning `InvalidObject` on platform truncation. `uncompressed_size` is also checked against the pack object output cap before any downstream allocation.
- `crates/objects/src/store/pack/pack_reader.rs`: decoded pack `uncompressed_size` / `compressed_size` continue through the reader's checked conversion path, now also rejecting absurd uncompressed output sizes before allocation or zero-copy slicing.
- `crates/objects/src/store/compression/mod.rs`: zstd expected-size capacity and test delta output-size conversion use `usize::try_from`; streaming decompression length growth uses checked arithmetic.
- `crates/objects/src/store/fs/fs_io.rs`: file length conversions for Vec capacity and mmap length comparison use fallible `usize::try_from`.
- `crates/cli/src/bridge/git_notes.rs`: replaced the notes signature `as_secs() as i64` cast with an explicit `i64::try_from` conversion.
- `crates/cli/src/bridge/git_reconstruct.rs`: commit reconstruction now validates actor timestamp plus timezone offset with checked i64 arithmetic and returns `InvalidObject` on overflow.

## Regression Coverage

- Added pack header parser tests for u64 sizes that would truncate on 32-bit and for `u64::MAX` size fields.
- Added a pack reader test that rejects an absurd uncompressed size before allocation in both Vec and zero-copy paths.
- Updated the oversized delta fixture to encode the hostile u64 length directly instead of passing through a `usize` API.
- Added reconstruct tests for overflowing actor timestamp arithmetic and unchanged valid actor-line serialization.
- Enabled module-local `clippy::cast_possible_truncation` denies on the hardened modules that did not flood.

## Validation

- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo run -p heddle-devtools -- check-no-silent-default-tree-load`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`
- Focused regressions for pack header truncation, pack reader absurd uncompressed size, and reconstruct timestamp overflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783923294&installation_id=132405951&pr_number=694&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F694&signature=85b0c6a35ec54d3d738857c83140df96bbf50c46b58e0d78c8e7e67ccd075734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->