### PR TITLE
Fix lossy attribution for cached git subtrees

### DIFF
--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -259,11 +259,11 @@ pub fn import_commit(
         })
         .collect::<GitResult<Vec<_>>>()?;
 
-    // Canonical lossy marker (#567): if importing this commit's tree dropped or
-    // converted any unrepresentable entry, the rebuilt tree no longer hashes to
-    // the original, so record it on the State. `import_tree` appends to the
-    // importer's running lossy-entry log (even for cached subtrees), so a growth
-    // across this call means this commit's content is lossy.
+    // Canonical lossy marker (#567): if importing this commit's tree newly
+    // dropped or converted any unrepresentable entry, the rebuilt tree no
+    // longer hashes to the original, so record it on the State. Cached subtrees
+    // do not append to the running log; their lossy entries were already
+    // attributed to the commit that first introduced that tree in this import.
     let lossy_before = tree_importer.lossy_entries().len();
     let tree_hash = tree_importer.import_tree(tree_id)?;
     let git_lossy = tree_importer.lossy_entries().len() > lossy_before;

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -28,7 +28,6 @@ pub struct GitTreeImporter<'a> {
     blob_cache: HashMap<gix::hash::ObjectId, ContentHash>,
     options: GitImportOptions,
     lossy_entries: Vec<LossyGitImportEntry>,
-    lossy_by_tree: HashMap<gix::hash::ObjectId, Vec<LossyGitImportEntry>>,
     /// When set, imported blobs/trees/states stream into a single native
     /// pack instead of N loose objects (heddle#555). `None` keeps the
     /// legacy loose-write path for callers like [`import_git_tree`].
@@ -52,7 +51,6 @@ impl<'a> GitTreeImporter<'a> {
             blob_cache: HashMap::new(),
             options,
             lossy_entries: Vec::new(),
-            lossy_by_tree: HashMap::new(),
             pack: None,
         }
     }
@@ -74,7 +72,6 @@ impl<'a> GitTreeImporter<'a> {
             blob_cache: HashMap::new(),
             options,
             lossy_entries: Vec::new(),
-            lossy_by_tree: HashMap::new(),
             pack: Some(sink),
         }
     }
@@ -163,13 +160,6 @@ impl<'a> GitTreeImporter<'a> {
         path_prefix: &str,
     ) -> GitResult<ContentHash> {
         if let Some(hash) = self.tree_cache.get(&tree_oid) {
-            if let Some(entries) = self.lossy_by_tree.get(&tree_oid) {
-                self.lossy_entries.extend(
-                    entries
-                        .iter()
-                        .map(|entry| rebase_lossy_entry(path_prefix, entry)),
-                );
-            }
             return Ok(*hash);
         }
 
@@ -179,7 +169,6 @@ impl<'a> GitTreeImporter<'a> {
             .map_err(|err| GitBridgeError::Git(err.to_string()))?;
 
         let mut entries = Vec::new();
-        let before_lossy = self.lossy_entries.len();
 
         for entry in git_tree.iter() {
             let entry = entry.map_err(|err| GitBridgeError::Git(err.to_string()))?;
@@ -252,16 +241,10 @@ impl<'a> GitTreeImporter<'a> {
                 }
             }
         }
-        let tree_lossy_entries = self.lossy_entries[before_lossy..]
-            .iter()
-            .map(|entry| entry_relative_to_prefix(path_prefix, entry))
-            .collect::<Vec<_>>();
-
         let tree = Tree::from_entries(entries);
         let hash = tree.hash();
         self.write_tree(hash, &tree)?;
         self.tree_cache.insert(tree_oid, hash);
-        self.lossy_by_tree.insert(tree_oid, tree_lossy_entries);
         Ok(hash)
     }
 
@@ -367,26 +350,6 @@ fn display_tree_name(name: &str) -> String {
     } else {
         name.to_string()
     }
-}
-
-fn rebase_lossy_entry(prefix: &str, entry: &LossyGitImportEntry) -> LossyGitImportEntry {
-    let mut rebased = entry.clone();
-    if !prefix.is_empty() {
-        rebased.path = format!("{prefix}/{}", entry.path);
-    }
-    rebased
-}
-
-fn entry_relative_to_prefix(prefix: &str, entry: &LossyGitImportEntry) -> LossyGitImportEntry {
-    if prefix.is_empty() {
-        return entry.clone();
-    }
-
-    let mut relative = entry.clone();
-    if let Some(stripped) = entry.path.strip_prefix(prefix) {
-        relative.path = stripped.trim_start_matches('/').to_string();
-    }
-    relative
 }
 
 /// Per-process counter so concurrent imports stage to distinct pack basenames.

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -724,6 +724,87 @@ fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
 }
 
 #[test]
