### PR TITLE
Surface harness config and JSON parse warnings

### DIFF
--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -39,7 +39,7 @@ use crate::{
             snapshot::{summarize_confidence, summarize_verification},
             worktree_cmd::helpers::{prepare_worktree_target, write_isolated_checkout},
         },
-        worktree_status_options,
+        style, worktree_status_options,
     },
     config::{
         HarnessMode, HarnessTranscriptMode, HarnessTransport, UserConfig, UserHarnessOverride,
@@ -161,11 +161,10 @@ pub(crate) fn relay_harness_event(
     payload: &str,
 ) -> Result<()> {
     let mut runtime = init_harness_runtime(repo)?;
-    let json = if payload.trim().is_empty() {
-        Value::Null
-    } else {
-        serde_json::from_str::<Value>(payload).unwrap_or(Value::Null)
-    };
+    let (json, warning) = parse_relay_payload(payload);
+    if let Some(warning) = warning {
+        eprintln!("{}", style::warn(&warning));
+    }
     match harness {
         "codex" => relay_codex(&mut runtime, event, &json),
         "claude-code" => relay_claude(&mut runtime, event, &json),
@@ -175,11 +174,51 @@ pub(crate) fn relay_harness_event(
 }
 
 fn init_harness_runtime(repo: &Repository) -> Result<HarnessBridgeRuntime> {
-    let user_config = UserConfig::load_default().unwrap_or_default();
+    let (user_config, warning) = load_harness_user_config(UserConfig::default_path());
+    if let Some(warning) = warning {
+        eprintln!("{}", style::warn(&warning));
+    }
     Ok(HarnessBridgeRuntime::new(
         Repository::open(repo.root())?,
         user_config,
     ))
+}
+
+fn load_harness_user_config(default_path: Option<PathBuf>) -> (UserConfig, Option<String>) {
+    let Some(path) = default_path else {
+        return (UserConfig::default(), None);
+    };
+    match UserConfig::load(&path) {
+        Ok(config) => (config, None),
+        Err(err) if is_not_found(&err) => (UserConfig::default(), None),
+        Err(err) => {
+            let warning = format!(
+                "warning: failed to load user config from {}: {err}; continuing with defaults",
+                path.display()
+            );
+            (UserConfig::default(), Some(warning))
+        }
+    }
+}
+
+fn is_not_found(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<std::io::Error>()
+        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+}
+
+fn parse_relay_payload(payload: &str) -> (Value, Option<String>) {
+    if payload.trim().is_empty() {
+        return (Value::Null, None);
+    }
+    match serde_json::from_str::<Value>(payload) {
+        Ok(value) => (value, None),
+        Err(err) => (
+            Value::Null,
+            Some(format!(
+                "warning: failed to parse harness relay payload as JSON: {err}; continuing with null payload"
+            )),
+        ),
+    }
 }
 
 struct HarnessBridgeRuntime {
@@ -2816,6 +2855,75 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         (temp, repo)
+    }
+
+    #[test]
+    fn harness_config_load_missing_path_defaults_without_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let missing = temp.path().join("missing-config.toml");
+
+        let (config, warning) = load_harness_user_config(Some(missing));
+
+        assert_eq!(config.harness.transport, HarnessTransport::Spool);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn harness_config_load_malformed_path_warns_and_defaults() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("config.toml");
+        std::fs::write(&path, "[harness\ntransport = \"direct\"\n").unwrap();
+
+        let (config, warning) = load_harness_user_config(Some(path.clone()));
+
+        assert_eq!(config.harness.transport, HarnessTransport::Spool);
+        let warning = warning.expect("malformed config should produce a warning");
+        assert!(warning.contains("failed to load user config"));
+        assert!(warning.contains(&path.display().to_string()));
+        assert!(warning.contains("continuing with defaults"));
+    }
+
+    #[test]
+    fn harness_config_load_valid_path_loads_without_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[harness]\ntransport = \"direct\"\ntranscript = \"summary\"\n",
+        )
+        .unwrap();
+
+        let (config, warning) = load_harness_user_config(Some(path));
+
+        assert_eq!(config.harness.transport, HarnessTransport::Direct);
+        assert_eq!(config.harness.transcript, HarnessTranscriptMode::Summary);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn relay_payload_parse_invalid_json_warns_and_uses_null() {
+        let (value, warning) = parse_relay_payload("{not-json");
+
+        assert_eq!(value, Value::Null);
+        let warning = warning.expect("invalid JSON should produce a warning");
+        assert!(warning.contains("failed to parse harness relay payload as JSON"));
+        assert!(warning.contains("continuing with null payload"));
+    }
+
+    #[test]
+    fn relay_payload_parse_empty_payload_uses_null_without_warning() {
+        let (value, warning) = parse_relay_payload("  \n");
+
+        assert_eq!(value, Value::Null);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn relay_payload_parse_valid_json_without_warning() {
+        let (value, warning) = parse_relay_payload(r#"{"message":"hello"}"#);
+
+        assert_eq!(value["message"], "hello");
+        assert!(warning.is_none());
     }
 
     /// Harness subagent/root-actor checkout paths must use the SAME canonical

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,9 +15,9 @@ use cli::cli::{
 use cli::{
     cli::{
         ActorCommands, AgentCommands, Cli, CloneArgs, CollapseArgs, Commands, ContextCommands,
-        DaemonCommands, DiagnoseArgs, DiffArgs, LogArgs, MergeArgs, ResolveArgs, RetroArgs,
-        RevertArgs, RunArgs, SessionCommands, SessionEndArgs, SessionListArgs, SessionSegmentArgs,
-        SessionShowArgs, SessionStartArgs, UndoArgs,
+        DaemonCommands, DiagnoseArgs, DiffArgs, IntegrationCommands, LogArgs, MergeArgs,
+        ResolveArgs, RetroArgs, RevertArgs, RunArgs, SessionCommands, SessionEndArgs,
+        SessionListArgs, SessionSegmentArgs, SessionShowArgs, SessionStartArgs, UndoArgs,
         cli_args::{LandArgs, SyncArgs},
         commands::{
             LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
@@ -207,6 +207,10 @@ async fn async_main() -> Result<()> {
     // would propagate to `main` and print via anyhow's Debug impl.
     let user_config = match UserConfig::load_default() {
         Ok(config) => config,
+        // Hidden harness relay hooks must reach harness init so that a bad
+        // user config is reported as a warning and the hook can continue.
+        // Normal foreground commands keep the strict typed error path.
+        Err(_) if is_harness_relay_invocation(&cli.command) => UserConfig::default(),
         Err(err) => {
             let code = HeddleExitCode::from_error(&err);
             print_error_with_hint(&cli, &err);
@@ -843,6 +847,15 @@ async fn async_main() -> Result<()> {
             std::process::exit(code.into());
         }
     }
+}
+
+fn is_harness_relay_invocation(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Integration {
+            command: IntegrationCommands::Relay(_),
+        }
+    )
 }
 
 fn rewrite_phase_2_alias_argv(argv: &[String]) -> Option<Vec<String>> {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -52,6 +52,8 @@ mod git_overlay_remote_ref_import;
 mod git_overlay_sync_adoption;
 #[path = "cli_integration/git_replacement_matrix.rs"]
 mod git_replacement_matrix;
+#[path = "cli_integration/harness_error_surface.rs"]
+mod harness_error_surface;
 #[path = "cli_integration/hooks.rs"]
 mod hooks;
 #[path = "cli_integration/hydrate.rs"]

--- a/crates/cli/tests/cli_integration/harness_error_surface.rs
+++ b/crates/cli/tests/cli_integration/harness_error_surface.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Output, Stdio},
+};
+
+use tempfile::TempDir;
+
+use super::heddle;
+
+fn run_relay(cwd: &Path, config_path: &Path, payload: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(["integration", "relay", "codex", "agent_done"])
+        .current_dir(cwd)
+        .env("HEDDLE_CONFIG", config_path)
+        .env_remove("NO_COLOR")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn heddle relay");
+    child
+        .stdin
+        .take()
+        .expect("relay stdin")
+        .write_all(payload.as_bytes())
+        .expect("write relay payload");
+    child.wait_with_output().expect("wait for heddle relay")
+}
+
+#[test]
+fn harness_relay_warns_on_malformed_user_config_and_continues() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let config = temp.path().join("bad-config.toml");
+    std::fs::write(&config, "[harness\ntransport = \"direct\"\n").unwrap();
+
+    let output = run_relay(temp.path(), &config, r#"{"message":"hello"}"#);
+
+    assert!(
+        output.status.success(),
+        "relay should continue with defaults; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: failed to load user config"),
+        "malformed config warning should be visible: {stderr}"
+    );
+    assert!(
+        stderr.contains(&config.display().to_string()),
+        "warning should name the config path: {stderr}"
+    );
+}
+
+#[test]
+fn harness_relay_missing_user_config_defaults_without_warning() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let missing = temp.path().join("missing-config.toml");
+
+    let output = run_relay(temp.path(), &missing, r#"{"message":"hello"}"#);
+
+    assert!(
+        output.status.success(),
+        "relay should continue with defaults; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to load user config"),
+        "missing config should not warn: {stderr}"
+    );
+}
+
+#[test]
+fn harness_relay_valid_user_config_loads_without_warning() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let config = temp.path().join("config.toml");
+    std::fs::write(&config, "[harness]\ntransport = \"spool\"\n").unwrap();
+
+    let output = run_relay(temp.path(), &config, r#"{"message":"hello"}"#);
+
+    assert!(
+        output.status.success(),
+        "relay should load valid config; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to load user config"),
+        "valid config should not warn: {stderr}"
+    );
+}
+
+#[test]
+fn harness_relay_warns_on_invalid_payload_json_and_continues() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let config = temp.path().join("config.toml");
+    std::fs::write(&config, "[harness]\ntransport = \"spool\"\n").unwrap();
+
+    let output = run_relay(temp.path(), &config, "{not-json");
+
+    assert!(
+        output.status.success(),
+        "relay should continue with null payload; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: failed to parse harness relay payload as JSON"),
+        "invalid JSON warning should be visible: {stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #610

## Summary
- warn and continue when harness relay config exists but cannot be loaded
- keep missing harness config silent/defaulted
- warn and continue when harness relay payload JSON is invalid

## Verification
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo run -p heddle-devtools -- check-no-silent-default-tree-load
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-cli
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783933253&installation_id=132405951&pr_number=709&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F709&signature=67afee4bb18317617b9cb2d876bcf69338c730eea35b85d1631490e96b126018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->