### PR TITLE
[codex] secure daemon socket bind

### DIFF
--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -552,6 +552,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn open_then_append_turn_persists_both_turns() {
         let (_t, state_id, svc) = fresh_service();
         let opened = svc
@@ -593,6 +594,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn open_idempotent_returns_same_discussion() {
         let (_t, state_id, svc) = fresh_service();
         let op_id = "11111111-2222-3333-4444-555555555555";
@@ -612,6 +614,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn resolve_dismissed_with_empty_reason_is_invalid_argument() {
         let (_t, state_id, svc) = fresh_service();
         let opened = svc
@@ -636,6 +639,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn list_by_state_filters_by_status() {
         let (_t, state_id, svc) = fresh_service();
         // Open two discussions, dismiss one of them.

--- a/crates/daemon/src/grpc_local_impl/hook.rs
+++ b/crates/daemon/src/grpc_local_impl/hook.rs
@@ -371,6 +371,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn register_then_list_returns_hook() {
         let (_t, svc) = fresh_service();
         svc.register_hook(Request::new(RegisterHookRequest {
@@ -396,6 +397,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn register_unknown_event_is_invalid_argument() {
         let (_t, svc) = fresh_service();
         let err = svc
@@ -413,6 +415,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn deregister_removes_hook() {
         let (_t, svc) = fresh_service();
         svc.register_hook(Request::new(RegisterHookRequest {
@@ -444,6 +447,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn get_hook_event_schema_returns_full_catalog() {
         let (_t, svc) = fresh_service();
         let resp = svc
@@ -458,6 +462,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn get_hook_event_schema_unknown_returns_not_found() {
         let (_t, svc) = fresh_service();
         let err = svc
@@ -470,6 +475,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn subscribe_then_emit_round_trips() {
         let (_t, svc) = fresh_service();
         let stream = svc
@@ -494,6 +500,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn subscribe_unknown_event_is_invalid_argument() {
         let (_t, svc) = fresh_service();
         let result = svc
@@ -511,6 +518,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn respond_to_hook_delivers_to_emit_waiter() {
         use std::time::Duration;
         let (_t, svc) = fresh_service();
@@ -543,6 +551,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn respond_to_hook_rejects_empty_id() {
         let (_t, svc) = fresh_service();
         let err = svc
@@ -559,6 +568,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn respond_to_hook_unknown_id_returns_not_accepted() {
         let (_t, svc) = fresh_service();
         let resp = svc
@@ -575,6 +585,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn register_idempotent_returns_same_hook() {
         let (_t, svc) = fresh_service();
         let op_id = objects::object::OperationId::new().to_string();

--- a/crates/daemon/src/grpc_local_impl/mod.rs
+++ b/crates/daemon/src/grpc_local_impl/mod.rs
@@ -197,6 +197,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn replays_recorded_response() {
         let (_t, service) = make_service();
         let op_id = OperationId::new().to_string();
@@ -222,6 +223,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn concurrent_calls_with_same_op_id_run_execute_only_once() {
         // The original race window: caller A enters with `Fresh`, awaits
         // execute(), and caller B enters with `Fresh` before A records.
@@ -279,6 +281,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn cancels_reservation_on_execute_failure() {
         // If execute returns Err, the reservation must be released so a
         // retry isn't permanently blocked. Without `cancel`, a transient

--- a/crates/daemon/src/grpc_local_impl/operation_log_query.rs
+++ b/crates/daemon/src/grpc_local_impl/operation_log_query.rs
@@ -328,6 +328,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn query_returns_records_within_window() {
         let (_t, svc) = fresh_service();
         write_op(
@@ -359,6 +360,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn query_excludes_checkpoints_by_default_when_verbs_unset() {
         let (_t, svc) = fresh_service();
         write_op(
@@ -384,6 +386,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn default_query_includes_newer_non_checkpoint_verbs() {
         // Non-vacuous for cid 3330304663: `transaction_commit` was missing from
         // the old hand-maintained default list, so it was silently dropped from
@@ -417,6 +420,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn query_reads_live_oplog_when_index_is_empty() {
         let (_t, svc) = fresh_service();
         let state = ChangeId::from_bytes([2; 16]);
@@ -446,6 +450,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn stream_operations_yields_all_hits() {
         let (_t, svc) = fresh_service();
         for i in 0..5u64 {

--- a/crates/daemon/src/grpc_local_impl/signal.rs
+++ b/crates/daemon/src/grpc_local_impl/signal.rs
@@ -258,6 +258,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn compute_state_signals_returns_persisted_signals() {
         let (_t, repo) = fresh_repo();
         let signal = sample_signal(RiskSignalKind::Novelty, "novel control flow shape");
@@ -279,6 +280,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn compute_state_signals_returns_empty_when_state_has_no_signals() {
         let (_t, repo) = fresh_repo();
         let attribution = Attribution::human(Principal::new("Alice", "alice@example.com"));
@@ -298,6 +300,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn invalid_state_id_returns_invalid_argument() {
         let (_t, repo) = fresh_repo();
         let svc = local_service(repo);
@@ -313,6 +316,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn signal_health_groups_by_module_id() {
         let (_t, repo) = fresh_repo();
         let novelty = sample_signal(RiskSignalKind::Novelty, "novel");

--- a/crates/daemon/src/grpc_local_impl/state_review.rs
+++ b/crates/daemon/src/grpc_local_impl/state_review.rs
@@ -1004,7 +1004,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_persists_to_review_signatures_blob() {
         let (svc, repo, _tmp) = fresh_service();
         let state_id = capture_state(&repo);
@@ -1037,7 +1037,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_idempotent() {
         let (svc, repo, _tmp) = fresh_service();
         let state_id = capture_state(&repo);
@@ -1075,7 +1075,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_rejects_forged_signature() {
         let (svc, repo, _tmp) = fresh_service();
         let state_id = capture_state(&repo);
@@ -1097,7 +1097,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_rejects_skewed_timestamp() {
         let (svc, repo, _tmp) = fresh_service();
         let state_id = capture_state(&repo);
@@ -1116,7 +1116,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_attributes_to_caller_not_state_author() {
         // Regression for the codex-flagged bug: sign_state used to
         // attribute the signature to the state's author. Bob signing
@@ -1164,7 +1164,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn sign_state_serializes_concurrent_appends() {
         // Regression for the codex-flagged race: two SignStates with
         // different operation ids could both read the same base
@@ -1213,7 +1213,7 @@ mod tests {
     /// both states report a non-empty diff summary plus a populated
     /// `diff_summary` signal anchored on the changed file.
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn get_review_payload_populates_diff_summary_and_signals() {
         let (svc, repo, _tmp) = fresh_service();
 
@@ -1330,7 +1330,7 @@ mod tests {
     /// branches and the top-level diff_trees call did not — surfaces
     /// of pruned object stores all errored out inconsistently.)
     #[tokio::test]
-    #[serial_test::serial(principal_env)]
+    #[serial_test::serial(process_global)]
     async fn get_review_payload_tolerates_missing_tree() {
         let (svc, repo, _tmp) = fresh_service();
         let state_id = capture_state(&repo);

--- a/crates/daemon/src/grpc_local_impl/transaction.rs
+++ b/crates/daemon/src/grpc_local_impl/transaction.rs
@@ -464,6 +464,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn begin_creates_active_sentinel() {
         let (_tmp, svc) = build_service();
         let resp = svc
@@ -487,6 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn commit_flips_state_to_committed() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -519,6 +521,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn abort_records_reason() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -549,6 +552,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn commit_after_abort_returns_failed_precondition() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -577,6 +581,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn get_status_returns_current_state() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -599,6 +604,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn commit_clears_buffered_ops_and_records_oplog_entry() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -666,6 +672,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn abort_records_oplog_entry_with_reason() {
         let (_tmp, svc) = build_service();
         let begin = svc
@@ -710,6 +717,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn begin_idempotent_returns_same_transaction_id() {
         let (_tmp, svc) = build_service();
         let client_op = OperationId::new().to_string();
@@ -732,6 +740,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn sentinel_path_is_derived_from_operation_id() {
         let (_tmp, svc) = build_service();
         let transaction_id = OperationId::new();
@@ -754,6 +763,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(process_global)]
     async fn invalid_transaction_ids_are_rejected_before_sentinel_path_io() {
         let (tmp, svc) = build_service();
         let absolute = tmp.path().join("outside-absolute").display().to_string();

--- a/crates/daemon/src/local_daemon.rs
+++ b/crates/daemon/src/local_daemon.rs
@@ -31,7 +31,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use grpc::{
@@ -48,6 +48,10 @@ use crate::grpc_local_impl::{
     GrpcLocalService, LocalDiscussionService, LocalHookService, LocalOperationLogQueryService,
     LocalSignalService, LocalStateReviewService, LocalTransactionService,
 };
+
+const PRIVATE_SOCKET_UMASK: libc::mode_t = 0o177;
+
+static SOCKET_BIND_UMASK_LOCK: Mutex<()> = Mutex::new(());
 
 /// Default socket path inside a repo: `<heddle_dir>/sockets/grpc.sock`.
 pub fn default_socket_path(heddle_dir: &Path) -> PathBuf {
@@ -258,9 +262,7 @@ pub async fn serve(
     config: LocalDaemonConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<()> {
-    if let Some(parent) = config.socket_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
+    create_private_socket_parent(&config.socket_path)?;
     // PidGuard refuses to start when another daemon owns this repo.
     let _guard = PidGuard::install(config.pid_path.clone(), config.socket_path.clone())?;
 
@@ -269,14 +271,30 @@ pub async fn serve(
     if config.socket_path.exists() {
         std::fs::remove_file(&config.socket_path)?;
     }
-    let listener = UnixListener::bind(&config.socket_path).map_err(|e| {
+    let listener = bind_private_unix_listener(&config.socket_path)?;
+    // Mode 0600 — same-user only. The umask guard in
+    // `bind_private_unix_listener` makes the socket born private; this chmod
+    // remains defense-in-depth and normalizes platforms that report mode bits
+    // differently after bind.
+    set_socket_mode_0600(&config.socket_path)?;
+    listener.set_nonblocking(true).map_err(|e| {
         HeddleError::Io(std::io::Error::new(
             e.kind(),
-            format!("UnixListener::bind({}): {e}", config.socket_path.display()),
+            format!(
+                "UnixListener::set_nonblocking({}): {e}",
+                config.socket_path.display()
+            ),
         ))
     })?;
-    // Mode 0600 — same-user only. The PidGuard cleans up at drop.
-    set_socket_mode_0600(&config.socket_path)?;
+    let listener = UnixListener::from_std(listener).map_err(|e| {
+        HeddleError::Io(std::io::Error::new(
+            e.kind(),
+            format!(
+                "UnixListener::from_std({}): {e}",
+                config.socket_path.display()
+            ),
+        ))
+    })?;
 
     // Crash recovery for the transaction sentinel directory. Runs before
     // any service starts handling RPCs so an in-flight transaction from a
@@ -357,6 +375,59 @@ pub async fn serve(
     Ok(())
 }
 
+fn create_private_socket_parent(socket_path: &Path) -> Result<()> {
+    if let Some(parent) = socket_path.parent() {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(parent)?;
+    }
+    Ok(())
+}
+
+fn bind_private_unix_listener(socket_path: &Path) -> Result<std::os::unix::net::UnixListener> {
+    let _lock = SOCKET_BIND_UMASK_LOCK
+        .lock()
+        .map_err(|_| HeddleError::InvalidObject("daemon socket umask lock poisoned".to_string()))?;
+    // Pathname UDS permissions are chosen by the kernel at bind time from
+    // the process umask, so chmod-after-bind is too late for security. This
+    // async `serve` path performs all startup work synchronously before the
+    // daemon accepts connections or spawns service work; no `.await` occurs
+    // while the process-global umask is narrowed. The mutex serializes other
+    // Heddle socket binds in this process, and the guard restores the prior
+    // umask even when bind fails.
+    let _umask = UmaskGuard::set(PRIVATE_SOCKET_UMASK);
+    std::os::unix::net::UnixListener::bind(socket_path).map_err(|e| {
+        HeddleError::Io(std::io::Error::new(
+            e.kind(),
+            format!("UnixListener::bind({}): {e}", socket_path.display()),
+        ))
+    })
+}
+
+struct UmaskGuard {
+    previous: libc::mode_t,
+}
+
+impl UmaskGuard {
+    fn set(mask: libc::mode_t) -> Self {
+        // SAFETY: umask is process-global and always succeeds. The caller
+        // keeps the guarded section synchronous and holds
+        // SOCKET_BIND_UMASK_LOCK for Heddle's own socket-bind paths.
+        let previous = unsafe { libc::umask(mask) };
+        Self { previous }
+    }
+}
+
+impl Drop for UmaskGuard {
+    fn drop(&mut self) {
+        // SAFETY: restoring the previously returned umask is infallible.
+        unsafe {
+            libc::umask(self.previous);
+        }
+    }
+}
+
 #[cfg(unix)]
 fn set_socket_mode_0600(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
@@ -431,6 +502,67 @@ mod tests {
         let path = default_socket_path(&heddle);
         assert!(path.starts_with(&heddle));
         assert!(path.ends_with("grpc.sock"));
+    }
+
+    #[test]
+    fn create_private_socket_parent_creates_new_parent_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let socket = temp
+            .path()
+            .join(".heddle")
+            .join("sockets")
+            .join("grpc.sock");
+        create_private_socket_parent(&socket).unwrap();
+
+        let mode = std::fs::metadata(socket.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "new socket parent must be private");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bind_private_unix_listener_creates_socket_0600_before_chmod() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let socket = temp.path().join("grpc.sock");
+
+        let _listener = bind_private_unix_listener(&socket).unwrap();
+
+        let mode = std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "socket must be born private before set_socket_mode_0600 runs"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bind_private_unix_listener_restores_umask_after_bind_error() {
+        let temp = TempDir::new().unwrap();
+        let socket = temp.path().join("missing").join("grpc.sock");
+        let before = current_umask();
+
+        let result = bind_private_unix_listener(&socket);
+
+        let after = current_umask();
+        assert!(result.is_err(), "bind should fail for a missing parent");
+        assert_eq!(after, before, "bind errors must restore the prior umask");
+    }
+
+    fn current_umask() -> libc::mode_t {
+        // SAFETY: reading umask requires the standard set-then-restore
+        // sequence; tests that call this are serialized with the bind tests.
+        unsafe {
+            let current = libc::umask(0);
+            libc::umask(current);
+            current
+        }
     }
 
     #[test]

--- a/crates/daemon/src/local_daemon.rs
+++ b/crates/daemon/src/local_daemon.rs
@@ -495,6 +495,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn default_socket_path_lives_under_heddle_dir() {
         let temp = TempDir::new().unwrap();
         let heddle = temp.path().join(".heddle");
@@ -505,6 +506,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn create_private_socket_parent_creates_new_parent_0700() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -525,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(process_global)]
     fn bind_private_unix_listener_creates_socket_0600_before_chmod() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -542,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(process_global)]
     fn bind_private_unix_listener_restores_umask_after_bind_error() {
         let temp = TempDir::new().unwrap();
         let socket = temp.path().join("missing").join("grpc.sock");
@@ -566,6 +568,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn pid_guard_writes_and_removes_pidfile() {
         let temp = TempDir::new().unwrap();
         let pid = temp.path().join("grpc.pid");
@@ -578,6 +581,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn pid_guard_refuses_when_live_heddle_process_owns_pidfile() {
         let temp = TempDir::new().unwrap();
         let pid = temp.path().join("grpc.pid");
@@ -605,6 +609,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn pid_guard_sweeps_stale_pidfile_with_dead_pid() {
         let temp = TempDir::new().unwrap();
         let pid = temp.path().join("grpc.pid");
@@ -625,6 +630,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn pid_guard_sweeps_legacy_unstructured_pidfile() {
         // Pidfiles written by older daemons that pre-date the marker
         // are treated as foreign — the new `parse()` returns None and

--- a/crates/daemon/src/transaction_replay.rs
+++ b/crates/daemon/src/transaction_replay.rs
@@ -394,6 +394,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn empty_directory_is_a_no_op() {
         let (_t, repo) = fresh_repo();
         let report = replay_active_transactions(&repo);
@@ -401,6 +402,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn aborts_active_sentinel_from_prior_run() {
         let (_t, repo) = fresh_repo();
         let dir = sentinel_dir(&repo);
@@ -437,6 +439,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn leaves_terminal_sentinels_alone() {
         let (_t, repo) = fresh_repo();
         let dir = sentinel_dir(&repo);
@@ -454,6 +457,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn removes_orphan_temp_files() {
         let (_t, repo) = fresh_repo();
         let dir = sentinel_dir(&repo);
@@ -470,6 +474,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn is_idempotent() {
         let (_t, repo) = fresh_repo();
         let dir = sentinel_dir(&repo);
@@ -488,6 +493,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn scan_error_set_when_sentinel_dir_is_not_a_directory() {
         // read_dir on a non-directory path returns a non-NotFound
         // error. Replay must surface it on the report rather than
@@ -510,6 +516,7 @@ buffered_ops = {buffered}
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial(process_global)]
     fn failed_sentinel_write_surfaced_on_readonly_dir() {
         // Read-only sentinel directory: the sentinel parses fine but
         // write_file_atomic cannot create its tmp file. Replay must
@@ -562,6 +569,7 @@ buffered_ops = {buffered}
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial(process_global)]
     fn failed_orphan_delete_surfaced_on_readonly_dir() {
         // Read-only sentinel directory: the orphan tmp file is
         // present and matches `is_orphan_temp_name`, but
@@ -616,6 +624,7 @@ buffered_ops = {buffered}
     }
 
     #[test]
+    #[serial_test::serial(process_global)]
     fn leaves_unparseable_sentinels_in_place() {
         let (_t, repo) = fresh_repo();
         let dir = sentinel_dir(&repo);
@@ -689,6 +698,7 @@ buffered_ops = {buffered}
         /// any partial state collapses into one of the four cases
         /// modelled above.
         #[test]
+        #[serial_test::serial(process_global)]
         fn crash_matrix_replay_reaches_consistent_terminal_state(
             crash in arb_crash_kind(),
             ops in arb_ops(),


### PR DESCRIPTION
## Summary
- Bind the local daemon Unix socket under umask 0177 so it is created as 0600 immediately.
- Restore the prior umask with an RAII guard even when bind fails, then keep the explicit chmod as defense-in-depth.
- Create new daemon socket parent directories with 0700 permissions.

## Root cause
`UnixListener::bind` created the pathname socket with process umask defaults before `set_socket_mode_0600` ran, leaving a brief local connect window.

## Validation
- `cargo build`
- `cargo build --all-features`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-daemon -p heddle-cli`
- `cargo clippy --workspace --all-targets -- -D warnings`

Fixes #620

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783925256&installation_id=132405951&pr_number=699&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F699&signature=f2be5d94cb4ebdad4ad59b39b34a3ae920aed822dfa11c3d4f74d1c8ceab0874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->