### PR TITLE
[codex] Fix index checkpoint recovery duplication

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_advanced.rs
+++ b/crates/cli/src/cli/cli_args/commands_advanced.rs
@@ -8,6 +8,11 @@ pub struct CheckpointArgs {
     /// Git-facing commit summary for the current captured work.
     #[arg(short = 'm', long)]
     pub message: Option<String>,
+
+    /// Internal recovery: retry a failed staged-index commit checkpoint against the current
+    /// preserved Heddle state without requiring the dirty worktree to match it.
+    #[arg(long = "from-index-snapshot", hide = true)]
+    pub from_index_snapshot: bool,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -73,11 +73,12 @@ pub async fn run(cli: &Cli, args: &CheckpointArgs) -> Result<()> {
     }
 
     let repo = Repository::open(start)?;
-    let record = create_git_checkpoint(
-        &repo,
-        args.message.as_deref(),
-        worktree_status_options(Some(repo.config())),
-    )?;
+    let status_options = worktree_status_options(Some(repo.config()));
+    let record = if args.from_index_snapshot {
+        create_git_checkpoint_from_index_snapshot(&repo, args.message.as_deref(), status_options)?
+    } else {
+        create_git_checkpoint(&repo, args.message.as_deref(), status_options)?
+    };
     let state = repo
         .current_state()?
         .ok_or_else(|| anyhow!("no captured state found after checkpoint"))?;
@@ -145,11 +146,6 @@ fn create_git_checkpoint_inner(
         .store()
         .get_state(&state_id)?
         .ok_or_else(|| anyhow!("no captured state found after bootstrap"))?;
-    if principal_is_default_unknown(&state.attribution.principal)
-        && git_config_identity_with_global_fallback(repo.root())?.is_none()
-    {
-        return Err(anyhow!(missing_checkpoint_identity_advice("checkpoint")));
-    }
     if require_clean_worktree {
         let tree = repo.require_tree(&state.tree)?;
         let status = repo.compare_worktree_cached_detailed_with_options(&tree, &status_options)?;
@@ -160,6 +156,14 @@ fn create_git_checkpoint_inner(
                 "the current Heddle state was left unchanged; these paths have not been captured",
             )));
         }
+    }
+    if let Some(record) = repo.latest_git_checkpoint_for_change(&state.change_id)? {
+        return Ok(record);
+    }
+    if principal_is_default_unknown(&state.attribution.principal)
+        && git_config_identity_with_global_fallback(repo.root())?.is_none()
+    {
+        return Err(anyhow!(missing_checkpoint_identity_advice("checkpoint")));
     }
 
     let summary = message

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1165,12 +1165,16 @@ fn commit_checkpoint_failed_advice(
 }
 
 fn checkpoint_recovery_command(message: Option<&str>, index_only: bool) -> String {
-    // Preserve the index-only (`--no-all`) intent on the staged-index path: a
-    // plain `heddle commit` retry would sweep unstaged worktree changes into a
-    // new capture and lose the staged-only state the user committed.
-    let scope = if index_only { " --no-all" } else { "" };
+    // The Heddle state already exists when checkpoint recovery is offered. The
+    // retry must repair only the Git checkpoint instead of re-entering commit
+    // and minting another capture from the same tree.
+    let scope = if index_only {
+        " --from-index-snapshot"
+    } else {
+        ""
+    };
     format!(
-        "heddle commit{scope} -m {}",
+        "heddle checkpoint{scope} -m {}",
         shell_double_quoted(message.unwrap_or("commit"))
     )
 }
@@ -1405,32 +1409,31 @@ mod tests {
         assert!(advice.error.contains("git write failed"));
         assert_eq!(
             advice.primary_command,
-            "heddle commit -m \"say \\\"hello\\\"\""
+            "heddle checkpoint -m \"say \\\"hello\\\"\""
         );
         assert_eq!(
             advice.recovery_commands,
-            vec!["heddle commit -m \"say \\\"hello\\\"\""]
+            vec!["heddle checkpoint -m \"say \\\"hello\\\"\""]
         );
         assert!(advice.preserved.contains("change-123"));
     }
 
