### PR TITLE
[codex] Wire discussion anchor travel into snapshots

### DIFF
--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use objects::object::{
-    Blob, ContentHash, Discussion, DiscussionResolution, DiscussionsBlob, EntryType, State, Tree,
+    Blob, ChangeId, ContentHash, Discussion, DiscussionResolution, DiscussionsBlob, EntryType,
+    State, Tree,
 };
 use objects::store::ObjectStore;
 use oplog::OpLogBackend;
@@ -48,13 +49,19 @@ where
             return Ok(Some(parent_discussions_hash));
         }
 
-        let parent_tree = self
-            .store()
-            .get_tree(&parent_state.tree)?
-            .ok_or_else(|| missing_object("tree", parent_state.tree))?;
-        let old_files = self.collect_tree_file_bytes(&parent_tree)?;
         let new_files = self.collect_tree_file_bytes(new_tree)?;
-        let updates = travel_anchors(&old_files, &new_files, &open_discussions);
+        let baseline_files = self.collect_discussion_baseline_file_bytes(&open_discussions)?;
+        let mut updates = Vec::new();
+        for (opened_against_state, discussions) in
+            group_discussions_by_opened_state(open_discussions)
+        {
+            let old_files = baseline_files.get(&opened_against_state).ok_or_else(|| {
+                HeddleError::Config(format!(
+                    "missing discussion baseline files for state {opened_against_state}"
+                ))
+            })?;
+            updates.extend(travel_anchors(old_files, &new_files, &discussions));
+        }
 
         for update in updates {
             if let Some(discussion) = discussions
@@ -79,6 +86,31 @@ where
         let mut files = HashMap::new();
         self.collect_tree_file_bytes_inner(tree, PathBuf::new(), &mut files)?;
         Ok(files)
+    }
+
+    fn collect_discussion_baseline_file_bytes(
+        &self,
+        discussions: &[Discussion],
+    ) -> Result<HashMap<ChangeId, HashMap<String, Vec<u8>>>> {
+        let mut baselines = HashMap::new();
+        for discussion in discussions {
+            if baselines.contains_key(&discussion.opened_against_state) {
+                continue;
+            }
+            let baseline_state = self
+                .store()
+                .get_state(&discussion.opened_against_state)?
+                .ok_or_else(|| missing_state(discussion.opened_against_state))?;
+            let baseline_tree = self
+                .store()
+                .get_tree(&baseline_state.tree)?
+                .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
+            baselines.insert(
+                discussion.opened_against_state,
+                self.collect_tree_file_bytes(&baseline_tree)?,
+            );
+        }
+        Ok(baselines)
     }
 
     fn collect_tree_file_bytes_inner(
@@ -119,6 +151,26 @@ fn missing_object(object_type: &str, hash: ContentHash) -> HeddleError {
         object_type: object_type.to_string(),
         id: hash.to_hex(),
     }
+}
+
+fn missing_state(change_id: ChangeId) -> HeddleError {
+    HeddleError::MissingObject {
+        object_type: "state".to_string(),
+        id: change_id.to_string_full(),
+    }
+}
+
+fn group_discussions_by_opened_state(
+    discussions: Vec<Discussion>,
+) -> HashMap<ChangeId, Vec<Discussion>> {
+    let mut grouped = HashMap::new();
+    for discussion in discussions {
+        grouped
+            .entry(discussion.opened_against_state)
+            .or_insert_with(Vec::new)
+            .push(discussion);
+    }
+    grouped
 }
 
 #[cfg(test)]
