### PR TITLE
Stabilize ready output fields

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -3744,6 +3744,561 @@
             "agent_may_fill"
           ],
           "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "ReadyChecksSchema": {
+          "properties": {
+            "reason": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "ReadyReadinessSchema": {
+          "properties": {
+            "blockers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "captured": {
+              "type": "boolean"
+            },
+            "captured_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "changed_path_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "changed_paths": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "checks": {
+              "$ref": "#/$defs/ReadyChecksSchema"
+            },
+            "conflict_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "conflicts": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "type": "string"
+            },
+            "impact": {
+              "type": "string"
+            },
+            "impact_categories": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "integration": {
+              "type": "string"
+            },
+            "merge_type": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "captured",
+            "checks",
+            "integration",
+            "freshness",
+            "merge_type",
+            "changed_path_count",
+            "changed_paths",
+            "conflict_count",
+            "conflicts",
+            "impact",
+            "impact_categories",
+            "blockers"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MachineContractCoverageSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -3755,10 +4310,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "captured": {
           "type": "boolean"
@@ -3836,6 +4388,9 @@
           ],
           "type": "string"
         },
+        "readiness": {
+          "$ref": "#/$defs/ReadyReadinessSchema"
+        },
         "recommended_action": {
           "type": [
             "string",
@@ -3868,22 +4423,26 @@
             "null"
           ]
         },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        },
         "warnings": {
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [
         "status",
         "action",
         "message",
+        "blockers",
+        "warnings",
         "captured",
+        "readiness",
         "report",
+        "verification",
         "output_kind"
       ],
       "title": "ReadySchema",
@@ -12654,6 +13213,561 @@
             "agent_may_fill"
           ],
           "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "ReadyChecksSchema": {
+          "properties": {
+            "reason": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "ReadyReadinessSchema": {
+          "properties": {
+            "blockers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "captured": {
+              "type": "boolean"
+            },
+            "captured_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "changed_path_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "changed_paths": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "checks": {
+              "$ref": "#/$defs/ReadyChecksSchema"
+            },
+            "conflict_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "conflicts": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "type": "string"
+            },
+            "impact": {
+              "type": "string"
+            },
+            "impact_categories": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "integration": {
+              "type": "string"
+            },
+            "merge_type": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "captured",
+            "checks",
+            "integration",
+            "freshness",
+            "merge_type",
+            "changed_path_count",
+            "changed_paths",
+            "conflict_count",
+            "conflicts",
+            "impact",
+            "impact_categories",
+            "blockers"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MachineContractCoverageSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -12665,10 +13779,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         },
         "captured": {
           "type": "boolean"
@@ -12746,6 +13857,9 @@
           ],
           "type": "string"
         },
