### PR TITLE
[codex] Gate objects compression bench API

### DIFF
--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -38,6 +38,7 @@ aws-smithy-async = { workspace = true, optional = true }
 runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
 
 [features]
+bench = []
 s3 = ["dep:aws-sdk-s3", "dep:aws-smithy-async", "dep:tokio", "dep:runtime-bridge"]
 memory-backend = []
 zstd = ["dep:zstd"]
@@ -58,19 +59,24 @@ name = "objects"
 [[bench]]
 name = "hashing"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "compression"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "pack_io"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "tree_diff"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "delta"
 harness = false
+required-features = ["bench"]

--- a/crates/objects/benches/compression.rs
+++ b/crates/objects/benches/compression.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! zstd compression/decompression throughput benchmarks.
 //!
-//! Run: `cargo bench -p heddle-objects --features zstd --bench compression`
+//! Run: `cargo bench -p heddle-objects --features bench,zstd --bench compression`
 
 use std::hint::black_box;
 

--- a/crates/objects/src/store/compression/mod.rs
+++ b/crates/objects/src/store/compression/mod.rs
@@ -121,20 +121,26 @@ pub enum CompressionError {
 
 #[cfg(feature = "zstd")]
 /// Compress data using zstd.
-pub fn compress_zstd(data: &[u8], level: i32) -> Result<Vec<u8>, CompressionError> {
+fn compress_zstd_impl(data: &[u8], level: i32) -> Result<Vec<u8>, CompressionError> {
     zstd::encode_all(data, level).map_err(|e| CompressionError::CompressionFailed(e.to_string()))
 }
 
 #[cfg(not(feature = "zstd"))]
-pub fn compress_zstd(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionError> {
+fn compress_zstd_impl(_data: &[u8], _level: i32) -> Result<Vec<u8>, CompressionError> {
     Err(CompressionError::InvalidOperation(
         "zstd compression support not compiled into this build".to_string(),
     ))
 }
 
+#[cfg(feature = "bench")]
+/// Compress data using zstd.
+pub fn compress_zstd(data: &[u8], level: i32) -> Result<Vec<u8>, CompressionError> {
+    compress_zstd_impl(data, level)
+}
+
 #[cfg(feature = "zstd")]
 /// Decompress zstd data while enforcing the recorded output size.
-pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
+fn decompress_zstd_impl(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
     validate_size(expected_size)?;
     let expected_capacity = checked_size_to_usize("zstd expected size", expected_size)?;
 
@@ -170,11 +176,17 @@ pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, Compr
 }
 
 #[cfg(not(feature = "zstd"))]
-pub fn decompress_zstd(_data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
+fn decompress_zstd_impl(_data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
     validate_size(expected_size)?;
     Err(CompressionError::InvalidOperation(
         "zstd-compressed data is unsupported in this build".to_string(),
     ))
+}
+
+#[cfg(feature = "bench")]
+/// Decompress zstd data while enforcing the recorded output size.
+pub fn decompress_zstd(data: &[u8], expected_size: u64) -> Result<Vec<u8>, CompressionError> {
+    decompress_zstd_impl(data, expected_size)
 }
 
 /// Compress data with automatic algorithm selection.
@@ -192,7 +204,7 @@ pub fn compress(
     validate_size(data.len() as u64)?;
 
     // Try zstd compression
-    let compressed = compress_zstd(data, config.level)?;
+    let compressed = compress_zstd_impl(data, config.level)?;
 
     // Only use compression if it actually helps
     if compressed.len() >= data.len() {
@@ -361,7 +373,7 @@ where
     F: Fn(&[u8]) -> Result<u64, CompressionError>,
 {
     let uncompressed_size = read_size(data)?;
-    let decompressed = decompress_zstd(&data[header_len..], uncompressed_size)?;
+    let decompressed = decompress_zstd_impl(&data[header_len..], uncompressed_size)?;
     validate_decompressed_len(uncompressed_size, decompressed.len())?;
     Ok(decompressed)
 }


### PR DESCRIPTION
## Summary

- Add the `bench` feature to `heddle-objects` and require it for all objects benchmark targets.
- Keep `compress_zstd` and `decompress_zstd` available to the compression bench only when the `bench` feature is enabled.
- Preserve the default objects public API by routing normal crate internals through private implementation helpers.

Fixes #434

## Validation

- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build -p heddle-objects`
- external API probe confirmed `compress_zstd`/`decompress_zstd` are unresolved imports with `zstd` but without `bench`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build -p heddle-objects --features bench`
- `python3 scripts/discover-benches.py` lists objects benches with `bench,zstd`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo bench -p heddle-objects --features bench,zstd --bench compression --no-run`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783968964&installation_id=132405951&pr_number=725&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F725&signature=8ff6f8588fe825c4777ebcac86809de97c2743c6266b00e5bcf1691310408d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->