### PR TITLE
Unify pack header codec

### DIFF
--- a/crates/objects/src/store/pack/mod.rs
+++ b/crates/objects/src/store/pack/mod.rs
@@ -11,6 +11,7 @@ mod pack_reader;
 mod shared;
 mod streaming_builder;
 pub(crate) mod varint;
+mod versioned_header;
 
 #[cfg(test)]
 mod pack_tests;
@@ -20,10 +21,10 @@ pub use pack_builder::PackBuilder;
 pub use pack_index::PackIndex;
 pub use pack_reader::PackReader;
 pub use shared::{
-    PACK_CHECKSUM_LEN, PackContainerSpec, PackEntryHeader, PackObjectId, PackObjectRecord,
     append_container_checksum, compress_pack_payload, decode_tagged_entry_header,
     decompress_pack_payload, encode_tagged_entry, encode_tagged_entry_parts, has_zstd_magic,
-    try_decode_tagged_entry_header, verify_container, write_container_header,
+    try_decode_tagged_entry_header, verify_container, write_container_header, PackContainerSpec,
+    PackEntryHeader, PackObjectId, PackObjectRecord, PACK_CHECKSUM_LEN,
 };
 pub use streaming_builder::StreamingPackBuilder;
 

--- a/crates/objects/src/store/pack/pack_index.rs
+++ b/crates/objects/src/store/pack/pack_index.rs
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pack index for fast object lookup within packfiles.
 
-use crate::store::{Result, pack::PackObjectId};
+use crate::store::{
+    pack::{
+        versioned_header::{HeaderChecksum, VersionedHeader},
+        PackObjectId,
+    },
+    Result,
+};
 
-pub(super) const INDEX_MAGIC: &[u8] = b"LMI\0";
+pub(super) const INDEX_MAGIC: &[u8; 4] = b"LMI\0";
 pub(super) const INDEX_VERSION: u32 = 2;
 const MIN_INDEX_ENTRY_LEN: usize = 17 + 8;
 
