### PR TITLE
[codex] Harden local daemon identity checks

### DIFF
--- a/crates/cli/src/cli/commands/agent.rs
+++ b/crates/cli/src/cli/commands/agent.rs
@@ -251,15 +251,15 @@ async fn run_stop(cli: &Cli) -> Result<()> {
             return Ok(());
         }
         // Identity check — protects against PID reuse after a dirty
-        // crash. If the running process at `pid` isn't a heddle binary,
+        // crash. If the running process at `pid` isn't this executable,
         // the pidfile is stale and we must not signal.
         if !is_heddle_process(pid) {
             let _ = std::fs::remove_file(&pid_path);
             return Err(anyhow!(RecoveryAdvice::safety_refusal(
                 "agent_pid_not_heddle",
-                format!("pid {pid} is alive but does not look like a heddle process"),
+                format!("pid {pid} is alive but does not match this Heddle executable"),
                 "Rerun `heddle agent stop` only if a fresh Heddle agent pidfile appears.",
-                format!("pidfile pointed at live non-Heddle pid {pid}"),
+                format!("pidfile pointed at live pid {pid} with a different executable identity"),
                 "sending SIGTERM could stop a process Heddle does not own",
                 "the stale pidfile was removed; repository objects, refs, and worktree files were left unchanged",
                 "heddle agent status",

--- a/crates/cli/src/client/local_daemon.rs
+++ b/crates/cli/src/client/local_daemon.rs
@@ -10,11 +10,13 @@
 //! Three layers:
 //!
 //! 1. [`detect_local_daemon`] — file-stat probe (pidfile + liveness via
-//!    `kill(pid, 0)`). Cheap, syscall-only, used as the cheap negative
-//!    case ("no daemon, fall through to in-process").
+//!    `kill(pid, 0)` + same-executable identity). Cheap, syscall-only,
+//!    used as the cheap negative case ("no daemon, fall through to
+//!    in-process").
 //! 2. [`detect_local_daemon_with_connect_probe`] — same as (1) but
-//!    actually opens a `UnixStream` to confirm the listener accepts.
-//!    Catches the "stale socket file with a live unrelated PID" race.
+//!    actually opens a `UnixStream` and checks kernel-reported peer
+//!    credentials to confirm the listener is owned by our uid. Catches
+//!    the "stale socket file with a live unrelated PID" race.
 //! 3. [`connect_local_daemon_channel`] — full path: build a tonic
 //!    [`tonic::transport::Channel`] over the UDS, run the gRPC
 //!    `Health.Check` handshake, and cache the working channel for the
@@ -25,9 +27,13 @@
 //! invocation that touches one repo pays the probe cost exactly once.
 
 use std::{
+    io,
     path::{Path, PathBuf},
     time::Duration,
 };
+
+#[cfg(unix)]
+use daemon::local_daemon::is_heddle_process;
 
 use crate::util::OnceMap;
 
@@ -102,7 +108,10 @@ pub async fn detect_local_daemon_with_connect_probe(
     )
     .await
     {
-        Ok(Ok(_stream)) => Some(target),
+        Ok(Ok(stream)) => match check_peer_uid_matches_self(&stream) {
+            Ok(()) => Some(target),
+            Err(_) => None,
+        },
         // Either the connect errored (socket present but listener
         // dead — rare but possible during a graceful shutdown) or
         // the connect timed out (daemon hung). Either way it's not
@@ -215,6 +224,7 @@ async fn build_channel(
         let socket_path = socket_path.clone();
         async move {
             let stream = tokio::net::UnixStream::connect(&socket_path).await?;
+            check_peer_uid_matches_self(&stream)?;
             // tonic 0.14 requires the connector's response type to
             // implement `hyper::rt::{Read, Write}`. `TokioIo` is the
             // standard adapter and it's what tonic's own UDS connector
@@ -293,7 +303,8 @@ pub struct LocalDaemonProbe {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LocalDaemonStatus {
-    /// Socket and pidfile both exist and the pid is alive.
+    /// Socket and pidfile both exist, the pid is alive, and the pid resolves
+    /// to the same executable as this client.
     Running { pid: u32 },
     /// Pidfile exists but the pid is dead. The socket may be a leftover.
     Stale { pid: u32 },
@@ -301,13 +312,15 @@ pub enum LocalDaemonStatus {
     Absent,
 }
 
-/// Probe the per-repo daemon directory. Cheap (two file stats + one
-/// `kill(pid, 0)`).
+/// Probe the per-repo daemon directory. Cheap (two file stats, `kill(pid, 0)`,
+/// and same-executable identity for live pids).
 pub fn probe(heddle_dir: &Path) -> LocalDaemonProbe {
     let socket_path = heddle_dir.join("sockets").join("grpc.sock");
     let pid_path = heddle_dir.join("sockets").join("grpc.pid");
     let status = match read_pid(&pid_path) {
-        Some(pid) if pid_alive(pid) => LocalDaemonStatus::Running { pid },
+        Some(pid) if pid_alive(pid) && pid_identity_verified(pid) => {
+            LocalDaemonStatus::Running { pid }
+        }
         Some(pid) => LocalDaemonStatus::Stale { pid },
         None => LocalDaemonStatus::Absent,
     };
@@ -330,6 +343,37 @@ fn read_pid(path: &Path) -> Option<u32> {
         .parse::<u32>()
         .ok()
         .or_else(|| raw.trim().parse::<u32>().ok())
+}
+
+#[cfg(unix)]
+fn pid_identity_verified(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    is_heddle_process(pid)
+}
+
+#[cfg(not(unix))]
+fn pid_identity_verified(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn check_peer_uid_matches_self(stream: &tokio::net::UnixStream) -> io::Result<()> {
+    let creds = stream.peer_cred()?;
+    // SAFETY: geteuid() never fails.
+    enforce_peer_uid(creds.uid(), unsafe { libc::geteuid() })
+}
+
+#[cfg(unix)]
+fn enforce_peer_uid(peer_uid: u32, our_uid: u32) -> io::Result<()> {
+    if peer_uid != our_uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("daemon peer uid {peer_uid} does not match client uid {our_uid}"),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -380,6 +424,29 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn stale_when_pidfile_holds_live_non_heddle_pid() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .env_clear()
+            .spawn()
+            .expect("spawn sleep");
+        let temp = TempDir::new().unwrap();
+        let sockets = temp.path().join("sockets");
+        std::fs::create_dir_all(&sockets).unwrap();
+        std::fs::write(sockets.join("grpc.pid"), child.id().to_string()).unwrap();
+
+        let probe = probe(temp.path());
+
+        let _ = child.kill();
+        let _ = child.wait();
+        match probe.status {
+            LocalDaemonStatus::Stale { pid } => assert_eq!(pid, child.id()),
+            other => panic!("expected Stale for live non-Heddle pid, got {other:?}"),
+        }
+    }
+
     #[test]
     fn detect_returns_target_when_running() {
         let temp = TempDir::new().unwrap();
@@ -401,6 +468,19 @@ mod tests {
         // A fresh temp dir with no `sockets/` subtree — probe returns
         // Absent, detect collapses that to None.
         assert!(detect_local_daemon(temp.path()).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enforce_peer_uid_accepts_matching_uid() {
+        assert!(enforce_peer_uid(1000, 1000).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enforce_peer_uid_rejects_mismatched_uid() {
+        let err = enforce_peer_uid(1001, 1000).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     #[cfg(unix)]
@@ -444,6 +524,13 @@ mod tests {
             result.is_some(),
             "connect probe should succeed when a listener is bound"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_peer_uid_matches_self_accepts_socketpair() {
+        let (peer, _local) = tokio::net::UnixStream::pair().expect("socketpair");
+        assert!(check_peer_uid_matches_self(&peer).is_ok());
     }
 
     #[cfg(unix)]

--- a/crates/daemon/src/local_daemon.rs
+++ b/crates/daemon/src/local_daemon.rs
@@ -107,7 +107,7 @@ pub const PIDFILE_MARKER: &str = "heddle-agent";
 /// ```
 ///
 /// The marker line lets `agent stop` reject a pidfile that wasn't written
-/// by us. Combined with the process-identity check in
+/// by us. Combined with the same-executable identity check in
 /// [`is_heddle_process`], this closes the "PID got reused after a dirty
 /// crash" hole that the reviewer flagged: even if `<pid>` now belongs to
 /// some unrelated process, we won't SIGTERM it.
@@ -151,7 +151,7 @@ impl PidGuard {
         }
         // If a stale pidfile exists for a dead PID, clean both files and
         // proceed. If the PID is alive AND the file contains our marker
-        // AND the running process actually looks like heddle, refuse to
+        // AND the running process is this exact executable, refuse to
         // start. A foreign-format pidfile is treated as stale (we wrote
         // it, or it's debris) — we don't want to refuse forever because
         // some other tool dropped a file with the same name.
@@ -213,13 +213,13 @@ pub fn pid_alive(_pid: i32) -> bool {
     true
 }
 
-/// Best-effort check that `pid` actually belongs to a heddle binary.
+/// Verify that `pid` belongs to the same executable as this process.
 ///
 /// The pidfile marker alone doesn't protect against the "daemon dies
 /// uncleanly, OS reuses the PID" case the reviewer flagged: the marker
 /// stays in the file but the PID now points at someone else. So before
 /// any signal is delivered we also verify that the process at `pid` is
-/// running an executable whose path contains "heddle".
+/// running this exact executable, not merely a path containing "heddle".
 ///
 /// On Linux we read the `/proc/{pid}/exe` symlink — the kernel resolves
 /// it to the absolute on-disk path of the running binary. On macOS we
@@ -227,32 +227,70 @@ pub fn pid_alive(_pid: i32) -> bool {
 /// `false` (operators on those platforms can use `--force-clear` to
 /// override; better to refuse than to SIGTERM the wrong process).
 pub fn is_heddle_process(pid: i32) -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        let exe = std::path::PathBuf::from(format!("/proc/{pid}/exe"));
-        match std::fs::read_link(&exe) {
-            Ok(path) => path.to_string_lossy().contains("heddle"),
-            // ENOENT (process gone) or EACCES (different user) — treat
-            // as "not a heddle process we can verify" and refuse to act.
-            Err(_) => false,
-        }
+    process_uid_matches_self(pid) && process_exe_matches_current(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn process_uid_matches_self(pid: i32) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let path = PathBuf::from(format!("/proc/{pid}"));
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    // SAFETY: geteuid() never fails.
+    metadata.uid() == unsafe { libc::geteuid() }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_uid_matches_self(_pid: i32) -> bool {
+    true
+}
+
+fn process_exe_matches_current(pid: i32) -> bool {
+    let Some(process_exe) = process_exe_path(pid) else {
+        return false;
+    };
+    let Ok(current_exe) = std::env::current_exe() else {
+        return false;
+    };
+    executable_identity_matches(&process_exe, &current_exe)
+}
+
+fn executable_identity_matches(process_exe: &Path, current_exe: &Path) -> bool {
+    let Ok(process_exe) = process_exe.canonicalize() else {
+        return false;
+    };
+    let Ok(current_exe) = current_exe.canonicalize() else {
+        return false;
+    };
+    process_exe == current_exe
+}
+
+#[cfg(target_os = "linux")]
+fn process_exe_path(pid: i32) -> Option<PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+#[cfg(target_os = "macos")]
+fn process_exe_path(pid: i32) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let mut buf = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+    // SAFETY: buf is owned and large enough per the macOS contract.
+    let len = unsafe { libc::proc_pidpath(pid, buf.as_mut_ptr() as *mut _, buf.len() as u32) };
+    if len <= 0 {
+        return None;
     }
-    #[cfg(target_os = "macos")]
-    {
-        let mut buf = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
-        // SAFETY: buf is owned and large enough per the macOS contract.
-        let len = unsafe { libc::proc_pidpath(pid, buf.as_mut_ptr() as *mut _, buf.len() as u32) };
-        if len <= 0 {
-            return false;
-        }
-        let path = String::from_utf8_lossy(&buf[..len as usize]);
-        path.contains("heddle")
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        let _ = pid;
-        false
-    }
+    Some(PathBuf::from(OsString::from_vec(
+        buf[..len as usize].to_vec(),
+    )))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn process_exe_path(_pid: i32) -> Option<PathBuf> {
+    None
 }
 
 /// Open a [`Repository`] at `repo_path`, then run the local gRPC daemon
@@ -586,25 +624,12 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let pid = temp.path().join("grpc.pid");
         let sock = temp.path().join("grpc.sock");
-        // Write our own PID with the heddle marker. The current process
-        // (cargo test) doesn't have "heddle" in its binary path, so the
-        // identity check would fail in production — but to exercise the
-        // refusal branch we need to simulate a fresh owner. We do that by
-        // pre-installing a guard (which writes the correct format) and
-        // then immediately attempting a second install on the same path.
+        // Pre-installing a guard writes the current process PID with the
+        // marker. A second install must refuse because the recorded PID is
+        // alive and resolves to this exact test executable.
         let first = PidGuard::install(pid.clone(), sock.clone()).unwrap();
-        if is_heddle_process(std::process::id() as i32) {
-            // Test process happens to look like a heddle binary — the
-            // double-install should refuse.
-            let result = PidGuard::install(pid.clone(), sock.clone());
-            assert!(result.is_err(), "expected refusal for live owner");
-        } else {
-            // Test process isn't seen as heddle (cargo test harness),
-            // which means the identity check intentionally treats the
-            // pidfile as stale. That's the correct behavior — verify
-            // the second install succeeds and replaces the first.
-            let _second = PidGuard::install(pid.clone(), sock.clone()).unwrap();
-        }
+        let result = PidGuard::install(pid.clone(), sock.clone());
+        assert!(result.is_err(), "expected refusal for live owner");
         drop(first);
     }
 
@@ -668,6 +693,35 @@ mod tests {
         // Legacy single-integer pidfile body. Parser refuses because it
         // can't verify the file is ours.
         assert!(PidFileContents::parse("12345").is_none());
+    }
+
+    #[test]
+    fn executable_identity_accepts_same_canonical_path() {
+        let current = std::env::current_exe().unwrap();
+        assert!(executable_identity_matches(&current, &current));
+    }
+
+    #[test]
+    fn executable_identity_rejects_spoofed_heddle_path() {
+        let temp = TempDir::new().unwrap();
+        let spoofed = temp.path().join("contains-heddle").join("heddle-spoof");
+        std::fs::create_dir_all(spoofed.parent().unwrap()).unwrap();
+        std::fs::write(&spoofed, "not the current executable").unwrap();
+
+        let current = std::env::current_exe().unwrap();
+
+        assert!(
+            !executable_identity_matches(&spoofed, &current),
+            "a pathname containing heddle must not satisfy executable identity"
+        );
+    }
+
+    #[test]
+    fn is_heddle_process_accepts_self_pid() {
+        assert!(
+            is_heddle_process(std::process::id() as i32),
+            "the current process should resolve to the current executable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the spoofable "heddle" substring PID check with canonical same-executable identity verification
- require same-UID kernel peer credentials before adopting a reachable local daemon socket
- add regression coverage for spoofed paths, self identity, live non-Heddle PIDs, and peer UID enforcement

## Root Cause
The daemon PID verifier accepted any executable path containing "heddle", so a local process could spoof daemon identity by choosing a matching binary or directory name.

## Validation
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle bash scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-daemon
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-cli
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings

Fixes #621

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783933009&installation_id=132405951&pr_number=708&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F708&signature=58a1c7df45296e8af79c8e48a61941afa2ef93e51d2468f5997484385e2bbeff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->