### PR TITLE
Fix indented conflict marker recognition

### DIFF
--- a/crates/semantic/src/merge_driver/mod.rs
+++ b/crates/semantic/src/merge_driver/mod.rs
@@ -204,19 +204,18 @@ fn resolve_conflict_sides(text: &str) -> Option<(String, String)> {
     let mut theirs = String::new();
     let mut state = State::Normal;
     for line in text.split_inclusive('\n') {
-        let body = line.strip_suffix('\n').unwrap_or(line);
-        let body = body.strip_suffix('\r').unwrap_or(body);
-        if body.starts_with("<<<<<<<") {
+        let marker = conflict_marker(line);
+        if matches!(marker, Some(ConflictMarker::Start)) {
             match state {
                 State::Normal => state = State::Ours,
                 _ => return None,
             }
-        } else if body == "=======" {
+        } else if matches!(marker, Some(ConflictMarker::Separator)) {
             match state {
                 State::Ours => state = State::Theirs,
                 _ => return None,
             }
-        } else if body.starts_with(">>>>>>>") {
+        } else if matches!(marker, Some(ConflictMarker::End)) {
             match state {
                 State::Theirs => state = State::Normal,
                 _ => return None,
@@ -236,6 +235,35 @@ fn resolve_conflict_sides(text: &str) -> Option<(String, String)> {
         State::Normal => Some((ours, theirs)),
         _ => None,
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConflictMarker {
+    Start,
+    Separator,
+    End,
+}
+
+fn conflict_marker(line: &str) -> Option<ConflictMarker> {
+    let body = line.strip_suffix('\n').unwrap_or(line);
+    let body = body.strip_suffix('\r').unwrap_or(body).trim_start();
+
+    if marker_body_matches(body, "<<<<<<<") {
+        Some(ConflictMarker::Start)
+    } else if marker_body_matches(body, "=======") {
+        Some(ConflictMarker::Separator)
+    } else if marker_body_matches(body, ">>>>>>>") {
+        Some(ConflictMarker::End)
+    } else {
+        None
+    }
+}
+
+fn marker_body_matches(body: &str, marker: &str) -> bool {
+    let Some(rest) = body.strip_prefix(marker) else {
+        return false;
+    };
+    rest.is_empty() || rest.starts_with(' ')
 }
 
 /// Whether a clean `output` conserves the structure of its inputs. Re-parses

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -2760,38 +2760,87 @@ fn foo() { 2 }
     );
 }
 
+#[test]
+fn resolve_conflict_sides_recognizes_indented_markers() {
+    let start = "<<<<<<<";
+    let sep = "=======";
+    let end = ">>>>>>>";
+    let text = format!(
+        "\
+mod m {{
+    {start} OURS
+    fn f() {{
+    {sep}
+    fn f() {{}}
+    {end} THEIRS
+}}
+"
+    );
+    let (ours, theirs) =
+        super::resolve_conflict_sides(&text).expect("indented conflict markers must resolve");
+
+    assert!(
+        !ours.contains("<<<<<<<") && !ours.contains("=======") && !ours.contains(">>>>>>>"),
+        "ours side must not retain conflict markers:\n{ours}"
+    );
+    assert!(
+        !theirs.contains("<<<<<<<") && !theirs.contains("=======") && !theirs.contains(">>>>>>>"),
+        "theirs side must not retain conflict markers:\n{theirs}"
+    );
+    assert!(
+        !super::conflict_well_formed(text.as_bytes(), crate::parser::Language::Rust),
+        "indented markers must route through structural side parsing, where the broken ours side fails"
+    );
+}
+
+#[test]
+fn resolve_conflict_sides_does_not_treat_marker_like_data_as_markers() {
+    let start = "<<<<<<<";
+    let sep = "=======";
+    let end = ">>>>>>>";
+    let text = format!(
+        "\
+fn f() {{
+    {start}not a marker
+    {sep}not a marker
+    {end}not a marker
+}}
+"
+    );
+    let (ours, theirs) =
+        super::resolve_conflict_sides(&text).expect("marker-like content must remain content");
+
+    assert_eq!(ours, text);
+    assert_eq!(theirs, text);
+}
+
+#[test]
+fn resolve_conflict_sides_preserves_column_zero_conflicts() {
+    let start = "<<<<<<<";
+    let sep = "=======";
+    let end = ">>>>>>>";
+    let text = format!(
+        "\
+{start} OURS
+fn f() {{ 1 }}
+{sep}
+fn f() {{ 2 }}
+{end} THEIRS
+"
+    );
+    let (ours, theirs) =
+        super::resolve_conflict_sides(&text).expect("column-zero conflict must resolve");
+
+    assert_eq!(ours, "fn f() { 1 }\n");
+    assert_eq!(theirs, "fn f() { 2 }\n");
+}
+
 // Resolve a conflict-marked text into its two sides (take-ours, take-theirs) by
 // dropping the markers and the opposite side's hunks. Mirrors the marker shape
 // emitted by `heddle-merge::markers` / `emit_addadd_conflict`.
 fn resolve_both_sides(text: &str) -> [String; 2] {
-    #[derive(PartialEq)]
-    enum S {
-        Normal,
-        Ours,
-        Theirs,
-    }
-    let mut ours = String::new();
-    let mut theirs = String::new();
-    let mut state = S::Normal;
-    for line in text.split_inclusive('\n') {
-        let trimmed = line.strip_suffix('\n').unwrap_or(line);
-        if trimmed.starts_with("<<<<<<<") {
-            state = S::Ours;
-        } else if trimmed == "=======" {
-            state = S::Theirs;
-        } else if trimmed.starts_with(">>>>>>>") {
-            state = S::Normal;
-        } else {
-            match state {
-                S::Normal => {
-                    ours.push_str(line);
-                    theirs.push_str(line);
-                }
-                S::Ours => ours.push_str(line),
-                S::Theirs => theirs.push_str(line),
-            }
-        }
-    }
+    let (ours, theirs) =
+        super::resolve_conflict_sides(text).expect("conflict markers must resolve in test output");
     [ours, theirs]
 }
 


### PR DESCRIPTION
Fixes #525

## Summary
- recognize conflict markers after leading indentation using exact 7-character marker tokens plus a boundary
- keep original line content when resolving sides so indentation is preserved
- add resolver coverage for indented markers, marker-like data, and column-zero conflicts

## Verification
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-semantic
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --all-features
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

Note: cargo fmt --check was attempted and fails on existing repo-wide formatting drift outside this change; no unrelated formatting changes are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783959006&installation_id=132405951&pr_number=724&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F724&signature=5b3d79b902810f037ece8f103ce681203a52098d25468948b25205b4f1900560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->