@@ -225,6 +277,62 @@ mod tests {
         let persisted = read_discussions(&repo, &second);
         assert!(persisted.discussions[0].body_changed_since_open);
         assert!(!persisted.discussions[0].orphaned);
+    }
+
+    #[test]
+    fn snapshot_keeps_body_changed_since_open_after_later_noop_transition() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n\nfn bar() {\n    let y = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        attach_discussions_to_main_head(
+            &repo,
+            &first,
+            vec![discussion("d1", first.change_id, "src.rs", "foo")],
+        );
+
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 2;\n}\n\nfn bar() {\n    let y = 1;\n}\n",
+        )
+        .unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("second".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted_second = read_discussions(&repo, &second);
+        assert!(persisted_second.discussions[0].body_changed_since_open);
+        assert!(!persisted_second.discussions[0].orphaned);
+
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 2;\n}\n\nfn bar() {\n    let y = 2;\n}\n",
+        )
+        .unwrap();
+        let third = repo
+            .snapshot_with_attribution(
+                Some("third".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted_third = read_discussions(&repo, &third);
+        assert!(persisted_third.discussions[0].body_changed_since_open);
+        assert!(!persisted_third.discussions[0].orphaned);
     }
 
     #[test]

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Snapshot-time persistence for discussion anchor travel.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use objects::object::{
+    Blob, ContentHash, Discussion, DiscussionResolution, DiscussionsBlob, EntryType, State, Tree,
+};
+use objects::store::ObjectStore;
+use oplog::OpLogBackend;
+use refs::RefBackend;
+
+use crate::discussion_anchor_travel::travel_anchors;
+use crate::{HeddleError, Repository, Result};
+
+impl<R, O, S> Repository<R, O, S>
+where
+    R: RefBackend,
+    O: OpLogBackend,
+    S: ObjectStore,
+{
+    pub(crate) fn compute_and_persist_discussion_anchor_travel(
+        &self,
+        parent_state: &State,
+        new_tree: &Tree,
+    ) -> Result<Option<ContentHash>> {
+        let Some(parent_discussions_hash) = parent_state.discussions else {
+            return Ok(None);
+        };
+        let parent_blob = self
+            .store()
+            .get_blob(&parent_discussions_hash)?
+            .ok_or_else(|| missing_object("blob", parent_discussions_hash))?;
+        let mut discussions = DiscussionsBlob::decode(parent_blob.content()).map_err(|err| {
+            HeddleError::Serialization(format!("decode parent discussions blob: {err}"))
+        })?;
+        let open_discussions: Vec<Discussion> = discussions
+            .discussions
+            .iter()
+            .filter(|discussion| matches!(discussion.resolution, DiscussionResolution::Open))
+            .cloned()
+            .collect();
+
+        if open_discussions.is_empty() {
+            return Ok(Some(parent_discussions_hash));
+        }
+
+        let parent_tree = self
+            .store()
+            .get_tree(&parent_state.tree)?
+            .ok_or_else(|| missing_object("tree", parent_state.tree))?;
+        let old_files = self.collect_tree_file_bytes(&parent_tree)?;
+        let new_files = self.collect_tree_file_bytes(new_tree)?;
+        let updates = travel_anchors(&old_files, &new_files, &open_discussions);
+
+        for update in updates {
+            if let Some(discussion) = discussions
+                .discussions
+                .iter_mut()
+                .find(|discussion| discussion.id == update.discussion_id)
+            {
+                discussion.anchor = update.new_anchor;
+                discussion.body_changed_since_open = update.body_changed_since_open;
+                discussion.orphaned = update.orphaned;
+            }
+        }
+
+        let bytes = discussions
+            .encode()
+            .map_err(|err| HeddleError::Serialization(format!("encode discussions blob: {err}")))?;
+        let hash = self.store().put_blob(&Blob::new(bytes))?;
+        Ok(Some(hash))
+    }
+
+    fn collect_tree_file_bytes(&self, tree: &Tree) -> Result<HashMap<String, Vec<u8>>> {
+        let mut files = HashMap::new();
+        self.collect_tree_file_bytes_inner(tree, PathBuf::new(), &mut files)?;
+        Ok(files)
+    }
+
+    fn collect_tree_file_bytes_inner(
+        &self,
+        tree: &Tree,
+        prefix: PathBuf,
+        files: &mut HashMap<String, Vec<u8>>,
+    ) -> Result<()> {
+        for entry in tree.entries() {
+            let path = prefix.join(&entry.name);
+            match entry.entry_type {
+                EntryType::Blob => {
+                    let Some(path) = path.to_str() else {
+                        continue;
+                    };
+                    let blob = self
+                        .store()
+                        .get_blob(&entry.hash)?
+                        .ok_or_else(|| missing_object("blob", entry.hash))?;
+                    files.insert(path.to_string(), blob.content().to_vec());
+                }
+                EntryType::Tree => {
+                    let subtree = self
+                        .store()
+                        .get_tree(&entry.hash)?
+                        .ok_or_else(|| missing_object("tree", entry.hash))?;
+                    self.collect_tree_file_bytes_inner(&subtree, path, files)?;
+                }
+                EntryType::Symlink => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+fn missing_object(object_type: &str, hash: ContentHash) -> HeddleError {
+    HeddleError::MissingObject {
+        object_type: object_type.to_string(),
+        id: hash.to_hex(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use objects::object::{
+        Attribution, ChangeId, Discussion, DiscussionTurn, Principal, SymbolAnchor, ThreadName,
+        VisibilityTier,
+    };
+    use refs::Head;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn create_test_repo() -> (TempDir, Repository) {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+        (temp_dir, repo)
+    }
+
+    fn discussion(id: &str, state: ChangeId, file: &str, symbol: &str) -> Discussion {
+        Discussion {
+            id: id.to_string(),
+            anchor: SymbolAnchor::new(file, symbol),
+            opened_against_state: state,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: Principal::new("Alice", "alice@example.com"),
+                body: "please check this".to_string(),
+                posted_at: 1_700_000_000,
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            orphaned: false,
+            visibility: VisibilityTier::default(),
+            resolved_annotation_id: None,
+        }
+    }
+
+    fn attach_discussions_to_main_head(
+        repo: &Repository,
+        state: &State,
+        discussions: Vec<Discussion>,
+    ) -> State {
+        let bytes = DiscussionsBlob::new(discussions).encode().unwrap();
+        let hash = repo.store().put_blob(&Blob::new(bytes)).unwrap();
+        let mut decorated = state.clone().with_discussions(hash);
+        repo.put_authored_state(&mut decorated).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::new("main"), &decorated.change_id)
+            .unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: ThreadName::new("main"),
+            })
+            .unwrap();
+        decorated
+    }
+
+    fn read_discussions(repo: &Repository, state: &State) -> DiscussionsBlob {
+        let hash = state
+            .discussions
+            .expect("snapshot should carry discussions");
+        let blob = repo.store().get_blob(&hash).unwrap().unwrap();
+        DiscussionsBlob::decode(blob.content()).unwrap()
+    }
+
+    #[test]
+    fn snapshot_marks_discussion_body_changed_since_open() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        attach_discussions_to_main_head(
+            &repo,
+            &first,
+            vec![discussion("d1", first.change_id, "src.rs", "foo")],
+        );
+
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 2;\n}\n",
+        )
+        .unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("second".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted = read_discussions(&repo, &second);
+        assert!(persisted.discussions[0].body_changed_since_open);
+        assert!(!persisted.discussions[0].orphaned);
+    }
+
+    #[test]
+    fn snapshot_marks_discussion_orphaned_when_anchor_disappears() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        attach_discussions_to_main_head(
+            &repo,
+            &first,
+            vec![discussion("d1", first.change_id, "src.rs", "foo")],
+        );
+
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn bar() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("second".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted = read_discussions(&repo, &second);
+        assert!(!persisted.discussions[0].body_changed_since_open);
+        assert!(persisted.discussions[0].orphaned);
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -9,6 +9,10 @@ compile_error!(
 
 pub mod atomic;
 pub mod daemon;
+#[cfg(feature = "tree-sitter-symbols")]
+mod discussion_anchor_travel;
+#[cfg(feature = "tree-sitter-symbols")]
+mod discussion_snapshot_travel;
 mod ephemeral_thread;
 mod fsmonitor;
 pub mod git_worktree_status;

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -269,6 +269,21 @@ impl SnapshotMutation<'_> {
                     tracing::warn!(error = %err, "risk signal computation failed; continuing without signals");
                 }
             }
+
+            if let Some(parent_state) = prior_state.as_ref() {
+                match self
+                    .repo
+                    .compute_and_persist_discussion_anchor_travel(parent_state, &tree)
+                {
+                    Ok(Some(hash)) => {
+                        state = state.with_discussions(hash);
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(error = %err, "discussion anchor travel failed; continuing without discussions");
+                    }
+                }
+            }
         }
 
         // Auto-sign every captured state (heddle#482) via the capture-path


### PR DESCRIPTION
## Summary

- Compile the existing `discussion_anchor_travel` module under `tree-sitter-symbols`.
- Add snapshot-time discussion refresh that carries parent discussions forward and populates `body_changed_since_open` / `orphaned` from `travel_anchors` before the new state is persisted.
- Add feature-gated repo tests that drive the snapshot write path and read back the persisted `DiscussionsBlob` for body-changed and orphaned anchors.

Fixes #492.

## Validation

- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build -p heddle-repo --features tree-sitter-symbols`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo check -p heddle-repo --features tree-sitter-symbols`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo --features tree-sitter-symbols`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle bash scripts/check-no-silent-default-tree-load.sh`
- `CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy --workspace --all-targets -- -D warnings`

Note: workspace-level `cargo build --features tree-sitter-symbols` is not valid because `heddle-cli` does not define that feature; the package-scoped feature build above is the valid equivalent for `heddle-repo`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783971991&installation_id=132405951&pr_number=732&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F732&signature=2d2a4d11623f06c8bbb3b25e0daaf892470f6e0b2359084efc410ae4774f0daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->