+        "readiness": {
+          "$ref": "#/$defs/ReadyReadinessSchema"
+        },
         "recommended_action": {
           "type": [
             "string",
@@ -12778,22 +13892,26 @@
             "null"
           ]
         },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        },
         "warnings": {
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [
         "status",
         "action",
         "message",
+        "blockers",
+        "warnings",
         "captured",
+        "readiness",
         "report",
+        "verification",
         "output_kind"
       ],
       "title": "ReadySchema",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -196,7 +196,7 @@ export interface AgentHeartbeatSchema {
 
 export interface AgentReadySchema {
   action: string;
-  blockers?: string[] | null;
+  blockers: string[];
   captured: boolean;
   captured_state?: string | null;
   idempotency_status?: string | null;
@@ -206,13 +206,15 @@ export interface AgentReadySchema {
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "ready";
+  readiness: ReadyReadinessSchema;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
   report: unknown;
   status: string;
   thread_state?: string | null;
-  warnings?: string[] | null;
+  verification: RepositoryVerificationStateSchema;
+  warnings: string[];
 }
 
 export interface AgentReleaseSchema {
@@ -1418,9 +1420,31 @@ export interface QuerySchema {
   output_kind: "query";
 }
 
+export interface ReadyChecksSchema {
+  reason: string;
+  status: string;
+}
+
+export interface ReadyReadinessSchema {
+  blockers: string[];
+  captured: boolean;
+  captured_state?: string | null;
+  changed_path_count: number;
+  changed_paths: string[];
+  checks: ReadyChecksSchema;
+  conflict_count: number;
+  conflicts: string[];
+  freshness: string;
+  impact: string;
+  impact_categories: string[];
+  integration: string;
+  merge_type: string;
+  status: string;
+}
+
 export interface ReadySchema {
   action: string;
-  blockers?: string[] | null;
+  blockers: string[];
   captured: boolean;
   captured_state?: string | null;
   idempotency_status?: string | null;
@@ -1430,13 +1454,15 @@ export interface ReadySchema {
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "ready";
+  readiness: ReadyReadinessSchema;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
   report: unknown;
   status: string;
   thread_state?: string | null;
-  warnings?: string[] | null;
+  verification: RepositoryVerificationStateSchema;
+  warnings: string[];
 }
 
 export interface RebaseSchema {

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -8,7 +8,10 @@ use repo::{
     GitOverlayImportHint, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus,
     ThreadState,
 };
-use serde::Serialize;
+use serde::{
+    Serialize, Serializer,
+    ser::{Error as SerError, SerializeStruct},
+};
 
 use super::{
     action_line::print_next,
@@ -36,18 +39,105 @@ use crate::{
     config::UserConfig,
 };
 
-#[derive(Serialize)]
 struct ReadyOutput {
-    #[serde(flatten)]
     operator: OperatorCommandOutput,
     captured: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     captured_state: Option<String>,
     thread_state: String,
-    #[serde(skip_serializing)]
-    #[serde(rename = "verification")]
     trust: RepositoryVerificationState,
     report: ThreadPreviewReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ReadyReadinessSummary {
+    status: String,
+    captured: bool,
+    captured_state: Option<String>,
+    checks: ReadyChecksSummary,
+    integration: String,
+    freshness: String,
+    merge_type: String,
+    changed_path_count: usize,
+    changed_paths: Vec<String>,
+    conflict_count: usize,
+    conflicts: Vec<String>,
+    impact: String,
+    impact_categories: Vec<String>,
+    blockers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ReadyChecksSummary {
+    status: String,
+    reason: String,
+}
+
+impl ReadyOutput {
+    fn readiness_summary(&self) -> ReadyReadinessSummary {
+        let checks = ready_checks_summary(self);
+        let integration = ready_integration_summary(&self.report);
+        let freshness = ready_freshness_summary(&self.report);
+        let merge_type = ready_merge_type_summary(&self.report);
+        let impact = if self.report.impact_categories.is_empty() {
+            "none".to_string()
+        } else {
+            self.report.impact_categories.join(", ")
+        };
+        ReadyReadinessSummary {
+            status: ready_status_summary(&self.report),
+            captured: self.captured,
+            captured_state: self.captured_state.clone(),
+            checks,
+            integration,
+            freshness,
+            merge_type,
+            changed_path_count: self.report.changed_path_count,
+            changed_paths: self.report.changed_paths.clone(),
+            conflict_count: self.report.conflict_count,
+            conflicts: self.report.conflicts.clone(),
+            impact,
+            impact_categories: self.report.impact_categories.clone(),
+            blockers: self.report.blockers.clone(),
+        }
+    }
+}
+
+impl Serialize for ReadyOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let next_action = normalized_action(self.operator.next_action.clone().unwrap_or_default());
+        let recommended_action =
+            normalized_action(self.operator.recommended_action.clone().unwrap_or_default());
+        let next_action_template = next_action
+            .as_deref()
+            .and_then(super::git_overlay_health::action_template);
+        let recommended_action_template = recommended_action
+            .as_deref()
+            .and_then(super::git_overlay_health::action_template);
+        let verification = serde_json::to_value(&self.trust).map_err(S::Error::custom)?;
+        let readiness = self.readiness_summary();
+
+        let mut state = serializer.serialize_struct("ReadyOutput", 18)?;
+        state.serialize_field("output_kind", "ready")?;
+        state.serialize_field("status", &self.operator.status)?;
+        state.serialize_field("action", &self.operator.action)?;
+        state.serialize_field("message", &self.operator.message)?;
+        state.serialize_field("blockers", &self.operator.blockers)?;
+        state.serialize_field("warnings", &self.operator.warnings)?;
+        state.serialize_field("next_action", &next_action)?;
+        state.serialize_field("next_action_template", &next_action_template)?;
+        state.serialize_field("recommended_action", &recommended_action)?;
+        state.serialize_field("recommended_action_template", &recommended_action_template)?;
+        state.serialize_field("captured", &self.captured)?;
+        state.serialize_field("captured_state", &self.captured_state)?;
+        state.serialize_field("thread_state", &self.thread_state)?;
+        state.serialize_field("readiness", &readiness)?;
+        state.serialize_field("report", &self.report)?;
+        state.serialize_field("verification", &verification)?;
+        state.end()
+    }
 }
 
 pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
@@ -394,23 +484,11 @@ fn write_ready_output_inner(
                 style::warn_marker()
             };
             println!("{marker} {}", output.operator.message);
-            if output.captured {
-                match output.captured_state.as_deref() {
-                    Some(state) => println!(
-                        "  {}",
-                        style::field("captured", &format!("state {}", style::change_id(state)))
-                    ),
-                    None => println!("  {}", style::field("captured", "yes")),
-                }
-            }
         }
         if !output.trust.verified && !missing_intent {
             write_trust_blocked_setup(output.operator.recommended_action.as_deref());
         } else {
-            write_preview_report(
-                &output.report,
-                output.operator.recommended_action.as_deref(),
-            );
+            write_preview_report(output, output.operator.recommended_action.as_deref());
         }
     }
     exit_if_blocked_operator_status(&output.operator.status);
@@ -438,7 +516,10 @@ fn write_trust_blocked_setup(recommended_action: Option<&str>) {
         "  {}",
         style::field("status", &style::thread_state("blocked"))
     );
-    println!("  {}", style::field("checks", "not run"));
+    println!(
+        "  {}",
+        style::field("checks", "not run (repository verification is blocked)")
+    );
     if let Some(recommended_action) = non_empty_action(recommended_action) {
         println!();
         print_next(recommended_action);
@@ -601,50 +682,42 @@ fn missing_ready_capture_intent_report_for(
     }
 }
 
-fn write_preview_report(report: &ThreadPreviewReport, recommended_action: Option<&str>) {
-    let no_target = report.merge_relation == "no_target";
+fn write_preview_report(output: &ReadyOutput, recommended_action: Option<&str>) {
+    let report = &output.report;
+    let summary = output.readiness_summary();
     println!();
     println!("{}", style::section("Readiness"));
     println!("  {}", style::field("thread", &style::bold(&report.thread)));
-    if no_target {
-        println!(
-            "  {}",
-            style::field("status", &style::thread_state("clean"))
-        );
-        println!("  {}", style::field("integration", "none configured"));
-    } else {
-        println!(
-            "  {}",
-            style::field("state", &style::thread_state(&report.thread_state))
-        );
-        println!(
-            "  {}",
-            style::field(
-                "freshness",
-                &style::thread_state(&report.freshness.replace('_', " "))
-            )
-        );
-        println!(
-            "  {}",
-            style::field(
-                "merge type",
-                &style::thread_state(&ready_merge_type_label(&report.merge_relation))
-            )
-        );
-    }
+    println!(
+        "  {}",
+        style::field("status", &style::thread_state(&summary.status))
+    );
+    println!(
+        "  {}",
+        style::field("captured", &ready_captured_label(&summary))
+    );
+    println!(
+        "  {}",
+        style::field("checks", &ready_checks_label(&summary.checks))
+    );
+    println!("  {}", style::field("integration", &summary.integration));
+    println!("  {}", style::field("freshness", &summary.freshness));
+    println!("  {}", style::field("merge type", &summary.merge_type));
     println!(
         "  {}",
         style::field(
             "changed paths",
-            &style::bold(&report.changed_path_count.to_string())
+            &style::bold(&summary.changed_path_count.to_string())
         )
     );
-    if !report.impact_categories.is_empty() {
-        println!(
-            "  {}",
-            style::field("impact", &report.impact_categories.join(", "))
-        );
-    }
+    println!(
+        "  {}",
+        style::field(
+            "conflicts",
+            &style::bold(&summary.conflict_count.to_string())
+        )
+    );
+    println!("  {}", style::field("impact", &summary.impact));
     if !report.blockers.is_empty() {
         println!();
         println!("{}", style::warn("Blocked by"));
@@ -656,6 +729,80 @@ fn write_preview_report(report: &ThreadPreviewReport, recommended_action: Option
         println!();
         print_next(recommended_action);
     }
+}
+
+fn ready_status_summary(report: &ThreadPreviewReport) -> String {
+    if report.merge_relation == "no_target" && report.blockers.is_empty() {
+        "clean".to_string()
+    } else {
+        report.thread_health.replace('_', " ")
+    }
+}
+
+fn ready_checks_summary(output: &ReadyOutput) -> ReadyChecksSummary {
+    if ready_blocked_by_missing_intent(output) {
+        ReadyChecksSummary {
+            status: "not_run".to_string(),
+            reason: "commit intent is required before readiness checks can run".to_string(),
+        }
+    } else if !output.trust.verified {
+        ReadyChecksSummary {
+            status: "not_run".to_string(),
+            reason: "repository verification is blocked".to_string(),
+        }
+    } else if output.report.merge_relation == "not_checked" {
+        ReadyChecksSummary {
+            status: "not_run".to_string(),
+            reason: "readiness preview was not reached".to_string(),
+        }
+    } else {
+        ReadyChecksSummary {
+            status: "completed".to_string(),
+            reason: "readiness preview ran".to_string(),
+        }
+    }
+}
+
+fn ready_integration_summary(report: &ThreadPreviewReport) -> String {
+    if report.merge_relation == "no_target" {
+        "n/a (no integration target configured)".to_string()
+    } else if report.merge_relation == "not_checked" {
+        "not checked (readiness checks did not run)".to_string()
+    } else if report.merge_relation == "blocked" {
+        "not checked (repository verification is blocked)".to_string()
+    } else {
+        "configured".to_string()
+    }
+}
+
+fn ready_freshness_summary(report: &ThreadPreviewReport) -> String {
+    match report.merge_relation.as_str() {
+        "no_target" => "n/a (no integration target configured)".to_string(),
+        "not_checked" => "not checked (readiness checks did not run)".to_string(),
+        "blocked" => "not checked (repository verification is blocked)".to_string(),
+        _ => report.freshness.replace('_', " "),
+    }
+}
+
+fn ready_merge_type_summary(report: &ThreadPreviewReport) -> String {
+    match report.merge_relation.as_str() {
+        "no_target" => "n/a (no integration target configured)".to_string(),
+        "not_checked" => "not checked (readiness checks did not run)".to_string(),
+        "blocked" => "not checked (repository verification is blocked)".to_string(),
+        other => ready_merge_type_label(other),
+    }
+}
+
+fn ready_captured_label(summary: &ReadyReadinessSummary) -> String {
+    match summary.captured_state.as_deref() {
+        Some(state) => format!("yes (state {})", style::change_id(state)),
+        None if summary.captured => "yes".to_string(),
+        None => "no".to_string(),
+    }
+}
+
+fn ready_checks_label(checks: &ReadyChecksSummary) -> String {
+    format!("{} ({})", checks.status.replace('_', " "), checks.reason)
 }
 
 fn ready_merge_type_label(result: &str) -> String {

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -1203,8 +1203,8 @@ pub struct ReadySchema {
     pub status: String,
     pub action: String,
     pub message: String,
-    pub blockers: Option<Vec<String>>,
-    pub warnings: Option<Vec<String>>,
+    pub blockers: Vec<String>,
+    pub warnings: Vec<String>,
     pub next_action: Option<String>,
     pub next_action_template: Option<ActionTemplateSchema>,
     pub recommended_action: Option<String>,
@@ -1212,7 +1212,34 @@ pub struct ReadySchema {
     pub captured: bool,
     pub captured_state: Option<String>,
     pub thread_state: Option<String>,
+    pub readiness: ReadyReadinessSchema,
     pub report: Value,
+    #[serde(rename = "verification")]
+    pub verification: RepositoryVerificationStateSchema,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReadyReadinessSchema {
+    pub status: String,
+    pub captured: bool,
+    pub captured_state: Option<String>,
+    pub checks: ReadyChecksSchema,
+    pub integration: String,
+    pub freshness: String,
+    pub merge_type: String,
+    pub changed_path_count: usize,
+    pub changed_paths: Vec<String>,
+    pub conflict_count: usize,
+    pub conflicts: Vec<String>,
+    pub impact: String,
+    pub impact_categories: Vec<String>,
+    pub blockers: Vec<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReadyChecksSchema {
+    pub status: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -3321,7 +3348,7 @@ mod tests {
     }
 
     #[test]
-    fn ready_schema_does_not_require_omitted_empty_operator_lists() {
+    fn ready_schema_requires_stable_operator_and_readiness_fields() {
         let schema = schema_for_verb("ready").expect("ready schema");
         let properties = schema
             .get("properties")
@@ -3335,14 +3362,26 @@ mod tests {
             properties.contains_key("warnings"),
             "ready schema should still document warnings when emitted"
         );
+        assert!(
+            properties.contains_key("readiness"),
+            "ready schema should document the stable readiness summary"
+        );
+        assert!(
+            properties.contains_key("verification"),
+            "ready schema should document the repository verification proof"
+        );
 
         let required = required_fields(&schema);
-        for omitted_when_empty in ["blockers", "warnings"] {
+        for stable_field in ["blockers", "warnings", "readiness", "verification"] {
             assert!(
-                !required.contains(&omitted_when_empty),
-                "ready schema must not require `{omitted_when_empty}` because successful JSON output omits empty operator lists: {schema}"
+                required.contains(&stable_field),
+                "ready schema must require `{stable_field}` because ready JSON always emits the stable field set: {schema}"
             );
         }
+        assert!(
+            properties.contains_key("captured_state"),
+            "ready schema should document captured_state even though schemars models nullable Option fields as optional"
+        );
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6826,10 +6826,36 @@ fn ready_text_names_ready_and_already_ready_noop_states() {
         "ready text should name the clean no-target state: {first_stdout}"
     );
     assert!(
-        first_stdout.contains("integration: none configured")
+        first_stdout.contains("integration: n/a (no integration target configured)")
             && !first_stdout.contains("semantic: no_target")
             && !first_stdout.contains("state: ready"),
         "ready text should translate no-target internals into human workflow language: {first_stdout}"
+    );
+    for field in [
+        "thread:",
+        "status:",
+        "captured:",
+        "checks:",
+        "integration:",
+        "freshness:",
+        "merge type:",
+        "changed paths:",
+        "conflicts:",
+        "impact:",
+    ] {
+        assert!(
+            first_stdout.contains(field),
+            "ready text should always show stable field `{field}`: {first_stdout}"
+        );
+    }
+    assert!(
+        first_stdout.contains("checks: completed (readiness preview ran)")
+            && first_stdout.contains("captured: no")
+            && first_stdout.contains("freshness: n/a (no integration target configured)")
+            && first_stdout.contains("merge type: n/a (no integration target configured)")
+            && first_stdout.contains("conflicts: 0")
+            && first_stdout.contains("impact: none"),
+        "ready no-target text should make non-applicable fields explicit: {first_stdout}"
     );
     assert!(
         !first_stdout.contains("heddle merge main"),
@@ -6850,7 +6876,7 @@ fn ready_text_names_ready_and_already_ready_noop_states() {
         "ready no-op text should explicitly name the clean no-target state: {second_stdout}"
     );
     assert!(
-        second_stdout.contains("integration: none configured")
+        second_stdout.contains("integration: n/a (no integration target configured)")
             && !second_stdout.contains("semantic: no_target")
             && !second_stdout.contains("state: ready"),
         "ready no-op text should keep no-target internals out of the human surface: {second_stdout}"
@@ -6885,7 +6911,7 @@ fn ready_capture_is_visible_and_carries_confidence() {
     assert!(text.status.success(), "ready should succeed");
     let stdout = String::from_utf8_lossy(&text.stdout);
     assert!(
-        stdout.contains("captured: state hd-"),
+        stdout.contains("captured: yes (state hd-"),
         "ready text should explicitly name the captured state when it saves work: {stdout}"
     );
 
@@ -6931,6 +6957,33 @@ fn ready_refuses_dirty_capture_without_intent() {
     assert_eq!(ready["output_kind"], "ready");
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], false);
+    assert_eq!(ready["captured_state"], serde_json::Value::Null);
+    assert_eq!(ready["blockers"].as_array().unwrap().len(), 1);
+    assert_eq!(ready["warnings"], serde_json::json!([]));
+    assert_eq!(ready["readiness"]["captured"], false);
+    assert_eq!(
+        ready["readiness"]["captured_state"],
+        serde_json::Value::Null
+    );
+    assert_eq!(ready["readiness"]["checks"]["status"], "not_run");
+    assert_eq!(
+        ready["readiness"]["checks"]["reason"],
+        "commit intent is required before readiness checks can run"
+    );
+    assert_eq!(
+        ready["readiness"]["integration"],
+        "not checked (readiness checks did not run)"
+    );
+    assert_eq!(
+        ready["readiness"]["freshness"],
+        "not checked (readiness checks did not run)"
+    );
+    assert_eq!(
+        ready["readiness"]["merge_type"],
+        "not checked (readiness checks did not run)"
+    );
+    assert_eq!(ready["readiness"]["conflict_count"], 0);
+    assert_eq!(ready["readiness"]["impact"], "none");
     assert_eq!(ready["recommended_action"], "heddle commit -m \"...\"");
     assert_eq!(
         ready["recommended_action_template"]["argv_template"],

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -580,7 +580,27 @@ saves a Heddle state without recommending a Git checkpoint.
   "captured": true,
   "captured_state": "hd-sqr398dvx9ay",
   "thread_state": "ready",
-  "report": {}
+  "readiness": {
+    "status": "ready",
+    "captured": true,
+    "captured_state": "hd-sqr398dvx9ay",
+    "checks": {
+      "status": "completed",
+      "reason": "readiness preview ran"
+    },
+    "integration": "configured",
+    "freshness": "current",
+    "merge_type": "fast-forward",
+    "changed_path_count": 1,
+    "changed_paths": ["src/parser.rs"],
+    "conflict_count": 0,
+    "conflicts": [],
+    "impact": "none",
+    "impact_categories": [],
+    "blockers": []
+  },
+  "report": {},
+  "verification": {}
 }
 ```
 
@@ -626,7 +646,7 @@ saves a Heddle state without recommending a Git checkpoint.
 | `status` | string | required for `capture`/`checkpoint`/`commit`/`ready`/`land` | Machine-stable success status for the operation. |
 | `action` | string | required for `capture`/`checkpoint`/`commit`/`undo`/`undo --redo`/`land` | Logical operation name. |
 | `batches` | array<object> | required for `undo`/`undo --redo` | Oplog batches affected by the operation. Empty if none are reported. |
-| `thread_state`, `report` | string \| null / object | required for `ready` | Readiness result and structured readiness report. |
+| `thread_state`, `readiness`, `report` | string \| null / object / object | required for `ready` | Readiness result, stable human/machine summary, and structured preview report. `readiness` always carries the same fields; non-applicable checks/integration/freshness/merge details are represented with explicit `not_run`, `not checked`, or `n/a` values and reasons rather than omitted. |
 | `thread`, `captured`, `checkpointed`, `synced`, `integrated`, `pushed`, `pushed_remote` | string / bool / string \| null | required for `land` | Thread landed, which local/publish steps completed, and the remote name pushed when publish ran. |
 | `performed_steps`, `skipped_steps`, `merge_state`, `chosen_path` | array<string> / string \| null / string | required for `land` | Machine-readable path through the land loop and the merge state landed, when one exists. |
 | `verification` | object \| null | required | Post-operation verification proof. `null` only for undo / undo --redo paths that cannot compute it. |


### PR DESCRIPTION
Fixes #543

## Summary
- Add a stable `readiness` summary to `heddle ready --output json` with explicit values/reasons for non-applicable fields.
- Render the same ready text field set/order across normal, no-target, captured, and blocked states.
- Update ready schema/docs/tests and regenerate npm schema artifacts.

## Verification
- `cargo build --workspace`
- `cargo build --workspace --all-features`
- `cargo test -p heddle-cli`
- `cargo test -p heddle-cli --test cli_integration ready -- --nocapture`
- `cargo test -p heddle-cli --test cli_integration output_kind -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `scripts/gen-ts-types.sh`
- `heddle doctor docs --all --output json`
- `heddle doctor schemas --output json`
- `cargo test -p heddle-cli --test ts_types_in_sync -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783937206&installation_id=132405951&pr_number=712&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F712&signature=c83dd03a56f278968385c3f7ab143936069181e0df0556857a28e1931d2a838e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->