### PR TITLE
Unify thread worktree target validation

### DIFF
--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -155,21 +155,24 @@ fn validate_worktree_target(
         return Err(anyhow::anyhow!(worktree_target_storage_advice(path)));
     }
 
-    if let Ok(metadata) = std::fs::symlink_metadata(path) {
-        if metadata.file_type().is_symlink() {
-            return Err(anyhow::anyhow!(worktree_target_symlink_advice(path)));
-        }
-
-        if !metadata.is_dir() {
-            return Err(anyhow::anyhow!(worktree_target_not_directory_advice(path)));
-        }
-
-        if std::fs::read_dir(path)?.next().transpose()?.is_some() {
-            return Err(anyhow::anyhow!(worktree_target_not_empty_advice(path)));
-        }
-    }
+    repo::validate_thread_worktree_target(path).map_err(worktree_target_shape_advice)?;
 
     Ok(())
+}
+
+fn worktree_target_shape_advice(error: repo::ThreadWorktreeTargetError) -> anyhow::Error {
+    match error {
+        repo::ThreadWorktreeTargetError::Symlink { path } => {
+            anyhow::anyhow!(worktree_target_symlink_advice(&path))
+        }
+        repo::ThreadWorktreeTargetError::NotDirectory { path } => {
+            anyhow::anyhow!(worktree_target_not_directory_advice(&path))
+        }
+        repo::ThreadWorktreeTargetError::NotEmpty { path } => {
+            anyhow::anyhow!(worktree_target_not_empty_advice(&path))
+        }
+        repo::ThreadWorktreeTargetError::Io { source, .. } => anyhow::anyhow!(source),
+    }
 }
 
 /// True if `candidate` (already known to live under `threads_root`) falls

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -47,6 +47,7 @@ mod thread_model;
 mod thread_record_store;
 mod thread_stack;
 mod thread_storage;
+mod thread_worktree_target;
 mod worktree_ignore;
 pub mod worktree_index;
 pub mod visibility;
@@ -116,6 +117,9 @@ pub use thread_model::{
 };
 pub use thread_record_store::{FilesystemThreadRecordStore, ThreadRecordStore};
 pub use thread_storage::{SyncedThreadMetadata, Thread, ThreadManager};
