### PR TITLE
Roll back GitBridge mapping state on sync failure

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -492,7 +492,7 @@ impl WriteThroughOutcome {
 }
 
 /// Mapping between Heddle ChangeIds and Git commit object IDs.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SyncMapping {
     /// Maps Heddle ChangeId -> Git object id
     heddle_to_git: HashMap<ChangeId, ObjectId>,
@@ -676,6 +676,39 @@ pub struct GitBridge<'a> {
     pub(crate) commit_message_overrides: HashMap<ChangeId, String>,
 }
 
+struct MappingFileSnapshot {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl MappingFileSnapshot {
+    fn read(path: PathBuf) -> GitResult<Self> {
+        let contents = match fs::read(&path) {
+            Ok(contents) => Some(contents),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        Ok(Self { path, contents })
+    }
+
+    fn restore(self) -> GitResult<()> {
+        match self.contents {
+            Some(contents) => {
+                if let Some(parent) = self.path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(&self.path, contents)?;
+            }
+            None => match fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            },
+        }
+        Ok(())
+    }
+}
+
 impl<'a> GitBridge<'a> {
     /// Trailer keys used in Git commit messages for Heddle metadata.
     pub(crate) const TRAILER_CHANGE_ID: &'static str = "Heddle-Change-Id";
@@ -816,6 +849,33 @@ impl<'a> GitBridge<'a> {
     /// Import Git commits into Heddle states.
     pub fn import(&mut self, git_path: Option<&Path>) -> GitResult<super::git_util::ImportStats> {
         import_all(self, git_path)
+    }
+
+    pub(crate) fn with_mapping_rollback<T>(
+        &mut self,
+        operation: impl FnOnce(&mut Self) -> GitResult<T>,
+    ) -> GitResult<T> {
+        let mapping = self.mapping.clone();
+        let commit_message_overrides = self.commit_message_overrides.clone();
+        let mapping_file = MappingFileSnapshot::read(self.mapping_path())?;
+        let mapping_tmp_file = MappingFileSnapshot::read(self.mapping_tmp_path())?;
+
+        match operation(self) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.mapping = mapping;
+                self.commit_message_overrides = commit_message_overrides;
+                if let Err(rollback_error) = mapping_file
+                    .restore()
+                    .and_then(|()| mapping_tmp_file.restore())
+                {
+                    return Err(GitBridgeError::Git(format!(
+                        "operation failed ({error}); additionally failed to roll back git bridge mapping state ({rollback_error})"
+                    )));
+                }
+                Err(error)
+            }
+        }
     }
 
     /// Push to a Git remote. Returns the full names of the refs written

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -279,12 +279,12 @@ pub fn export_tree(
 
 /// Export all Heddle states to Git commits.
 pub fn export_all(bridge: &mut GitBridge) -> GitResult<ExportStats> {
-    export_scoped(bridge, None)
+    bridge.with_mapping_rollback(|bridge| export_scoped(bridge, None))
 }
 
 /// Export one Heddle thread to its matching Git branch.
 pub fn export_current_thread(bridge: &mut GitBridge, thread: &str) -> GitResult<ExportStats> {
-    export_scoped(bridge, Some(thread))
+    bridge.with_mapping_rollback(|bridge| export_scoped(bridge, Some(thread)))
 }
 
 fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<ExportStats> {

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -515,7 +515,9 @@ pub fn backfill_fidelity(bridge: &mut GitBridge<'_>) -> GitResult<BackfillStats>
 
 /// Import Git commits into Heddle states.
 pub fn import_all(bridge: &mut GitBridge, git_path: Option<&Path>) -> GitResult<ImportStats> {
-    import_with_ref_filter(bridge, git_path, None, GitImportOptions::default(), None)
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(bridge, git_path, None, GitImportOptions::default(), None)
+    })
 }
 
 pub fn import_all_with_options(
@@ -523,7 +525,9 @@ pub fn import_all_with_options(
     git_path: Option<&Path>,
     options: GitImportOptions,
 ) -> GitResult<ImportStats> {
-    import_with_ref_filter(bridge, git_path, None, options, None)
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(bridge, git_path, None, options, None)
+    })
 }
 
 /// Like [`import_all`], reporting the running commit count to `progress`
@@ -533,13 +537,15 @@ pub fn import_all_with_progress(
     git_path: Option<&Path>,
     progress: Option<&mut dyn FnMut(usize)>,
 ) -> GitResult<ImportStats> {
-    import_with_ref_filter(
-        bridge,
-        git_path,
-        None,
-        GitImportOptions::default(),
-        progress,
-    )
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(
+            bridge,
+            git_path,
+            None,
+            GitImportOptions::default(),
+            progress,
+        )
+    })
 }
 
 pub fn import_selected_refs(
@@ -548,13 +554,15 @@ pub fn import_selected_refs(
     refs: &[String],
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(
-        bridge,
-        git_path,
-        Some(&wanted),
-        GitImportOptions::default(),
-        None,
-    )
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(
+            bridge,
+            git_path,
+            Some(&wanted),
+            GitImportOptions::default(),
+            None,
+        )
+    })
 }
 
 pub fn import_selected_refs_with_options(
@@ -564,7 +572,9 @@ pub fn import_selected_refs_with_options(
     options: GitImportOptions,
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(bridge, git_path, Some(&wanted), options, None)
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(bridge, git_path, Some(&wanted), options, None)
+    })
 }
 
 /// Like [`import_selected_refs`], reporting the running commit count to
