### PR TITLE
Pin pre-fidelity state hash vector

### DIFF
--- a/crates/objects/src/object/state_core.rs
+++ b/crates/objects/src/object/state_core.rs
@@ -1214,6 +1214,46 @@ mod tests {
         }
     }
 
+    #[test]
+    fn pre_fidelity_hash_matches_legacy_golden_vector() {
+        let state = State::new_snapshot(
+            ContentHash::compute(b"issue-633-tree"),
+            vec![ChangeId::from_bytes([0x11; 16])],
+            Attribution::with_agent(
+                Principal::new("Legacy Author", "legacy@example.com"),
+                crate::object::Agent::new("openai", "gpt-5")
+                    .with_session("session-633", "segment-001")
+                    .with_policy("policy-legacy"),
+            ),
+        )
+        .with_logical_change_id(ChangeId::from_bytes([0x63; 16]))
+        .with_intent("freeze pre-565 hash")
+        .with_confidence(0.875)
+        .with_timestamp(DateTime::from_timestamp(1_700_000_000, 0).expect("valid timestamp"))
+        .with_committer(Principal::new("Legacy Committer", "committer@example.com"))
+        .with_tz_offsets(3600, -18000)
+        .with_authored_at(DateTime::from_timestamp(1_699_999_000, 0).expect("valid timestamp"))
+        .with_raw_message(b"legacy commit message\n")
+        .with_extra_headers(vec![(b"encoding".to_vec(), b"UTF-8".to_vec())])
+        .with_status(Status::Published);
+
+        let legacy_hash = state.compute_hash_pre_fidelity();
+        // Golden vector for the pre-#565 state hash format. Legacy
+        // StateSignature verification depends on `compute_hash_pre_fidelity`
+        // staying byte-identical to that old format; if `hash_len_core` and
+        // `update_hash_core` drift, real pre-#565 signatures become
+        // unverifiable even though round-trip tests can still pass.
+        assert_eq!(
+            legacy_hash.to_hex(),
+            "b89e1b40e681a1bf88679db7cfcacdafb1f370bc40ed5d50760dae1d4ab49dab",
+        );
+        assert_ne!(
+            legacy_hash,
+            state.compute_hash(),
+            "fixture must distinguish the pre-#565 legacy path from the current hash",
+        );
+    }
+
     /// extra_headers order is load-bearing (#566): the same pairs in a
     /// different order must hash differently.
     #[test]


### PR DESCRIPTION
Fixes #633

## What changed
- Added a deterministic golden-vector test for `State::compute_hash_pre_fidelity()`.
- The fixture freezes the current confirmed pre-#565 legacy hash for fixed state input.
- The same fixture also asserts the legacy hash differs from the current post-#565 hash, so the test is specifically pinning the legacy path.

## Why
A future `hash_len_core` / `update_hash_core` drift could otherwise pass round-trip legacy-signature tests while breaking real pre-#565 `StateSignature` verification. This test fails loudly if that legacy byte format changes.

## Validation
- `cargo test -p heddle-objects pre_fidelity_hash_matches_legacy_golden_vector` twice
- `cargo test -p heddle-objects`
- `cargo build`
- `cargo build --all-features`
- `cargo clippy --all-targets -- -D warnings`

Note: workspace/package `cargo fmt --check` reports pre-existing rustfmt drift in unrelated files; no formatter changes were applied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783926276&installation_id=132405951&pr_number=701&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F701&signature=e569f3c0cc7facedb17d5ba46cfc6edf813441ccd9e7d6717a15fb488b2587eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->