### PR TITLE
[codex] Add release_node contract tests

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -2959,8 +2959,9 @@ impl<S: ObjectStore> MountInner<S> {
     /// the per-NodeId lifecycle: decrement the open count carried on
     /// `state[node]`; on the final close of an Orphan, drop bytes
     /// and remove the state entry; on the final close of a Live
-    /// (or untracked) node, promote any hot buffer to warm via
-    /// `flush_node`.
+    /// node, promote any hot buffer to warm via `flush_node`. A
+    /// release for an untracked but real node is a safe no-op; a
+    /// release for an unknown NodeId is rejected with `NotFound`.
     ///
     /// The orphan branch never warm-promotes — an orphan's bytes are
     /// unreachable by path post-T1/T3, so promoting them would leak
@@ -2974,19 +2975,29 @@ impl<S: ObjectStore> MountInner<S> {
             /// is a no-op for Orphan, so the mid-life Orphan case is
             /// also safe to forward.)
             Flush,
-            /// Final close of an Orphan. Bytes were dropped under the
-            /// lock; nothing else to do (no warm promotion — see the
-            /// doc comment above).
-            OrphanFinalDone,
+            /// Final close of an Orphan. Dirty hot bytes must still
+            /// cross the durability boundary before the anonymous
+            /// inode is retired, but they must not be warm-promoted
+            /// into the path-indexed pending tree.
+            OrphanFinal { hot: Option<(PathBuf, Vec<u8>)> },
+            /// No lifecycle state and no hot buffer. We validate
+            /// outside the pending lock so double-release of a real
+            /// inode is a no-op, while a bogus NodeId is rejected.
+            MaybeUntrackedNoop,
         }
         let outcome = {
             let mut pending = self.pending.lock().expect("pending lock");
             match pending.state.get(&node.0).copied() {
                 None => {
                     // Untracked release (no on_open was ever
-                    // recorded). Treat as Live final-close — flush
-                    // any hot buffer.
-                    Outcome::Flush
+                    // recorded). Treat a tracked hot buffer as Live
+                    // final-close; otherwise validate the NodeId
+                    // outside this lock.
+                    if pending.hot.contains_key(&node.0) {
+                        Outcome::Flush
+                    } else {
+                        Outcome::MaybeUntrackedNoop
+                    }
                 }
                 Some(NodeState::Live { open_count }) => {
                     let n = open_count.saturating_sub(1);
@@ -3003,12 +3014,14 @@ impl<S: ObjectStore> MountInner<S> {
                     let n = open_count.saturating_sub(1);
                     if n == 0 {
                         // Final release of an Orphan — POSIX "inode
-                        // lives until last close" ends here. Drop
-                        // bytes and the state entry.
-                        pending.state.remove(&node.0);
-                        pending.hot.remove(&node.0);
-                        pending.warm.remove(&node.0);
-                        Outcome::OrphanFinalDone
+                        // lives until last close" ends here. Snapshot
+                        // hot bytes so they can be persisted outside
+                        // the lock before retiring the anonymous state.
+                        let hot = pending
+                            .hot
+                            .get(&node.0)
+                            .map(|buf| (buf.path.clone(), buf.bytes.clone()));
+                        Outcome::OrphanFinal { hot }
                     } else {
                         pending
                             .state
@@ -3022,7 +3035,35 @@ impl<S: ObjectStore> MountInner<S> {
         };
         match outcome {
             Outcome::Flush => self.flush_node(node),
-            Outcome::OrphanFinalDone => Ok(()),
+            Outcome::MaybeUntrackedNoop => {
+                if !self
+                    .inodes
+                    .lock()
+                    .expect("inode lock")
+                    .by_id
+                    .contains_key(&node.0)
+                {
+                    return Err(MountError::NotFound(format!("node {}", node.0)));
+                }
+                Ok(())
+            }
+            Outcome::OrphanFinal { hot } => {
+                if let Some((path, bytes)) = hot {
+                    let size = bytes.len() as u64;
+                    let blob = Blob::new(bytes);
+                    let blob_oid = self
+                        .repo
+                        .store()
+                        .put_blob(&blob)
+                        .map_err(MountError::Store)?;
+                    debug!(?path, %blob_oid, size, "persisted orphan hot buffer to CAS");
+                }
+                let mut pending = self.pending.lock().expect("pending lock");
+                pending.state.remove(&node.0);
+                pending.hot.remove(&node.0);
+                pending.warm.remove(&node.0);
+                Ok(())
+            }
         }
     }
 }

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -369,6 +369,17 @@ fn read_captured_blob(mount: &ContentAddressedMount, change_id: &ChangeId, path:
     blob.into_content()
 }
 
+fn store_contains_blob_with_bytes(mount: &ContentAddressedMount, bytes: &[u8]) -> bool {
+    let store = mount.repo_handle().store();
+    store.list_blobs().unwrap().into_iter().any(|hash| {
+        store
+            .get_blob(&hash)
+            .unwrap()
+            .map(|blob| blob.into_content() == bytes)
+            .unwrap_or(false)
+    })
+}
+
 #[test]
 fn partial_overwrite_preserves_captured_tail() {
     // Write "HELLO" at offset 0 over a captured file of "hello world\n".
@@ -718,6 +729,91 @@ fn flush_promotes_buffer_to_warm_tier() {
     let warm = mount.warm_keys();
     assert_eq!(warm.len(), 1);
     assert_eq!(warm[0], std::path::PathBuf::from("out.txt"));
+}
+
+#[test]
+fn test_release_orphaned_node_flushes_pending_writes() {
+    let (_temp, mount) = open_mount();
+    let node = mount.lookup_path("hello.txt").unwrap();
+    let payload = b"release-orphan-cas-bytes";
+
+    mount.on_open(node).expect("open");
+    mount.write(node, 0, payload).expect("write hot bytes");
+    assert!(
+        !store_contains_blob_with_bytes(&mount, payload),
+        "sanity: dirty hot bytes must not be in CAS before release"
+    );
+
+    mount
+        .unlink_entry(NodeId::ROOT, OsStr::new("hello.txt"))
+        .expect("unlink while open");
+    assert!(
+        mount.orphans_contains(node),
+        "unlink while open must mark the node orphaned"
+    );
+
+    mount.release(node).expect("final release");
+
+    assert!(
+        !mount.orphans_contains(node),
+        "final release must retire orphan lifecycle state"
+    );
+    assert!(
+        store_contains_blob_with_bytes(&mount, payload),
+        "final release of an orphan must persist dirty hot bytes to CAS"
+    );
+    assert!(
+        mount
+            .lookup(NodeId::ROOT, OsStr::new("hello.txt"))
+            .unwrap()
+            .is_none(),
+        "orphan CAS persistence must not resurrect the unlinked path"
+    );
+}
+
+#[test]
+fn test_double_release_is_guarded() {
+    let (_temp, mount) = open_mount();
+    let node = mount.lookup_path("hello.txt").unwrap();
+    let payload = b"double-release-cas-bytes";
+
+    mount.on_open(node).expect("open");
+    mount.write(node, 0, payload).expect("write hot bytes");
+    mount.release(node).expect("first release flushes");
+    let blob = mount
+        .warm_blob("hello.txt")
+        .expect("first release promoted to warm CAS blob");
+
+    mount.release(node).expect("second release is a safe no-op");
+
+    assert_eq!(
+        mount.warm_blob("hello.txt"),
+        Some(blob),
+        "double release must not corrupt or replace the warm blob"
+    );
+    assert_eq!(
+        mount.hot_buffer_count(),
+        0,
+        "double release must not recreate a hot buffer"
+    );
+    assert!(
+        store_contains_blob_with_bytes(&mount, payload),
+        "flushed bytes must remain readable from CAS after double release"
+    );
+}
+
+#[test]
+fn test_release_nonexistent_node_safe_error() {
+    let (_temp, mount) = open_mount();
+    let err = mount
+        .release(NodeId(9_999_999_617))
+        .expect_err("release of an unknown node must fail safely");
+
+    assert!(
+        matches!(err, MountError::NotFound(_)),
+        "unexpected release error: {err:?}"
+    );
+    assert_eq!(err.to_errno(), libc::ENOENT);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds targeted `ContentAddressedMount::release_node` contract coverage for the data-loss prevention path:

- final release of an orphaned dirty node persists hot bytes into CAS without resurrecting the unlinked path
- double release of a real node is a safe no-op that does not corrupt the warm blob
- release of an unknown NodeId returns a safe `NotFound` error

The tests exposed a real gap: final orphan release retired the hot buffer without first writing it to CAS. The fix persists those anonymous hot bytes to CAS before retiring orphan state, while still avoiding warm promotion into the pending tree so POSIX unlink semantics remain intact.

Fixes #617

## Validation

- `cargo test -p heddle-mount`
- `cargo build`
- `cargo build --all-features`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783924739&installation_id=132405951&pr_number=697&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F697&signature=ca61bb0182fd9a574df7b75125781a8f3af675c1bd6227f52bf296f7d073002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->