@@ -576,13 +586,15 @@ pub fn import_selected_refs_with_progress(
     progress: Option<&mut dyn FnMut(usize)>,
 ) -> GitResult<ImportStats> {
     let wanted = refs.iter().cloned().collect::<HashSet<_>>();
-    import_with_ref_filter(
-        bridge,
-        git_path,
-        Some(&wanted),
-        GitImportOptions::default(),
-        progress,
-    )
+    bridge.with_mapping_rollback(|bridge| {
+        import_with_ref_filter(
+            bridge,
+            git_path,
+            Some(&wanted),
+            GitImportOptions::default(),
+            progress,
+        )
+    })
 }
 
 fn import_with_ref_filter(

--- a/crates/cli/src/bridge/test_support.rs
+++ b/crates/cli/src/bridge/test_support.rs
@@ -195,6 +195,18 @@ pub fn mapping_mut<'a>(bridge: &'a mut GitBridge<'_>) -> &'a mut SyncMapping {
     &mut bridge.mapping
 }
 
+pub fn commit_message_overrides<'a>(bridge: &'a GitBridge<'_>) -> &'a HashMap<ChangeId, String> {
+    &bridge.commit_message_overrides
+}
+
+pub fn set_commit_message_override(
+    bridge: &mut GitBridge<'_>,
+    state_id: ChangeId,
+    message: String,
+) {
+    bridge.set_commit_message_override(state_id, message);
+}
+
 pub fn mapping_path(bridge: &GitBridge<'_>) -> PathBuf {
     bridge.mapping_path()
 }
@@ -216,14 +228,6 @@ pub fn open_git_repo(bridge: &GitBridge<'_>) -> GitResult<gix::Repository> {
 
 pub fn heddle_repo<'a>(bridge: &'a GitBridge<'a>) -> &'a HeddleRepository {
     bridge.heddle_repo
-}
-
-pub fn set_commit_message_override(
-    bridge: &mut GitBridge<'_>,
-    state_id: ChangeId,
-    message: String,
-) {
-    bridge.set_commit_message_override(state_id, message);
 }
 
 pub fn open_repo(path: &Path) -> GitResult<gix::Repository> {

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -17,7 +17,7 @@ use std::{
 use base64::Engine;
 use gix::refs::transaction::PreviousValue;
 use objects::object::{
-    Blob, ChangeId, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry,
+    Blob, ChangeId, ContentHash, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry,
 };
 use repo::Repository;
 use tempfile::TempDir;
@@ -1598,6 +1598,54 @@ fn import_rejects_branch_name_that_is_not_a_valid_thread_id() {
 }
 
 #[test]
+fn failed_import_restores_mapping_and_overrides() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_git_temp, git_repo) = init_git_repo();
+
+    let tree_oid = empty_tree_oid(&git_repo);
+    let base = commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "base", &[]);
+    commit_with_tree(
+        &git_repo,
+        Some("refs/heads/evil;rm"),
+        tree_oid,
+        "evil",
+        &[base],
+    );
+
+    let mut bridge = GitBridge::new(&repo);
+    test_support::set_commit_message_override(
+        &mut bridge,
+        ChangeId::from_bytes([3; 16]),
+        "pre-call override".to_string(),
+    );
+    let pre_mapping = test_support::mapping(&bridge).clone();
+    let pre_overrides = test_support::commit_message_overrides(&bridge).clone();
+
+    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir")))
+        .expect_err("invalid branch name must fail after commits are mapped");
+
+    assert_eq!(
+        test_support::mapping(&bridge),
+        &pre_mapping,
+        "failed import must restore the pre-call mapping"
+    );
+    assert_eq!(
+        test_support::commit_message_overrides(&bridge),
+        &pre_overrides,
+        "failed import must restore pre-call commit message overrides"
+    );
+
+    test_support::build_existing_mapping(&mut bridge, Some(git_repo.workdir().expect("workdir")))
+        .expect("mapping rebuild after failed import");
+    assert_eq!(
+        test_support::mapping(&bridge),
+        &pre_mapping,
+        "rebuilding after a failed import must not recover partial mappings from the sidecar"
+    );
+}
+
+#[test]
 fn push_exports_local_branches_and_tags_to_path_remote() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
@@ -2544,6 +2592,98 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
         !stats.branches.iter().any(|b| b.name == "scratch"),
         "dropped scratch thread is not a synced branch: {:?}",
         stats.branches
+    );
+}
+
+#[test]
+fn failed_export_restores_mapping_and_overrides_after_purge() {
+    use chrono::Utc;
+    use objects::object::{Attribution, Principal, State, StateVisibility, VisibilityTier};
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init_default(heddle_temp.path()).expect("init heddle");
+    let mut cfg = repo.config().clone();
+    cfg.set_principal("Grace Hopper", "grace@example.com");
+    cfg.save(&repo.heddle_dir().join("config.toml"))
+        .expect("save principal");
+    let repo = Repository::open(heddle_temp.path()).expect("reopen heddle");
+
+    let attribution = || Attribution::human(Principal::new("Grace Hopper", "grace@example.com"));
+    let store = repo.store();
+    let blob_hash = store
+        .put_blob(&Blob::from_slice(b"public\n"))
+        .expect("put blob");
+    let tree_hash = store
+        .put_tree(&Tree::from_entries(vec![TreeEntry::file(
+            "public.txt".to_string(),
+            blob_hash,
+            false,
+        )
+        .expect("tree entry")]))
+        .expect("put tree");
+    let exported_state = State::new(tree_hash, Vec::new(), attribution());
+    store.put_state(&exported_state).expect("put exported state");
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &exported_state.change_id)
+        .expect("set main thread");
+
+    let mut bridge = GitBridge::new(&repo);
+    export_all(&mut bridge).expect("initial export seeds mapping");
+
+    repo.put_state_visibility(StateVisibility {
+        state: exported_state.change_id,
+        tier: VisibilityTier::Private {
+            scope_label: "embargo".to_string(),
+        },
+        embargo_until: None,
+        declarer: Principal::new("Grace Hopper", "grace@example.com"),
+        declared_at: Utc::now(),
+        signature: None,
+        supersedes: None,
+    })
+    .expect("mark exported state private");
+
+    let bad_tree_hash = store
+        .put_tree(&Tree::from_entries(vec![TreeEntry::file(
+            "missing.txt".to_string(),
+            ContentHash::from_bytes([9; 32]),
+            false,
+        )
+        .expect("tree entry")]))
+        .expect("put bad tree");
+    let bad_state = State::new(bad_tree_hash, Vec::new(), attribution());
+    store.put_state(&bad_state).expect("put bad state");
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &bad_state.change_id)
+        .expect("set main to bad state");
+
+    test_support::set_commit_message_override(
+        &mut bridge,
+        exported_state.change_id,
+        "pre-call override".to_string(),
+    );
+    let pre_mapping = test_support::mapping(&bridge).clone();
+    let pre_overrides = test_support::commit_message_overrides(&bridge).clone();
+
+    export_all(&mut bridge).expect_err("missing blob must fail after visibility purge");
+
+    assert_eq!(
+        test_support::mapping(&bridge),
+        &pre_mapping,
+        "failed export must restore the pre-call mapping"
+    );
+    assert_eq!(
+        test_support::commit_message_overrides(&bridge),
+        &pre_overrides,
+        "failed export must restore pre-call commit message overrides"
+    );
+
+    test_support::build_existing_mapping(&mut bridge, None)
+        .expect("mapping rebuild after failed export");
+    assert_eq!(
+        test_support::mapping(&bridge),
+        &pre_mapping,
+        "rebuilding after a failed export must behave as if the purge never ran"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add a rollback boundary around GitBridge export/import entry points so mapping and commit message overrides are restored on errors.
- Restore the bridge mapping sidecar/temp files on failed sync operations so later mapping rebuilds do not recover partial state.
- Add regression coverage for failed export purge and failed import branch-sync paths.

Fixes #607

## Validation
- cargo build
- cargo build --all-features
- cargo run -p heddle-devtools -- check-no-silent-default-tree-load
- cargo test -p heddle-cli
- cargo test -p heddle-cli --test git_bridge_integration failed_import_restores_mapping_and_overrides -- --nocapture
- cargo test -p heddle-cli --test git_bridge_integration failed_export_restores_mapping_and_overrides_after_purge -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783933623&installation_id=132405951&pr_number=710&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F710&signature=e284a24dad131af1c5702670b31a8392b027b10873be84360801fbfc6631691d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->