-    // heddle#464: the staged-index (`--no-all`) checkpoint-failure recovery must
-    // keep the index-only intent, otherwise a plain `heddle commit` retry would
-    // sweep unstaged worktree changes into a new capture and lose the staged-only
-    // state the user committed.
+    // heddle#485: the staged-index checkpoint-failure recovery must retry only
+    // the Git checkpoint against the already-preserved state. Re-entering commit
+    // would create a duplicate capture from the same staged index tree.
     #[test]
-    fn commit_checkpoint_failure_advice_preserves_index_only_intent() {
+    fn commit_checkpoint_failure_advice_retries_index_snapshot_checkpoint() {
         let error = anyhow!("git write failed");
         let advice =
             commit_checkpoint_failed_advice("change-456", Some("index only"), &error, true);
 
         assert_eq!(
             advice.primary_command,
-            "heddle commit --no-all -m \"index only\""
+            "heddle checkpoint --from-index-snapshot -m \"index only\""
         );
         assert_eq!(
             advice.recovery_commands,
-            vec!["heddle commit --no-all -m \"index only\""]
+            vec!["heddle checkpoint --from-index-snapshot -m \"index only\""]
         );
     }
 

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -869,6 +869,104 @@ fn git_overlay_matrix_commit_no_all_nothing_staged_refuses_before_identity_prefl
 }
 
 #[test]
