### PR TITLE
Validate negative refspec construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "gix-index",
  "gix-pack",
  "gix-protocol",
+ "gix-refspec",
  "gix-transport",
  "heddle-cli-shared",
  "heddle-client",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ gix-config = "0.57"
 gix-index = "0.52"
 gix-pack = "0.71"
 gix-protocol = { version = "0.62", features = ["blocking-client"] }
+gix-refspec = "0.42"
 gix-transport.workspace = true
 gix.workspace = true
 hex.workspace = true

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -267,6 +267,11 @@ mod refspec {
             forced: bool,
         ) -> GitResult<Self> {
             let destination = destination.into();
+            if source.is_none() && destination.is_empty() {
+                return Err(super::GitBridgeError::InvalidMapping(
+                    "refspec source and destination cannot both be empty".to_string(),
+                ));
+            }
             if let Some(source) = source.as_deref() {
                 validate_refspec_ref(source)?;
             }
@@ -316,24 +321,44 @@ pub use refspec::RefSpec;
 
 /// A negative refspec (`^source`) excluding refs from a fetch or push. Ported
 /// from jj's `NegativeRefSpec` (`lib/src/git.rs`).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NegativeRefSpec {
-    source: String,
-}
+mod negative_refspec {
+    use super::{GitBridgeError, GitResult, validate_refspec_ref};
 
-impl NegativeRefSpec {
-    /// A negative refspec excluding `source`.
-    pub fn new(source: impl Into<String>) -> Self {
-        Self {
-            source: source.into(),
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct NegativeRefSpec {
+        source: String,
+    }
+
+    impl NegativeRefSpec {
+        /// Construct a negative refspec after validating the rendered `^source`
+        /// form Git will receive.
+        pub fn new(source: impl Into<String>) -> GitResult<Self> {
+            let source = source.into();
+            validate_refspec_ref(&source)?;
+            let rendered = format!("^{source}");
+            gix_refspec::parse(
+                rendered.as_str().into(),
+                gix_refspec::parse::Operation::Fetch,
+            )
+            .map_err(|error| {
+                GitBridgeError::InvalidMapping(format!(
+                    "invalid negative refspec source '{source}': {error}"
+                ))
+            })?;
+            Ok(Self { source })
+        }
+
+        /// Render in `git` refspec syntax (`^source`).
+        pub fn to_git_format(&self) -> String {
+            format!("^{}", self.source)
         }
     }
-
-    /// Render in `git` refspec syntax (`^source`).
-    pub fn to_git_format(&self) -> String {
-        format!("^{}", self.source)
-    }
 }
+
+// Keep the concrete fields in a private submodule. Callers outside this module
+// cannot construct `NegativeRefSpec { ... }` directly (E0451), so all values
+// pass through `NegativeRefSpec::new`.
+pub use negative_refspec::NegativeRefSpec;
 
 /// The fetch refspecs heddle uses to mirror a remote: every branch and every
 /// heddle note, forced. Built through [`RefSpec`] so the wire format has a
@@ -4000,9 +4025,29 @@ mod tests {
     }
 
     #[test]
+    fn refspec_constructor_rejects_empty_source_and_destination() {
+        let err = RefSpec::new(None, "", false)
+            .expect_err("empty source plus empty destination is rejected");
+        assert!(err.to_string().contains("cannot both be empty"));
+    }
+
+    #[test]
     fn negative_refspec_prefixes_caret() {
-        let spec = NegativeRefSpec::new("refs/heads/wip/*");
-        assert_eq!(spec.to_git_format(), "^refs/heads/wip/*");
+        let spec = NegativeRefSpec::new("refs/heads/wip").expect("valid negative refspec");
+        assert_eq!(spec.to_git_format(), "^refs/heads/wip");
+    }
+
+    #[test]
+    fn negative_refspec_constructor_rejects_unparseable_negation() {
+        let err = NegativeRefSpec::new("refs/heads/wip/*").expect_err("negative glob is rejected");
+        assert!(err.to_string().contains("Negative glob patterns"));
+    }
+
+    #[test]
+    fn negative_refspec_constructor_rejects_reserved_remote_name() {
+        let err = NegativeRefSpec::new("refs/remotes/git/main")
+            .expect_err("reserved remote negative source is rejected");
+        assert!(err.to_string().contains("reserved namespace"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move `NegativeRefSpec` behind a private submodule and make `NegativeRefSpec::new` fallible
- validate rendered negative refspecs with `gix-refspec`, preserving #622's RefSpec constructor pattern
- reject empty source plus empty destination at `RefSpec::new` construction

RefSpec field privacy and reserved-name validation were already handled by #622; this PR closes the residual NegativeRefSpec and empty-refspec invariants.

Fixes #611

## Validation
- `cargo test -p heddle-cli refspec`
- `cargo build`
- `cargo build --all-features`
- `scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-cli --lib refspec`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783929630&installation_id=132405951&pr_number=706&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F706&signature=8f8c2e0f26494658e828e578490fb2c4d7f9e902bee2586e38d3970f6365dd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->