+fn import_all_lossy_does_not_reattribute_cached_shared_subtree_entries() {
+    let (_git_temp, git_repo) = init_git_repo();
+    let shared_tree = gitlink_tree(&git_repo, "vendor");
+
+    let mut first_editor = git_repo
+        .edit_tree(empty_tree_oid(&git_repo))
+        .expect("first tree editor");
+    first_editor
+        .upsert("shared", gix::object::tree::EntryKind::Tree, shared_tree)
+        .expect("insert shared subtree");
+    let first_tree = first_editor.write().expect("write first tree").detach();
+    let first_commit = commit_with_tree(&git_repo, None, first_tree, "add shared subtree", &[]);
+
+    let note_blob = git_repo
+        .write_blob(b"second\n")
+        .expect("note blob")
+        .detach();
+    let mut second_editor = git_repo
+        .edit_tree(empty_tree_oid(&git_repo))
+        .expect("second tree editor");
+    second_editor
+        .upsert("shared", gix::object::tree::EntryKind::Tree, shared_tree)
+        .expect("reuse shared subtree");
+    second_editor
+        .upsert("note.txt", gix::object::tree::EntryKind::Blob, note_blob)
+        .expect("insert unrelated root change");
+    let second_tree = second_editor.write().expect("write second tree").detach();
+    let second_commit = commit_with_tree(
+        &git_repo,
+        Some("refs/heads/main"),
+        second_tree,
+        "reuse shared subtree",
+        &[first_commit],
+    );
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut bridge = GitBridge::new(&repo);
+    let stats = import_all_with_options(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir")),
+        GitImportOptions { lossy: true },
+    )
+    .expect("lossy import accepts shared gitlink subtree");
+
+    assert_eq!(stats.states_created, 2);
+    assert_eq!(
+        stats.lossy_entries.len(),
+        1,
+        "the cached shared subtree must not inflate lossy stats"
+    );
+    assert_eq!(stats.lossy_entries[0].path, "shared/vendor");
+
+    let mapping =
+        std::fs::read_to_string(test_support::mapping_path(&bridge)).expect("mapping sidecar");
+    let mapping: serde_json::Value = serde_json::from_str(&mapping).expect("mapping json");
+    let entries = mapping["entries"].as_array().expect("mapping entries");
+    let first_entry = entries
+        .iter()
+        .find(|entry| entry["git_oid"] == first_commit.to_string())
+        .expect("first commit mapping");
+    let second_entry = entries
+        .iter()
+        .find(|entry| entry["git_oid"] == second_commit.to_string())
+        .expect("second commit mapping");
+
+    let first_lossy_entries = first_entry["lossy_entries"]
+        .as_array()
+        .expect("first lossy entries");
+    assert_eq!(first_lossy_entries.len(), 1);
+    assert_eq!(first_lossy_entries[0]["path"], "shared/vendor");
+    assert!(
+        second_entry
+            .get("lossy_entries")
+            .and_then(|entries| entries.as_array())
+            .is_none_or(Vec::is_empty),
+        "second commit must not be attributed the parent's shared subtree loss"
+    );
+}
+
+#[test]
 fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
     let (_git_temp, git_repo) = init_gitlink_repo();
     let git_path = git_repo.workdir().expect("workdir");


### PR DESCRIPTION
## Summary
- stop the Git tree importer cache-hit path from re-appending cached lossy entries to the shared lossy accumulator
- remove the now-unused per-tree lossy rebase cache
- add a regression where a second commit reuses a parent shared subtree with a gitlink and must not inherit that lossy attribution

Fixes #455

## Validation
- `cargo build --workspace`
- `cargo run -p heddle-devtools -- check-no-silent-default-tree-load`
- `cargo build --workspace --all-features`
- `cargo test -p heddle-cli --lib`
- `cargo test -p heddle-cli --test git_bridge_integration lossy -- --nocapture`
- `cargo test -p heddle-cli --test git_bridge_integration`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Known unrelated failure
- `cargo test -p heddle-cli --tests` failed in `oss_cli_polish::ready_capture_is_visible_and_carries_confidence` and `oss_cli_polish::ready_text_names_ready_and_already_ready_noop_states`; both expect `integration: none configured`, while runtime output prints `integration: n/a (no integration target configured)`. These readiness-copy tests are outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783936357&installation_id=132405951&pr_number=711&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F711&signature=83ebb78cbd7a449d99e402ad37c6c9802dc2fd0c47cd008525d43666bf4e9cdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->