### PR TITLE
docs(bridge): fix stale reserved-remote-name rejection comment in parse_git_ref

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -228,7 +228,10 @@ pub fn parse_git_ref(ref_name: &str) -> Option<ParsedGitRef<'_>> {
         // real remote-tracking branch. A remote literally named `git` collides
         // with the local sentinel ([`REMOTE_NAME_FOR_LOCAL_GIT_REPO`]); aliasing
         // it onto local refs would make remote-tracking branches
-        // indistinguishable from `refs/heads/*`, so it is rejected here —
+        // indistinguishable from `refs/heads/*`. Such a remote is already
+        // rejected by the `RefSpec::new` validation at the top of this function
+        // (`validate_refspec_ref` → `reject_reserved_git_remote_name`), so by the
+        // time we reach this branch `remote` is guaranteed not to collide —
         // matching jj's parser and the sentinel ownership contract.
         (name != "HEAD").then_some(ParsedGitRef {
             kind: GitRefKind::Branch,


### PR DESCRIPTION
Cosmetic doc-only fix. The comment in `parse_git_ref`'s `refs/remotes/` branch (git_core.rs:227-232) said a `git`-named remote collision is "rejected here", but **#622 (PR #695)** moved that validation up into `RefSpec::new` (`validate_refspec_ref → reject_reserved_git_remote_name`), which `parse_git_ref` now calls at line 216 before reaching this branch. The comment now accurately points at the real rejection site.

No behavior change (comment-only, +4/-1). Verified: `cargo build -p heddle-cli` ✓, `cargo clippy -p heddle-cli -- -D warnings` ✓.

Closes the follow-up flagged during #695 verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783950999&installation_id=132405951&pr_number=720&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F720&signature=8f1b5fd235f1d01cfdc8bcf82de02d9cf0587c69b70da459dc76c0a397c8dae8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->