### PR TITLE
Eliminate pack delta window payload clone

### DIFF
--- a/crates/objects/src/store/pack/pack_builder.rs
+++ b/crates/objects/src/store/pack/pack_builder.rs
@@ -4,14 +4,14 @@
 use std::collections::{HashMap, VecDeque};
 
 use super::{
-    ObjectType, PackObjectId, PackObjectRecord, PackStats, append_container_checksum,
-    compress_pack_payload, encode_tagged_entry, pack_container_spec, pack_index::PackIndex,
-    write_container_header,
+    append_container_checksum, compress_pack_payload, encode_tagged_entry,
+    encode_tagged_entry_parts, pack_container_spec, pack_index::PackIndex, write_container_header,
+    ObjectType, PackObjectId, PackObjectRecord, PackStats,
 };
 use crate::{
     delta::DeltaEncoder,
     object::ContentHash,
-    store::{Result, compression::CompressionConfig},
+    store::{compression::CompressionConfig, Result},
 };
 
 const MIN_DELTA_SIZE: usize = 64;
@@ -278,14 +278,14 @@ impl PackBuilder {
 
             *total_compressed += final_data.len() as u64;
 
-            let record = PackObjectRecord {
-                id: PackObjectId::Hash(hash),
-                obj_type,
-                data: data.clone(),
-                delta_base: base_hash.map(PackObjectId::Hash),
-                path_hint: None,
-            };
-            Self::write_entry(pack_data, &record, entry_type, &final_data)?;
+            Self::write_entry_parts(
+                pack_data,
+                PackObjectId::Hash(hash),
+                entry_type,
+                data.len(),
+                base_hash.map(PackObjectId::Hash),
+                &final_data,
+            )?;
 
             // Add to window (build index once, reuse for all future comparisons)
             let entry_index = DeltaEncoder::build_index(&data);
@@ -330,5 +330,23 @@ impl PackBuilder {
         compressed: &[u8],
     ) -> Result<()> {
         encode_tagged_entry(pack, record, obj_type, compressed)
+    }
+
+    fn write_entry_parts(
+        pack: &mut Vec<u8>,
+        id: PackObjectId,
+        obj_type: ObjectType,
+        uncompressed_size: usize,
+        delta_base: Option<PackObjectId>,
+        compressed: &[u8],
+    ) -> Result<()> {
+        encode_tagged_entry_parts(
+            pack,
+            id,
+            obj_type,
+            uncompressed_size,
+            delta_base,
+            compressed,
+        )
     }
 }

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -3,11 +3,11 @@
 
 use tempfile::TempDir;
 
-use super::{ObjectType, PackBuilder, PackObjectId, PackReader, pack_index::PackIndex};
+use super::{pack_index::PackIndex, ObjectType, PackBuilder, PackObjectId, PackReader};
 use crate::{
     delta::MAX_DELTA_OUTPUT_SIZE,
     object::{ChangeId, ContentHash},
-    store::{StoreError, compression::CompressionConfig, pack::pack_container_spec},
+    store::{compression::CompressionConfig, pack::pack_container_spec, StoreError},
 };
 
 fn create_test_hash(n: u8) -> ContentHash {
@@ -512,7 +512,7 @@ fn test_pack_reader_missing_object_returns_none() {
 /// with the expected diagnostic phrase.
 #[test]
 fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
-    use crate::store::{StoreError, pack::pack_index::PackIndex};
+    use crate::store::{pack::pack_index::PackIndex, StoreError};
 
     let blob_a = b"alpha-payload alpha-payload alpha-payload alpha".to_vec();
     let blob_b = b"bravo-payload bravo-payload bravo-payload bravo".to_vec();
@@ -658,6 +658,39 @@ fn test_delta_chain_produces_deltas() {
         stats.delta_count >= 1,
         "expected deltas, got {}",
         stats.delta_count
+    );
+}
+
+#[test]
+fn test_delta_window_pack_bytes_are_stable() {
+    let shared = b"Stable pack bytes fixture. ".repeat(16);
+    let mut builder = PackBuilder::new(CompressionConfig {
+        enabled: false,
+        level: 0,
+        min_size: usize::MAX,
+        max_delta_size: 10_000_000,
+    });
+
+    for i in 0..4u8 {
+        let mut data = shared.clone();
+        data.extend_from_slice(format!("version {i} suffix").as_bytes());
+        builder.add_with_path(
+            ContentHash::compute(&data),
+            ObjectType::Blob,
+            data,
+            Some("src/stable.rs".to_string()),
+        );
+    }
+
+    let (pack_data, index_data, stats) = builder.build().unwrap();
+    assert!(stats.delta_count > 0);
+    assert_eq!(
+        blake3::hash(&pack_data).to_string(),
+        "4dc15365d17fbdf22ee4c1a8a44ee3414dda6dbdcb93c583536a4629c575e8ca"
+    );
+    assert_eq!(
+        blake3::hash(&index_data).to_string(),
+        "60f164bdc2dbb696c68f1c07a0b84e18f678fe915d7d446e43b1966f365b74f9"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #614.

Eliminates the full uncompressed payload clone in the pack builder delta-window loop. The loop now emits delta-window entries via the tagged-entry parts encoder using the original payload length, then moves the original `Vec<u8>` directly into the sliding `WindowEntry` for future delta-base reads.

This keeps pack contents byte-identical while avoiding one full-payload `Vec` allocation per windowed hash object. Because the builder path is single-threaded and the emitted record is not retained, this avoids adding `Arc`/`Rc` refcount overhead entirely.

## Validation

- `rustfmt --check crates/objects/src/store/pack/pack_builder.rs crates/objects/src/store/pack/pack_tests.rs`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects store::pack::pack_tests -- --nocapture`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects --features zstd store::pack::pack_tests -- --nocapture`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`

Note: workspace-wide `cargo fmt --check` still reports unrelated pre-existing formatting diffs outside this PR's scope, so I formatted and checked only the touched pack files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783926581&installation_id=132405951&pr_number=702&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F702&signature=1a855dc5bf701f5acbd0b174d401a81fb8c2891a7148e7c98a528126c8d80378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->