@@ -49,9 +55,7 @@ impl PackIndex {
     /// Serialize to bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut result = Vec::new();
-        result.extend_from_slice(INDEX_MAGIC);
-        result.extend_from_slice(&INDEX_VERSION.to_be_bytes());
-        result.extend_from_slice(&(self.entries.len() as u64).to_be_bytes());
+        index_header().write_vec(&mut result, self.entries.len() as u64);
         for entry in &self.entries {
             entry.id.encode_tagged(&mut result);
             result.extend_from_slice(&entry.offset.to_be_bytes());
@@ -61,27 +65,9 @@ impl PackIndex {
 
     /// Deserialize from bytes.
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
-        if data.len() < 16 {
-            return Err(crate::store::StoreError::InvalidObject(
-                "Index too short".to_string(),
-            ));
-        }
-        if &data[0..4] != INDEX_MAGIC {
-            return Err(crate::store::StoreError::InvalidObject(
-                "Invalid index magic".to_string(),
-            ));
-        }
-        let version = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
-        if version != INDEX_VERSION {
-            return Err(crate::store::StoreError::InvalidObject(format!(
-                "Unsupported index version: {}",
-                version
-            )));
-        }
-        let count = u64::from_be_bytes([
-            data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
-        ]);
-        let max_entries = ((data.len() - 16) / MIN_INDEX_ENTRY_LEN) as u64;
+        let header = index_header().verify(data)?;
+        let count = header.count;
+        let max_entries = ((data.len() - header.header_len) / MIN_INDEX_ENTRY_LEN) as u64;
         if count > max_entries {
             return Err(crate::store::StoreError::InvalidObject(format!(
                 "Index entry count {} exceeds available data capacity {}",
@@ -94,7 +80,7 @@ impl PackIndex {
             )
         })?;
         let mut entries = Vec::with_capacity(count);
-        let mut pos = 16;
+        let mut pos = header.header_len;
         for _ in 0..count {
             let (id, id_len) = PackObjectId::decode_tagged(&data[pos..])?;
             pos += id_len;
@@ -123,5 +109,17 @@ impl PackIndex {
 impl Default for PackIndex {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub(super) fn index_header() -> VersionedHeader {
+    VersionedHeader {
+        magic: INDEX_MAGIC,
+        version: INDEX_VERSION,
+        checksum: HeaderChecksum::None,
+        too_short: "Index too short",
+        invalid_magic: "Invalid index magic",
+        unsupported_version: "Unsupported index version",
+        checksum_mismatch: "",
     }
 }

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -44,6 +44,39 @@ fn assert_invalid_object_message_contains(error: StoreError, expected: &str) {
 }
 
 #[test]
+fn test_pack_container_header_codec_matches_legacy_bytes() {
+    let mut legacy = Vec::new();
+    legacy.extend_from_slice(b"LMPK");
+    legacy.extend_from_slice(&2_u32.to_be_bytes());
+    legacy.extend_from_slice(&0_u64.to_be_bytes());
+    let checksum = blake3::hash(&legacy);
+    legacy.extend_from_slice(checksum.as_bytes());
+
+    let mut encoded = Vec::new();
+    super::write_container_header(&mut encoded, pack_container_spec(), 0);
+    super::append_container_checksum(&mut encoded);
+
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        super::verify_container(&legacy, pack_container_spec()).unwrap(),
+        (0, 16, 16)
+    );
+}
+
+#[test]
+fn test_pack_index_header_codec_matches_legacy_bytes() {
+    let legacy = b"LMI\0\
+        \0\0\0\x02\
+        \0\0\0\0\0\0\0\0"
+        .to_vec();
+
+    let encoded = PackIndex::new().to_bytes();
+
+    assert_eq!(encoded, legacy);
+    assert!(PackIndex::from_bytes(&legacy).unwrap().ids().is_empty());
+}
+
+#[test]
 fn test_pack_index_roundtrip() {
     let mut index = PackIndex::new();
     index.add(PackObjectId::Hash(create_test_hash(1)), 100);

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(clippy::cast_possible_truncation)]
 
-use super::{ObjectType, varint};
+use super::{
+    varint,
+    versioned_header::{HeaderChecksum, VersionedHeader},
+    ObjectType,
+};
 use crate::{
     object::{ChangeId, ContentHash},
-    store::{Result, StoreError, compression::CompressionConfig},
+    store::{compression::CompressionConfig, Result, StoreError},
 };
 
 pub const PACK_CHECKSUM_LEN: usize = 32;
@@ -94,45 +98,28 @@ pub struct PackEntryHeader {
 }
 
 pub fn write_container_header(buf: &mut Vec<u8>, spec: PackContainerSpec, count: u64) {
-    buf.extend_from_slice(spec.magic);
-    buf.extend_from_slice(&spec.version.to_be_bytes());
-    buf.extend_from_slice(&count.to_be_bytes());
+    pack_container_header(spec).write_vec(buf, count);
 }
 
 pub fn verify_container(data: &[u8], spec: PackContainerSpec) -> Result<(u64, usize, usize)> {
-    if data.len() < 16 + PACK_CHECKSUM_LEN {
-        return Err(StoreError::InvalidObject("Pack too short".to_string()));
-    }
-    if &data[..4] != spec.magic {
-        return Err(StoreError::InvalidObject("Invalid pack magic".to_string()));
-    }
-    let version = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
-    if version != spec.version {
-        return Err(StoreError::InvalidObject(format!(
-            "Unsupported pack version: {}",
-            version
-        )));
-    }
-
-    let content_end = data.len() - PACK_CHECKSUM_LEN;
-    let content = &data[..content_end];
-    let stored_checksum = &data[content_end..];
-    let computed_checksum = blake3::hash(content);
-    if computed_checksum.as_bytes() != stored_checksum {
-        return Err(StoreError::InvalidObject(
-            "Pack checksum mismatch".to_string(),
-        ));
-    }
-
-    let count = u64::from_be_bytes([
-        data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
-    ]);
-    Ok((count, 16, content_end))
+    let header = pack_container_header(spec).verify(data)?;
+    Ok((header.count, header.header_len, header.content_end))
 }
 
 pub fn append_container_checksum(buf: &mut Vec<u8>) {
-    let checksum = blake3::hash(buf);
-    buf.extend_from_slice(checksum.as_bytes());
+    HeaderChecksum::Blake3Trailer.append(buf);
+}
+
+fn pack_container_header(spec: PackContainerSpec) -> VersionedHeader {
+    VersionedHeader {
+        magic: spec.magic,
+        version: spec.version,
+        checksum: HeaderChecksum::Blake3Trailer,
+        too_short: "Pack too short",
+        invalid_magic: "Invalid pack magic",
+        unsupported_version: "Unsupported pack version",
+        checksum_mismatch: "Pack checksum mismatch",
+    }
 }
 
 pub fn encode_tagged_entry(

--- a/crates/objects/src/store/pack/streaming_builder.rs
+++ b/crates/objects/src/store/pack/streaming_builder.rs
@@ -63,7 +63,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::{ObjectType, PackObjectId, PackStats, pack_container_spec, write_container_header};
+use super::{pack_container_spec, write_container_header, ObjectType, PackObjectId, PackStats};
 
 /// How many bytes to reserve for the compressed-size varint in the
 /// streaming path. 10 is enough to encode any `u64` (max 9 7-bit
@@ -74,7 +74,7 @@ use super::{ObjectType, PackObjectId, PackStats, pack_container_spec, write_cont
 const CSIZE_PLACEHOLDER_LEN: usize = 10;
 use crate::{
     object::ContentHash,
-    store::{Result, StoreError, compression::CompressionConfig},
+    store::{compression::CompressionConfig, Result, StoreError},
 };
 
 /// Number of buckets per id variant. 256 = one bucket per first byte
@@ -479,13 +479,7 @@ impl<W: Write + Read + Seek> StreamingPackBuilder<W> {
 /// big-endian version, 8-byte big-endian count) so a reader written
 /// against the existing format works without modification.
 fn write_index_header<W: Write>(out: &mut W, count: u64) -> Result<()> {
-    out.write_all(super::pack_index::INDEX_MAGIC)
-        .map_err(StoreError::from)?;
-    out.write_all(&super::pack_index::INDEX_VERSION.to_be_bytes())
-        .map_err(StoreError::from)?;
-    out.write_all(&count.to_be_bytes())
-        .map_err(StoreError::from)?;
-    Ok(())
+    super::pack_index::index_header().write_to(out, count)
 }
 
 /// Append one `(id, offset)` index entry to `out`. The encoding

--- a/crates/objects/src/store/pack/versioned_header.rs
+++ b/crates/objects/src/store/pack/versioned_header.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+
+use crate::store::{Result, StoreError};
+
+pub(super) const VERSIONED_HEADER_LEN: usize = 16;
+pub(super) const BLAKE3_TRAILER_LEN: usize = 32;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum HeaderChecksum {
+    None,
+    Blake3Trailer,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct VersionedHeader {
+    pub magic: &'static [u8; 4],
+    pub version: u32,
+    pub checksum: HeaderChecksum,
+    pub too_short: &'static str,
+    pub invalid_magic: &'static str,
+    pub unsupported_version: &'static str,
+    pub checksum_mismatch: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct VerifiedHeader {
+    pub count: u64,
+    pub header_len: usize,
+    pub content_end: usize,
+}
+
+impl VersionedHeader {
+    pub fn write_vec(self, buf: &mut Vec<u8>, count: u64) {
+        buf.extend_from_slice(self.magic);
+        buf.extend_from_slice(&self.version.to_be_bytes());
+        buf.extend_from_slice(&count.to_be_bytes());
+    }
+
+    pub fn write_to<W: Write>(self, out: &mut W, count: u64) -> Result<()> {
+        out.write_all(self.magic).map_err(StoreError::from)?;
+        out.write_all(&self.version.to_be_bytes())
+            .map_err(StoreError::from)?;
+        out.write_all(&count.to_be_bytes())
+            .map_err(StoreError::from)?;
+        Ok(())
+    }
+
+    pub fn verify(self, data: &[u8]) -> Result<VerifiedHeader> {
+        let trailer_len = self.checksum.trailer_len();
+        if data.len() < VERSIONED_HEADER_LEN + trailer_len {
+            return Err(StoreError::InvalidObject(self.too_short.to_string()));
+        }
+        if &data[..4] != self.magic {
+            return Err(StoreError::InvalidObject(self.invalid_magic.to_string()));
+        }
+
+        let version = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+        if version != self.version {
+            return Err(StoreError::InvalidObject(format!(
+                "{}: {}",
+                self.unsupported_version, version
+            )));
+        }
+
+        let content_end = data.len() - trailer_len;
+        self.checksum
+            .verify(data, content_end, self.checksum_mismatch)?;
+
+        let count = u64::from_be_bytes([
+            data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+        ]);
+        Ok(VerifiedHeader {
+            count,
+            header_len: VERSIONED_HEADER_LEN,
+            content_end,
+        })
+    }
+}
+
+impl HeaderChecksum {
+    pub fn append(self, buf: &mut Vec<u8>) {
+        match self {
+            Self::None => {}
+            Self::Blake3Trailer => {
+                let checksum = blake3::hash(buf);
+                buf.extend_from_slice(checksum.as_bytes());
+            }
+        }
+    }
+
+    fn trailer_len(self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Blake3Trailer => BLAKE3_TRAILER_LEN,
+        }
+    }
+
+    fn verify(self, data: &[u8], content_end: usize, mismatch: &'static str) -> Result<()> {
+        match self {
+            Self::None => Ok(()),
+            Self::Blake3Trailer => {
+                let content = &data[..content_end];
+                let stored_checksum = &data[content_end..];
+                let computed_checksum = blake3::hash(content);
+                if computed_checksum.as_bytes() != stored_checksum {
+                    return Err(StoreError::InvalidObject(mismatch.to_string()));
+                }
+                Ok(())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one shared versioned pack header codec for the 16-byte magic/version/count prefix.
- Routes pack container verification/writes and both pack index write paths through the shared codec.
- Keeps the on-disk bytes unchanged: pack containers still use `LMPK`, version 2, and a BLAKE3 trailer; pack indexes still use `LMI\0`, version 2, and no trailer checksum.
- Adds byte-identity tests for the legacy pack container header/trailer and a literal legacy empty pack index.

Fixes #424

## Validation

- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-objects`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783948359&installation_id=132405951&pr_number=715&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F715&signature=0e276b561354d975fc74b1798f88892d6bb06413cfb0f36c1b0a083d7ba562e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->