### PR TITLE
[codex] Fix zstd decompression size truncation

### DIFF
--- a/crates/objects/src/store/compression/compression_tests.rs
+++ b/crates/objects/src/store/compression/compression_tests.rs
@@ -143,6 +143,45 @@ fn test_decompress_rejects_oversized_header() {
 }
 
 #[test]
+#[cfg(feature = "zstd")]
+fn test_decompress_zstd_rejects_expected_size_above_effective_limit() {
+    let compressed_payload = zstd::encode_all(&b"tiny"[..], 3).unwrap();
+    let size = max_decompressed_size() + 1;
+
+    let error = decompress_zstd(&compressed_payload, size).unwrap_err();
+
+    let CompressionError::SizeLimitExceeded { size: actual, max } = error else {
+        panic!("expected size-limit error");
+    };
+    assert_eq!(actual, size);
+    assert_eq!(max, max_decompressed_size());
+}
+
+#[test]
+fn test_effective_decompressed_size_limit_caps_at_platform_limit() {
+    let platform_limit = u64::from(u32::MAX);
+    let configured_limit = platform_limit + 1;
+
+    assert_eq!(
+        effective_decompressed_size_limit(configured_limit, platform_limit),
+        platform_limit
+    );
+}
+
+#[test]
+#[cfg(target_pointer_width = "32")]
+fn test_expected_size_to_capacity_rejects_unrepresentable_u64() {
+    let size = u64::try_from(usize::MAX).expect("32-bit usize must fit in u64 for this test") + 1;
+
+    let error = expected_size_to_capacity(size).unwrap_err();
+
+    assert!(matches!(
+        error,
+        CompressionError::SizeLimitExceeded { size: actual, .. } if actual == size
+    ));
+}
+
+#[test]
 fn test_decompress_none_header_rejects_size_mismatch() {
     let payload = b"tiny";
     let mut encoded = vec![CompressionType::None as u8];

--- a/crates/objects/src/store/compression/mod.rs
+++ b/crates/objects/src/store/compression/mod.rs
@@ -133,11 +133,11 @@ pub fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionEr
 #[cfg(feature = "zstd")]
 /// Decompress zstd data while enforcing the recorded output size.
 pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
-    validate_size(expected_size)?;
+    let expected_capacity = validated_decompressed_capacity(expected_size)?;
 
     let mut decoder = zstd::stream::read::Decoder::new(data)
         .map_err(|e| CompressionError::DecompressionFailed(e.to_string()))?;
-    let mut decompressed = Vec::with_capacity(expected_size as usize);
+    let mut decompressed = Vec::with_capacity(expected_capacity);
     let mut buffer = [0u8; 8192];
 
     loop {
@@ -408,14 +408,38 @@ fn read_u64_size(data: &[u8]) -> Result<u64, CompressionError> {
 }
 
 fn validate_size(size: u64) -> Result<(), CompressionError> {
-    if size > MAX_DECOMPRESSED_SIZE {
-        return Err(CompressionError::SizeLimitExceeded {
-            size,
-            max: MAX_DECOMPRESSED_SIZE,
-        });
+    let max = max_decompressed_size();
+    if size > max {
+        return Err(CompressionError::SizeLimitExceeded { size, max });
     }
 
     Ok(())
+}
+
+fn max_decompressed_size() -> u64 {
+    effective_decompressed_size_limit(MAX_DECOMPRESSED_SIZE, platform_max_decompressed_size())
+}
+
+fn effective_decompressed_size_limit(configured_limit: u64, platform_limit: u64) -> u64 {
+    configured_limit.min(platform_limit)
+}
+
+fn platform_max_decompressed_size() -> u64 {
+    u64::try_from(usize::MAX).unwrap_or(u64::MAX)
+}
+
+#[cfg(feature = "zstd")]
+fn validated_decompressed_capacity(expected_size: u64) -> Result<usize, CompressionError> {
+    validate_size(expected_size)?;
+    expected_size_to_capacity(expected_size)
+}
+
+#[cfg(any(feature = "zstd", all(test, target_pointer_width = "32")))]
+fn expected_size_to_capacity(expected_size: u64) -> Result<usize, CompressionError> {
+    usize::try_from(expected_size).map_err(|_| CompressionError::SizeLimitExceeded {
+        size: expected_size,
+        max: max_decompressed_size(),
+    })
 }
 
 fn validate_decompressed_len(expected: u64, actual: usize) -> Result<(), CompressionError> {


### PR DESCRIPTION
## Summary

- make the zstd decompression allocation capacity a fallible `usize::try_from(expected_size)` conversion instead of `expected_size as usize`
- compute the effective decompressed-size cap as the configured limit capped by the platform `usize` maximum before accepting a recorded size
- add regression coverage for the effective limit path and a 32-bit-only direct guard test for an unrepresentable `u64` expected size

## Root Cause

A zstd payload records `expected_size` as `u64`. The previous code validated that value against the decompression limit, then truncated it with `expected_size as usize` for `Vec::with_capacity`. On 32-bit targets, a future limit above `usize::MAX` could allow a hostile `u64` to pass the `u64` comparison and allocate with a small truncated capacity.

## Validation

- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`

## Lint Note

A crate/workspace `clippy::cast_possible_truncation` policy would help close this broader class. I did not add that lint here because #623 is already coordinating the broader cast cleanup/lint discussion.

Security fix.

Fixes #619

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783925023&installation_id=132405951&pr_number=698&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F698&signature=6acccc1b2752a27f8e775160b765384c1f2660b9537521edf0a0c576a509c100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->