### PR TITLE
Unify Tokio feature baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6610,7 +6610,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chron
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 tempfile = "3"
 thiserror = "2"
+# Tokio is centralized here so optional crate opt-ins cannot resolve a
+# weaker runtime than the CLI-level feature union needs. Member crates
+# should use `tokio.workspace = true` (or `dep:tokio` for optional
+# features) and only add local Tokio features when a new actual API need
+# is not already covered by this baseline.
 tokio = { version = "1", default-features = false, features = [
     "rt",          # current_thread runtime
     "macros",      # #[tokio::main], select!, pin!, join!

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -45,7 +45,7 @@ zstd = ["dep:zstd"]
 [dev-dependencies]
 criterion = "0.8"
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 s3s.workspace = true
 s3s-fs.workspace = true
 hyper-util.workspace = true


### PR DESCRIPTION
## Summary
- document the workspace Tokio dependency as the shared runtime baseline, including `rt-multi-thread`
- remove `tokio/full` from `heddle-objects` dev-dependencies so it inherits the shared workspace feature set
- refresh `Cargo.lock` to drop Tokio's now-unused `parking_lot` feature dependency

## Verification
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --locked --workspace`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --locked --workspace --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test --locked -p heddle-objects --features s3`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo tree --locked -i tokio --workspace`

Fixes #612

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783929196&installation_id=132405951&pr_number=705&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F705&signature=7cd01db3643a96e3393fd6605a74db9e0992249a59070999f1ad8d767ff85e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->