+fn git_overlay_matrix_index_checkpoint_recovery_reuses_preserved_snapshot() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_with_branch(temp.path(), "main");
+    std::fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+    git_commit_all(temp.path(), "seed");
+    heddle_adopt(temp.path());
+
+    std::fs::write(temp.path().join("file.txt"), "staged\n").unwrap();
+    git(&["add", "file.txt"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "staged\nunstaged\n").unwrap();
+    std::fs::write(temp.path().join("scratch.txt"), "left behind\n").unwrap();
+
+    let git_dir = temp.path().join(".git");
+    std::fs::write(git_dir.join("index.lock"), "held by test\n").unwrap();
+    let failed = heddle_output(
+        &[
+            "--output",
+            "json",
+            "commit",
+            "--no-all",
+            "-m",
+            "index only recovery",
+        ],
+        Some(temp.path()),
+    )
+    .expect("invoke faulted index-only commit");
+    assert!(
+        !failed.status.success(),
+        "locked index should fail after preserving the Heddle state"
+    );
+    let stderr = std::str::from_utf8(&failed.stderr).unwrap();
+    let envelope: Value =
+        serde_json::from_str(stderr).expect("checkpoint failure should emit JSON advice");
+    assert_eq!(envelope["kind"], "commit_checkpoint_failed");
+    assert_eq!(
+        envelope["recovery_commands"],
+        serde_json::json!(["heddle checkpoint --from-index-snapshot -m \"index only recovery\""])
+    );
+
+    let repo = Repository::open(temp.path()).expect("open repo after failed commit");
+    let preserved = repo
+        .current_state()
+        .expect("read current state")
+        .expect("failed commit should preserve a current state")
+        .change_id;
+    assert_eq!(
+        snapshot_count_for_change(temp.path(), &preserved),
+        1,
+        "the failed commit should preserve exactly one staged-index snapshot"
+    );
+    assert!(
+        repo.latest_git_checkpoint_for_change(&preserved)
+            .expect("read checkpoints")
+            .is_none(),
+        "the locked-index failure should not have recorded the Git checkpoint yet"
+    );
+
+    std::fs::remove_file(git_dir.join("index.lock")).unwrap();
+    let recovered = json(
+        temp.path(),
+        &[
+            "checkpoint",
+            "--from-index-snapshot",
+            "-m",
+            "index only recovery",
+        ],
+    );
+    assert_eq!(recovered["output_kind"], "checkpoint");
+    assert_eq!(recovered["change_id"], preserved.short());
+    assert_eq!(
+        snapshot_count_for_change(temp.path(), &preserved),
+        1,
+        "recovery must not re-enter commit_staged_index and mint a duplicate snapshot"
+    );
+
+    let repo = Repository::open(temp.path()).expect("reopen repo after recovery");
+    let checkpoint = repo
+        .latest_git_checkpoint_for_change(&preserved)
+        .expect("read checkpoint after recovery")
+        .expect("recovery should record the Git checkpoint");
+    assert_eq!(
+        git_stdout(temp.path(), &["rev-parse", "HEAD"]),
+        checkpoint.git_commit,
+        "recovery should advance Git HEAD to the checkpoint commit"
+    );
+    assert_eq!(
+        git_stdout(temp.path(), &["show", "HEAD:file.txt"]),
+        "staged",
+        "the recovered Git checkpoint should commit the preserved staged index tree"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+        "staged\nunstaged\n",
+        "checkpoint recovery must preserve unstaged worktree edits after checkpointing the staged tree"
+    );
+}
+
+#[test]
 fn git_overlay_matrix_plain_git_no_commit_bootstrap_commands() {
     let temp = TempDir::new().unwrap();
     init_git_repo_with_branch(temp.path(), "trunk");
@@ -6264,6 +6362,24 @@ fn collapse_records(path: &std::path::Path) -> Vec<(Vec<String>, String, Option<
         .collect()
 }
 
+fn snapshot_count_for_change(
+    path: &std::path::Path,
+    change_id: &objects::object::ChangeId,
+) -> usize {
+    let repo = Repository::open(path).expect("repo should open");
+    repo.oplog()
+        .recent(512)
+        .expect("read oplog")
+        .into_iter()
+        .filter(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::Snapshot { new_state, .. } if new_state == change_id
+            )
+        })
+        .count()
+}
+
 fn thread_tip(path: &std::path::Path, thread: &str) -> String {
     let repo = Repository::open(path).expect("repo should open");
     repo.refs()
@@ -6462,7 +6578,10 @@ fn git_overlay_matrix_manual_resolution_land_squashes_and_undo_restores_source_t
     assert_latest_undo_batch_has_land_squash_ops(temp.path());
     let undo = json(temp.path(), &["--output", "json", "undo"]);
     assert_eq!(undo["status"], "completed", "{undo}");
-    assert_eq!(git_stdout(temp.path(), &["rev-parse", "HEAD"]), pre_land_git);
+    assert_eq!(
+        git_stdout(temp.path(), &["rev-parse", "HEAD"]),
+        pre_land_git
+    );
     assert_eq!(thread_tip(temp.path(), "main"), target_tip_before);
     assert_eq!(
         thread_tip(temp.path(), "feature/manual-squash"),


### PR DESCRIPTION
## Summary

Fixes #485.

This changes checkpoint-failure recovery so a preserved staged-index commit retries only the Git checkpoint step instead of re-entering `commit_staged_index` and creating a second Heddle snapshot from the same index tree.

## Changes

- Route commit checkpoint recovery advice to `heddle checkpoint`, with a hidden `--from-index-snapshot` recovery mode for staged-index snapshots.
- Make checkpoint creation idempotent for an already-checkpointed current state, while preserving the normal dirty-worktree refusal for regular `heddle checkpoint`.
- Add a regression test that locks the Git index after the staged-index snapshot is preserved, runs recovery, and asserts exactly one snapshot exists for the preserved change id while the Git checkpoint is present.

## Validation

- `cargo test -p heddle-cli --lib`
- `cargo test -p heddle-cli --test cli_integration git_overlay_matrix_index_checkpoint_recovery_reuses_preserved_snapshot -- --nocapture`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo build --workspace`
- `cargo build --workspace --all-features`
- `cargo test -p heddle-cli --test cli_integration checkpoint -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`

Note: `cargo fmt --check` still reports pre-existing formatting drift outside this patch; the touched files were formatted directly with `rustfmt --edition 2024`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783948055&installation_id=132405951&pr_number=714&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F714&signature=c26a0de58c50d4011b69e7ba92539206c062bd6e340dbdf4bbe9d7b1b70f7673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->