+pub use thread_worktree_target::{
+    ThreadWorktreeTargetDisposition, ThreadWorktreeTargetError, validate_thread_worktree_target,
+};
 pub use worktree_index::{DirectoryCacheEntry, IndexEntry, WorktreeIndex};
 pub use worktree_state::WorktreeState;
 pub use worktree_status_options::{

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -31,6 +31,9 @@ use tracing::{debug, instrument};
 use super::{HeddleError, Repository, Result};
 use crate::thread_manifest::{ManifestFile, ThreadManifest, read_manifest, write_manifest};
 use crate::visibility::{AudienceTier, visible};
+use crate::{
+    ThreadWorktreeTargetDisposition, ThreadWorktreeTargetError, validate_thread_worktree_target,
+};
 use objects::object::VisibilityTier;
 
 /// Filename of the operator-local courtesy placeholder written when a
@@ -60,6 +63,77 @@ pub enum ThreadCaptureOutcome {
     NoOp,
     /// A new state was written and the thread head advanced.
     Captured { state_id: ChangeId },
+}
+
+fn thread_worktree_target_error(error: ThreadWorktreeTargetError) -> HeddleError {
+    match error {
+        ThreadWorktreeTargetError::Io { source, .. } => HeddleError::Io(source),
+        ThreadWorktreeTargetError::Symlink { path } => HeddleError::Conflict(format!(
+            "thread worktree target '{}' cannot be a symlink",
+            path.display()
+        )),
+        ThreadWorktreeTargetError::NotDirectory { path } => HeddleError::Conflict(format!(
+            "thread worktree target '{}' must be a directory",
+            path.display()
+        )),
+        ThreadWorktreeTargetError::NotEmpty { path } => HeddleError::Conflict(format!(
+            "thread worktree target '{}' is not empty",
+            path.display()
+        )),
+    }
+}
+
+fn prepare_thread_worktree_target(dest: &Path) -> Result<ThreadWorktreeTargetDisposition> {
+    let disposition =
+        validate_thread_worktree_target(dest).map_err(thread_worktree_target_error)?;
+    if disposition == ThreadWorktreeTargetDisposition::Absent {
+        fs::create_dir_all(dest).map_err(HeddleError::Io)?;
+        validate_thread_worktree_target(dest).map_err(thread_worktree_target_error)?;
+    }
+    Ok(disposition)
+}
+
+fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(dir)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_thread_worktree_target(
+    dest: &Path,
+    disposition: ThreadWorktreeTargetDisposition,
+) -> Result<()> {
+    match clear_dir_contents(dest) {
+        Ok(()) => {}
+        Err(err)
+            if err.kind() == std::io::ErrorKind::NotFound
+                || err.kind() == std::io::ErrorKind::NotADirectory => {}
+        Err(err) => return Err(HeddleError::Io(err)),
+    }
+
+    if disposition == ThreadWorktreeTargetDisposition::Absent {
+        match fs::remove_dir(dest) {
+            Ok(()) => {}
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.kind() == std::io::ErrorKind::NotADirectory => {}
+            Err(err) => return Err(HeddleError::Io(err)),
+        }
+    }
+
+    Ok(())
 }
 
 impl Repository {
@@ -96,6 +170,7 @@ impl Repository {
             .store()
             .get_state(&change_id)?
             .ok_or_else(|| HeddleError::Config(format!("state for {thread} missing")))?;
+        let target_disposition = prepare_thread_worktree_target(dest)?;
 
         // Route through the single visibility-gated checkout chokepoint, which
         // either materializes the real tree or writes the operator-local
@@ -103,44 +178,54 @@ impl Repository {
         // outside the checkout dir), so it is written here based on the gate
         // outcome — not in the chokepoint, which `write_isolated_checkout` also
         // calls without wanting a thread manifest.
-        match self.checkout_state_gated(&change_id, &state, dest, audience)? {
-            CheckoutMaterialization::Withheld { tier } => {
-                // Manifest reflects disk truth: no tracked files were
-                // materialized (the placeholder is untracked). `tree_hash`
-                // still names the real embargoed state's tree so the sidecar
-                // identifies which state this checkout stands in for. The
-                // `withheld` flag here is diagnostic only — it records that the
-                // *last* materialize of this thread was withheld, but the
-                // per-thread manifest is clobbered by a sibling worktree of the
-                // same thread. The authoritative, per-worktree non-capturable
-                // signal is the withheld marker written by
-                // `checkout_state_gated`, keyed on the worktree root (heddle#316).
-                let mut manifest =
-                    ThreadManifest::new(change_id, state.tree, canonical_worktree_path(dest));
-                manifest.withheld = true;
-                write_manifest(self.heddle_dir(), thread, &manifest).map_err(HeddleError::Io)?;
-                debug!(
-                    thread = %thread,
-                    state_id = %change_id,
-                    tier = tier.as_str(),
-                    "thread checkout rendered courtesy stub (under-tier for audience)"
-                );
-                Ok(manifest)
+        let result = (|| -> Result<ThreadManifest> {
+            match self.checkout_state_gated(&change_id, &state, dest, audience)? {
+                CheckoutMaterialization::Withheld { tier } => {
+                    // Manifest reflects disk truth: no tracked files were
+                    // materialized (the placeholder is untracked). `tree_hash`
+                    // still names the real embargoed state's tree so the sidecar
+                    // identifies which state this checkout stands in for. The
+                    // `withheld` flag here is diagnostic only — it records that the
+                    // *last* materialize of this thread was withheld, but the
+                    // per-thread manifest is clobbered by a sibling worktree of the
+                    // same thread. The authoritative, per-worktree non-capturable
+                    // signal is the withheld marker written by
+                    // `checkout_state_gated`, keyed on the worktree root (heddle#316).
+                    let mut manifest =
+                        ThreadManifest::new(change_id, state.tree, canonical_worktree_path(dest));
+                    manifest.withheld = true;
+                    write_manifest(self.heddle_dir(), thread, &manifest)
+                        .map_err(HeddleError::Io)?;
+                    debug!(
+                        thread = %thread,
+                        state_id = %change_id,
+                        tier = tier.as_str(),
+                        "thread checkout rendered courtesy stub (under-tier for audience)"
+                    );
+                    Ok(manifest)
+                }
+                CheckoutMaterialization::Materialized { tree } => {
+                    let mut manifest =
+                        ThreadManifest::new(change_id, state.tree, canonical_worktree_path(dest));
+                    populate_manifest_from_tree(self, &tree, dest, "", &mut manifest.files)?;
+                    write_manifest(self.heddle_dir(), thread, &manifest)
+                        .map_err(HeddleError::Io)?;
+                    debug!(
+                        thread = %thread,
+                        state_id = %change_id,
+                        files = manifest.files.len(),
+                        "thread materialized"
+                    );
+                    Ok(manifest)
+                }
             }
-            CheckoutMaterialization::Materialized { tree } => {
-                let mut manifest =
-                    ThreadManifest::new(change_id, state.tree, canonical_worktree_path(dest));
-                populate_manifest_from_tree(self, &tree, dest, "", &mut manifest.files)?;
-                write_manifest(self.heddle_dir(), thread, &manifest).map_err(HeddleError::Io)?;
-                debug!(
-                    thread = %thread,
-                    state_id = %change_id,
-                    files = manifest.files.len(),
-                    "thread materialized"
-                );
-                Ok(manifest)
-            }
+        })();
+
+        if result.is_err() {
+            cleanup_thread_worktree_target(dest, target_disposition)?;
         }
+
+        result
     }
 
     /// THE visibility-gated checkout chokepoint. Resolve `change_id`'s
@@ -1176,6 +1261,14 @@ mod tests {
     use super::*;
     use crate::thread_manifest::read_manifest;
 
+    fn seeded_repo() -> (TempDir, Repository) {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+        fs::write(repo_dir.path().join("file.txt"), b"tracked\n").unwrap();
+        repo.snapshot(Some("seed".into()), None).unwrap();
+        (repo_dir, repo)
+    }
+
     #[test]
     fn materialize_thread_writes_manifest_with_files() {
         let repo_dir = TempDir::new().unwrap();
@@ -1221,6 +1314,92 @@ mod tests {
         );
     }
 
+    #[test]
+    fn materialize_thread_creates_absent_target() {
+        let (_repo_dir, repo) = seeded_repo();
+        let dest_holder = TempDir::new().unwrap();
+        let dest = dest_holder.path().join("out");
+
+        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
+
+        assert!(dest.is_dir());
+        assert_eq!(
+            fs::read_to_string(dest.join("file.txt")).unwrap(),
+            "tracked\n"
+        );
+    }
+
+    #[test]
+    fn materialize_thread_adopts_empty_directory() {
+        let (_repo_dir, repo) = seeded_repo();
+        let dest_holder = TempDir::new().unwrap();
+        let dest = dest_holder.path().join("out");
+        fs::create_dir(&dest).unwrap();
+
+        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap();
+
+        assert!(dest.is_dir());
+        assert_eq!(
+            fs::read_to_string(dest.join("file.txt")).unwrap(),
+            "tracked\n"
+        );
+    }
+
+    #[test]
+    fn materialize_thread_rejects_non_empty_directory() {
+        let (_repo_dir, repo) = seeded_repo();
+        let dest_holder = TempDir::new().unwrap();
+        let dest = dest_holder.path().join("out");
+        fs::create_dir(&dest).unwrap();
+        fs::write(dest.join("existing.txt"), b"user data\n").unwrap();
+
+        let err = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("is not empty"), "{err}");
+        assert_eq!(
+            fs::read_to_string(dest.join("existing.txt")).unwrap(),
+            "user data\n"
+        );
+        assert!(!dest.join("file.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_thread_rejects_symlink_target() {
+        let (_repo_dir, repo) = seeded_repo();
+        let dest_holder = TempDir::new().unwrap();
+        let real = dest_holder.path().join("real");
+        fs::create_dir(&real).unwrap();
+        let dest = dest_holder.path().join("link");
+        std::os::unix::fs::symlink(&real, &dest).unwrap();
+
+        let err = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cannot be a symlink"), "{err}");
+        assert!(!real.join("file.txt").exists());
+    }
+
+    #[test]
+    fn materialize_thread_rejects_file_target() {
+        let (_repo_dir, repo) = seeded_repo();
+        let dest_holder = TempDir::new().unwrap();
+        let dest = dest_holder.path().join("file");
+        fs::write(&dest, b"user data\n").unwrap();
+
+        let err = repo
+            .materialize_thread("main", &dest, &AudienceTier::Internal)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("must be a directory"), "{err}");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "user data\n");
+    }
+
     fn embargo_state_with_tier(repo: &Repository, tier: VisibilityTier) -> ChangeId {
         use chrono::Utc;
         use objects::object::{Principal, StateVisibility};
@@ -1243,6 +1422,25 @@ mod tests {
         })
         .expect("put visibility");
         state_id
+    }
+
+    fn checkout_main(
+        repo: &Repository,
+        dest: &Path,
+        audience: &AudienceTier,
+    ) -> CheckoutMaterialization {
+        let change_id = repo
+            .refs()
+            .resolve("main")
+            .unwrap()
+            .expect("main thread exists");
+        let state = repo
+            .store()
+            .get_state(&change_id)
+            .unwrap()
+            .expect("main state exists");
+        repo.checkout_state_gated(&change_id, &state, dest, audience)
+            .unwrap()
     }
 
     #[test]
@@ -1334,8 +1532,7 @@ mod tests {
         let dest = dest_holder.path().join("out");
 
         // First: under-tier materialize of the root → only the stub lands.
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         assert!(
             dest.join(COURTESY_STUB_FILENAME).exists(),
             "under-tier materialize must write the stub"
@@ -1343,19 +1540,16 @@ mod tests {
         assert!(!dest.join("secret.rs").exists());
 
         // Then: re-materialize the SAME root for an authorized audience.
-        let manifest = repo
-            .materialize_thread(
-                "main",
-                &dest,
-                &AudienceTier::Restricted("sec-embargo".into()),
-            )
-            .unwrap();
+        checkout_main(
+            &repo,
+            &dest,
+            &AudienceTier::Restricted("sec-embargo".into()),
+        );
 
         assert!(
             dest.join("secret.rs").exists(),
             "authorized re-materialize must write the real tree"
         );
-        assert!(manifest.files.contains_key("secret.rs"));
         assert!(
             !dest.join(COURTESY_STUB_FILENAME).exists(),
             "the stale courtesy stub must be removed on the authorized re-materialize"
@@ -1389,18 +1583,16 @@ mod tests {
 
         // Visible materialize: the real tree lands — the very bytes a later
         // under-tier materialize must withhold.
-        repo.materialize_thread(
-            "main",
+        checkout_main(
+            &repo,
             &dest,
             &AudienceTier::Restricted("sec-embargo".into()),
-        )
-        .unwrap();
+        );
         assert!(dest.join("secret.rs").exists());
         assert!(dest.join("nested/inner.rs").exists());
 
         // Under-tier re-materialize of the SAME root — the leak case.
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
 
         assert!(
             dest.join(COURTESY_STUB_FILENAME).exists(),
@@ -1447,23 +1639,19 @@ mod tests {
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
 
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         assert!(dest.join(COURTESY_STUB_FILENAME).exists());
         assert!(!dest.join("secret.rs").exists());
 
-        let manifest = repo
-            .materialize_thread(
-                "main",
-                &dest,
-                &AudienceTier::Restricted("sec-embargo".into()),
-            )
-            .unwrap();
+        checkout_main(
+            &repo,
+            &dest,
+            &AudienceTier::Restricted("sec-embargo".into()),
+        );
         assert!(
             dest.join("secret.rs").exists(),
             "authorized re-materialize must write the real tree"
         );
-        assert!(manifest.files.contains_key("secret.rs"));
         assert!(
             !dest.join(COURTESY_STUB_FILENAME).exists(),
             "the stale courtesy stub must be removed on the authorized re-materialize"
@@ -1485,8 +1673,7 @@ mod tests {
 
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         assert!(dest.join("keep.rs").exists());
         assert!(dest.join("stale.rs").exists());
 
@@ -1498,8 +1685,7 @@ mod tests {
         repo.snapshot(Some("advance".into()), None).unwrap();
 
         // Re-materialize the SAME root at the new (still visible) head.
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         assert!(dest.join("keep.rs").exists(), "an unchanged leaf stays");
         assert!(dest.join("fresh.rs").exists(), "the new leaf is written");
         assert!(
@@ -1531,14 +1717,12 @@ mod tests {
         let dest_holder = TempDir::new().unwrap();
         let dest = dest_holder.path().join("out");
 
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         assert!(dest.join(COURTESY_STUB_FILENAME).exists());
         assert!(!dest.join("secret.rs").exists());
 
-        // Second under-tier materialize of the same root: still only the stub.
-        repo.materialize_thread("main", &dest, &AudienceTier::Internal)
-            .unwrap();
+        // Second under-tier checkout of the same root: still only the stub.
+        checkout_main(&repo, &dest, &AudienceTier::Internal);
         let remaining: Vec<_> = fs::read_dir(&dest)
             .unwrap()
             .map(|e| e.unwrap().file_name())
@@ -1627,8 +1811,7 @@ mod tests {
         // clobber-proof per-root record for A captures `old-secret.txt`.
         let a_holder = TempDir::new().unwrap();
         let root_a = a_holder.path().join("root-a");
-        repo.materialize_thread("main", &root_a, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &root_a, &AudienceTier::Internal);
         assert!(root_a.join("old-secret.txt").exists());
 
         // Advance the thread to S2: the secret is REMOVED before this state, a
@@ -1674,8 +1857,7 @@ mod tests {
         // S2's tree does not contain `old-secret.txt`, and the per-thread
         // manifest no longer names A — only the clobber-proof per-root record can
         // drive its removal.
-        repo.materialize_thread("main", &root_a, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &root_a, &AudienceTier::Internal);
 
         assert!(
             root_a.join(COURTESY_STUB_FILENAME).exists(),
@@ -1720,8 +1902,7 @@ mod tests {
         // .leaves(R) = {a.txt}.
         let holder = TempDir::new().unwrap();
         let root = holder.path().join("root");
-        repo.materialize_thread("main", &root, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &root, &AudienceTier::Internal);
         assert!(root.join("a.txt").exists());
 
         // User adds `b.txt` in R and captures → head advances to S2 = {a, b}.
@@ -1758,8 +1939,7 @@ mod tests {
         // Re-materialize R WITHHELD (Internal under-tier for the Private S3). S3's
         // own tree has no b.txt, so the withheld reduction can only remove the
         // capture-added b.txt by sourcing the refreshed per-root record.
-        repo.materialize_thread("main", &root, &AudienceTier::Internal)
-            .unwrap();
+        checkout_main(&repo, &root, &AudienceTier::Internal);
 
         assert!(
             root.join(COURTESY_STUB_FILENAME).exists(),

--- a/crates/repo/src/thread_worktree_target.rs
+++ b/crates/repo/src/thread_worktree_target.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared thread-worktree target shape validation.
+
+use std::path::{Path, PathBuf};
+
+/// Whether a target accepted by [`validate_thread_worktree_target`] already
+/// existed or must be created by the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThreadWorktreeTargetDisposition {
+    /// The target path does not exist yet.
+    Absent,
+    /// The target is an existing, empty, non-symlink directory.
+    EmptyDirectory,
+}
+
+/// Why a thread-worktree target is not safe to materialize into.
+#[derive(Debug)]
+pub enum ThreadWorktreeTargetError {
+    Symlink {
+        path: PathBuf,
+    },
+    NotDirectory {
+        path: PathBuf,
+    },
+    NotEmpty {
+        path: PathBuf,
+    },
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for ThreadWorktreeTargetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Symlink { path } => {
+                write!(
+                    f,
+                    "thread worktree target '{}' cannot be a symlink",
+                    path.display()
+                )
+            }
+            Self::NotDirectory { path } => {
+                write!(
+                    f,
+                    "thread worktree target '{}' must be a directory",
+                    path.display()
+                )
+            }
+            Self::NotEmpty { path } => {
+                write!(
+                    f,
+                    "thread worktree target '{}' is not empty",
+                    path.display()
+                )
+            }
+            Self::Io { path, source } => {
+                write!(
+                    f,
+                    "inspect thread worktree target '{}': {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ThreadWorktreeTargetError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Symlink { .. } | Self::NotDirectory { .. } | Self::NotEmpty { .. } => None,
+        }
+    }
+}
+
+/// Enforce the shared thread-create directory contract:
+///
+/// - absent path: accepted; caller creates it
+/// - existing empty, non-symlink directory: accepted; caller adopts it
+/// - symlink, non-directory, or non-empty directory: rejected
+///
+/// This intentionally mirrors the original CLI `validate_worktree_target`
+/// leaf-shape check. Repo-specific reserved-path policy remains in the CLI
+/// validator; this function owns only the filesystem shape contract that both
+/// the CLI and `Repository::materialize_thread` must share.
+pub fn validate_thread_worktree_target(
+    path: &Path,
+) -> std::result::Result<ThreadWorktreeTargetDisposition, ThreadWorktreeTargetError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(_) => return Ok(ThreadWorktreeTargetDisposition::Absent),
+    };
+
+    if metadata.file_type().is_symlink() {
+        return Err(ThreadWorktreeTargetError::Symlink {
+            path: path.to_path_buf(),
+        });
+    }
+
+    if !metadata.is_dir() {
+        return Err(ThreadWorktreeTargetError::NotDirectory {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let has_entry = std::fs::read_dir(path)
+        .and_then(|mut entries| entries.next().transpose().map(|entry| entry.is_some()))
+        .map_err(|source| ThreadWorktreeTargetError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if has_entry {
+        return Err(ThreadWorktreeTargetError::NotEmpty {
+            path: path.to_path_buf(),
+        });
+    }
+
+    Ok(ThreadWorktreeTargetDisposition::EmptyDirectory)
+}


### PR DESCRIPTION
Fixes #537

## Summary
- Add one shared repo-level thread worktree target shape validator for absent/empty-dir/symlink/file/non-empty handling.
- Route the CLI target validator through the shared validator while preserving existing recovery advice kinds.
- Enforce the same target contract in Repository::materialize_thread and add the library target matrix tests.

## Verification
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo repository_thread_materialize
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- bash scripts/check-no-silent-default-tree-load.sh
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings

Note: `cargo test -p heddle-cli` had one unrelated existing contract drift failure: `oss_cli_polish::doctor_schemas_reports_runtime_and_documented_coverage` reports documented schema verb `expand` lacks parseable samples.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783950577&installation_id=132405951&pr_number=717&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F717&signature=b9beee930a99868414d9e9edefd1edc66dd90f451df77b4b6ebcfa3d0506f6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->