### PR TITLE
perf(adopt): write git mirror as one pack

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -3634,42 +3634,55 @@ pub(crate) fn copy_reachable_objects(
         )));
     }
 
-    for oid in collect_reachable_object_ids(source, roots)? {
-        let object = source.find_object(oid).map_err(git_err)?;
-        let object_ref =
-            gix::objs::ObjectRef::from_bytes(&object.data, object.kind, source.object_hash())
-                .map_err(git_err)?;
-        target.write_object(object_ref).map_err(git_err)?;
-    }
-
-    Ok(())
+    let entries = collect_reachable_entries(source, roots)?;
+    install_objects_pack(target, entries)
 }
 
-fn collect_reachable_object_ids(
+/// Walk every object reachable from `roots` in `source`, reading each object
+/// once and serializing it into a base pack entry.
+pub(crate) fn collect_reachable_entries(
     source: &gix::Repository,
     roots: impl IntoIterator<Item = ObjectId>,
-) -> GitResult<Vec<ObjectId>> {
-    let mut stack: Vec<ObjectId> = roots.into_iter().collect();
+) -> GitResult<Vec<gix_pack::data::output::Entry>> {
     let mut seen = HashSet::new();
-    let mut ordered = Vec::new();
+    collect_reachable_entries_excluding(source, roots, &mut seen)
+}
+
+pub(crate) fn collect_reachable_entries_excluding(
+    source: &gix::Repository,
+    roots: impl IntoIterator<Item = ObjectId>,
+    seen: &mut HashSet<ObjectId>,
+) -> GitResult<Vec<gix_pack::data::output::Entry>> {
+    let object_hash = source.object_hash();
+    let mut stack: Vec<ObjectId> = roots.into_iter().collect();
+    let mut entries = Vec::new();
 
     while let Some(oid) = stack.pop() {
         if !seen.insert(oid) {
             continue;
         }
-        ordered.push(oid);
 
         let object = source.find_object(oid).map_err(git_err)?;
-        match object.kind {
+        let kind = object.kind;
+        let data = gix::objs::Data {
+            kind,
+            data: &object.data,
+            object_hash,
+        };
+        let count = gix_pack::data::output::Count::from_data(oid, None);
+        let entry = gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?;
+        entries.push(entry);
+
+        match kind {
             gix::objs::Kind::Commit => {
-                let commit = source.find_commit(oid).map_err(git_err)?;
+                let commit = object.into_commit();
                 stack.push(commit.tree_id().map_err(git_err)?.detach());
                 for parent in commit.parent_ids() {
                     stack.push(parent.detach());
                 }
             }
             gix::objs::Kind::Tree => {
-                let tree = source.find_tree(oid).map_err(git_err)?;
+                let tree = object.into_tree();
                 for entry in tree.iter() {
                     let entry = entry.map_err(git_err)?;
                     // Gitlink (mode 160000) entries point at a commit
@@ -3694,14 +3707,70 @@ fn collect_reachable_object_ids(
                 }
             }
             gix::objs::Kind::Tag => {
-                let tag = source.find_tag(oid).map_err(git_err)?;
+                let tag = object.into_tag();
                 stack.push(tag.target_id().map_err(git_err)?.detach());
             }
             gix::objs::Kind::Blob => {}
         }
     }
 
-    Ok(ordered)
+    Ok(entries)
+}
+
+/// Install reachable objects into `target` as one packfile instead of N loose
+/// object writes. Packed objects keep the same OIDs and are read transparently
+/// by Git/gix, so mirror fidelity is unchanged.
+pub(crate) fn install_objects_pack(
+    target: &gix::Repository,
+    entries: Vec<gix_pack::data::output::Entry>,
+) -> GitResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let object_hash = target.object_hash();
+    let num_entries: u32 = entries.len().try_into().map_err(|_| {
+        GitBridgeError::Git(format!(
+            "mirror pack has too many objects to encode: {}",
+            entries.len()
+        ))
+    })?;
+
+    let mut pack = Vec::new();
+    {
+        let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
+        let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
+            input,
+            &mut pack,
+            num_entries,
+            gix_pack::data::Version::V2,
+            object_hash,
+        );
+        for result in writer.by_ref() {
+            result.map_err(git_err)?;
+        }
+    }
+
+    let pack_dir = target.git_dir().join("objects").join("pack");
+    fs::create_dir_all(&pack_dir)?;
+    let outcome = gix_pack::Bundle::write_to_directory(
+        &mut std::io::Cursor::new(pack.as_slice()),
+        Some(&pack_dir),
+        &mut gix::progress::Discard,
+        &AtomicBool::new(false),
+        None::<gix::objs::find::Never>,
+        gix_pack::bundle::write::Options {
+            object_hash,
+            ..Default::default()
+        },
+    )
+    .map_err(git_err)?;
+
+    if let Some(keep) = outcome.keep_path {
+        let _ = fs::remove_file(keep);
+    }
+
+    Ok(())
 }
 
 fn fetch_network_remote(
@@ -3898,33 +3967,22 @@ fn pack_reachable_objects(
     repo: &gix::Repository,
     roots: impl IntoIterator<Item = ObjectId>,
 ) -> GitResult<Vec<u8>> {
-    let oids = collect_reachable_object_ids(repo, roots)?;
-    let mut entries = Vec::with_capacity(oids.len());
-    for oid in &oids {
-        let object = repo.find_object(*oid).map_err(git_err)?;
-        let data = gix::objs::Data {
-            kind: object.kind,
-            data: &object.data,
-            object_hash: repo.object_hash(),
-        };
-        let count = gix_pack::data::output::Count::from_data(*oid, None);
-        let entry = gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?;
-        entries.push(entry);
-    }
+    let entries = collect_reachable_entries(repo, roots)?;
+    let num_entries: u32 = entries.len().try_into().map_err(|_| {
+        GitBridgeError::Git(format!(
+            "push pack has too many objects to encode: {}",
+            entries.len()
+        ))
+    })?;
 
     let mut pack = Vec::new();
     let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
     let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
         input,
         &mut pack,
-        oids.len().try_into().map_err(|_| {
-            GitBridgeError::Git(format!(
-                "push pack has too many objects to encode: {}",
-                oids.len()
-            ))
-        })?,
+        num_entries,
         gix_pack::data::Version::V2,
-        ObjectHashKind::Sha1,
+        repo.object_hash(),
     );
     for result in writer.by_ref() {
         result.map_err(git_err)?;

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -18,8 +18,8 @@ use super::git_import_tree::{PackImportSink, fail_lossy_entry};
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, RefNamespace, RefUpdate, SyncMapping,
-        apply_ref_updates, copy_reachable_objects, git_err, open_repo, parse_git_ref,
-        thread_is_unclaimed_bootstrap,
+        apply_ref_updates, collect_reachable_entries_excluding, copy_reachable_objects, git_err,
+        install_objects_pack, open_repo, parse_git_ref, thread_is_unclaimed_bootstrap,
     },
     git_notes,
     git_util::{GitImportOptions, ImportStats, PartialMirrorRef, SkippedRef},
@@ -792,28 +792,36 @@ fn import_with_ref_filter(
     //      `sync_marker_to_tag` skip the rewrite — leaving the
     //      annotated tag intact through to the destination push.
     //
-    // We do this **per ref** rather than as a single bulk copy. A ref
-    // whose ancestry references a missing object (a known failure mode
-    // in real-world repos like git-lfs, where pack data carries dangling
-    // references that `git fsck` doesn't catch) doesn't poison the rest
-    // of the mirror — only that one ref loses SHA stability.
+    // We collect entries **per ref** so a ref whose ancestry references a
+    // missing object (a known failure mode in real-world repos like git-lfs,
+    // where pack data carries dangling references that `git fsck` doesn't
+    // catch) doesn't poison the rest of the mirror. Successful refs are then
+    // installed together as one pack, avoiding N loose writes and N per-ref
+    // packfiles on the adopt path.
     if git_path.is_some() {
         bridge.init_mirror()?;
         let mirror_repo = bridge.open_git_repo()?;
         if mirror_repo.git_dir() != repo.git_dir() {
             let mut successful_updates: Vec<RefUpdate> = Vec::new();
+            let mut mirror_entries = Vec::new();
+            let mut mirror_seen = HashSet::new();
             for plan in &plans {
                 // Roots include both the immediate target (tag object for
                 // annotated tags) and the peeled commit (so the walker
                 // descends through commit→tree→blob even when the
                 // immediate object is a tag).
                 let roots = [plan.immediate_oid, plan.peeled_commit_oid];
-                match copy_reachable_objects(&repo, &mirror_repo, roots) {
-                    Ok(()) => successful_updates.push(RefUpdate {
-                        name: plan.short_name.clone(),
-                        target: plan.immediate_oid,
-                        namespace: plan.namespace,
-                    }),
+                let mut candidate_seen = mirror_seen.clone();
+                match collect_reachable_entries_excluding(&repo, roots, &mut candidate_seen) {
+                    Ok(entries) => {
+                        mirror_seen = candidate_seen;
+                        mirror_entries.extend(entries);
+                        successful_updates.push(RefUpdate {
+                            name: plan.short_name.clone(),
+                            target: plan.immediate_oid,
+                            namespace: plan.namespace,
+                        });
+                    }
                     Err(err) => {
                         let full = match plan.namespace {
                             RefNamespace::Branch => format!("refs/heads/{}", plan.short_name),
@@ -833,6 +841,7 @@ fn import_with_ref_filter(
                     }
                 }
             }
+            install_objects_pack(&mirror_repo, mirror_entries)?;
             // Write source refs into the mirror. For annotated tags this
             // points refs/tags/<name> at the tag object (not the peeled
             // commit), which is what preserves the annotated form across

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -3151,6 +3151,89 @@ fn import_isolates_per_ref_mirror_failures() {
         );
     }
 }
+
+/// #561: `adopt` writes the mirror's reachable objects as one packfile, not as
+/// one loose object write per source object. The packed mirror must still carry
+/// the same object bytes, including annotated tag objects.
+#[test]
+fn import_writes_mirror_as_single_pack_with_identical_object_set() {
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let (_src_temp, source_repo) = init_git_repo();
+
+    // Use a stored blob/tree instead of the synthetic empty tree so source and
+    // mirror object stores can be compared directly.
+    let blob = source_repo.write_blob(b"hello\n").expect("blob").detach();
+    let mut editor = source_repo
+        .edit_tree(gix::hash::ObjectId::empty_tree(source_repo.object_hash()))
+        .expect("tree editor");
+    editor
+        .upsert("file.txt", gix::object::tree::EntryKind::Blob, blob)
+        .expect("upsert blob");
+    let tree = editor.write().expect("tree").detach();
+
+    let first = commit_with_tree(&source_repo, Some("refs/heads/main"), tree, "first", &[]);
+    let second = commit_with_tree(
+        &source_repo,
+        Some("refs/heads/main"),
+        tree,
+        "second",
+        &[first],
+    );
+    let tag_oid = create_annotated_tag(&source_repo, "v1.0", second, "release");
+
+    let mut bridge = GitBridge::new(&repo);
+    bridge
+        .import(Some(source_repo.workdir().expect("workdir")))
+        .expect("import");
+
+    let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
+    let pack_dir = mirror.git_dir().join("objects").join("pack");
+    let pack_count = std::fs::read_dir(&pack_dir)
+        .expect("read pack dir")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "pack"))
+        .count();
+    assert_eq!(pack_count, 1, "adopt mirror should write exactly one pack");
+
+    let loose_dirs: Vec<_> = std::fs::read_dir(mirror.git_dir().join("objects"))
+        .expect("read objects dir")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.len() == 2 && name.chars().all(|c| c.is_ascii_hexdigit())
+        })
+        .collect();
+    assert!(
+        loose_dirs.is_empty(),
+        "mirror must not contain loose object directories: {loose_dirs:?}"
+    );
+
+    let source_set: std::collections::HashSet<_> = source_repo
+        .objects
+        .iter()
+        .expect("source object iter")
+        .map(|result| result.expect("source oid"))
+        .collect();
+    let mirror_set: std::collections::HashSet<_> = mirror
+        .objects
+        .iter()
+        .expect("mirror object iter")
+        .map(|result| result.expect("mirror oid"))
+        .collect();
+    assert_eq!(
+        mirror_set, source_set,
+        "packed mirror object set must equal the source object set"
+    );
+
+    let source_tag = source_repo.find_object(tag_oid).expect("source tag present");
+    let mirror_tag = mirror.find_object(tag_oid).expect("mirror tag present");
+    assert_eq!(source_tag.kind, gix::objs::Kind::Tag);
+    assert_eq!(mirror_tag.kind, source_tag.kind);
+    assert_eq!(mirror_tag.data, source_tag.data);
+}
+
 #[test]
 fn import_honors_legacy_heddle_change_id_trailer() {
     let heddle_temp = TempDir::new().expect("heddle temp");


### PR DESCRIPTION
Fixes #561.

Supersedes stale PR #563 by re-applying the adopt-pack optimization onto current main after the `git_core.rs` and integration-test restructuring.

## What changed
- Replace mirror loose-object writes with generated pack/index installation under `objects/pack`.
- Batch successful adopt mirror refs into one pack while preserving per-ref failure isolation before refs are written.
- Reuse the reachable-object serialization path for push packs to avoid a second object read.
- Move the stale PR coverage into `crates/cli/tests/git_bridge_integration.rs` and assert adopt leaves exactly one pack, no loose object fanout dirs, and byte-identical annotated tag objects.

## Validation
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --workspace`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --workspace --all-features`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle bash scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-cli --lib`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-cli --test git_bridge_integration --no-fail-fast`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-cli --tests --no-fail-fast`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783950947&installation_id=132405951&pr_number=719&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F719&signature=69f4dfa1a5eecf843ac31a5761571f1744dc5f94dbeebb6d72a80429336b139e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->