### PR TITLE
Kill O(n^2) reflog SHA dedup

### DIFF
--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -15,7 +15,10 @@
 //! in downstream modules; [`Importer::run`] leaves their seams wired but
 //! stubbed behind TODOs so we can land milestones independently.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use objects::{
     object::{Blob, ChangeId, ContentHash, Tree, TreeEntry},
@@ -170,14 +173,15 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
         // can't steer us into dangling territory.
         let live_shas: Vec<String> = heads.iter().map(|h| h.target_sha.clone()).collect();
         let reflog_shas = self.git.reflog_commit_shas()?;
+        let mut seed_seen: HashSet<String> = live_shas.iter().cloned().collect();
         let reflog_only_commits = reflog_shas
             .iter()
-            .filter(|s| !live_shas.iter().any(|live| live == *s))
+            .filter(|s| !seed_seen.contains(*s))
             .count();
 
         let mut seed = live_shas;
         for s in reflog_shas {
-            if !seed.contains(&s) {
+            if seed_seen.insert(s.clone()) {
                 seed.push(s);
             }
         }


### PR DESCRIPTION
## Summary
- Replace reflog SHA linear membership scans in importer seed construction with a HashSet-backed membership cache
- Preserve seed ordering: live refs first, then reflog-only SHAs in the existing reflog order
- Keep reflog-only count behavior identical while dropping dedup complexity from O(n^2) to O(n) average

Fixes #613

## Validation
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-ingest
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783927769&installation_id=132405951&pr_number=704&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F704&signature=f98275c1881d2730e0c011f802ca035c1cb56691e791f6aebd60ce21e41680f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->