### PR TITLE
Harden CAS isolation coverage test

### DIFF
--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -17,7 +17,8 @@ pub use oplog_backend::{OpLogBackend, VisibilitySidecarSnapshots};
 pub use oplog_core::OpLog;
 pub use oplog_types::{
     ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    RedactionUndoClass, ThreadUpdateSnapshots, isolation_keys_for_record,
+    RedactionUndoClass, ThreadUpdateSnapshots, is_transaction_commit, is_transaction_commit_for,
+    isolation_keys_for_record,
 };
 #[cfg(feature = "postgres")]
 pub use pg_oplog::PgOpLogBackend;

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -13,7 +13,7 @@ use objects::{
 
 use super::oplog_types::{
     ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    ThreadUpdateSnapshots,
+    ThreadUpdateSnapshots, is_transaction_commit_for,
 };
 
 /// Before/after snapshots of a per-state visibility sidecar, captured around a
@@ -73,13 +73,10 @@ pub trait OpLogBackend: Send + Sync {
         async move {
             let recent = self.recent_batches_scoped(recent_window, scope).await?;
             if recent.iter().any(|batch| {
-                batch.entries.iter().any(|entry| {
-                    matches!(
-                        &entry.operation,
-                        OpRecord::TransactionCommit { transaction_id: id, .. }
-                            if id == transaction_id
-                    )
-                })
+                batch
+                    .entries
+                    .iter()
+                    .any(|entry| is_transaction_commit_for(&entry.operation, transaction_id))
             }) {
                 return Ok(None);
             }

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -17,20 +17,10 @@ use super::{
     oplog_backend::OpLogBackend,
     oplog_types::{
         ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-        isolation_keys_for_record,
+        is_transaction_commit, is_transaction_commit_for, isolation_keys_for_record,
     },
     packed_oplog::{PackedOpLog, PackedOpLogIndex},
 };
-
-/// A `TransactionCommit` marker carries no user-facing operation: it is the
-/// atomic commit sentinel, not a forward op. The undo/redo eligibility scans
-/// ignore it so a record-less transaction (e.g. an `undo`/`redo` whose commit
-/// batch holds only the marker) is never itself selected as an undoable or
-/// redoable unit. A batch with at least one *non-marker* entry (the common
-/// `[op, …, TransactionCommit]` shape) still qualifies on that entry.
-fn is_transaction_commit(op: &OpRecord) -> bool {
-    matches!(op, OpRecord::TransactionCommit { .. })
-}
 
 /// Operation log for tracking operations and enabling undo.
 pub struct OpLog {
@@ -302,13 +292,10 @@ impl OpLog {
 
         let recent = index.collect_batches_scoped(recent_window, |_| true, scope)?;
         if recent.iter().any(|batch| {
-            batch.entries.iter().any(|entry| {
-                matches!(
-                    &entry.operation,
-                    OpRecord::TransactionCommit { transaction_id: id, .. }
-                        if id == transaction_id
-                )
-            })
+            batch
+                .entries
+                .iter()
+                .any(|entry| is_transaction_commit_for(&entry.operation, transaction_id))
         }) {
             return Ok(None);
         }
@@ -445,7 +432,6 @@ impl OpLog {
             .unwrap()
             .committed_batch_records(transaction_id)
     }
-
 
     fn update_batch_undone_state(&self, batch: &OpBatch, undone: bool) -> Result<OpBatch> {
         let _lock = self.write_lock()?;

--- a/crates/oplog/src/oplog/oplog_types.rs
+++ b/crates/oplog/src/oplog/oplog_types.rs
@@ -327,6 +327,29 @@ pub enum OpRecord {
     },
 }
 
+/// True when `record` is the atomic transaction commit marker.
+///
+/// A `TransactionCommit` marker carries no user-facing operation: it is the
+/// atomic commit sentinel, not a forward op. Undo/redo eligibility scans ignore
+/// it so a record-less transaction is never itself selected as an undoable or
+/// redoable unit. A batch with at least one non-marker entry still qualifies on
+/// that entry.
+pub fn is_transaction_commit(record: &OpRecord) -> bool {
+    matches!(record, OpRecord::TransactionCommit { .. })
+}
+
+/// True when `record` is the atomic transaction commit marker for
+/// `transaction_id`.
+pub fn is_transaction_commit_for(record: &OpRecord, transaction_id: &str) -> bool {
+    matches!(
+        record,
+        OpRecord::TransactionCommit {
+            transaction_id: id,
+            ..
+        } if id == transaction_id
+    )
+}
+
 /// Optional ThreadManager record snapshots captured around a [`ThreadUpdate`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ThreadUpdateSnapshots {
@@ -965,7 +988,7 @@ impl OpBatch {
             && self
                 .entries
                 .iter()
-                .all(|entry| matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+                .all(|entry| is_transaction_commit(&entry.operation))
     }
 }
 

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -605,7 +605,7 @@ impl PackedOpLogIndex {
         Ok(batch
             .entries
             .into_iter()
-            .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+            .filter(|entry| !super::oplog_types::is_transaction_commit(&entry.operation))
             .map(|entry| entry.operation)
             .collect())
     }
@@ -890,7 +890,7 @@ impl PackedOpLogIndex {
             let mut cursor =
                 Cursor::new(&bytes[*offset as usize..self.footer.entry_data_end as usize]);
             let entry = parse_entry_with_schema(&mut cursor, self.record_schema()?)?;
-            if !matches!(entry.operation, OpRecord::TransactionCommit { .. }) {
+            if !super::oplog_types::is_transaction_commit(&entry.operation) {
                 return Err(HeddleError::InvalidObject(
                     "oplog transaction directory references a non-commit entry".to_string(),
                 ));

--- a/crates/oplog/src/oplog/pg_oplog.rs
+++ b/crates/oplog/src/oplog/pg_oplog.rs
@@ -21,7 +21,7 @@ use super::{
     oplog_backend::OpLogBackend,
     oplog_types::{
         ConditionalCommitOutcome, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-        isolation_keys_for_record,
+        is_transaction_commit, isolation_keys_for_record,
     },
 };
 
@@ -335,7 +335,7 @@ impl OpLogBackend for PgOpLogBackend {
                     .map(Self::row_to_entry)
                     .collect::<Result<Vec<_>>>()?
                     .into_iter()
-                    .filter(|entry| !matches!(entry.operation, OpRecord::TransactionCommit { .. }))
+                    .filter(|entry| !is_transaction_commit(&entry.operation))
                     .map(|entry| entry.operation)
                     .collect();
                 tx.rollback().await.map_err(sqlx_err)?;

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -3,21 +3,21 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
 use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName, VisibilityTier};
 use oplog::{
-    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord,
-    isolation_keys_for_record,
+    isolation_keys_for_record, ConditionalCommitOutcome, IsolationKey, IsolationPrecondition,
+    OpLogBackend, OpRecord, ThreadUpdateSnapshots,
 };
 use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
 
 use super::{
-    AtomicMutation, Compensator, DeferredMutation, EagerMutation, RewindLedger, StagedCommit, Tx,
-    execute,
+    execute, AtomicMutation, Compensator, DeferredMutation, EagerMutation, RewindLedger,
+    StagedCommit, Tx,
 };
 use crate::Repository;
 
@@ -681,22 +681,19 @@ fn all_ten_readers_reconcile() {
             .unwrap(),
         Some(remote_state)
     );
-    assert!(
-        refs.list_threads()
-            .unwrap()
-            .contains(&ThreadName::new("ft"))
-    );
-    assert!(
-        refs.list_markers()
-            .unwrap()
-            .contains(&MarkerName::new("mk"))
-    );
+    assert!(refs
+        .list_threads()
+        .unwrap()
+        .contains(&ThreadName::new("ft")));
+    assert!(refs
+        .list_markers()
+        .unwrap()
+        .contains(&MarkerName::new("mk")));
     assert!(refs.list_remotes().unwrap().contains(&"origin".to_string()));
-    assert!(
-        refs.list_remote_threads("origin")
-            .unwrap()
-            .contains(&ThreadName::new("rt"))
-    );
+    assert!(refs
+        .list_remote_threads("origin")
+        .unwrap()
+        .contains(&ThreadName::new("rt")));
     assert_eq!(refs.resolve("ft").unwrap(), Some(thread_state));
 }
 
@@ -1159,33 +1156,278 @@ fn retry_cap_returns_structured_conflict() {
 #[test]
 fn staged_record_keys_are_covered_by_declared_root_keys() {
     let scope = "lane-a";
-    let mut declared = BTreeSet::new();
-    declared.insert(IsolationKey::Thread("main".to_string()));
-    declared.insert(IsolationKey::Thread("feature".to_string()));
-    declared.insert(IsolationKey::LocalHead {
-        scope: scope.to_string(),
-    });
-    let records = vec![
-        snapshot_on("main"),
-        OpRecord::FastForward {
-            source_thread: "feature".to_string(),
-            target_thread: "main".to_string(),
-            pre_target_id: ChangeId::generate(),
-            post_target_id: ChangeId::generate(),
-        },
-        OpRecord::Goto {
-            target: ChangeId::generate(),
-            prev_head: None,
-            head: ChangeId::generate(),
-        },
-    ];
+    let cases = staged_record_coverage_cases(scope);
+    let declared = cases
+        .iter()
+        .flat_map(|(_, expected)| expected.iter().cloned())
+        .collect::<BTreeSet<_>>();
 
-    for record in records {
+    for (record, expected) in cases {
+        let variant = op_record_variant_name(&record);
         let touched = isolation_keys_for_record(&record, Some(scope));
+        assert_eq!(
+            touched, expected,
+            "coverage fixture for {variant} drifted: staged record {record:?}"
+        );
         assert!(
             touched.is_subset(&declared),
-            "staged record {record:?} touched {touched:?}, outside {declared:?}"
+            "staged record {variant} {record:?} touched {touched:?}, outside declared root keys {declared:?}"
         );
+    }
+}
+
+fn staged_record_coverage_cases(scope: &str) -> Vec<(OpRecord, BTreeSet<IsolationKey>)> {
+    let local_head = IsolationKey::LocalHead {
+        scope: scope.to_string(),
+    };
+    let main = IsolationKey::Thread("main".to_string());
+    let feature = IsolationKey::Thread("feature".to_string());
+    let visibility_state = ChangeId::generate();
+    let promoted_state = ChangeId::generate();
+
+    vec![
+        (snapshot_on("main"), keys([main.clone()])),
+        (
+            OpRecord::Snapshot {
+                new_state: ChangeId::generate(),
+                prev_head: None,
+                head: Some(ChangeId::generate()),
+                thread: None,
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            OpRecord::Goto {
+                target: ChangeId::generate(),
+                prev_head: None,
+                head: ChangeId::generate(),
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            OpRecord::ThreadCreate {
+                name: "main".to_string(),
+                state: ChangeId::generate(),
+                manager_snapshot: Some(vec![1]),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::ThreadDelete {
+                name: "feature".to_string(),
+                state: ChangeId::generate(),
+            },
+            keys([feature.clone()]),
+        ),
+        (
+            OpRecord::ThreadUpdate {
+                name: "main".to_string(),
+                old_state: ChangeId::generate(),
+                new_state: ChangeId::generate(),
+                manager_snapshots: ThreadUpdateSnapshots::from_parts(Some(vec![1]), Some(vec![2])),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::Fork {
+                from: ChangeId::generate(),
+                new_state: ChangeId::generate(),
+                thread: Some("main".to_string()),
+                head: None,
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::Fork {
+                from: ChangeId::generate(),
+                new_state: ChangeId::generate(),
+                thread: None,
+                head: Some(ChangeId::generate()),
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            OpRecord::Fork {
+                from: ChangeId::generate(),
+                new_state: ChangeId::generate(),
+                thread: None,
+                head: None,
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::Collapse {
+                sources: vec![ChangeId::generate(), ChangeId::generate()],
+                result: ChangeId::generate(),
+                thread: Some("feature".to_string()),
+                pre_thread_state: Some(ChangeId::generate()),
+            },
+            keys([feature.clone()]),
+        ),
+        (
+            OpRecord::Collapse {
+                sources: vec![ChangeId::generate()],
+                result: ChangeId::generate(),
+                thread: None,
+                pre_thread_state: None,
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            OpRecord::MarkerCreate {
+                name: "release".to_string(),
+                state: ChangeId::generate(),
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::MarkerDelete {
+                name: "release".to_string(),
+                state: ChangeId::generate(),
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::Checkpoint {
+                parent: None,
+                state: ChangeId::generate(),
+                thread: Some("main".to_string()),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::Checkpoint {
+                parent: None,
+                state: ChangeId::generate(),
+                thread: None,
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            OpRecord::TransactionAbort {
+                transaction_id: "tx-abort".to_string(),
+                reason: "test".to_string(),
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::EphemeralThreadCollapse {
+                thread: "main".to_string(),
+                final_state: ChangeId::generate(),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::ConflictResolved {
+                conflict_id: "conflict-1".to_string(),
+                resolution: "ours".to_string(),
+            },
+            BTreeSet::new(),
+        ),
+        (commit_marker("tx-commit", 1), BTreeSet::new()),
+        (
+            OpRecord::Redact {
+                redaction_id: ContentHash::from_bytes([1u8; 32]),
+                blob: ContentHash::from_bytes([2u8; 32]),
+                state: ChangeId::generate(),
+                path: "secret.txt".to_string(),
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::Purge {
+                redaction_id: ContentHash::from_bytes([3u8; 32]),
+                blob: ContentHash::from_bytes([4u8; 32]),
+            },
+            BTreeSet::new(),
+        ),
+        (
+            OpRecord::FastForward {
+                source_thread: "feature".to_string(),
+                target_thread: "main".to_string(),
+                pre_target_id: ChangeId::generate(),
+                post_target_id: ChangeId::generate(),
+            },
+            keys([feature.clone(), main.clone()]),
+        ),
+        (
+            OpRecord::GitCheckpoint {
+                branch: "main".to_string(),
+                state: ChangeId::generate(),
+                previous_git_oid: None,
+                new_git_oid: "abc123".to_string(),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::RemoteThreadUpdate {
+                remote: "origin".to_string(),
+                thread: "main".to_string(),
+                state: ChangeId::generate(),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::RemoteThreadDelete {
+                remote: "origin".to_string(),
+                thread: "main".to_string(),
+                state: ChangeId::generate(),
+            },
+            keys([main.clone()]),
+        ),
+        (
+            OpRecord::UndoRecoveryUpdate {
+                state: ChangeId::generate(),
+            },
+            keys([local_head.clone()]),
+        ),
+        (
+            visibility_set_on(visibility_state),
+            keys([IsolationKey::StateVisibility(visibility_state)]),
+        ),
+        (
+            OpRecord::StateVisibilityPromote {
+                state: promoted_state,
+                superseded: ContentHash::from_bytes([5u8; 32]),
+                record_id: ContentHash::from_bytes([6u8; 32]),
+                tier: VisibilityTier::Public,
+                prior_sidecar: Some(vec![1]),
+                new_sidecar: Some(vec![2]),
+            },
+            keys([IsolationKey::StateVisibility(promoted_state)]),
+        ),
+    ]
+}
+
+fn keys<const N: usize>(keys: [IsolationKey; N]) -> BTreeSet<IsolationKey> {
+    keys.into_iter().collect()
+}
+
+fn op_record_variant_name(record: &OpRecord) -> &'static str {
+    match record {
+        OpRecord::Snapshot { .. } => "Snapshot",
+        OpRecord::Goto { .. } => "Goto",
+        OpRecord::ThreadCreate { .. } => "ThreadCreate",
+        OpRecord::ThreadDelete { .. } => "ThreadDelete",
+        OpRecord::ThreadUpdate { .. } => "ThreadUpdate",
+        OpRecord::Fork { .. } => "Fork",
+        OpRecord::Collapse { .. } => "Collapse",
+        OpRecord::MarkerCreate { .. } => "MarkerCreate",
+        OpRecord::MarkerDelete { .. } => "MarkerDelete",
+        OpRecord::Checkpoint { .. } => "Checkpoint",
+        OpRecord::TransactionAbort { .. } => "TransactionAbort",
+        OpRecord::EphemeralThreadCollapse { .. } => "EphemeralThreadCollapse",
+        OpRecord::ConflictResolved { .. } => "ConflictResolved",
+        OpRecord::TransactionCommit { .. } => "TransactionCommit",
+        OpRecord::Redact { .. } => "Redact",
+        OpRecord::Purge { .. } => "Purge",
+        OpRecord::FastForward { .. } => "FastForward",
+        OpRecord::GitCheckpoint { .. } => "GitCheckpoint",
+        OpRecord::RemoteThreadUpdate { .. } => "RemoteThreadUpdate",
+        OpRecord::RemoteThreadDelete { .. } => "RemoteThreadDelete",
+        OpRecord::UndoRecoveryUpdate { .. } => "UndoRecoveryUpdate",
+        OpRecord::StateVisibilitySet { .. } => "StateVisibilitySet",
+        OpRecord::StateVisibilityPromote { .. } => "StateVisibilityPromote",
     }
 }
 
@@ -1324,11 +1566,10 @@ fn reconcile_folds_every_record_shape() {
     let threads = refs.list_threads().unwrap();
     assert!(threads.contains(&ThreadName::new("t_coll")));
     assert!(threads.contains(&ThreadName::new("t_ff")));
-    assert!(
-        refs.list_markers()
-            .unwrap()
-            .contains(&MarkerName::new("mk2"))
-    );
+    assert!(refs
+        .list_markers()
+        .unwrap()
+        .contains(&MarkerName::new("mk2")));
     let remotes = refs.list_remotes().unwrap();
     assert!(remotes.contains(&"origin".to_string()));
     let remote_threads = refs.list_remote_threads("origin").unwrap();


### PR DESCRIPTION
## Summary
- strengthen the staged-record isolation coverage test to cover every current OpRecord variant and assert exact touched keys before root-key coverage
- single-source TransactionCommit marker predicates for backend/default/Postgres filtering paths

Fixes #398

## Verification
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo staged_record_keys_are_covered_by_declared_root_keys
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-oplog --features postgres
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783947896&installation_id=132405951&pr_number=713&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F713&signature=3b6f113c424f5817c871deb7c32785476d9b8ef8a217c133a4612f16df002224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->